### PR TITLE
[FIX] stock: unable to return goods from the delivery order

### DIFF
--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -1022,7 +1022,7 @@ class Warehouse(models.Model):
                 'default_location_src_id': False,
                 'sequence': max_sequence + 6,
                 'show_reserved': True,
-                'sequence_code': 'IN',
+                'sequence_code': 'RET',
                 'company_id': self.company_id.id,
             },
         }, max_sequence + 6


### PR DESCRIPTION
From PR #185966, the return sequence will have a prefix from the sequence_code of the operation type, leading to the inability to return goods from the delivery order due to duplicate references. The solution is for the sequence_code of the operation type to be set to 'RET' to avoid conflicts with the receiving operation type.

Steps to reproduce:
Open any delivery order and click the 'Return' button anh click the 'Return' button on wizard.
You will receive the warning 'The operation cannot be completed: Reference must be unique per company!'.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
