### PR TITLE
[FIX] web: remove flicker with the avatar widget

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.scss
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.scss
@@ -43,6 +43,9 @@
             @include o-text-overflow(inline-block);
             max-width: 200px;
             color: inherit;
+        }
+
+        .o_badge_text {
             line-height: 1.1;
         }
 

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -647,6 +647,14 @@
                 }
             }
         }
+
+        &.o_field_many2one_avatar .o_m2o_avatar > img {
+            display: block;
+        }
+
+        &.o_field_many2many_tags_avatar {
+            --fieldWidget-display: inline;
+        }
     }
     .o_field_widget, .btn {
         .o_field_widget {


### PR DESCRIPTION
Previously the space between a field with the avatar widget and the field 
underneath changes depending on a user is set or not which creates a small flicker.

After this commit there will be no flicker when a user is set on an avatar field.

Task-3996557

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
