### PR TITLE
[FIX] web: don't change z-index of buttons in dropdown

### DIFF
--- a/addons/web/static/src/scss/bootstrap_review_backend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_backend.scss
@@ -84,12 +84,6 @@
 // ============================================================================
 .btn-group {
     > .btn, .btn-group {
-        // Ensure that active buttons will always be rendered on top, including
-        // hovered ones.
-        &:active, &.active, &:active:hover, &.active:hover {
-            z-index: 2;
-        }
-
         &:not(:first-child) {
             margin-left: var(--btn-group-gap, $btn-border-width); 
         }


### PR DESCRIPTION
**Steps to reproduce:**
- Install l10n_mx_reports (not mandatory but easier to reproduce)
- Switch to a Mexican company (e.g. ESCUELA KEMPER URGATE)
- Go to "Accounting / Reporting / Audit Reports / Trial Balance"
- Select "Last Month" as data filter
- Select "Previous Month: 9" as comparison filter
- Click on dropdown button next to PDF button
- Click on a button that is displayed in front of the header of the report (e.g. XLSX)

**Issue:**
The action is not triggered.
Once the button has been clicked, the dropdown menu disappears behind the header of the report.

**Cause:**
The buttons in the dropdown menu have z-index:1000 and the thead
of the report has the z-index:999, which displays the buttons in
front the header of the report.
However, when clicked, the button becomes active and its z-index
falls to 2, putting it behind the header.

opw-4265087




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
