### PR TITLE
[FIX] base: Prevent quick creation of `ir_model_fields`

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -913,13 +913,12 @@ class IrModelFields(models.Model):
         for vals in vals_list:
             if 'model_id' in vals:
                 vals['model'] = IrModel.browse(vals['model_id']).model
-            assert vals.get('model'), f"missing model name for {vals}"
-            models.add(vals['model'])
 
         # for self._get_ids() in _update_selection()
         self.clear_caches()
 
         res = super(IrModelFields, self).create(vals_list)
+        models = set(res.mapped('model'))
 
         for vals in vals_list:
             if vals.get('state', 'manual') == 'manual':

--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from psycopg2 import IntegrityError
+from psycopg2.errors import NotNullViolation
 
 from odoo.exceptions import ValidationError
 from odoo.tests.common import Form, TransactionCase, HttpCase, tagged
@@ -374,6 +375,20 @@ class TestIrModel(TransactionCase):
         self.env["ir.model"].browse(model.ids + model2.ids).unlink()
         self.assertFalse(model.exists())
         self.assertFalse(model2.exists())
+
+    @mute_logger('odoo.sql_db')
+    def test_ir_model_fields_name_create(self):
+        # Quick create an ir_model_field should not be possible
+        # It should be raise a ValidationError
+        with self.assertRaises(NotNullViolation):
+            self.env['ir.model.fields'].name_create("field_name")
+
+        # But with default_ we should be able to name_create
+        self.env['ir.model.fields'].with_context(
+            default_model_id=self.bananas_model.id,
+            default_model=self.bananas_model.name,
+            default_ttype="char"
+        ).name_create("field_name")
 
 
 @tagged('test_eval_context')


### PR DESCRIPTION
The problem can be reproduced in two ways
- by finding a view that integrates a many2one on `ir.model.fields` used without no_create
- manually add the field via studio on any view.

I found a view with the problem: `marketing_campaign_view_form` which uses the field `unique_field_id` which is defined as such: 
```py
    unique_field_id = fields.Many2one(
        ir.model.fields', string='Unique Field',
        compute='_compute_unique_field_id', readonly=False, store=True)
```

To get there:
- Install `marketing_automation`.
- Open the app
- You arrive in the campaigns view
- Create a new record
- Write the name of a field that doesn't exist, like `dkfjl`.
- A dropdown asks you to “Create `dkfjl`”.
- Click on it
- Crash

```
  File “/home/achraf/src/160/odoo/odoo/addons/base/models/ir_model.py”, line 916, in create
    if not vals.get('model'):
AssertionError: missing model name for {'field_description': 'dfasf'}
```

This commit removes the assertion to use `model` returned by `super().create`
so that the web client catches the error and proposes to create the
record with not one field name but all the required fields

opw-4116187
