### PR TITLE
[FIX] l10n_sa_edi: Use journal company for correct API URL

### DIFF
--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -546,7 +546,7 @@ class AccountJournal(models.Model):
         """
             Helper function to make api calls to the ZATCA API Endpoint
         """
-        api_url = ZATCA_API_URLS[self.env.company.l10n_sa_api_mode]
+        api_url = ZATCA_API_URLS[self.company_id.l10n_sa_api_mode]
         request_url = urljoin(api_url, request_url)
         try:
             request_response = requests.request(method, request_url, data=request_data.get('body'),


### PR DESCRIPTION
Issue:
When multiple companies are set up, if you are working in a company with a different l10n_sa configuration and attempt to send an EDI document for another company, the retrieved API URL may be incorrect depending on the other company's configuration.

Steps to reproduce:
1. Create Company A and set `l10n_sa_api_mode` to production.
2. Create Company B and set `l10n_sa_api_mode` to sandbox.
3. Navigate to Company B (keeping Company A selected).
4. Create an invoice for Company A or attempt to send the EDI.

The API URL retrieved will be for Company B, while it should be for Company A.

New behavior:
The API URL is now correctly retrieved using the company linked to the journal. Additionally, we now follow the same access as in lines 440 and 539 to fetch the SA environment.

opw-4253449
