### PR TITLE
[IMP] stock: always pass warehouses as a list in the context of forecast report

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1051,7 +1051,7 @@ class MrpProduction(models.Model):
         }
         warehouse = self.picking_type_id.warehouse_id
         if warehouse:
-            action['context']['warehouse_id'] = warehouse.id
+            action['context']['warehouse_id'] = [warehouse.id]
         return action
 
     def action_update_bom(self):

--- a/addons/purchase_mrp/report/mrp_report_mo_overview.py
+++ b/addons/purchase_mrp/report/mrp_report_mo_overview.py
@@ -12,7 +12,6 @@ class ReportMrpReport_Mo_Overview(models.AbstractModel):
         domain = [('state', 'in', ['draft', 'sent', 'to approve']), ('product_id', '=', product.id)]
         warehouse_id = self.env.context.get('warehouse_id', False)
         if warehouse_id:
-            warehouse_id = warehouse_id if isinstance(warehouse_id, list) else [warehouse_id]
             domain += [('order_id.picking_type_id.warehouse_id', 'in', warehouse_id)]
         po_lines = self.env['purchase.order.line'].search(domain, order='date_planned, id')
 

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -126,7 +126,7 @@ class PurchaseOrderLine(models.Model):
         }
         warehouse = self.order_id.picking_type_id.warehouse_id
         if warehouse:
-            action['context']['warehouse_id'] = warehouse.id
+            action['context']['warehouse_id'] = [warehouse.id]
         return action
 
     def unlink(self):

--- a/addons/purchase_stock/report/stock_forecasted.py
+++ b/addons/purchase_stock/report/stock_forecasted.py
@@ -13,7 +13,6 @@ class StockForecasted_Product_Product(models.AbstractModel):
         domain += self._product_purchase_domain(product_template_ids, product_ids)
         warehouse_id = self.env.context.get('warehouse_id', False)
         if warehouse_id:
-            warehouse_id = warehouse_id if isinstance(warehouse_id, list) else [warehouse_id]
             domain += [('order_id.picking_type_id.warehouse_id', 'in', warehouse_id)]
         po_lines = self.env['purchase.order.line'].search(domain)
         in_sum = sum(po_lines.mapped('product_uom_qty'))

--- a/addons/sale_mrp/tests/test_sale_mrp_report.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_report.py
@@ -109,7 +109,7 @@ class TestSaleMrpInvoices(AccountTestInvoicingCommon):
 
         ])
         (so_1 | so_2).action_confirm()
