### PR TITLE
[IMP] mail: ";" to trigger canned response

### DIFF
--- a/addons/im_livechat/data/digest_data.xml
+++ b/addons/im_livechat/data/digest_data.xml
@@ -16,7 +16,7 @@
             <field name="tip_description" type="html">
 <div>
     <p class="tip_title">Tip: Use canned responses to chat faster</p>
-    <p class="tip_content">Use canned responses to define templates of messages in the livechat app. To load a canned response, start your sentence with ':' and select the template.</p>
+    <p class="tip_content">Use canned responses to define templates of messages in the livechat app. To load a canned response, start your sentence with ';' and select the template.</p>
     <img src="https://download.odoocdn.com/digests/im_livechat/static/src/img/milk-canned-responses.gif" width="540" class="illustration_border" />
 </div>
             </field>

--- a/addons/im_livechat/static/tests/composer_patch.test.js
+++ b/addons/im_livechat/static/tests/composer_patch.test.js
@@ -59,7 +59,7 @@ test('Receives visitor typing status "is typing"', async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-discuss-Typing", { text: "" });
+    await contains(".o-discuss-composerFooterHint", { text: "" });
     const channel = pyEnv["discuss.channel"].search_read([["id", "=", channelId]])[0];
     // simulate receive typing notification from livechat visitor "is typing"
     withGuest(guestId, () =>
@@ -68,5 +68,5 @@ test('Receives visitor typing status "is typing"', async () => {
             channel_id: channel.id,
         })
     );
-    await contains(".o-discuss-Typing", { text: "Visitor 20 is typing..." });
+    await contains(".o-discuss-composerFooterHint", { text: "Visitor 20 is typing..." });
 });

--- a/addons/im_livechat/static/tests/suggestions.test.js
+++ b/addons/im_livechat/static/tests/suggestions.test.js
@@ -12,7 +12,7 @@ import { defineLivechatModels } from "./livechat_test_helpers";
 describe.current.tags("desktop");
 defineLivechatModels();
 
