### PR TITLE
[FIX] point_of_sale: load only necessary attribute values

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -313,11 +313,12 @@ class ProductTemplateAttributeValue(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data):
-        loaded_product_tmpl_ids = list({p['product_tmpl_id'] for p in data['product.product']['data']})
+        ptav_ids = {ptav_id for p in data['product.product']['data'] for ptav_id in p['product_template_variant_value_ids']}
+        ptav_ids.update({ptav_id for ptal in data['product.template.attribute.line']['data'] for ptav_id in ptal['product_template_value_ids']})
         return AND([
             [('ptav_active', '=', True)],
             [('attribute_id', 'in', [attr['id'] for attr in data['product.attribute']['data']])],
-            [('product_tmpl_id', 'in', loaded_product_tmpl_ids)]
+            [('id', 'in', list(ptav_ids))]
         ])
 
     @api.model


### PR DESCRIPTION
Before this commit, some unnecessary attributes might be loaded. This change ensures that only the required attributes are loaded, improving efficiency and performance.

opw-4298915

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
