### PR TITLE
[IMP] base: CLI: help message

### DIFF
--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -75,3 +75,4 @@ from . import test_config_parameter
 from . import test_ir_module_category
 from . import test_configmanager
 from . import test_num2words_ar
+from . import test_cli

--- a/odoo/addons/base/tests/test_cli.py
+++ b/odoo/addons/base/tests/test_cli.py
@@ -1,0 +1,62 @@
+import re
+import sys
+import subprocess as sp
+
+from odoo.cli.command import commands, load_addons_commands, load_internal_commands
+from odoo.tools import config
+from odoo.tests import BaseCase
+
+
+class TestCommand(BaseCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.odoo_bin = sys.argv[0]
+        assert 'odoo-bin' in cls.odoo_bin
+
+    def run_command(self, *args, check=True, capture_output=True, text=True, **kwargs):
+        return sp.run(
+            [
+                sys.executable,
+                self.odoo_bin,
+                f'--addons-path={config["addons_path"]}',
+                *args,
+            ],
+            capture_output=capture_output,
+            check=check,
+            text=text,
+            **kwargs
+        )
+
+    def test_docstring(self):
+        load_internal_commands()
+        load_addons_commands()
+        for name, cmd in commands.items():
+            self.assertTrue(cmd.__doc__,
+                msg=f"Command {name} needs a docstring to be displayed with 'odoo-bin help'")
+            self.assertFalse('\n' in cmd.__doc__ or len(cmd.__doc__) > 120,
+                msg=f"Command {name}'s docstring format is invalid for 'odoo-bin help'")
+
+    def test_help(self):
+        expected = {
+            'cloc',
+            'db',
+            'deploy',
+            'help',
+            'neutralize',
+            'obfuscate',
+            'populate',
+            'scaffold',
+            'server',
+            'shell',
+            'start',
+            'upgrade_code',
+        }
+        for option in ('help', '-h', '--help'):
+            with self.subTest(option=option):
+                actual = set()
+                for line in self.run_command(option).stdout.splitlines():
+                    if line.startswith("   ") and (result := re.search(r'    (\w+)\s+(\w.*)$', line)):
+                        actual.add(result.groups()[0])
+                self.assertGreaterEqual(actual, expected, msg="Help is not showing required commands")

--- a/odoo/cli/__init__.py
+++ b/odoo/cli/__init__.py
@@ -1,2 +1,3 @@
 # Import just the command, the rest will get imported as needed
 from .command import Command, main  # noqa: F401
+from .help import Help  # noqa: F401

--- a/odoo/cli/help.py
+++ b/odoo/cli/help.py
@@ -1,0 +1,36 @@
+from .command import Command, commands, load_addons_commands, load_internal_commands
+
+import odoo.release
+
+
+class Help(Command):
+    """ Display the list of available commands """
+
+    template = """\
+usage: {prog_name} [--addons-path=PATH,...] <command> [...]
+
+Odoo {version}
+Available commands:
+
+{command_list}
+
+Use '{prog_name} server --help' for regular server options.
+Use '{prog_name} <command> --help' for other individual commands options.
+"""
+
+    def run(self, args):
+        load_internal_commands()
+        load_addons_commands()
+
+        padding = max(len(cmd_name) for cmd_name in commands) + 2
+        name_desc = [
+            (cmd_name, (cmd.__doc__ or "").strip())
+            for cmd_name, cmd in sorted(commands.items())
+        ]
+        command_list = "\n".join(f"    {name:<{padding}}{desc}" for name, desc in name_desc)
+
+        print(Help.template.format(  # noqa: T201
+            prog_name=self.prog_name,
+            version=odoo.release.version,
+            command_list=command_list,
+        ))

--- a/odoo/cli/upgrade_code.py
+++ b/odoo/cli/upgrade_code.py
@@ -108,6 +108,8 @@ def migrate(
 
 
 class UpgradeCode(Command):
+    """ Rewrite the entire source code using the scripts found at /odoo/upgrade_code """
+
     name = 'upgrade_code'
 
     def run(self, cmdargs):


### PR DESCRIPTION
- When running `odoo --help` instead of executing `odoo server --help` it should execute `odoo help` to get the list of commands.
 `odoo server --help` should continue running as is.
- The `prog_name` variable will be re-used in other Commands, so we may as well factor it in the base `Command` class.
- Made some textual improvements on the `odoo-bin help` command output.
- Added a test.

Task [link](https://www.odoo.com/odoo/project/967/tasks/4306695)
task-4306695