### PR TITLE
account_peppol: Fix the issue of same PublicWidget name

### DIFF
--- a/addons/account_peppol/static/src/js/portal.js
+++ b/addons/account_peppol/static/src/js/portal.js
@@ -1,17 +1,16 @@
 /** @odoo-module **/
 
-import publicWidget from "@web/legacy/js/public/public_widget";
+import portalDetails from "@portal/js/portal";
 
-publicWidget.registry.portalDetails = publicWidget.Widget.extend({
-    selector: '.o_portal_details',
-    events: {
-        'change select[name="invoice_sending_method"]': '_onSendingMethodChange',
-    },
+portalDetails.include({
+    events: Object.assign({}, portalDetails.prototype.events, {
+        'change select[name="invoice_sending_method"]': "_onSendingMethodChange",
+    }),
 
     start() {
         this._showPeppolConfig();
         this.orm = this.bindService("orm");
-        return this._super.apply(this, arguments);
+        return this._super(...arguments);
     },
 
     _showPeppolConfig() {
@@ -19,9 +18,9 @@ publicWidget.registry.portalDetails = publicWidget.Widget.extend({
         const divToToggle = document.querySelectorAll(".portal_peppol_toggle");
         for (const peppolDiv of divToToggle) {
             if (method === "peppol") {
-                peppolDiv.classList.remove("d-none")
+                peppolDiv.classList.remove("d-none");
             } else {
-                peppolDiv.classList.add("d-none")
+                peppolDiv.classList.add("d-none");
             }
         }
     },

--- a/addons/portal/static/src/js/portal.js
+++ b/addons/portal/static/src/js/portal.js
@@ -50,6 +50,8 @@ publicWidget.registry.portalDetails = publicWidget.Widget.extend({
     },
 });
 
+export default publicWidget.registry.portalDetails;
+
 export const PortalHomeCounters = publicWidget.Widget.extend({
     selector: '.o_portal_my_home',
 


### PR DESCRIPTION
When we install portal as well as account_peppol module and go to My Account, so feature are not working, for e.g. changing country will not change State selection, it is because we have PublicWidget with name `publicWidget.registry.portalDetails` in portal module while we are using same name in account_peppol module which replaces the existing PublicWidget `portalDetails`.

To fix this issue we have used `inlcude` feature which will patch existing class `portalDetails` of portal module.

The issue arise with commit: https://github.com/odoo/odoo/pull/182585/commits/857b9a188c77cef2e3cd8a1c6b3035e7cd8d1305#diff-e0a8e9753f5e3ae55848bc264b7546eb7e187fe77c7500f9ebd97b1edfb23f46



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
