### PR TITLE
[FIX] stock: use correct operator in PickingType._search_is_favorite

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -219,7 +219,7 @@ class StockPickingType(models.Model):
     def _search_is_favorite(self, operator, value):
         if operator not in ['=', '!='] or not isinstance(value, bool):
             raise NotImplementedError(_('Operation not supported'))
-        return [('favorite_user_ids', 'in' if (operator == '=') == value else 'in', self.env.uid)]
+        return [('favorite_user_ids', 'in' if (operator == '=') == value else 'not in', self.env.uid)]
 
     def _compute_is_favorite(self):
         for picking_type in self:


### PR DESCRIPTION
This was noticed in one of the B2B PRs: https://github.com/odoo/odoo/pull/150360#pullrequestreview-2315013726

Since the issue was not reported, I've created a PR to master. I can change the target branch to 17.3, if necessary.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
