### PR TITLE
[FIX] web: restore proper notification positioning for the frontend

### DIFF
--- a/addons/web/static/src/core/notifications/notification.scss
+++ b/addons/web/static/src/core/notifications/notification.scss
@@ -3,7 +3,8 @@
 // The notification just add overlays.
 
 .o_notification_manager {
-    @include o-position-absolute($top: $o-navbar-height * 1.15, $right: $o-notification-margin, $left: $o-notification-margin);
+    position: fixed;
+    inset: ($o-navbar-height * 1.15) $o-notification-margin auto $o-notification-margin;
     z-index: $o-notification-zindex;
 
     @include media-breakpoint-up(sm) {


### PR DESCRIPTION
Since [1], the notifications were not positioned properly anymore. Indeed, if the page was scrolled, the notifications were scrolled with it, meaning that they would not be visible at the top of the viewport as intended, but at the top of the scrolled body.

Steps to reproduce:
- Install website_mass_mailing
- Go to your website homepage in edit mode
- Add enough content to make the page scrollable
- Add a "Newsletter" inner block inside the footer
- Save
- Scroll to your footer and register to the newsletter => A popup is shown but you can't see it (scroll to the top to see it).

The solution is simple: the previous notification manager was positioned based on the fact the body is never scrolled (position: absolute), we now position it based on the viewport (position: fixed) as it could have already been.

[1]: https://github.com/odoo/odoo/commit/189a7c96e6e26825dc05c0c6466576fe63aa091e

Closes https://github.com/odoo/odoo/issues/186432
Related to task-4190506
