### PR TITLE
[FIX] spreadsheet: update chart data source on type change

### DIFF
--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin_test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin_test.js
@@ -188,7 +188,7 @@ QUnit.module("spreadsheet > odoo chart plugin", {}, () => {
         model.dispatch("UPDATE_CHART", {
             definition: {
                 ...newDefinition,
-                type: "odoo_bar",
+                background: "#00FF00",
             },
             id: chartId,
             sheetId,
@@ -611,6 +611,25 @@ QUnit.module("spreadsheet > odoo chart plugin", {}, () => {
             model.getters.getChartRuntime(chartId).chartJsConfig.options.plugins.legend.labels
                 .color,
             "#FFFFFF"
+        );
+    });
+
+    QUnit.test("Chart data source is recreated when chart type is updated", async (assert) => {
+        const { model } = await createSpreadsheetWithChart({ type: "odoo_bar" });
+        const sheetId = model.getters.getActiveSheetId();
+        const chartId = model.getters.getChartIds(sheetId)[0];
+        const chartDataSource = model.getters.getChartDataSource(chartId);
+        model.dispatch("UPDATE_CHART", {
+            definition: {
+                ...model.getters.getChartDefinition(chartId),
+                type: "odoo_line",
+            },
+            id: chartId,
+            sheetId,
+        });
+        assert.ok(
+            chartDataSource !== model.getters.getChartDataSource(chartId),
+            "The data source should have been recreated"
         );
     });
 });


### PR DESCRIPTION
Before this commit, when changing the chart type, the data source was not updated. Which was a problem, because the data returned for different chart types is different (eg. pie charts filter empty points).

That meant that when changing the chart type from line => pie we displayed a pie with empty points, but when reloading the page the data would change to the correct one.

Task: [4306227](https://www.odoo.com/web#id=4306227&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
