### PR TITLE
Master chat bubble no dropdown boi

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -2,34 +2,65 @@ import { ImStatus } from "@mail/core/common/im_status";
 
 import { Component, useEffect, useRef, useState } from "@odoo/owl";
 
-import { useService } from "@web/core/utils/hooks";
+import { useChildRef, useService } from "@web/core/utils/hooks";
 import { useHover, useMovable } from "@mail/utils/common/hooks";
-import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
-import { Dropdown } from "@web/core/dropdown/dropdown";
+import { usePopover } from "@web/core/popover/popover_hook";
 import { CountryFlag } from "@mail/core/common/country_flag";
+
+class ChatBubblePreview extends Component {
+    static props = ["chatWindow", "close"];
+    static template = "mail.ChatBubblePreview";
+
+    /** @returns {import("models").Thread} */
+    get thread() {
+        return this.props.chatWindow.thread;
+    }
+
+    get previewContent() {
+        const lastMessage = this.thread?.newestPersistentNotEmptyOfAllMessage;
+        if (!lastMessage) {
+            return false;
+        }
+        return lastMessage.inlineBody;
+    }
+}
 
 /**
  * @typedef {Object} Props
  * @extends {Component<Props, Env>}
  */
 export class ChatBubble extends Component {
-    static components = { CountryFlag, ImStatus, Dropdown };
+    static components = { CountryFlag, ImStatus };
     static props = ["chatWindow"];
     static template = "mail.ChatBubble";
 
     setup() {
         super.setup();
         this.store = useState(useService("mail.store"));
-        this.wasHover = false;
-        this.hover = useHover(["root", "preview*"], {
-            onHover: () => (this.preview.isOpen = true),
-            onHovering: [100, () => (this.state.showClose = true)],
-            onAway: () => {
-                this.state.showClose = false;
-                this.preview.isOpen = false;
-            },
+        const popoverRef = useChildRef();
+        this.popover = usePopover(ChatBubblePreview, {
+            animation: false,
+            position: "left-middle",
+            popoverClass: "dropdown-menu bg-view border-0 p-0 overflow-visible rounded-3 mx-1",
+            onClose: () => (this.state.showClose = false),
+            ref: popoverRef,
         });
-        this.preview = useDropdownState();
+        this.env.bus.addEventListener("ChatBubble:preview-will-open", ({ detail }) => {
+            if (detail === this) {
+                return;
+            }
+            this.popover.close();
+        });
+        this.hover = useHover(["root", popoverRef], {
+            onHover: () => {
+                if (!this.env.embedLivechat) {
+                    this.env.bus.trigger("ChatBubble:preview-will-open", this);
+                    this.popover.open(this.rootRef.el, { chatWindow: this.props.chatWindow });
+                }
+            },
+            onHovering: [100, () => (this.state.showClose = true)],
+            onAway: () => this.popover.close(),
+        });
         this.rootRef = useRef("root");
         this.state = useState({ bouncing: false, showClose: true });
         useEffect(
@@ -53,13 +84,5 @@ export class ChatBubble extends Component {
     /** @returns {import("models").Thread} */
     get thread() {
         return this.props.chatWindow.thread;
-    }
-
-    get previewContent() {
-        const lastMessage = this.thread?.newestPersistentNotEmptyOfAllMessage;
-        if (!lastMessage) {
-            return false;
-        }
-        return lastMessage.inlineBody;
     }
 }

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -1,17 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.ChatBubble">
-        <Dropdown t-if="!env.embedLivechat" state="preview" position="'left-middle'" menuClass="'bg-view border-0 p-0 overflow-visible rounded-3 mx-1'" arrow="true" manual="true">
-            <t t-call="mail.ChatBubble.core"/>
-            <t t-set-slot="content">
-                <t t-call="mail.ChatBubble.preview"/>
-            </t>
-        </Dropdown>
-        <t t-else="" t-call="mail.ChatBubble.core"/>
-    </t>
-
-    <t t-name="mail.ChatBubble.core">
-        <div class="o-mail-ChatBubble bg-view position-relative" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': preview.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
+        <div class="o-mail-ChatBubble bg-view position-relative" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': popover.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
             <span class="o-mail-ChatBubble-unreadIndicator position-absolute" t-att-class="{ 'opacity-50': thread?.isUnread and !thread?.importantCounter, 'opacity-0': !thread?.isUnread or thread?.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
             <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
@@ -23,9 +13,9 @@
         </div>
     </t>
 
-    <t t-name="mail.ChatBubble.preview">
-        <div class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border rounded" t-ref="preview">
-            <div class="text-truncate fw-bolder mb-0 mx-2" t-esc="props.chatWindow.displayName"/>
+    <t t-name="mail.ChatBubblePreview">
+        <div class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border rounded">
+            <div class="text-truncate base-fs fw-bolder mb-0 mx-2" t-esc="props.chatWindow.displayName"/>
             <div t-if="previewContent" class="text-truncate small mx-2 text-muted">
                 <t t-call="mail.message_preview_prefix">
                     <t t-set="message" t-value="thread?.newestPersistentNotEmptyOfAllMessage"/>

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -72,9 +72,9 @@ export function onExternalClick(refName, cb) {
 }
 
 /**
- * @param {string | string[]} refNames name of refs that determine whether this is in state "hovering".
+ * @param {string | string[] | Function} refNames name of refs that determine whether this is in state "hovering".
  *   ref name that end with "*" means it takes parented HTML node into account too. Useful for floating
- *   menu where dropdown menu container is not accessible.
+ *   menu where dropdown menu container is not accessible. Function type is for useChildRef support.
  * @param {Object} param1
  * @param {() => void} [param1.onHover] callback when hovering the ref names.
  * @param {() => void} [param1.onAway] callback when stop hovering the ref names.
@@ -89,6 +89,11 @@ export function useHover(refNames, { onHover, onAway, onHovering } = {}) {
     let hoveringTimeout;
     let awayTimeout;
     for (const refName of refNames) {
+        if (typeof refName === "function") {
+            // Special case: useChildRef support
+            targets.push({ ref: refName });
+            continue;
+        }
         targets.push({
             ref: refName.endsWith("*")
                 ? useRef(refName.substring(0, refName.length - 1))

--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -52,7 +52,6 @@ export class Dropdown extends Component {
     static template = xml`<t t-slot="default"/>`;
     static components = {};
     static props = {
-        arrow: { optional: true },
         menuClass: { optional: true },
         position: { type: String, optional: true },
         slots: {
@@ -105,7 +104,6 @@ export class Dropdown extends Component {
         navigationOptions: { type: Object, optional: true },
     };
     static defaultProps = {
-        arrow: false,
         disabled: false,
         holdOnHover: false,
         menuClass: "",
@@ -140,7 +138,7 @@ export class Dropdown extends Component {
 
         this.popover = usePopover(DropdownPopover, {
             animation: false,
-            arrow: this.props.arrow,
+            arrow: false,
             closeOnClickAway: (target) => {
                 return this.popoverCloseOnClickAway(target, activeEl);
             },

--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -116,9 +116,6 @@ export class Popover extends Component {
         this.position = usePosition("ref", () => this.props.target, {
             onPositioned: (el, solution) => {
                 (this.props.onPositioned || this.onPositioned.bind(this))(el, solution);
-                if (this.props.arrow && this.props.onPositioned) {
-                    this.onPositioned.bind(this)(el, solution);
-                }
 
                 // opening animation
                 if (shouldAnimate) {

--- a/addons/web/static/tests/core/popover/popover.test.js
+++ b/addons/web/static/tests/core/popover/popover.test.js
@@ -204,7 +204,7 @@ test("reposition popover should properly change classNames", async () => {
     class TestPopover extends Popover {
         setup() {
             // Don't call super.setup() in order to replace the use of usePosition hook...
-            usePosition("ref", () => this.props.target, {
+            this.position = usePosition("ref", () => this.props.target, {
                 container,
                 onPositioned: this.onPositioned.bind(this),
                 position: this.props.position,
@@ -225,6 +225,7 @@ test("reposition popover should properly change classNames", async () => {
         props: {
             target: queryOne(".popover-target"),
             component: Content,
+            animation: false,
         },
     });
 
@@ -234,7 +235,7 @@ test("reposition popover should properly change classNames", async () => {
 
     // Should have classes for a "bottom-middle" placement
     expect(".o_popover").toHaveClass(
-        "o_popover popover mw-100 o-popover--with-arrow bs-popover-bottom o-popover-bottom o-popover--bm"
+        "o_popover popover mw-100 o-popover--with-arrow bs-popover-bottom o-popover--bm"
     );
     expect(".popover-arrow").toHaveClass("popover-arrow start-0 end-0 mx-auto");
 
@@ -246,9 +247,9 @@ test("reposition popover should properly change classNames", async () => {
     await animationFrame();
 
     expect(".o_popover").toHaveClass(
-        "o_popover popover mw-100 o-popover--with-arrow bs-popover-end o-popover-right o-popover--re"
+        "o_popover popover mw-100 o-popover--with-arrow bs-popover-end o-popover--re"
     );
-    expect(".popover-arrow").toHaveClass("popover-arrow top-auto");
+    expect(".popover-arrow").toHaveClass("popover-arrow");
 });
 
 test("within iframe", async () => {
@@ -337,6 +338,7 @@ test("within iframe -- wrong element class", async () => {
 test("popover fixed position", async () => {
     class TestPopover extends Popover {
         onPositioned() {
+            super.onPositioned(...arguments);
             expect.step("onPositioned");
         }
     }
@@ -368,4 +370,30 @@ test("popover fixed position", async () => {
     await animationFrame();
 
     expect.verifySteps([]);
+});
+
+test("popover with arrow and onPositioned", async () => {
+    class TestPopover extends Popover {
+        onPositioned() {
+            expect.step("onPositioned (from override)");
+            super.onPositioned(...arguments);
+        }
+    }
+
+    await mountWithCleanup(TestPopover, {
+        props: {
+            target: getFixture(),
+            component: Content,
+            arrow: true,
+            onPositioned() {
+                expect.step("onPositioned (from props)");
+            },
+        },
+    });
+
+    expect.verifySteps(["onPositioned (from override)", "onPositioned (from props)"]);
+    expect(".o_popover").toHaveClass(
+        "o_popover popover mw-100 o-popover--with-arrow bs-popover-bottom o-popover--bm"
+    );
+    expect(".o_popover > .popover-arrow").toHaveClass("start-0 end-0 mx-auto");
 });

--- a/addons/web/static/tests/core/popover/popover_service.test.js
+++ b/addons/web/static/tests/core/popover/popover_service.test.js
@@ -140,13 +140,15 @@ test("close popover if target is removed", async () => {
         static props = ["*"];
     }
 
-    getService("popover").add(target, Comp);
+    const popoverTarget = document.createElement("div");
+    target.appendChild(popoverTarget);
+    getService("popover").add(popoverTarget, Comp);
     await animationFrame();
 
     expect(".o_popover").toHaveCount(1);
     expect(".o_popover #comp").toHaveCount(1);
 
-    target.remove();
+    popoverTarget.remove();
     await animationFrame();
 
     expect(".o_popover").toHaveCount(0);


### PR DESCRIPTION
**[FIX] web,mail: clean a wrong dropdown property**
Since [1], the ChatBubble component have been introduced by using a
Dropdown component in its template. The Dropdown component is used with
advanced props in order to give it a simple tooltip behavior.
In order to achieve this, the Dropdown component has been updated
by adding a new `arrow` property, which is passed to the underlying
Popover component that, in turn, had to get updated in order to support
this simple use case.

This commit reverts the changes to the Dropdown and Popover components
and adapts the ChatBubble component in order to use a simple popover,
which is controlled in such a way that it behaves as a tooltip.

Additional note:
- simple tooltips could not have been used in this case as
  the ChatBubble needs are greater than the [data-tooltip-*] attributes
  could offer, especially for styling but also because complex objects
  are passed (proxies) to the preview template, which could not get
  stringified to get passed as elements' attributes.

[1]: https://github.com/odoo/odoo/commit/82e3295d43f7809661a40d1b21ffbcbce23c700b

**[FIX] web: allow popover onPositioned/arrow combo**
Before this commit:
- have a popover with arrow=true and an onPositioned callback
- the arrow classes logic does not get applied

After this commit:
- the onPositioned callback is called after the arrow classes logic
- also after the animate and fixedPosition logic,
  which differs from before
- a little bit of refactoring in order to clarify things
- some arrow classes have been cleaned up as they did nothing (no style)
