### PR TITLE
[PERF] stock_account:16.0 improve _validate_accounting_entries

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3607,11 +3607,9 @@ class AccountMove(models.Model):
         })
 
         for invoice in to_post:
-            invoice.message_subscribe([
-                p.id
-                for p in [invoice.partner_id]
-                if p not in invoice.sudo().message_partner_ids
-            ])
+            partner_id = invoice.partner_id
+            subscribers = [partner_id.id] if partner_id and partner_id not in invoice.sudo().message_partner_ids else None
+            invoice.message_subscribe(subscribers)
 
             if (
                 invoice.is_sale_document()

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -156,13 +156,13 @@ class StockMove(models.Model):
         """
         am_vals_list = super()._account_entry_move(qty, description, svl_id, cost)
         returned_move = self.origin_returned_move_id
-        pdiff_exists = bool((self | returned_move).stock_valuation_layer_ids.stock_valuation_layer_ids.account_move_line_id)
+        move = (self | returned_move).with_prefetch(self._prefetch_ids)
+        pdiff_exists = bool(move.stock_valuation_layer_ids.stock_valuation_layer_ids.account_move_line_id)
 
         if not am_vals_list or not self.purchase_line_id or pdiff_exists or float_is_zero(qty, precision_rounding=self.product_id.uom_id.rounding):
             return am_vals_list
 
         layer = self.env['stock.valuation.layer'].browse(svl_id)
-        returned_move = self.origin_returned_move_id
 
         if returned_move and self._is_out() and self._is_returned(valued_type='out'):
             returned_layer = returned_move.stock_valuation_layer_ids.filtered(lambda svl: not svl.stock_valuation_layer_id)[:1]

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -4,6 +4,8 @@
 from odoo import api, fields, models, tools
 from odoo.tools import float_compare, float_is_zero
 
+from itertools import chain
+from odoo.tools import groupby
 from collections import defaultdict
 
 
@@ -57,12 +59,14 @@ class StockValuationLayer(models.Model):
         if am_vals:
             account_moves = self.env['account.move'].sudo().create(am_vals)
             account_moves._post()
-        for svl in self:
-            move = svl.stock_move_id
-            product = svl.product_id
-            if svl.company_id.anglo_saxon_accounting:
-                move._get_related_invoices()._stock_account_anglo_saxon_reconcile_valuation(product=product)
-            for aml in (move | move.origin_returned_move_id)._get_all_related_aml():
+        products_svl = groupby(self, lambda svl: svl.product_id)
+        for product, svls in products_svl:
+            svls = self.browse(svl.id for svl in svls)
+            moves = svls.stock_move_id
+            if svls.company_id.anglo_saxon_accounting:
+                moves._get_related_invoices()._stock_account_anglo_saxon_reconcile_valuation(product=product)
+            moves = (moves | moves.origin_returned_move_id).with_prefetch(chain(moves._prefetch_ids, moves.origin_returned_move_id._prefetch_ids))
+            for aml in moves._get_all_related_aml():
                 if aml.reconciled or aml.move_id.state != "posted" or not aml.account_id.reconcile:
                     continue
                 aml_to_reconcile[(product, aml.account_id)].add(aml.id)


### PR DESCRIPTION
The function _validate_accounting_entries is notorious for not using proper batching which results in a lot of SQL queries. Originally, it had to iterate individual svls and invoke functions in an unbatched way, even when all svls belonged to the same product. The changes here are to use as much batching as possible and enforcing the use of prefetch_ids to lower the total number of queries.

Benchmarks:

|no. queries before| no. queries after | total time before | total time after|
|-----|-----|------|-----|
|95991|83352|1.59 min|1.48 min|


opw-4283347
opw-4096108




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
