### PR TITLE
[FIX] web_editor: adjust cursor behavior for links at line end

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -84,6 +84,7 @@ import {
     ZERO_WIDTH_CHARS_REGEX,
     getAdjacentCharacter,
     isLinkEligibleForZwnbsp,
+    isZwnbsp,
 } from './utils/utils.js';
 import { editorCommands } from './commands/commands.js';
 import { Powerbox } from './powerbox/Powerbox.js';
@@ -4092,6 +4093,7 @@ export class OdooEditor extends EventTarget {
      * @private
      */
     _onKeyDown(ev) {
+        delete this._isNavigatingByMouse;
         const selection = this.document.getSelection();
         if (selection.anchorNode && isProtected(selection.anchorNode)) {
             return;
@@ -4388,6 +4390,40 @@ export class OdooEditor extends EventTarget {
             this.deselectTable();
         }
         const anchorNode = selection.anchorNode;
+        const isSelectionInEditable = this.isSelectionInEditable(selection);
+        if (this._isNavigatingByMouse && selection.isCollapsed && isSelectionInEditable) {
+            delete this._isNavigatingByMouse;
+            const { startContainer, startOffset, endContainer, endOffset } = getDeepRange(this.editable);
+            const linkElement = closestElement(startContainer, "a");
+            if (
+                linkElement &&
+                linkElement.textContent.startsWith("\uFEFF") &&
+                linkElement.textContent.endsWith("\uFEFF")
+            ) {
+                const linkDescendants = descendants(linkElement);
+
+                // Check if the cursor is positioned at the begining of link.
+                const isCursorAtStartOfLink = isZwnbsp(startContainer)
+                    ? linkDescendants.indexOf(startContainer) === 0
+                    : startContainer.nodeType === Node.TEXT_NODE &&
+                    linkDescendants.indexOf(startContainer) === 1 &&
+                    startOffset === 0;
+
+                // Check if the cursor is positioned at the end of link.
+                const isCursorAtEndOfLink = isZwnbsp(endContainer)
+                    ? linkDescendants.indexOf(endContainer) === linkDescendants.length - 1
+                    : endContainer.nodeType === Node.TEXT_NODE &&
+                    linkDescendants.indexOf(endContainer) === linkDescendants.length - 2 &&
+                    endOffset === nodeSize(endContainer);
+
+                // Handle selection movement.
+                if (isCursorAtStartOfLink || isCursorAtEndOfLink) {
+                    const block = closestBlock(linkElement);
+                    const linkIndex = [...block.childNodes].indexOf(linkElement);
+                    setSelection(block, isCursorAtStartOfLink ? linkIndex - 1 : linkIndex + 2);
+                }
+            }
+        }
         // Correct cursor if at editable root.
         if (
             selection.isCollapsed &&
@@ -4401,7 +4437,7 @@ export class OdooEditor extends EventTarget {
         if (
             selection.isCollapsed && anchorNode &&
             anchorNode.nodeName === "DIV" && anchorNode.innerHTML.trim() === "" &&
-            this.isSelectionInEditable(selection)
+            isSelectionInEditable
         ) {
             this._fixSelectionInEmptyDiv(selection);
             // The _onSelectionChange handler is going to be triggered again.
@@ -4410,7 +4446,6 @@ export class OdooEditor extends EventTarget {
         if (selection.rangeCount && selection.getRangeAt(0)) {
             this._handleSelectionInTable();
         }
-        const isSelectionInEditable = this.isSelectionInEditable(selection);
         if (!hasTableSelection(this.editable)) {
             this._updateToolbar(!selection.isCollapsed && isSelectionInEditable);
         }
@@ -4854,6 +4889,7 @@ export class OdooEditor extends EventTarget {
 
     _onMouseDown(ev) {
         this._currentMouseState = ev.type;
+        this._isNavigatingByMouse = true;
         this._lastMouseClickPosition = [ev.x, ev.y];
 
         if (this.canActivateContentEditable) {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1011,7 +1011,7 @@ export function getAdjacentCharacter(editable, side) {
     return closestBlock(focusNode) === originalBlock ? adjacentCharacter : undefined;
 }
 
-function isZwnbsp(node) {
+export function isZwnbsp(node) {
     return node.nodeType === Node.TEXT_NODE && node.textContent === '\ufeff';
 }
 

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -156,7 +156,7 @@ wTourUtils.registerWebsitePreviewTour('edit_link_popover', {
             actions.click();
             const el = this.$anchor[0];
             const sel = el.ownerDocument.getSelection();
-            sel.collapse(el, 0);
+            sel.collapse(el.childNodes[1], 1);
             el.focus();
         },
     },


### PR DESCRIPTION
Steps to reproduce:

- Set up the editor with a link at the end of a line.
- Refresh to start with fresh content.
- Place the cursor at the end of the line with the link.
- Notice that the cursor defaults inside the link, displaying the green overlay.
- Attempt to type after the link—this requires pressing right arrow key to exit.

Description of the issue/feature this PR addresses:

- Clicking at the end or start of a line with a link placed the cursor inside the link by default, displaying the green overlay.
- Typing outside the link required pressing the arrow key.

Current behavior before PR:

- Placing the cursor at the start or end of a line with a link now defaults to positioning it outside the link.
- Green overlay is no longer shown, enabling direct text entry beside link.
- Accessing the link requires an intentional left or right arrow key press.

task-4089085