### PR TITLE
[FIX] hr_work_entry_contract: apply null safety check on contract calendar

### DIFF
--- a/addons/hr_calendar/models/res_partner.py
+++ b/addons/hr_calendar/models/res_partner.py
@@ -56,6 +56,7 @@ class Partner(models.Model):
 
         # Compute all work intervals per calendar
         for calendar, employees in employees_by_calendar.items():
+            calendar = calendar or self.env.company.resource_calendar_id # No calendar if fully flexible
             work_intervals = calendar._work_intervals_batch(start_period, stop_period, resources=employees, tz=timezone(calendar.tz))
             del work_intervals[False]
             # Merge all employees intervals to avoid to compute it multiples times
@@ -69,6 +70,7 @@ class Partner(models.Model):
         for employee, calendar_periods in calendar_periods_by_employee.items():
             employee_interval = Intervals([])
             for (start, stop, calendar) in calendar_periods:
+                calendar = calendar or self.env.company.resource_calendar_id # No calendar if fully flexible
                 interval = Intervals([(start, stop, self.env['resource.calendar'])])
                 if merge:
                     calendar_interval = interval_by_calendar[calendar]


### PR DESCRIPTION
**Issue:**
An employee can't access its calendar if it has a contract based on attendances with a null allowed value for its working schedule (fully flexible).

**Expected:**
An employee should be able to access its calendar.

**Steps to reproduce:**
- Activate Payroll app and presence based on attendances in employees' settings;
- Open or create a contract through the current user's employee's file;
- Set "Work Entry Source" to "Attendances" and leave "Working Schedule" empty;
- Try to access the Calendar app.

**Cause:**
No calendar found on a contract.
https://github.com/odoo/odoo/blob/18.0/addons/hr_work_entry_contract/models/hr_contract.py#L154
https://github.com/odoo/odoo/blob/18.0/addons/hr_work_entry_contract/models/hr_work_entry.py

**Fix:**
Retrieve a default temporary fully flexible calendar if none has been found on the contract.

**Linked:**
Enterprise PR:
https://github.com/odoo/enterprise/pull/73274

opw-4288878