### PR TITLE
[PERF] sale_stock: fix memory error in anglo_saxon price

### DIFF
--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -135,7 +135,12 @@ class AccountMoveLine(models.Model):
                 qty_to_invoice = -qty_to_invoice
             account_moves = so_line.invoice_lines.move_id.filtered(lambda m: m.state == 'posted' and bool(m.reversed_entry_id) == is_line_reversing)
 
-            posted_cogs = account_moves.line_ids.filtered(lambda l: l.display_type == 'cogs' and l.product_id == self.product_id and l.balance > 0)
+            posted_cogs = self.env['account.move.line'].search([
+                ('move_id', 'in', account_moves.ids),
+                ('display_type', '=', 'cogs'),
+                ('product_id', '=', self.product_id.id),
+                ('balance', '>', 0),
+            ])
             qty_invoiced = 0
             product_uom = self.product_id.uom_id
             for line in posted_cogs:
@@ -144,8 +149,13 @@ class AccountMoveLine(models.Model):
                 else:
                     qty_invoiced += line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id)
             value_invoiced = sum(posted_cogs.mapped('balance'))
-
-            reversal_cogs = posted_cogs.move_id.reversal_move_id.line_ids.filtered(lambda l: l.display_type == 'cogs' and l.product_id == self.product_id and l.balance > 0)
+            reversal_moves = self.env['account.move']._search([('reversed_entry_id', 'in', posted_cogs.move_id.ids)])
+            reversal_cogs = self.env['account.move.line'].search([
+                ('move_id', 'in', reversal_moves),
+                ('display_type', '=', 'cogs'),
+                ('product_id', '=', self.product_id.id),
+                ('balance', '>', 0)
+            ])
             for line in reversal_cogs:
                 if float_compare(line.quantity, 0, precision_rounding=product_uom.rounding) and line.move_id.move_type == 'out_refund' and any(line.move_id.invoice_line_ids.sale_line_ids.mapped('is_downpayment')):
                     qty_invoiced -= line.product_uom_id._compute_quantity(abs(line.quantity), line.product_id.uom_id)


### PR DESCRIPTION
Inside `_stock_account_get_anglo_saxon_price_unit` we are retrieving the posted cogs linked to the account.moves. To do that, currently we are retrieving every cogs and then calling `filtered` on the result.

This can lead to a huge number of cogs to fetch in large databases. As this filtered call can easily be turned into a search_domain, we replace it by a search call. That way the number of cogs retrieved is way smaller. This has the effect of greatly reducing the memory footprint of the method, as fetching all the fields on a large number of cogs quickly filled up the memory prior to this commit.

#### Benchmark

In a customer database with 5M account.move.lines, the peak memory consumption of the method when posting 
an invoice of 5 000 lines goes `1.5 GB -> 250 MB` according to memray

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
