### PR TITLE
[FIX] l10n_il: fix default purchase tax

### DIFF
--- a/addons/l10n_il/models/template_il.py
+++ b/addons/l10n_il/models/template_il.py
@@ -31,6 +31,6 @@ class AccountChartTemplate(models.AbstractModel):
                 'income_currency_exchange_account_id': 'il_account_201000',
                 'expense_currency_exchange_account_id': 'il_account_202100',
                 'account_sale_tax_id': 'il_vat_sales_17',
-                'account_purchase_tax_id': 'il_vat_self_inv_purchase',
+                'account_purchase_tax_id': 'il_vat_inputs_17',
             },
         }

--- a/doc/cla/corporate/retama.md
+++ b/doc/cla/corporate/retama.md
@@ -1,0 +1,15 @@
+Israel, 2024-07-29
+
+Retama Software Solutions agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Yedidel Elhayany yedidel@retama.co.il https://github.com/yediel
+
+List of contributors:
+
+Yedidel Elhayany yedidel@retama.co.il https://github.com/yediel


### PR DESCRIPTION
### Steps to Reproduce

1. Install i10n_il module
2. Go to Settings->Invoicing

**Expected behavior:**
Tax il_vat_inputs_17 (VAT inputs) is selected as default Purchase tax

**Actual behavior:**
Tax il_vat_self_inv_purchase (Self Invoice) is selected as default Purchase tax.
This causes new Vendor Bills to be created without VAT