### PR TITLE
[FIX] core: remove more field data when uninstall

### DIFF
--- a/odoo/addons/test_inherit/ir.model.access.csv
+++ b/odoo/addons/test_inherit/ir.model.access.csv
@@ -1,4 +1,5 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+access_test_inherit_animal,access_test_inherit_animal,model_test_inherit_animal,base.group_system,1,1,1,1
 access_test_inherit_mother,access_test_inherit_mother,model_test_inherit_mother,base.group_system,1,1,1,1
 access_test_inherit_mother_underscore,access_test_mother_underscore,test_inherit.model_test_mother_underscore,base.group_system,1,1,1,1
 access_test_inherit_daughter,access_test_inherit_daughter,model_test_inherit_daughter,base.group_system,1,1,1,1

--- a/odoo/addons/test_inherit/models/__init__.py
+++ b/odoo/addons/test_inherit/models/__init__.py
@@ -1,3 +1,4 @@
+from . import animal
 from . import mother_base
 from . import mother_inherit_1
 from . import mother_inherit_2

--- a/odoo/addons/test_inherit/models/animal.py
+++ b/odoo/addons/test_inherit/models/animal.py
@@ -1,0 +1,8 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class TestInheritAnimal(models.Model):
+    _name = 'test.inherit.animal'
+    _description = 'Test Inherit Animal'

--- a/odoo/addons/test_inherit/tests/__init__.py
+++ b/odoo/addons/test_inherit/tests/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import test_inherit
+from . import test_uninstall

