### PR TITLE
[FIX] mail: make image action usable on small images

### DIFF
--- a/addons/mail/static/src/components/attachment_image/attachment_image.js
+++ b/addons/mail/static/src/components/attachment_image/attachment_image.js
@@ -1,11 +1,37 @@
 /** @odoo-module **/
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { isMobileOS } from "@web/core/browser/feature_detection";
+import core from "web.core";
 
-const { Component } = owl;
+const { Component, useState } = owl;
+const _t = core._t;
+
+class ImageActions extends Component {
+    setup() {
+        super.setup();
+        this.actionsMenuState = useState({
+            isOpen: false,
+        });
+        this.isMobileOS = isMobileOS();
+    }
+
+    async setActionsMenuState(state) {
+        this.actionsMenuState.isOpen = state.open;
+    }
+}
+
+Object.assign(ImageActions, {
+    props: ["actions", "imagesHeight"],
+    template: "mail.ImageActions",
+    components: { Dropdown, DropdownItem },
+});
+
+registerMessagingComponent(ImageActions);
 
 export class AttachmentImage extends Component {
-
     /**
      * @returns {AttachmentImage}
      */
@@ -13,11 +39,32 @@ export class AttachmentImage extends Component {
         return this.props.record;
     }
 
+    getActions(attachmentImage) {
+        const res = [];
+        if (attachmentImage.attachment.isDeletable) {
+            res.push({
+                label: _t("Remove"),
+                icon: "fa fa-trash",
+                class: "o_AttachmentImage_actionUnlink",
+                onSelect: (ev) => attachmentImage.onClickUnlink(ev),
+            });
+        }
+        if (attachmentImage.hasDownloadButton) {
+            res.push({
+                label: _t("Download"),
+                icon: "fa fa-download",
+                class: "o_AttachmentImage_actionDownload",
+                onSelect: (ev) => attachmentImage.onClickDownload(ev),
+            });
+        }
+        return res;
+    }
 }
 
 Object.assign(AttachmentImage, {
-    props: { record: Object },
-    template: 'mail.AttachmentImage',
+    props: { record: Object, imagesHeight: Number },
+    template: "mail.AttachmentImage",
+    components: { ImageActions },
 });
 
 registerMessagingComponent(AttachmentImage);

--- a/addons/mail/static/src/components/attachment_image/attachment_image.xml
+++ b/addons/mail/static/src/components/attachment_image/attachment_image.xml
@@ -3,7 +3,7 @@
     <t t-name="mail.AttachmentImage" owl="1">
         <t t-if="attachmentImage">
             <div t-attf-class="{{ className }}" role="menu" t-att-aria-label="attachmentImage.attachment.displayName" t-ref="root">
-                <div class="o_AttachmentImage d-flex position-relative flex-shrink-0"
+                <div class="o_AttachmentImage d-flex position-relative flex-shrink-0 o-viewable"
                     t-att-class="{
                         'o-isUploading': attachmentImage.attachment.isUploading,
                     }"
@@ -24,15 +24,30 @@
                         </div>
                     </t>
                     <div class="o_AttachmentImage_imageOverlay position-absolute top-0 bottom-0 start-0 end-0 p-2 text-white opacity-0 opacity-100-hover d-flex align-items-end flax-wrap flex-column">
-                        <div t-if="attachmentImage.attachment.isDeletable" class="o_AttachmentImage_action o_AttachmentImage_actionUnlink btn btn-sm btn-dark rounded opacity-75 opacity-100-hover" t-att-class="{'o-pretty': attachmentImage.attachmentList.composerViewOwner}" tabindex="0" aria-label="Remove" role="menuitem" t-on-click="attachmentImage.onClickUnlink" title="Remove">
-                            <i class="fa fa-trash"/>
-                        </div>
-                        <div t-if="attachmentImage.hasDownloadButton" class="o_AttachmentImage_action o_AttachmentImage_actionDownload btn btn-sm btn-dark rounded opacity-75 opacity-100-hover mt-auto" t-on-click="attachmentImage.onClickDownload" title="Download">
-                            <i class="fa fa-download"/>
-                        </div>
+                        <ImageActions actions="getActions(attachmentImage)" imagesHeight="props.imagesHeight"/>
                     </div>
                 </div>
             </div>
         </t>
     </t>
