### PR TITLE
[FIX] point_of_sale: remove combo product margin

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1479,8 +1479,12 @@ class PosOrderLine(models.Model):
     @api.depends('price_subtotal', 'total_cost')
     def _compute_margin(self):
         for line in self:
-            line.margin = line.price_subtotal - line.total_cost
-            line.margin_percent = not float_is_zero(line.price_subtotal, precision_rounding=line.currency_id.rounding) and line.margin / line.price_subtotal or 0
+            if line.product_id.type == 'combo':
+                line.margin = 0
+                line.margin_percent = 0
+            else:
+                line.margin = line.price_subtotal - line.total_cost
+                line.margin_percent = not float_is_zero(line.price_subtotal, precision_rounding=line.currency_id.rounding) and line.margin / line.price_subtotal or 0
 
     def _prepare_tax_base_line_values(self, sign=1):
         """ Convert pos order lines into dictionaries that would be used to compute taxes later.

--- a/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
@@ -96,6 +96,9 @@ registry.category("web_tour.tours").add("PosComboPriceCheckTour", {
             ProductScreen.selectedOrderlineHas("Whiteboard Pen", "1.0", "0.96"),
             ProductScreen.totalAmountIs("7.00"),
             ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
         ].flat(),
 });
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1379,6 +1379,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             {
                 "available_in_pos": True,
                 "list_price": 7,
+                "standard_price": 10,
                 "name": "Desk Combo",
                 "type": "combo",
                 "taxes_id": False,
@@ -1391,6 +1392,9 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosComboPriceCheckTour', login="pos_user")
+        order = self.env['pos.order'].search([], limit=1)
+        self.assertEqual(order.lines.filtered(lambda l: l.product_id.type == 'combo').margin, 0)
+        self.assertEqual(order.lines.filtered(lambda l: l.product_id.type == 'combo').margin_percent, 0)
 
     def test_customer_display_as_public(self):
         self.main_pos_config.customer_display_type = 'remote'


### PR DESCRIPTION
If you create a product with a cost and type combo, and you sell it in the PoS. The margin would not be 0 but it should always be 0 as this is the combo product.

Steps to reproduce:
-------------------
* Create a product, and set a cost on it
* Change the product type to combo
* Open PoS and sell this product
* Go back to the order list
> Observation: On the order you just made you will see that the margin
for the combo product is not 0.

Why the fix:
------------
We make sure to always set the margin to 0 for combo products. Actually combo product should never have a cost, but if you set a cost before changing it's type to combo it would be the case.

opw-4171177
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
