### PR TITLE
[FIX] hw_*: improve log error handling

### DIFF
--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -49,9 +49,8 @@ class ConnectionManager(Thread):
                 self.pairing_uuid = result['pairing_uuid']
             elif all(key in result for key in ['url', 'token', 'db_uuid', 'enterprise_code']):
                 self._connect_to_server(result['url'], result['token'], result['db_uuid'], result['enterprise_code'])
-        except Exception as e:
-            _logger.error('Could not reach iot-proxy.odoo.com')
-            _logger.error('A error encountered : %s ' % e)
+        except Exception:
+            _logger.exception('Could not reach iot-proxy.odoo.com')
 
     def _connect_to_server(self, url, token, db_uuid, enterprise_code):
         # Save DB URL and token

--- a/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
@@ -91,9 +91,8 @@ class KeyboardUSBDriver(Driver):
             server = server + '/iot/keyboard_layouts'
             try:
                 pm.request('POST', server, fields={'available_layouts': json.dumps(cls.available_layouts)})
-            except Exception as e:
-                _logger.error('Could not reach configured server')
-                _logger.error('A error encountered : %s ' % e)
+            except Exception:
+                _logger.exception('Could not reach configured server to send available layouts')
 
     @classmethod
     def load_layouts_list(cls):

--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -72,9 +72,8 @@ class Manager(Thread):
                         'Accept': 'text/plain',
                     },
                 )
-            except Exception as e:
-                _logger.error('Could not reach configured server')
-                _logger.error('A error encountered : %s ' % e)
+            except Exception:
+                _logger.exception('Could not reach configured server to send all IoT devices')
         else:
             _logger.warning('Odoo server not set')
 
@@ -105,8 +104,8 @@ class Manager(Thread):
                 i = interface()
                 i.daemon = True
                 i.start()
-            except Exception as e:
-                _logger.error("Error in %s: %s", str(interface), e)
+            except Exception:
+                _logger.exception("Interface %s could not be started", str(interface))
 
         # Set scheduled actions
         schedule and schedule.every().day.at("00:00").do(helpers.get_certificate_status)
@@ -123,7 +122,7 @@ class Manager(Thread):
                 schedule and schedule.run_pending()
             except Exception:
                 # No matter what goes wrong, the Manager loop needs to keep running
-                _logger.error(format_exc())
+                _logger.exception("Manager loop unexpected error")
 
 # Must be started from main thread
 if DBusGMainLoop:

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -158,9 +158,8 @@ def check_git_branch():
                     subprocess.check_call(git + ['remote', 'set-branches', 'origin', db_branch])
                     os.system('/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh')
 
-    except Exception as e:
-        _logger.error('Could not reach configured server')
-        _logger.error('A error encountered : %s ', e)
+    except Exception:
+        _logger.exception('An error occurred while trying to update the code with git')
 
 def check_image():
     """
@@ -207,7 +206,7 @@ def generate_password():
             subprocess.run(('sudo', 'cp', '/etc/shadow', '/root_bypass_ramdisks/etc/shadow'), check=True)
         return password
     except subprocess.CalledProcessError as e:
-        _logger.error("Failed to generate password: %s", e.output)
+        _logger.exception("Failed to generate password: %s", e.output)
         return 'Error: Check IoT log'
 
 
@@ -394,9 +393,8 @@ def download_iot_handlers(auto=True):
                     path = path_file(str(Path().joinpath(*drivers_path)))
                     zip_file = zipfile.ZipFile(io.BytesIO(resp.data))
                     zip_file.extractall(path)
-        except Exception as e:
-            _logger.error('Could not reach configured server')
-            _logger.error('A error encountered : %s ' % e)
+        except Exception:
+            _logger.exception('Could not reach configured server to download IoT handlers')
 
 def compute_iot_handlers_addon_name(handler_kind, handler_file_name):
     # TODO: replace with `removesuffix` (for Odoo version using an IoT image that use Python >= 3.9)
@@ -418,9 +416,8 @@ def load_iot_handlers():
                 module = util.module_from_spec(spec)
                 try:
                     spec.loader.exec_module(module)
-                except Exception as e:
-                    _logger.error('Unable to load file: %s ', file)
-                    _logger.error('An error encountered : %s ', e)
+                except Exception:
+                    _logger.exception('Unable to load handler file: %s', file)
     lazy_property.reset_all(http.root)
 
 def list_file_by_os(file_list):
@@ -471,8 +468,8 @@ def download_from_url(download_url, path_to_filename):
         request_response.raise_for_status()
         write_file(path_to_filename, request_response.content, 'wb')
         _logger.info('Downloaded %s from %s', path_to_filename, download_url)
-    except Exception as e:
-        _logger.error('Failed to download from %s: %s', download_url, e)
+    except Exception:
+        _logger.exception('Failed to download from %s', download_url)
 
 def unzip_file(path_to_filename, path_to_extract):
     """
