### PR TITLE
[REF] point_of_sale,pos_hr,pos_viva_wallet: clean get_cashier method

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -173,7 +173,6 @@ export class ClosePosPopup extends Component {
         return true;
     }
     async closeSession() {
-        this.pos._resetConnectedCashier();
         if (this.pos.config.customer_display_type === "proxy") {
             const proxyIP = this.pos.getDisplayDeviceIP();
             fetch(`${deduceUrl(proxyIP)}/hw_proxy/customer_facing_display`, {

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
@@ -18,7 +18,7 @@ export class ProductInfoPopup extends Component {
     }
     _hasMarginsCostsAccessRights() {
         const isAccessibleToEveryUser = this.pos.config.is_margins_costs_accessible_to_every_user;
-        const isCashierManager = this.pos.get_cashier().role === "manager";
+        const isCashierManager = this.pos.cashier.user.role === "manager";
         return isAccessibleToEveryUser || isCashierManager;
     }
     editProduct() {

--- a/addons/point_of_sale/static/src/app/navbar/cashier_name/cashier_name.js
+++ b/addons/point_of_sale/static/src/app/navbar/cashier_name/cashier_name.js
@@ -2,7 +2,6 @@ import { Component, useState } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { useService } from "@web/core/utils/hooks";
 
-// Previously UsernameWidget
 export class CashierName extends Component {
     static template = "point_of_sale.CashierName";
     static props = {};
@@ -12,11 +11,10 @@ export class CashierName extends Component {
         this.ui = useState(useService("ui"));
     }
     get username() {
-        const cashier = this.pos.get_cashier();
-        return cashier ? cashier.name : "";
+        return this.pos.cashier.user.name || "";
     }
     get avatar() {
-        const user_id = this.pos.get_cashier_user_id();
+        const user_id = this.pos.cashier.user.id;
         const id = user_id ? user_id : -1;
         return `/web/image/res.users/${id}/avatar_128`;
     }

--- a/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.js
@@ -17,23 +17,16 @@ export class LoginScreen extends Component {
     }
 
     openRegister() {
-        this.selectUser();
-    }
-
-    selectUser() {
-        this.selectOneCashier(this.pos.user);
+        this.pos.setSessionCashierInfo({ userId: this.pos.user.id });
+        this.cashierLogIn();
     }
     cashierLogIn() {
+        this.pos.cashier.logged = true;
         const selectedScreen =
             this.pos.previousScreen && this.pos.previousScreen !== "LoginScreen"
                 ? this.pos.previousScreen
                 : this.pos.firstScreen;
         this.pos.showScreen(selectedScreen);
-        this.pos.hasLoggedIn = true;
-    }
-    selectOneCashier(cashier) {
-        this.pos.set_cashier(cashier);
-        this.cashierLogIn();
     }
     get backBtnName() {
         return _t("Backend");

--- a/addons/pos_hr/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
+++ b/addons/pos_hr/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
@@ -5,7 +5,7 @@ patch(CashMovePopup.prototype, {
     _prepare_try_cash_in_out_payload() {
         const result = super._prepare_try_cash_in_out_payload(...arguments);
         if (this.pos.config.module_pos_hr) {
-            const employee_id = this.pos.get_cashier().id;
+            const employee_id = this.pos.cashier.employee.id;
             result[result.length - 1] = { ...result[result.length - 1], employee_id };
         }
         return result;

--- a/addons/pos_hr/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/pos_hr/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -11,3 +11,10 @@ patch(ClosePosPopup, {
         });
     },
 });
+
+patch(ClosePosPopup.prototype, {
+    closeSession() {
+        this.pos.setSessionCashierInfo({ employeeId: false });
+        return super.closeSession(...arguments);
+    },
+});

--- a/addons/pos_hr/static/src/app/select_cashier_mixin.js
+++ b/addons/pos_hr/static/src/app/select_cashier_mixin.js
@@ -21,7 +21,7 @@ export function useCashierSelector({ exclusive, onScan } = { onScan: () => {}, e
                 );
                 if (
                     employee &&
-                    employee !== pos.get_cashier() &&
+                    employee !== pos.cashier.employee &&
                     (!employee._pin || (await checkPin(employee)))
                 ) {
                     onScan && onScan(employee);
@@ -85,7 +85,7 @@ export function useCashierSelector({ exclusive, onScan } = { onScan: () => {}, e
 
         let employee = false;
         const allEmployees = pos.models["hr.employee"].filter(
-            (employee) => employee.id !== pos.get_cashier()?.id
+            (employee) => employee.id !== pos.cashier.employee?.id
         );
         const pinMatchEmployees = allEmployees.filter(
             (employee) => !pin || Sha1.hash(pin) === employee._pin
@@ -129,7 +129,7 @@ export function useCashierSelector({ exclusive, onScan } = { onScan: () => {}, e
         }
 
         if (login && employee) {
-            pos.hasLoggedIn = true;
+            pos.cashier.logged = true;
             pos.set_cashier(employee);
         }
 

--- a/addons/pos_hr/static/src/overrides/components/cashier_name/cashier_name.js
+++ b/addons/pos_hr/static/src/overrides/components/cashier_name/cashier_name.js
@@ -10,11 +10,11 @@ patch(CashierName.prototype, {
     //@Override
     get avatar() {
         if (this.pos.config.module_pos_hr) {
-            const cashier = this.pos.get_cashier();
-            if (!(cashier && cashier.id)) {
+            const employee = this.pos.cashier.employee;
+            if (!(employee && employee.id)) {
                 return "";
             }
-            return `/web/image/hr.employee.public/${cashier.id}/avatar_128`;
+            return `/web/image/hr.employee.public/${employee.id}/avatar_128`;
         }
         return super.avatar;
     },
@@ -24,5 +24,8 @@ patch(CashierName.prototype, {
             return { oe_status: true };
         }
         return super.cssClass;
+    },
+    get username() {
+        return this.pos.cashier?.employee?.name || "";
     },
 });

--- a/addons/pos_hr/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_hr/static/src/overrides/components/payment_screen/payment_screen.js
@@ -3,8 +3,8 @@ import { patch } from "@web/core/utils/patch";
 
 patch(PaymentScreen.prototype, {
     async validateOrder(isForceValidate) {
-        if (this.pos.config.module_pos_hr && this.pos.get_cashier() === null) {
-            this.currentOrder.employee_id = this.pos.get_cashier();
+        if (this.pos.config.module_pos_hr && this.pos.cashier.employee === null) {
+            this.currentOrder.employee_id = this.pos.cashier.employee;
         }
 
         await super.validateOrder(...arguments);

--- a/addons/pos_hr/static/src/overrides/screens/login_screen/login_screen.js
+++ b/addons/pos_hr/static/src/overrides/screens/login_screen/login_screen.js
@@ -11,17 +11,18 @@ patch(LoginScreen.prototype, {
 
         this.state = useState({
             pin: "",
+            login: false,
         });
 
         if (this.pos.config.module_pos_hr) {
             this.selectCashier = useCashierSelector({
-                onScan: (employee) => employee && this.selectOneCashier(employee),
+                onScan: (employee) => employee && this.selectEmployee(employee),
                 exclusive: true,
             });
 
             useAutofocus();
             useExternalListener(window, "keypress", async (ev) => {
-                if (this.pos.login && ev.key === "Enter" && this.state.pin) {
+                if (this.state.login && ev.key === "Enter" && this.state.pin) {
                     await this.selectCashier(this.state.pin, true);
                 }
             });
@@ -29,15 +30,18 @@ patch(LoginScreen.prototype, {
 
         onWillUnmount(() => {
             this.state.pin = "";
-            this.pos.login = false;
+            this.state.login = false;
         });
     },
+    selectEmployee(employee) {
+        this.pos.cashier.employee = employee;
+    },
     unlockRegister() {
-        this.pos.login = true;
+        this.state.login = true;
     },
     openRegister() {
         if (this.pos.config.module_pos_hr) {
-            this.pos.login = true;
+            this.state.login = true;
         } else {
             super.openRegister();
         }
@@ -48,9 +52,9 @@ patch(LoginScreen.prototype, {
             return;
         }
 
-        if (this.pos.login) {
+        if (this.state.login) {
             this.state.pin = "";
-            this.pos.login = false;
+            this.state.login = false;
         } else {
             const employee = await this.selectCashier();
             if (
@@ -63,6 +67,8 @@ patch(LoginScreen.prototype, {
         }
     },
     get backBtnName() {
-        return this.pos.login && this.pos.config.module_pos_hr ? _t("Discard") : super.backBtnName;
+        return this.state.login && this.pos.config.module_pos_hr
+            ? _t("Discard")
+            : super.backBtnName;
     },
 });

--- a/addons/pos_hr/static/src/overrides/screens/login_screen/login_screen.xml
+++ b/addons/pos_hr/static/src/overrides/screens/login_screen/login_screen.xml
@@ -2,10 +2,10 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_hr.LoginScreen" t-inherit="point_of_sale.LoginScreen" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('screen-login')]" position="attributes">
-            <attribute name="t-if">!this.pos.config.module_pos_hr || !this.pos.login</attribute>
+            <attribute name="t-if">!this.pos.config.module_pos_hr || !this.state.login</attribute>
         </xpath>
         <xpath expr="//div[hasclass('screen-login')]" position="after">
-            <div t-if="this.pos.config.module_pos_hr and this.pos.login" class="screen-login flex-grow-1 d-flex align-items-center justify-content-center">
+            <div t-if="this.pos.config.module_pos_hr and this.state.login" class="screen-login flex-grow-1 d-flex align-items-center justify-content-center">
                 <div class="d-flex bg-white p-3 gap-2 rounded">
                     <input t-model="this.state.pin"
                         t-ref="autofocus"

--- a/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
+++ b/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
@@ -80,7 +80,7 @@ export class PaymentVivaWallet extends PaymentInterface {
         var data = {
             sessionId: line.sessionId,
             terminalId: line.payment_method_id.viva_wallet_terminal_id,
-            cashRegisterId: this.pos.get_cashier().name,
+            cashRegisterId: this.pos.cashier.user.name,
             amount: roundPrecision(line.amount * 100),
             currencyCode: this.pos.currency.iso_numeric.toString(),
             merchantReference: line.sessionId + "/" + this.pos.session.id,
@@ -103,7 +103,7 @@ export class PaymentVivaWallet extends PaymentInterface {
 
         var data = {
             sessionId: line.sessionId,
-            cashRegisterId: this.pos.get_cashier().name,
+            cashRegisterId: this.pos.cashier.user.name,
         };
         return this._call_viva_wallet(data, "viva_wallet_send_payment_cancel").then((data) => {
             this._viva_wallet_handle_response(data);


### PR DESCRIPTION
Before this commit `get_cashier` was returning different objects depending on which modules was installed.

When pos_hr was installed, `get_cashier` was returning the `hr.employee` object, when pos_hr was not installed, `get_cashier` was returning the `res.users` object.

In this commit, `get_cashier` will always return this:

```js
{
    user: "res.users",
    employee: "hr.employee",
    logged: "boolean"
}
```