### PR TITLE
[IMP] stock: compute dirty quant availability at move line creation

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -5,6 +5,7 @@ from collections import Counter, defaultdict
 
 from odoo import _, api, fields, tools, models, Command
 from odoo.exceptions import UserError, ValidationError
+from odoo.osv import expression
 from odoo.tools import OrderedSet, groupby
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
@@ -288,6 +289,42 @@ class StockMoveLine(models.Model):
             qty = ml.product_uom_id._compute_quantity(ml.quantity, ml.product_id.uom_id)
             addtional_qty[ml.location_dest_id.id] = addtional_qty.get(ml.location_dest_id.id, 0) - qty
         return addtional_qty
+
+    def get_move_line_quant_match(self, move_id, quant_ids):
+        # Since the quant_id field is neither stored nor computed, this method is used to compute the match if it exists
+        move = self.env['stock.move'].browse(move_id)
+        deleted_move_line_ids = move.move_line_ids - self
+        quants_data = []
+        move_lines_data = []
+        domain = [("id", "in", quant_ids)]
+        for move_line in self | deleted_move_line_ids:
+            move_line_domain = [
+                ("product_id", "=", move_line.product_id.id),
+                ("lot_id", "=", move_line.lot_id.id),
+                ("location_id", "=", move_line.location_id.id),
+                ("package_id", "=", move_line.package_id.id),
+                ("owner_id", "=", move_line.owner_id.id),
+            ]
+            domain = expression.OR([domain, move_line_domain])
+        if domain:
+            quants = self.env['stock.quant'].search(domain)
+            for quant in quants:
+                move_lines = self.filtered(lambda ml: ml.product_id == quant.product_id
+                    and ml.lot_id == quant.lot_id
+                    and ml.location_id == quant.location_id
+                    and ml.package_id == quant.package_id
+                    and ml.owner_id == quant.owner_id
+                )
+                deleted_move_lines = deleted_move_line_ids.filtered(lambda ml: ml.product_id == quant.product_id
+                    and ml.lot_id == quant.lot_id
+                    and ml.location_id == quant.location_id
+                    and ml.package_id == quant.package_id
+                    and ml.owner_id == quant.owner_id
+                )
+                quants_data.append((quant.id, {"available_quantity": quant.available_quantity + sum(ml.quantity_product_uom for ml in deleted_move_lines), "move_line_ids": move_lines.ids}))
+                move_lines_data += [(ml.id, {"quantity": ml.quantity, "quant_id": quant.id}) for ml in move_lines]
+        return [quants_data, move_lines_data]
+
 
     def init(self):
         if not tools.index_exists(self._cr, 'stock_move_line_free_reservation_index'):

--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -4,9 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
 import { useSelectCreate, useOpenMany2XRecord} from "@web/views/fields/relational_utils";