--- a/odoo/addons/test_inherit/tests/test_uninstall.py
+++ b/odoo/addons/test_inherit/tests/test_uninstall.py
@@ -1,0 +1,158 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import standalone
+from odoo.tools import sql
+
+
+@standalone('inherit_uninstall')
+def test_inherited_fields_after_uninstall(env):
+    """
+    =================================
+    module: test_inherit
+
+    class TestInheritAnimal
+        _name = 'test.inherit.animal'
+
+    =================================
+    module: test_inherit_depends
+    depends: test_inherit
+
+    class TestInheritAnimal(models.Model):
+        _inherit = ['test.inherit.animal']
+
+        name = fields.Char(default='Animal')
+        height = fields.Integer()
+
+    =================================
+    module: test_inherit_inherits_depends
+    depends: test_inherit
+
+    class TestInheritBird(models.Model):
+        _name = 'test.inherit.bird'
+        _inherit = ['test.inherit.animal']
+
+        name = fields.Char(default='Bird')
+
+
+    class TestInheritOwl(models.Model):
+        _name = 'test.inherit.owl'
+        _inherit = ['test.inherit.bird]
+
+
+    class TestInheritPet(models.Model):
+        _name = 'test.inherit.pet'
+        _inherits = {'animal_id': 'test.inherit.animal'}
+
+        name = fields.Char(default='Pet')
+        animal_id = fields.Many2one('test.inherit.animal')
+
+    """
+
+    def test_fields(expected, ignore=None):
+        ignore = ignore or {}
+        for (model_name, field_name), exist in expected.items():
+            table_name = model_name.replace('.', '_')
+
+            if 'registry' not in ignore.get((model_name, field_name), ()):
+                assert (model_name in env and field_name in env[model_name]._fields) == exist
+
+            if 'column' not in ignore.get((model_name, field_name), ()):
+                assert bool(sql.column_exists(env.cr, table_name, field_name)) == exist
+
+            if 'ir.model.fields' not in ignore.get((model_name, field_name), ()):
+                assert bool(env['ir.model.fields'].search([('model', '=', model_name), ('name', '=', field_name)])) == exist
+
+            if 'ir.model.data' not in ignore.get((model_name, field_name), ()):
+                assert bool(env['ir.model.data'].search([('name', '=', f"field_{table_name}__{field_name}")])) == exist
+
+    module_test_inherit_depends, module_test_inherit_inherits_depends = env['ir.module.module'].sudo().search([('name', 'in', ('test_inherit_depends', 'test_inherit_inherits_depends'))], order='name')
+
+    # {('field_name', 'field_name'): if_field_should_exist
+    initial_expected = {
+        ('test.inherit.animal', 'name'): False,
+        ('test.inherit.animal', 'height'): False,
+        ('test.inherit.bird', 'name'): False,
+        ('test.inherit.bird', 'height'): False,
+        ('test.inherit.owl', 'name'): False,
+        ('test.inherit.owl', 'height'): False,
+        ('test.inherit.pet', 'name'): False,
+        ('test.inherit.pet', 'height'): False,
+    }
+
+    test_fields(initial_expected)
+    module_test_inherit_depends.button_immediate_install()
+    module_test_inherit_inherits_depends.button_immediate_install()
+    module_test_inherit_depends.button_immediate_uninstall()
+    test_fields({
+        ('test.inherit.animal', 'name'): False,
+        ('test.inherit.animal', 'height'): False,
+        ('test.inherit.bird', 'name'): True,
+        ('test.inherit.bird', 'height'): False,
+        ('test.inherit.owl', 'name'): True,
+        ('test.inherit.owl', 'height'): False,
+        ('test.inherit.pet', 'name'): True,
+        ('test.inherit.pet', 'height'): False,
+    })
+    module_test_inherit_inherits_depends.button_immediate_uninstall()
+
+    test_fields(initial_expected)
+
+    module_test_inherit_inherits_depends.button_immediate_install()
+    module_test_inherit_depends.button_immediate_install()
+    module_test_inherit_depends.button_immediate_uninstall()
+    test_fields({
+        ('test.inherit.animal', 'name'): False,
+        ('test.inherit.animal', 'height'): False,
+        ('test.inherit.bird', 'name'): True,
+        ('test.inherit.bird', 'height'): False,
+        ('test.inherit.owl', 'name'): True,
+        ('test.inherit.owl', 'height'): False,
+        ('test.inherit.pet', 'name'): True,
+        ('test.inherit.pet', 'height'): False,
+    })
+    module_test_inherit_inherits_depends.button_immediate_uninstall()
+
+    test_fields(initial_expected)
+
+    module_test_inherit_depends.button_immediate_install()
+    module_test_inherit_inherits_depends.button_immediate_install()
+    module_test_inherit_inherits_depends.button_immediate_uninstall()
+    test_fields({
+        ('test.inherit.animal', 'name'): True,
+        ('test.inherit.animal', 'height'): True,
+        ('test.inherit.bird', 'name'): False,
+        ('test.inherit.bird', 'height'): False,
+        ('test.inherit.owl', 'name'): False,
+        ('test.inherit.owl', 'height'): False,
+        ('test.inherit.pet', 'name'): False,
+        ('test.inherit.pet', 'height'): False,
+    })
+    module_test_inherit_depends.button_immediate_uninstall()
+
+    test_fields(initial_expected)
+
+    module_test_inherit_inherits_depends.button_immediate_install()
+    module_test_inherit_depends.button_immediate_install()
+    module_test_inherit_inherits_depends.button_immediate_uninstall()
+    test_fields({
+        ('test.inherit.animal', 'name'): True,
+        ('test.inherit.animal', 'height'): True,
+        ('test.inherit.bird', 'name'): False,
+        ('test.inherit.bird', 'height'): False,
+        ('test.inherit.owl', 'name'): False,
+        ('test.inherit.owl', 'height'): False,
+        ('test.inherit.pet', 'name'): False,
+        ('test.inherit.pet', 'height'): False,
+    }, ignore={
+        # improve it if you can
+        # ir.model.data is not removed when the module is uninstalled
+        ('test.inherit.bird', 'name'): ('ir.model.data',),
+        ('test.inherit.bird', 'height'): ('ir.model.data',),
+        ('test.inherit.owl', 'name'): ('ir.model.data',),
+        ('test.inherit.owl', 'height'): ('ir.model.data',),
+        ('test.inherit.pet', 'name'): ('ir.model.data',),
+        ('test.inherit.pet', 'height'): ('ir.model.data',),
+    })
+    module_test_inherit_depends.button_immediate_uninstall()
+
+    test_fields(initial_expected)

