### PR TITLE
[IMP] test_mail: make access tests independent from discuss models

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1463,13 +1463,15 @@ class Lead(models.Model):
         :param opportunities: see ``_merge_dependences``
         """
         self.ensure_one()
-        for opportunity in opportunities:
-            for message in opportunity.message_ids:
-                if message.subject:
-                    subject = _("From %(source_name)s : %(source_subject)s", source_name=opportunity.name, source_subject=message.subject)
+        # sudo usage: because we want to go through all messages, whatever the real ACLs
+        # current user has on them
+        for opportunity_su in opportunities.sudo():
+            for message_su in opportunity_su.message_ids:
+                if message_su.subject:
+                    subject = _("From %(source_name)s : %(source_subject)s", source_name=opportunity_su.name, source_subject=message_su.subject)
                 else:
-                    subject = _("From %(source_name)s", source_name=opportunity.name)
-                message.write({
+                    subject = _("From %(source_name)s", source_name=opportunity_su.name)
+                message_su.write({
                     'res_id': self.id,
                     'subject': subject,
                 })

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -858,11 +858,7 @@ class Message(models.Model):
                 'name': message_sudo.author_guest_id.name,
             } if message_sudo.author_guest_id else [('clear',)]
             if message_sudo.model and message_sudo.res_id:
-                record_name = self.env[message_sudo.model] \
-                    .browse(message_sudo.res_id) \
-                    .sudo() \
-                    .with_prefetch(thread_ids_by_model_name[message_sudo.model]) \
-                    .display_name
+                record_name = self.env[message_sudo.model].browse(message_sudo.res_id).sudo().with_prefetch(thread_ids_by_model_name[message_sudo.model]).display_name
             else:
                 record_name = False
             reactions_per_content = defaultdict(self.env['mail.message.reaction'].sudo().browse)

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1080,7 +1080,7 @@ class Message(models.Model):
             records = self.env[model].browse([res_id])
         else:
             records = self.env[model] if model else self.env['mail.thread']
-        return records._notify_get_reply_to(default=email_from)[res_id]
+        return records.sudo()._notify_get_reply_to(default=email_from)[res_id]
 
     @api.model
     def _get_message_id(self, values):

--- a/addons/mail/tests/test_res_users.py
+++ b/addons/mail/tests/test_res_users.py
@@ -3,7 +3,9 @@
 
 from psycopg2 import IntegrityError
 
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
+from odoo.tests import tagged
 from odoo.tools import mute_logger
 
 
@@ -20,3 +22,19 @@ class TestUser(MailCommon):
                 notification_type='inbox',
                 groups='base.group_portal',
             )
+
+
+@tagged('-at_install', 'post_install')
+class TestUserTours(HttpCaseWithUserDemo):
+
+    def test_user_modify_own_profile(self):
+        """" A user should be able to modify their own profile.
+        Even if that user does not have access rights to write on the res.users model. """
+        if 'hr.employee' in self.env and not self.user_demo.employee_id:
+            self.env['hr.employee'].create({
+                'name': 'Marc Demo',
+                'user_id': self.user_demo.id,
+            })
+        self.user_demo.tz = "Europe/Brussels"
+        self.start_tour("/web", "mail/static/tests/tours/user_modify_own_profile_tour.js", login="demo")
+        self.assertEqual(self.user_demo.email, "updatedemail@example.com")

--- a/addons/mail/tests/test_user_modify_own_profile.py
+++ b/addons/mail/tests/test_user_modify_own_profile.py
@@ -1,21 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import tagged
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
 
-@tagged('-at_install', 'post_install')
 class TestUserModifyOwnProfile(HttpCaseWithUserDemo):
-
-    def test_user_modify_own_profile(self):
-        """" A user should be able to modify their own profile.
-        Even if that user does not have access rights to write on the res.users model. """
-        if 'hr.employee' in self.env and not self.user_demo.employee_id:
-            self.env['hr.employee'].create({
-                'name': 'Marc Demo',
-                'user_id': self.user_demo.id,
-            })
-        self.user_demo.tz = "Europe/Brussels"
-        self.start_tour("/web", "mail/static/tests/tours/user_modify_own_profile_tour.js", login="demo")
-        self.assertEqual(self.user_demo.email, "updatedemail@example.com")
+    pass

--- a/addons/test_mail/models/__init__.py
+++ b/addons/test_mail/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import mail_test_access
 from . import test_mail_corner_case_models
 from . import test_mail_models
 from . import test_mail_thread_models

--- a/addons/test_mail/models/mail_test_access.py
+++ b/addons/test_mail/models/mail_test_access.py
@@ -1,0 +1,60 @@
+from odoo import exceptions, fields, models
+
+
+class MailTestAccess(models.Model):
+    """ Test access on mail models without depending on real models like channel
+    or partner which have their own set of ACLs. """
+    _description = 'Mail Access Test'
+    _name = 'mail.test.access'
+    _inherit = ['mail.thread.blacklist']
+    _mail_post_access = 'write'  # default value but ease mock
+    _order = 'id DESC'
+    _primary_email = 'email_from'
+
+    name = fields.Char()
+    email_from = fields.Char()
+    phone = fields.Char()
+    customer_id = fields.Many2one('res.partner', 'Customer')
+    access = fields.Selection(
+        [
+            ('public', 'public'),
+            ('logged', 'Logged'),
+            ('logged_ro', 'Logged readonly for portal'),
+            ('followers', 'Followers'),
+            ('internal', 'Internal'),
+            ('internal_ro', 'Internal readonly'),
+            ('admin', 'Admin'),
+        ],
+        name='Access', default='public')
+
+    def _mail_get_partner_fields(self):
+        return ['customer_id']
+
+
+class MailTestAccessCusto(models.Model):
+    """ Test access on mail models without depending on real models like channel
+    or partner which have their own set of ACLs. """
+    _description = 'Mail Access Test with Custo'
+    _name = 'mail.test.access.custo'
+    _inherit = ['mail.thread.blacklist']
+    _mail_post_access = 'write'  # default value but ease mock
+    _order = 'id DESC'
+    _primary_email = 'email_from'
+
+    name = fields.Char()
+    email_from = fields.Char()
+    phone = fields.Char()
+    customer_id = fields.Many2one('res.partner', 'Customer')
+    is_locked = fields.Boolean()
+
+    def _mail_get_partner_fields(self):
+        return ['customer_id']
+
+    def _get_mail_message_access(self, res_ids, operation, model_name=None):
+        # customize message creation
+        if operation == "create":
+            if any(record.is_locked for record in self.browse(res_ids)):
+                raise exceptions.AccessError('Cannot post on locked records')
+            else:
+                return "read"
+        return super()._get_mail_message_access(res_ids, operation, model_name=model_name)

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -1,6 +1,11 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_mail_performance_thread,access_mail_performance_thread,model_mail_performance_thread,,1,1,1,1
 access_mail_performance_tracking_user,mail.performance.tracking,model_mail_performance_tracking,base.group_user,1,1,1,1
+access_mail_test_access_portal,mail.access.portal.portal,model_mail_test_access,base.group_portal,1,1,0,0
+access_mail_test_access_public,mail.access.portal.public,model_mail_test_access,base.group_public,1,0,0,0
+access_mail_test_access_user,mail.access.portal.user,model_mail_test_access,base.group_user,1,1,1,1
+access_mail_test_access_custo_portal,mail.access.portal.portal,model_mail_test_access_custo,base.group_portal,1,0,0,0
+access_mail_test_access_custo_user,mail.access.portal.user,model_mail_test_access_custo,base.group_user,1,1,1,1
 access_mail_test_simple_portal,mail.test.simple.portal,model_mail_test_simple,base.group_portal,1,0,0,0
 access_mail_test_simple_user,mail.test.simple.user,model_mail_test_simple,base.group_user,1,1,1,1
 access_mail_test_gateway_portal,mail.test.gateway.portal,model_mail_test_gateway,base.group_portal,1,0,0,0

--- a/addons/test_mail/security/test_mail_security.xml
+++ b/addons/test_mail/security/test_mail_security.xml
@@ -1,6 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
 
+    <record id="ir_rule_mail_test_access_public" model="ir.rule">
+        <field name="name">Public: public only</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access"/>
+        <field name="domain_force">[('access', '=', 'public')]</field>
+        <field name="groups" eval="[(4, ref('base.group_public'))]"/>
+    </record>
+    <record id="ir_rule_mail_test_access_portal" model="ir.rule">
+        <field name="name">Portal: public/logged/logged readonly only</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access"/>
+        <field name="domain_force">[
+            '|', ('access', 'in', ('public', 'logged', 'logged_ro')),
+            '&amp;', ('access', '=', 'followers'), ('message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+    <record id="ir_rule_mail_test_access_portal_update" model="ir.rule">
+        <field name="name">Portal: update logged only</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access"/>
+        <field name="domain_force">[
+            '|', ('access', '=', 'logged'),
+            '&amp;', ('access', '=', 'followers'), ('message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="perm_write" eval="True"/>
+    </record>
+    <record id="ir_rule_mail_test_access_internal" model="ir.rule">
+        <field name="name">Internal: read not admin</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access"/>
+        <field name="domain_force">[('access', '!=', 'admin')]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+    <record id="ir_rule_mail_test_access_internal_update" model="ir.rule">
+        <field name="name">Internal: update not admin and not readonly</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access"/>
+        <field name="domain_force">[('access', 'not in', ('internal_ro', 'admin'))]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+    <record id="ir_rule_mail_test_access_admin" model="ir.rule">
+        <field name="name">Admin: all</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('base.group_system'))]"/>
+    </record>
+
+
+    <record id="mail_test_multi_company_rule" model="ir.rule">
+        <field name="name">Mail Test Multi Company</field>
+        <field name="model_id" ref="test_mail.model_mail_test_multi_company"/>
+        <field eval="True" name="global"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
+
     <record id="mail_test_multi_company_rule" model="ir.rule">
         <field name="name">Mail Test Multi Company</field>
         <field name="model_id" ref="test_mail.model_mail_test_multi_company"/>

--- a/addons/test_mail/tests/__init__.py
+++ b/addons/test_mail/tests/__init__.py
@@ -7,6 +7,7 @@ from . import test_mail_composer
 from . import test_mail_composer_mixin
 from . import test_mail_followers
 from . import test_mail_message
+from . import test_mail_message_security
 from . import test_mail_mail
 from . import test_mail_gateway
 from . import test_mail_multicompany

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -1,13 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import base64
-from unittest.mock import patch
-
-from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.test_mail.tests.common import TestMailCommon
-from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
-from odoo.exceptions import AccessError, UserError
+from odoo.exceptions import UserError
 from odoo.tools import is_html_empty, mute_logger, formataddr
 from odoo.tests import tagged, users
 
@@ -96,20 +91,6 @@ class TestMessageValues(TestMailCommon):
             record._message_update_content(tracking_message, '', [])
 
     @mute_logger('odoo.models.unlink')
-    def test_mail_message_format(self):
-        record1 = self.env['mail.test.simple'].create({'name': 'Test1'})
-        message = self.env['mail.message'].create([{
-            'model': 'mail.test.simple',
-            'res_id': record1.id,
-        }])
-        res = message.message_format()
-        self.assertEqual(res[0].get('record_name'), 'Test1')
-
-        record1.write({"name": "Test2"})
-        res = message.message_format()
-        self.assertEqual(res[0].get('record_name'), 'Test2')
-
-    @mute_logger('odoo.models.unlink')
     def test_mail_message_format_access(self):
         """
         User that doesn't have access to a record should still be able to fetch
