### PR TITLE
[IMP] website: review `s_rating` snippet design

### DIFF
--- a/addons/website/static/src/snippets/s_rating/options.js
+++ b/addons/website/static/src/snippets/s_rating/options.js
@@ -1,4 +1,5 @@
 import { MediaDialog } from "@web_editor/components/media_dialog/media_dialog";
+import { _t } from "@web/core/l10n/translation";
 
 import options from "@web_editor/js/editor/snippets.options";
 
@@ -99,6 +100,13 @@ options.registry.Rating = options.Class.extend({
         }
         return this._super(...arguments);
     },
+
+    async _computeWidgetVisibility(widgetName, params) {
+        if (widgetName === "rating_icon_xl") {
+            return false;
+        }
+        return this._super(...arguments);
+    },
     /**
      * Creates the icons.
      *
@@ -110,9 +118,9 @@ options.registry.Rating = options.Class.extend({
         this.$target.find('.s_rating_icons i').remove();
         for (let i = 0; i < this.nbTotalIcons; i++) {
             if (i < this.nbActiveIcons) {
-                $activeIcons.append('<i></i> ');
+                $activeIcons.append('<i role="presentation"></i> ');
             } else {
-                $inactiveIcons.append('<i></i> ');
+                $inactiveIcons.append('<i role="presentation"></i> ');
             }
         }
         this._renderIcons();
@@ -123,18 +131,15 @@ options.registry.Rating = options.Class.extend({
      * @private
      */
     _renderIcons: function () {
-        const icons = {
-            'fa-star': 'fa-star-o',
-            'fa-thumbs-up': 'fa-thumbs-o-up',
-            'fa-circle': 'fa-circle-o',
-            'fa-square': 'fa-square-o',
-            'fa-heart': 'fa-heart-o'
-        };
         const faClassActiveIcons = (this.iconType === "custom") ? this.faClassActiveCustomIcons : 'fa ' + this.iconType;
-        const faClassInactiveIcons = (this.iconType === "custom") ? this.faClassInactiveCustomIcons : 'fa ' + icons[this.iconType];
+        const faClassInactiveIcons = (this.iconType === "custom") ? this.faClassInactiveCustomIcons : 'fa ' + this.iconType;
         const $activeIcons = this.$target.find('.s_rating_active_icons > i');
         const $inactiveIcons = this.$target.find('.s_rating_inactive_icons > i');
         $activeIcons.removeClass().addClass(faClassActiveIcons);
         $inactiveIcons.removeClass().addClass(faClassInactiveIcons);
+        this.$target[0].setAttribute("aria-label", _t("%(amount)s out of %(total)s stars", {
+            amount: this.nbActiveIcons || 0,
+            total: this.nbTotalIcons,
+        }));
     },
 });

--- a/addons/website/views/snippets/s_rating.xml
+++ b/addons/website/views/snippets/s_rating.xml
@@ -2,17 +2,17 @@
 <odoo>
 
 <template id="s_rating" name="Rating">
-    <div class="s_rating pt16 pb16" data-vcss="001" data-icon="fa-star">
-        <h4 class="s_rating_title">Quality</h4>
+    <div class="s_rating s_rating_no_title pt16 pb16" data-vcss="001" data-icon="fa-star" aria-label="3 out of 5 stars">
+        <h4 class="s_rating_title">Rating</h4>
         <div class="s_rating_icons o_not_editable">
-            <span class="s_rating_active_icons">
-                <i class="fa fa-star"/>
-                <i class="fa fa-star"/>
-                <i class="fa fa-star"/>
+            <span class="s_rating_active_icons" style="color: #f3cc00;">
+                <i class="fa fa-star" role="presentation"/>
+                <i class="fa fa-star" role="presentation"/>
+                <i class="fa fa-star" role="presentation"/>
             </span>
-            <span class="s_rating_inactive_icons">
-                <i class="fa fa-star-o"/>
-                <i class="fa fa-star-o"/>
+            <span class="s_rating_inactive_icons" style="color: var(--border-color);">
+                <i class="fa fa-star" role="presentation"/>
+                <i class="fa fa-star" role="presentation"/>
             </span>
         </div>
     </div>
@@ -48,13 +48,22 @@
             </we-row>
             <we-button-group string="Size" data-apply-to=".s_rating_icons">
                 <we-button data-select-class="" title="Small" data-img="/website/static/src/img/snippets_options/size_small.svg"/>
-                <we-button data-select-class="fa-2x" title="Medium" data-img="/website/static/src/img/snippets_options/size_medium.svg"/>
-                <we-button data-select-class="fa-3x" title="Large" data-img="/website/static/src/img/snippets_options/size_large.svg"/>
+                <we-button data-select-class="fa-lg" title="Medium" data-img="/website/static/src/img/snippets_options/size_medium.svg"/>
+
+                <!--
+                This one is hidden and only there for compatibility (allowing to
+                remove the fa-3x class. Note that it is put in the middle to
+                make sure rounded corners are properly applied on the first and
+                last buttons of the group.
+                -->
+                <we-button data-select-class="fa-3x" data-name="rating_icon_xl"/>
+
+                <we-button data-select-class="fa-2x" title="Large" data-img="/website/static/src/img/snippets_options/size_large.svg"/>
             </we-button-group>
             <we-select string="Title Position">
                 <we-button data-select-class="">Top</we-button>
                 <we-button data-select-class="s_rating_inline">Left</we-button>
-                <we-button data-select-class="s_rating_no_title">None</we-button>
+                <we-button data-select-class="s_rating_no_title">Hidden</we-button>
             </we-select>
         </div>
     </xpath>


### PR DESCRIPTION
This PR aims to review the `s_rating` snippet design to make it more in line with the new snippets design.

With the new snippets introduced in Odoo 18 and all the new possibilities unlocked for the user, it made perfectly sense to review the design of the `s_rating` snippet to make it fit as much scenario as possible.

- requires https://github.com/odoo/design-themes/pull/1041

task-4306631

| Master | This PR |
|--------|--------|
| <img width="142" alt="image" src="https://github.com/user-attachments/assets/36387746-e7f8-497d-8813-f300c5cdd765"> | <img width="143" alt="image" src="https://github.com/user-attachments/assets/4b0eab87-8b77-4e10-b1ef-3cd636598513"> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
