### PR TITLE
[FIX] mail: discuss_channel_tour tour

### DIFF
--- a/addons/mail/data/web_tour_tour.xml
+++ b/addons/mail/data/web_tour_tour.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="discuss_channel_tour" model="web_tour.tour">
         <field name="name">discuss_channel_tour</field>
-        <field name="sequence">80</field>
-        <field name="url">/odoo/action-mail.action_discuss</field>
+        <field name="sequence">2000</field>
+        <field name="url">/odoo</field>
     </record>
 </odoo>

--- a/addons/mail/static/src/js/tours/discuss_channel_tour.js
+++ b/addons/mail/static/src/js/tours/discuss_channel_tour.js
@@ -4,8 +4,15 @@ import { registry } from "@web/core/registry";
 import { markup } from "@odoo/owl";
 
 registry.category("web_tour.tours").add("discuss_channel_tour", {
-    url: "/odoo/action-mail.action_discuss",
+    url: "/odoo",
     steps: () => [
+        {
+            isActive: ["enterprise"],
+            trigger: "a[data-menu-xmlid='mail.menu_root_discuss']",
+            content: _t("Open Discuss App"),
+            tooltipPosition: "bottom",
+            run: "click",
+        },
         {
             trigger: ".o-mail-DiscussSidebarCategory-channel .o-mail-DiscussSidebarCategory-add",
             content: markup(


### PR DESCRIPTION
In this commit, we fix the sequence and the url of discuss_channel_tour tour with the aim to start in last position after all the functional and with the aim to see the baball  on the app.

task~4309858

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