@@ -128,6 +109,10 @@ class TestMessageValues(TestMailCommon):
         self.env.invalidate_all()
         res = message.with_user(self.user_employee).message_format()
         self.assertEqual(res[0].get('record_name'), 'Test1')
+
+        record1.write({"name": "Test2"})
+        res = message.with_user(self.user_employee).message_format()
+        self.assertEqual(res[0].get('record_name'), 'Test2')
 
     def test_mail_message_values_body_base64_image(self):
         msg = self.env['mail.message'].with_user(self.user_employee).create({
@@ -320,194 +305,3 @@ class TestMessageValues(TestMailCommon):
         self.assertIn('reply_to', msg.message_id.split('@')[0])
         self.assertNotIn('mail.test.container', msg.message_id.split('@')[0])
         self.assertNotIn('-%d-' % self.alias_record.id, msg.message_id.split('@')[0])
-
-
-@tagged('mail_message')
-class TestMessageAccess(TestMailCommon):
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestMessageAccess, cls).setUpClass()
-
-        cls.user_employee_1 = mail_new_test_user(cls.env, login='tao', groups='base.group_user', name='Tao Lee')
-        cls.user_public = mail_new_test_user(cls.env, login='bert', groups='base.group_public', name='Bert Tartignole')
-        cls.user_portal = mail_new_test_user(cls.env, login='chell', groups='base.group_portal', name='Chell Gladys')
-
-        cls.group_restricted_channel = cls.env['mail.channel'].browse(cls.env['mail.channel'].channel_create(name='Channel for Groups', group_id=cls.env.ref('base.group_user').id)['id'])
-        cls.public_channel = cls.env['mail.channel'].browse(cls.env['mail.channel'].channel_create(name='Public Channel', group_id=None)['id'])
-        cls.private_group = cls.env['mail.channel'].browse(cls.env['mail.channel'].create_group(partners_to=cls.user_employee_1.partner_id.ids, name="Group")['id'])
-        cls.message = cls.env['mail.message'].create({
-            'body': 'My Body',
-            'model': 'mail.channel',
-            'res_id': cls.private_group.id,
-        })
-
-    @mute_logger('odoo.addons.mail.models.mail_mail')
-    def test_mail_message_access_search(self):
-        # Data: various author_ids, partner_ids, documents
-        msg1 = self.env['mail.message'].create({
-            'subject': '_ZTest', 'body': 'A', 'subtype_id': self.ref('mail.mt_comment')})
-        msg2 = self.env['mail.message'].create({
-            'subject': '_ZTest', 'body': 'A+B', 'subtype_id': self.ref('mail.mt_comment'),
-            'partner_ids': [(6, 0, [self.user_public.partner_id.id])]})
-        msg3 = self.env['mail.message'].create({
-            'subject': '_ZTest', 'body': 'A Pigs', 'subtype_id': False,
-            'model': 'mail.channel', 'res_id': self.group_restricted_channel.id})
-        msg4 = self.env['mail.message'].create({
-            'subject': '_ZTest', 'body': 'A+P Pigs', 'subtype_id': self.ref('mail.mt_comment'),
-            'model': 'mail.channel', 'res_id': self.group_restricted_channel.id,
-            'partner_ids': [(6, 0, [self.user_public.partner_id.id])]})
-        msg5 = self.env['mail.message'].create({
-            'subject': '_ZTest', 'body': 'A+E Pigs', 'subtype_id': self.ref('mail.mt_comment'),
-            'model': 'mail.channel', 'res_id': self.group_restricted_channel.id,
-            'partner_ids': [(6, 0, [self.user_employee.partner_id.id])]})
-        msg6 = self.env['mail.message'].create({
-            'subject': '_ZTest', 'body': 'A Birds', 'subtype_id': self.ref('mail.mt_comment'),
-            'model': 'mail.channel', 'res_id': self.private_group.id})
-        msg7 = self.env['mail.message'].with_user(self.user_employee).create({
-            'subject': '_ZTest', 'body': 'B', 'subtype_id': self.ref('mail.mt_comment')})
-        msg8 = self.env['mail.message'].with_user(self.user_employee).create({
-            'subject': '_ZTest', 'body': 'B+E', 'subtype_id': self.ref('mail.mt_comment'),
-            'partner_ids': [(6, 0, [self.user_employee.partner_id.id])]})
-
-        # Test: Public: 2 messages (recipient)
-        messages = self.env['mail.message'].with_user(self.user_public).search([('subject', 'like', '_ZTest')])
-        self.assertEqual(messages, msg2 | msg4)
-
-        # Test: Employee: 3 messages on Channel Employee can read (employee can read group with default values)
-        messages = self.env['mail.message'].with_user(self.user_employee).search([('subject', 'like', '_ZTest'), ('body', 'ilike', 'A')])
-        self.assertEqual(messages, msg3 | msg4 | msg5)
-
-        # Test: Employee: 3 messages on Channel Employee can read (employee can read group with default values), 0 on Birds (private group) + 2 messages as author
-        messages = self.env['mail.message'].with_user(self.user_employee).search([('subject', 'like', '_ZTest')])
-        self.assertEqual(messages, msg3 | msg4 | msg5 | msg7 | msg8)
-
-        # Test: Admin: all messages
-        messages = self.env['mail.message'].search([('subject', 'like', '_ZTest')])
-        self.assertEqual(messages, msg1 | msg2 | msg3 | msg4 | msg5 | msg6 | msg7 | msg8)
-
-        # Test: Portal: 0 (no access to groups, not recipient)
-        messages = self.env['mail.message'].with_user(self.user_portal).search([('subject', 'like', '_ZTest')])
-        self.assertFalse(messages)
-
-        # Test: Portal: 2 messages (public channel)
-        self.group_restricted_channel.write({'group_public_id': False})
-        messages = self.env['mail.message'].with_user(self.user_portal).search([('subject', 'like', '_ZTest')])
-        self.assertEqual(messages, msg4 | msg5)
-
-    # --------------------------------------------------
-    # READ
-    # --------------------------------------------------
-
-    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
-    def test_mail_message_access_read_crash(self):
-        with self.assertRaises(AccessError):
-            self.message.with_user(self.user_employee).read()
-
-    @mute_logger('odoo.models')
-    def test_mail_message_access_read_crash_portal(self):
-        with self.assertRaises(AccessError):
-            self.message.with_user(self.user_portal).read(['body', 'message_type', 'subtype_id'])
-
-    def test_mail_message_access_read_ok_portal(self):
-        self.message.write({'subtype_id': self.ref('mail.mt_comment'), 'res_id': self.public_channel.id})
-        self.message.with_user(self.user_portal).read(['body', 'message_type', 'subtype_id'])
-
-    def test_mail_message_access_read_notification(self):
-        attachment = self.env['ir.attachment'].create({
-            'datas': base64.b64encode(b'My attachment'),
-            'name': 'doc.txt',
-            'res_model': self.message._name,
-            'res_id': self.message.id})
-        # attach the attachment to the message
-        self.message.write({'attachment_ids': [(4, attachment.id)]})
-        self.message.write({'partner_ids': [(4, self.user_employee.partner_id.id)]})
-        self.message.with_user(self.user_employee).read()
-        # Test: Employee has access to attachment, ok because they can read message
-        attachment.with_user(self.user_employee).read(['name', 'datas'])
-
-    def test_mail_message_access_read_author(self):
-        self.message.write({'author_id': self.user_employee.partner_id.id})
-        self.message.with_user(self.user_employee).read()
-
-    def test_mail_message_access_read_doc(self):
-        self.message.write({'model': 'mail.channel', 'res_id': self.public_channel.id})
-        # Test: Employee reads the message, ok because linked to a doc they are allowed to read
-        self.message.with_user(self.user_employee).read()
-
-    # --------------------------------------------------
-    # CREATE
-    # --------------------------------------------------
-
-    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.addons.base.models.ir_rule')
-    def test_mail_message_access_create_crash_public(self):
-        # Public creates a message on Channel for groups -> ko, no enter rights
-        with self.assertRaises(AccessError):
-            self.env['mail.message'].with_user(self.user_public).create({'model': 'mail.channel', 'res_id': self.group_restricted_channel.id, 'body': 'Test'})
-
-        # Public create a message on Public Channel -> ko, no creation rights
-        with self.assertRaises(AccessError):
-            self.env['mail.message'].with_user(self.user_public).create({'model': 'mail.channel', 'res_id': self.public_channel.id, 'body': 'Test'})
-
-    @mute_logger('odoo.models')
-    def test_mail_message_access_create_crash(self):
-        # Do: Employee create a private message -> ko, no creation rights
-        with self.assertRaises(AccessError):
-            self.env['mail.message'].with_user(self.user_employee).create({'model': 'mail.channel', 'res_id': self.private_group.id, 'body': 'Test'})
-
-    @mute_logger('odoo.models')
-    def test_mail_message_access_create_doc(self):
-        Message = self.env['mail.message'].with_user(self.user_employee)
-        # Do: Employee creates a message on Public Channel -> ok, write access to the related document
-        Message.create({'model': 'mail.channel', 'res_id': self.public_channel.id, 'body': 'Test'})
-        # Do: Employee creates a message on Group -> ko, no write access to the related document
-        with self.assertRaises(AccessError):
-            Message.create({'model': 'mail.channel', 'res_id': self.private_group.id, 'body': 'Test'})
-
-    def test_mail_message_access_create_private(self):
-        self.env['mail.message'].with_user(self.user_employee).create({'body': 'Test'})
-
-    def test_mail_message_access_create_reply(self):
-        # TDE FIXME: should it really work ? not sure - catchall makes crash (aka, post will crash also)
-        self.env['ir.config_parameter'].set_param('mail.catchall.domain', False)
-        self.message.write({'partner_ids': [(4, self.user_employee.partner_id.id)]})
-        self.env['mail.message'].with_user(self.user_employee).create({'model': 'mail.channel', 'res_id': self.private_group.id, 'body': 'Test', 'parent_id': self.message.id})
-
-    def test_mail_message_access_create_wo_parent_access(self):
-        """ Purpose is to test posting a message on a record whose first message / parent
-        is not accessible by current user. """
-        test_record = self.env['mail.test.simple'].with_context(self._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
-        partner_1 = self.env['res.partner'].create({
-            'name': 'Jitendra Prajapati (jpr-odoo)',
-            'email': 'jpr@odoo.com',
-        })
-        test_record.message_subscribe((partner_1 | self.user_admin.partner_id).ids)
-
-        message = test_record.message_post(
-            body='<p>This is First Message</p>', subject='Subject',
-            message_type='comment', subtype_xmlid='mail.mt_note')
-        # portal user have no rights to read the message
-        with self.assertRaises(AccessError):
-            message.with_user(self.user_portal).read(['subject, body'])
-
-        with patch.object(MailTestSimple, 'check_access_rights', return_value=True):
-            with self.assertRaises(AccessError):
-                message.with_user(self.user_portal).read(['subject, body'])
-
-            # parent message is accessible to references notification mail values
-            # for _notify method and portal user have no rights to send the message for this model
-            new_msg = test_record.with_user(self.user_portal).message_post(
-                body='<p>This is Second Message</p>',
-                subject='Subject',
-                parent_id=message.id,
-                message_type='comment',
-                subtype_xmlid='mail.mt_comment',
-                mail_auto_delete=False)
-
-        new_mail = self.env['mail.mail'].sudo().search([
-            ('mail_message_id', '=', new_msg.id),
-            ('references', '=', f'{message.message_id} {new_msg.message_id}'),
-        ])
-
-        self.assertTrue(new_mail)
-        self.assertEqual(new_msg.parent_id, message)

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -1,0 +1,200 @@
+import base64
+from unittest.mock import patch
+
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.test_mail.tests.common import TestMailCommon
+from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
+from odoo.exceptions import AccessError
+from odoo.tools import mute_logger
+from odoo.tests import tagged
+
+
+@tagged('mail_message', 'security', 'post_install', '-at_install')
+class TestMessageAccess(TestMailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestMessageAccess, cls).setUpClass()
+
+        cls.user_employee_1 = mail_new_test_user(cls.env, login='tao', groups='base.group_user', name='Tao Lee')
+        cls.user_public = mail_new_test_user(cls.env, login='bert', groups='base.group_public', name='Bert Tartignole')
+        cls.user_portal = mail_new_test_user(cls.env, login='chell', groups='base.group_portal', name='Chell Gladys')
+
+        cls.group_restricted_channel = cls.env['mail.channel'].browse(cls.env['mail.channel'].channel_create(name='Channel for Groups', group_id=cls.env.ref('base.group_user').id)['id'])
+        cls.public_channel = cls.env['mail.channel'].browse(cls.env['mail.channel'].channel_create(name='Public Channel', group_id=None)['id'])
+        cls.private_group = cls.env['mail.channel'].browse(cls.env['mail.channel'].create_group(partners_to=cls.user_employee_1.partner_id.ids, name="Group")['id'])
+        cls.message = cls.env['mail.message'].create({
+            'body': 'My Body',
+            'model': 'mail.channel',
+            'res_id': cls.private_group.id,
+        })
+
+    @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_mail_message_access_search(self):
+        # Data: various author_ids, partner_ids, documents
+        msg1 = self.env['mail.message'].create({
+            'subject': '_ZTest', 'body': 'A', 'subtype_id': self.ref('mail.mt_comment')})
+        msg2 = self.env['mail.message'].create({
+            'subject': '_ZTest', 'body': 'A+B', 'subtype_id': self.ref('mail.mt_comment'),
+            'partner_ids': [(6, 0, [self.user_public.partner_id.id])]})
+        msg3 = self.env['mail.message'].create({
+            'subject': '_ZTest', 'body': 'A Pigs', 'subtype_id': False,
+            'model': 'mail.channel', 'res_id': self.group_restricted_channel.id})
+        msg4 = self.env['mail.message'].create({
+            'subject': '_ZTest', 'body': 'A+P Pigs', 'subtype_id': self.ref('mail.mt_comment'),
+            'model': 'mail.channel', 'res_id': self.group_restricted_channel.id,
+            'partner_ids': [(6, 0, [self.user_public.partner_id.id])]})
+        msg5 = self.env['mail.message'].create({
+            'subject': '_ZTest', 'body': 'A+E Pigs', 'subtype_id': self.ref('mail.mt_comment'),
+            'model': 'mail.channel', 'res_id': self.group_restricted_channel.id,
+            'partner_ids': [(6, 0, [self.user_employee.partner_id.id])]})
+        msg6 = self.env['mail.message'].create({
+            'subject': '_ZTest', 'body': 'A Birds', 'subtype_id': self.ref('mail.mt_comment'),
+            'model': 'mail.channel', 'res_id': self.private_group.id})
+        msg7 = self.env['mail.message'].with_user(self.user_employee).create({
+            'subject': '_ZTest', 'body': 'B', 'subtype_id': self.ref('mail.mt_comment')})
+        msg8 = self.env['mail.message'].with_user(self.user_employee).create({
+            'subject': '_ZTest', 'body': 'B+E', 'subtype_id': self.ref('mail.mt_comment'),
+            'partner_ids': [(6, 0, [self.user_employee.partner_id.id])]})
+
+        # Test: Public: 2 messages (recipient)
+        messages = self.env['mail.message'].with_user(self.user_public).search([('subject', 'like', '_ZTest')])
+        self.assertEqual(messages, msg2 | msg4)
+
+        # Test: Employee: 3 messages on Channel Employee can read (employee can read group with default values)
+        messages = self.env['mail.message'].with_user(self.user_employee).search([('subject', 'like', '_ZTest'), ('body', 'ilike', 'A')])
+        self.assertEqual(messages, msg3 | msg4 | msg5)
+
+        # Test: Employee: 3 messages on Channel Employee can read (employee can read group with default values), 0 on Birds (private group) + 2 messages as author
+        messages = self.env['mail.message'].with_user(self.user_employee).search([('subject', 'like', '_ZTest')])
+        self.assertEqual(messages, msg3 | msg4 | msg5 | msg7 | msg8)
+
+        # Test: Admin: all messages
+        messages = self.env['mail.message'].search([('subject', 'like', '_ZTest')])
+        self.assertEqual(messages, msg1 | msg2 | msg3 | msg4 | msg5 | msg6 | msg7 | msg8)
+
+        # Test: Portal: 0 (no access to groups, not recipient)
+        messages = self.env['mail.message'].with_user(self.user_portal).search([('subject', 'like', '_ZTest')])
+        self.assertFalse(messages)
+
+        # Test: Portal: 2 messages (public channel)
+        self.group_restricted_channel.write({'group_public_id': False})
+        messages = self.env['mail.message'].with_user(self.user_portal).search([('subject', 'like', '_ZTest')])
+        self.assertEqual(messages, msg4 | msg5)
+
+    # --------------------------------------------------
+    # READ
+    # --------------------------------------------------
+
+    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
+    def test_mail_message_access_read_crash(self):
+        with self.assertRaises(AccessError):
+            self.message.with_user(self.user_employee).read()
+
+    @mute_logger('odoo.models')
+    def test_mail_message_access_read_crash_portal(self):
+        with self.assertRaises(AccessError):
+            self.message.with_user(self.user_portal).read(['body', 'message_type', 'subtype_id'])
+
+    def test_mail_message_access_read_ok_portal(self):
+        self.message.write({'subtype_id': self.ref('mail.mt_comment'), 'res_id': self.public_channel.id})
+        self.message.with_user(self.user_portal).read(['body', 'message_type', 'subtype_id'])
+
+    def test_mail_message_access_read_notification(self):
+        attachment = self.env['ir.attachment'].create({
+            'datas': base64.b64encode(b'My attachment'),
+            'name': 'doc.txt',
+            'res_model': self.message._name,
+            'res_id': self.message.id})
+        # attach the attachment to the message
+        self.message.write({'attachment_ids': [(4, attachment.id)]})
+        self.message.write({'partner_ids': [(4, self.user_employee.partner_id.id)]})
+        self.message.with_user(self.user_employee).read()
+        # Test: Employee has access to attachment, ok because they can read message
+        attachment.with_user(self.user_employee).read(['name', 'datas'])
+
+    def test_mail_message_access_read_author(self):
+        self.message.write({'author_id': self.user_employee.partner_id.id})
+        self.message.with_user(self.user_employee).read()
+
+    def test_mail_message_access_read_doc(self):
+        self.message.write({'model': 'mail.channel', 'res_id': self.public_channel.id})
+        # Test: Employee reads the message, ok because linked to a doc they are allowed to read
+        self.message.with_user(self.user_employee).read()
+
+    # --------------------------------------------------
+    # CREATE
+    # --------------------------------------------------
+
+    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.addons.base.models.ir_rule')
+    def test_mail_message_access_create_crash_public(self):
+        # Public creates a message on Channel for groups -> ko, no enter rights
+        with self.assertRaises(AccessError):
+            self.env['mail.message'].with_user(self.user_public).create({'model': 'mail.channel', 'res_id': self.group_restricted_channel.id, 'body': 'Test'})
+
+        # Public create a message on Public Channel -> ko, no creation rights
+        with self.assertRaises(AccessError):
+            self.env['mail.message'].with_user(self.user_public).create({'model': 'mail.channel', 'res_id': self.public_channel.id, 'body': 'Test'})
+
+    @mute_logger('odoo.models')
+    def test_mail_message_access_create_crash(self):
+        # Do: Employee create a private message -> ko, no creation rights
+        with self.assertRaises(AccessError):
+            self.env['mail.message'].with_user(self.user_employee).create({'model': 'mail.channel', 'res_id': self.private_group.id, 'body': 'Test'})
+
+    @mute_logger('odoo.models')
+    def test_mail_message_access_create_doc(self):
+        Message = self.env['mail.message'].with_user(self.user_employee)
+        # Do: Employee creates a message on Public Channel -> ok, write access to the related document
+        Message.create({'model': 'mail.channel', 'res_id': self.public_channel.id, 'body': 'Test'})
+        # Do: Employee creates a message on Group -> ko, no write access to the related document
+        with self.assertRaises(AccessError):
+            Message.create({'model': 'mail.channel', 'res_id': self.private_group.id, 'body': 'Test'})
+
+    def test_mail_message_access_create_private(self):
+        self.env['mail.message'].with_user(self.user_employee).create({'body': 'Test'})
+
+    def test_mail_message_access_create_reply(self):
+        # TDE FIXME: should it really work ? not sure - catchall makes crash (aka, post will crash also)
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain', False)
+        self.message.write({'partner_ids': [(4, self.user_employee.partner_id.id)]})
+        self.env['mail.message'].with_user(self.user_employee).create({'model': 'mail.channel', 'res_id': self.private_group.id, 'body': 'Test', 'parent_id': self.message.id})
+
+    def test_mail_message_access_create_wo_parent_access(self):
+        """ Purpose is to test posting a message on a record whose first message / parent
+        is not accessible by current user. """
+        test_record = self.env['mail.test.simple'].with_context(self._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
+        partner_1 = self.env['res.partner'].create({
+            'name': 'Jitendra Prajapati (jpr-odoo)',
+            'email': 'jpr@odoo.com',
+        })
+        test_record.message_subscribe((partner_1 | self.user_admin.partner_id).ids)
+
+        message = test_record.message_post(
+            body='<p>This is First Message</p>', subject='Subject',
+            message_type='comment', subtype_xmlid='mail.mt_note')
+        # portal user have no rights to read the message
+        with self.assertRaises(AccessError):
+            message.with_user(self.user_portal).read(['subject, body'])
+
+        with patch.object(MailTestSimple, 'check_access_rights', return_value=True):
+            with self.assertRaises(AccessError):
+                message.with_user(self.user_portal).read(['subject, body'])
+
+            # parent message is accessible to references notification mail values
+            # for _notify method and portal user have no rights to send the message for this model
+            new_msg = test_record.with_user(self.user_portal).message_post(
+                body='<p>This is Second Message</p>',
+                subject='Subject',
+                parent_id=message.id,
+                message_type='comment',
+                subtype_xmlid='mail.mt_comment',
+                mail_auto_delete=False)
+
+        new_mail = self.env['mail.mail'].sudo().search([
+            ('mail_message_id', '=', new_msg.id),
+            ('references', '=', f'{message.message_id} {new_msg.message_id}'),
+        ])
+
+        self.assertTrue(new_mail)
+        self.assertEqual(new_msg.parent_id, message)

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -1,7 +1,9 @@
 import base64
+
 from unittest.mock import patch
 
 from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.test_mail.models.mail_test_access import MailTestAccess
 from odoo.addons.test_mail.tests.common import TestMailCommon
 from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
 from odoo.exceptions import AccessError
@@ -9,170 +11,329 @@ from odoo.tools import mute_logger
 from odoo.tests import tagged
 
 
-@tagged('mail_message', 'security', 'post_install', '-at_install')
-class TestMessageAccess(TestMailCommon):
+class MessageAccessCommon(TestMailCommon):
 
     @classmethod
     def setUpClass(cls):
-        super(TestMessageAccess, cls).setUpClass()
+        super().setUpClass()
 
-        cls.user_employee_1 = mail_new_test_user(cls.env, login='tao', groups='base.group_user', name='Tao Lee')
-        cls.user_public = mail_new_test_user(cls.env, login='bert', groups='base.group_public', name='Bert Tartignole')
-        cls.user_portal = mail_new_test_user(cls.env, login='chell', groups='base.group_portal', name='Chell Gladys')
+        cls.user_public = mail_new_test_user(
+            cls.env,
+            groups='base.group_public',
+            login='bert',
+            name='Bert Tartignole',
+        )
+        cls.user_portal = mail_new_test_user(
+            cls.env,
+            groups='base.group_portal',
+            login='chell',
+            name='Chell Gladys',
+        )
+        cls.user_portal_2 = mail_new_test_user(
+            cls.env,
+            groups='base.group_portal',
+            login='portal2',
+            name='Chell Gladys',
+        )
 
-        cls.group_restricted_channel = cls.env['mail.channel'].browse(cls.env['mail.channel'].channel_create(name='Channel for Groups', group_id=cls.env.ref('base.group_user').id)['id'])
-        cls.public_channel = cls.env['mail.channel'].browse(cls.env['mail.channel'].channel_create(name='Public Channel', group_id=None)['id'])
-        cls.private_group = cls.env['mail.channel'].browse(cls.env['mail.channel'].create_group(partners_to=cls.user_employee_1.partner_id.ids, name="Group")['id'])
-        cls.message = cls.env['mail.message'].create({
-            'body': 'My Body',
-            'model': 'mail.channel',
-            'res_id': cls.private_group.id,
-        })
+        (
+            cls.record_public, cls.record_portal, cls.record_portal_ro,
+            cls.record_followers,
+            cls.record_internal, cls.record_internal_ro,
+            cls.record_admin
+        ) = cls.env['mail.test.access'].create([
+            {'access': 'public', 'name': 'Public Record'},
+            {'access': 'logged', 'name': 'Portal Record'},
+            {'access': 'logged_ro', 'name': 'Portal RO Record'},
+            {'access': 'followers', 'name': 'Followers Record'},
+            {'access': 'internal', 'name': 'Internal Record'},
+            {'access': 'internal_ro', 'name': 'Internal Readonly Record'},
+            {'access': 'admin', 'name': 'Admin Record'},
+        ])
+        for record in (cls.record_public + cls.record_portal + cls.record_portal_ro + cls.record_followers +
+                       cls.record_internal + cls.record_internal_ro + cls.record_admin):
+            record.message_post(
+                body='Test Comment',
+                message_type='comment',
+                subtype_id=cls.env.ref('mail.mt_comment').id,
+            )
+            record.message_post(
+                body='Test Answer',
+                message_type='comment',
+                subtype_id=cls.env.ref('mail.mt_comment').id,
+            )
 
-    @mute_logger('odoo.addons.mail.models.mail_mail')
-    def test_mail_message_access_search(self):
-        # Data: various author_ids, partner_ids, documents
-        msg1 = self.env['mail.message'].create({
-            'subject': '_ZTest', 'body': 'A', 'subtype_id': self.ref('mail.mt_comment')})
-        msg2 = self.env['mail.message'].create({
-            'subject': '_ZTest', 'body': 'A+B', 'subtype_id': self.ref('mail.mt_comment'),
-            'partner_ids': [(6, 0, [self.user_public.partner_id.id])]})
-        msg3 = self.env['mail.message'].create({
-            'subject': '_ZTest', 'body': 'A Pigs', 'subtype_id': False,
-            'model': 'mail.channel', 'res_id': self.group_restricted_channel.id})
-        msg4 = self.env['mail.message'].create({
-            'subject': '_ZTest', 'body': 'A+P Pigs', 'subtype_id': self.ref('mail.mt_comment'),
-            'model': 'mail.channel', 'res_id': self.group_restricted_channel.id,
-            'partner_ids': [(6, 0, [self.user_public.partner_id.id])]})
-        msg5 = self.env['mail.message'].create({
-            'subject': '_ZTest', 'body': 'A+E Pigs', 'subtype_id': self.ref('mail.mt_comment'),
-            'model': 'mail.channel', 'res_id': self.group_restricted_channel.id,
-            'partner_ids': [(6, 0, [self.user_employee.partner_id.id])]})
-        msg6 = self.env['mail.message'].create({
-            'subject': '_ZTest', 'body': 'A Birds', 'subtype_id': self.ref('mail.mt_comment'),
-            'model': 'mail.channel', 'res_id': self.private_group.id})
-        msg7 = self.env['mail.message'].with_user(self.user_employee).create({
-            'subject': '_ZTest', 'body': 'B', 'subtype_id': self.ref('mail.mt_comment')})
-        msg8 = self.env['mail.message'].with_user(self.user_employee).create({
-            'subject': '_ZTest', 'body': 'B+E', 'subtype_id': self.ref('mail.mt_comment'),
-            'partner_ids': [(6, 0, [self.user_employee.partner_id.id])]})
 
-        # Test: Public: 2 messages (recipient)
-        messages = self.env['mail.message'].with_user(self.user_public).search([('subject', 'like', '_ZTest')])
-        self.assertEqual(messages, msg2 | msg4)
-
-        # Test: Employee: 3 messages on Channel Employee can read (employee can read group with default values)
-        messages = self.env['mail.message'].with_user(self.user_employee).search([('subject', 'like', '_ZTest'), ('body', 'ilike', 'A')])
-        self.assertEqual(messages, msg3 | msg4 | msg5)
-
-        # Test: Employee: 3 messages on Channel Employee can read (employee can read group with default values), 0 on Birds (private group) + 2 messages as author
-        messages = self.env['mail.message'].with_user(self.user_employee).search([('subject', 'like', '_ZTest')])
-        self.assertEqual(messages, msg3 | msg4 | msg5 | msg7 | msg8)
-
-        # Test: Admin: all messages
-        messages = self.env['mail.message'].search([('subject', 'like', '_ZTest')])
-        self.assertEqual(messages, msg1 | msg2 | msg3 | msg4 | msg5 | msg6 | msg7 | msg8)
-
-        # Test: Portal: 0 (no access to groups, not recipient)
-        messages = self.env['mail.message'].with_user(self.user_portal).search([('subject', 'like', '_ZTest')])
-        self.assertFalse(messages)
-
-        # Test: Portal: 2 messages (public channel)
-        self.group_restricted_channel.write({'group_public_id': False})
-        messages = self.env['mail.message'].with_user(self.user_portal).search([('subject', 'like', '_ZTest')])
-        self.assertEqual(messages, msg4 | msg5)
-
-    # --------------------------------------------------
-    # READ
-    # --------------------------------------------------
-
-    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
-    def test_mail_message_access_read_crash(self):
-        with self.assertRaises(AccessError):
-            self.message.with_user(self.user_employee).read()
-
-    @mute_logger('odoo.models')
-    def test_mail_message_access_read_crash_portal(self):
-        with self.assertRaises(AccessError):
-            self.message.with_user(self.user_portal).read(['body', 'message_type', 'subtype_id'])
-
-    def test_mail_message_access_read_ok_portal(self):
-        self.message.write({'subtype_id': self.ref('mail.mt_comment'), 'res_id': self.public_channel.id})
-        self.message.with_user(self.user_portal).read(['body', 'message_type', 'subtype_id'])
-
-    def test_mail_message_access_read_notification(self):
-        attachment = self.env['ir.attachment'].create({
-            'datas': base64.b64encode(b'My attachment'),
-            'name': 'doc.txt',
-            'res_model': self.message._name,
-            'res_id': self.message.id})
-        # attach the attachment to the message
-        self.message.write({'attachment_ids': [(4, attachment.id)]})
-        self.message.write({'partner_ids': [(4, self.user_employee.partner_id.id)]})
-        self.message.with_user(self.user_employee).read()
-        # Test: Employee has access to attachment, ok because they can read message
-        attachment.with_user(self.user_employee).read(['name', 'datas'])
-
-    def test_mail_message_access_read_author(self):
-        self.message.write({'author_id': self.user_employee.partner_id.id})
-        self.message.with_user(self.user_employee).read()
-
-    def test_mail_message_access_read_doc(self):
-        self.message.write({'model': 'mail.channel', 'res_id': self.public_channel.id})
-        # Test: Employee reads the message, ok because linked to a doc they are allowed to read
-        self.message.with_user(self.user_employee).read()
-
-    # --------------------------------------------------
-    # CREATE
-    # --------------------------------------------------
+@tagged('mail_message', 'security', 'post_install', '-at_install')
+class TestMailMessageAccess(MessageAccessCommon):
 
     @mute_logger('odoo.addons.base.models.ir_model', 'odoo.addons.base.models.ir_rule')
-    def test_mail_message_access_create_crash_public(self):
-        # Public creates a message on Channel for groups -> ko, no enter rights
-        with self.assertRaises(AccessError):
-            self.env['mail.message'].with_user(self.user_public).create({'model': 'mail.channel', 'res_id': self.group_restricted_channel.id, 'body': 'Test'})
+    def test_assert_initial_values(self):
+        """ Just ensure tests data """
+        for record in (
+            self.record_public + self.record_portal + self.record_portal_ro + self.record_followers +
+            self.record_internal + self.record_internal_ro + self.record_admin):
+            self.assertFalse(record.message_follower_ids)
+            self.assertEqual(len(record.message_ids), 3)
 
-        # Public create a message on Public Channel -> ko, no creation rights
-        with self.assertRaises(AccessError):
-            self.env['mail.message'].with_user(self.user_public).create({'model': 'mail.channel', 'res_id': self.public_channel.id, 'body': 'Test'})
+            for index, msg in enumerate(record.message_ids):
+                body = ['<p>Test Answer</p>', '<p>Test Comment</p>', '<p>Mail Access Test created</p>'][index]
+                message_type = ['comment', 'comment', 'notification'][index]
+                subtype_id = [self.env.ref('mail.mt_comment'), self.env.ref('mail.mt_comment'), self.env.ref('mail.mt_note')][index]
+                self.assertEqual(msg.author_id, self.partner_root)
+                self.assertEqual(msg.body, body)
+                self.assertEqual(msg.message_type, message_type)
+                self.assertFalse(msg.notified_partner_ids)
+                self.assertFalse(msg.partner_ids)
+                self.assertEqual(msg.subtype_id, subtype_id)
 
-    @mute_logger('odoo.models')
-    def test_mail_message_access_create_crash(self):
-        # Do: Employee create a private message -> ko, no creation rights
-        with self.assertRaises(AccessError):
-            self.env['mail.message'].with_user(self.user_employee).create({'model': 'mail.channel', 'res_id': self.private_group.id, 'body': 'Test'})
+        # public user access check
+        for allowed in self.record_public:
+            allowed.with_user(self.user_public).read(['name'])
+        for forbidden in self.record_portal + self.record_portal_ro + self.record_followers + self.record_internal + self.record_internal_ro + self.record_admin:
+            with self.assertRaises(AccessError):
+                forbidden.with_user(self.user_public).read(['name'])
+        for forbidden in self.record_public + self.record_portal + self.record_portal_ro + self.record_followers + self.record_internal + self.record_internal_ro + self.record_admin:
+            with self.assertRaises(AccessError):
+                forbidden.with_user(self.user_public).write({'name': 'Update'})
 
-    @mute_logger('odoo.models')
-    def test_mail_message_access_create_doc(self):
-        Message = self.env['mail.message'].with_user(self.user_employee)
-        # Do: Employee creates a message on Public Channel -> ok, write access to the related document
-        Message.create({'model': 'mail.channel', 'res_id': self.public_channel.id, 'body': 'Test'})
-        # Do: Employee creates a message on Group -> ko, no write access to the related document
-        with self.assertRaises(AccessError):
-            Message.create({'model': 'mail.channel', 'res_id': self.private_group.id, 'body': 'Test'})
+        # portal user access check
+        for allowed in self.record_public + self.record_portal + self.record_portal_ro:
+            allowed.with_user(self.user_portal).read(['name'])
+        for forbidden in self.record_internal + self.record_internal_ro + self.record_admin:
+            with self.assertRaises(AccessError):
+                forbidden.with_user(self.user_portal).read(['name'])
+        for allowed in self.record_portal:
+            allowed.with_user(self.user_portal).write({'name': 'Update'})
+        for forbidden in self.record_public + self.record_portal_ro + self.record_followers + self.record_internal + self.record_internal_ro + self.record_admin:
+            with self.assertRaises(AccessError):
+                forbidden.with_user(self.user_portal).write({'name': 'Update'})
+        self.record_followers.message_subscribe(self.user_portal.partner_id.ids)
+        self.record_followers.with_user(self.user_portal).read(['name'])
+        self.record_followers.with_user(self.user_portal).write({'name': 'Update'})
 
-    def test_mail_message_access_create_private(self):
-        self.env['mail.message'].with_user(self.user_employee).create({'body': 'Test'})
+        # internal user access check
+        for allowed in self.record_public + self.record_portal + self.record_portal_ro + self.record_followers + self.record_internal + self.record_internal_ro:
+            allowed.with_user(self.user_employee).read(['name'])
+        for forbidden in self.record_admin:
+            with self.assertRaises(AccessError):
+                forbidden.with_user(self.user_employee).read(['name'])
+        for allowed in self.record_public + self.record_portal + self.record_portal_ro + self.record_followers + self.record_internal:
+            allowed.with_user(self.user_employee).write({'name': 'Update'})
+        for forbidden in self.record_internal_ro + self.record_admin:
+            with self.assertRaises(AccessError):
+                forbidden.with_user(self.user_employee).write({'name': 'Update'})
 
-    def test_mail_message_access_create_reply(self):
-        # TDE FIXME: should it really work ? not sure - catchall makes crash (aka, post will crash also)
-        self.env['ir.config_parameter'].set_param('mail.catchall.domain', False)
-        self.message.write({'partner_ids': [(4, self.user_employee.partner_id.id)]})
-        self.env['mail.message'].with_user(self.user_employee).create({'model': 'mail.channel', 'res_id': self.private_group.id, 'body': 'Test', 'parent_id': self.message.id})
+        # elevated user access check
+        for allowed in self.record_public + self.record_portal + self.record_portal_ro + self.record_followers + self.record_internal + self.record_internal_ro + self.record_admin:
+            allowed.with_user(self.user_admin).read(['name'])
 
-    def test_mail_message_access_create_wo_parent_access(self):
+    # ------------------------------------------------------------
+    # CREATE
+    # - Criterions
+    #  - "private message" (no model, no res_id) -> deprecated
+    #  - follower of document
+    #  - document-based (write or create, using '_get_mail_message_access'
+    #    hence '_mail_post_access' by default)
+    #  - notified of parent message
+    # ------------------------------------------------------------
+
+    @mute_logger('odoo.addons.base.models.ir_rule')
+    def test_access_create(self):
+        """ Test 'group_user' creation rules """
+        # prepare 'notified of parent' condition
+        admin_msg = self.record_admin.message_ids[0]
+        admin_msg.write({'partner_ids': [(4, self.user_employee.partner_id.id)]})
+
+        # prepare 'followers' condition
+        record_admin_fol = self.env['mail.test.access'].create({
+            'access': 'admin',
+            'name': 'Admin Record Follower',
+        })
+        record_admin_fol.message_subscribe(self.user_employee.partner_id.ids)
+
+        for record, msg_vals, should_crash, reason in [
+            # private-like
+            (self.env["mail.test.access"], {}, False, 'Private message like is ok'),
+            # document based
+            (self.record_internal, {}, False, 'W Access on record'),
+            (self.record_internal_ro, {}, True, 'No W Access on record'),
+            (self.record_admin, {}, True, 'No access on record (and not notified on first message)'),
+            (record_admin_fol, {
+                'reply_to': 'avoid.catchall@my.test.com',  # otherwise crashes
+            }, False, 'Followers > no access on record'),
+            # parent based
+            (self.record_admin, {  # note: force reply_to normally computed by message_post avoiding ACLs issues
+                'parent_id': admin_msg.id,
+            }, False, 'No access on record but reply to notified parent'),
+        ]:
+            with self.subTest(record=record, msg_vals=msg_vals, reason=reason):
+                if should_crash:
+                    with self.assertRaises(AccessError):
+                        self.env['mail.message'].with_user(self.user_employee).create({
+                            'model': record._name if record else False,
+                            'res_id': record.id if record else False,
+                            'body': 'Test',
+                            **msg_vals,
+                        })
+                    if record:
+                        with self.assertRaises(AccessError):
+                            record.with_user(self.user_employee).message_post(
+                                body='Test',
+                                subtype_id=self.env.ref('mail.mt_comment').id,
+                            )
+                else:
+                    _message = self.env['mail.message'].with_user(self.user_employee).create({
+                        'model': record._name if record else False,
+                        'res_id': record.id if record else False,
+                        'body': 'Test',
+                        **msg_vals,
+                    })
+                    if record:
+                        # TDE note: due to parent_id flattening, doing message_post
+                        # with parent_id which should allow posting crashes, as
+                        # parent_id is changed to an older message the employee cannot
+                        # access. Won't fix that in stable.
+                        if record == self.record_admin and 'parent_id' in msg_vals:
+                            continue
+                        record.with_user(self.user_employee).message_post(
+                            body='Test',
+                            subtype_id=self.env.ref('mail.mt_comment').id,
+                            **msg_vals,
+                        )
+
+    def test_access_create_customized(self):
+        """ Test '_get_mail_message_access' support """
+        record = self.env['mail.test.access.custo'].with_user(self.user_employee).create({'name': 'Open'})
+        for user in self.user_employee + self.user_portal:
+            _message = record.message_post(
+                body='A message',
+                subtype_id=self.env.ref('mail.mt_comment').id,
+            )
+        # lock -> see '_get_mail_message_access'
+        record.write({'is_locked': True})
+        for user in self.user_employee + self.user_portal:
+            with self.assertRaises(AccessError):
+                _message_portal = record.with_user(self.user_portal).message_post(
+                    body='Another portal message',
+                    subtype_id=self.env.ref('mail.mt_comment').id,
+                )
+
+    def test_access_create_mail_post_access(self):
+        """ Test 'mail_post_access' support that allows creating a message with
+        other rights than 'write' access on document """
+        for post_value, should_crash in [
+            ('read', False),
+            ('write', True),
+        ]:
+            with self.subTest(post_value=post_value):
+                with patch.object(MailTestAccess, '_mail_post_access', post_value):
+                    if should_crash:
+                        with self.assertRaises(AccessError):
+                            self.env['mail.message'].with_user(self.user_employee).create({
+                                'model': self.record_internal_ro._name,
+                                'res_id': self.record_internal_ro.id,
+                                'body': 'Test',
+                            })
+                    else:
+                        self.env['mail.message'].with_user(self.user_employee).create({
+                            'model': self.record_internal_ro._name,
+                            'res_id': self.record_internal_ro.id,
+                            'body': 'Test',
+                        })
+
+    @mute_logger('odoo.addons.base.models.ir_rule')
+    def test_access_create_portal(self):
+        """ Test group_portal creation rules """
+        # prepare 'notified of parent' condition
+        admin_msg = self.record_admin.message_ids[-1]
+        admin_msg.write({'partner_ids': [(4, self.user_portal.partner_id.id)]})
+
+        # prepare 'followers' condition
+        record_admin_fol = self.env['mail.test.access'].create({
+            'access': 'admin',
+            'name': 'Admin Record',
+        })
+        record_admin_fol.message_subscribe(self.user_portal.partner_id.ids)
+
+        for record, msg_vals, should_crash, reason in [
+            # private-like
+            (self.env["mail.test.access"], {}, False, 'Private message like is ok'),
+            # document based
+            (self.record_portal, {}, False, 'W Access on record'),
+            (self.record_portal_ro, {}, True, 'No W Access on record'),
+            (self.record_internal, {}, True, 'No R/W Access on record'),
+            (record_admin_fol, {
+                'reply_to': 'avoid.catchall@my.test.com',  # otherwise crashes
+            }, False, 'Followers > no access on record'),
+            # parent based
+            (self.record_admin, {
+                'parent_id': admin_msg.id,
+            }, False, 'No access on record but reply to notified parent'),
+        ]:
+            with self.subTest(record=record, msg_vals=msg_vals, reason=reason):
+                if should_crash:
+                    with self.assertRaises(AccessError):
+                        self.env['mail.message'].with_user(self.user_portal).create({
+                            'model': record._name if record else False,
+                            'res_id': record.id if record else False,
+                            'body': 'Test',
+                            **msg_vals,
+                        })
+                else:
+                    _message = self.env['mail.message'].with_user(self.user_portal).create({
+                        'model': record._name if record else False,
+                        'res_id': record.id if record else False,
+                        'body': 'Test',
+                        **msg_vals,
+                    })
+
+        # check '_mail_post_access', reducing W to R
+        with patch.object(MailTestAccess, '_mail_post_access', 'read'):
+            _message = self.env['mail.message'].with_user(self.user_portal).create({
+                'model': self.record_portal._name,
+                'res_id': self.record_portal.id,
+                'body': 'Test',
+            })
+
+    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.addons.base.models.ir_rule')
+    def test_access_create_public(self):
+        """ Public can never create messages """
+        for record in [
+            self.env['mail.test.access'],  # old private message: no document
+            self.record_public,  # read access
+            self.record_portal,  # read access
+        ]:
+            with self.subTest(record=record):
+                # can never create message, simple
+                with self.assertRaises(AccessError):
+                    self.env['mail.message'].with_user(self.user_public).create({
+                        'model': record._name if record else False,
+                        'res_id': record.id if record else False,
+                        'body': 'Test',
+                    })
+
+    @mute_logger('odoo.tests')
+    def test_access_create_wo_parent_access(self):
         """ Purpose is to test posting a message on a record whose first message / parent
-        is not accessible by current user. """
-        test_record = self.env['mail.test.simple'].with_context(self._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
+        is not accessible by current user. This cause issues notably when computing
+        references, checking ancestors message_ids. """
+        test_record = self.env['mail.test.simple'].with_context(self._test_context).create({
+            'email_from': 'ignasse@example.com',
+            'name': 'Test',
+        })
         partner_1 = self.env['res.partner'].create({
-            'name': 'Jitendra Prajapati (jpr-odoo)',
-            'email': 'jpr@odoo.com',
+            'name': 'Not Jitendra Prajapati',
+            'email': 'not.jitendra@mycompany.example.com',
         })
         test_record.message_subscribe((partner_1 | self.user_admin.partner_id).ids)
 
         message = test_record.message_post(
-            body='<p>This is First Message</p>', subject='Subject',
-            message_type='comment', subtype_xmlid='mail.mt_note')
+            body='<p>This is First Message</p>',
+            message_type='comment',
+            subject='Subject',
+            subtype_xmlid='mail.mt_note',
+        )
         # portal user have no rights to read the message
         with self.assertRaises(AccessError):
             message.with_user(self.user_portal).read(['subject, body'])
@@ -183,18 +344,433 @@ class TestMessageAccess(TestMailCommon):
 
             # parent message is accessible to references notification mail values
             # for _notify method and portal user have no rights to send the message for this model
-            new_msg = test_record.with_user(self.user_portal).message_post(
-                body='<p>This is Second Message</p>',
-                subject='Subject',
-                parent_id=message.id,
-                message_type='comment',
-                subtype_xmlid='mail.mt_comment',
-                mail_auto_delete=False)
+            with self.mock_mail_gateway():
+                new_msg = test_record.with_user(self.user_portal).message_post(
+                    body='<p>This is Second Message</p>',
+                    subject='Subject',
+                    parent_id=message.id,
+                    mail_auto_delete=False,
+                    message_type='comment',
+                    subtype_xmlid='mail.mt_comment',
+                )
+            self.assertEqual(new_msg.sudo().parent_id, message)
 
         new_mail = self.env['mail.mail'].sudo().search([
             ('mail_message_id', '=', new_msg.id),
             ('references', '=', f'{message.message_id} {new_msg.message_id}'),
         ])
-
         self.assertTrue(new_mail)
         self.assertEqual(new_msg.parent_id, message)
+
+    # ------------------------------------------------------------
+    # READ
+    # - Criterions
+    #  - author
+    #  - recipients / notified
+    #  - document-based: read, using '_get_mail_message_access'
+    # - share users: limited to 'not internal' (flag or subtype)
+    # ------------------------------------------------------------
+
+    def test_access_read(self):
+        """ Read access check for internal users. """
+        for msg, msg_vals, should_crash, reason in [
+            # document based
+            (self.record_internal.message_ids[0], {}, False, 'R Access on record'),
+            (self.record_internal_ro.message_ids[0], {}, False, 'R Access on record'),
+            (self.record_admin.message_ids[0], {}, True, 'No access on record'),
+            # author
+            (self.record_admin.message_ids[0], {
+                'author_id': self.user_employee.partner_id.id,
+            }, False, 'Author > no access on record'),
+            # notified
+            (self.record_admin.message_ids[0], {
+                'notification_ids': [(0, 0, {
+                    'res_partner_id': self.user_employee.partner_id.id,
+                })],
+            }, False, 'Notified > no access on record'),
+            (self.record_admin.message_ids[0], {
+                'partner_ids': [(4, self.user_employee.partner_id.id)],
+            }, False, 'Recipients > no access on record'),
+        ]:
+            original_vals = {
+                'author_id': msg.author_id.id,
+                'notification_ids': [(6, 0, {})],
+                'parent_id': msg.parent_id.id,
+            }
+            with self.subTest(msg=msg, reason=reason):
+                if msg_vals:
+                    msg.write(msg_vals)
+                if should_crash:
+                    with self.assertRaises(AccessError):
+                        msg.with_user(self.user_employee).read(['body'])
+                else:
+                    msg.with_user(self.user_employee).read(['body'])
+                if msg_vals:
+                    msg.write(original_vals)
+
+    def test_access_read_portal(self):
+        """ Read access check for portal users """
+        for msg, msg_vals, should_crash, reason in [
+            # document based
+            (self.record_portal.message_ids[0], {}, False, 'Access on record'),
+            (self.record_internal.message_ids[0], {}, True, 'No access on record'),
+            # author
+            (self.record_internal.message_ids[0], {
+                'author_id': self.user_portal.partner_id.id,
+            }, False, 'Author > no access on record'),
+            # notified
+            (self.record_admin.message_ids[0], {
+                'notification_ids': [(0, 0, {
+                    'res_partner_id': self.user_portal.partner_id.id,
+                })],
+            }, False, 'Notified > no access on record'),
+            # forbidden
+            (self.record_portal.message_ids[0], {
+                'subtype_id': self.env.ref('mail.mt_note').id,
+            }, True, 'Note cannot be read by portal users'),
+            (self.record_portal.message_ids[0], {
+                'is_internal': True,
+            }, True, 'Internal message cannot be read by portal users'),
+        ]:
+            original_vals = {
+                'author_id': msg.author_id.id,
+                'is_internal': False,
+                'notification_ids': [(6, 0, {})],
+                'parent_id': msg.parent_id.id,
+                'subtype_id': self.env.ref('mail.mt_comment').id,
+            }
+            with self.subTest(msg=msg, reason=reason):
+                if msg_vals:
+                    msg.write(msg_vals)
+                if should_crash:
+                    with self.assertRaises(AccessError):
+                        msg.with_user(self.user_portal).read(['body'])
+                else:
+                    msg.with_user(self.user_portal).read(['body'])
+                if msg_vals:
+                    msg.write(original_vals)
+
+    def test_access_read_public(self):
+        """ Read access check for public users """
+        for msg, msg_vals, should_crash, reason in [
+            # document based
+            (self.record_public.message_ids[0], {}, False, 'Access on record'),
+            (self.record_portal.message_ids[0], {}, True, 'No access on record'),
+            # author
+            (self.record_internal.message_ids[0], {
+                'author_id': self.user_public.partner_id.id,
+            }, False, 'Author > no access on record'),
+            # notified
+            (self.record_admin.message_ids[0], {
+                'notification_ids': [(0, 0, {
+                    'res_partner_id': self.user_public.partner_id.id,
+                })],
+            }, False, 'Notified > no access on record'),
+            # forbidden
+            (self.record_public.message_ids[0], {
+                'subtype_id': self.env.ref('mail.mt_note').id,
+            }, True, 'Note cannot be read by public users'),
+            (self.record_public.message_ids[0], {
+                'is_internal': True,
+            }, True, 'Internal message cannot be read by public users'),
+        ]:
+            original_vals = {
+                'author_id': msg.author_id.id,
+                'is_internal': False,
+                'notification_ids': [(6, 0, {})],
+                'parent_id': msg.parent_id.id,
+                'subtype_id': self.env.ref('mail.mt_comment').id,
+            }
+            with self.subTest(msg=msg, reason=reason):
+                if msg_vals:
+                    msg.write(msg_vals)
+                if should_crash:
+                    with self.assertRaises(AccessError):
+                        msg.with_user(self.user_public).read(['body'])
+                else:
+                    msg.with_user(self.user_public).read(['body'])
+                if msg_vals:
+                    msg.write(original_vals)
+
+    # ------------------------------------------------------------
+    # UNLINK
+    # - Criterion: document-based (write or create), using '_get_mail_message_access'
+    # ------------------------------------------------------------
+
+    def test_access_unlink(self):
+        """ Unlink access check for internal users """
+        for msg, msg_vals, should_crash, reason in [
+            # document based
+            (self.record_portal.message_ids[0], {}, False, 'W Access on record'),
+            (self.record_internal_ro.message_ids[0], {}, True, 'R Access on record'),
+            # notified
+            (self.record_admin.message_ids[0], {
+                'notification_ids': [(0, 0, {
+                    'res_partner_id': self.user_portal.partner_id.id,
+                })],
+            }, True, 'Even notified, cannot remove'),
+        ]:
+            with self.subTest(msg=msg, reason=reason):
+                if msg_vals:
+                    msg.write(msg_vals)
+                if should_crash:
+                    with self.assertRaises(AccessError):
+                        msg.with_user(self.user_portal).unlink()
+                else:
+                    msg.with_user(self.user_portal).unlink()
+
+    def test_access_unlink_portal(self):
+        """ Unlink access check for portal users. """
+        for msg, msg_vals, should_crash, reason in [
+            # document based
+            (self.record_portal.message_ids[0], {}, False, 'W Access on record but unlink limited'),
+            (self.record_portal_ro.message_ids[0], {}, True, 'R Access on record'),
+            # notified
+            (self.record_admin.message_ids[0], {
+                'notification_ids': [(0, 0, {
+                    'res_partner_id': self.user_portal.partner_id.id,
+                })],
+            }, True, 'Even notified, cannot remove'),
+        ]:
+            with self.subTest(msg=msg, reason=reason):
+                if msg_vals:
+                    msg.write(msg_vals)
+                if should_crash:
+                    with self.assertRaises(AccessError):
+                        msg.with_user(self.user_portal).unlink()
+                else:
+                    msg.with_user(self.user_portal).unlink()
+
+    # ------------------------------------------------------------
+    # WRITE
+    # - Criterions
+    #   - author
+    #   - recipients / notified
+    #   - document-based (write or create), using '_get_mail_message_access'
+    # ------------------------------------------------------------
+
+    def test_access_write(self):
+        """ Test updating message content as internal user """
+        for msg, msg_vals, should_crash, reason in [
+            # document based
+            (self.record_internal.message_ids[0], {}, False, 'W Access on record'),
+            (self.record_internal_ro.message_ids[0], {}, True, 'No W Access on record'),
+            (self.record_admin.message_ids[0], {}, True, 'No access on record'),
+            # author
+            (self.record_admin.message_ids[0], {
+                'author_id': self.user_employee.partner_id.id,
+            }, False, 'Author > no access on record'),
+            # notified
+            (self.record_admin.message_ids[0], {
+                'notification_ids': [(0, 0, {
+                    'res_partner_id': self.user_employee.partner_id.id,
+                })],
+            }, False, 'Notified > no access on record'),
+        ]:
+            original_vals = {
+                'author_id': msg.author_id.id,
+                'notification_ids': [(6, 0, {})],
+                'parent_id': msg.parent_id.id,
+            }
+            with self.subTest(msg=msg, reason=reason):
+                if msg_vals:
+                    msg.write(msg_vals)
+                if should_crash:
+                    with self.assertRaises(AccessError):
+                        msg.with_user(self.user_employee).write({'body': 'Update'})
+                else:
+                    msg.with_user(self.user_employee).write({'body': 'Update'})
+                if msg_vals:
+                    msg.write(original_vals)
+
+    @mute_logger('odoo.addons.base.models.ir_rule')
+    def test_access_write_envelope(self):
+        """ Test updating message envelope require some privileges """
+        message = self.record_internal.with_user(self.user_employee).message_ids[0]
+        message.write({'body': 'Update Me'})
+        # To change in 18+
+        message.write({'model': 'res.partner'})
+        message.sudo().write({'model': self.record_internal._name})  # back to original model
+        # To change in 18+
+        message.write({'partner_ids': [(4, self.user_portal_2.partner_id.id)]})
+        # To change in 18+
+        message.write({'res_id': self.record_public.id})
+        # To change in 18+
+        message.write({'notification_ids': [
+            (0, 0, {'res_partner_id': self.user_portal_2.partner_id.id})
+        ]})
+
+    @mute_logger('odoo.addons.base.models.ir_rule')
+    def test_access_write_portal_notification(self):
+        """ Test updating message notification content as portal user """
+        self.record_followers.message_subscribe(self.user_portal.partner_id.ids)
+        test_record = self.record_followers.with_user(self.user_portal)
+        test_record.read(['name'])
+        with self.assertRaises(AccessError):
+            test_record.with_user(self.user_portal_2).read(['name'])
+        message = test_record.message_ids[0].with_user(self.user_portal)
+        message.write({'body': 'Updated'})
+        with self.assertRaises(AccessError):
+            message.with_user(self.user_portal_2).read(['subject'])
+
+    # ------------------------------------------------------------
+    # SEARCH
+    # ------------------------------------------------------------
+
+    def test_search(self):
+        """ Test custom 'search' implemented on 'mail.message' that replicates
+        custom rules defined on 'read' override """
+        base_msg_vals = {
+            'message_type': 'comment',
+            'model': self.record_internal._name,
+            'res_id': self.record_internal.id,
+            'subject': '_ZTest',
+        }
+
+        msgs = self.env['mail.message'].create([
+            dict(base_msg_vals,
+                 body='Private Comment (mention portal)',
+                 model=False,
+                 partner_ids=[(4, self.user_portal.partner_id.id)],
+                 res_id=False,
+                 subtype_id=self.ref('mail.mt_comment'),
+                ),
+            dict(base_msg_vals,
+                 body='Internal Log',
+                 subtype_id=False,
+                ),
+            dict(base_msg_vals,
+                 body='Internal Note',
+                 subtype_id=self.ref('mail.mt_note'),
+                ),
+            dict(base_msg_vals,
+                 body='Internal Comment (mention portal)',
+                 partner_ids=[(4, self.user_portal.partner_id.id)],
+                 subtype_id=self.ref('mail.mt_comment'),
+                ),
+            dict(base_msg_vals,
+                 body='Internal Comment (mention employee)',
+                 partner_ids=[(4, self.user_employee.partner_id.id)],
+                 subtype_id=self.ref('mail.mt_comment'),
+                ),
+            dict(base_msg_vals,
+                 body='Internal Comment',
+                 subtype_id=self.ref('mail.mt_comment'),
+                ),
+        ])
+        msg_record_admin = self.env['mail.message'].create(dict(base_msg_vals,
+            body='Admin Comment',
+            model=self.record_admin._name,
+            res_id=self.record_admin.id,
+            subtype_id=self.ref('mail.mt_comment'),
+        ))
+        msg_record_portal = self.env['mail.message'].create(dict(base_msg_vals,
+            body='Portal Comment',
+            model=self.record_portal._name,
+            res_id=self.record_portal.id,
+            subtype_id=self.ref('mail.mt_comment'),
+        ))
+        msg_record_public = self.env['mail.message'].create(dict(base_msg_vals,
+            body='Public Comment',
+            model=self.record_public._name,
+            res_id=self.record_public.id,
+            subtype_id=self.ref('mail.mt_comment'),
+        ))
+
+        for (test_user, add_domain), exp_messages in zip([
+            (self.user_public, []),
+            (self.user_portal, []),
+            (self.user_employee, []),
+            (self.user_employee, [('body', 'ilike', 'Internal')]),
+            (self.user_admin, []),
+        ], [
+            msg_record_public,
+            msgs[0] + msgs[3] + msg_record_portal + msg_record_public,
+            msgs[1:6] + msg_record_portal + msg_record_public,
+            msgs[1:6],
+            msgs[1:] + msg_record_admin + msg_record_portal + msg_record_public
+        ]):
+            with self.subTest(test_user=test_user.name, add_domain=add_domain):
+                domain = [('subject', 'like', '_ZTest')] + add_domain
+                self.assertEqual(self.env['mail.message'].with_user(test_user).search(domain), exp_messages)
+
+
+@tagged('mail_message', 'security', 'post_install', '-at_install')
+class TestMessageSubModelAccess(MessageAccessCommon):
+
+    def test_ir_attachment_read_message_notification(self):
+        message = self.record_admin.message_ids[0]
+        attachment = self.env['ir.attachment'].create({
+            'datas': base64.b64encode(b'My attachment'),
+            'name': 'doc.txt',
+            'res_model': message._name,
+            'res_id': message.id})
+        # attach the attachment to the message
+        message.write({'attachment_ids': [(4, attachment.id)]})
+        message.write({'partner_ids': [(4, self.user_employee.partner_id.id)]})
+        message.with_user(self.user_employee).read()
+        # Test: Employee has access to attachment, ok because they can read message
+        attachment.with_user(self.user_employee).read(['name', 'datas'])
+
+    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.addons.base.models.ir_rule')
+    def test_mail_follower(self):
+        """ Read access check on sub entities of mail.message """
+        internal_record = self.record_internal.with_user(self.user_employee)
+        internal_record.message_subscribe(
+            partner_ids=self.user_portal.partner_id.ids
+        )
+
+        # employee can access
+        follower = internal_record.message_follower_ids.filtered(
+            lambda f: f.partner_id == self.user_portal.partner_id
+        )
+        self.assertTrue(follower)
+        with self.assertRaises(AccessError):
+            follower.with_user(self.user_portal).read(['partner_id'])
+
+        # employee cannot update
+        with self.assertRaises(AccessError):
+            follower.write({'partner_id': self.user_admin.partner_id.id})
+        follower.with_user(self.user_admin).write({'partner_id': self.user_admin.partner_id.id})
+
+    @mute_logger('odoo.addons.base.models.ir_rule')
+    def test_mail_notification(self):
+        """ Limit update of notifications for internal users """
+        internal_record = self.record_internal.with_user(self.user_admin)
+        message = internal_record.message_post(
+            body='Hello People',
+            message_type='comment',
+            partner_ids=(self.user_portal.partner_id + self.user_employee.partner_id).ids,
+            subtype_id=self.env.ref('mail.mt_comment').id,
+        )
+        notifications = message.with_user(self.user_employee).notification_ids
+        self.assertEqual(len(notifications), 2)
+        self.assertTrue(bool(notifications.read(['is_read'])), 'Internal can read')
+
+        notif_other = notifications.filtered(lambda n: n.res_partner_id == self.user_portal.partner_id)
+        with self.assertRaises(AccessError):
+            notif_other.write({'is_read': True})
+
+        notif_own = notifications.filtered(lambda n: n.res_partner_id == self.user_employee.partner_id)
+        notif_own.write({'is_read': True})
+        # with self.assertRaises(AccessError):
+        #     notif_own.write({'author_id': self.user_portal.partner_id.id})
+        with self.assertRaises(AccessError):
+            notif_own.write({'mail_message_id': self.record_internal.message_ids[0]})
+        with self.assertRaises(AccessError):
+            notif_own.write({'res_partner_id': self.user_admin.partner_id.id})
+
+    def test_mail_notification_portal(self):
+        """ In any case, portal should not modify notifications """
+        self.assertFalse(self.env['mail.notification'].with_user(self.user_portal).check_access_rights('write', raise_exception=False))
+        portal_record = self.record_portal.with_user(self.user_portal)
+        message = portal_record.message_post(
+            body='Hello People',
+            message_type='comment',
+            partner_ids=(self.user_portal_2.partner_id + self.user_employee.partner_id).ids,
+            subtype_id=self.env.ref('mail.mt_comment').id,
+        )
+        notifications = message.notification_ids
+        self.assertEqual(len(notifications), 2)
+        self.assertTrue(bool(notifications.read(['is_read'])), 'Portal can read')
+        self.assertEqual(notifications.res_partner_id, self.user_portal_2.partner_id + self.user_employee.partner_id)


### PR DESCRIPTION
Improve access related tests for mail.message and their sub models. Currently
tests are dependent on discuss.channel model, and not always written in a
clear way. Understanding the purpose of each test is not crystal clear.

We now use a test model with simple rules, defined in test_mail addon. It
allows to simulate models with

  * public access;
  * portal access;
  * internal access;
  * admin access;

using ACLs and ir.rules. Tests are rewritten to be more concise and precise
and use new models.

This is done in stable to keep coherency in tests codebase. It also eases
writing bugfixes as tests won't have to be modified during forward port
process. Finally it allows to backport improvements or fixes in later
versions if it applies to previous versions.

Task-4320561