### PR TITLE
[FIX] hr_{contract,attendance}: disable employee buttons by company

### DIFF
--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -29,7 +29,7 @@
                         class="oe_stat_button"
                         icon="fa-history"
                         type="object"
-                        invisible="total_overtime == 0.0"
+                        invisible="total_overtime == 0.0 or company_id not in allowed_company_ids"
                         groups="hr_attendance.group_hr_attendance_officer">
                     <div class="o_stat_info">
                         <span class="o_stat_value text-success" invisible="total_overtime &lt; 0">
@@ -41,6 +41,24 @@
                         <span class="o_stat_text">Extra Hours</span>
                     </div>
                 </button>
+                <!-- same but disabled when employee company is not selected -->
+                <button name="action_open_last_month_overtime"
+                    class="oe_stat_button disabled"
+                    disabled="1"
+                    icon="fa-history"
+                    type="object"
+                    invisible="total_overtime == 0.0 or company_id in allowed_company_ids"
+                    groups="hr_attendance.group_hr_attendance_officer">
+                <div class="o_stat_info">
+                    <span class="o_stat_value text-success" invisible="total_overtime &lt; 0">
+                        <field name="total_overtime" widget="float_time"/>
+                    </span>
+                    <span class="o_stat_value text-danger" invisible="total_overtime &gt;= 0">
+                        <field name="total_overtime" widget="float_time"/>
+                    </span>
+                    <span class="o_stat_text">Extra Hours</span>
+                </div>
+            </button>
             </xpath>
             <xpath expr="//group[@name='managers']" position="inside">
                 <field name="attendance_manager_id" string="Attendance" widget="many2one_avatar_user"/>

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -46,7 +46,44 @@
                                 'default_resource_calendar_id': resource_calendar_id.id or False,
                                 'from_action_open_contract': True,
                             }"
-                            invisible="employee_type not in ['employee', 'student', 'trainee']">
+                            invisible="employee_type not in ['employee', 'student', 'trainee'] or company_id not in allowed_company_ids">
+                            <div invisible="not first_contract_date" class="o_stat_info">
+                                <span class="o_stat_text text-success" invisible="contract_warning" title="In Contract Since"> In Contract Since</span>
+                                <span class="o_stat_value text-success" invisible="contract_warning">
+                                    <field name="first_contract_date" readonly="1"/>
+                                </span>
+                                <span class="o_stat_text text-danger" invisible="not contract_warning" title="In Contract Since">
+                                    In Contract Since
+                                </span>
+                                <span class="o_stat_value text-danger" invisible="not contract_warning">
+                                    <field name="first_contract_date" readonly="1"/>
+                                </span>
+                            </div>
+                            <div invisible="first_contract_date" class="o_stat_info">
+                                <span class="o_stat_value text-danger">
+                                    <field name="contracts_count"/>
+                                </span>
+                                <span invisible="contracts_count != 1" class="o_stat_text text-danger" >
+                                    Contract
+                                </span>
+                                <span invisible="contracts_count == 1" class="o_stat_text text-danger">
+                                    Contracts
+                                </span>
+                            </div>
+                        </button>
+                        <!-- same but disabled for when the employee's company is not selected in the widget -->
+                        <button name="action_open_contract"
+                            class="oe_stat_button disabled"
+                            icon="fa-book"
+                            type="object"
+                            groups="hr_contract.group_hr_contract_manager"
+                            context="{
+                                'default_employee_id': id,
+                                'default_resource_calendar_id': resource_calendar_id.id or False,
+                                'from_action_open_contract': True,
+                            }"
+                            disabled="1"
+                            invisible="employee_type not in ['employee', 'student', 'trainee'] or company_id in allowed_company_ids">
                             <div invisible="not first_contract_date" class="o_stat_info">
                                 <span class="o_stat_text text-success" invisible="contract_warning" title="In Contract Since"> In Contract Since</span>
                                 <span class="o_stat_value text-success" invisible="contract_warning">

--- a/addons/hr_work_entry/views/hr_employee_views.xml
+++ b/addons/hr_work_entry/views/hr_employee_views.xml
@@ -8,13 +8,31 @@
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <field name="has_work_entries" invisible="1"/>
-                <button invisible="not has_work_entries" type="object" class="oe_stat_button" id="open_work_entries"
-                    icon="fa-calendar" name="action_open_work_entries">
+                <button invisible="not has_work_entries or company_id not in allowed_company_ids" 
+                    id="open_work_entries"
+                    icon="fa-calendar" 
+                    class="oe_stat_button" 
+                    type="object" 
+                    name="action_open_work_entries">
                     <div class="o_stat_info">
-                            <span class="o_stat_text">
-                            Work Entries
-                            </span>
-                        </div>
+                        <span class="o_stat_text">
+                        Work Entries
+                        </span>
+                    </div>
+                </button>
+                <!-- same but disabled when company not selected -->
+                <button invisible="not has_work_entries or company_id in allowed_company_ids" 
+                    id="open_work_entries"
+                    icon="fa-calendar" 
+                    class="oe_stat_button disabled" 
+                    disabled="1" 
+                    type="object" 
+                    name="action_open_work_entries">
+                    <div class="o_stat_info">
+                        <span class="o_stat_text">
+                        Work Entries
+                        </span>
+                    </div>
                 </button>
             </div>
         </field>


### PR DESCRIPTION
When on an employee form of an employee whose company is **not** one of
those selected in the top-right widget, the following buttons should be
disabled:
* contract
* work_entries
* goals (cf enterprise PR)
* extra_hours
* time off (cf https://github.com/odoo/odoo/commit/9897361fbad389eb3653a440fe97daa1eb61d244)

task-4307014
