### PR TITLE
[FIX] website: fix `rounded box` header missing `padding`

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1514,7 +1514,7 @@
                 </div>
             </t>
             <t t-call="website.template_header_mobile">
-                <t t-set="_extra_navbar_classes" t-valuef="o_full_border mx-1 rounded-pill"/>
+                <t t-set="_extra_navbar_classes" t-valuef="o_full_border mx-1 rounded-pill px-3"/>
             </t>
         </div>
     </xpath>


### PR DESCRIPTION
This PR aims to fix a spacing issue within the `rounded box` header template, which has no spacing in mobile, making the first and last element stick to the border of the header.

To fix that behavior, we simply need to set a `padding` utility class on Mobile as well.

- task-3608124
- extracted from https://github.com/odoo/odoo/pull/171050

| 18.0 | This PR |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/34c55e62-6081-4c87-abb2-d485e57bb071) | ![image](https://github.com/user-attachments/assets/31ea1841-8b38-4f0c-b74b-ce1be9bf79b5) | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
