### PR TITLE
[FIX] mail: Disable Log Note for users without access

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -21,7 +21,7 @@
                         'btn-primary active': state.composerType === 'note',
                         'btn-secondary': state.composerType !== 'note',
                         'my-2': !props.compactHeight
-                    }" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
+                    }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
                         Log note
                     </button>
                     <button t-if="props.has_activities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap" t-att-class="{ 'my-2': !props.compactHeight }" data-hotkey="shift+a" t-on-click="scheduleActivity">


### PR DESCRIPTION
Currently, a user without access rights can attempt to post a log note in various chatters. This will trigger a NotFound() error after their access rights are denied which leads to poor user experience. To avoid this I have adapted logic from the Send Message Button to also apply to the log note button for users with read access but not write access.

OPW-4280451

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
