### PR TITLE
[FIX] web_editor: don't sanitize currency spans

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
@@ -160,6 +160,7 @@ function sanitizeNode(node, root) {
         && !node.hasAttributes()
         && !hasPseudoElementContent(node, "::before")
         && !hasPseudoElementContent(node, "::after")
+        && !node.querySelector(".oe_currency_value")
     ) {
         // Unwrap the contents of SPAN and FONT elements without attributes.
         getDeepRange(root, { select: true });


### PR DESCRIPTION
Steps to reproduce the issue:
=============================
- Set the company of the website to one that uses (euro) currency.
- Open the website editor
- Drag a banner block and a products carousel block under it
- Set the last template to the products block (last one in the list)
- Try to edit the title of the banner block
- One of two keystrokes are reverted

Origin of the issue:
====================
When we added content, we do historyStep which calls sanitize on the
target (the editable), which will sanitize the non editable elements
inside it and have `oe_unremovable`. observerApply now will mark
this._toRollback as true so in the next keystroke it will revert the
changes and so on...

Solution:
=========
We should not unwrap content for `oe_currency_value` spans

opw-4252743