### PR TITLE
[IMP] website_sale(_stock): little improvements

### DIFF
--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -6,6 +6,7 @@ from odoo.tests import tagged
 from odoo.addons.sale.tests.test_sale_product_attribute_value_config import (
     TestSaleProductAttributeValueCommon,
 )
+from odoo.addons.website.tools import MockRequest
 
 
 @tagged('post_install', '-at_install', 'product_attribute')
@@ -21,6 +22,13 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         cls.other_currency = cls.setup_other_currency('GBP')
 
     def test_get_combination_info(self):
+        # Setup website.
+        website = self.env['website'].create({
+            'name': "Test website",
+            'company_id': self.env.company.id,
+            'user_id': self.env.user.id,
+        })
+
         # Setup pricelist: make sure the pricelist has a 10% discount
         self.env['product.pricelist'].search([]).action_archive()
         pricelist = self.env['product.pricelist'].create({
@@ -31,14 +39,7 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
                 'price_discount': 10,
                 'compute_price': 'formula',
             })],
-        })
-
-        # Setup website.
-        website = self.env['website'].create({
-            'name': "Test website",
-            'company_id': self.env.company.id,
-            'user_id': self.env.user.id,
-            'pricelist_ids': [Command.set(pricelist.ids)],
+            'website_id': website.id,
         })
 
         # Setup product with 15% tax.
@@ -53,18 +54,19 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         currency_ratio = 2
 
         # CASE: B2B setting (default)
-        combination_info = product_template._get_combination_info()
-        self.assertEqual(combination_info['price'], 2222 * discount_rate * currency_ratio)
-        self.assertEqual(combination_info['list_price'], 2222 * currency_ratio)
-        self.assertEqual(combination_info['has_discounted_price'], True)
+        with MockRequest(product_template.env, website=website, website_sale_current_pl=pricelist.id):
+            combination_info = product_template._get_combination_info()
+            self.assertEqual(combination_info['price'], 2222 * discount_rate * currency_ratio)
+            self.assertEqual(combination_info['list_price'], 2222 * currency_ratio)
+            self.assertEqual(combination_info['has_discounted_price'], True)
 
-        # CASE: B2C setting
-        website.show_line_subtotals_tax_selection = 'tax_included'
+            # CASE: B2C setting
+            website.show_line_subtotals_tax_selection = 'tax_included'
 
-        combination_info = product_template._get_combination_info()
-        self.assertEqual(combination_info['price'], 2222 * discount_rate * currency_ratio * tax_ratio)
-        self.assertAlmostEqual(combination_info['list_price'], 2222 * currency_ratio * tax_ratio)
-        self.assertEqual(combination_info['has_discounted_price'], True)
+            combination_info = product_template._get_combination_info()
+            self.assertEqual(combination_info['price'], 2222 * discount_rate * currency_ratio * tax_ratio)
+            self.assertAlmostEqual(combination_info['list_price'], 2222 * currency_ratio * tax_ratio)
+            self.assertEqual(combination_info['has_discounted_price'], True)
 
     def test_get_combination_info_with_fpos(self):
         # Setup product.
@@ -78,11 +80,19 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
             'company_id': self.env.company.id,
         })
 
+        # Setup website.
+        website = self.env['website'].create({
+            'name': "Test website",
+            'company_id': self.env.company.id,
+            'user_id': self.env.user.id,
+        })
+
         # Setup pricelist: make sure the pricelist has a 10% discount
         self.env['product.pricelist'].search([]).action_archive()
         pricelist = self.env['product.pricelist'].create({
             'name': "test_get_combination_info",
             'company_id': self.env.company.id,
+            'website_id': website.id,
             'item_ids': [Command.create({
                 'applied_on': "1_product",
                 'base': "list_price",
@@ -90,14 +100,6 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
                 'fixed_price': 500,
                 'product_tmpl_id': product.id,
             })],
-        })
-
-        # Setup website.
-        website = self.env['website'].create({
-            'name': "Test website",
-            'company_id': self.env.company.id,
-            'user_id': self.env.user.id,
-            'pricelist_ids': [Command.set(pricelist.ids)],
         })
 
         product = product.with_context(website_id=website.id)
@@ -113,7 +115,8 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         # Enable tax included
         website.show_line_subtotals_tax_selection = 'tax_included'
 
-        combination_info = product._get_combination_info()
+        with MockRequest(product.env, website=website):
+            combination_info = product._get_combination_info()
         self.assertEqual(combination_info['price'], 575, "500$ + 15% tax")
         self.assertEqual(combination_info['list_price'], 2530, "500$ + 15% tax (2)")
 
@@ -133,7 +136,8 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         # Now with fiscal position, taxes should be mapped
         self.env.user.partner_id.country_id = us_country
         website.invalidate_recordset(['fiscal_position_id'])
-        combination_info = product._get_combination_info()
+        with MockRequest(product.env, website=website):
+            combination_info = product._get_combination_info()
         self.assertEqual(combination_info['price'], 500, "500% + 0% tax (mapped from fp 15% -> 0%)")
         self.assertEqual(combination_info['list_price'], 2200, "500% + 0% tax (mapped from fp 15% -> 0%)")
 
