### PR TITLE
[FIX] account: restore markup to tour step

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -28,7 +28,7 @@ registry.category("web_tour.tours").add('account_tour', {
     url: "/web",
     sequence: 60,
     steps: () => [
-    ...accountTourSteps.goToAccountMenu('Send invoices to your customers in no time with the <b>Invoicing app</b>.'),
+    ...accountTourSteps.goToAccountMenu(markup(_t('Send invoices to your customers in no time with the <b>Invoicing app</b>.'))),
     ...accountTourSteps.onboarding(),
     ...accountTourSteps.newInvoice(),
     {


### PR DESCRIPTION
Problem: Account tour was reworked in 17.4, but the markup was lost in the initial `goToAccountMenu` step

Solution: Restore the markup to display message as intended

opw-4311046