### PR TITLE
[FIX] project_{purchase,stock,mrp}: add missing views in top bar actions and PO count fix

### DIFF
--- a/addons/project_mrp/models/project_project.py
+++ b/addons/project_mrp/models/project_project.py
@@ -36,7 +36,7 @@ class ProjectProject(models.Model):
             'res_model': 'mrp.bom',
             'domain': [('project_id', '=', self.id)],
             'name': self.env._('Bills of Materials'),
-            'view_mode': 'list,form',
+            'view_mode': 'list,kanban,form',
             'context': {'default_project_id': self.id},
             'help': "<p class='o_view_nocontent_smiling_face'>%s</p><p>%s</p>" % (
                 _("No bill of materials found. Let's create one."),

--- a/addons/project_purchase/models/project_project.py
+++ b/addons/project_purchase/models/project_project.py
@@ -14,7 +14,10 @@ class Project(models.Model):
     def _compute_purchase_orders_count(self):
         purchase_orders_per_project = dict(
             self.env['purchase.order']._read_group(
-                domain=[('project_id', 'in', self.ids)],
+                domain=[
+                    ('project_id', 'in', self.ids),
+                    ('order_line', '!=', False),
+                ],
                 groupby=['project_id'],
                 aggregates=['id:array_agg'],
             )
@@ -52,7 +55,10 @@ class Project(models.Model):
             'name': self.env._('Purchase Orders'),
             'type': 'ir.actions.act_window',
             'res_model': 'purchase.order',
-            'view_mode': 'list,kanban,form,calendar,pivot,graph,activity',
+            'views': [
+                [False, 'list'], [self.env.ref('purchase.purchase_order_view_kanban_without_dashboard').id, 'kanban'],
+                [False, 'form'], [False, 'calendar'], [False, 'pivot'], [False, 'graph'], [False, 'activity'],
+            ],
             'domain': [('id', 'in', purchase_orders.ids)],
             'context': {
                 'default_project_id': self.id,

--- a/addons/project_purchase/models/project_project.py
+++ b/addons/project_purchase/models/project_project.py
@@ -52,7 +52,7 @@ class Project(models.Model):
             'name': self.env._('Purchase Orders'),
             'type': 'ir.actions.act_window',
             'res_model': 'purchase.order',
-            'views': [[False, 'list'], [False, 'form']],
+            'view_mode': 'list,kanban,form,calendar,pivot,graph,activity',
             'domain': [('id', 'in', purchase_orders.ids)],
             'context': {
                 'default_project_id': self.id,

--- a/addons/project_purchase/tests/test_project_purchase.py
+++ b/addons/project_purchase/tests/test_project_purchase.py
@@ -11,7 +11,6 @@ class TestProjectPurchase(TestProjectPurchaseProfitability):
         project1 = self.env['project.project'].create({'name': 'Project'})
         project1.account_id = self.analytic_account  # Project with analytics
         order_line_values = {
-            'analytic_distribution': {self.analytic_account.id: 100},
             'product_id': self.product_order.id,
             'product_qty': 1,
             'price_unit': self.product_order.standard_price,
@@ -21,18 +20,19 @@ class TestProjectPurchase(TestProjectPurchaseProfitability):
             {
                 'name': 'Purchase Order 1',
                 'partner_id': self.partner_a.id,
-                'order_line': [Command.create(order_line_values)],
+                'order_line': [Command.create({**order_line_values, 'analytic_distribution': {self.analytic_account.id: 100}})]
             },
             {
                 'name': 'Purchase Order 2',
                 'partner_id': self.partner_a.id,
                 'project_id': project1.id,
+                'order_line': [Command.create(order_line_values)],
             },
             {
                 'name': 'Purchase Order 3',
                 'partner_id': self.partner_a.id,
                 'project_id': project1.id,
-                'order_line': [Command.create(order_line_values)],
+                'order_line': [Command.create({**order_line_values, 'analytic_distribution': {self.analytic_account.id: 100}})]
             },
         ])
         self.assertEqual(project1.purchase_orders_count, 3, 'The number of purchase orders linked to project1 should be equal to 3.')
@@ -44,11 +44,13 @@ class TestProjectPurchase(TestProjectPurchaseProfitability):
                 'name': 'Purchase Order 4',
                 'partner_id': self.partner_a.id,
                 'project_id': project2.id,
+                'order_line': [Command.create(order_line_values)],
             },
             {
                 'name': 'Purchase Order 5',
                 'partner_id': self.partner_a.id,
                 'project_id': project2.id,
+                'order_line': [Command.create(order_line_values)],
             },
         ])
         self.assertEqual(project2.purchase_orders_count, 2, 'The number of purchase orders linked to project2 should be equal to 2.')

--- a/addons/project_stock/models/project_project.py
+++ b/addons/project_stock/models/project_project.py
@@ -31,7 +31,7 @@ class ProjectProject(models.Model):
             'name': action_name,
             'type': 'ir.actions.act_window',
             'res_model': 'stock.picking',
-            'view_mode': 'list,kanban,form,calendar,activity',
+            'view_mode': f"list,kanban,form,calendar,{'map' if picking_type == 'outgoing' else 'activity'}",
             'domain': domain,
             'context': context,
             'help': self.env['ir.ui.view']._render_template(

--- a/addons/project_stock/models/project_project.py
+++ b/addons/project_stock/models/project_project.py
@@ -31,7 +31,7 @@ class ProjectProject(models.Model):
             'name': action_name,
             'type': 'ir.actions.act_window',
             'res_model': 'stock.picking',
-            'views': [[False, 'list'], [False, 'form'], [False, 'kanban']],
+            'view_mode': 'list,kanban,form,calendar,activity',
             'domain': domain,
             'context': context,
             'help': self.env['ir.ui.view']._render_template(


### PR DESCRIPTION
1) Added views for the following top bar actions:
- Purchase Orders
- To WH
- From WH
- Stock Moves

2) In project dashboard, the count of purchase orders in the stat button was taking empty purchase orders
into account. However, when clicking on it, only the POs containing lines were shown, which is not consistent.
We then remove the empty POs from the count, this is also to be consistent with the count of sales orders
which does not take the empty SOs into account.

task-4313971
version-18.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
