### PR TITLE
[FIX] account: Show company-specific icon for settings fields

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -168,10 +168,10 @@
                                     </div>
                                 </div>
                             </setting>
-                            <setting id="total_amount_words" help="Display the total amount of an invoice in letters">
+                            <setting id="total_amount_words" company_dependent="1" help="Display the total amount of an invoice in letters">
                                 <field name="display_invoice_amount_total_words"/>
                             </setting>
-                            <setting id="display_invoice_tax_company_currency" help="Taxes are also displayed in local currency on invoices">
+                            <setting id="display_invoice_tax_company_currency" company_dependent="1" help="Taxes are also displayed in local currency on invoices">
                                 <field name="display_invoice_tax_company_currency"/>
                             </setting>
                         </block>


### PR DESCRIPTION
In Settings, the fields `total_amount_words` and `display_invoice_tax_company_currency` are linked to the company, but the "company-specific" icon was missing. Adding this icon informs users that enabling these settings only affects the currently selected company.

task-4297925

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
