### PR TITLE
16.0 fix website event sidebar photos bvr

### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -216,7 +216,7 @@ class IrUiView(models.Model):
 
     @api.model
     def _get_allowed_root_attrs(self):
-        return ['style', 'class', 'target']
+        return ['style', 'class', 'target', 'href']
 
     def replace_arch_section(self, section_xpath, replacement, replace_tail=False):
         # the root of the arch section shouldn't actually be replaced as it's

--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -236,6 +236,8 @@ class IrUiView(models.Model):
         for attribute in self._get_allowed_root_attrs():
             if attribute in replacement.attrib:
                 root.attrib[attribute] = replacement.attrib[attribute]
+            elif attribute in root.attrib:
+                del root.attrib[attribute]
 
         # Note: after a standard edition, the tail *must not* be replaced
         if replace_tail:

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -549,11 +549,19 @@ var SnippetEditor = Widget.extend({
         if ($parent.closest(':data("snippet-editor")').length) {
             const isEmptyAndRemovable = ($el, editor) => {
                 editor = editor || $el.data('snippet-editor');
-                const isEmpty = $el.text().trim() === ''
+
+                // Consider a <figure> element as empty if it only contains a
+                // <figcaption> element (e.g., when its image has just been
+                // removed).
+                const isEmptyFigureEl = $el[0].matches("figure")
+                    && $el[0].children.length === 1
+                    && $el[0].children[0].matches("figcaption");
+
+                const isEmpty = isEmptyFigureEl || ($el.text().trim() === ''
                     && $el.children().toArray().every(el => {
                         // Consider layout-only elements (like bg-shapes) as empty
                         return el.matches(this.layoutElementsSelector);
-                    });
+                    }));
                 return isEmpty && !$el.hasClass('oe_structure')
                     && !$el.parent().hasClass('carousel-item')
                     && (!editor || editor.isTargetParentEditable)

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5494,7 +5494,7 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
      * @see this.selectClass for parameters
      */
     setLink(previewMode, widgetValue, params) {
-        const parentEl = this.$target[0].parentNode;
+        const parentEl = this._searchSupportedParentLinkEl();
         if (parentEl.tagName !== 'A') {
             const wrapperEl = document.createElement('a');
             this.$target[0].after(wrapperEl);
@@ -5519,7 +5519,7 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
      * @see this.selectClass for parameters
      */
     setNewWindow(previewMode, widgetValue, params) {
-        const linkEl = this.$target[0].parentElement;
+        const linkEl = this._searchSupportedParentLinkEl();
         if (widgetValue) {
             linkEl.setAttribute('target', '_blank');
         } else {
@@ -5532,7 +5532,7 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
      * @see this.selectClass for parameters
      */
     setUrl(previewMode, widgetValue, params) {
-        const linkEl = this.$target[0].parentElement;
+        const linkEl = this._searchSupportedParentLinkEl();
         let url = widgetValue;
         if (!url) {
             // As long as there is no URL, the image is not considered a link.
@@ -5570,7 +5570,8 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
      * @private
      */
     _activateLinkTool() {
-        if (this.$target[0].parentElement.tagName === 'A') {
+        const parentEl = this._searchSupportedParentLinkEl();
+        if (parentEl.tagName === 'A') {
             this._requestUserValueWidgets('media_url_opt')[0].focus();
         } else {
             this._requestUserValueWidgets('media_link_opt')[0].enable();
@@ -5580,7 +5581,7 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
      * @private
      */
     _deactivateLinkTool() {
-        const parentEl = this.$target[0].parentNode;
+        const parentEl = this._searchSupportedParentLinkEl();
         if (parentEl.tagName === 'A') {
             this._requestUserValueWidgets('media_link_opt')[0].enable();
         }
@@ -5589,7 +5590,7 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
      * @override
      */
     _computeWidgetState(methodName, params) {
-        const parentEl = this.$target[0].parentElement;
+        const parentEl = this._searchSupportedParentLinkEl();
         const linkEl = parentEl.tagName === 'A' ? parentEl : null;
         switch (methodName) {
             case 'setLink': {
@@ -5612,11 +5613,20 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
     async _computeWidgetVisibility(widgetName, params) {
         if (widgetName === 'media_link_opt') {
             if (this.$target[0].matches('img')) {
-                return isImageSupportedForStyle(this.$target[0]);
+                return isImageSupportedForStyle(this.$target[0])
+                    && !this._searchSupportedParentLinkEl().matches("a[data-oe-xpath]");
             }
             return !this.$target[0].classList.contains('media_iframe_video');
         }
         return this._super(...arguments);
+    },
+    /**
+     * @private
+     * @returns {Element} The "closest" element that can be supported as a <a>.
+     */
+    _searchSupportedParentLinkEl() {
+        const parentEl = this.$target[0].parentElement;
+        return parentEl.matches("figure") ? parentEl.parentElement : parentEl;
     },
 });
 

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1380,7 +1380,22 @@ const Wysiwyg = Widget.extend({
                 params.node.replaceWith(element);
             }
             this.odooEditor.unbreakableStepUnactive();
-            this.odooEditor.historyStep();
+
+            if (params.node.matches(".oe_unremovable")) {
+                // The "oe_unremovable" class prevents element deletion and must
+                // be removed during the "historyStep" to allow media
+                // replacement. If the class remains, the "sanitize" function in
+                // "historyStep" will block the replacement.
+                params.node.classList.remove("oe_unremovable");
+                element.classList.remove("oe_unremovable");
+                this.odooEditor.historyStep();
+                this.odooEditor.observerUnactive("unremovable");
+                element.classList.add("oe_unremovable");
+                this.odooEditor.observerActive("unremovable");
+            } else {
+                this.odooEditor.historyStep();
+            }
+
             // Refocus again to save updates when calling `_onWysiwygBlur`
             this.odooEditor.editable.focus();
         } else {

--- a/addons/website_event/static/src/scss/event_templates_list.scss
+++ b/addons/website_event/static/src/scss/event_templates_list.scss
@@ -117,6 +117,11 @@
             color: #fff;
         }
     }
+    a:has(.o_wevent_sidebar_figure) {
+        // This is required for Chrome. Without it, the <figcaption> element
+        // inside the second photo will not be editable properly.
+        display: block;
+    }
     .o_half_screen_height {
         // Set min-height to the same value as the header
         min-height: 200px !important;

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -302,14 +302,14 @@
         <h6 class="o_wevent_sidebar_title">Photos</h6>
         <a href="/event">
             <figure class="o_wevent_sidebar_block o_wevent_sidebar_figure figure">
-                <img class="figure-img img-fluid rounded" src="/website_event/static/src/img/event_past_0.jpg" alt=""/>
-                <figcaption class="figure-caption">A past event</figcaption>
+                <img class="figure-img img-fluid rounded oe_unremovable" src="/website_event/static/src/img/event_past_0.jpg" alt=""/>
+                <figcaption class="figure-caption oe_unremovable">A past event</figcaption>
             </figure>
         </a>
         <a href="/event">
             <figure class="o_wevent_sidebar_block o_wevent_sidebar_figure figure">
-                <img class="figure-img img-fluid rounded" src="/website_event/static/src/img/event_training_0.jpg" alt=""/>
-                <figcaption class="figure-caption">Our Trainings</figcaption>
+                <img class="figure-img img-fluid rounded oe_unremovable" src="/website_event/static/src/img/event_training_0.jpg" alt=""/>
+                <figcaption class="figure-caption oe_unremovable">Our Trainings</figcaption>
             </figure>
         </a>
     </xpath>


### PR DESCRIPTION
**task-4280164
opw-3985404**

---
**[FIX] web_editor: removes figure parent of removed image**

Steps to reproduce the issue:

- In website, edit mode.
- Drag and drop a "Picture" snippet onto the page.
- Click the image in the "Picture" snippet.
- Delete the image by clicking the "Remove" button in the image options.
- Inspect the DOM of the "Picture" snippet.
- Bug: The figure element which wrapped the image is still there.

After this commit, when an image wrapped by a figure element is removed,
the figure is also removed.

---
**[FIX] web_editor: allows to edit events sidebar photos link**

Before this commit, it was not possible to edit the link of the events
sidebar photos.

This occurred for 2 reasons:

A - The image link option didn't work with images wrapped in a figure
element.
B - After fixing point A, the "href" attribute modification was ignored
when saving the "/event" page.

Steps to reproduce A:

- Go to the "/event" page in edit mode.
- Click on the 'Customize' tab and enable the sidebar.
- Click a photo in the sidebar.
- Bug: the URL input for setting the link is not available in the
"Image" options.

Steps to reproduce B (after fixing A):

- Go to the "/event" page in edit mode.
- Click on the 'Customize' tab and enable the sidebar.
- Click a photo in the sidebar.
- Edit the "Your URL" input. (e.g. [www.odoo.com](http://www.odoo.com/))
- Save the page.
- Click the image with the modified link.
- Bug: the new link was not saved.

To fix issue B, we added the "href" attribute to the list of allowed
root attributes.

---
**[FIX] website_event: prevents removing sidebar photos**

Steps to reproduce the issue:

- Go to the "/event" page in edit mode.
- Enable the sidebar.
- Click a photo in the sidebar.
- Click the "Delete" button in the image options.
- The image is removed even though it shouldn't be allowed to remove it.

This commit hide the "Delete" button for these sidebar images.

---
**[FIX] website_event: fix editing of figcaption for event sidebar photos**

Steps to reproduce the bug (only on Chrome):

- Go to the "/event" page.
- Enter edit mode.
- Click the "Customize" tab and enable the "Sidebar".
- Try to add a character at the end of the figcaption of the second
photo in the sidebar.
- Bug: it's not possible to add a new character.

This requires further investigation, but the issue comes from how Chrome
handles editing elements inside links. The fact that the <a> element was
set to display inline caused the issue.

This commit fixes the issue by setting the <a> element to display block,
which is more appropriate anyway.