### PR TITLE
[FIX] hr_recruitment: allow Recruitment Users to load recruitment data

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -404,7 +404,7 @@ class Job(models.Model):
     def _action_load_recruitment_scenario(self):
 
         convert_file(
-            self.env,
+            self.sudo().env,
             "hr_recruitment",
             "data/scenarios/hr_recruitment_scenario.xml",
             None,

--- a/addons/hr_recruitment/static/src/views/recruitment_helper_view.js
+++ b/addons/hr_recruitment/static/src/views/recruitment_helper_view.js
@@ -1,4 +1,5 @@
 import { useService } from "@web/core/utils/hooks";
+import { user } from "@web/core/user";
 import { Component, onWillStart, useState } from "@odoo/owl";
 
 export class RecruitmentActionHelper extends Component {
@@ -14,6 +15,7 @@ export class RecruitmentActionHelper extends Component {
             const categoryTags = await this.orm.searchRead("hr.applicant.category", [], ["name"]);
             const demoTag = categoryTags.filter((tag) => tag.name === "Demo");
             this.state.hasDemoData = demoTag.length === 1;
+            this.isRecruitmentUser = await user.hasGroup("hr_recruitment.group_hr_recruitment_user");
         });
     }
 

--- a/addons/hr_recruitment/static/src/views/recruitment_helper_view.xml
+++ b/addons/hr_recruitment/static/src/views/recruitment_helper_view.xml
@@ -9,7 +9,7 @@
                 <p>
                     Let's create a job position.
                 </p>
-                <t t-if="!state.hasDemoData">
+                <t t-if="!state.hasDemoData and isRecruitmentUser">
                     <div class="d-flex gap-3 align-items-center or-separator">
                         <hr class="flex-grow-1" /> or <hr class="flex-grow-1" />
                     </div>


### PR DESCRIPTION
Currently an error was generated when the user with access right `Officer: Manage all applicants` tries to load recruitment data by clicking `Load Sample data` from recruitment.

error: `ParseError: while parsing /home/odoo/src/odoo/18.0/addons/hr_rec...`

This is because when the user tries to load recruitment data, it tries to create a `Mail Tracking Value` that requires admin rights. 

This commit allows non-admin users to load the recruitment scenerio and make
the `Load Sample data` button visible to the recruitment users.

sentry-6042340046