### PR TITLE
[FIX] l10n_pe_website_sale: cannot edit address

### DIFF
--- a/addons/l10n_pe_website_sale/controllers/main.py
+++ b/addons/l10n_pe_website_sale/controllers/main.py
@@ -37,7 +37,7 @@ class L10nPEWebsiteSale(WebsiteSale):
         if request.website.sudo().company_id.country_id.code != 'PE':
             return rendering_values
 
-        if address_type == 'billing':
+        if kwargs.get('use_delivery_as_billing') and address_type == 'delivery' or address_type == 'billing':
             can_edit_vat = rendering_values['can_edit_vat']
             LatamIdentificationType = request.env['l10n_latam.identification.type'].sudo()
             rendering_values.update({

--- a/addons/l10n_pe_website_sale/views/templates.xml
+++ b/addons/l10n_pe_website_sale/views/templates.xml
@@ -62,7 +62,7 @@
 
     <template id="address" inherit_id="website_sale.address">
         <div id="div_vat" position="before">
-            <t t-if="address_type == 'billing' and res_company.country_id.code == 'PE'">
+            <t t-if="(use_delivery_as_billing and address_type == 'delivery' or address_type == 'billing') and res_company.country_id.code == 'PE'">
                 <div class="w-100" />
                 <t t-call="l10n_pe_website_sale.partner_info" />
             </t>


### PR DESCRIPTION
- Change the company of the first website to the localized company
- Open web shop as public user
- Make a purchase
- Checkout and fill the address
- Edit the address
- Confirm

Issue: Traceback will raise because of the missing localization fields

opw-4232531

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
