### PR TITLE
[FIX] stock: create a return with the correct location_dest_id

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1125,6 +1125,7 @@ class Picking(models.Model):
         if vals.get('location_id'):
             after_vals['location_id'] = vals['location_id']
         if vals.get('location_dest_id'):
+
             after_vals['location_dest_id'] = vals['location_dest_id']
         if 'partner_id' in vals:
             after_vals['partner_id'] = vals['partner_id']


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1” with the following BoM:
    - type: subcontracting
    - subcontractor: Azure interior
    - Component: C1 - route in C1: resupply from subcontractor

- Create a purchase order for one unit of P1
- Confirm the PO
- Go to the created resupply transfer
- Validate it
- Create a return to WH/stock

Problem:
A picking is created with “Subcontracted location” as dest location instead of WH/stock

opw-4307119

