### PR TITLE
[IMP] website_sale_loyalty: filter irrelevant rewards

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -1319,19 +1319,20 @@ class SaleOrder(models.Model):
         elif program in self._get_applied_programs():
             return {'error': _('This program is already applied to this order.'), 'already_applied': True}
         elif program.reward_ids:
-            global_reward = program.reward_ids.filtered('is_global_discount')
+            global_rewards = program.reward_ids.filtered('is_global_discount')
             applied_global_reward = self._get_applied_global_discount()
-            if (
-                global_reward
-                and applied_global_reward
-                and self._best_global_discount_already_applied(applied_global_reward, global_reward)
-            ):
-                return {'error': _(
-                    'This discount (%(discount)s) is not compatible with "%(other_discount)s". '
-                    'Please remove it in order to apply this one.',
-                    discount=global_reward.description,
-                    other_discount=applied_global_reward.program_id.reward_ids.description,
-                )}
+            for global_reward in global_rewards:
+                if (
+                    global_reward
+                    and applied_global_reward
+                    and self._best_global_discount_already_applied(applied_global_reward, global_reward)
+                ):
+                    return {'error': _(
+                        'This discount (%(discount)s) is not compatible with "%(other_discount)s". '
+                        'Please remove it in order to apply this one.',
+                        discount=global_reward.description,
+                        other_discount=applied_global_reward.program_id.reward_ids.description,
+                    )}
         # Check for applicability from the program's triggers/rules.
         # This step should also compute the amount of points to give for that program on that order.
         status = self._program_check_compute_points(program)[program]

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -234,6 +234,15 @@ class SaleOrder(models.Model):
                         res[coupon] |= reward
                     else:
                         res[coupon] = reward
+
+        for coupon, rewards in list(res.items()):
+            if coupon.program_id.applies_on == 'current':
+                global_discounts = rewards.filtered(lambda r: (
+                    r.reward_type == 'discount' and r.discount_applicability == 'order'
+                ))
+                if global_discounts:
+                    res[coupon] -= global_discounts - max(global_discounts, key=lambda d: d.discount)
+
         return res
 
     def _cart_find_product_line(self, product_id, line_id=None, **kwargs):

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -237,15 +237,14 @@ class SaleOrder(models.Model):
 
         for coupon, rewards in list(res.items()):
             if coupon.program_id.applies_on == 'current':
-                global_discounts = rewards.filtered(lambda r: (
-                    r.reward_type == 'discount' and r.discount_applicability == 'order'
-                ))
-                if global_discounts:
-                    best_discount = global_discounts[0]
-                    for discount in global_discounts[1:]:
-                        if not self._best_global_discount_already_applied(best_discount, discount):
-                            best_discount = discount
-                    res[coupon] -= global_discounts - best_discount
+                discounts = rewards.filtered(
+                    lambda r: r.reward_type == 'discount' and r.discount_applicability == 'order')
+                if discounts:
+                    _, best_discount = min(
+                        (sum(value['price_unit'] for value in self._get_reward_values_discount(d, coupon)), d)
+                        for d in discounts
+                    )
+                    res[coupon] -= discounts - best_discount
 
         return res
 

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -241,7 +241,11 @@ class SaleOrder(models.Model):
                     r.reward_type == 'discount' and r.discount_applicability == 'order'
                 ))
                 if global_discounts:
-                    res[coupon] -= global_discounts - max(global_discounts, key=lambda d: d.discount)
+                    best_discount = global_discounts[0]
+                    for discount in global_discounts[1:]:
+                        if not self._best_global_discount_already_applied(best_discount, discount):
+                            best_discount = discount
+                    res[coupon] -= global_discounts - best_discount
 
         return res
 

--- a/addons/website_sale_loyalty/tests/__init__.py
+++ b/addons/website_sale_loyalty/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_free_product_reward
 from . import test_ewallet
 from . import test_website_sale_auto_invoice
 from . import test_shop_multi_reward
+from . import test_website_sale_loyalty_filter

