### PR TITLE
[FIX] maintenance: wait for drag_and_drop target rendering

### DIFF
--- a/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
+++ b/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
@@ -56,6 +56,10 @@ registry.category("web_tour.tours").add("test_drag_and_drop_event_in_calendar", 
             trigger: ".o_scale_button_month",
         },
         {
+            trigger: '.fc-dayGridMonth-view',
+            isCheck: true,
+        },
+        {
             content: "Move event to 15th of the month",
             trigger: 'a[data-event-id="1"]',
             run: 'drag_and_drop_native .fc-day.fc-widget-content[data-date$="15"]',


### PR DESCRIPTION
During `test_drag_and_drop_event_in_calendar`, an error occurs due to the target not being found in drag and drop steps.

When the test is performed on the same week as the event, there is a likely chance for the drag and drop steps to be triggered before the rendering of the Monthly Calendar view. When we are changing from weekly to monthly view, we will wait for the latter to be rendered before calling the next steps.

runbot-error-105708
runbot-error-105709