### PR TITLE
[REF] web_tour: remove tour automatic callback from tour_service

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -33,7 +33,7 @@ export class TourAutomatic {
         return tourConfig.debug !== false;
     }
 
-    start(pointer, callback) {
+    start(pointer) {
         const macroSteps = this.steps
             .filter((step) => step.index >= this.currentIndex)
             .flatMap((step) => {
@@ -96,21 +96,37 @@ export class TourAutomatic {
                 ];
             });
 
+        const end = () => {
+            transitionConfig.disabled = false;
+            tourState.clear();
+            pointer.stop();
+        };
+
         const macro = {
             name: this.name,
             checkDelay: this.checkDelay,
             steps: macroSteps,
             onError: (error) => {
                 this.throwError(error);
-                transitionConfig.disabled = false;
-                callback();
+                console.error("tour not succeeded");
+                end();
             },
             onComplete: () => {
-                transitionConfig.disabled = false;
-                callback();
+                browser.console.log("tour succeeded");
+                // Used to see easily in the python console and to know which tour has been succeeded in suite tours case.
+                const succeeded = `║ TOUR ${this.name} SUCCEEDED ║`;
+                const msg = [succeeded];
+                msg.unshift("╔" + "═".repeat(succeeded.length - 2) + "╗");
+                msg.push("╚" + "═".repeat(succeeded.length - 2) + "╝");
+                browser.console.log(`\n\n${msg.join("\n")}\n`);
+                end();
             },
         };
-
+        if (this.debugMode) {
+            // Starts the tour with a debugger to allow you to choose devtools configuration.
+            // eslint-disable-next-line no-debugger
+            debugger;
+        }
         transitionConfig.disabled = true;
         //Activate macro in exclusive mode (only one macro per MacroEngine)
         this.macroEngine.activate(macro, true);

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -76,22 +76,6 @@ export const tourService = {
             sequence: 30,
         }));
 
-        function endTour({ name }) {
-            if (tourState.getCurrentTourOnError()) {
-                console.error("tour not succeeded");
-            } else {
-                // Used to signal the python test runner that the tour finished without error.
-                browser.console.log("tour succeeded");
-                // Used to see easily in the python console and to know which tour has been succeeded in suite tours case.
-                const succeeded = `║ TOUR ${name} SUCCEEDED ║`;
-                const msg = [succeeded];
-                msg.unshift("╔" + "═".repeat(succeeded.length - 2) + "╗");
-                msg.push("╚" + "═".repeat(succeeded.length - 2) + "╝");
-                browser.console.log(`\n\n${msg.join("\n")}\n`);
-            }
-            tourState.clear();
-        }
-
         function getTourFromRegistry(tourName) {
             let tour = null;
             if (tourRegistry.contains(tourName)) {
@@ -170,11 +154,6 @@ export const tourService = {
             tourState.setCurrentConfig(tourConfig);
             tourState.setCurrentTour(tour.name);
             tourState.setCurrentIndex(0);
-            if (tourConfig.debug !== false) {
-                // Starts the tour with a debugger to allow you to choose devtools configuration.
-                // eslint-disable-next-line no-debugger
-                debugger;
-            }
 
             const willUnload = callWithUnloadCheck(() => {
                 if (tour.url && tourConfig.startUrl != tour.url && tourConfig.redirect) {
@@ -214,14 +193,12 @@ export const tourService = {
             );
 
             if (tourConfig.mode === "auto") {
-                new TourAutomatic(tour).start(pointer, () => {
-                    pointer.stop();
-                    endTour(tour);
-                });
+                new TourAutomatic(tour).start(pointer);
             } else {
                 new TourInteractive(tour).start(pointer, async () => {
                     pointer.stop();
-                    endTour(tour);
+                    tourState.clear();
+                    browser.console.log("tour succeeded");
                     let message = tourConfig.rainbowManMessage || tour.rainbowManMessage;
                     if (message) {
                         message = window.DOMPurify.sanitize(tourConfig.rainbowManMessage);

--- a/addons/web_tour/static/src/tour_service/tour_step_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_step_automatic.js
@@ -47,7 +47,6 @@ export class TourStepAutomatic extends TourStep {
      * @returns {Boolean}
      */
     async doAction() {
-        clearTimeout(this._timeout);
         let result = false;
         if (!this.skipped) {
             // TODO: Delegate the following routine to the `ACTION_HELPERS` in the macro module.


### PR DESCRIPTION
In this commit, we move the tour_automatic callback in the tour_service to the tour_automatic class. This allows for clearer handling of tour error or success messages.
We take advantage of this commit to remove a small error (clearTimeout(this._timeout)) in the tour_step_automatic where this._timeout no longer exists.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
