### PR TITLE
[FIX] html_editor: power buttons should be visible on undo

### DIFF
--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -33,6 +33,14 @@ export class PowerButtonsPlugin extends Plugin {
         this.createPowerButtons();
     }
 
+    handleCommand(command) {
+        switch (command) {
+            case "CONTENT_UPDATED":
+                this.updatePowerButtons();
+                break;
+        }
+    }
+
     createPowerButtons() {
         this.powerButtons = document.createElement("div");
         this.powerButtons.className = `o_we_power_buttons d-flex justify-content-center d-none`;

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -54,6 +54,17 @@ describe.tags("desktop")("visibility", () => {
         await setupEditor("<p>[]<br><br></p>");
         expect(".o_we_power_buttons").not.toBeVisible();
     });
+
+    test("should show power buttons on undo", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        expect(".o_we_power_buttons").toBeVisible();
+        insertText(editor, "a");
+        await animationFrame();
+        expect(".o_we_power_buttons").not.toBeVisible();
+        await press(["ctrl", "z"]);
+        expect(".odoo-editor-editable p").toHaveText("");
+        expect(".o_we_power_buttons").toBeVisible();
+    });
 });
 
 describe.tags("desktop")("buttons", () => {


### PR DESCRIPTION
Steps to Reproduce:

1. Insert some text into the editor (e.g., type "a").
2. Press `Ctrl + Z` to undo the insertion.
3. Observe that the power buttons are not visible.

Description of the issue/feature this PR addresses:

Power buttons were not visible after pressing Ctrl+Z (undo).

Desired behavior after PR is merged:

Trigger `updatePowerButtons` when the `CONTENT_UPDATED` command is dispatched,
ensuring that the power buttons are updated and made visible.

task-4309762