### PR TITLE
[FIX] website: check missing zoomable elements

### DIFF
--- a/addons/website/static/src/js/content/website_root.js
+++ b/addons/website/static/src/js/content/website_root.js
@@ -37,9 +37,12 @@ export const WebsiteRoot = publicRootData.PublicRoot.extend({
      * @override
      */
     start: function () {
-        // Enable magnify on zommable img
-        this.$('.zoomable img[data-zoom]').zoomOdoo();
+        // Enable magnify on zoomable img
+        var zoomable_elements = this.$('.zoomable img[data-zoom]')
+        if (zoomable_elements.zoomOdoo === undefined)
+            return this;
 
+        zoomable_elements.zoomOdoo();
         return this._super.apply(this, arguments);
     },
 


### PR DESCRIPTION
Steps to reproduce:
- Sign app > Upload PDF > Add a 'Signature' field > Send > Cancel
- In mailhog open the email > Click 'Sign Document'
- Redirected to 404 as expected
- Traceback '$(...).zoomOdoo is not a function'

No zoomable elements are found by JQuery on the 404 redirection page, meaning the functions which assume such an element must exist cause an error. The option to cancel sign requests is available in saas-17.4 and above only.

opw-4261794

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
