### PR TITLE
[FIX] account: update "ir.default" records when merging accounts

### DIFF
--- a/addons/account/tests/test_account_merge_wizard.py
+++ b/addons/account/tests/test_account_merge_wizard.py
@@ -95,6 +95,9 @@ class TestAccountMergeWizard(TestAccountMergeCommon):
         self.accounts[2].with_context({'lang': 'fr_FR'}).name = "Mon troisième compte"
         self.accounts[2].with_context({'lang': 'nl_NL'}).name = "Mijn derde conto"
 
+        # Set an "ir.default" for an "account.account" field to a value that will be merged
+        self.env['ir.default'].set('res.partner', 'property_account_receivable_id', self.accounts[2].id)
+
         # 2. Check that the merge wizard groups accounts 1 and 3 together, and accounts 2 and 4 together.
         wizard = self._create_account_merge_wizard(self.accounts)
         expected_wizard_line_vals = [
@@ -185,6 +188,9 @@ class TestAccountMergeWizard(TestAccountMergeCommon):
         # 8. Check that the name translations are merged correctly
         self.assertRecordValues(self.accounts[0].with_context({'lang': 'fr_FR'}), [{'name': "Mon premier compte"}])
         self.assertRecordValues(self.accounts[0].with_context({'lang': 'nl_NL'}), [{'name': "Mijn derde conto"}])
+
+        # 9. Check that the "ir.default" has been updated correctly
+        self.assertEqual(self.env['ir.default']._get('res.partner', 'property_account_receivable_id'), self.accounts[0].id)
 
     def test_cannot_merge_same_company(self):
         """ Check that you cannot merge two accounts belonging to the same company. """


### PR DESCRIPTION
**Steps to reproduce:**
- Install accountant and contacts
- Create a new company
- Set a fiscal localization for that company (e.g. Belgium)
- Select the 2 companies in the company selector
- Go to "Accounting / Configuration / Accounting / Chart of Accounts"
- Add "Receivable" filter
- Select:
  * [121000] Account Receivable (from the main company)
  * [400000] Customers (from the Belgian company)
- Merge the 2 accounts
- Select the Belgian company in the company selector as main company
- Try to create a contact

**Issue:**
A traceback is raised due to a missing account record.

**Cause:**
There is a "User-defined default" with "property_account_receivable_id" and "property_account_payable_id" fields of "res.partner" model that is created automatically for each company.
As its value (i.e. account ID) is not updated when the accounts are merged, it is using an account ID that doesn't exist anymore.

**Solution:**
Check the "User-defined defaults" that are linked to an "account.account" field when merging accounts.

opw-4269925




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
