### PR TITLE
[FIX] mail: DM chat avatar should not be editable

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -8,7 +8,7 @@
                 <t t-if="thread">
                     <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
                         <img class="rounded o_object_fit_cover" t-att-src="thread.avatarUrl" alt="Thread Image"/>
-                        <FileUploader t-if="thread.is_editable" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
+                        <FileUploader t-if="thread.is_editable and thread.channel_type !== 'chat'" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
                                 <a href="#" class="position-absolute z-1 h-100 w-100 rounded start-0 bottom-0" title="Upload Avatar">
                                     <i class="position-absolute top-50 start-50 fa fa-sm fa-pencil text-white"/>

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1613,6 +1613,29 @@ test("Thread avatar image is displayed in top bar of channels of type 'group'", 
     await contains(".o-mail-Discuss-header .o-mail-Discuss-threadAvatar");
 });
 
+test("Thread avatar is not editable in DM chat", async () => {
+    const pyEnv = await startServer();
+    const demoUid = pyEnv["res.users"].create({ name: "Demo" });
+    const demoPid = pyEnv["res.partner"].create({ name: "Demo", user_ids: [demoUid] });
+    const [groupChatId] = pyEnv["discuss.channel"].create([
+        { channel_type: "group", name: "GroupChat" },
+        {
+            channel_member_ids: [
+                Command.create({ partner_id: serverState.partnerId }),
+                Command.create({ partner_id: demoPid }),
+            ],
+            channel_type: "chat",
+        },
+    ]);
+    await start();
+    await openDiscuss(groupChatId);
+    await contains(".o-mail-Discuss-threadName[title='GroupChat']");
+    await contains(".o-mail-Discuss-threadAvatar .fa-pencil");
+    await click(".o-mail-DiscussSidebar-item:contains('Demo')");
+    await contains(".o-mail-Discuss-threadName[title='Demo']");
+    await contains(".o-mail-Discuss-threadAvatar .fa-pencil", { count: 0 });
+});
+
 test("Do not trigger chat name server update when it is unchanged", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ channel_type: "chat" });


### PR DESCRIPTION
Before this commit, mouse-hovering on DM chat avatar in discuss app was showing the pencil icon, which gives the impression that we could edit the avatar of a DM chat.

Steps to reproduce:
- with Mitchell Admin, open the Discuss App
- Open a DM chat with Marc Demo
- Mouse-hover on avatar in the topbar of discuss app => the avatar is editable when it shouldn't

This commit disables the feature as this is not intended to be used. Thankfully changing the avatar had no impact, because the avatar of the correspondent is necessarily used rather than the avatar of the conversation.

Backport of https://github.com/odoo/odoo/pull/186016

<img width="2557" alt="Screenshot 2024-10-31 at 16 36 59" src="https://github.com/user-attachments/assets/ab222cd2-9508-41c7-82a5-d335b3f74551">
