### PR TITLE
[FIX] l10n_in: Remove Enterprise Widget from E-invoice

### DIFF
--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -10,7 +10,7 @@
                     <field name="group_l10n_in_reseller"/>
                 </setting>
                 <setting help="Connect to NIC (National Informatics Center) to submit invoices on posting." name="electronic_invoices_in" invisible="country_code != 'IN'" documentation="/applications/finance/accounting/fiscal_localizations/localizations/india.html#indian-e-invoicing">
-                    <field name="module_l10n_in_edi" class="oe_inline" widget="upgrade_boolean"/>
+                    <field name="module_l10n_in_edi" class="oe_inline"/>
                 </setting>
                 <setting help="Connect to NIC (National Informatics Center) to submit e-waybill on posting." name="electronic_waybill_in" invisible="country_code != 'IN'" documentation="/applications/finance/accounting/fiscal_localizations/localizations/india.html#indian-e-waybill">
                     <field name="module_l10n_in_edi_ewaybill" class="oe_inline"/>


### PR DESCRIPTION
System shows Enterprise Widget on E-invoice  module

Although the module is available in community addons

Steps to Reproduce :
Run only community
Install l10n_in module.
Now Go to the Settings -> Invoicing.
See the Enterprise Widget is on E-Invoice (Indian Integration).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
