### PR TITLE
[FIX] portal: fix customer information form if no country set

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -377,9 +377,14 @@ class CustomerPortal(Controller):
         error_message = []
 
         request.update_context(portal_form_country_id=data['country_id'])
+        partner = request.env.user.partner_id
+
         # Validation
         for field_name in self._get_mandatory_fields():
             if not data.get(field_name):
+                if field_name == 'country_id' and not partner.can_edit_vat():
+                    # you cannot edit the country ID in that case so we skip the error, see the XML form for details
+                    continue
                 error[field_name] = 'missing'
                 if field_name == 'zipcode':
                     error['zip'] = 'missing'
@@ -390,7 +395,6 @@ class CustomerPortal(Controller):
             error_message.append(_('Invalid Email! Please enter a valid email address.'))
 
         # vat validation
-        partner = request.env.user.partner_id
         if data.get("vat") and partner and partner.vat != data.get("vat"):
             # Check the VAT if it is the public user too.
             if partner_creation or partner.can_edit_vat():


### PR DESCRIPTION
Having no country on a portal user would cause attempting to edit personal information through the portal to have an internal server error.

Added a check to country_id to ensure that the country_id is a numerical value before casting to an int to avoid this internal server error.

opw-4309159
