### PR TITLE
[FIX] crm: enable alphabetical ordering of Contact list by name

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -57,7 +57,8 @@
             <field eval="8" name="priority"/>
             <field name="arch" type="xml">
                 <tree string="Contacts" sample="1" multi_edit="1">
-                    <field name="display_name" string="Name"/>
+                    <field name="display_name" string="Name" invisible="1"/>
+                    <field name="complete_name" string="Name"/>
                     <field name="function" column_invisible="True"/>
                     <field name="phone" class="o_force_ltr" optional="show"/>
                     <field name="mobile" optional="hide"/>


### PR DESCRIPTION
Steps to reproduce:
Go to Accounting > Customers > Customers.

Current behavior:
The contact list cannot be ordered alphabetically by name.

The `Name` field is `display_name`, a computed field in `res.partner` that is not stored, preventing alphabetical sorting.

In future versions (starting from saas-17.2), `display_name` will be replaced by `complete_name`, a stored field containing the full name of the customer, which supports alphabetical ordering.

opw-4262464

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