+
+    <t t-name="mail.ImageActions" owl="1">
+        <div class="o_AttachmentImage_actions position-absolute top-0 bottom-0 start-0 end-0 p-1 text-white d-flex o-opacity-hoverable opacity-100-hover align-items-end flex-wrap flex-column" t-att-class="{ 'opacity-0': !actionsMenuState.isOpen }">
+            <button t-if="props.actions.length === 1 and props.imagesHeight gt 75" class="btn btn-sm btn-light rounded px-1 py-0" t-att-class="{ 'opacity-75 opacity-100-hover': !isMobileOS }" tabindex="0" t-att-aria-label="props.actions[0].label" t-att-title="props.actions[0].label" role="menuitem" t-on-click.stop="props.actions[0].onSelect">
+                <i t-att-class="props.actions[0].icon"/>
+            </button>
+            <Dropdown t-else="" onStateChanged="(state) => this.setActionsMenuState(state)" togglerClass="'btn btn-sm btn-light rounded px-1 py-0 o_AttachmentImage_actionDropdown'" menuClass="'d-flex flex-column py-0' + (props.actions.length gt 1 ? ' py-0' : '')" position="'right-start'">
+                <t t-set-slot="toggler">
+                    <i class="fa fa-fw fa-chevron-down" t-att-class="{ 'opacity-75 opacity-100-hover py-0': !isMobileOS }" tabindex="0" aria-label="Actions" title="Actions" role="menuitem"/>
+                </t>
+                <t t-set-slot="default">
+                    <DropdownItem t-foreach="props.actions" t-as="action" t-key="action_index" class="`px-2 py-1 d-flex align-items-center rounded-0 ${action.class}`" onSelected="action.onSelect">
+                        <i class="fa-fw" t-att-class="action.icon"/>
+                        <span class="mx-2" t-esc="action.label"/>
+                    </DropdownItem>
+                </t>
+            </Dropdown>
+        </div>
+    </t>
+
 </templates>

--- a/addons/mail/static/src/components/attachment_list/attachment_list.xml
+++ b/addons/mail/static/src/components/attachment_list/attachment_list.xml
@@ -6,7 +6,7 @@
             <div class="o_AttachmentList d-flex flex-column mt-1" t-att-class="{ 'me-2 pe-4': attachmentList.isInChatWindowAndIsAlignedLeft and !attachmentList.composerViewOwner, 'ms-2 ps-4': attachmentList.isInChatWindowAndIsAlignedRight and !attachmentList.composerViewOwner }" t-attf-class="{{ className }}" t-ref="root">
                 <div t-if="attachmentList.attachmentImages.length > 0" class="o_AttachmentList_partialList o_AttachmentList_partialListImages d-flex flex-grow-1 flex-wrap" t-att-class="{ 'justify-content-end': attachmentList.isInChatWindowAndIsAlignedRight and !attachmentList.composerViewOwner }">
                     <t t-foreach="attachmentList.attachmentImages" t-as="attachmentImage" t-key="attachmentImage.localId">
