### PR TITLE
[FIX] sale_stock: correct delivery color

### DIFF
--- a/addons/sale_stock/i18n/sale_stock.pot
+++ b/addons/sale_stock/i18n/sale_stock.pot
@@ -124,6 +124,14 @@ msgid "Available in stock"
 msgstr ""
 
 #. module: sale_stock
+#: model:ir.model.fields,help:sale_stock.field_sale_order__delivery_status
+msgid ""
+"Blue: Not Delivered/Started\n"
+"            Orange: Partially Delivered\n"
+"            Green: Fully Delivered"
+msgstr ""
+
+#. module: sale_stock
 #: model:ir.model.fields,help:sale_stock.field_stock_rules_report__so_route_ids
 msgid "Choose to apply SO lines specific routes."
 msgstr ""
@@ -460,14 +468,6 @@ msgstr ""
 #. module: sale_stock
 #: model_terms:ir.ui.view,arch_db:sale_stock.sale_order_portal_content_inherit_sale_stock
 msgid "RETURN"
-msgstr ""
-
-#. module: sale_stock
-#: model:ir.model.fields,help:sale_stock.field_sale_order__delivery_status
-msgid ""
-"Red: Late\n"
-"            Orange: To process today\n"
-"            Green: On time"
 msgstr ""
 
 #. module: sale_stock

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -35,9 +35,9 @@ class SaleOrder(models.Model):
         ('partial', 'Partially Delivered'),
         ('full', 'Fully Delivered'),
     ], string='Delivery Status', compute='_compute_delivery_status', store=True,
-       help="Red: Late\n\
-            Orange: To process today\n\
-            Green: On time")
+       help="Blue: Not Delivered/Started\n\
+            Orange: Partially Delivered\n\
+            Green: Fully Delivered")
     procurement_group_id = fields.Many2one('procurement.group', 'Procurement Group', copy=False)
     effective_date = fields.Datetime("Effective Date", compute='_compute_effective_date', store=True, help="Completion date of the first delivery order.")
     expected_date = fields.Datetime( help="Delivery date you can promise to the customer, computed from the minimum lead time of "


### PR DESCRIPTION
[FIX] sale_stock: correct delivery color
The issue:
In the Sale order list view, the help message for Delivery Status states:
- Red: Late
- Orange: To process today
- Green: On time

However, in practice, the `delivery_status` color does not reflect the delivery timing.

Steps to reproduce
- Enable `delivery_status` in the `sale_order` list view.

https://github.com/odoo/odoo/commit/470b756297f308f7b2a81f9d45c60d6d9655c647 introduced `delivery_status`for `sale_order` with tag colors based on delivery timing. However, https://github.com/odoo/odoo/commit/ab53ea9db8dc2ab9791d9d813b727a748c5ff8c6 modified the color computation for `delivery_status` to no longer depend on delivery timing.

opw-4280651
