### PR TITLE
[FIX] web,mail: clean a wrong dropdown property

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -2,36 +2,71 @@ import { ImStatus } from "@mail/core/common/im_status";
 
 import { Component, useEffect, useRef, useState } from "@odoo/owl";
 
-import { useService } from "@web/core/utils/hooks";
+import { useChildRef, useService } from "@web/core/utils/hooks";
 import { useHover, useMovable } from "@mail/utils/common/hooks";
-import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
-import { Dropdown } from "@web/core/dropdown/dropdown";
+import { usePopover } from "@web/core/popover/popover_hook";
+
+class ChatBubblePreview extends Component {
+    static props = ["chatWindow", "close"];
+    static template = "mail.ChatBubble.preview";
+
+    /** @returns {import("models").Thread} */
+    get thread() {
+        return this.props.chatWindow.thread;
+    }
+
+    get previewContent() {
+        const lastMessage = this.thread?.newestPersistentNotEmptyOfAllMessage;
+        if (!lastMessage) {
+            return false;
+        }
+        return lastMessage.inlineBody;
+    }
+}
 
 /**
  * @typedef {Object} Props
  * @extends {Component<Props, Env>}
  */
 export class ChatBubble extends Component {
-    static components = { ImStatus, Dropdown };
+    static components = { ImStatus };
     static props = ["chatWindow"];
     static template = "mail.ChatBubble";
 
     setup() {
         super.setup();
         this.store = useState(useService("mail.store"));
+        const popoverRef = useChildRef();
+        this.popover = usePopover(ChatBubblePreview, {
+            animation: false,
+            position: "left-middle",
+            popoverClass: "bg-view border-0 p-0 overflow-visible rounded-3",
+            ref: popoverRef,
+        });
+        this.env.bus.addEventListener("chat-bubble:preview-will-open", ({ detail }) => {
+            if (detail === this) {
+                return;
+            }
+            this.popover.close();
+        });
         this.wasHover = false;
-        this.hover = useHover(["root", "preview*"], () => {
-            this.preview.isOpen = this.hover.isHover;
+        this.hover = useHover(["root", popoverRef], () => {
             if (this.hover.isHover && !this.wasHover) {
                 clearTimeout(this.showCloseTimeout);
                 this.showCloseTimeout = setTimeout(() => (this.state.showClose = true), 100);
+                if (!this.env.embedLivechat) {
+                    this.env.bus.trigger("chat-bubble:preview-will-open", this);
+                    this.popover.open(this.rootRef.el.querySelector(".o-mail-ChatHub-bubbleBtn"), {
+                        chatWindow: this.props.chatWindow,
+                    });
+                }
             } else if (!this.hover.isHover) {
                 clearTimeout(this.showCloseTimeout);
                 this.state.showClose = false;
+                this.popover.close();
             }
             this.wasHover = this.hover.isHover;
         });
-        this.preview = useDropdownState();
         this.rootRef = useRef("root");
         this.state = useState({ bouncing: false, showClose: true });
         useEffect(
@@ -55,13 +90,5 @@ export class ChatBubble extends Component {
     /** @returns {import("models").Thread} */
     get thread() {
         return this.props.chatWindow.thread;
-    }
-
-    get previewContent() {
-        const lastMessage = this.thread?.newestPersistentNotEmptyOfAllMessage;
-        if (!lastMessage) {
-            return false;
-        }
-        return lastMessage.inlineBody;
     }
 }

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.ChatBubble">
-        <Dropdown t-if="!env.embedLivechat" state="preview" position="'left-middle'" menuClass="'bg-view border-0 p-0 overflow-visible rounded-3'" arrow="true" manual="true">
-            <t t-call="mail.ChatBubble.core"/>
-            <t t-set-slot="content">
-                <t t-call="mail.ChatBubble.preview"/>
-            </t>
-        </Dropdown>
-        <t t-else="" t-call="mail.ChatBubble.core"/>
-    </t>
-
-    <t t-name="mail.ChatBubble.core">
-        <div class="o-mail-ChatBubble" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': preview.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
+        <div class="o-mail-ChatBubble" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': popover.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
+            <span class="o-mail-ChatBubble-unreadIndicator position-absolute" t-att-class="{ 'opacity-50': thread?.isUnread and !thread?.importantCounter, 'opacity-0': !thread?.isUnread or thread?.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
             <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Window" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
             <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" persona="thread.correspondent.persona" thread="thread"/>
@@ -22,8 +13,8 @@
     </t>
 
     <t t-name="mail.ChatBubble.preview">
-        <div class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border rounded" t-ref="preview">
-            <div class="text-truncate fw-bolder mb-0 mx-2" t-esc="props.chatWindow.displayName"/>
+        <div class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border rounded">
+            <div class="text-truncate base-fs fw-bolder mb-0 mx-2" t-esc="props.chatWindow.displayName"/>
             <div t-if="previewContent" class="text-truncate small mx-2 text-muted">
                 <t t-call="mail.message_preview_prefix">
                     <t t-set="message" t-value="thread?.newestPersistentNotEmptyOfAllMessage"/>

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -71,7 +71,7 @@ export function onExternalClick(refName, cb) {
 }
 
 /**
- * @param {string | string[]} refNames
+ * @param {string | string[] | Function} refNames
  * @param {(boolean) => void} callback
  * @returns {({ isHover: boolean })}
  */
@@ -79,6 +79,11 @@ export function useHover(refNames, callback = () => {}) {
     refNames = Array.isArray(refNames) ? refNames : [refNames];
     const targets = [];
     for (const refName of refNames) {
+        if (typeof refName === "function") {
+            // Special case for using a child ref
+            targets.push({ ref: refName });
+            continue;
+        }
         const withDirectParent = refName.endsWith("*");
         targets.push({
             ref: refName.endsWith("*")

--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -52,7 +52,6 @@ export class Dropdown extends Component {
     static template = xml`<t t-slot="default"/>`;
     static components = {};
     static props = {
-        arrow: { optional: true },
         menuClass: { optional: true },
         position: { type: String, optional: true },
         slots: {
@@ -105,7 +104,6 @@ export class Dropdown extends Component {
         navigationOptions: { type: Object, optional: true },
     };
     static defaultProps = {
-        arrow: false,
         disabled: false,
         holdOnHover: false,
         menuClass: "",
@@ -140,7 +138,7 @@ export class Dropdown extends Component {
 
         this.popover = usePopover(DropdownPopover, {
             animation: false,
-            arrow: this.props.arrow,
+            arrow: false,
             closeOnClickAway: (target) => {
                 return this.popoverCloseOnClickAway(target, activeEl);
             },

--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -116,9 +116,6 @@ export class Popover extends Component {
         this.position = usePosition("ref", () => this.props.target, {
             onPositioned: (el, solution) => {
                 (this.props.onPositioned || this.onPositioned.bind(this))(el, solution);
-                if (this.props.arrow && this.props.onPositioned) {
-                    this.onPositioned.bind(this)(el, solution);
-                }
 
                 // opening animation
                 if (shouldAnimate) {


### PR DESCRIPTION
Since [1], the ChatBubble component have been introduced by using a Dropdown component in its template. The Dropdown component is used with advanced props in order to give it a simple tooltip behavior. In order to achieve this, the Dropdown component has been updated by adding a new `arrow` property, which is passed to the underlying Popover component that, in turn, had to get updated in order to support this simple use case.

This commit reverts the changes to the Dropdown and Popover components and adapts the ChatBubble component in order to use a simple popover, which is controlled in such a way that it behaves as a tooltip.

Additional note:
- simple tooltips could not have been used in this case as the ChatBubble needs are greater than the [data-tooltip-*] attributes could offer, especially for styling but also because complex objects are passed (proxies) to the preview template, which could not get stringified to get passed as elements' attributes.

[1]: https://github.com/odoo/odoo/commit/82e3295d43f7809661a40d1b21ffbcbce23c700b
