### PR TITLE
[IMP] mail: contact activity view uses lang specific date format

### DIFF
--- a/addons/mail/static/src/views/web/activity/activity_cell.js
+++ b/addons/mail/static/src/views/web/activity/activity_cell.js
@@ -6,6 +6,7 @@ import { Avatar } from "@mail/views/web/fields/avatar/avatar";
 import { Component, useRef } from "@odoo/owl";
 
 import { usePopover } from "@web/core/popover/popover_hook";
+import { formatDate } from "@web/core/l10n/dates";
 
 export class ActivityCell extends Component {
     static components = {
@@ -36,9 +37,7 @@ export class ActivityCell extends Component {
     }
 
     get reportingDateFormatted() {
-        return luxon.DateTime.fromISO(this.props.reportingDate).toLocaleString(
-            luxon.DateTime.DATE_SHORT
-        );
+        return formatDate(luxon.DateTime.fromISO(this.props.reportingDate));
     }
 
     get ongoingActivityCount() {

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -10,7 +10,7 @@ import { start } from "@mail/../tests/helpers/test_utils";
 
 import { RelationalModel } from "@web/model/relational_model/relational_model";
 import { Domain } from "@web/core/domain";
-import { serializeDate } from "@web/core/l10n/dates";
+import { serializeDate, formatDate } from "@web/core/l10n/dates";
 import { deepEqual, omit } from "@web/core/utils/objects";
 import { session } from "@web/session";
 import testUtils from "@web/../tests/legacy/helpers/test_utils";
@@ -237,7 +237,7 @@ QUnit.module("test_mail", {}, function () {
             'should contain "Meeting Room Furnitures" in first colum of second row'
         );
 
-        const today = DateTime.now().toLocaleString(luxon.DateTime.DATE_SHORT);
+        const today = formatDate(DateTime.now());
 
         assert.ok(
             $activity.find(
@@ -374,15 +374,11 @@ QUnit.module("test_mail", {}, function () {
         });
         // Cells dates
         await contains(".o-mail-ActivityCell-deadline", {
-            text: luxon.DateTime.fromISO(uploadPlannedActs[0].date_deadline).toLocaleString(
-                luxon.DateTime.DATE_SHORT
-            ),
+            text: formatDate(luxon.DateTime.fromISO(uploadPlannedActs[0].date_deadline)),
             target: domRowMeetingCellUpload,
         });
         await contains(".o-mail-ActivityCell-deadline", {
-            text: luxon.DateTime.fromISO(uploadDoneActs[1].date_done).toLocaleString(
-                luxon.DateTime.DATE_SHORT
-            ),
+            text: formatDate(luxon.DateTime.fromISO(uploadDoneActs[1].date_done)),
             target: domRowOfficeCellUpload,
         });
         // Activity list popovers content
@@ -399,18 +395,15 @@ QUnit.module("test_mail", {}, function () {
         await contains(".o-mail-ActivityListPopover .badge.text-bg-secondary", { text: "1" }); // 1 done
         await contains(".o-mail-ActivityListPopoverItem", { text: uploadDoneActs[0].user_id[1] });
         await contains(".o-mail-ActivityListPopoverItem", {
-            text: luxon.DateTime.fromISO(uploadDoneActs[0].date_done).toLocaleString(
-                luxon.DateTime.DATE_SHORT
-            ),
+            text: formatDate(luxon.DateTime.fromISO(uploadDoneActs[0].date_done), {format: "M/d/yyyy"})
         });
 
         await click(domActivity, `${selRowOfficeCellUpload} > div`);
         await contains(".o-mail-ActivityListPopover .badge.text-bg-secondary", { text: "3" }); // 3 done
         for (const actIdx of [1, 2, 3]) {
+            console.log();
             await contains(".o-mail-ActivityListPopoverItem", {
-                text: luxon.DateTime.fromISO(uploadDoneActs[actIdx].date_done).toLocaleString(
-                    luxon.DateTime.DATE_SHORT
-                ),
+                text: formatDate(luxon.DateTime.fromISO(uploadDoneActs[actIdx].date_done), {format: "M/d/yyyy"}),
             });
             await contains(".o-mail-ActivityListPopoverItem", {
                 text: uploadDoneActs[actIdx].user_id[1],


### PR DESCRIPTION
Previously (ref.1) introduced DATE_SHORT,
this commit uses custom format specified in the current language

Reproduce
---
- -i contacts,calendar
- change current language date format to something custom like %m/%b/%y
- open contacts -> activity view
- add some activity-> BUG: Custom date format not used

(Ref.1)
---
[IMP] {test_}mail: allow to keep done activities and improve activity view b6c236df54abb66b30d8643dea797f385d3036f1

opw-4151431

### note, debate
If user uses some long date_format it may not look too nice, however it will keep the date consistent across odoo, consulted with creator and PO. 

code originally stems from here https://github.com/odoo/odoo/pull/138135
