### PR TITLE
[FIX] html_editor: ChatGPT alternatives dialog and insert fixups

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -12,6 +12,7 @@ import {
     isShrunkBlock,
     isTangible,
     isTextNode,
+    isVisibleTextNode,
     isWhitespace,
     isZWS,
     nextLeaf,
@@ -595,7 +596,7 @@ export class DeletePlugin extends Plugin {
             // The joinable in this case is its sibling (previous for the start
             // side, next for the end side), but only if inline.
             const sibling = childNodes(commonAncestor)[side === "start" ? offset - 1 : offset];
-            if (sibling && !isBlock(sibling)) {
+            if (sibling && !isBlock(sibling) && !(sibling.nodeType === Node.TEXT_NODE && !isVisibleTextNode(sibling))) {
                 return { node: sibling, type: "inline" };
             }
             // No fragment to join.

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_alternatives_dialog.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_alternatives_dialog.js
@@ -128,4 +128,10 @@ export class ChatGPTAlternativesDialog extends ChatGPTDialog {
         }
         this.state.messagesInProgress = 0;
     }
+
+    preventDialogMousedown(ev) {
+        // Prevent the default behavior of a mousedown event on the dialog
+        // itself so it doesn't cancel the user's text selection in the editor.
+        ev.preventDefault();
+    }
 }

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_alternatives_dialog.xml
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_alternatives_dialog.xml
@@ -1,7 +1,7 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="html_editor.ChatGPTAlternativesDialog">
-    <Dialog size="'lg'" title.translate="AI Copywriter">
+    <Dialog size="'lg'" title.translate="AI Copywriter" t-on-mousedown="preventDialogMousedown">
         <div class="md-8">
             <div class="mb-3">
                 <t t-foreach="Object.entries(props.alternativesModes)"

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -381,6 +381,21 @@ describe("not collapsed selection", () => {
         });
     });
 
+    test("should delete selection and insert html in its place (3)", async () => {
+        await testEditor({
+            contentBefore: "<h1>[abc</h1><p>def]</p>",
+            stepFunction: async editor => {
+                // There's an empty text node after the paragraph:
+                editor.editable.lastChild.after(editor.document.createTextNode(""));
+                editor.shared.dom.insert(
+                    parseHTML(editor.document, "<p>ghi</p><p>jkl</p>")
+                );
+                editor.shared.history.addStep();
+            },
+            contentAfter: "<p>ghi</p><p>jkl[]</p>",
+        });
+    });
+
     test("should remove a fully selected table then insert a span before it", async () => {
         await testEditor({
             contentBefore: unformat(
@@ -561,6 +576,7 @@ describe("not collapsed selection", () => {
             contentAfter: `<p><span class="a">TEST</span>[]</p>`,
         });
     });
+
     test("should insert html containing ZWNBSP", async () => {
         await testEditor({
             contentBefore: "<p>[]<br></p>",


### PR DESCRIPTION
In the following HTML:

```html
<h1>[test</h1><p>content]</p>\n
```

The "\n" text node is invisible whitespace. When deleting the selection, failing to account for that, the content of the heading was "joined" with the invisible text node so that the heading's first child was that text node. This enventually snowballed when inserting new content as the start container was now a text node at offset 0, signalling to `insert` to do its insertion before its parent, and we ended up with an empty block after our insertion.

This fixes it by correcting `getJoinableFragment` so it doesn't join with an invisible text node.

-----

This prevents the default behavior of a mousedown event on the ChatGPT alternatives dialog so it doesn't cancel the user's text selection in the editor. This way, like with every other dialog, whenever it's open nothing can happen in the background.

task-4258167

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
