### PR TITLE
18.0 clean mtso aels

### DIFF
--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -126,7 +126,7 @@ class StockWarehouse(models.Model):
             'manufacture_mto_pull_id': {
                 'depends': ['manufacture_steps', 'manufacture_to_resupply'],
                 'create_values': {
-                    'procure_method': 'mts_else_mto',
+                    'procure_method': 'make_to_order',
                     'company_id': self.company_id.id,
                     'action': 'pull',
                     'auto': 'manual',

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -650,7 +650,7 @@ class TestReorderingRule(TransactionCase):
         customer_loc, _ = warehouse._get_partner_locations()
         mto_rule = self.env['stock.rule'].search(
             [('warehouse_id', '=', warehouse.id),
-             ('procure_method', '=', 'mts_else_mto'),
+             ('procure_method', '=', 'make_to_order'),
              ('location_dest_id', '=', customer_loc.id)
             ]
         )

--- a/addons/repair/models/stock_warehouse.py
+++ b/addons/repair/models/stock_warehouse.py
@@ -67,7 +67,7 @@ class StockWarehouse(models.Model):
             'repair_mto_pull_id': {
                 'depends': ['repair_type_id'],
                 'create_values': {
-                    'procure_method': 'mts_else_mto',
+                    'procure_method': 'make_to_order',
                     'company_id': self.company_id.id,
                     'action': 'pull',
                     'auto': 'manual',

--- a/addons/repair/tests/test_rules_installation.py
+++ b/addons/repair/tests/test_rules_installation.py
@@ -13,7 +13,7 @@ class TestGlobalRouteRulesInstallation(common.TransactionCase):
             ('picking_type_id.name', '=', 'Repairs'),
         ])
         self.assertTrue(rule, "Stock rule was not created")
-        self.assertEqual(rule.procure_method, 'mts_else_mto', "Procure method is incorrect")
+        self.assertEqual(rule.procure_method, 'make_to_order', "Procure method is incorrect")
         self.assertEqual(rule.company_id.id, self.company.id, "Company ID is incorrect")
         self.assertEqual(rule.action, 'pull', "Action is incorrect")
         self.assertEqual(rule.auto, 'manual', "Auto is incorrect")

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -298,7 +298,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         order.action_confirm()
 
         # Verify buttons are working as expected
-        self.assertEqual(order.mrp_production_count, 1, "User should see the closest manufacture order in the smart button")
+        self.assertEqual(order.mrp_production_count, 2, "Mo for product A + child mo for product B")
 
         # ===============================================================================
         #  Sales order of 10 Dozen product A should create production order

--- a/addons/sale_mrp/tests/test_sale_mrp_procurement.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_procurement.py
@@ -178,7 +178,7 @@ class TestSaleMrpProcurement(TransactionCase):
         sale_order_so0.action_confirm()
 
         # Verify buttons are working as expected
-        self.assertEqual(sale_order_so0.mrp_production_count, 2, "User should see the correct number of manufacture orders in smart button")
+        self.assertEqual(sale_order_so0.mrp_production_count, 3, "2 Mos for the 2 sale order line + 1 child Mo for the complex product")
 
         pickings = sale_order_so0.picking_ids
 

--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -451,7 +451,7 @@ msgstr ""
 #: code:addons/stock/models/stock_rule.py:0
 msgid ""
 "<br>If the products are not available in <b>%s</b>, a rule will be triggered"
-" to bring products in this location."
+" to bring the missing quantity in this location."
 msgstr ""
 
 #. module: stock

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -168,7 +168,7 @@ class StockRule(models.Model):
             if self.procure_method == 'make_to_order' and self.location_src_id:
                 suffix += _("<br>A need is created in <b>%s</b> and a rule will be triggered to fulfill it.", source)
             if self.procure_method == 'mts_else_mto' and self.location_src_id:
-                suffix += _("<br>If the products are not available in <b>%s</b>, a rule will be triggered to bring products in this location.", source)
+                suffix += _("<br>If the products are not available in <b>%s</b>, a rule will be triggered to bring the missing quantity in this location.", source)
             message_dict = {
                 'pull': _(
                     'When products are needed in <b>%(destination)s</b>, <br> <b>%(operation)s</b> are created from <b>%(source_location)s</b> to fulfill the need.',

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -453,7 +453,7 @@ class Warehouse(models.Model):
                 'depends': ['delivery_steps'],
                 'create_values': {
                     'active': True,
-                    'procure_method': 'mts_else_mto',
+                    'procure_method': 'make_to_order',
                     'company_id': self.company_id.id,
                     'action': 'pull',
                     'auto': 'manual',

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -41,9 +41,8 @@ class TestDropship(common.TransactionCase):
         })
 
     def test_change_qty(self):
-        # enable the dropship and MTO route on the product
-        mto_route = self.env.ref('stock.route_warehouse0_mto')
-        self.dropship_product.write({'route_ids': [(6, 0, [self.dropshipping_route.id, mto_route.id])]})
+        # enable the dropship route on the product
+        self.dropship_product.write({'route_ids': [(6, 0, [self.dropshipping_route.id])]})
 
         # sell one unit of dropship product
         so = self.env['sale.order'].create({

--- a/addons/stock_dropshipping/tests/test_stockvaluation.py
+++ b/addons/stock_dropshipping/tests/test_stockvaluation.py
@@ -22,10 +22,9 @@ class TestStockValuation(ValuationReconciliationTestCommon):
         })
 
     def _dropship_product1(self):
-        # enable the dropship and MTO route on the product
+        # enable the dropship route on the product
         dropshipping_route = self.env.ref('stock_dropshipping.route_drop_shipping')
-        mto_route = self.env.ref('stock.route_warehouse0_mto')
-        self.product1.write({'route_ids': [(6, 0, [dropshipping_route.id, mto_route.id])]})
+        self.product1.write({'route_ids': [(6, 0, [dropshipping_route.id])]})
 
         # add a vendor
         vendor1 = self.env['res.partner'].create({'name': 'vendor1'})


### PR DESCRIPTION
This PR introduces a couple of modifications regarding procurement methods, namely

 *  Stock to Customer/Production rules are now using make to order procurement method instead of mts_else_mto
 * mts_else_mto message has been modified to better reflect its behavior now




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