-import { onMounted } from "@odoo/owl"
-import { Domain } from "@web/core/domain";
-
 export class SMLX2ManyField extends X2ManyField {
     setup() {
         super.setup();
@@ -18,41 +15,6 @@ export class SMLX2ManyField extends X2ManyField {
             onCreateEdit: () => this.createOpenRecord(),
         });
 
-        onMounted(async () => {
-            const orm = this.env.model.orm;
-            this.quantsData = [];
-            const usedByQuant = {};
-            if (this.props.record.data.move_line_ids.records.length) {
-                const domains = [];
-                for (const ml of this.props.record.data.move_line_ids.records) {
-                    domains.push([
-                        ["product_id", "=", ml.data.product_id[0]],
-                        ["lot_id", "=", ml.data.lot_id?.[0] || false],
-                        ["location_id", "=", ml.data.location_id[0]],
-                        ["package_id", "=", ml.data.package_id?.[0] || false],
-                        ["owner_id", "=", ml.data.owner_id?.[0] || false],
-                    ]);
-                }
-                if (domains.length) {
-                    const quant_fields = ['display_name', 'product_id', 'lot_id', 'location_id', 'package_id', 'owner_id', 'available_quantity'];
-                    const quants = await orm.searchRead("stock.quant", Domain.or(domains).toList(), quant_fields);
-                    const quants_by_key = Object.fromEntries(quants.map(x => [
-                        [x.product_id[0], x.lot_id?.[0] || false, x.location_id[0], x.package_id?.[0] || false, x.owner_id?.[0] || false],
-                        [x.id, x.display_name, x.available_quantity]
-                    ]));
-                    for (const ml of this.props.record.data.move_line_ids.records) {
-                        const entry = quants_by_key[[ml.data.product_id[0], ml.data.lot_id?.[0] || false, ml.data.location_id[0], ml.data.package_id?.[0] || false, ml.data.owner_id?.[0] || false].toString()];
-                        if (!entry) {  // product not storable or has no quant yet
-                            continue;
-                        }
-                        ml.data.quant_id = [entry[0], entry[1]];
-                        usedByQuant[ml.data.quant_id[0]] = (usedByQuant[ml.data.quant_id[0]] || 0) + ml.data.quantity;
-                    }
-                    this.quantsData = quants.map(x => [x.id, x.available_quantity + (usedByQuant[x.id] || 0)]);
-                }
-            }
-        });
-
         this.selectCreate = (params) => {
             return selectCreate(params);
         };
@@ -60,6 +22,7 @@ export class SMLX2ManyField extends X2ManyField {
             resModel: "stock.quant",
             activeActions: this.activeActions,
             onRecordSaved: (record) => this.selectRecord([record.resId]),
+            onRecordDiscarted: (resId) => this.selectRecord(resId),
             fieldString: this.props.string,
             is2Many: true,
         });
@@ -76,9 +39,9 @@ export class SMLX2ManyField extends X2ManyField {
             search_default_on_hand: true,
             search_default_in_stock: true,
         };
-        const data = this.props.record.data;
-        const productName = data.product_id[1];
+        const productName = this.props.record.data.product_id[1];
         const title = _t("Add line: %s", productName);
