### PR TITLE
[FIX] point_of_sale: fix cancel order confirmation

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -352,6 +352,7 @@ export class PosStore extends Reactive {
             order.uiState.displayed = false;
             await this.afterOrderDeletion();
         }
+        return orderIsDeleted;
     }
     async afterOrderDeletion() {
         this.set_order(this.get_open_orders().at(-1) || this.createNewOrder());

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -36,13 +36,14 @@ patch(PosStore.prototype, {
         return screen === "LoginScreen" ? "LoginScreen" : "FloorScreen";
     },
     async onDeleteOrder(order) {
+        const orderIsDeleted = await super.onDeleteOrder(...arguments);
         if (
+            orderIsDeleted &&
             this.config.module_pos_restaurant &&
             this.mainScreen.component.name !== "TicketScreen"
         ) {
             this.showScreen("FloorScreen");
         }
-        return super.onDeleteOrder(...arguments);
     },
     // using the same floorplan.
     async ws_syncTableCount(data) {

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -96,5 +96,13 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             NumberPopup.isShown("5"),
             Dialog.confirm(),
             ProductScreen.guestNumberIs("5"),
+
+            // Test Cancel Order Button
+            Dialog.cancel(),
+            Order.hasLine({ productName: "Water", quantity: "5" }),
+            ProductScreen.clickControlButton("Cancel Order"),
+            Dialog.confirm(),
+            Order.doesNotHaveLine(),
+            FloorScreen.isShown(),
         ].flat(),
 });


### PR DESCRIPTION
- Fixed an issue in `pos_restaurant` where canceling a non-empty order (from the actions menu) immediately cancel the order and go back to the floorplan without user confirmation (from the confirmation dialog).
Now, canceling an order will wait the user for confirmation, ensuring the order is not canceled prematurely.

- Add test tour to cancel an order (from actions menu)

task-id: 4155617



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
