### PR TITLE
[FIX] hr_contract: Fix Duplicate Contract Overlap Check

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -142,7 +142,7 @@ class Contract(models.Model):
                 end_domain = ['|', ('date_end', '>=', contract.date_start), ('date_end', '=', False)]
             else:
                 start_domain = [('date_start', '<=', contract.date_end)]
-                end_domain = ['|', ('date_end', '>', contract.date_start), ('date_end', '=', False)]
+                end_domain = ['|', ('date_end', '>=', contract.date_start), ('date_end', '=', False)]
 
             domain = expression.AND([domain, start_domain, end_domain])
             if self.search_count(domain):

--- a/addons/hr_contract/tests/test_contract.py
+++ b/addons/hr_contract/tests/test_contract.py
@@ -55,6 +55,21 @@ class TestHrContracts(TestContractCommon):
             end = datetime.strptime('2015-12-30', '%Y-%m-%d').date()
             self.create_contract('draft', 'done', start, end)
 
+    def test_incoming_overlapping_contract_same_start_date(self):
+        start = datetime.strptime('2015-11-01', '%Y-%m-%d').date()
+        end = datetime.strptime('2015-11-30', '%Y-%m-%d').date()
+        end2 = datetime.strptime('2015-12-30', '%Y-%m-%d').date()
+
+        # Contract 2 incoming after contract 1
+        with self.assertRaises(ValidationError, msg="It should not create two contract in state open or incoming"):
+            self.create_contract('open', 'normal', start, end)
+            self.create_contract('draft', 'done', end, end2)
+
+        # Contract 2 incoming before contract 1
+        with self.assertRaises(ValidationError, msg="It should not create two contract in state open or incoming"):
+            self.create_contract('draft', 'done', end, end2)
+            self.create_contract('open', 'normal', start, end)
+
     def test_pending_overlapping_contract(self):
         start = datetime.strptime('2015-11-01', '%Y-%m-%d').date()
         end = datetime.strptime('2015-11-30', '%Y-%m-%d').date()


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Fix Duplicate Contract Overlap Check

Current behavior before PR:
- No duplicate error is triggered when confirming a contract that is one day after the previous contract.
- An error is still triggered if the previous contract is adjusted to be one day before the subsequent contract.

Desired behavior after PR is merged:
- Trigger a duplicate error in both of the above cases.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
