### PR TITLE
Declare fields on BaseModel

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -80,7 +80,7 @@ class BaseAutomation(models.Model):
     name = fields.Char(string="Automation Rule Name", required=True, translate=True)
     description = fields.Html(string="Description")
     model_id = fields.Many2one(
-        "ir.model", string="Model", domain=[("field_id", "!=", False)], required=True, ondelete="cascade",
+        "ir.model", string="Model", domain=[("abstract", "=", False)], required=True, ondelete="cascade",
         help="Model on which the automation rule runs."
     )
     model_name = fields.Char(related="model_id.model", string="Model Name", readonly=True, inverse="_inverse_model_name")

--- a/addons/hr_skills/report/hr_employee_skill_report.py
+++ b/addons/hr_skills/report/hr_employee_skill_report.py
@@ -9,7 +9,6 @@ class HrEmployeeSkillReport(models.BaseModel):
     _description = 'Employee Skills Report'
     _order = 'employee_id, level_progress desc'
 
-    id = fields.Id()
     display_name = fields.Char(related='employee_id.name')
     company_id = fields.Many2one('res.company', readonly=True)
     department_id = fields.Many2one('hr.department', readonly=True)

--- a/addons/lunch/report/lunch_cashmove_report.py
+++ b/addons/lunch/report/lunch_cashmove_report.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, tools, _
+from odoo import fields, models, tools, _
 
 
 class LunchCashmoveReport(models.Model):
@@ -9,7 +9,7 @@ class LunchCashmoveReport(models.Model):
     _auto = False
     _order = "date desc"
 
-    id = fields.Integer('ID')
+    id = fields.Id(string='ID')
     amount = fields.Float('Amount')
     date = fields.Date('Date')
     currency_id = fields.Many2one('res.currency', string='Currency')

--- a/addons/mail/models/mail_alias.py
+++ b/addons/mail/models/mail_alias.py
@@ -39,7 +39,6 @@ class MailAlias(models.Model):
         'Alias Name', copy=False,
         help="The name of the email alias, e.g. 'jobs' if you want to catch emails for <jobs@example.odoo.com>")
     alias_full_name = fields.Char('Alias Email', compute='_compute_alias_full_name', store=True, index='btree_not_null')
