### PR TITLE
[IMP] maintenance, stock_maintenance: location improvements

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -145,7 +145,6 @@ class MaintenanceEquipment(models.Model):
                                   tracking=True, group_expand='_read_group_category_ids')
     partner_id = fields.Many2one('res.partner', string='Vendor', check_company=True)
     partner_ref = fields.Char('Vendor Reference')
-    location = fields.Char('Location')
     model = fields.Char('Model')
     serial_no = fields.Char('Serial Number', copy=False)
     assign_date = fields.Date('Assigned Date', tracking=True)

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -383,7 +383,7 @@
                         <label for="name"/>
                         <h1><field name="name" string="Name" placeholder="e.g. LED Monitor"/></h1>
                     </div>
-                    <group>
+                    <group name="service_info_group">
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="category_id" options="{&quot;no_open&quot;: True}" context="{'default_company_id':company_id}"/>
@@ -395,7 +395,6 @@
                             <field name="technician_user_id" domain="[('share', '=', False)]"/>
                             <field name="assign_date" groups="base.group_no_one"/>
                             <field name="scrap_date" groups="base.group_no_one"/>
-                            <field name="location" string="Used in location"/>
                         </group>
                     </group>
                     <field name="equipment_properties" nolabel="1" columns="2"/>

--- a/addons/stock_maintenance/__manifest__.py
+++ b/addons/stock_maintenance/__manifest__.py
@@ -12,6 +12,7 @@ Open the record of the serial number from an equipment form
     'depends': ['stock', 'maintenance'],
     'data': [
         'views/maintenance_views.xml',
+        'views/stock_location.xml',
     ],
     'summary': 'See lots used in maintenance',
     'auto_install': True,

--- a/addons/stock_maintenance/models/__init__.py
+++ b/addons/stock_maintenance/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import maintenance
+from . import stock_location

--- a/addons/stock_maintenance/models/maintenance.py
+++ b/addons/stock_maintenance/models/maintenance.py
@@ -6,6 +6,7 @@ from odoo import api, fields, models
 class MaintenanceEquipment(models.Model):
     _inherit = 'maintenance.equipment'
 
+    location_id = fields.Many2one('stock.location', 'Location', domain="[('usage', '=', 'internal')]")
     match_serial = fields.Boolean(compute='_compute_match_serial')
 
     @api.depends('serial_no')

--- a/addons/stock_maintenance/models/stock_location.py
+++ b/addons/stock_maintenance/models/stock_location.py
@@ -1,0 +1,18 @@
+from odoo import fields, models
+
+
+class StockLocation(models.Model):
+    _inherit = 'stock.location'
+
+    equipment_count = fields.Integer('Equipment Count', compute='_compute_equipment_count')
+
+    def _compute_equipment_count(self):
+        equipment_data = self.env['maintenance.equipment']._read_group([('location_id', 'in', self.ids)], ['location_id'], ['__count'])
+        mapped_data = {location.id: count for location, count in equipment_data}
+        for location in self:
+            location.equipment_count = mapped_data.get(location.id, 0)
+
+    def action_view_equipments_records(self):
+        action = self.env["ir.actions.actions"]._for_xml_id("maintenance.hr_equipment_action")
+        action['domain'] = [('location_id', '=', self.id)]
+        return action

--- a/addons/stock_maintenance/views/maintenance_views.xml
+++ b/addons/stock_maintenance/views/maintenance_views.xml
@@ -14,7 +14,9 @@
                     <field string="Serial Number" name="serial_no" widget="statinfo"/>
                 </button>
             </button>
+            <xpath expr="//group[@name='service_info_group']/group[last()]" position="inside">
+                <field name="location_id" string="Used in location"/>
+            </xpath>
         </field>
     </record>
-
 </odoo>

--- a/addons/stock_maintenance/views/stock_location.xml
+++ b/addons/stock_maintenance/views/stock_location.xml
@@ -1,0 +1,25 @@
+<odoo>
+  <data>
+    <record id="stock_location_form_maintenance_equipments" model="ir.ui.view">
+        <field name="name">stock.location.form.inherit.maintenance.equipments</field>
+        <field name="model">stock.location</field>
+        <field name="inherit_id" ref="stock.view_location_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
+                <button class="oe_stat_button" name="action_view_equipments_records"
+                    type="object" icon="fa-wrench"
+                    invisible="equipment_count == 0">
+                    <div class="o_stat_info">
+                        <span class="o_stat_value">
+                            <field name="equipment_count" />
+                        </span>
+                        <span class="o_stat_text">
+                            Equipments
+                        </span>
+                    </div>
+                </button>
+            </xpath>
+        </field>
+    </record>
+  </data>
+</odoo>


### PR DESCRIPTION
This commit improves to the location field for maintenance equipment:
- Changed the location field from a character type to a many2one type
- The location field will now only be displayed when the 
  `maintenance_stock` module is installed
- Added a maintenance equipment stat button to the location form view, 
  allowing to view maintenance equipment based on the current location

Task: [4287060](https://www.odoo.com/odoo/my-tasks/4287060)
