### PR TITLE
[IMP] registry: RO cursor fall back to RW

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -964,6 +964,10 @@ class Registry(Mapping):
     def cursor(self, /, readonly=False):
         """ Return a new cursor for the database. The cursor itself may be used
             as a context manager to commit/rollback and close automatically.
+
+            :param readonly: Attempt to acquire a cursor on a replica database.
+                Acquire a read/write cursor on the primary database in case no
+                replica exists or that no readonly cursor could be acquired.
         """
         if self.test_cr is not None:
             # in test mode we use a proxy object that uses 'self.test_cr' underneath
@@ -971,10 +975,15 @@ class Registry(Mapping):
                 _logger.info('Explicitly ignoring readonly flag when generating a cursor')
             return TestCursor(self.test_cr, self.test_lock, readonly and self.test_readonly_enabled)
 
-        connection = self._db
         if readonly and self._db_readonly is not None:
-            connection = self._db_readonly
-        return connection.cursor()
+            try:
+                return self._db_readonly.cursor()
+            except psycopg2.OperationalError:
+                # Setting _db_readonly to None will deactivate the readonly mode until
+                # worker restart / recycling.
+                self._db_readonly = None
+                _logger.warning('Failed to open a readonly cursor, falling back to read-write cursor')
+        return self._db.cursor()
 
 
 class DummyRLock(object):


### PR DESCRIPTION
When using Odoo with a read-only replica, it is necessary for the replica to be online, otherwise read-only requests will fail.

This commit implements a simple failover mechanism: if a RO cursor cannot be acquired, we fall back to the RW cursor. We also deactivate the RO feature by setting `_db_readonly` to `None`. It will have the effect of deactivating the RO feature for the subsequent requests until Odoo is restarted or the worker is recycled.

In the context of the Postgres replication, such behavior is useful since synchronous replication doesn't guarantee that the replica is actually up-to-date in some edge cases. The most common case being the unexpected restart of the replica: there is a short period of time during which the replica accepts incoming requests but is still catching up with the master. Delaying the use of the replica should help reducing the race conditions in such cases.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