-    display_name = fields.Char(string='Display Name', compute='_compute_display_name', search='_search_display_name')
     alias_domain_id = fields.Many2one(
         'mail.alias.domain', string='Alias Domain', ondelete='restrict',
         default=lambda self: self.env.company.alias_domain_id)

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -287,9 +287,7 @@ class ProjectTask(models.Model):
 
     # Quick creation shortcuts
     display_name = fields.Char(
-        compute='_compute_display_name',
         inverse='_inverse_display_name',
-        search='_search_display_name',
         help="""Use these keywords in the title to set new tasks:\n
             #tags Set tags on the task
             @user Assign the task to a user

--- a/addons/website_hr_recruitment/models/hr_department.py
+++ b/addons/website_hr_recruitment/models/hr_department.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields
@@ -8,4 +7,4 @@ class HrDepartment(models.Model):
     _inherit = ['hr.department']
 
     # Get department name using superuser, because model is not accessible for portal users
-    display_name = fields.Char(compute='_compute_display_name', search='_search_display_name', compute_sudo=True)
+    display_name = fields.Char(compute_sudo=True)

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2411,7 +2411,7 @@ class Base(models.AbstractModel):
         left_group = E.group()
         right_group = E.group()
         for fname, field in self._fields.items():
-            if field.automatic:
+            if fname in models.MAGIC_COLUMNS or (fname == 'display_name' and field.readonly):
                 continue
             elif field.type in ('one2many', 'many2many', 'text', 'html'):
                 # append to sheet left and right group if needed

--- a/odoo/addons/base/models/res_users_settings.py
+++ b/odoo/addons/base/models/res_users_settings.py
@@ -17,7 +17,7 @@ class ResUsersSettings(models.Model):
     @api.model
     def _get_fields_blacklist(self):
         """ Get list of fields that won't be formatted. """
-        return []
+        return ['display_name']
 
     @api.model
     def _find_or_create_for_user(self, user):
@@ -32,7 +32,7 @@ class ResUsersSettings(models.Model):
         if fields_to_format:
             fields_to_format = [field for field in fields_to_format if field not in fields_blacklist]
         else:
-            fields_to_format = [name for name, field in self._fields.items() if name == 'id' or (not field.automatic and name not in fields_blacklist)]
+            fields_to_format = [name for name, field in self._fields.items() if name == 'id' or (name not in models.MAGIC_COLUMNS and name not in fields_blacklist)]
         res = self._format_settings(fields_to_format)
         return res
 

--- a/odoo/addons/base/report/ir_model_templates.xml
+++ b/odoo/addons/base/report/ir_model_templates.xml
@@ -12,6 +12,8 @@
                         </td>
                         <td colspan="8">
                             <p>Type: <span t-field="o.state"/></p>
+                            <p t-if="o.abstract">Abstract: True</p>
+                            <p t-if="not o.abstract">Abstract: False</p>
                             <p t-if="o.transient">Transient: True</p>
                             <p t-if="not o.transient">Transient: False</p>
                             <p>Apps: <span t-field="o.modules"/></p>

--- a/odoo/addons/base/tests/test_orm.py
+++ b/odoo/addons/base/tests/test_orm.py
@@ -38,7 +38,8 @@ class TestORM(TransactionCase):
     def test_access_partial_deletion(self):
         """ Check accessing a record from a recordset where another record has been deleted. """
         Model = self.env['res.country']
-        self.assertTrue(type(Model).display_name.automatic, "test assumption not satisfied")
+        display_name_field = Model._fields['display_name']
+        self.assertTrue(display_name_field.compute and not display_name_field.store, "test assumption not satisfied")
 
         # access regular field when another record from the same prefetch set has been deleted
         records = Model.create([{'name': name[0], 'code': name[1]} for name in (['Foo', 'ZV'], ['Bar', 'ZX'], ['Baz', 'ZY'])])

--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -38,6 +38,7 @@
                             <field name="name"/>
                             <field name="model" readonly="id"/>
                             <field name="order"/>
+                            <field name="abstract" readonly="id" groups="base.group_no_one"/>
                             <field name="transient" readonly="id" groups="base.group_no_one"/>
                         </group>
                         <group>
@@ -226,6 +227,7 @@
                 <search string="Model Description">
                     <field name="name" filter_domain="['|', ('name','ilike',self), ('model','ilike',self)]" string="Model"/>
                     <field name="model" filter_domain="[('model','ilike',self)]" string="Technical Name"/>
+                    <filter string="Abstract" name="abstract" domain="[('abstract', '=', True)]"/>
                     <filter string="Transient" name="transient" domain="[('transient', '=', True)]"/>
                     <separator/>
                     <filter string="Custom" name="custom" domain="[('state', '=', 'manual')]"/>

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -26,9 +26,7 @@ class Test_New_ApiCategory(models.Model):
     depth = fields.Integer(compute="_compute_depth")
     root_categ = fields.Many2one('test_new_api.category', compute='_compute_root_categ')
     display_name = fields.Char(
-        compute='_compute_display_name',
         inverse='_inverse_display_name',
-        search='_search_display_name',
         recursive=True,
     )
     dummy = fields.Char(store=False)
@@ -141,7 +139,7 @@ class Test_New_ApiMessage(models.Model):
     body = fields.Text(index='trigram')
     author = fields.Many2one('res.users', default=lambda self: self.env.user)
     name = fields.Char(string='Title', compute='_compute_name', store=True)
-    display_name = fields.Char(string='Abstract', compute='_compute_display_name')
+    display_name = fields.Char(string='Abstract')
     size = fields.Integer(compute='_compute_size', search='_search_size')
     double_size = fields.Integer(compute='_compute_double_size')
     discussion_name = fields.Char(related='discussion.name', string="Discussion Name", readonly=False)
@@ -661,7 +659,7 @@ class Test_New_ApiRecursive(models.Model):
     name = fields.Char(required=True)
     parent = fields.Many2one('test_new_api.recursive', ondelete='cascade')
     full_name = fields.Char(compute='_compute_full_name', recursive=True)
-    display_name = fields.Char(compute='_compute_display_name', recursive=True, store=True)
+    display_name = fields.Char(recursive=True, store=True)
     context_dependent_name = fields.Char(compute='_compute_context_dependent_name', recursive=True)
 
     @api.depends('name', 'parent.full_name')
@@ -699,7 +697,7 @@ class Test_New_ApiRecursiveTree(models.Model):
     name = fields.Char(required=True)
     parent_id = fields.Many2one('test_new_api.recursive.tree', ondelete='cascade')
     children_ids = fields.One2many('test_new_api.recursive.tree', 'parent_id')
-    display_name = fields.Char(compute='_compute_display_name', recursive=True, store=True)
+    display_name = fields.Char(recursive=True, store=True)
 
     @api.depends('name', 'children_ids.display_name')
     def _compute_display_name(self):
@@ -1138,7 +1136,7 @@ class Test_New_ApiModel_Child_Nocheck(models.Model):
 class Test_New_ApiDisplay(models.Model):
     _description = 'Model that overrides display_name'
 
-    display_name = fields.Char(compute='_compute_display_name', store=True)
+    display_name = fields.Char(store=True)
 
     def _compute_display_name(self):
         for record in self:

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -266,7 +266,6 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
     def test_10_display_name(self):
         """ test definition of automatic field 'display_name' """
         field = type(self.env['test_new_api.discussion']).display_name
-        self.assertTrue(field.automatic)
         self.assertTrue(field.compute)
         self.assertEqual(self.registry.field_depends[field], ('name',))
 
@@ -3831,14 +3830,12 @@ class TestMagicFields(TransactionCase):
         self.patch(registry, 'models', OrderedDict(sorted(models.items())))
         registry.setup_models(self.cr)
         field = registry['test_new_api.display'].display_name
-        self.assertFalse(field.automatic)
         self.assertTrue(field.store)
 
         # check setup of models in reverse alphanumeric order
         self.patch(registry, 'models', OrderedDict(sorted(models.items(), reverse=True)))
         registry.setup_models(self.cr)
         field = registry['test_new_api.display'].display_name
-        self.assertFalse(field.automatic)
         self.assertTrue(field.store)
 
 

--- a/odoo/addons/test_new_api/tests/test_views.py
+++ b/odoo/addons/test_new_api/tests/test_views.py
@@ -12,7 +12,7 @@ class TestDefaultView(common.TransactionCase):
     def test_default_form_view(self):
         self.assertEqual(
             etree.tostring(self.env['test_new_api.message']._get_default_form_view()),
-            b'<form><sheet string="Test New API Message"><group><group><field name="discussion"/></group></group><group><field name="body"/></group><group><group><field name="author"/><field name="display_name"/><field name="double_size"/><field name="author_partner"/><field name="label"/><field name="active"/><field name="attributes"/></group><group><field name="name"/><field name="size"/><field name="discussion_name"/><field name="important"/><field name="priority"/><field name="has_important_sibling"/></group></group><group><separator/></group></sheet></form>'
+            b'<form><sheet string="Test New API Message"><group><group><field name="discussion"/></group></group><group><field name="body"/></group><group><group><field name="author"/><field name="size"/><field name="discussion_name"/><field name="important"/><field name="priority"/><field name="has_important_sibling"/></group><group><field name="name"/><field name="double_size"/><field name="author_partner"/><field name="label"/><field name="active"/><field name="attributes"/></group></group><group><separator/></group></sheet></form>'
         )
         self.assertEqual(
             etree.tostring(self.env['test_new_api.creativework.edition']._get_default_form_view()),

--- a/odoo/addons/test_read_group/models.py
+++ b/odoo/addons/test_read_group/models.py
@@ -27,7 +27,7 @@ class Test_Read_GroupAggregate(models.Model):
     value = fields.Integer("Value")
     numeric_value = fields.Float(digits=(4, 2))
     partner_id = fields.Many2one('res.partner')
-    display_name = fields.Char()
+    display_name = fields.Char(store=True)
 
 
 # we use a selection that is in reverse lexical order, in order to check the

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -354,7 +354,7 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
         :param owner: the owner class of the field (the model's definition or registry class)
         :param name: the name of the field
         """
-        assert issubclass(owner, _models.BaseModel)
+        assert isinstance(owner, _models.MetaModel)
         self.model_name = owner._name
         self.name = name
         if getattr(owner, 'pool', None) is None:  # models.is_definition_class(owner)

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -257,7 +257,6 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
     _direct = False                     # whether self may be used directly (shared)
     _toplevel = False                   # whether self is on the model's registry class
 
-    automatic = False                   # whether the field is automatically created ("magic" field)
     inherited = False                   # whether the field is inherited (_inherits)
     inherited_field = None              # the corresponding inherited field
 
@@ -551,12 +550,6 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
             deps = getattr(func, '_depends', ())
             depends.extend(deps(model) if callable(deps) else deps)
             depends_context.extend(getattr(func, '_depends_context', ()))
-
-        # display_name may depend on context['lang'] (`test_lp1071710`)
-        if self.automatic and self.name == 'display_name' and model._rec_name:
-            if model._fields[model._rec_name].base_field.translate:
-                if 'lang' not in depends_context:
-                    depends_context.append('lang')
 
         return depends, depends_context
 

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -324,6 +324,22 @@ class Char(_String):
     _description_size = property(attrgetter('size'))
     _description_trim = property(attrgetter('trim'))
 
+    def get_depends(self, model):
+        depends, depends_context = super().get_depends(model)
+
+        # display_name may depend on context['lang'] (`test_lp1071710`)
+        if (
+            self.name == 'display_name'
+            and self.compute
+            and not self.store
+            and model._rec_name
+            and model._fields[model._rec_name].base_field.translate
+            and 'lang' not in depends_context
+        ):
+            depends_context.append('lang')
+
+        return depends, depends_context
+
 
 class Text(_String):
     """ Very similar to :class:`Char` but used for longer contents, does not

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -247,12 +247,9 @@ class MetaModel(api.Meta):
                     setattr(self, name, field)
                     field.__set_name__(self, name)
 
-            add('id', Id(automatic=True))
-            add_default('display_name', Char(
-                string='Display Name', automatic=True,
-                compute='_compute_display_name',
-                search='_search_display_name',
-            ))
+            # make sure `id` field is still a `fields.Id`
+            if not isinstance(self.id, Id):
+                raise TypeError(f"Field {self.id} is not an instance of fields.Id")
 
             if attrs.get('_log_access', self._auto):
                 from .fields_relational import Many2one  # noqa: PLC0415
@@ -561,6 +558,14 @@ class BaseModel(metaclass=MetaModel):
     "maximum number of transient records, unlimited if ``0``"
     _transient_max_hours = lazy_classproperty(lambda _: config.get('transient_age_limit'))
     "maximum idle lifetime (in hours), unlimited if ``0``"
+
+    id = Id(automatic=True)
+    display_name = Char(
+        string='Display Name',
+        compute='_compute_display_name',
+        search='_search_display_name',
+        automatic=True,
+    )
 
     def _valid_field_parameter(self, field, name):
         """ Return whether the given parameter name is valid for the field. """

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -254,13 +254,13 @@ class MetaModel(api.Meta):
             if attrs.get('_log_access', self._auto):
                 from .fields_relational import Many2one  # noqa: PLC0415
                 add_default('create_uid', Many2one(
-                    'res.users', string='Created by', automatic=True, readonly=True))
+                    'res.users', string='Created by', readonly=True))
                 add_default('create_date', Datetime(
-                    string='Created on', automatic=True, readonly=True))
+                    string='Created on', readonly=True))
                 add_default('write_uid', Many2one(
-                    'res.users', string='Last Updated by', automatic=True, readonly=True))
+                    'res.users', string='Last Updated by', readonly=True))
                 add_default('write_date', Datetime(
-                    string='Last Updated on', automatic=True, readonly=True))
+                    string='Last Updated on', readonly=True))
 
 
 # special columns automatically created by the ORM
@@ -559,12 +559,11 @@ class BaseModel(metaclass=MetaModel):
     _transient_max_hours = lazy_classproperty(lambda _: config.get('transient_age_limit'))
     "maximum idle lifetime (in hours), unlimited if ``0``"
 
-    id = Id(automatic=True)
+    id = Id()
     display_name = Char(
         string='Display Name',
         compute='_compute_display_name',
         search='_search_display_name',
-        automatic=True,
     )
 
     def _valid_field_parameter(self, field, name):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
Fields `id` and `display_name` are added on  the model if they have not been declared.
It means that if we define in `BaseModel` some attributes, they are not inherited.

Desired behavior after PR is merged:
Fields on `BaseModel` behave as normal fields. `Field.automatic` is not relevant anymore.

Future work: make a mixin for log_access fields.


odoo/enterprise#73225

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
