### PR TITLE
[FIX] account: fix empty string and False/None inconsistencies

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -475,12 +475,12 @@ class AccountMoveLine(models.Model):
             elif line.journal_id.type == 'purchase':
                 if product.description_purchase:
                     values.append(product.description_purchase)
-            return '\n'.join(values)
+            return '\n'.join(values) if values else False
 
         for line in self:
             if line.display_type == 'payment_term':
                 if not line.name or line._origin.name == line._origin.move_id.payment_reference:
-                    line.name = line.move_id.payment_reference or ''
+                    line.name = line.move_id.payment_reference or False
                 continue
             if not line.product_id or line.display_type in ('line_section', 'line_note'):
                 continue

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -2518,7 +2518,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertEqual(payment_term_line.name, 'test')
         with Form(self.invoice) as move_form:
             move_form.payment_reference = False
-        self.assertEqual(payment_term_line.name, '', 'Payment term line was not changed')
+        self.assertEqual(payment_term_line.name, False, 'Payment term line was not changed')
 
     def test_purchase_uom_on_vendor_bills(self):
         uom_gram = self.env.ref('uom.product_uom_gram')


### PR DESCRIPTION
**[FIX] account: fix empty string and False/None inconsistencies**

When empty, the `name` field of `account.move.line` could inconsistently hold either an empty string or False. This inconsistency led to different results when searching for lines with an empty label, as `label->not set` and `label == ""` yielded different outcomes. The latter behavior aligns with expected ORM operations.

This fix ensures the name field is set to False whenever the computed result is an empty string, standardizing search behavior.

opw-4167139

[Enterprise PR](https://github.com/odoo/enterprise/pull/73256)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
