### PR TITLE
[IMP] base, hw_drivers: load addons commands change, move genproxytoken

### DIFF
--- a/addons/hw_drivers/cli/genproxytoken.py
+++ b/addons/hw_drivers/cli/genproxytoken.py
@@ -4,7 +4,7 @@ import textwrap
 
 from passlib.hash import pbkdf2_sha512
 
-from . import Command
+from odoo.cli import Command
 from odoo.tools import config
 
 

--- a/odoo/addons/base/tests/test_cli.py
+++ b/odoo/addons/base/tests/test_cli.py
@@ -5,9 +5,11 @@ import subprocess as sp
 import unittest
 from pathlib import Path
 
+import odoo.addons
 from odoo.cli.command import commands, load_addons_commands, load_internal_commands
 from odoo.tools import config, file_path
 from odoo.tests import BaseCase, Like
+
 
 class TestCommand(BaseCase):
 
@@ -46,8 +48,14 @@ class TestCommand(BaseCase):
                 msg=f"Command {name}'s docstring format is invalid for 'odoo-bin help'")
 
     def test_unknown_command(self):
-        command_output = self.run_command('bonbon', check=False).stderr.strip()
-        self.assertEqual(command_output, "Unknown command 'bonbon'")
+        for name in ('bonbon', 'café'):
+            with self.subTest(name):
+                command_output = self.run_command(name, check=False).stderr.strip()
+                self.assertEqual(
+                    command_output, 
+                    f"Unknown command '{name}'.\n"
+                    "Use 'odoo-bin --help' to see the list of available commands."
+                )
 
     def test_help(self):
         expected = {

--- a/odoo/cli/command.py
+++ b/odoo/cli/command.py
@@ -7,8 +7,7 @@ from pathlib import Path
 
 import odoo.init  # import first for core setup
 import odoo.cli
-from odoo.modules import initialize_sys_path
-from odoo.modules.migration import load_script
+from odoo.modules import initialize_sys_path, load_script
 from odoo.tools import config
 
 

--- a/odoo/cli/command.py
+++ b/odoo/cli/command.py
@@ -1,19 +1,21 @@
 import argparse
 import contextlib
-import logging
+import re
 import sys
 from inspect import cleandoc
 from pathlib import Path
 
 import odoo.init  # import first for core setup
 import odoo.cli
-from odoo.modules import get_module_path, get_modules, initialize_sys_path
+from odoo.modules import initialize_sys_path
+from odoo.modules.migration import load_script
 from odoo.tools import config
 
+
+COMMAND_NAME_RE = re.compile(r'^[a-z][a-z0-9_]*$', re.I)
+PROG_NAME = Path(sys.argv[0]).name
 commands = {}
 """All loaded commands"""
-
-PROG_NAME = Path(sys.argv[0]).name
 
 
 class Command:
@@ -24,7 +26,16 @@ class Command:
 
     def __init_subclass__(cls):
         cls.name = cls.name or cls.__name__.lower()
-        commands[cls.name] = cls
+        module = cls.__module__.rpartition('.')[2]
+        if not cls.is_valid_name(cls.name):
+            raise ValueError(
+                f"Command name {cls.name!r} "
+                f"must match {COMMAND_NAME_RE.pattern!r}")
+        if cls.name != module:
+            raise ValueError(
+                f"Command name {cls.name!r} "
+                f"must match Module name {module!r}")
+        commands[cls.name] = cls 
 
     @property
     def prog(self):
@@ -41,9 +52,13 @@ class Command:
             )
         return self._parser
 
+    @classmethod
+    def is_valid_name(cls, name):
+        return re.match(COMMAND_NAME_RE, name)
+
 
 def load_internal_commands():
-    """Load `commands` from `odoo.cli`"""
+    """ Load ``commands`` from ``odoo.cli`` """
     for path in odoo.cli.__path__:
         for module in Path(path).iterdir():
             if module.suffix != '.py':
@@ -51,33 +66,44 @@ def load_internal_commands():
             __import__(f'odoo.cli.{module.stem}')
 
 
-def load_addons_commands():
-    """Load `commands` from `odoo.addons.*.cli`"""
-    logging.disable(logging.CRITICAL)
+def load_addons_commands(command=None):
+    """
+    Search the addons path for modules with a ``cli/{command}.py`` file.
+    In case no command is provided, discover and load all the commands.
+    """
+    if command is None:
+        command = '*'
+    elif not Command.is_valid_name(command):
+        return
+
+    mapping = {}
     initialize_sys_path()
