### PR TITLE
[FIX] account: auto instanciate CoA for countries without any defined

### DIFF
--- a/addons/account/models/ir_module.py
+++ b/addons/account/models/ir_module.py
@@ -71,6 +71,7 @@ class IrModule(models.Model):
                 tname
                 for tname, tvals in self.account_templates.items()
                 if tvals['country_id'] == self.env.company.country_id.id
+                or not tvals['country_id']
             ), None))
         ):
             def try_loading(env):

--- a/addons/l10n_fr_account/models/template_mc.py
+++ b/addons/l10n_fr_account/models/template_mc.py
@@ -9,7 +9,6 @@ class AccountChartTemplate(models.AbstractModel):
     @template('mc')
     def _get_mc_template_data(self):
         return {
-            'name': 'Monaco',
             'code_digits': '6',
             'parent': 'fr',
         }


### PR DESCRIPTION
A previous fix[^1] prevents installing a wrong l10n if the country doesn't match. But it should still match if the template is not for a specific country.

For instance, Fiji should instanciate the generic CoA. If a better one should be installed instead, the hook will be overridden when the module will be installed thanks to the `countries` flag of the l10n manifests.

[^1]: 7f3a094a117477833b2814f0cfd3d574c6c22b53