--- a/addons/website_sale_loyalty/tests/test_website_sale_loyalty_filter.py
+++ b/addons/website_sale_loyalty/tests/test_website_sale_loyalty_filter.py
@@ -1,0 +1,185 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleLoyaltyFilter(TransactionCase):
+
+    def test_filter_irrelevant_global_discounts(self):
+        program = self.env['loyalty.program'].create({
+            'name': 'Global Promotions',
+            'program_type': 'promo_code',
+            'applies_on': 'current',
+            'trigger': 'auto',
+            'rule_ids': [
+                Command.create({
+                    'mode': 'with_code',
+                    'code': '12345',
+                    'reward_point_amount': 400,
+                }),
+            ],
+            'reward_ids': [
+                Command.create({
+                    'discount_applicability': 'order',
+                    'required_points': 100,
+                    'reward_type': 'discount',
+                    'discount': 10,
+                }),
+                Command.create({
+                    'discount_applicability': 'order',
+                    'required_points': 200,
+                    'reward_type': 'discount',
+                    'discount': 20,
+                }),
+                Command.create({
+                    'discount_applicability': 'order',
+                    'required_points': 300,
+                    'reward_type': 'discount',
+                    'discount': 30,
+                }),
+            ],
+        })
+
+        irrelevant_rewards = program.reward_ids[:2]
+        really_good_reward = program.reward_ids[2]
+
+        product = self.env['product.product'].create({
+            'name': "Some amazing product",
+            'list_price': 100,
+        })
+
+        partner = self.env['res.partner'].create({
+            'name': 'Test Partner',
+        })
+
+        order = self.env['sale.order'].create({
+            'partner_id': partner.id,
+            'order_line': [
+                Command.create({
+                    'product_id': product.id,
+                }),
+            ]
+        })
+
+        order._try_apply_code('12345')
+        res = order._get_claimable_and_showable_rewards()
+        all_rewards = self.env['loyalty.reward']
+        for reward in res.values():
+            all_rewards |= reward
+
+        self.assertIn(really_good_reward, all_rewards, "The best reward should be accessible to the customer")
+        self.assertFalse(bool(all_rewards & irrelevant_rewards), "The lesser attractive rewards should be filtered out")
+
+    def test_dont_filter_other_type_of_discount(self):
+        test_product = self.env['product.product'].create({
+            'name': "Test Product",
+            'list_price': 1234,
+        })
+        cheap_product = self.env['product.product'].create({
+            'name': "Cheap Product",
+            'list_price': 1,
+        })
+
+        global_program = self.env['loyalty.program'].create({
+            'name': 'Global Promotions',
+            'program_type': 'promotion',
+            'applies_on': 'current',
+            'trigger': 'auto',
+            'rule_ids': [
+                Command.create({
+                    'reward_point_amount': 300,
+                }),
+            ],
+            'reward_ids': [
+                Command.create({
+                    'discount_applicability': 'order',
+                    'required_points': 100,
+                    'reward_type': 'discount',
+                    'discount': 10,
+                }),
+                Command.create({
+                    'discount_applicability': 'order',
+                    'required_points': 300,
+                    'reward_type': 'discount',
+                    'discount': 30,
+                }),
+            ],
+        })
+        specific_program = self.env['loyalty.program'].create({
+            'name': '10% on Test Product',
+            'program_type': 'promotion',
+            'applies_on': 'current',
+            'trigger': 'auto',
+            'rule_ids': [
+                Command.create({
+                    'product_ids': test_product,
+                    'reward_point_amount': 100,
+                    'minimum_qty': 1,
+                }),
+            ],
+            'reward_ids': [
+                Command.create({
+                    'discount_applicability': 'specific',
+                    'required_points': 100,
+                    'reward_type': 'discount',
+                    'discount': 10,
+                    'discount_product_ids': test_product,
+                }),
+            ],
+        })
+        cheapest_program = self.env['loyalty.program'].create({
+            'name': '10% on Cheapest Product',
+            'program_type': 'promotion',
+            'applies_on': 'current',
+            'trigger': 'auto',
+            'rule_ids': [
+                Command.create({
+                    'product_ids': cheap_product,
+                    'minimum_qty': 1,
+                    'reward_point_amount': 100,
+                }),
+            ],
+            'reward_ids': [
+                Command.create({
+                    'discount_applicability': 'cheapest',
+                    'required_points': 100,
+                    'reward_type': 'discount',
+                    'discount': 10,
+                }),
+            ],
+        })
+
+        specific_reward = specific_program.reward_ids
+        cheapest_reward = cheapest_program.reward_ids
+        other_type_rewards = specific_reward | cheapest_reward
+        irrelevant_reward = global_program.reward_ids[0]
+        really_good_reward = global_program.reward_ids[1]
+
+        partner = self.env['res.partner'].create({
+            'name': 'Test Partner',
+        })
+
+        order = self.env['sale.order'].create({
+            'partner_id': partner.id,
+            'order_line': [
+                Command.create({
+                    'product_id': test_product.id,
+                }),
+                Command.create({
+                    'product_id': cheap_product.id,
+                }),
+            ]
+        })
+        order._update_programs_and_rewards()
+
+        res = order._get_claimable_and_showable_rewards()
+        all_rewards = self.env['loyalty.reward']
+        for reward in res.values():
+            all_rewards |= reward
+
+        self.assertIn(really_good_reward, all_rewards, "The best reward should be accessible to the customer")
+        self.assertTrue(other_type_rewards <= all_rewards, "The other types of reward should not be touched")
+        self.assertTrue(irrelevant_reward not in all_rewards, "The lesser attractive reward should be filtered out")


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Avoid showing useless rewards to customers:

If several rewards for the same program with no possibility to keep points for later (use point = current order)
Example:
- 10% in exchange of 1 pts
- 15% in exchange of 2 pts
- 20% in exchange of 3 pts
The customer will never take 10% or 15% (if they have 3 points)

Current behavior before PR:
On the checkout page, if several rewards exists for a program that applies on the current order only, all the rewards are shown.

Desired behavior after PR is merged:
On the checkout page, if several rewards exists for a program that applies on the current order only, only the "relevant" rewards are shown. This means,  any rewards that is not a `discount`, and that has the best discount possible.

task-4192041

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
