### PR TITLE
[FIX] event: prevent error for registration_ids and tickets_hash not found

### DIFF
--- a/addons/event/controllers/main.py
+++ b/addons/event/controllers/main.py
@@ -28,7 +28,7 @@ class EventController(Controller):
         ])
 
     @route(['/event/<int:event_id>/my_tickets'], type='http', auth='public')
-    def event_my_tickets(self, event_id, registration_ids, tickets_hash, badge_mode=False, responsive_html=False):
+    def event_my_tickets(self, event_id=False, registration_ids=False, tickets_hash=False, badge_mode=False, responsive_html=False):
         """ Returns a pdf response, containing all tickets for attendees in registration_ids for event_id.
 
         Throw Forbidden if no registration is valid / hash is invalid / parameters are missing.


### PR DESCRIPTION
This error occurs because the user is either manually removing ``registration_ids`` and ``tickets_hash`` or they are not receiving them when viewing the ticket.

Steps to reproduce:
---
- Install ``Events Organization`` module
- Go to any event > Click on ``Attendees`` button
- Create a new Attendee and Save
- In chatter ticket PDF will get generated > Click on ``View Tickets``
- Remove ``registration_ids`` and ``tickets_hash`` from the URL

Traceback: 
---
```
TypeError
EventController.event_my_tickets() missing 2 required positional arguments: 'registration_ids' and 'tickets_hash'
```
When the system calls a route ``/event/<int:event_id>/my_tickets`` without ``registration_ids`` and ``tickets_hash`` we face the error.

At [1], we are already handling the error if ``registration_ids`` and ``tickets_hash`` are missing. To prevent this error, we can provide default values for ``registration_ids`` and ``tickets_hash``.

[1]- https://github.com/odoo/odoo/blob/2ca24e04a24f557149d8fe6dd15efff897a6c37c/addons/event/controllers/main.py#L44-L45

sentry-4952598215

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
