### PR TITLE
[FIX] maintenance: fix test_drag_and_drop_event_in_calendar tour

### DIFF
--- a/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
+++ b/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
@@ -68,6 +68,10 @@ registry.category("web_tour.tours").add("test_drag_and_drop_event_in_calendar", 
             run: "click",
         },
         {
+            content: "Wait the view is month",
+            trigger: ".fc-dayGridMonth-view",
+        },
+        {
             content: "Move event to 15th of the month",
             trigger: 'a[data-event-id="1"]',
             run: 'drag_and_drop .fc-daygrid-day[data-date$="15"] .fc-daygrid-day-events',


### PR DESCRIPTION
In this commit, we add a check step to ensure the view is Month view before to drag and drop the item or drag and drop will be directly executed ... and tour fails.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
