### PR TITLE
[IMP] web_tour: add check for undeterminisms

### DIFF
--- a/addons/web/static/src/core/macro.js
+++ b/addons/web/static/src/core/macro.js
@@ -117,8 +117,8 @@ export class Macro {
         }
         if (proceedToAction) {
             this.safeCall(this.onStep, this.currentElement, this.currentStep);
-            const actionResult = await this.performAction();
             this.clearTimer();
+            const actionResult = await this.performAction();
             if (!actionResult) {
                 // If falsy action result, it means the action worked properly.
                 // So we can proceed to the next step.

--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -4,6 +4,7 @@ import { TourStepAutomatic } from "./tour_step_automatic";
 import { Macro } from "@web/core/macro";
 import { browser } from "@web/core/browser/browser";
 import { setupEventActions } from "@web/../lib/hoot-dom/helpers/events";
+import { delay } from "@odoo/hoot-dom";
 
 export class TourAutomatic {
     mode = "auto";
@@ -12,8 +13,7 @@ export class TourAutomatic {
     constructor(data) {
         Object.assign(this, data);
         this.steps = this.steps.map((step, index) => new TourStepAutomatic(step, this, index));
-        const tourConfig = tourState.getCurrentConfig();
-        this.stepDelay = tourConfig.stepDelay;
+        this.config = tourState.getCurrentConfig() || {};
     }
 
     get currentIndex() {
@@ -25,15 +25,18 @@ export class TourAutomatic {
     }
 
     get debugMode() {
-        const tourConfig = tourState.getCurrentConfig() || {};
-        return tourConfig.debug !== false;
+        return this.config.debug !== false;
+    }
+
+    get checkForUndeterminisms() {
+        return this.config.delayToCheckUndeterminisms > 0;
     }
 
     start(pointer) {
         const macroSteps = this.steps
             .filter((step) => step.index >= this.currentIndex)
             .flatMap((step) => {
-                const timeout = (step.timeout || 10000) + this.stepDelay;
+                const timeout = (step.timeout || 10000) + this.config.stepDelay;
                 return [
                     {
                         action: async () => {
@@ -52,9 +55,9 @@ export class TourAutomatic {
                             // This delay is important for making the current set of tour tests pass.
                             // IMPROVEMENT: Find a way to remove this delay.
                             await new Promise((resolve) => requestAnimationFrame(resolve));
-                            await new Promise((resolve) =>
-                                browser.setTimeout(resolve, this.stepDelay)
-                            );
+                            if (this.config.stepDelay > 0) {
+                                await delay(this.config.stepDelay);
+                            }
                         },
                     },
                     {
@@ -64,15 +67,23 @@ export class TourAutomatic {
                         trigger: () => step.findTrigger(),
                         timeout,
                         action: async () => {
+                            if (this.checkForUndeterminisms) {
+                                try {
+                                    await step.checkForUndeterminisms();
+                                } catch (error) {
+                                    this.throwError([
+                                        ...this.currentStep.describeWhyIFailed,
+                                        error.message,
+                                    ]);
+                                }
+                            }
                             this.previousStepIsJustACheck = !this.currentStep.hasAction;
                             if (this.debugMode) {
                                 this.paused = step.pause;
                                 if (!step.skipped && this.showPointerDuration > 0 && step.element) {
                                     // Useful in watch mode.
                                     pointer.pointTo(step.element, this);
-                                    await new Promise((r) =>
-                                        browser.setTimeout(r, this.showPointerDuration)
-                                    );
+                                    await delay(this.showPointerDuration);
                                     pointer.hide();
                                 }
                                 console.log(step.element);

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -142,6 +142,7 @@ export const tourService = {
             }
 
             let tourConfig = {
+                delayToCheckUndeterminisms: 0,
                 stepDelay: 0,
                 keepWatchBrowser: false,
                 mode: "auto",

--- a/addons/web_tour/static/src/tour_service/tour_step_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_step_automatic.js
@@ -4,6 +4,7 @@ import { callWithUnloadCheck } from "./tour_utils";
 import { TourHelpers } from "./tour_helpers";
 import { TourStep } from "./tour_step";
 import { getTag } from "@web/core/utils/xml";
+import { browser } from "@web/core/browser/browser";
 
 export class TourStepAutomatic extends TourStep {
     skipped = false;
@@ -12,6 +13,26 @@ export class TourStepAutomatic extends TourStep {
         super(data, tour);
         this.index = index;
         this.tourConfig = tourState.getCurrentConfig();
+    }
+
+    async checkForUndeterminisms() {
+        const delay = this.tourConfig.delayToCheckUndeterminisms;
+        if (delay > 0 && this.element) {
+            const snapshot = this.element.cloneNode(true);
+            return new Promise((resolve, reject) => {
+                browser.setTimeout(() => {
+                    if (this.element.isEqualNode(snapshot)) {
+                        resolve();
+                    } else {
+                        reject(
+                            new Error(
+                                `UNDETERMINISM: two differents elements have been found in ${delay}ms for trigger ${this.trigger}`
+                            )
+                        );
+                    }
+                }, delay);
+            });
+        }
     }
 
     get describeWhyIFailed() {

--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -1538,3 +1538,64 @@ test("a tour where hoot trigger failed", async () => {
 SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '.button1:brol(:machin)' is not a valid selector.`,
     ]);
 });
+
+test("check for undeterminisms", async () => {
+    patchWithCleanup(browser.console, {
+        warn: (s) => {},
+        error: (s) => expect.step(`error: ${s}`),
+        log: (s) => expect.step(`log: ${s}`),
+    });
+    await makeMockEnv();
+
+    class Root extends Component {
+        static components = {};
+        static template = xml/*html*/ `
+            <t>
+                <div class="container">
+                    <button class="button0">Button 0</button>
+                    <button class="button1">Button 1</button>
+                    <button class="button2">Button 2</button>
+                </div>
+            </t>
+        `;
+        static props = ["*"];
+    }
+
+    await mountWithCleanup(Root);
+    registry.category("web_tour.tours").add("tour_und", {
+        steps: () => [
+            {
+                trigger: ".button0",
+                run: "click",
+            },
+            {
+                trigger: ".button1",
+                run: "click",
+            },
+            {
+                trigger: ".button2",
+                run: "click",
+            },
+        ],
+    });
+    await odoo.startTour("tour_und", {
+        mode: "auto",
+        delayToCheckUndeterminisms: 3000,
+    });
+    await advanceTime(10);
+    await advanceTime(500);
+    expect.verifySteps(["log: [1/3] Tour tour_und → Step .button0"]);
+    await advanceTime(3001);
+    await advanceTime(10);
+    await advanceTime(500);
+    expect.verifySteps(["log: [2/3] Tour tour_und → Step .button1"]);
+    await advanceTime(1000);
+    queryFirst(".button1").textContent = "Text has changed :)";
+    await advanceTime(1500);
+    await advanceTime(10000);
+    expect.verifySteps([
+        `error: FAILED: [2/3] Tour tour_und → Step .button1.
+Element has been found.
+UNDETERMINISM: two differents elements have been found in 3000ms for trigger .button1`,
+    ]);
+});

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2060,10 +2060,16 @@ class HttpCase(TransactionCase):
             'keepWatchBrowser': kwargs.get('watch', False),
             'debug': kwargs.get('debug', False),
             'startUrl': url_path,
+            'delayToCheckUndeterminisms': kwargs.pop('delay_to_check_undeterminisms', 0),
         }
         code = kwargs.pop('code', f"odoo.startTour({tour_name!r}, {json.dumps(options)})")
         ready = kwargs.pop('ready', f"odoo.isTourReady({tour_name!r})")
-        return self.browser_js(url_path=url_path, code=code, ready=ready, success_signal="tour succeeded", **kwargs)
+        timeout = kwargs.pop('timeout', 60)
+
+        if options["delayToCheckUndeterminisms"] > 0:
+            timeout = timeout + 1000 * options["delayToCheckUndeterminisms"]
+            _logger.runbot("Tour %s is launched with mode: check for undeterminisms.", tour_name)
+        return self.browser_js(url_path=url_path, code=code, ready=ready, timeout=timeout, success_signal="tour succeeded", **kwargs)
 
     def profile(self, **kwargs):
         """


### PR DESCRIPTION
In this commit, we add a new feature in tour engine that allows to check if there are potential indeterminisms related to the triggers. To do this, we will "simply" check if the targeted element (trigger) is not altered within a delay.
If this is the case, it is then possible that we do not wait long enough before targeting the element in the tour, or that the trigger is not precise enough.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
