### PR TITLE
[FIX] hr_attendance: fix double sign-in sign-out

### DIFF
--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
@@ -7,7 +7,6 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-import { useDebounced } from "@web/core/utils/timing";
 import { isIosApp } from "@web/core/browser/feature_detection";
 const { DateTime } = luxon;
 
@@ -26,7 +25,6 @@ export class ActivityMenu extends Component {
             isDisplayed: false
         });
         this.date_formatter = registry.category("formatters").get("float_time")
-        this.onClickSignInOut = useDebounced(this.signInOut, 200, true);
         // load data but do not wait for it to render to prevent from delaying
         // the whole webclient
         this.searchReadEmployee();
@@ -55,6 +53,8 @@ export class ActivityMenu extends Component {
     }
 
     async signInOut() {
+        // to close the dropdown
+        document.body.click()
         // iOS app lacks permissions to call `getCurrentPosition`
         if (!isIosApp()) {
             navigator.geolocation.getCurrentPosition(

--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.xml
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.xml
@@ -27,14 +27,14 @@
                                 <small class="text-muted">Total today</small>
                                 <h2 t-esc="this.hoursToday" class="mb-0 fs-2"/>
                             </div>
-                            <button t-on-click="() => this.onClickSignInOut()" class="flex-basis-100 mt-3" t-attf-class="btn btn-{{ this.state.checkedIn ? 'warning' : 'success' }}">
+                            <button t-on-click="() => this.signInOut()" class="flex-basis-100 mt-3" t-attf-class="btn btn-{{ this.state.checkedIn ? 'warning' : 'success' }}">
                                 <span t-if="!this.state.checkedIn">Check in</span>
                                 <span t-else="">Check out</span>
                                 <i t-attf-class="fa fa-sign-{{ this.state.checkedIn ? 'out' : 'in' }} ms-1"/>
                             </button>
                         </div>
                     </div>
-                    <button t-if="this.isFirstAttendance" t-on-click="() => this.onClickSignInOut()" t-attf-class="btn btn-{{ this.state.checkedIn ? 'warning' : 'success' }}">
+                    <button t-if="this.isFirstAttendance" t-on-click="() => this.signInOut()" t-attf-class="btn btn-{{ this.state.checkedIn ? 'warning' : 'success' }}">
                         <span t-if="!this.state.checkedIn">Check in</span>
                         <span t-else="">Check out</span>
                         <i t-attf-class="fa fa-sign-{{ this.state.checkedIn ? 'out' : 'in' }} ms-1"/>


### PR DESCRIPTION
Before this commit, a user was able to double click on check-in/check-out with the template's reload. To avoid that the pop-up will be automatically closed when the button will be clicked.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
