### PR TITLE
[FIX] account: test payment with early payment discount

### DIFF
--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -550,7 +550,12 @@ class TestAccountPayment(AccountTestInvoicingCommon):
         invoice2 = invoice1.copy()
         invoice2.action_post()
         self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice2.ids).create({})._create_payments()
-        self.assertTrue(invoice2._is_eligible_for_early_payment_discount(invoice2.currency_id, invoice2.invoice_date))
+
+        # In the community edition, a journal entry is created for a payment regardless of whether an outstanding account is set.
+        # This removes the eligibility for early payment discount.
+        is_accounting_installed = invoice1._get_invoice_in_payment_state() == 'in_payment'
+
+        self.assertEqual(invoice2._is_eligible_for_early_payment_discount(invoice2.currency_id, invoice2.invoice_date), is_accounting_installed)
 
     def test_payments_invoice_payment_state_without_outstanding_accounts(self):
         """ Ensures that, without outstanding accounts set on the bank journal payment method,


### PR DESCRIPTION
The test_payments_epd_eligible_on_move_with_payment is no longer passing in community since this commit https://github.com/odoo/odoo/commit/0c2810df991b5ac48483f03d4cd0f5d281ece4b8. This is because a journal entry is now always generated in community edition, whether an outstanding account is provided or not.

runbot issue: 105488

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