@@ -489,5 +486,5 @@ def unzip_file(path_to_filename, path_to_extract):
                 zip_file.extractall(path_file(path_to_extract))
             Path(path).unlink()
         _logger.info('Unzipped %s to %s', path_to_filename, path_to_extract)
-    except Exception as e:
-        _logger.error('Failed to unzip %s: %s', path_to_filename, e)
+    except Exception:
+        _logger.exception('Failed to unzip %s', path_to_filename)

--- a/addons/hw_posbox_homepage/controllers/main.py
+++ b/addons/hw_posbox_homepage/controllers/main.py
@@ -387,7 +387,7 @@ class IoTboxHomepage(Home):
         except subprocess.CalledProcessError as e:
             raise Exception(e.output)
         except Exception as e:
-            _logger.error('A error encountered : %s ' % e)
+            _logger.exception("Flashing create partition failed")
             return Response(str(e), status=500)
 
     @http.route('/hw_proxy/perform_flashing_download_raspios', type='http', auth='none')
@@ -401,7 +401,7 @@ class IoTboxHomepage(Home):
             raise Exception(e.output)
         except Exception as e:
             self.clean_partition()
-            _logger.error('A error encountered : %s ' % e)
+            _logger.exception("Flashing download raspios failed")
             return Response(str(e), status=500)
 
     @http.route('/hw_proxy/perform_flashing_copy_raspios', type='http', auth='none')
@@ -415,7 +415,7 @@ class IoTboxHomepage(Home):
             raise Exception(e.output)
         except Exception as e:
             self.clean_partition()
-            _logger.error('A error encountered : %s ' % e)
+            _logger.exception("Flashing copy raspios failed")
             return Response(str(e), status=500)
 
     @http.route('/iot_restart_odoo_or_reboot', type='json', auth='none', cors='*', csrf=False)
@@ -428,7 +428,7 @@ class IoTboxHomepage(Home):
                 subprocess.call(['sudo', 'reboot'])
             return 'success'
         except Exception as e:
-            _logger.error('An error encountered : %s ', e)
+            _logger.exception("Failed to restart/reboot the IoT")
             return str(e)
 
     def _get_logger_effective_level_str(self, logger):


### PR DESCRIPTION
Before this commit:
 Some logger.error(...) were ambigious and would just catch the exception to log it's error name without much details.
 Therefore it was wasting time trying to figure the cause of the error as we lack the traceback details

After this commit:
 Most of them were switch to logger.exception which does add the Exception information to the logging messages automatically.
 Which include the error message alongside the full traceback. Log messages were also rewrote to be more comprehensive than the: "An error encountered"

Example of logs that would be improved:
```
2024-11-19 07:19:50,611 1138 ERROR ? odoo.addons.hw_drivers.tools.helpers: Unable to load file: PrinterInterface_L.py  
2024-11-19 07:19:50,612 1138 ERROR ? odoo.addons.hw_drivers.tools.helpers: An error encountered : (1280, 'Success')
``` 