+        const alreadySelected = this.props.record.data.move_line_ids.records.filter((line) => line.data.quant_id?.[0]);
         let domain = [
             ["product_id", "=", this.props.record.data.product_id[0]],
             ["location_id", "child_of", this.props.context.default_location_id],
@@ -86,20 +49,9 @@ export class SMLX2ManyField extends X2ManyField {
         if (this.props.domain) {
             domain = [...domain, ...this.props.domain()];
         }
-        const usedByQuant = this.props.record.data.move_line_ids.records.reduce((result, current) => {
-            const quant_id = current.data.quant_id[0];
-            if (!quant_id)
-                return result;
-            result[quant_id] = (result[quant_id] || 0) + current.data.quantity;
-            return result;
-        }, {});
-        const fullyUsed = this.quantsData
-            .filter(([id, available_quantity]) => (usedByQuant[id] || 0) >= available_quantity)
-            .map(([id]) => id);
-
-        if (fullyUsed.length)
-            domain.push(["id", "not in", fullyUsed]);
-
+        if (alreadySelected.length) {
+            domain.push(["id", "not in", alreadySelected.map((line) => line.data.quant_id[0])]);
+        }
         return this.selectCreate({ domain, context, title });
     }
 
@@ -107,15 +59,10 @@ export class SMLX2ManyField extends X2ManyField {
         const params = {
             context: { default_quant_id: res_ids[0] },
         };
-        this.list.addNewRecord(params).then(async (record) => {
+        this.list.addNewRecord(params).then((record) => {
             // Make it dirty to force the save of the record. addNewRecord make
             // the new record dirty === False by default to remove them at unfocus event
             record.dirty = true;
-            if (record.data.quant_id[0] && this.quantsData.every(a => a[0] != record.data.quant_id[0])) {
-                const orm = this.env.model.orm;
-                const quants = await orm.searchRead("stock.quant", [["id", "=", record.data.quant_id[0]]], ['available_quantity']);
-                this.quantsData.push([quants[0].id, quants[0].available_quantity]);
-            }
         });
     }
 

--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -4,10 +4,14 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
 import { useSelectCreate, useOpenMany2XRecord} from "@web/views/fields/relational_utils";
+import { useService } from "@web/core/utils/hooks";
+import { Domain } from "@web/core/domain";
+
 export class SMLX2ManyField extends X2ManyField {
     setup() {
         super.setup();
-
+        this.orm = useService("orm");
+        this.dirtyQuantsData = new Map();
         const selectCreate = useSelectCreate({
             resModel: "stock.quant",
             activeActions: this.activeActions,
@@ -22,7 +26,6 @@ export class SMLX2ManyField extends X2ManyField {
             resModel: "stock.quant",
             activeActions: this.activeActions,
             onRecordSaved: (record) => this.selectRecord([record.resId]),
-            onRecordDiscarted: (resId) => this.selectRecord(resId),
             fieldString: this.props.string,
             is2Many: true,
         });
@@ -32,6 +35,9 @@ export class SMLX2ManyField extends X2ManyField {
         if (!this.props.record.data.show_quant) {
             return super.onAdd(...arguments);
         }
+        // Compute the quant offset from move lines quantity changes that were not saved yet.
+        // Hence, did not yet affect quant's quantity in DB.
+        await this.updateDirtyQuantsData();
         context = {
             ...context,
             single_product: true,
@@ -41,7 +47,6 @@ export class SMLX2ManyField extends X2ManyField {
         };
         const productName = this.props.record.data.product_id[1];
         const title = _t("Add line: %s", productName);
-        const alreadySelected = this.props.record.data.move_line_ids.records.filter((line) => line.data.quant_id?.[0]);
         let domain = [
             ["product_id", "=", this.props.record.data.product_id[0]],
             ["location_id", "child_of", this.props.context.default_location_id],
@@ -49,16 +54,102 @@ export class SMLX2ManyField extends X2ManyField {
         if (this.props.domain) {
             domain = [...domain, ...this.props.domain()];
         }
-        if (alreadySelected.length) {
-            domain.push(["id", "not in", alreadySelected.map((line) => line.data.quant_id[0])]);
+        if (this.dirtyQuantsData.size) {
+            const notFullyUsed = [];
+            const fullyUsed = [];
+            for (const [quantId, quantData] of this.dirtyQuantsData.entries()) {
+                if (quantData.available_quantity > 0) {
+                    notFullyUsed.push(quantId);
+                } else {
+                    fullyUsed.push(quantId);
+                }
+            }
+            if (fullyUsed.length) {
+                domain = Domain.and([domain, [["id", "not in", fullyUsed]]]).toList();
+            }
+            if (notFullyUsed.length) {
+                domain = Domain.or([domain, [["id", "in", notFullyUsed]]]).toList();
+            }
         }
         return this.selectCreate({ domain, context, title });
     }
 
-    selectRecord(res_ids) {
+    async updateDirtyQuantsData() {
+        // Since changes of move line quantities will not affect the available quantity of the quant before
+        // the record has been saved, it is necessary to determine the offset of the DB quant data.
+        this.dirtyQuantsData.clear();
+        const dirtyQuantityMoveLines = this.props.record.data.move_line_ids.records.filter(
+            (ml) => !ml.data.quant_id && ml._values.quantity - ml._changes.quantity
+        );
+        const dirtyQuantMoveLines = this.props.record.data.move_line_ids.records.filter(
+            (ml) => ml.data.quant_id[0]
+        );
+        const dirtyMoveLines = [...dirtyQuantityMoveLines, ...dirtyQuantMoveLines];
+        if (!dirtyMoveLines.length) {
+            return;
+        }
+        const match = await this.orm.call(
+            "stock.move.line",
+            "get_move_line_quant_match",
+            [
+                dirtyMoveLines.map((rec) => rec.resId),
+                this.props.record.resId,
+                dirtyQuantMoveLines.map((ml) => ml.data.quant_id[0]),
+            ],
+            {}
+        );
+        const quants = match[0];
+        if (!quants.length) {
+            return;
+        }
+        const dbMoveLinesData = new Map();
+        for (const data of match[1]) {
+            dbMoveLinesData.set(data[0], { quantity: data[1].quantity, quantId: data[1].quant_id });
+        }
+        const offsetByQuant = new Map();
+        for (const ml of dirtyQuantMoveLines) {
+            const quantId = ml.data.quant_id[0];
+            offsetByQuant.set(quantId, (offsetByQuant.get(quantId) || 0) - ml.data.quantity);
+            const dbQuantId = dbMoveLinesData.get(ml.resId)?.quantId;
+            if (dbQuantId && quantId != dbQuantId) {
+                offsetByQuant.set(
+                    dbQuantId,
+                    (offsetByQuant.get(dbQuantId) || 0) + dbMoveLinesData.get(ml.resId).quantity
+                );
+            }
+        }
+        const offsetByQuantity = new Map();
+        for (const ml of dirtyQuantityMoveLines) {
+            offsetByQuantity.set(ml.resId, ml._values.quantity - ml._changes.quantity);
+        }
+        for (const quant of quants) {
+            const quantityOffest = quant[1].move_line_ids
+                .map((ml) => offsetByQuantity.get(ml) || 0)
+                .reduce((val, sum) => val + sum, 0);
+            const quantOffest = offsetByQuant.get(quant[0]) || 0;
+            this.dirtyQuantsData.set(quant[0], {
+                available_quantity: quant[1].available_quantity + quantityOffest + quantOffest,
+            });
+        }
+    }
+
+    async selectRecord(res_ids) {
+        const demand =
+            this.props.record.data.product_uom_qty -
+            this.props.record.data.move_line_ids.records
+                .map((ml) => ml.data.quantity)
+                .reduce((val, sum) => val + sum, 0);
         const params = {
             context: { default_quant_id: res_ids[0] },
         };
+        if (demand <= 0) {
+            params.context.default_quantity = 0;
+        } else if (this.dirtyQuantsData.has(res_ids[0])) {
+            params.context.default_quantity = Math.min(
+                this.dirtyQuantsData.get(res_ids[0]).available_quantity,
+                demand
+            );
+        }
         this.list.addNewRecord(params).then((record) => {
             // Make it dirty to force the save of the record. addNewRecord make
             // the new record dirty === False by default to remove them at unfocus event

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -172,3 +172,192 @@ registry.category("web_tour.tours").add('test_onchange_twice_lot_ids', {
         },
     ]
 });
+
+registry.category("web_tour.tours").add("test_add_new_line_in_detailled_op", {
+    test: true,
+    steps: () => [
+        {
+            trigger: ".o_list_view.o_field_x2many .o_data_row button[name='Open Move']",
+            run: "click",
+        },
+        {
+            trigger: ".modal-content",
+            isCheck: true,
+        },
+        {
+            content: "Check that the first line is associated with LOT001",
+            trigger:
+                ".modal-content .o_data_row:nth-child(1) .o_data_cell[name=quant_id]:contains(WH/Stock - LOT001)",
+            isCheck: true,
+        },
+        {
+            content: "Modify the quant associated to the second line to fully use LOT003",
+            trigger: ".modal-content .o_data_row:nth-child(2) .o_data_cell[name=quant_id]",
+            run: "click",
+        },
+        {
+            trigger: ".modal-content .o_data_row:nth-child(2) .o_field_widget[name=quant_id] input",
+            run: "text LOT003",
+        },
+        {
+            trigger: ".dropdown-item:contains(LOT003)",
+            run: "click",
+        },
+        {
+            content: "Modify the quantity of the first line from 10 to 8",
+            trigger: ".modal-content .o_data_row:nth-child(1) .o_data_cell[name=quantity]",
+            run: "click",
+        },
+        {
+            trigger: ".modal-content .o_data_row:nth-child(1) .o_data_cell[name=quantity] .o_input",
+            run: "text 8",
+        },
+        {
+            trigger: ".modal-header .modal-title:contains(Open: Stock move)",
+            run: "click",
+        },
+        {
+            trigger: ".modal-content .o_list_number:contains(18.00)",
+            isCheck: true,
+        },
+        {
+            trigger: ".o_field_x2many_list_row_add > a",
+            run: "click",
+        },
+        {
+            content: "LOT003 should not appear as it is not available",
+            trigger: ".modal-header .modal-title:contains(Add line: Product Lot)",
+            run: () => {
+                const lines = document.querySelectorAll(".o_data_row .o_data_cell[name=lot_id]");
+                if (lines.length !== 2) {
+                    throw new TourError(
+                        "Wrong number of available quants: " + lines.length + " instead of 2."
+                    );
+                }
+                const lineLOT003 = Array.from(lines).filter((line) =>
+                    line.textContent.includes("LOT003")
+                );
+                if (lineLOT003.length) {
+                    throw new TourError("LOT003 shoudld not be displayed as unavailable.");
+                }
+            },
+        },
+        {
+            content: "Pick LOT001 to create a move line with a quantity of 2.00",
+            trigger: ".o_data_row .o_data_cell[name=lot_id]:contains(LOT001)",
+            run: "click",
+        },
+        {
+            trigger: ".modal-content .o_list_number:contains(20.00)",
+            isCheck: true,
+        },
+        {
+            trigger: ".modal-header .modal-title:contains(Open: Stock move)",
+            run: "click",
+        },
+        {
+            content: "Check that 2 units of LOT001 were added",
+            trigger:
+                ".o_data_row:has(.o_data_cell[name=quant_id]:contains(WH/Stock - LOT001)) .o_data_cell[name=quantity]:contains(2.00)",
+            isCheck: true,
+        },
+        {
+            content: "Check that the third line is associated with LOT003",
+            trigger:
+                ".modal-content .o_data_row:nth-child(3) .o_data_cell[name=quant_id]:contains(WH/Stock - LOT003)",
+            isCheck: true,
+        },
+        {
+            content: "Modify the quant associated to the third line to use LOT002",
+            trigger: ".modal-content .o_data_row:nth-child(3) .o_data_cell[name=quant_id]",
+            run: "click",
+        },
+        {
+            trigger: ".modal-content .o_data_row:nth-child(3) .o_field_widget[name=quant_id] input",
+            run: "text LOT002",
+        },
+        {
+            trigger: ".dropdown-item:contains(LOT002)",
+            run: "click",
+        },
+        {
+            trigger: ".modal-header .modal-title:contains(Open: Stock move)",
+            run: "click",
+        },
+        {
+            content: "Modify the quantity of the first line from 10 to 15 to change the demand",
+            trigger: ".modal-content .o_data_row:nth-child(3) .o_data_cell[name=quantity]",
+            run: "click",
+        },
+        {
+            trigger: ".modal-content .o_data_row:nth-child(3) .o_data_cell[name=quantity] .o_input",
+            run: "text 15",
+        },
+        {
+            trigger: ".modal-header .modal-title:contains(Open: Stock move)",
+            run: "click",
+        },
+        {
+            contnet: "Remove the LOT001 line with a quantity of 8.00",
+            trigger:
+                ".o_data_row:has(.o_data_cell[name=quantity]:contains(8.00)) .o_list_record_remove",
+            run: "click",
+        },
+        {
+            trigger: ".modal-content .o_list_number:contains(17.00)",
+            isCheck: true,
+        },
+        {
+            trigger: ".o_field_x2many_list_row_add > a",
+            run: "click",
+        },
+        {
+            content: "LOT002 should not appear as it is not available",
+            trigger: ".modal-header .modal-title:contains(Add line: Product Lot)",
+            run: () => {
+                const lines = document.querySelectorAll(".o_data_row .o_data_cell[name=lot_id]");
+                if (lines.length !== 2) {
+                    throw new TourError(
+                        "Wrong number of available quants: " + lines.length + " instead of 2."
+                    );
+                }
+                const lineLOT002 = Array.from(lines).filter((line) =>
+                    line.textContent.includes("LOT002")
+                );
+                if (lineLOT002.length) {
+                    throw new TourError("LOT002 shoudld not be displayed as unavailable.");
+                }
+            },
+        },
+        {
+            content: "Pick LOT001 to create move line to fullfill the demand of 3",
+            trigger: ".o_data_row .o_data_cell[name=lot_id]:contains(LOT001)",
+            run: "click",
+        },
+        {
+            trigger: ".modal-content .o_list_number:contains(20.00)",
+            isCheck: true,
+        },
+        {
+            trigger: ".modal-header .modal-title:contains(Open: Stock move)",
+            run: "click",
+        },
+        {
+            content: "Check that 3 units of LOT001 were added",
+            trigger:
+                ".o_data_row:has(.o_data_cell[name=quant_id]:contains(WH/Stock - LOT001)) .o_data_cell[name=quantity]:contains(3.00)",
+            isCheck: true,
+        },
+        {
+            trigger: ".modal-content .o_form_button_save",
+            run: "click",
+        },
+        {
+            trigger: ".o_form_button_save",
+        },
+        {
+            trigger: ".o_form_renderer.o_form_saved",
+            isCheck: true,
+        },
+    ],
+});

--- a/addons/stock/tests/test_picking_tours.py
+++ b/addons/stock/tests/test_picking_tours.py
@@ -92,6 +92,52 @@ class TestStockPickingTour(HttpCase):
         names = self.receipt.move_ids.move_line_ids.mapped('lot_name')
         self.assertEqual(names, ["two", "one"])
 
+    def test_add_new_line_in_detailled_op(self):
+        """
+        Check that the unsaved quantity/location changes of the detailed operations impact dynamically
+        the creation of new move lines (considering the real avaible quantity rather than DB data's).
+        """
+        warehouse = self.env.ref("stock.warehouse0")
+        product_lot = self.env['product.product'].create({
+            'name': 'Product Lot',
+            'type': 'product',
+            'tracking': 'lot',
+        })
+        lot_1, lot_2, lot_3 = self.env['stock.lot'].create([
+            {'name': 'LOT001', 'product_id': product_lot.id, 'company_id': warehouse.company_id.id},
+            {'name': 'LOT002', 'product_id': product_lot.id, 'company_id': warehouse.company_id.id},
+            {'name': 'LOT003', 'product_id': product_lot.id, 'company_id': warehouse.company_id.id},
+        ])
+        self.env['stock.quant']._update_available_quantity(product_lot, warehouse.lot_stock_id, quantity=10, lot_id=lot_1)
+        self.env['stock.quant']._update_available_quantity(product_lot, warehouse.lot_stock_id, quantity=15, lot_id=lot_2)
+        self.env['stock.quant']._update_available_quantity(product_lot, warehouse.lot_stock_id, quantity=10, lot_id=lot_3)
+        partner = self.env['res.partner'].create({'name': 'Bob'})
+        delivery = self.picking_in = self.env['stock.picking'].create({
+            'picking_type_id': warehouse.out_type_id.id,
+            'partner_id': partner.id,
+            'location_id': warehouse.lot_stock_id.id,
+            'location_dest_id': self.ref('stock.stock_location_customers'),
+            'move_ids': [Command.create({
+                'name': product_lot.name,
+                'product_id': product_lot.id,
+                'location_id': warehouse.lot_stock_id.id,
+                'location_dest_id': self.ref('stock.stock_location_customers'),
+                'product_uom_qty': 20,
+            })]
+        })
+        delivery.action_confirm()
+        self.assertRecordValues(delivery.move_line_ids, [
+            {'lot_id': lot_1.id, 'quantity': 10.0},
+            {'lot_id': lot_2.id, 'quantity': 10.0},
+        ])
+        url = self._get_picking_url(delivery.id)
+        self.start_tour(url, 'test_add_new_line_in_detailled_op', login='admin', timeout=60)
+        self.assertRecordValues(delivery.move_line_ids.sorted("quantity"), [
+            {'quantity': 2.0, 'lot_id': lot_1.id},
+            {'quantity': 3.0, 'lot_id': lot_1.id},
+            {'quantity': 15.0, 'lot_id': lot_2.id},
+        ])
+
     def test_edit_existing_line(self):
         self.uom_unit = self.env.ref('uom.product_uom_unit')
         product_one = self.env['product.product'].create({


### PR DESCRIPTION
Content of the IMP:
---

In the form picking view, it is possible to edit the move lines that are related to a given move by using the `SMLX2ManyField`. However, untill you save the record, available quantity of quants present in the  DB are not updated. This commit ensures that the quants proposed for your  move line creation have an available quantity (even if currenlty dirty) and that the quantity used for the next move line creation is both related to the demand of the move, and the real availability of the quant used to create it.

[FIX] stock: avoid move line reset when opening detailled ops
---

This reverts [1] commit b45e249f8f5f36cffdb1ff615953eac7bb45b995.

### Steps to reproduce:

- Enable Multi-step routes
- Create a storable product: put 5 units on shelf 1 and 5 on shelf 2
- Create and "mark as todo" a delivery order for 3 units
- Click on the detailed operation and change the reservation from shelf 1 to shelf 2 > save (the subrecord not the record)
- Reopen the details operation
#### > The records get resets in front of you

### Cause of the issue:

One of the main problems of [1] is that it modifies dirrectly the data's of the props of the component used by the X2many dialog:
https://github.com/odoo/odoo/blob/7e01d83ac08f9b076e0cd7d7e644679d5264ff7d/addons/stock/static/src/fields/stock_move_line_x2_many_field.js#L48
As such, as soon as you mount that component, you will reset the data's used by that same component. Worse, the component is doing this to itself. Hence, if you did not perform a save before opening the details operation you will reset the values to match the DB's data. Furthermore this data change modifying the props of the component we are looking at will force to reload the component with the newly hardcoded data (which explains that you see your last change resetting in front of you).

In addition, the `quant_id` field of the stock.move.line model is a very particular field as it is neither stored or computed but is used by the create and the write for the stock.move.line data's to match some of the quant informations:
https://github.com/odoo/odoo/blob/7e01d83ac08f9b076e0cd7d7e644679d5264ff7d/addons/stock/models/stock_move_line.py#L85
https://github.com/odoo/odoo/blob/7e01d83ac08f9b076e0cd7d7e644679d5264ff7d/addons/stock/models/stock_move_line.py#L310-L311
Therefore this field will never be set on a move. line that was not  modified in JS and is not saved yet. In order to take into account  the offset between the DB Data and the data's we are setting on the form of stock move it is therefore necessary to perform an rpc to **guess**  what quant was used to create a given line. HOWEVER, as teached by the JS framework formation:
```
The first rule of customizing Odoo in JS is: do it in python
```
So that you should not do that matching in JS but rather where it belongs.

Finally, modifying the props of a component during the `onMounted` is a super hacky way to use OWL as it is the first Hook for which OWL does not destroy the component because of props inconsistency...

opw-4294650

Original issue of the reverted "FIX":
---

### Steps to reproduce

- In the setting enable Multi Step Routes
- Create a storable prodcut and put 5 units on shelf 1
- Create and Mark as Todo a delivery order for 3 units of your product
- Set the quantity of the move to 0 and save the record
- Click on the "burger list icon" of the stock move to edit the
  detailed operations and make the reservations for your 3 units
- We want to make the reservation in 2 lines targetting the same quant
- Add a new line selecting your shelf 1 quant and set the qty to 1
- Try to add a second one the quant is not proposed

### Cause of the issue:

When a quant has been selected at least once and the record is not yet saved the js data of the record contains the info of the quant used to create/update the move line because of the non stored not computed dummy field `quant_id` of the stock move. As such the quant will be considered to already having been used in this transaction and hence not available:
https://github.com/odoo/odoo/blame/54e06a1b25ed9e317e368e89979c7c77ddbffc08/addons/stock/static/src/fields/stock_move_line_x2_many_field.js#L52-L54

### Note:
The IMP fixes the original issue + more.
This reverted commit already required an other fix: Commit ea4fca8faa4ee84693e645514085a65b92364842

opw-4072541
opw-4294650
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
