### PR TITLE
[FIX] hr_payroll: prevent generating payslips with archived employees

### DIFF
--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -16,7 +16,8 @@
         <field name="path">work-entries</field>
         <field name="view_mode">calendar,list,form,pivot</field>
         <field name="context">{
-            'search_default_work_entries_error': True
+            'search_default_work_entries_error': True,
+            'search_default_employee_active': True,
         }</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
@@ -125,6 +126,8 @@
                 <filter name="work_entries_draft" string="Draft" domain="[('state', '=', 'draft')]"/>
                 <filter name="work_entries_validated" string="Validated" domain="[('state', '=', 'validated')]"/>
                 <filter name="work_entries_error" string="Conflicting" domain="[('state', '=', 'conflict')]"/>
+                <separator/>
+                <filter name="employee_active" string="Active Employees" domain="[('employee_id.active', '=', True)]"/>
                 <separator/>
                 <filter name="date_filter" string="Date" date="date_start"/>
                 <filter name="current_month" string="Current Month" domain="[


### PR DESCRIPTION
In the work entry view, when removing the conflicting filter, archived employees
 are included. There should be another filter to keep only active employees.

Task: 4268938
