### PR TITLE
[FIX] l10n_it_stock_ddt: creating a new operation type in transfer

### DIFF
--- a/addons/l10n_it_stock_ddt/models/stock_picking.py
+++ b/addons/l10n_it_stock_ddt/models/stock_picking.py
@@ -73,7 +73,7 @@ class StockPickingType(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             company = self.env['res.company'].browse(vals.get('company_id', False)) or self.env.company
-            if company.country_id.code == 'IT' and vals['code'] == 'outgoing' and ('l10n_it_ddt_sequence_id' not in vals or not vals['l10n_it_ddt_sequence_id']):
+            if company.country_id.code == 'IT' and vals.get('code') == 'outgoing' and ('l10n_it_ddt_sequence_id' not in vals or not vals['l10n_it_ddt_sequence_id']):
                 ir_seq_name, ir_seq_prefix = self._get_dtt_ir_seq_vals(vals.get('warehouse_id'), vals['sequence_code'])
                 vals['l10n_it_ddt_sequence_id'] = self.env['ir.sequence'].create({
                         'name': ir_seq_name,


### PR DESCRIPTION
This error occurs when we are creating a new operation type in transfer.

Steps to reproduce:
---
- Install ``l10n_it_stock_ddt`` module
- Switch company to ``IT Company``
- Go to transfer and create any new operation type

Traceback:
---
``KeyError: 'code'``

At [1], we are facing this error because we are attempting to retrieve ``code`` from the ``vals``, but when we create a new operation type, we only receive ``name`` in the ``vals``.

[1]- https://github.com/odoo/odoo/blob/2489a4c4a5aae829bb7dafe24d93529767ce07db/addons/l10n_it_stock_ddt/models/stock_picking.py#L76

sentry-6037671568

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
