### PR TITLE
[FIX] l10n_gcc_invoice: display Arabic and English in product description

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -287,14 +287,14 @@
                                         <span t-field="line.product_uom_id" groups="uom.group_uom"/>
                                     </td>
                                     <td name="account_invoice_line_name" class="text-end">
-                                        <t t-set="line_name" t-value="
-                                            line.with_context(lang=o.partner_id.lang).product_id.display_name
-                                                if line.product_id and line.name in (
-                                                line.with_context(lang='ar_001').product_id.display_name,
-                                                line.with_context(lang='en_US').product_id.display_name
-                                            ) else line.name
-                                        "/>
-                                        <span t-out="line_name" t-options="{'widget': 'text'}"/>
+                                        <t t-if="line.product_id">
+                                            <t t-set="english_name" t-value="line.with_context(lang='en_US').product_id.display_name"/>
+                                            <t t-set="arabic_name" t-value="line.with_context(lang='ar_001').product_id.display_name"/>
+
+                                            <span t-out="arabic_name + '\n'" t-if="arabic_name not in line.name" t-options="{'widget': 'text'}"/>
+                                            <span t-out="english_name + '\n'" t-if="(english_name != arabic_name) and (english_name not in line.name)" t-options="{'widget': 'text'}"/>
+                                        </t>
+                                        <span t-out="line.name" t-options="{'widget': 'text'}"/>
                                     </td>
 
                                 </t>


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_sa" and the Arabic language
- Create a product and translate its name to Arabic
- Create an invoice and print it
- In the invoice lines under the description column only one translation displays and not both as it should.

### Cause:
The code was changed to only display the current language in this [commit](https://github.com/odoo/odoo/commit/67b041521d05cbcf5adaf04998278c10fa046790). The goal of this commit was to prevent the duplication of the product name because it is already contained in line.name.

### Solution:
The way line.name is computed is by taking the sales description (or purchase one) and concatenating it with the product name. It can also be changed manually in the invoice form view under "label". So to display the product name in both languages and this label without any duplicate this commit adds conditions:
- the label is always displayed
- the Arabic name is displayed if the label does not contains it
- the English name is displayed if the label does not contains it and if it is different from the Arabic one (ie if it is translated)

opw-4187577