### PR TITLE
[FIX] stock: fixed domain error when locations are None

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -258,14 +258,14 @@ class Product(models.Model):
 
         def _search_ids(model, values):
             ids = set()
-            domain = []
+            domains = []
             for item in values:
                 if isinstance(item, int):
                     ids.add(item)
                 else:
-                    domain = expression.OR([[(self.env[model]._rec_name, 'ilike', item)], domain])
-            if domain:
-                ids |= set(self.env[model].search(domain).ids)
+                    domains.append([(self.env[model]._rec_name, 'ilike', item)])
+            if domains:
+                ids |= set(self.env[model].search(expression.OR(domains)).ids)
             return ids
 
         # We may receive a location or warehouse from the context, either by explicit
@@ -303,22 +303,31 @@ class Product(models.Model):
         return self._get_domain_locations_new(location_ids)
 
     def _get_domain_locations_new(self, location_ids):
+        if not location_ids:
+            return [[expression.FALSE_LEAF]] * 3
         locations = self.env['stock.location'].browse(location_ids)
         # TDE FIXME: should move the support of child_of + auto_join directly in expression
-        loc_domain, dest_loc_domain = [], []
         # this optimizes [('location_id', 'child_of', locations.ids)]
         # by avoiding the ORM to search for children locations and injecting a
         # lot of location ids into the main query
-        for location in locations:
-            loc_domain = loc_domain and ['|'] + loc_domain or loc_domain
-            loc_domain.append(('location_id.parent_path', '=like', location.parent_path + '%'))
-            dest_loc_domain = dest_loc_domain and ['|'] + dest_loc_domain or dest_loc_domain
-            dest_loc_domain.append(('location_dest_id.parent_path', '=like', location.parent_path + '%'))
+        loc_domain = expression.OR([
+            [('location_id.parent_path', '=like', location.parent_path + '%')]
+            for location in locations
+        ])
+        dest_loc_domain = expression.OR([
+            [
+                '|',
+                '&', ('location_final_id', '!=', False), ('location_final_id.parent_path', '=like', location.parent_path + '%'),
+                '&', ('location_final_id', '=', False), ('location_dest_id.parent_path', '=like', location.parent_path + '%'),
+            ]
+            for location in locations
+        ])
 
+        # returns: (domain_quant_loc, domain_move_in_loc, domain_move_out_loc)
         return (
             loc_domain,
-            dest_loc_domain + ['!'] + loc_domain if loc_domain else dest_loc_domain,
-            loc_domain + ['!'] + dest_loc_domain if dest_loc_domain else loc_domain
+            dest_loc_domain + ['!'] + loc_domain,
+            loc_domain + ['!'] + dest_loc_domain,
         )
 
     def _search_qty_available(self, operator, value):


### PR DESCRIPTION
backport this commit:
https://github.com/odoo/odoo/pull/160979/

Issue Summary:

During the upgrade from Odoo version 16.0 to 17.0, a discrepancy has emerged in the product configuration, specifically with the "Buy" route.
The problem arises when computing the available quantity using the _compute_quantities_dict function.

see:
 odoo@6d8f184

Problem Description:

In version 17.0, when fetching the domain_Quant using the _get_domain_locations function, the domain returned is ('location_id', 'any', [(0, '=', 1)])
 if no locations are found.
In version 16.0, it returns an empty list [] if no locations are found. This change results in the domain_quant in version 17.0 being
 [('product_id', 'in', [2684, 5474, 5475, 5478, 5487, 5522]), ('location_id', 'any', [(0, '=', 1)])],
 which leads to {} values, whereas in version 16.0, the domain
 would be [('product_id', 'in', [2684, 5474, 5475, 5478, 5487, 5522])], which returns actual values.

Impact:

The inconsistency in the domain operation between versions results in incorrect or missing quantity data after the upgrade, affecting the accuracy of product availability.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
