### PR TITLE
[FIX] sale_{margin,stock_margin}: find margin when line added from delivery

### DIFF
--- a/addons/sale_margin/models/sale_order_line.py
+++ b/addons/sale_margin/models/sale_order_line.py
@@ -38,5 +38,11 @@ class SaleOrderLine(models.Model):
     @api.depends('price_subtotal', 'product_uom_qty', 'purchase_price')
     def _compute_margin(self):
         for line in self:
-            line.margin = line.price_subtotal - (line.purchase_price * line.product_uom_qty)
-            line.margin_percent = line.price_subtotal and line.margin/line.price_subtotal
+            # Find alternative calculation when line is added to order from delivery
+            if line.qty_delivered and not line.product_uom_qty:
+                calculated_subtotal = line.price_unit * line.qty_delivered
+                line.margin = calculated_subtotal - (line.purchase_price * line.qty_delivered)
+                line.margin_percent = calculated_subtotal and line.margin / calculated_subtotal
+            else:
+                line.margin = line.price_subtotal - (line.purchase_price * line.product_uom_qty)
+                line.margin_percent = line.price_subtotal and line.margin / line.price_subtotal

--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, models
 
 
 class SaleOrderLine(models.Model):
@@ -9,18 +9,20 @@ class SaleOrderLine(models.Model):
 
     @api.depends('move_ids', 'move_ids.stock_valuation_layer_ids', 'move_ids.picking_id.state')
     def _compute_purchase_price(self):
-        lines_without_moves = self.browse()
+        line_ids_to_pass = set()
         for line in self:
+            # ignore lines without moves or lines for std cost products (no valuation action needed)
+            if (not line.has_valued_move_ids() or
+                line.product_id.with_company(line.company_id).categ_id.property_cost_method == 'standard'
+            ):
+                line_ids_to_pass.add(line.id)
+                continue
             product = line.product_id.with_company(line.company_id)
-            if not line.has_valued_move_ids():
-                lines_without_moves |= line
-            elif product and product.categ_id.property_cost_method != 'standard':
-                purch_price = product._compute_average_price(0, line.product_uom_qty, line.move_ids)
-                if line.product_uom and line.product_uom != product.uom_id:
-                    purch_price = product.uom_id._compute_price(purch_price, line.product_uom)
-                to_cur = line.currency_id or line.order_id.currency_id
-                line.purchase_price = line._convert_to_sol_currency(
-                    purch_price,
-                    product.cost_currency_id,
-                )
-        return super(SaleOrderLine, lines_without_moves)._compute_purchase_price()
+            purch_price = product._compute_average_price(0, line.product_uom_qty, line.move_ids)
+            if line.product_uom != product.uom_id:
+                purch_price = product.uom_id._compute_price(purch_price, line.product_uom)
+            line.purchase_price = line._convert_to_sol_currency(
+                purch_price,
+                product.cost_currency_id,
+            )
+        return super(SaleOrderLine, self.browse(line_ids_to_pass))._compute_purchase_price()


### PR DESCRIPTION
**Current behavior:**
Adding a product which is invoiced based on delivered
quantities to the delivery of a sale which has already been
confirmed, then validating the delivery, does not reflect the
change in price (which will be invoiced) on the sale order.

**Expected behavior:**
The sale order should show the actual amount of money to be
charged to the orderer.

**Steps to reproduce:**
1. Create a stored product with some price and change its
invoicing policy to 'delivery'

2. Create a new sale order, add 1 of the created product,
then confirm it

3. Open the delivery, add another line to it for the same
created product, fill in the quantities for each move, then
validate the picking

4. Check the sale order line to see that, while the price unit
is populated with the product's price, the subtotal/total fields
are not

**Cause of the issue:**
Order lines added in this manner have `product_uom_qty == 0`
which will zero-out the price computation.

**Fix:**
First, `_compute_purchase_price` is modified such that lines for
standard cost product will have a value computed (where
previously they were skipped).

Then for `_compute_margin`:
use `qty_delivered` and an on-the-fly calculated
`price_subtotal` to find a margin value for a SOL added from a
delivery (which is determined when `product_uom_qty == 0` and
`qty_delivered != 0`

opw-4210056