### PR TITLE
[IMP] account: enable copy of account report expressions

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -691,6 +691,10 @@ class AccountReportExpression(models.Model):
 
         return result
 
+    def copy_data(self, default=None):
+        vals_list = super().copy_data(default=default)
+        return [dict(vals, label=self.env._("%s (copy)", expression.label)) for expression, vals in zip(self, vals_list)]
+
     @api.ondelete(at_uninstall=False)
     def _unlink_archive_used_tags(self):
         """


### PR DESCRIPTION
this commit enables the copy of account report expressions. This is currently not possible because the name is copied with the same value and a constraint states that the name must be unique.

task-3748928




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
