### PR TITLE
[FIX] mail: hide message failures for deleted records

### DIFF
--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -3,6 +3,7 @@
 
 from odoo import _, api, fields, models, tools
 from odoo.osv import expression
+from collections import defaultdict
 
 
 class Partner(models.Model):
@@ -141,6 +142,14 @@ class Partner(models.Model):
             ('mail_message_id.model', '!=', False),
             ('mail_message_id.res_id', '!=', 0),
         ], limit=100)
+        found = defaultdict(list)
+        for message in notifications.mail_message_id:
+            found[message.model].append(message.res_id)
+        existing = {
+            model: set(self.env[model].browse(ids).exists().ids)
+            for model, ids in found.items()
+        }
+        notifications = notifications.filtered(lambda n: n.mail_message_id.res_id in existing[n.mail_message_id.model])
         return notifications.mail_message_id._message_notification_format()
 
     def _get_channels_as_member(self):


### PR DESCRIPTION


Description of the issue/feature this PR addresses:
Do not display useless notification failures.

Current behavior before PR:
When a record that inherits from `mail.thread` is deleted by an `ondelete="cascade"` SQL constraint, its messages and notifiations are kept in DB.

If some of those notifications is in status `bounce` or `exception`, it will keep being displayed to the user. However, the user won't be able to do anything with it. Actually, if they try to, they'll get an exception.

<details>
<summary>Exception</summary>

```
Traceback (most recent call last):
  File \"/opt/odoo/custom/src/odoo/odoo/api.py\", line 997, in get
    cache_value = field_cache[record._ids[0]]
KeyError: 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 1161, in __get__
    value = env.cache.get(record, self)
  File \"/opt/odoo/custom/src/odoo/odoo/api.py\", line 1004, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: 'account.payment(1,).company_id'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/opt/odoo/custom/src/odoo/odoo/api.py\", line 997, in get
    cache_value = field_cache[record._ids[0]]
KeyError: 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 1161, in __get__
    value = env.cache.get(record, self)
  File \"/opt/odoo/custom/src/odoo/odoo/api.py\", line 1004, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: 'account.payment(1,).move_id'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 1210, in __get__
    self.compute_value(recs)
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 1392, in compute_value
    records._compute_field_value(self)
  File \"/opt/odoo/auto/addons/mail/models/mail_thread.py\", line 403, in _compute_field_value
    return super()._compute_field_value(field)
  File \"/opt/odoo/custom/src/odoo/odoo/models.py\", line 4241, in _compute_field_value
    fields.determine(field.compute, self)
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 101, in determine
    return needle(records, *args)
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 690, in _compute_related
    values = [first(value[name]) for value in values]
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 690, in <listcomp>
    values = [first(value[name]) for value in values]
  File \"/opt/odoo/custom/src/odoo/odoo/models.py\", line 5957, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 2804, in __get__
    return super().__get__(records, owner)
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 1191, in __get__
    raise MissingError(\"\
\".join([
odoo.exceptions.MissingError: Record does not exist or has been deleted.
(Record: account.payment(1,), User: 2)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/opt/odoo/custom/src/odoo/odoo/api.py\", line 997, in get
    cache_value = field_cache[record._ids[0]]
KeyError: 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 1161, in __get__
    value = env.cache.get(record, self)
  File \"/opt/odoo/custom/src/odoo/odoo/api.py\", line 1004, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: 'account.payment(1,).move_id'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/opt/odoo/custom/src/odoo/odoo/http.py\", line 1652, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File \"/opt/odoo/custom/src/odoo/odoo/service/model.py\", line 133, in retrying
    result = func()
  File \"/opt/odoo/custom/src/odoo/odoo/http.py\", line 1679, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File \"/opt/odoo/custom/src/odoo/odoo/http.py\", line 1883, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File \"/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py\", line 154, in _dispatch
    result = endpoint(**request.params)
  File \"/opt/odoo/custom/src/odoo/odoo/http.py\", line 734, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File \"/opt/odoo/auto/addons/web/controllers/dataset.py\", line 42, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File \"/opt/odoo/auto/addons/web/controllers/dataset.py\", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File \"/opt/odoo/custom/src/odoo/odoo/api.py\", line 464, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File \"/opt/odoo/custom/src/odoo/odoo/api.py\", line 435, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File \"/opt/odoo/auto/addons/snailmail/models/mail_thread.py\", line 22, in notify_cancel_by_type
    super().notify_cancel_by_type(notification_type)
  File \"/opt/odoo/auto/addons/sms/models/mail_thread.py\", line 383, in notify_cancel_by_type
    super().notify_cancel_by_type(notification_type)
  File \"/opt/odoo/auto/addons/mail/models/mail_thread.py\", line 2420, in notify_cancel_by_type
    self._notify_cancel_by_type_generic('email')
  File \"/opt/odoo/auto/addons/mail/models/mail_thread.py\", line 2406, in _notify_cancel_by_type_generic
    self.env['mail.message'].browse(msg_ids)._notify_message_notification_update()
  File \"/opt/odoo/auto/addons/mail/models/mail_message.py\", line 1017, in _notify_message_notification_update
    record.check_access_rule('read')
  File \"/opt/odoo/custom/src/odoo/odoo/models.py\", line 3494, in check_access_rule
    invalid = self - self._filter_access_rules_python(operation)
  File \"/opt/odoo/custom/src/odoo/odoo/models.py\", line 3549, in _filter_access_rules_python
    return self.sudo().filtered_domain(dom or [])
  File \"/opt/odoo/custom/src/odoo/odoo/models.py\", line 5508, in filtered_domain
    data = record.mapped(key)
  File \"/opt/odoo/custom/src/odoo/odoo/models.py\", line 5428, in mapped
    recs = recs._fields[name].mapped(recs)
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 1284, in mapped
    self.__get__(first(remaining), type(remaining))
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 2804, in __get__
    return super().__get__(records, owner)
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 1212, in __get__
    self.compute_value(record)
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 1392, in compute_value
    records._compute_field_value(self)
  File \"/opt/odoo/auto/addons/mail/models/mail_thread.py\", line 403, in _compute_field_value
    return super()._compute_field_value(field)
  File \"/opt/odoo/custom/src/odoo/odoo/models.py\", line 4241, in _compute_field_value
    fields.determine(field.compute, self)
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 101, in determine
    return needle(records, *args)
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 690, in _compute_related
    values = [first(value[name]) for value in values]
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 690, in <listcomp>
    values = [first(value[name]) for value in values]
  File \"/opt/odoo/custom/src/odoo/odoo/models.py\", line 5957, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 2804, in __get__
    return super().__get__(records, owner)
  File \"/opt/odoo/custom/src/odoo/odoo/fields.py\", line 1191, in __get__
    raise MissingError(\"\
\".join([
odoo.exceptions.MissingError: Record does not exist or has been deleted.
(Record: account.payment(1,), User: 2)
```

</details>

More details:
https://www.loom.com/share/a59e9f0bfb754711a970608247433459?sid=e97a41e1-7615-45ff-a6fc-086507d08130

Desired behavior after PR is merged:


This fix avoids displaying failures related to non-existing records. This clears noise and avoids situations where the user is unable to react to their notifications.

@moduon MT-7609 OPW-4285691


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
