### PR TITLE
[POC] payment: queue payment data for asynchronous processing

### DIFF
--- a/addons/payment/data/payment_cron.xml
+++ b/addons/payment/data/payment_cron.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <record model="ir.cron" id="cron_process_payment_data">
+        <field name="name">Payment: Process payment data</field>
+        <field name="model_id" ref="payment.model_payment_data" />
+        <field name="state">code</field>
+        <field name="code">model._cron_process()</field>
+        <field name="user_id" ref="base.user_root" />
+        <field name="interval_number">999999</field>
+        <field name="interval_type">hours</field>
+    </record>
+
     <record model="ir.cron" id="cron_post_process_payment_tx">
         <field name="name">Payment: Post-process transactions</field>
         <field name="model_id" ref="payment.model_payment_transaction" />

--- a/addons/payment/models/__init__.py
+++ b/addons/payment/models/__init__.py
@@ -2,6 +2,7 @@
 
 from . import ir_http
 from . import onboarding_step
+from . import payment_data
 from . import payment_method
 from . import payment_provider
 from . import payment_token

--- a/addons/payment/models/payment_data.py
+++ b/addons/payment/models/payment_data.py
@@ -1,0 +1,27 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class PaymentData(models.Model):
+    _description = "Payment Data"
+
+    provider_code = fields.Char(required=True)
+    payload = fields.Json(string="Payload", required=True)
+
+    def _cron_process(self):
+        """ Trigger the processing of payment data to update the transaction.
+
+        :return: None
+        """
+        data_to_process = self
+        if not data_to_process:
+            data_to_process = self.env['payment.data'].search([])
+
+        for payment_data in data_to_process:
+            payment_data = payment_data[0]  # Avoid pre-fetching after each cache invalidation.
+            self.env['payment.transaction']._handle_notification_data(
+                payment_data.provider_code, payment_data.payload, postpone=False
+            )
+            payment_data.unlink()
+            self.env.cr.commit()  # Commit to mitigate an eventual cron kill.

--- a/addons/payment/security/ir.model.access.csv
+++ b/addons/payment/security/ir.model.access.csv
@@ -1,6 +1,7 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_payment_link_wizard,access_payment_link_wizard,payment.model_payment_link_wizard,base.group_user,0,0,0,0
 payment_capture_wizard_user,payment.capture.wizard,model_payment_capture_wizard,base.group_user,1,1,1,0
+payment_data_system,payment.data.system,model_payment_data,base.group_system,1,1,1,1
 payment_provider_onboarding_wizard,payment.provider.onboarding.wizard,model_payment_provider_onboarding_wizard,base.group_system,1,1,1,0
 payment_provider_system,payment.provider.system,model_payment_provider,base.group_system,1,1,1,1
 payment_method_public,payment.method.all,model_payment_method,base.group_public,1,0,0,0


### PR DESCRIPTION
Currently, payment data processing occurs directly in the transaction flow, which can lead to race conditions when multiple requests attempt to process the same transaction simultaneously. It can typically happen when payment data are received asynchronously through a webhook: the webhook processes the data and commits, while the other thread tries to do the same with the payment response, sometimes right after requesting the payment (e.g., `the /payment/adyen/payments` controller, any call to the `_send_payment_request` method), encounters a serialization error, causing a retry for the second thread to commit. In the worst cases, the payment request is also retried.

This task aims to implement a queuing system for payment data processing that will:
- Prevent concurrent processing conflicts and their consequences.
- Allow for simpler test infrastructure due to fewer `cr.commit()` and easily reproducible flows (compared to triggering serialization errors).

task-4309611