### PR TITLE
[FIX] mail: no Threads and Invite People popover overflow

### DIFF
--- a/addons/mail/static/src/discuss/core/common/action_panel.scss
+++ b/addons/mail/static/src/discuss/core/common/action_panel.scss
@@ -3,7 +3,7 @@
 }
 
 .o-mail-ActionPanel:not(.o-mail-ActionPanel-chatter) {
-    @media (min-width: 800px) {
+    @media (min-width: 750px) {
         max-width: 30vw;
     }
     @media (min-width: 1000px) {
@@ -18,12 +18,12 @@
     @media (min-width: 2300px) {
         max-width: 75vw;
     }
+    .popover & {
+        width: 475px;
+        max-width: unset;
+    }
 }
 
 .o-mail-ActionPanel-header {
     z-index: $o-mail-NavigableList-zIndex - 1;
-
-    button:hover {
-        background-color: $gray-200;
-    }
 }

--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -13,7 +13,7 @@
     <t t-name="mail.ActionPanel.content">
         <div class="o-mail-ActionPanel-header position-sticky top-0 pt-2 pb-1 d-flex flex-column bg-inherit small" t-att-class="{ 'px-1': env.inChatWindow, 'px-2': !env.inChatWindow }">
             <div class="d-flex align-items-baseline gap-1">
-                <button t-if="env.closeActionPanel" class="btn p-1 opacity-75 opacity-100-hover text-muted" title="Close panel" t-on-click.stop="env.closeActionPanel">
+                <button t-if="env.closeActionPanel" class="btn p-1 opacity-25 opacity-100-hover" title="Close panel" t-on-click.stop="env.closeActionPanel">
                     <i class="oi oi-arrow-left fa-fw"/>
                 </button>
                 <i t-if="props.icon" class="text-muted opacity-50" t-att-class="props.icon"/>

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.ChannelInvitation">
         <ActionPanel title.translate="Invite people" resizable="false" icon="'fa fa-user-plus'">
-            <div class="d-flex flex-column flex-grow-1 bg-inherit" t-att-class="{ 'o-mail-Discuss-threadActionPopover': props.hasSizeConstraints }">
+            <div class="d-flex flex-column flex-grow-1 bg-inherit" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': props.hasSizeConstraints }">
                 <t t-if="store.self.type === 'partner'">
                     <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view" t-ref="input" placeholder="Type the name of a person" t-on-input="onInput"/>
                     <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': state.selectablePartners.length === 0 }">

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -4,7 +4,7 @@
         <ActionPanel title.translate="Threads" resizable="false" icon="'fa fa-comments-o'">
             <t t-set-slot="header">
                 <div class="d-flex align-items-center my-0">
-                    <div class="input-group my-2 me-2">
+                    <div class="input-group my-2">
                         <div class="form-control d-flex align-items-center p-0 bg-view" role="search" aria-autocomplete="list">
                             <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 h-100">
                                 <input t-ref="search" t-model="state.searchTerm" type="text" class="o_searchview_input rounded flex-grow-1 w-auto border-0 px-2" t-on-keydown="onKeydownSearch" placeholder="Search by name"/>
@@ -14,13 +14,13 @@
                             <i t-if="!state.loading" class="o_searchview_icon oi oi-search" role="img" aria-label="Search Sub Channels" title="Search Sub Channels"/>
                             <i t-else="" class="fa fa-spin fa-spinner" aria-label="Search in progress" title="Search in progress"/>
                         </button>
+                        <button t-if="store.self.isInternalUser" class="ms-1 btn btn-primary smaller" aria-label="Create Thread" t-on-click="onClickCreate">Create</button>
                     </div>
-                    <button t-if="store.self.isInternalUser" class="btn btn-primary smaller" aria-label="Create Thread" t-on-click="onClickCreate">Create</button>
                 </div>
             </t>
             <div class="o-mail-SubChannelList o-mail-Discuss-threadActionPopover mw-100 w-100 h-100" t-att-class="{ 'align-items-center justify-content-center': state.subChannels.length === 0 }">
                 <div t-if="state.subChannels.length === 0" class="flex-grow-1 d-flex flex-column justify-content-center align-items-center">
-                    <p class="my-1 py-2 text-center fst-italic text-500">
+                    <p class="my-1 pb-2 text-center fst-italic text-500">
                         <t t-if="state.searching" t-esc="NO_THREAD_FOUND"/>
                         <t t-else="">This channel has no thread yet.</t>
                     </p>


### PR DESCRIPTION
Before this commit, the "Threads" and "Invite People" actions in Discuss app could overflow and have horizontal scroll.

This happens because the `ActionPanel` has some responsive width when in a panel, but these panels could also be displayed in popover in which this rule shouldn't apply.

This commit fixes the issue by fixing a constant width to these action panels in popover, with similar width as the messaging menu.

Task-4292021


Before / After - Threads
<img width="400" alt="Screenshot 2024-11-13 at 18 42 41" src="https://github.com/user-attachments/assets/5701333c-9623-4ae8-bc10-0900251d353f"> <img width="593" alt="Screenshot 2024-11-13 at 18 45 41" src="https://github.com/user-attachments/assets/62393043-5a88-468d-acde-7fbee837be2e">



Before / After - Invite People
<img width="407" alt="Screenshot 2024-11-13 at 18 42 48" src="https://github.com/user-attachments/assets/03025c09-1e9c-4790-a708-627f0aa731ec"> <img width="691" alt="Screenshot 2024-11-13 at 18 43 10" src="https://github.com/user-attachments/assets/8ef9ad7c-d7b1-4a44-a0b3-f1e4525e0fa4">
