### PR TITLE
[FIX] account: allow group group_account_basic to create account tags

### DIFF
--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -74,6 +74,7 @@ access_account_tag_internal_user,account.account.tag internal user,model_account
 access_account_account_tax,account.account.tag,model_account_account_tag,account.group_account_user,1,1,1,1
 access_account_account_tax_readonly,account.account.tag,model_account_account_tag,account.group_account_readonly,1,0,0,0
 access_account_account_tax_user,account.account.tag,model_account_account_tag,account.group_account_invoice,1,0,0,0
+access_account_account_tax_basic,account.account.tag,model_account_account_tag,account.group_account_basic,1,0,1,0
 access_account_tax_repartition_line_user,account.tax repartition.line.user,model_account_tax_repartition_line,base.group_user,1,0,0,0
 access_account_tax_repartition_line_readonly,account.tax repartition.line.invoice,model_account_tax_repartition_line,account.group_account_readonly,1,0,0,0
 access_account_tax_repartition_line_invoice,account.tax repartition.line.invoice,model_account_tax_repartition_line,account.group_account_invoice,1,0,0,0


### PR DESCRIPTION
Steps to reproduce the issue:
1. On a new database, Install and open `industry_real_estate`
2. Try to add a column

The error:
The user is unable to create the column, because he does not have the access rights to create `account.account.tag` records.

Why it's happening:
By default, if we install `industry_real_estate`, it will also install `account` (Invoicing) which adds the user to the `group_account_basic` group. This group does not have access to create `account.account.tag`.

More context:
 In 17.2, this error didn't exist because, when installing `account` (Invoicing), the user was added to the group `group_account_user`, which had the right to create `account.account.tag` records. However, the accounting access rights have been refactored in 17.4 to add the new group `group_account_basic` for more granular access rights, which prevented some actions including creating `account.account.tag` records. Note that in 17.4, the user will be added to `group_account_user` after installing `account_accountant` (Accounting), and this is why the error is only present if we didn't install Accounting.

The fix:
Allow the group `account_group_basic` to create `account.account.tag` records.

opw-4274755
