### PR TITLE
[IMP] web_editor,website: image tooltip refinement

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/002.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/002.scss
@@ -85,7 +85,7 @@
 
     &:not(.o_slideshow) {
         img {
-            cursor: pointer;
+            cursor: default;
         }
     }
 


### PR DESCRIPTION
 This commit enhances tooltip behavior. Previously, the tooltip was
 displayed for only a brief period. Now, it remains visible as long as
 the cursor hovers over the image.

 task-4285601


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
