### PR TITLE
[FIX] web: format local week year

### DIFF
--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -127,14 +127,25 @@ export function clampDate(desired, minDate, maxDate) {
 }
 
 /**
- * Get the week number of a given date.
- * Returns the ISO week number of the Monday nearest to the first day of the week.
+ * Get the week number of a given date, in the user's locale settings.
  *
  * @param {Date | luxon.DateTime} date
  * @returns {number}
- *  the ISO week number (1-53) of the nearest Monday of the given date's week's start
+ *  the ISO week number (1-53) of the Monday nearest to the locale's first day of the week
  */
 export function getLocalWeekNumber(date) {
+    return getLocalYearAndWeek(date).week;
+}
+
+/**
+ * Get the week year and week number of a given date, in the user's locale settings.
+ *
+ * @param {Date | luxon.DateTime} date
+ * @returns {{ year: number, week: number }}
+ *  the year the week is part of, and
+ *  the ISO week number (1-53) of the Monday nearest to the locale's first day of the week
+ */
+export function getLocalYearAndWeek(date) {
     if (!date.isLuxonDateTime) {
         date = DateTime.fromJSDate(date);
     }
@@ -151,7 +162,7 @@ export function getLocalWeekNumber(date) {
     // count from previous year if week falls before Jan 4
     const diffDays =
         date < jan4 ? date.diff(jan4.minus({ years: 1 }), "day").days : date.diff(jan4, "day").days;
-    return Math.trunc(diffDays / 7) + 1;
+    return { year: date.year, week: Math.trunc(diffDays / 7) + 1 };
 }
 
 /**


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Enterprise PR: https://github.com/odoo/enterprise/pull/73318

Steps
-----
1. Have Planning installed;
2. change localisation to 'en_GB' (or any whose weeks start on Monday);
3. open in Gantt view in weekly granularity;
4. go to the week of 2024-12-30.

Issue
-----
Label on top right displays "W1 2024";

Cause
-----
It uses the `getLocalWeekNumber` function to get the week number of 2024-12-30, which falls in the first week of 2025. It then combines it with the `year` of the date, which is 2024.

Solution
--------
### Community:
Like the `weeknumber` function added in 9c47e911d0ca7 to `odoo.tools.date_utils`, have a function in `web` that returns both year and week number.

### Enterprise:
Define a `formatLocalWeekYear` function in `web_gantt` using the new `getLocalYearAndWeek` function from `web`.

opw-4280192