-    for module in get_modules():
-        if (Path(get_module_path(module)) / 'cli').is_dir():
-            with contextlib.suppress(ImportError):
-                __import__(f'odoo.addons.{module}')
-    logging.disable(logging.NOTSET)
-    return list(commands)
+    for path in odoo.addons.__path__:
+        for fullpath in Path(path).glob(f'*/cli/{command}.py'):
+            if (found_command := fullpath.stem) and Command.is_valid_name(found_command):
+                # loading as odoo.cli and not odoo.addons.{module}.cli
+                # so it doesn't load odoo.addons.{module}.__init__
+                mapping[f'odoo.cli.{found_command}'] = fullpath 
+
+    for fq_name, fullpath in mapping.items():
+        with contextlib.suppress(ImportError):
+            load_script(fullpath, fq_name)
 
 
 def find_command(name: str) -> Command | None:
     """ Get command by name. """
-    # check in the loaded commands
+
+    # built-in commands
     if command := commands.get(name):
         return command
+
     # import from odoo.cli
-    try:
+    with contextlib.suppress(ImportError):
         __import__(f'odoo.cli.{name}')
-    except ImportError:
-        pass
-    else:
-        if command := commands.get(name):
-            return command
-    # last try, import from odoo.addons.*.cli
-    load_addons_commands()
+        return commands[name]
+
+    # import from odoo.addons.*.cli
+    load_addons_commands(command=name)
     return commands.get(name)
 
 
@@ -104,7 +130,10 @@ def main():
         command_name = 'server'
 
     if command := find_command(command_name):
-        o = command()
-        o.run(args)
+        command().run(args)
     else:
-        sys.exit(f"Unknown command {command_name!r}")
+        message = (
+            f"Unknown command {command_name!r}.\n"
+            f"Use '{PROG_NAME} --help' to see the list of available commands."
+        )
+        sys.exit(message)

--- a/odoo/cli/help.py
+++ b/odoo/cli/help.py
@@ -1,7 +1,10 @@
 import textwrap
 
-from .command import PROG_NAME, Command, commands, load_addons_commands, load_internal_commands
+import odoo.addons
+import odoo.modules
 import odoo.release
+
+from .command import PROG_NAME, Command, commands, load_addons_commands, load_internal_commands
 
 
 class Help(Command):

--- a/odoo/modules/__init__.py
+++ b/odoo/modules/__init__.py
@@ -20,6 +20,7 @@ from .module import (
     initialize_sys_path,
     get_manifest,
     load_openerp_module,
+    load_script
 )
 
 from . import registry

--- a/odoo/modules/migration.py
+++ b/odoo/modules/migration.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import glob
-import importlib.util
 import inspect
 import itertools
 import logging
@@ -16,6 +15,7 @@ from os.path import join as opj
 
 import odoo.release as release
 import odoo.upgrade
+from odoo.modules.module import load_script
 from odoo.orm.registry import Registry
 from odoo.tools.misc import file_path
 from odoo.tools.parse_version import parse_version
@@ -53,15 +53,6 @@ VERSION_RE = re.compile(
     $""",
     re.VERBOSE | re.ASCII,
 )
-
-
-def load_script(path: str, module_name: str):
-    full_path = file_path(path) if not os.path.isabs(path) else path
-    spec = importlib.util.spec_from_file_location(module_name, full_path)
-    assert spec and spec.loader, f"spec not found for {module_name}"
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
 
 
 class MigrationManager:

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -543,3 +543,12 @@ def check_manifest_dependencies(manifest: dict) -> None:
             tools.find_in_path(binary)
         except OSError:
             raise Exception('Unable to find %r in path' % (binary,))
+
+
+def load_script(path: str, module_name: str):
+    full_path = file_path(path) if not os.path.isabs(path) else path
+    spec = importlib.util.spec_from_file_location(module_name, full_path)
+    assert spec and spec.loader, f"spec not found for {module_name}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module


### PR DESCRIPTION
- We now load the `addons/{addon}/cli/{command}.py` file instead of `addons/{addon}` to load addons commands.
  See this [TODO](https://github.com/odoo/odoo/blob/18.0/odoo/cli/command.py#L52) here, that calls for loading less stuff when loading addon commands. The loaded module will be put under `sys.modules[f"odoo.cli.{module}"]` anyway so addons modules will just keep on working as it did before.

- `genproxytoken` is a command that relates to the `hw_drivers` module, for the `l10n_eg_edi` localization (USB key signing kit for Egyptian EDI). The command is only used [in the Windows setup](https://github.com/odoo/odoo/blob/ac712610c72a84f6292fb46e45fef998b0da79f6/setup/win32/setup.nsi#L310) by the Odoo IoT box to write a hex key in the config. The key will be read by [this code](https://github.com/odoo/odoo/blob/ac712610c72a84f6292fb46e45fef998b0da79f6/addons/hw_drivers/iot_handlers/drivers/L10nEGDrivers.py#L27) in `L10nEGDrivers` to communicate with the USB key.

  The `genproxytoken` can then be moved to the `hw_drivers` module, given that **we don't load the entire module** as we are doing now. The `hw_drivers` module will start doing things (like requiring `sudo` system access) as soon as it is imported.

  *(There is no other actual `addons_command` in `master` at the moment than `genproxytoken`, so we don't have much to maintain.)*