@@ -143,19 +147,22 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         # Reset / Safety check
         self.env.user.partner_id.country_id = None
         website.invalidate_recordset(['fiscal_position_id'])
-        combination_info = product._get_combination_info()
+        with MockRequest(product.env, website=website):
+            combination_info = product._get_combination_info()
         self.assertEqual(combination_info['price'], 500, "434.78$ + 15% tax")
         self.assertEqual(combination_info['list_price'], 2200, "434.78$ + 15% tax (2)")
 
         # Now with fiscal position, taxes should be mapped
         self.env.user.partner_id.country_id = us_country.id
         website.invalidate_recordset(['fiscal_position_id'])
-        combination_info = product._get_combination_info()
+        with MockRequest(product.env, website=website):
+            combination_info = product._get_combination_info()
         self.assertEqual(round(combination_info['price'], 2), 434.78, "434.78$ + 0% tax (mapped from fp 15% -> 0%)")
         self.assertEqual(round(combination_info['list_price'], 2), 1913.04, "434.78$ + 0% tax (mapped from fp 15% -> 0%)")
 
         # Try same flow with tax included for apply tax
         tax0.write({'name': "Test tax 5", 'amount': 5, 'price_include_override': 'tax_included'})
-        combination_info = product._get_combination_info()
+        with MockRequest(product.env, website=website):
+            combination_info = product._get_combination_info()
         self.assertEqual(round(combination_info['price'], 2), 456.52, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")
         self.assertEqual(round(combination_info['list_price'], 2), 2008.7, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")

--- a/addons/website_sale/tests/test_website_sale_visitor.py
+++ b/addons/website_sale/tests/test_website_sale_visitor.py
@@ -67,17 +67,19 @@ class WebsiteSaleVisitorTests(TransactionCase):
             'sale_ok': True,
         })
 
-        self.website = self.website.with_user(public_user).with_context(website_id=self.website.id)
-        snippet_filter = self.env.ref('website_sale.dynamic_filter_newest_products')
+        website = self.website.with_user(public_user)
+        with MockRequest(website.env, website=website):
+            snippet_filter = self.env.ref('website_sale.dynamic_filter_newest_products')
+            res = snippet_filter._prepare_values(limit=16, search_domain=[])
 
-        res = snippet_filter._prepare_values(limit=16, search_domain=[])
         res_products = [res_product['_record'] for res_product in res]
         self.assertIn(product, res_products)
 
         product.product_tmpl_id.company_id = new_company
         product.product_tmpl_id.flush_recordset(['company_id'])
 
-        res = snippet_filter._prepare_values(limit=16, search_domain=[])
+        with MockRequest(website.env, website=website):
+            res = snippet_filter._prepare_values(limit=16, search_domain=[])
         res_products = [res_product['_record'] for res_product in res]
         self.assertNotIn(product, res_products)
 

--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -20,7 +20,10 @@ class ProductTemplate(models.Model):
         return self.is_storable and self.product_variant_id._is_sold_out()
 
     def _website_show_quick_add(self):
-        return (self.allow_out_of_stock_order or not self._is_sold_out()) and super()._website_show_quick_add()
+        return (
+            super()._website_show_quick_add()
+            and (self.allow_out_of_stock_order or not self._is_sold_out())
+        )
 
     def _get_additionnal_combination_info(self, product_or_template, quantity, date, website):
         res = super()._get_additionnal_combination_info(product_or_template, quantity, date, website)

--- a/addons/website_sale_stock/models/sale_order.py
+++ b/addons/website_sale_stock/models/sale_order.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, models
@@ -112,7 +111,7 @@ class SaleOrder(models.Model):
 
     def _all_product_available(self):
         self.ensure_one()
-        for line in self.with_context(website_sale_stock_get_quantity=True).order_line:
+        for line in self.order_line:
             product = line.product_id
             if not product.is_storable or product.allow_out_of_stock_order:
                 continue

--- a/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
@@ -74,14 +74,16 @@ class TestWebsiteSaleStockProductWarehouse(TestSaleProductAttributeValueCommon):
             # set warehouse_id
             self.website.warehouse_id = wh
 
-            combination_info = self.product_A.with_env(test_env)._get_combination_info_variant()
+            with MockRequest(test_env, website=self.website.with_env(test_env)):
+                combination_info = self.product_A.with_env(test_env)._get_combination_info_variant()
 
             # Check available quantity of product is according to warehouse
             self.assertEqual(
                 combination_info['free_qty'], qty_a,
                 f"{qty_a} units of Product A should be available in warehouse {wh}")
 
-            combination_info = self.product_B.with_env(test_env)._get_combination_info_variant()
+            with MockRequest(test_env, website=self.website.with_env(test_env)):
+                combination_info = self.product_B.with_env(test_env)._get_combination_info_variant()
 
             # Check available quantity of product is according to warehouse
             self.assertEqual(


### PR DESCRIPTION
* solve some remaining todos (avoid calling get_current_website to avoid useless queries)
* Rely on `_product_domain` to check product availabilities. This allows to remove overrides in sale_renting (enterprise)

See also odoo/enterprise#73304


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
