### PR TITLE
[FIX] base_automation: prevent non-stored trigger fields

### DIFF
--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -106,7 +106,7 @@
                                 />
                                 <field name="trigger_field_ids" string="When updating" placeholder="Select fields..."
                                     options="{'no_open': True, 'no_create': True}"
-                                    domain="[('model_id', '=', model_id)]"
+                                    domain="[('model_id', '=', model_id),('store','=',True)]"
                                     context="{'hide_model': 1}"
                                     invisible="trigger != 'on_create_or_write'" widget="many2many_tags" />
                                 <field name="on_change_field_ids" string="When updating" placeholder="Select fields..."


### PR DESCRIPTION
Issue:
When using non-stored fields as trigger_field_ids in an automation rule, old values will not be updated due to the following condition:
`and record._fields[field_name].store`

This condition prevents a write from occurring, as old_vals will not be retrieved when we pass the context to:
`old_vals = self._context['old_values'].get(record.id, {})`

Without old_vals, there are no detected differences, so the _check_trigger_fields function returns False instead of recognizing the updated field.

This condition was recently added as a bug fix in the following ticket: 
Ticket: opw-4106799
PR: #180965

As a result, non-stored fields can no longer be used as trigger fields.

Current behavior before PR:
non-stored fields do not trigger automation rules

Desired behavior after PR is merged:
prevent users from selecting non-stored fields as trigger fields

------------Steps----------
Steps to reproduce (opw-4207855):
1.) Create an automated action.
2.) Trigger: Set to "On Save."
3.) Leave "Before Update" and "Apply On" as default.
4.) When updating (trigger_field_ids): any non-stored field

Step to reproduce prior to pr (PR: #180965, opw-4106799)
1.) Create an automation rule on the Project model.
2.) Set Trigger to "On Save."
3.) Leave the remaining settings as default.
4.) Try to prioritize or deprioritize a project
5.) the project will not be starred until refreshed, or if clicked again, causing the rule to run twice (toggling the star each time).


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
