### PR TITLE
[IMP] account: update payment references while resequencing

### DIFF
--- a/addons/account/wizard/account_resequence_views.xml
+++ b/addons/account/wizard/account_resequence_views.xml
@@ -18,6 +18,9 @@
                     </group>
                 </group>
                 <group>
+                    <field name="update_payment_references" invisible="not show_update_payment_references"/>
+                </group>
+                <group>
                     <label for="preview_moves" string="Preview Modifications" colspan="2"/>
                     <field name="preview_moves" widget="account_resequence_widget" nolabel="1" colspan="2"/>
                 </group>


### PR DESCRIPTION
This commit offers the option to update payment references when invoices/bills are resequenced.

Current behavior:
When invoices are resequenced the payment references are unchanged which will then be displayed on the invoice preview incorrectly. Additionally the payment term account move line will have the old invoice name displayed on the label which may cause confusion.

Purpose of this PR:
Offer the feature to update the payment references to be uniform following the resequencing of invoice/bills. Also reflect the new sequence on the account move lines.

Notes:
Account moves that are of `move_type` 'entry' do not have payment references, so we should not offer to update the payment references for those entries.

opw-4282897

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
