### PR TITLE
[FIX] web: remove extra newline in report header when tagline is empty

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -343,7 +343,9 @@
                     <img t-if="company.logo" t-att-src="image_data_uri(company.logo)" alt="Logo"/>
                 </div>
                 <div class="col-6 text-end mb4">
-                    <div class="mt0 h4" t-field="company.report_header"/>
+                    <t t-if="company.report_header and company.report_header.strip() != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'">
+                        <div class="mt0 h4" t-field="company.report_header"/>
+                    </t>
                     <div name="company_address" class="float-end mb4">
                         <ul class="list-unstyled">
                             <li t-if="company.is_company_details_empty"><t t-esc="company.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/></li>


### PR DESCRIPTION
Steps to reproduce:
1. Go to Accounting > Invoices and print any invoice.
2. Go to Settings > Configure your document layout.
3. Set the layout to "Boxed" (default is "Light").
4. Add a Company Tagline (any value), save, then delete it completely.
5. Go back to Accounting > Invoices and print any invoice.

You can notice that the grey line and the text on the top right corner is more down compare to the first printed report.


When the Company Tagline `report_header` is cleared, it leaves an extra newline in the report because the HTML editor sets it to `<p><br></p>` instead of `false`. This causes the printed invoice layout to shift.

As a solution
I added a method that checks if `report_header` is empty or not and then display it only when it’s not empty (`<p><br></p>`).

Alternative solutions considered:
1. Clean the `report_header` field before saving it to the database OR use an on-change function to remove empty values.
2. Implement a custom widget or JS hook for better control.

The chosen solution is the simplest, requiring minimal code changes to address the issue effectively.

opw-4247281



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