-                        <AttachmentImage className="'o_AttachmentList_attachment mw-100 mb-1'" classNameObj="{ 'ms-1': attachmentList.isInChatWindowAndIsAlignedRight, 'me-1': !attachmentList.isInChatWindowAndIsAlignedRight }" record="attachmentImage"/>
+                        <AttachmentImage className="'o_AttachmentList_attachment mw-100 mb-1'" classNameObj="{ 'ms-1': attachmentList.isInChatWindowAndIsAlignedRight, 'me-1': !attachmentList.isInChatWindowAndIsAlignedRight }" record="attachmentImage" imagesHeight="75"/>
                     </t>
                 </div>
                 <div t-if="attachmentList.attachmentCards.length > 0" class="o_AttachmentList_partialList o_AttachmentList_partialListNonImages d-flex flex-grow-1 flex-wrap mt-1" t-att-class="{ 'justify-content-end': attachmentList.isInChatWindowAndIsAlignedRight and !attachmentList.composerViewOwner }">

--- a/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
@@ -592,11 +592,12 @@ QUnit.test('allow attachment delete on authored message', async function (assert
         "should have an attachment",
     );
     assert.containsOnce(
-        document.body,
-        '.o_AttachmentImage_actionUnlink',
-        "should have delete attachment button"
+        document.querySelector('.o_AttachmentImage_actions'),
+        '.o_AttachmentImage_actionDropdown',
+        'should have action dropdown button'
     );
 
+    await click('.o_AttachmentImage_actionDropdown');
     await click('.o_AttachmentImage_actionUnlink');
     assert.containsOnce(
         document.body,
@@ -657,7 +658,7 @@ QUnit.test('prevent attachment delete on non-authored message in channels', asyn
 });
 
 QUnit.test('allow attachment image download on message', async function (assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
@@ -671,7 +672,7 @@ QUnit.test('allow attachment image download on message', async function (assert)
         model: 'mail.channel',
         res_id: mailChannelId1,
     });
-    const { openDiscuss } = await start({
+    const { click, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: mailChannelId1,
@@ -680,9 +681,16 @@ QUnit.test('allow attachment image download on message', async function (assert)
     });
     await openDiscuss();
     assert.containsOnce(
+        document.querySelector('.o_AttachmentImage_actions'),
+        '.o_AttachmentImage_actionDropdown',
+        'should have action dropdown button'
+    );
+
+    await click('.o_AttachmentImage_actionDropdown');
+    assert.containsOnce(
         document.body,
         '.o_AttachmentImage_actionDownload',
-        "should have download attachment button"
+        'should have download attachment button'
     );
 });
 

--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -179,6 +179,7 @@ export class Dropdown extends Component {
             newState: { ...this.state },
         };
         Dropdown.bus.trigger("state-changed", stateChangedPayload);
+        this.props.onStateChanged({ ...this.state });
     }
 
     /**
@@ -305,6 +306,9 @@ export class Dropdown extends Component {
     }
 }
 Dropdown.bus = new EventBus();
+Dropdown.defaultProps = {
+    onStateChanged: () => {},
+};
 Dropdown.props = {
     class: {
         type: String,
@@ -332,6 +336,10 @@ Dropdown.props = {
         optional: true,
     },
     beforeOpen: {
+        type: Function,
+        optional: true,
+    },
+    onStateChanged: {
         type: Function,
         optional: true,
     },

--- a/addons/web/static/src/core/dropdown/dropdown_item.js
+++ b/addons/web/static/src/core/dropdown/dropdown_item.js
@@ -25,7 +25,7 @@ export class DropdownItem extends Component {
             ev.preventDefault();
         }
         if (onSelected) {
-            onSelected();
+            onSelected(ev);
         }
         const dropdown = this.env[DROPDOWN];
         if (!dropdown) {


### PR DESCRIPTION
On small images, the actions to delete image is barely usable. In mobile, these actions are always shown, so they could even prevent clicking on attachment to view in dialog. Also on big a image the 2 actions are far away, which is can be exhausting.

This commit fixes the issue by using a dropdown when there is more than 1 action or when the image is considered very small. Images visual is at most 75px width and height, so smaller images now show a background, which ensures image actions and clicking on image for preview are both reachable with ease, also added the required changes accordingly.

task-3563828

Backport of: https://github.com/odoo/odoo/pull/180671 