### PR TITLE
[IMP] mrp: add additional notes to the BoM

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -96,6 +96,8 @@ class MrpBom(models.Model):
     batch_size = fields.Float('Batch Size', default=1.0, digits='Product Unit', help="All automatically generated manufacturing orders for this product will be of this size.")
     enable_batch_size = fields.Boolean(default=False)
 
+    note = fields.Html(string="Additional Notes", help="Add this note on the manufacturing order to share any additional information")
+
     _qty_positive = models.Constraint(
         'check (product_qty > 0)',
         'The quantity to produce must be positive!',

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -301,6 +301,7 @@ class MrpProduction(models.Model):
         search='_search_date_category', readonly=True
     )
     serial_numbers_count = fields.Integer("Count of serial numbers", compute='_compute_serial_numbers_count')
+    note = fields.Html(string="Additional Notes", compute='_compute_note', store=True, help="Add this note on the manufacturing order to share any additional information")
 
     _name_uniq = models.Constraint(
         'unique(name, company_id)',
@@ -873,6 +874,16 @@ class MrpProduction(models.Model):
             qty_none_or_all = production.qty_producing in (0, production.product_qty)
             production.show_produce_all = state_ok and qty_none_or_all
             production.show_produce = state_ok and not qty_none_or_all
+
+    @api.depends('bom_id', 'bom_id.note')
+    def _compute_note(self):
+        for record in self:
+            if record.note:
+                continue
+            if record.bom_id:
+                record.note = record.bom_id.note
+            else:
+                record.note = False
 
     def _search_is_delayed(self, operator, value):
         if operator not in ('in', 'not in'):

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -173,6 +173,7 @@
                                     <field name="ready_to_produce" invisible="type == 'phantom'" string="Manufacturing Readiness" widget="radio" groups="mrp.group_mrp_routings"/>
                                     <field name="consumption" invisible="type == 'phantom'" widget="radio"/>
                                     <field name="allow_operation_dependencies" groups="mrp.group_mrp_workorder_dependencies"/>
+                                    <field name="note" />
                                 </group>
                                 <group>
                                     <field name="picking_type_id" invisible="type == 'phantom'" groups="stock.group_adv_location"/>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -546,6 +546,7 @@
                                     <field name="date_deadline"/>
                                     <field name="is_delayed" invisible="True"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" readonly="state != 'draft'" force_save="1"/>
+                                    <field name="note" readonly="False"/>
                                 </group>
                             </group>
                         </page>


### PR DESCRIPTION
This commits converts the log notes feature, now renamed as additional notes, into an HTML Field, making it available in Workorders, Manufacturing Orders, and now in the BoM. Previously a text field, it can now include complex content such as images and tags.

On the Shop Floor, when an additional note contains complex content, the content displayed in the display line will be simplified to a basic string. Otherwise, the display will showw the first few words of the note.

Additionally, this feature is now available in the BoM. When a user creates a Workoder with an attached BoM, the default content of the additional note will matchthat of the BoM.

task: 4274581


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
