### PR TITLE
[ADD] event_hr_skills: show events on employee profile

### DIFF
--- a/addons/event/views/event_tag_views.xml
+++ b/addons/event/views/event_tag_views.xml
@@ -24,6 +24,9 @@
                             <h1><field nolabel="1" name="name" placeholder='e.g. "Age Category"'/></h1>
                         </div>
                         <group>
+                            <!-- Placeholders in the layout for overrides -->
+                            <group id='left_header' invisible='1'/>
+                            <group id='right_header' invisible='1'/>
                             <field name="tag_ids" context="{'default_category_id': id}">
                                 <list string="Tags" editable="bottom">
                                     <field name="sequence" widget="handle"/>

--- a/addons/event_hr_skills/__init__.py
+++ b/addons/event_hr_skills/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/event_hr_skills/__manifest__.py
+++ b/addons/event_hr_skills/__manifest__.py
@@ -1,0 +1,25 @@
+{
+    'name': 'Events HR Skills',
+    'category': 'Marketing/Events',
+    'summary': "Manage Employees' Events",
+    'description': """
+Link Employees to the events they attend, and display them on their resume.
+""",
+    'depends': ['hr_skills', 'event'],
+    'data': [
+        'views/event_category_tag_views.xml',
+        'views/event_event_views.xml',
+        'views/hr_resume_line_views.xml',
+    ],
+    'demo': [
+        'data/event_hr_skills_demo.xml'
+    ],
+    'auto_install': True,
+    'assets': {
+        'web.assets_backend': [
+            'event_hr_skills/static/src/fields/**/*',
+        ],
+    },
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/event_hr_skills/data/event_hr_skills_demo.xml
+++ b/addons/event_hr_skills/data/event_hr_skills_demo.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+        <record id="event.event_tag_category_3" model="event.tag.category">
+            <field name="hr_resume_line_type_id" eval="ref('hr_skills.resume_type_experience')"/>
+        </record>
+
+        <record id="event.event_2" model="event.event">
+            <field name="tag_ids" eval="[(4, ref('event.event_tag_category_3_tag_2'))]"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/event_hr_skills/models/__init__.py
+++ b/addons/event_hr_skills/models/__init__.py
@@ -1,0 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import event_registration
+from . import event_tag_category
+from . import hr_resume_line

--- a/addons/event_hr_skills/models/event_registration.py
+++ b/addons/event_hr_skills/models/event_registration.py
@@ -1,0 +1,35 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class EventRegistration(models.Model):
+    _inherit = 'event.registration'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        new_registrations = super().create(vals_list)
+        new_registrations._create_resume_lines()
+        return new_registrations
+
+    def write(self, vals):
+        result = super().write(vals)
+        self._create_resume_lines()
+        return result
+
+    def _create_resume_lines(self):
+        ResumeLine = self.env['hr.resume.line']
+        resume_line_vals_list = []
+        registrations_by_event = self.filtered(lambda r: r.state == 'done').grouped('event_id')
+        for event, registrations in registrations_by_event.items():
+            if not event.tag_ids.category_id.hr_resume_line_type_id:
+                continue
+
+            resume_line_vals_list.extend([{
+                    **ResumeLine._values_from_event(event),
+                    'employee_id': employee.id,
+                }
+                for employee in registrations.partner_id.sudo().employee_ids
+                if event not in employee.resume_line_ids.event_id
+            ])
+        ResumeLine.sudo().create(resume_line_vals_list)

--- a/addons/event_hr_skills/models/event_tag_category.py
+++ b/addons/event_hr_skills/models/event_tag_category.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class EventTagCategory(models.Model):
+    _inherit = 'event.tag.category'
+
+    hr_resume_line_type_id = fields.Many2one(
+        'hr.resume.line.type', "Resume Section", ondelete='set null',
+        help="Assigning a Resume Section will automatically create a resume entry for employees who attend the event.",
+    )

--- a/addons/event_hr_skills/models/hr_resume_line.py
+++ b/addons/event_hr_skills/models/hr_resume_line.py
@@ -1,0 +1,42 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class HrResumeLine(models.Model):
+    _inherit = 'hr.resume.line'
+
+    display_type = fields.Selection(selection_add=[('event', 'Event')])
+    event_id = fields.Many2one(
+        'event.event', string="Event",
+        ondelete='set null',
+        domain=[('tag_ids.category_id', 'any', [('hr_resume_line_type_id', '!=', False)])],
+        groups='event.group_event_user',
+    )
+
+    date_start = fields.Date(compute='_compute_event_data', store=True, readonly=False)
+    date_end = fields.Date(compute='_compute_event_data', store=True, readonly=False)
+    line_type_id = fields.Many2one('hr.resume.line.type', compute='_compute_event_data', store=True, readonly=False)
+    name = fields.Char(compute='_compute_event_data', store=True, readonly=False)
+
+    @api.depends('event_id')
+    def _compute_event_data(self):
+        for event, lines in self.filtered('event_id').grouped('event_id').items():
+            values = self._values_from_event(event)
+            if not values.get('line_type_id'):
+                continue
+            lines.write(values)
+
+    @api.model
+    def _values_from_event(self, event):
+        line_type_id = False
+        if line_types := event.tag_ids.category_id.hr_resume_line_type_id:
+            line_type_id = line_types[0].id
+        return {
+            'date_start': event.date_begin,
+            'date_end': event.date_end,
+            'event_id': event.id,
+            'display_type': 'event',
+            'line_type_id': line_type_id,
+            'name': event.name,
+        }

--- a/addons/event_hr_skills/static/src/fields/resume_one2many/resume_one2many.xml
+++ b/addons/event_hr_skills/static/src/fields/resume_one2many/resume_one2many.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+<t t-inherit="hr_skills.ResumeListRenderer.RecordRow" t-inherit-mode="extension">
+    <xpath expr="//t[@id='row']" position='after'>
+        <t t-if="data.display_type === 'event'">
+            <td class="o_resume_timeline_cell position-relative pe-lg-2">
+                <div class="rounded-circle bg-info position-relative"/>
+            </td>
+            <td class="o_data_cell pt-0" t-on-click="(ev) => this.onCellClicked(record, null, ev)">
+                <div t-attf-class="o_resume_line {{data.display_type == 'certification' ? 'o_resume_line_display_certification' : ''}}" t-att-data-id="id">
+                    <small class="o_resume_line_dates fw-bold">
+                        <t t-out="formatDate(data.date_start)"/> -
+                        <t t-if="data.date_end" t-out="formatDate(data.date_end)"/>
+                        <t t-else="">Current</t>
+                    </small>
+                    <h4 class="o_resume_line_title mt-2" t-esc="data.name"/>
+                    <p t-if="data.description" class="o_resume_line_desc" t-out="data.description" t-ref="link-target-blank"/>
+                </div>
+            </td>
+        </t>
+    </xpath>
+</t>
+
+</templates>
+

--- a/addons/event_hr_skills/tests/__init__.py
+++ b/addons/event_hr_skills/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_event_hr_skills

--- a/addons/event_hr_skills/tests/test_event_hr_skills.py
+++ b/addons/event_hr_skills/tests/test_event_hr_skills.py
@@ -1,0 +1,61 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+from odoo.addons.event.tests.common import EventCase
+from odoo.tests import users
+
+
+class TestEventHrSkills(EventCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.test_contact = cls.env['res.partner'].create({'name': 'Bob'})
+        cls.test_employee = cls.env['hr.employee'].create({
+            'name': 'Alice',
+            'email': 'alice@example.com',
+        })
+        cls.test_category_tag = cls.env['event.tag.category'].create({
+            'name': 'Training',
+            'hr_resume_line_type_id': cls.env.ref('hr_skills.resume_type_experience').id,
+            'tag_ids': [
+                Command.create({'name': 'Sponsored MOOC'}),
+                Command.create({'name': 'Internal Training'}),
+            ],
+        })
+        cls.test_tag = cls.test_category_tag.tag_ids[1]
+        cls.test_event = cls.env['event.event'].create({
+            'name': 'Frobination Training',
+            'tag_ids': [Command.link(cls.test_tag.id)]
+        })
+
+    @users('admin', 'user_eventmanager')
+    def test_attending_creates_resume_line(self):
+        registrations = self._create_registrations(self.test_event, 3).with_env(self.env)
+        registrations[0].partner_id = self.test_employee.work_contact_id.id
+        registrations[1].partner_id = self.test_contact
+        registrations.state = 'done'
+
+        resume_line = self.env['hr.resume.line'].search([('event_id', '=', self.test_event.id)])
+        self.assertEqual(len(resume_line), 1, "Should have created a resume line for the event")
+        self.assertEqual(resume_line.line_type_id, self.env.ref('hr_skills.resume_type_experience'), "resume section should be determined by the event category")
+        self.assertEqual(resume_line.employee_id, self.test_employee, "resume line should be on the correct employee")
+
+    @users('admin', 'user_eventmanager')
+    def test_creating_done_registrations_creates_resume_lines(self):
+        self.env['event.registration'].create([{
+            'event_id': self.test_event.id,
+            'name': f'Test registration {i}',
+            'partner_id': partner_id,
+            'state': 'done',
+        } for i, partner_id in enumerate([
+            self.test_employee.work_contact_id.id,
+            self.test_contact.id,
+            False,
+        ])])
+
+        resume_line = self.env['hr.resume.line'].search([('event_id', '=', self.test_event.id)])
+        self.assertEqual(len(resume_line), 1, "Should have created a resume line for the event")
+        self.assertEqual(resume_line.line_type_id, self.env.ref('hr_skills.resume_type_experience'), "resume section should be determined by the event category")
+        self.assertEqual(resume_line.employee_id, self.test_employee, "resume line should be on the correct employee")

--- a/addons/event_hr_skills/views/event_category_tag_views.xml
+++ b/addons/event_hr_skills/views/event_category_tag_views.xml
@@ -1,28 +1,27 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0"?>
 <odoo>
 
     <record id="event_tag_category_view_form" model="ir.ui.view">
-        <field name="name">event.tag.category.view.form.inherit.website</field>
+        <field name="name">event.tag.category.view.form.inherit.event.hr.skills</field>
         <field name="model">event.tag.category</field>
         <field name="inherit_id" ref="event.event_tag_category_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@id='left_header']" position="inside">
-                    <field name="is_published" string="Show on Website" widget="boolean_toggle"/>
-                    <field name="website_id" groups="website.group_multi_website" string="Website" invisible="not is_published"/>
+            <xpath expr="//group[@id='right_header']" position="inside">
+                <field name="hr_resume_line_type_id"/>
             </xpath>
-            <xpath expr="//group[@id='left_header']" position="attributes">
+            <xpath expr="//group[@id='right_header']" position="attributes">
                 <attribute name='invisible'>0</attribute>
             </xpath>
         </field>
     </record>
 
     <record id="event_tag_category_view_tree" model="ir.ui.view">
-        <field name="name">event.tag.category.view.list.inherit.website</field>
+        <field name="name">event.tag.category.view.list.inherit.event.hr.skills</field>
         <field name="model">event.tag.category</field>
         <field name="inherit_id" ref="event.event_tag_category_view_tree"/>
         <field name="arch" type="xml">
             <field name="tag_ids" position="after">
-                <field name="is_published" string="Show on Website"/>
+                <field name="hr_resume_line_type_id" optional="hide"/>
             </field>
         </field>
     </record>

--- a/addons/event_hr_skills/views/event_event_views.xml
+++ b/addons/event_hr_skills/views/event_event_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="event_event_view_list_hr_skills_summary" model="ir.ui.view">
+        <field name="name">event.event.view.list.hr.skills.summary</field>
+        <field name="model">event.event</field>
+        <field name="arch" type="xml">
+            <list string="Events">
+                <field name="name"/>
+                <field name="user_id" readonly="1" widget="many2one_avatar_user"/>
+                <field name="date_begin" readonly="1"/>
+                <field name="date_end" readonly="1"/>
+            </list>
+        </field>
+    </record>
+</odoo>

--- a/addons/event_hr_skills/views/hr_resume_line_views.xml
+++ b/addons/event_hr_skills/views/hr_resume_line_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="resume_line_view_from" model="ir.ui.view">
+        <field name="name">hr.resume.line.view.form.inherit.event.hr.skills</field>
+        <field name="model">hr.resume.line</field>
+        <field name="inherit_id" ref="hr_skills.resume_line_view_form"/>
+        <field name="arch" type="xml">
+            <field name="display_type" position="after">
+                <field
+                    name="event_id"
+                    options="{'no_create': True}"
+                    context="{'list_view_ref': 'event_hr_skills.event_event_view_list_hr_skills_summary'}"
+                    invisible="display_type != 'event'"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -45,11 +45,11 @@
                         <group>
                             <field name="employee_id" invisible="1"/>
                             <field name="line_type_id"/>
-                            <field name="display_type" required="1"/>
                         </group>
                         <group>
                             <field name="date_start" string="Duration" widget="daterange" options="{'end_date_field': 'date_end'}"/>
                             <field name="date_end" invisible="1"/>
+                            <field name="display_type" required="1"/>
                         </group>
                     </group>
                     <field name="description" placeholder="Description"/>


### PR DESCRIPTION
Add a `event` x `hr_skills` bridge module to add the following feature:
    
After an employee attends some [^1] events, they will automatically be
displayed on their resume.
    
[^1]: configured via event tag categories
    
task-4283517