--- a/odoo/addons/test_inherit_depends/models.py
+++ b/odoo/addons/test_inherit_depends/models.py
@@ -16,3 +16,10 @@ class TestInheritMother(models.Model):
 
     def foo(self):
         return super().foo() * 2
+
+
+class TestInheritAnimal(models.Model):
+    _inherit = ['test.inherit.animal']
+
+    name = fields.Char(default='Animal')
+    height = fields.Integer()

--- a/odoo/addons/test_inherit_inherits_depends/__init__.py
+++ b/odoo/addons/test_inherit_inherits_depends/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/odoo/addons/test_inherit_inherits_depends/__manifest__.py
+++ b/odoo/addons/test_inherit_inherits_depends/__manifest__.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'test-inherit-inherits-depends',
+    'version': '1.0',
+    'category': 'Hidden/Tests',
+    'description': """A module to verify the inheritance using _inherit and _inherits across modules.""",
+    'depends': ['test_inherit', 'test_new_api'],
+    'data': [
+        'ir.model.access.csv',
+    ],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/odoo/addons/test_inherit_inherits_depends/ir.model.access.csv
+++ b/odoo/addons/test_inherit_inherits_depends/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+test_inherit_inherits_depends.access_test_inherit_bird,access_test_inherit_bird,model_test_inherit_bird,base.group_system,1,1,1,1
+test_inherit_inherits_depends.access_test_inherit_owl,access_test_inherit_owl,model_test_inherit_owl,base.group_system,1,1,1,1
+test_inherit_inherits_depends.access_test_inherit_pet,access_test_inherit_pet,model_test_inherit_pet,base.group_system,1,1,1,1

--- a/odoo/addons/test_inherit_inherits_depends/models.py
+++ b/odoo/addons/test_inherit_inherits_depends/models.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+
+
+class TestInheritBird(models.Model):
+    _name = 'test.inherit.bird'
+    _inherit = ['test.inherit.animal']
+    _description = 'Test Inherit Bird'
+
+    name = fields.Char(default='Bird')
+
+
+class TestInheritOwl(models.Model):
+    _name = 'test.inherit.owl'
+    _inherit = ['test.inherit.bird']
+    _description = 'Test Inherit Owl'
+
+
+class TestInheritPet(models.Model):
+    _name = 'test.inherit.pet'
+    _inherits = {'test.inherit.animal': 'animal_id'}
+    _description = 'Test Inherit Pet'
+
+    name = fields.Char(default='Pet')
+    animal_id = fields.Many2one('test.inherit.animal', required=True, ondelete='restrict')

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -560,6 +560,9 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
                 # Recursive reload, should only happen once, because there should be no
                 # modules to remove next time
                 cr.commit()
+                # remove ir.model.data for ir.model.fields deleted by ondelete cascade after uninstallation
+                # the deleted ir.model.data's res_id doesn't exist in ir_model_fields.id anymore
+                cr.execute("DELETE FROM ir_model_data WHERE model='ir.model.fields' AND res_id NOT IN (SELECT id FROM ir_model_fields)")
                 _logger.info('Reloading registry once more after uninstalling modules')
                 registry = Registry.new(
                     cr.dbname, force_demo, status, update_module


### PR DESCRIPTION
before this commit, data (column, ir.model.fields, ir.model.data) for field generated by model with _inherit and customized _name might be remained after uninstall.
this commit fixes the consistency issue for column and ir.model.fields, and add a standalone test to describe the behavior

1. install `sale_timesheet`
2. install `industry_fsm`
3. uninstall `sale_timesheet`
4. the `ir.model.fields` for `report.project.task.user.fsm.remaining_hours_so` is remained

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
