### PR TITLE
[FIX] point_of_sale: prevent error when searching for draft orders

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -67,7 +67,7 @@ patch(PosStore.prototype, {
                 tables
                     .map((t) => t["<-pos.order.table_id"])
                     .flat()
-                    .filter((o) => !o.finalized)
+                    .filter((o) => !o.finalized && typeof o.id === "number")
             ),
         ];
         await this.loadServerOrders([


### PR DESCRIPTION
Before this commit, if you opened a table on one device without adding any items, and then opened the same table on another device, added items, and pressed order, an error would occur due to searching with a string for the ID of an order.

opw-4299785

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
