### PR TITLE
[FIX] web: use context of the embedded action to call

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1487,6 +1487,7 @@ export function makeActionManager(env, router = _router) {
                 ];
                 const context = {
                     ...action.context,
+                    ...(embeddedAction.context ? makeContext([embeddedAction.context]) : {}),
                     active_id: params.resId,
                     active_model: params.resModel,
                     current_embedded_action_id: embeddedActionId,

--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -86,7 +86,10 @@ class Pony extends models.Model {
         { id: 9, name: "Fluttershy" },
     ];
     _views = {
-        "list,false": `<list><field name="name"/></list>`,
+        "list,false": `<list>
+                            <field name="name"/>
+                            <button name="action_test" type="object" string="Action Test" column_invisible="not context.get('display_button')"/>
+                        </list>`,
         "kanban,false": `<kanban>
                             <templates>
                                 <t t-name="card">
@@ -160,6 +163,9 @@ defineEmbeddedActions([
         type: "ir.embedded.actions",
         parent_action_id: 1,
         action_id: 3,
+        context: {
+            display_button: true,
+        },
     },
     {
         id: 3,
@@ -472,6 +478,10 @@ test("User should be redirected to the first embedded action set in localStorage
     });
     expect(".o_last_breadcrumb_item > span").toHaveText("Favorite Ponies", {
         message: "'Favorite Ponies' view should be loaded",
+    });
+    expect(".o_list_renderer .btn-link").toHaveCount(3, {
+        message:
+            "The button should be displayed since `display_button` is true in the context of the embedded action 2",
     });
 });
 


### PR DESCRIPTION
Before this commit, when the user creates a new billable project and change the order of the embedded actions inside the topbar of that project to put `Sales orders` embedded action first to be able to load that action first, the context of that embedded action is not given the `doAction` rpc and so the view loaded in the form view of SO to be able to create a new SO. The problem is if the user does not want to create a SO, it will not be able to change the first action to load for that project since the topbar is not visible in the form view.

This commit makes sure the context of the embedded action to load is given to `doAction` rpc.

Steps to reproduce the issue:
============================
1. Install Sales and project apps
2. Create new billable project
3. go inside that project to see the tasks of that project and open the top bar
4. display the `Sales Order` embedded actions inside the top bar of that project
5. reorder the embeddded actions inside the top bar to first load `Sales Order` action when we open that project.
6. Go back to the project kanban view
7. Click on that project

Expected Behavior
-----------------
The list view of sale.order model should be displayed

Current Behavior
----------------
The form view of sale.order model is opened to be able to create a new SO for that project.

task-4295738
