### PR TITLE
[FIX] google_calendar, mail: failure of deleted record cannot be removed

### DIFF
--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -91,7 +91,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
 
             events._sync_odoo2google(self.google_service)
 
-        with self.assertQueryCount(__system__=27):
+        with self.assertQueryCount(__system__=28):
             events.unlink()
 
 

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -737,7 +737,9 @@ class Message(models.Model):
         messages_by_partner = defaultdict(lambda: self.env['mail.message'])
         partners_with_user = self.partner_ids.filtered('user_ids')
         for elem in self:
-            for partner in elem.partner_ids & partners_with_user:
+            for partner in (
+                elem.partner_ids & partners_with_user | elem.notification_ids.author_id
+            ):
                 messages_by_partner[partner] |= elem
 
         # Notify front-end of messages deletion for partners having a user

--- a/addons/mail/static/src/core/common/notification_model.js
+++ b/addons/mail/static/src/core/common/notification_model.js
@@ -19,7 +19,11 @@ export class Notification extends Record {
 
     /** @type {number} */
     id;
-    message = Record.one("Message");
+    message = Record.one("Message", {
+        onDelete() {
+            this.delete();
+        },
+    });
     /** @type {string} */
     notification_status;
     /** @type {string} */

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -5,6 +5,7 @@ from . import test_link_preview
 from . import test_mail_activity
 from . import test_mail_composer
 from . import test_mail_mail_stable_selection
+from . import test_mail_message
 from . import test_mail_render
 from . import test_mail_template
 from . import test_mail_tools

--- a/addons/mail/tests/test_mail_message.py
+++ b/addons/mail/tests/test_mail_message.py
@@ -1,0 +1,28 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mail.tests import common
+from odoo.tests import new_test_user, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestMailMessage(common.MailCommon):
+    def test_unlink_failure_message_notify_author(self):
+        recipient = new_test_user(self.env, login="Bob", email="invalid_email_addr")
+        message = self.env.user.partner_id.message_post(
+            body="Hello world!", partner_ids=recipient.partner_id.ids
+        )
+        self.assertEqual(message.notification_ids.failure_type, "mail_email_invalid")
+        self.assertEqual(message.notification_ids.res_partner_id, recipient.partner_id)
+        self.assertEqual(message.notification_ids.author_id, self.env.user.partner_id)
+        self._reset_bus()
+        with self.assertBus(
+            [
+                (self.cr.dbname, "res.partner", recipient.partner_id.id),
+                (self.cr.dbname, "res.partner", self.env.user.partner_id.id),
+            ],
+            [
+                {"type": "mail.message/delete", "payload": {"message_ids": [message.id]}},
+                {"type": "mail.message/delete", "payload": {"message_ids": [message.id]}},
+            ],
+        ):
+            message.unlink()


### PR DESCRIPTION
When a failure occurs when sending an email or a sms, it is displayed in the messaging menu. Before this PR, it could not be removed after a record was deleted.

Steps to reproduce:
- Send a message on a record, add a recipient with an incorrect email.
- A red enveloppe is displayed next to the message and a notification is added in the messaging menu.
- Delete this record.
- Try to mark this failure as read.
- Nothing happens.

This occurs because the message deletion is only notified to the recipients, not the author. This PR fixes the issue.

opw-4272165