### PR TITLE
[FIX] pos_online_payment_self_order: send payment notification to kiosk

### DIFF
--- a/addons/pos_online_payment_self_order/controllers/payment_portal.py
+++ b/addons/pos_online_payment_self_order/controllers/payment_portal.py
@@ -27,7 +27,7 @@ class PaymentPortalSelfOrder(PaymentPortal):
         pos_order = request.env['pos.order'].sudo().browse(pos_order_id)
 
         if pos_order.config_id.self_ordering_mode == 'kiosk':
-            request.env['bus.bus']._sendone(f'pos_config-{pos_order.config_id.access_token}', 'ONLINE_PAYMENT_STATUS', {
+            pos_order.config_id._notify("ONLINE_PAYMENT_STATUS", {
                 'status': status, # progress, success, fail
                 'order': pos_order._export_for_self_order(),
             })


### PR DESCRIPTION
Currently, when using the kiosk with an online payment method, the kiosk does not receive notification about the payment status.

Steps to reproduce:
-------------------
* Select the **Point of Sale** App
* Under Configuration select **Payment Methods**
* Create a new payment method (Online payment, Allowed Providers: Demo)
* Now go into the setting of the restaurant (make sure session was closed)
* Change the Payment methods, remove the cash and add the one created
* Change Self Ordering to Kiosk then save
* Open the kiosk and create an order
* Go to pay the order
* Scan the qr code
* Pa with demo
> Observation: 2 observations. First we don't receive the "In progress" notification after scanning the qr code. Second, we are not redirected to the validation page after the order was paid. In the backend orders are marked as paid.

Why the fix:
------------
`request.env['bus.bus']` is empty. The issue was already solved in the next version with https://github.com/odoo/odoo/commit/31226b1a95242631a190d92e9ffb5ad97822bcbd#diff-a843415b00d5a84e604420ec6a19040426294ec9b5deeacf6f12876c12af06dd

opw-4120145