### PR TITLE
[FIX] project: validate project burndown chart custom domains

### DIFF
--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -72,7 +72,7 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
         IrModelFieldsSudo = self.env['ir.model.fields'].sudo()
         field_id = IrModelFieldsSudo.search([('name', '=', 'stage_id'), ('model', '=', 'project.task')]).id
 
-        groupby = self.env.context['project_task_burndown_chart_report_groupby']
+        groupby = self.env.context.get('project_task_burndown_chart_report_groupby', ['date:month', 'stage_id'])
         date_groupby = [g for g in groupby if g.startswith('date')][0]
 
         # Computes the interval which needs to be used in the `SQL` depending on the date group by interval.


### PR DESCRIPTION
Steps to reproduce:
- Project app > Any project > ':' Menu > Burndown Chart
- Add any custom filter > Click Add
- Sticky Note 'Domain is invalid. Please corect it'

The burndown chart view is dependent on groupby argument 'date', if you try to remove the groupby block from the search bar an error message will appear to stop you. This works properly when passing through `web_read_group` but here we take a slightly different path.

When adding a custom domain to the search bar, we validate that domain by simulating an SQL query using said domain. This request is made independantly of `web_read_group` since it's not intended to be displayed, hence why we don't have the groupby argument.

This causes the query building process to fail, so a default value is needed to restore the flow. Since we only want to validate the domain it does not matter what we put in so I used the default search value.

opw-4300254

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
