### PR TITLE
[FIX] point_of_sale: prevent error when doing cash move

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1644,7 +1644,7 @@ export class PosStore extends Reactive {
     getReceiptHeaderData(order) {
         return {
             company: this.company,
-            cashier: _t("Served by %s", order.getCashierName() || this.get_cashier()?.name),
+            cashier: _t("Served by %s", order?.getCashierName() || this.get_cashier()?.name),
             header: this.config.receipt_header,
         };
     }


### PR DESCRIPTION
Before this commit, performing a cash move would cause an error due to a missing order when calling `getReceiptHeaderData`.

opw-4309610

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