-        report_lines = self.env['stock.forecasted_product_product'].with_context(warehouse=warehouse.id).get_report_values(docids=product.ids)['docs']['lines']
+        report_lines = self.env['stock.forecasted_product_product'].with_context(warehouse=[warehouse.id]).get_report_values(docids=product.ids)['docs']['lines']
         self.assertEqual(len(report_lines), 3)
         so_1_line = next(filter(lambda line: line.get('document_out') and line['document_out'].get('id') == so_1.id, report_lines))
         self.assertEqual(

--- a/addons/sale_stock/report/stock_forecasted.py
+++ b/addons/sale_stock/report/stock_forecasted.py
@@ -53,6 +53,5 @@ class StockForecasted_Product_Product(models.AbstractModel):
             domain += [('product_id', 'in', product_ids)]
         warehouse_id = self.env.context.get('warehouse_id', False)
         if warehouse_id:
-            warehouse_id = warehouse_id if isinstance(warehouse_id, list) else [warehouse_id]
             domain += [('warehouse_id', 'in', warehouse_id)]
         return domain

--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
@@ -22,7 +22,7 @@ export class QtyAtDatePopover extends Component {
             additionalContext: {
                 active_model: 'product.product',
                 active_id: this.props.record.data.product_id[0],
-                warehouse_id: this.props.record.data.warehouse_id && this.props.record.data.warehouse_id[0],
+                warehouse_id: this.props.record.data.warehouse_id ? [this.props.record.data.warehouse_id[0]] : [],
                 move_to_match_ids: this.props.record.data.move_ids.records.map(record => record.resId),
                 sale_line_to_match_id: this.props.record.resId,
             },

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -846,7 +846,7 @@ Please change the quantity done or the rounding precision of your unit of measur
             warehouse = self.location_dest_id.warehouse_id
 
         if warehouse:
-            action['context']['warehouse_id'] = warehouse.id
+            action['context']['warehouse_id'] = [warehouse.id]
         return action
 
     def _do_unreserve(self):

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -234,7 +234,7 @@ class StockWarehouseOrderpoint(models.Model):
         }
         warehouse = self.warehouse_id
         if warehouse:
-            action['context']['warehouse_id'] = warehouse.id
+            action['context']['warehouse_id'] = [warehouse.id]
         return action
 
     @api.model

--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -115,8 +115,8 @@ class StockForecasted_Product_Product(models.AbstractModel):
         assert product_template_ids or product_ids
         res = {}
 
-        if self.env.context.get('warehouse_id') and isinstance(self.env.context['warehouse_id'], int):
-            warehouse = self.env['stock.warehouse'].browse(self.env.context.get('warehouse_id'))
+        if self.env.context.get('warehouse_id'):
+            warehouse = self.env['stock.warehouse'].browse(self.env.context['warehouse_id'][0])
         else:
             warehouse = self.env['stock.warehouse'].search([['active', '=', True]])[0]
 

--- a/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.js
@@ -24,15 +24,7 @@ export class ForecastedWarehouseFilter extends Component {
     }
 
     get activeWarehouse() {
-        let warehouseIds = null;
-        if (Array.isArray(this.context.warehouse_id)) {
-            warehouseIds = this.context.warehouse_id;
-        } else {
-            warehouseIds = [this.context.warehouse_id];
-        }
-        return warehouseIds
-            ? this.warehouses.find((w) => warehouseIds.includes(w.id))
-            : this.warehouses[0];
+        return this.warehouses.find(w => this.context.warehouse_id.includes(w.id)) || this.warehouses[0];
     }
 
     get warehousesItems() {

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -88,7 +88,7 @@ export class StockForecasted extends Component {
 
     async updateWarehouse(id) {
         const hasPreviousValue = this.context.warehouse_id !== undefined;
-        this.context.warehouse_id = id;
+        this.context.warehouse_id = [id];
         if (hasPreviousValue) {
             await this.reloadReport();
         }
@@ -107,12 +107,9 @@ export class StockForecasted extends Component {
     }
 
     get graphDomain() {
-        const warehouseIds = Array.isArray(this.context.warehouse_id)
-            ? this.context.warehouse_id
-            : [this.context.warehouse_id];
         const domain = [
             ["state", "=", "forecast"],
-            ["warehouse_id", "in", warehouseIds],
+            ["warehouse_id", "in", this.context.warehouse_id],
         ];
         if (this.resModel === "product.template") {
             domain.push(["product_tmpl_id", "=", this.productId]);

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -754,7 +754,7 @@ class TestReports(TestReportsCommon):
 
         report_values, docs, lines = self.get_report_forecast(
             product_template_ids=self.product_template.ids,
-            context={'warehouse_id': wh_2.id},
+            context={'warehouse_id': [wh_2.id]},
         )
         draft_picking_qty = docs['draft_picking_qty']
         self.assertEqual(len(lines), 0)
@@ -771,7 +771,7 @@ class TestReports(TestReportsCommon):
 
         report_values, docs, lines = self.get_report_forecast(
             product_template_ids=self.product_template.ids,
-            context={'warehouse_id': wh_2.id},
+            context={'warehouse_id': [wh_2.id]},
         )
         draft_picking_qty = docs['draft_picking_qty']
         self.assertEqual(len(lines), 0)
@@ -796,7 +796,7 @@ class TestReports(TestReportsCommon):
 
         report_values, docs, lines = self.get_report_forecast(
             product_template_ids=self.product_template.ids,
-            context={'warehouse_id': wh_2.id},
+            context={'warehouse_id': [wh_2.id]},
         )
         draft_picking_qty = docs['draft_picking_qty']
         self.assertEqual(len(lines), 0)
@@ -812,7 +812,7 @@ class TestReports(TestReportsCommon):
 
         report_values, docs, lines = self.get_report_forecast(
             product_template_ids=self.product_template.ids,
-            context={'warehouse_id': wh_2.id},
+            context={'warehouse_id': [wh_2.id]},
         )
         draft_picking_qty = docs['draft_picking_qty']
         self.assertEqual(len(lines), 1)
@@ -868,7 +868,7 @@ class TestReports(TestReportsCommon):
         self.assertEqual(len(inter_wh_delivery), 1)
         _, _, lines = self.get_report_forecast(
             product_template_ids=self.product_template.ids,
-            context={'warehouse_id': wh.id},
+            context={'warehouse_id': [wh.id]},
         )
         # The forecast should show 1 line linking the delivery with the replenish
         self.assertEqual(len(lines), 1)
@@ -912,7 +912,7 @@ class TestReports(TestReportsCommon):
 
         report_values, docs, lines = self.get_report_forecast(
             product_template_ids=self.product_template.ids,
-            context={'warehouse_id': wh_2.id},
+            context={'warehouse_id': [wh_2.id]},
         )
         draft_picking_qty = docs['draft_picking_qty']
         self.assertEqual(len(lines), 0, "Must have 0 line.")
@@ -930,7 +930,7 @@ class TestReports(TestReportsCommon):
 
         report_values, docs, lines = self.get_report_forecast(
             product_template_ids=self.product_template.ids,
-            context={'warehouse_id': wh_2.id},
+            context={'warehouse_id': [wh_2.id]},
         )
         self.assertEqual(len(lines), 1, "Must have 1 line.")
         self.assertEqual(lines[0]['document_in']['id'], wh_2_receipt.id)
@@ -1406,7 +1406,7 @@ class TestReports(TestReportsCommon):
             'product_uom_qty': 5.0,
         })
         move_pick._action_confirm()
-        _, _, lines = self.get_report_forecast(product_template_ids=self.product1.product_tmpl_id.ids, context={'warehouse_id': self.wh_2.id})
+        _, _, lines = self.get_report_forecast(product_template_ids=self.product1.product_tmpl_id.ids, context={'warehouse_id': [self.wh_2.id]})
         self.assertEqual(len(lines), 1)
         self.assertEqual(lines[0]['move_out']['id'], move_pick.id)
 

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -3940,8 +3940,8 @@ class TestStockValuation(TestStockValuationBase):
 
         # Opens the report for each company and compares the values.
         report = self.env['stock.forecasted_product_product']
-        report_for_company_1 = report.with_context(warehouse_id=warehouse_1.id)
-        report_for_company_2 = report.with_context(warehouse_id=warehouse_2.id)
+        report_for_company_1 = report.with_context(warehouse_id=[warehouse_1.id])
+        report_for_company_2 = report.with_context(warehouse_id=[warehouse_2.id])
         report_value_1 = report_for_company_1.get_report_values(docids=self.product1.ids)
         report_value_2 = report_for_company_2.get_report_values(docids=self.product1.ids)
         self.assertEqual(report_value_1['docs']['value'], "U 50.00")


### PR DESCRIPTION
In this PR
========================

1. For the forecast report, always pass warehouses as a list, regardless of whether it's one or more. This reduces unnecessary code and simplifies the logic.

 The main goal is to clean this PR: https://github.com/odoo/odoo/pull/178909

TaskId: 4214109
