### PR TITLE
[FIX] stock: define return type as RET instead of IN

### DIFF
--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -1022,7 +1022,7 @@ class Warehouse(models.Model):
                 'default_location_src_id': False,
                 'sequence': max_sequence + 6,
                 'show_reserved': True,
-                'sequence_code': 'IN',
+                'sequence_code': 'RET',
                 'company_id': self.company_id.id,
             },
         }, max_sequence + 6


### PR DESCRIPTION
Before #185966, while the `sequence_code` of the return picking type was 'IN', its sequence was always 'RET'. But since the sequence was always overwritten with the default 'RET', it went unnoticed. After that, it now picked the picking type `sequence_code` during update if it was defined, which means it would end up with a 'IN' sequence as well, creating duplicate names for pickings as two separate sequences would overlap.

Linked issue: https://github.com/odoo/odoo/issues/186365

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