-test("Suggestions are shown after delimiter was used in text (:)", async () => {
+test("Suggestions are shown after delimiter was used in text (;)", async () => {
     const pyEnv = await startServer();
     pyEnv["mail.canned.response"].create({
         source: "hello",
@@ -28,11 +28,11 @@ test("Suggestions are shown after delimiter was used in text (:)", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";he");
     await contains(".o-mail-Composer-suggestion strong", { text: "hello" });
     await insertText(".o-mail-Composer-input", ")");
     await contains(".o-mail-Composer-suggestion strong", { count: 0 });
-    await insertText(".o-mail-Composer-input", " :");
+    await insertText(".o-mail-Composer-input", " ;he");
     await contains(".o-mail-Composer-suggestion strong", { text: "hello" });
 });
 

--- a/addons/im_livechat/static/tests/thread_model_patch.test.js
+++ b/addons/im_livechat/static/tests/thread_model_patch.test.js
@@ -93,5 +93,7 @@ test("Display livechat custom name in typing status", async () => {
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", { text: "livechat custom username is typing..." });
+    await contains(".o-discuss-composerFooterHint", {
+        text: "livechat custom username is typing...",
+    });
 });

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1300,7 +1300,7 @@ class DiscussChannel(models.Model):
             "%(new_line)sType %(bold_start)s@username%(bold_end)s to mention someone, and grab their attention."
             "%(new_line)sType %(bold_start)s#channel%(bold_end)s to mention a channel."
             "%(new_line)sType %(bold_start)s/command%(bold_end)s to execute a command."
-            "%(new_line)sType %(bold_start)s:shortcut%(bold_end)s to insert a canned response in your message.",
+            "%(new_line)sType %(bold_start)s;shortcut%(bold_end)s to insert a canned response in your message.",
             bold_start=Markup("<b>"),
             bold_end=Markup("</b>"),
             new_line=Markup("<br>"),

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -79,14 +79,18 @@
                 </div>
             </div>
             <div class="o-mail-Composer-footer overflow-auto">
-                <AttachmentList
-                    t-if="allowUpload and props.composer.attachments.length > 0"
-                    attachments="props.composer.attachments"
-                    unlinkAttachment.bind="(...args) => attachmentUploader.unlink(...args)"
-                    imagesHeight="75"/>
-                <Picker t-props="picker"/>
+                    <AttachmentList
+                        t-if="allowUpload and props.composer.attachments.length > 0"
+                        attachments="props.composer.attachments"
+                        unlinkAttachment.bind="(...args) => attachmentUploader.unlink(...args)"
+                        imagesHeight="75"/>
+                    <div t-if="thread?.model === 'discuss.channel' and !compact" class="o-discuss-composerFooterHint d-flex">
+                        <span class="o-discuss-composerFooterHint-separator flex-grow-1"/>
+                        <span class="flex-shrink-0 text-muted small ms-1" t-out="props.composer.footerHint"/>
+                    </div>
+                    <Picker t-props="picker"/>
+                </div>
             </div>
-        </div>
         <div t-if="props.composer.message" class="d-flex align-items-center gap-1 w-100">
             <span t-if="props.composer.message" class="text-muted px-1 small" t-out="CANCEL_OR_SAVE_EDIT_TEXT" t-on-click="onClickCancelOrSaveEditText"/>
             <span class="flex-grow-1"/>

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -27,6 +27,7 @@ export class Composer extends Record {
     mentionedChannels = Record.many("Thread");
     cannedResponses = Record.many("mail.canned.response");
     text = "";
+    footerHint = "";
     thread = Record.one("Thread");
     /** @type {{ start: number, end: number, direction: "forward" | "backward" | "none"}}*/
     selection = {

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -2,6 +2,7 @@ import { useSequential } from "@mail/utils/common/hooks";
 import { status, useComponent, useEffect, useState } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
 
 class UseSuggestion {
     constructor(comp) {
@@ -11,6 +12,12 @@ class UseSuggestion {
                 this.update();
                 if (this.search.position === undefined || !this.search.delimiter) {
                     return; // nothing else to fetch
+                }
+                if (this.search.delimiter === ";" && this.search.term.length === 0) {
+                    return; // only trigger fetching canned response when extra character provided
+                }
+                if (this.search.delimiter === ":" && this.search.term.length === 0) {
+                    this.composer.footerHint = _t(`Type ";" to insert a canned response`);
                 }
                 if (this.composer.store.self.type !== "partner") {
                     return; // guests cannot access fetch suggestion method
@@ -63,6 +70,7 @@ class UseSuggestion {
         );
         useEffect(
             () => {
+                this.composer.footerHint = "";
                 this.detect();
             },
             () => [this.composer.selection.start, this.composer.selection.end, this.composer.text]
@@ -173,7 +181,7 @@ class UseSuggestion {
         const text = this.composer.text;
         let before = text.substring(0, this.search.position + 1);
         let after = text.substring(position, text.length);
-        if (this.search.delimiter === ":") {
+        if (this.search.delimiter === ";") {
             before = text.substring(0, this.search.position);
             after = text.substring(position, text.length);
         }

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -16,7 +16,8 @@ export class SuggestionService {
     }
 
     getSupportedDelimiters(thread) {
-        return [["@"], ["#"], [":"]];
+        // detecting ":" as it was the old delimiter for canned responses and we want to make a hint to the user while user still uses it
+        return [["@"], ["#"], [";"], [":"]];
     }
 
     async fetchSuggestions({ delimiter, term }, { thread } = {}) {
@@ -29,7 +30,7 @@ export class SuggestionService {
             case "#":
                 await this.fetchThreads(cleanedSearchTerm);
                 break;
-            case ":":
+            case ";":
                 await this.store.cannedReponses.fetch();
                 break;
         }
@@ -123,8 +124,10 @@ export class SuggestionService {
             }
             case "#":
                 return this.searchChannelSuggestions(cleanedSearchTerm, sort);
-            case ":":
-                return this.searchCannedResponseSuggestions(cleanedSearchTerm, sort);
+            case ";":
+                if (term.length > 0) {
+                    return this.searchCannedResponseSuggestions(cleanedSearchTerm, sort);
+                }
         }
         return {
             type: undefined,

--- a/addons/mail/static/src/discuss/typing/common/composer_patch.xml
+++ b/addons/mail/static/src/discuss/typing/common/composer_patch.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="mail.Composer" t-inherit-mode="extension">
-        <xpath expr="//AttachmentList" position="after">
-            <div t-if="thread?.model === 'discuss.channel' and !compact" class="o-discuss-Typing d-flex">
-                <Typing channel="thread" size="'medium'"/>
-            </div>
+        <xpath expr="//span[hasclass('o-discuss-composerFooterHint-separator')]" position="before">
+            <Typing channel="thread" size="'medium'"/>
         </xpath>
         <xpath expr="//*[hasclass('o-mail-Composer-input')]" position="attributes">
             <attribute name="t-on-input">detectTyping</attribute>

--- a/addons/mail/static/src/discuss/typing/common/typing.scss
+++ b/addons/mail/static/src/discuss/typing/common/typing.scss
@@ -29,7 +29,7 @@
     }
 }
 
-.o-discuss-Typing:before {
+.o-discuss-composerFooterHint:before {
     // invisible character so that typing status bar has constant height, regardless of text content.
     content: "\200b"; /* unicode zero width space character */
 }

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -817,7 +817,7 @@ test("Message is sent only once when pressing enter twice in a row", async () =>
     await contains(".o-mail-Message-content", { text: "Hello World!" });
 });
 
-test('display canned response suggestions on typing ":"', async () => {
+test('display canned response suggestions on typing ";"', async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Mario" });
     const channelId = pyEnv["discuss.channel"].create({
@@ -835,7 +835,7 @@ test('display canned response suggestions on typing ":"', async () => {
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-input");
     await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";he");
     await contains(".o-mail-Composer-suggestionList .o-open");
     await contains(".o-mail-NavigableList-item", { text: "helloHello! How are you?" });
 });
@@ -859,7 +859,7 @@ test("select a canned response suggestion", async () => {
     await contains(".o-mail-Composer-suggestionList");
     await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await contains(".o-mail-Composer-input", { value: "" });
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";he");
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", { value: "Hello! How are you? " });
 });
@@ -884,7 +884,7 @@ test("select a canned response suggestion with some text", async () => {
     await contains(".o-mail-Composer-input", { value: "" });
     await insertText(".o-mail-Composer-input", "bluhbluh ");
     await contains(".o-mail-Composer-input", { value: "bluhbluh " });
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";he");
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", { value: "bluhbluh Hello! How are you? " });
 });
@@ -907,7 +907,7 @@ test("add an emoji after a canned response", async () => {
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-suggestionList");
     await contains(".o-mail-Composer-input", { value: "" });
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";he");
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", { value: "Hello! How are you? " });
     await click("button[aria-label='Emojis']");
@@ -928,7 +928,7 @@ test("Canned response can be inserted from the bus", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-input");
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";he");
     await contains(".o-mail-NavigableList-item", { count: 0 });
     await insertText(".o-mail-Composer-input", "", { replace: true });
     pyEnv["mail.canned.response"].create({
@@ -936,7 +936,7 @@ test("Canned response can be inserted from the bus", async () => {
         substitution: "Hello! How are you?",
     });
     await contains(".o-mail-NavigableList-item", { count: 0 });
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";he");
     await contains(".o-mail-NavigableList-item", { text: "helloHello! How are you?" });
 });
 
@@ -957,14 +957,14 @@ test("Canned response can be updated from the bus", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-input");
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";he");
     await contains(".o-mail-NavigableList-item", { count: 1 });
     await insertText(".o-mail-Composer-input", "", { replace: true });
     pyEnv["mail.canned.response"].write([cannedResponseId], {
         substitution: "Howdy! How are you?",
     });
     await contains(".o-mail-NavigableList-item", { count: 0 });
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";he");
     await contains(".o-mail-NavigableList-item", { text: "helloHowdy! How are you?" });
 });
 
@@ -984,22 +984,22 @@ test("Canned response can be deleted from the bus", async () => {
             substitution: "Hello! How are you?",
         },
         {
-            source: "test",
-            substitution: "test",
+            source: "hey",
+            substitution: "hey test",
         },
     ]);
     await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";he");
     await contains(".o-mail-NavigableList-item", { count: 2 });
     await contains(".o-mail-NavigableList-item", { text: "hello" });
-    await contains(".o-mail-NavigableList-item", { text: "test" });
+    await contains(".o-mail-NavigableList-item", { text: "hey" });
     await insertText(".o-mail-Composer-input", "", { replace: true });
     await contains(".o-mail-NavigableList-item", { count: 0 });
     pyEnv["mail.canned.response"].unlink([cannedResponseId]);
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";he");
     await contains(".o-mail-NavigableList-item", { count: 1 });
-    await contains(".o-mail-NavigableList-item", { text: "test" });
+    await contains(".o-mail-NavigableList-item", { text: "hey" });
 });
 
 test("Canned response last used changes on posting", async () => {
@@ -1014,7 +1014,7 @@ test("Canned response last used changes on posting", async () => {
     ])[0];
     await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";te");
     await click(".o-mail-NavigableList-item", { text: "testTest a canned response?" });
     await contains(".o-mail-Composer-input", { value: "Test a canned response? " });
     expect(cannedResponse.last_used).toBeEmpty();
@@ -1032,7 +1032,7 @@ test("Does not auto-select 1st canned response suggestion", async () => {
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
     await contains(".o-mail-NavigableList-active", { text: "Mitchell Admin" });
-    await insertText(".o-mail-Composer-input", ":", { replace: true });
+    await insertText(".o-mail-Composer-input", ";he", { replace: true });
     await contains(".o-mail-NavigableList-item", { text: "HelloHello! How are you?" });
     await contains(".o-mail-NavigableList-active", { count: 0 });
 });
@@ -1042,31 +1042,31 @@ test("TAB/ARROW focuses 1st canned response suggestion", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     pyEnv["mail.canned.response"].create([
         { source: "Hello", substitution: "Hello! How are you?" },
-        { source: "Goodbye", substitution: "Goodbye! See you soon!" },
+        { source: "Hey", substitution: "Hey goodbye! See you soon!" },
     ]);
     await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";he");
     // Assuming the suggestions are displayed in alphabetical order
     await contains(".o-mail-NavigableList-item", {
-        text: "GoodbyeGoodbye! See you soon!",
-        before: [".o-mail-NavigableList-item", { text: "HelloHello! How are you?" }],
+        text: "HelloHello! How are you?",
+        before: [".o-mail-NavigableList-item", { text: "HeyHey goodbye! See you soon!" }],
     });
     await contains(".o-mail-NavigableList-active", { count: 0 });
     await triggerHotkey("Tab");
-    await contains(".o-mail-NavigableList-active", { text: "GoodbyeGoodbye! See you soon!" });
+    await contains(".o-mail-NavigableList-active", { text: "HelloHello! How are you?" });
     await triggerHotkey("Escape");
     await contains(".o-mail-NavigableList-item", { count: 0 });
-    await insertText(".o-mail-Composer-input", ":", { replace: true });
+    await insertText(".o-mail-Composer-input", ";he", { replace: true });
     await contains(".o-mail-NavigableList-item", { count: 2 });
     await triggerHotkey("ArrowDown");
-    await contains(".o-mail-NavigableList-active", { text: "GoodbyeGoodbye! See you soon!" });
+    await contains(".o-mail-NavigableList-active", { text: "HelloHello! How are you?" });
     await triggerHotkey("Escape");
     await contains(".o-mail-NavigableList-active", { count: 0 });
-    await insertText(".o-mail-Composer-input", ":", { replace: true });
+    await insertText(".o-mail-Composer-input", ";he", { replace: true });
     await contains(".o-mail-NavigableList-item", { count: 2 });
     await triggerHotkey("ArrowUp");
-    await contains(".o-mail-NavigableList-active", { text: "GoodbyeGoodbye! See you soon!" });
+    await contains(".o-mail-NavigableList-active", { text: "HelloHello! How are you?" });
 });
 
 test("ENTER closes canned response suggestions", async () => {
@@ -1075,7 +1075,7 @@ test("ENTER closes canned response suggestions", async () => {
     pyEnv["mail.canned.response"].create({ source: "Hello", substitution: "Hello! How are you?" });
     await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ";he");
     await contains(".o-mail-NavigableList-item", { text: "HelloHello! How are you?" });
     await contains(".o-mail-NavigableList-active", { count: 0 });
     await triggerHotkey("Enter");
@@ -1101,21 +1101,21 @@ test("Tab to select of canned response suggestion works in chat window", async (
     ]);
     pyEnv["mail.canned.response"].create([
         { source: "Hello", substitution: "Hello! How are you?" },
-        { source: "Goodbye", substitution: "Goodbye! See you soon!" },
+        { source: "Hey", substitution: "Hey goodbye! See you soon!" },
     ]);
     await start();
     await contains(".o-mail-ChatWindow", { count: 2 });
-    await insertText(".o-mail-ChatWindow:eq(0) .o-mail-Composer-input", ":");
+    await insertText(".o-mail-ChatWindow:eq(0) .o-mail-Composer-input", ";he");
     // Assuming the suggestions are displayed in alphabetical order
     await contains(".o-mail-NavigableList-item", {
-        text: "GoodbyeGoodbye! See you soon!",
-        before: [".o-mail-NavigableList-item", { text: "HelloHello! How are you?" }],
+        text: "HelloHello! How are you?",
+        before: [".o-mail-NavigableList-item", { text: "HeyHey goodbye! See you soon!" }],
     });
     await triggerHotkey("Tab");
-    await contains(".o-mail-NavigableList-active", { text: "GoodbyeGoodbye! See you soon!" });
+    await contains(".o-mail-NavigableList-active", { text: "HelloHello! How are you?" });
     await animationFrame();
     await triggerHotkey("Enter");
     await contains(".o-mail-ChatWindow:eq(0) .o-mail-Composer-input", {
-        value: "Goodbye! See you soon! ",
+        value: "Hello! How are you? ",
     });
 });

--- a/addons/mail/static/tests/discuss/typing/typing.test.js
+++ b/addons/mail/static/tests/discuss/typing/typing.test.js
@@ -38,8 +38,8 @@ test('receive other member typing status "is typing"', async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-discuss-Typing");
-    await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
+    await contains(".o-discuss-composerFooterHint");
+    await contains(".o-discuss-composerFooterHint", { count: 0, text: "Demo is typing...)" });
     // simulate receive typing notification from demo
     withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
@@ -47,7 +47,7 @@ test('receive other member typing status "is typing"', async () => {
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", { text: "Demo is typing..." });
+    await contains(".o-discuss-composerFooterHint", { text: "Demo is typing..." });
 });
 
 test('receive other member typing status "is typing" then "no longer is typing"', async () => {
@@ -63,8 +63,8 @@ test('receive other member typing status "is typing" then "no longer is typing"'
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-discuss-Typing");
-    await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
+    await contains(".o-discuss-composerFooterHint");
+    await contains(".o-discuss-composerFooterHint", { count: 0, text: "Demo is typing...)" });
     // simulate receive typing notification from demo "is typing"
     withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
@@ -72,7 +72,7 @@ test('receive other member typing status "is typing" then "no longer is typing"'
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", { text: "Demo is typing..." });
+    await contains(".o-discuss-composerFooterHint", { text: "Demo is typing..." });
     // simulate receive typing notification from demo "is no longer typing"
     withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
@@ -80,8 +80,8 @@ test('receive other member typing status "is typing" then "no longer is typing"'
             is_typing: false,
         })
     );
-    await contains(".o-discuss-Typing");
-    await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
+    await contains(".o-discuss-composerFooterHint");
+    await contains(".o-discuss-composerFooterHint", { count: 0, text: "Demo is typing...)" });
 });
 
 test('assume other member typing status becomes "no longer is typing" after long without any updated typing status', async () => {
@@ -98,8 +98,8 @@ test('assume other member typing status becomes "no longer is typing" after long
     await start();
     await openDiscuss(channelId);
     await advanceTime(Store.FETCH_DATA_DEBOUNCE_DELAY);
-    await contains(".o-discuss-Typing");
-    await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
+    await contains(".o-discuss-composerFooterHint");
+    await contains(".o-discuss-composerFooterHint", { count: 0, text: "Demo is typing...)" });
     // simulate receive typing notification from demo "is typing"
     withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
@@ -107,9 +107,9 @@ test('assume other member typing status becomes "no longer is typing" after long
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", { text: "Demo is typing..." });
+    await contains(".o-discuss-composerFooterHint", { text: "Demo is typing..." });
     await advanceTime(Store.OTHER_LONG_TYPING);
-    await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
+    await contains(".o-discuss-composerFooterHint", { count: 0, text: "Demo is typing...)" });
 });
 
 test('other member typing status "is typing" refreshes of assuming no longer typing', async () => {
@@ -126,8 +126,8 @@ test('other member typing status "is typing" refreshes of assuming no longer typ
     await start();
     await openDiscuss(channelId);
     await advanceTime(Store.FETCH_DATA_DEBOUNCE_DELAY);
-    await contains(".o-discuss-Typing");
-    await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
+    await contains(".o-discuss-composerFooterHint");
+    await contains(".o-discuss-composerFooterHint", { count: 0, text: "Demo is typing...)" });
     // simulate receive typing notification from demo "is typing"
     withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {
@@ -135,7 +135,7 @@ test('other member typing status "is typing" refreshes of assuming no longer typ
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", { text: "Demo is typing..." });
+    await contains(".o-discuss-composerFooterHint", { text: "Demo is typing..." });
     // simulate receive typing notification from demo "is typing" again after long time.
     await advanceTime(LONG_TYPING);
     await withUser(userId, () =>
@@ -145,9 +145,9 @@ test('other member typing status "is typing" refreshes of assuming no longer typ
         })
     );
     await advanceTime(LONG_TYPING);
-    await contains(".o-discuss-Typing", { text: "Demo is typing..." });
+    await contains(".o-discuss-composerFooterHint", { text: "Demo is typing..." });
     await advanceTime(Store.OTHER_LONG_TYPING - LONG_TYPING);
-    await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
+    await contains(".o-discuss-composerFooterHint", { count: 0, text: "Demo is typing...)" });
 });
 
 test('receive several other members typing status "is typing"', async () => {
@@ -173,8 +173,8 @@ test('receive several other members typing status "is typing"', async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-discuss-Typing");
-    await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
+    await contains(".o-discuss-composerFooterHint");
+    await contains(".o-discuss-composerFooterHint", { count: 0, text: "Demo is typing...)" });
     // simulate receive typing notification from other 10 (is typing)
     withUser(userId_1, () =>
         rpc("/discuss/channel/notify_typing", {
@@ -182,7 +182,7 @@ test('receive several other members typing status "is typing"', async () => {
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", { text: "Other 10 is typing..." });
+    await contains(".o-discuss-composerFooterHint", { text: "Other 10 is typing..." });
     // simulate receive typing notification from other 11 (is typing)
     withUser(userId_2, () =>
         rpc("/discuss/channel/notify_typing", {
@@ -190,7 +190,9 @@ test('receive several other members typing status "is typing"', async () => {
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", { text: "Other 10 and Other 11 are typing..." });
+    await contains(".o-discuss-composerFooterHint", {
+        text: "Other 10 and Other 11 are typing...",
+    });
     // simulate receive typing notification from other 12 (is typing)
     withUser(userId_3, () =>
         rpc("/discuss/channel/notify_typing", {
@@ -198,7 +200,9 @@ test('receive several other members typing status "is typing"', async () => {
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", { text: "Other 10, Other 11 and more are typing..." });
+    await contains(".o-discuss-composerFooterHint", {
+        text: "Other 10, Other 11 and more are typing...",
+    });
     // simulate receive typing notification from other 10 (no longer is typing)
     withUser(userId_1, () =>
         rpc("/discuss/channel/notify_typing", {
@@ -206,7 +210,9 @@ test('receive several other members typing status "is typing"', async () => {
             is_typing: false,
         })
     );
-    await contains(".o-discuss-Typing", { text: "Other 11 and Other 12 are typing..." });
+    await contains(".o-discuss-composerFooterHint", {
+        text: "Other 11 and Other 12 are typing...",
+    });
     // simulate receive typing notification from other 10 (is typing again)
     withUser(userId_1, () =>
         rpc("/discuss/channel/notify_typing", {
@@ -214,7 +220,9 @@ test('receive several other members typing status "is typing"', async () => {
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", { text: "Other 11, Other 12 and more are typing..." });
+    await contains(".o-discuss-composerFooterHint", {
+        text: "Other 11, Other 12 and more are typing...",
+    });
 });
 
 test("current partner notify is typing to other thread members", async () => {
@@ -274,8 +282,8 @@ test("current partner is typing should not translate on textual typing status", 
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "a");
     await waitForSteps(["notify_typing:true"]);
-    await contains(".o-discuss-Typing");
-    await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
+    await contains(".o-discuss-composerFooterHint");
+    await contains(".o-discuss-composerFooterHint", { count: 0, text: "Demo is typing...)" });
 });
 
 test("chat: correspondent is typing", async () => {

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -794,7 +794,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "<br><br>Type <b>@username</b> to mention someone, and grab their attention."
                             "<br>Type <b>#channel</b> to mention a channel."
                             "<br>Type <b>/command</b> to execute a command."
-                            "<br>Type <b>:shortcut</b> to insert a canned response in your message."
+                            "<br>Type <b>;shortcut</b> to insert a canned response in your message."
                             "</span>",
                         "thread": {
                             "id": channel.id,
@@ -835,7 +835,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "<br><br>Type <b>@username</b> to mention someone, and grab their attention."
                             "<br>Type <b>#channel</b> to mention a channel."
                             "<br>Type <b>/command</b> to execute a command."
-                            "<br>Type <b>:shortcut</b> to insert a canned response in your message."
+                            "<br>Type <b>;shortcut</b> to insert a canned response in your message."
                             "</span>",
                         "thread": {
                             "id": test_group.id,

--- a/addons/mail/views/mail_canned_response_views.xml
+++ b/addons/mail/views/mail_canned_response_views.xml
@@ -64,7 +64,7 @@
                     Create a new canned response
                 </p><p>
                     Canned responses allow you to insert prewritten responses in
-                    your messages by typing <i>:shortcut</i>. The shortcut is
+                    your messages by typing <i>;shortcut</i>. The shortcut is
                     replaced directly in your message, so that you can still edit
                     it before sending.
                 </p>

--- a/addons/mail_bot/models/mail_bot.py
+++ b/addons/mail_bot/models/mail_bot.py
@@ -92,7 +92,7 @@ class MailBot(models.AbstractModel):
                 self.env.user.odoobot_failed = False
                 self.env.user.odoobot_state = "onboarding_canned"
                 return self.env._(
-                    "Wonderful! 😇%(new_line)sTry typing %(command_start)s:%(command_end)s to use "
+                    "Wonderful! 😇%(new_line)sTry typing %(command_start)s;thanks%(command_end)s to use "
                     "canned responses. I've created a temporary one for you.",
                     **self._get_style_dict()
                 )


### PR DESCRIPTION
- switch the shortcut from : to ;
- the dropdown only shows when another character follows the ; shortcut

This is a preparation for the emoji shortcut that will be introduced later. By changing the shortcut to ; we can use : as a prefix for emojis.

task-4110505

https://github.com/odoo/enterprise/pull/73228
https://github.com/odoo/upgrade/pull/6716

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
