### PR TITLE
[PERF] stock: improve perf of _get_report_lines

### DIFF
--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -344,13 +344,16 @@ class StockForecasted(models.AbstractModel):
             for out in out_moves:
                 data = _get_out_move_taken_from_stock_data(out, currents, moves_data[out])
                 moves_data[out].update(data)
+        product_sum = defaultdict(float)
+        for product_loc, quantity in currents.items():
+            product_sum[product_loc[0]] += quantity
         lines = []
         for product in (ins | outs).product_id:
             product_rounding = product.uom_id.rounding
             unreconciled_outs = []
             # remaining stock
             free_stock = currents[product.id, wh_stock_location.id]
-            transit_stock = sum([v if k[0] == product.id else 0 for k, v in currents.items()]) - free_stock
+            transit_stock = product_sum[product.id] - free_stock
             # add report lines and see if remaining demand can be reconciled by unreservable stock or ins
             for out in outs_per_product[product.id]:
                 reserved_out = moves_data[out].get('reserved')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Improve  _get_report_lines performance

Current behavior before PR:
- A lag is seen when opening Manufacturing orders, because it goes to compute `components_availability`, calling
https://github.com/odoo/odoo/blob/0d3ab1203ad00e2c41768f3209e45cd673e519e7/addons/mrp/models/mrp_production.py#L344 function, which ends up calling https://github.com/odoo/odoo/blob/0d3ab1203ad00e2c41768f3209e45cd673e519e7/addons/stock/report/stock_forecasted.py#L190 
- currently, in `_get_report_lines` function, **transit_stock**
https://github.com/odoo/odoo/blob/0d3ab1203ad00e2c41768f3209e45cd673e519e7/addons/stock/report/stock_forecasted.py#L353  is calculated by summing quantities with list comprehension on the **currents** dictionary for each product.
https://github.com/odoo/odoo/blob/0d3ab1203ad00e2c41768f3209e45cd673e519e7/addons/stock/report/stock_forecasted.py#L327  
- This becomes slow when handling huge number of products and large currents entries. due to O(n * m) complexity

Desired behavior after PR is merged:
- A dictionary of pre-computed product quantity, minimizes the time taken.

### Here are few benchmarks and stats.

**At time of function call :** 
- As the test database is populated with 2 location ids `_get_report_lines` is called twice during testing, because of https://github.com/odoo/odoo/blob/6e9ace2df2dd3750472c227f818d3dc8d5ba5016/addons/stock/models/stock_move.py#L515-L517
- size of currents dict :  2539 + 2600 
- No. of product :  2539 + 2412

## Before
![before](https://github.com/user-attachments/assets/f99c11b3-ee11-4b09-80c1-e769589b6156)

## After
![after](https://github.com/user-attachments/assets/597687dc-fc1f-452f-b5a5-e5579880ed61)

opw- 4285618
upg- 2179723

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
