### PR TITLE
[IMP] l10n_in_pos: Enforce 'Closing Entry by Product' and Restrict HSN/SAC Code Changes

### DIFF
--- a/addons/l10n_in_pos/models/__init__.py
+++ b/addons/l10n_in_pos/models/__init__.py
@@ -6,3 +6,4 @@ from . import product_template
 from . import account_move
 from . import account_tax
 from . import pos_bill
+from . import pos_config

--- a/addons/l10n_in_pos/models/account_move.py
+++ b/addons/l10n_in_pos/models/account_move.py
@@ -8,7 +8,7 @@ class AccountMove(models.Model):
     @api.depends('pos_session_ids')
     def _compute_l10n_in_state_id(self):
         res = super()._compute_l10n_in_state_id()
-        to_compute = self.filtered(lambda m: m.country_code == 'IN' and not m.l10n_in_state_id and m.journal_id.type == 'general' and m.pos_session_ids)
+        to_compute = self.filtered(lambda m: m.country_code == 'IN' and not m.l10n_in_state_id and m.journal_id.type == 'general' and (m.pos_session_ids or m.reversed_pos_order_id))
         for move in to_compute:
             move.l10n_in_state_id = move.company_id.state_id
         return res

--- a/addons/l10n_in_pos/models/pos_config.py
+++ b/addons/l10n_in_pos/models/pos_config.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class PosConfig(models.Model):
+    _inherit = 'pos.config'
+
+    def _get_closing_entry_by_product(self):
+        if self.company_id.account_fiscal_country_id.code == 'IN':
+            return True
+        return super()._get_closing_entry_by_product()

--- a/addons/l10n_in_pos/models/product_template.py
+++ b/addons/l10n_in_pos/models/product_template.py
@@ -1,6 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models
+from odoo.exceptions import UserError
+from odoo.tools.translate import _
 
 
 class ProductTemplate(models.Model):
@@ -12,3 +14,8 @@ class ProductTemplate(models.Model):
         if self.env.company.country_id.code == 'IN':
             fields += ['l10n_in_hsn_code']
         return fields
+
+    @api.onchange('l10n_in_hsn_code')
+    def _onchange_l10n_in_hsn_code(self):
+        if self._origin.l10n_in_hsn_code and self.env['pos.session'].search_count([("company_id.account_fiscal_country_id.code", "=", "IN"), ("state", "!=", "closed")]):
+            raise UserError(_("Unable to change the HSN/SAC code. Please ensure all POS sessions are closed before proceeding."))

--- a/addons/l10n_in_pos/views/res_config_settings_views.xml
+++ b/addons/l10n_in_pos/views/res_config_settings_views.xml
@@ -10,6 +10,14 @@
                     <span>Please note that the kiosk for INR currency only works with Razorpay terminal</span>
                 </div>
             </xpath>
+            <xpath expr="//setting[@id='pos_closeing_entry_by_product']/field[@name='pos_is_closing_entry_by_product']" position="attributes">
+                <attribute name="invisible">country_code == 'IN'</attribute>
+            </xpath>
+            <xpath expr="//setting[@id='pos_closeing_entry_by_product']" position="inside">
+                <div class="text-warning" invisible="country_code != 'IN'">
+                    <span>NOTE: This setting is activated by default for India.</span>
+                </div>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -1049,3 +1049,7 @@ class PosConfig(models.Model):
 
         if not param_model.get_param("point_of_sale.limited_customer_count"):
             param_model.set_param("point_of_sale.limited_customer_count", 100)
+
+    def _get_closing_entry_by_product(self):
+        self.ensure_one()
+        return self.is_closing_entry_by_product

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -938,7 +938,7 @@ class PosSession(models.Model):
                         # for taxes
                         tuple(base_line['record'].tax_ids_after_fiscal_position.flatten_taxes_hierarchy().ids),
                         tuple(base_line['tax_tag_ids'].ids),
-                        base_line['product_id'].id if self.config_id.is_closing_entry_by_product else False,
+                        base_line['product_id'].id if self.config_id._get_closing_entry_by_product() else False,
                     )
                     total_amount_currency += to_update['amount_currency']
                     sales[sale_key] = self._update_amounts(
@@ -949,7 +949,7 @@ class PosSession(models.Model):
                         },
                         order.date_order,
                     )
-                    if self.config_id.is_closing_entry_by_product:
+                    if self.config_id._get_closing_entry_by_product():
                         sales[sale_key] = self._update_quantities(sales[sale_key], base_line['quantity'])
 
                 # Combine tax lines


### PR DESCRIPTION
**Before this PR:**
- In the Indian localization, the POS configuration setting `Closing Entry by Product` was optional and could be deactivated by users.

**After this PR:**
- For Indian localization, the `Closing Entry by Product` setting is now mandatory and automatically activated. Users are restricted from deactivating this setting.
- Additionally, a validation restriction has been introduced for products. If a POS session is open and the user attempts to change the HSN/SAC code of a product, a validation error will be raised to prevent such changes during active sessions.

Related Enterprise: https://github.com/odoo/enterprise/pull/73276
Related Upgrade: https://github.com/odoo/upgrade/pull/6723

Task Id: 4193554
