### PR TITLE
[FIX] purchase: allow printing multiple po foreign currency

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -232,7 +232,7 @@ class PurchaseOrder(models.Model):
                 order.company_id,
             )
             if order.currency_id != order.company_currency_id:
-                order.tax_totals['amount_total_cc'] = f"({formatLang(self.env, self.amount_total_cc, currency_obj=self.company_currency_id)})"
+                order.tax_totals['amount_total_cc'] = f"({formatLang(self.env, order.amount_total_cc, currency_obj=self.company_currency_id)})"
 
     @api.depends('company_id.account_fiscal_country_id', 'fiscal_position_id.country_id', 'fiscal_position_id.foreign_vat')
     def _compute_tax_country_id(self):


### PR DESCRIPTION
The issue: Printing multiple purchase orders with a currency different from the company’s caused a traceback:
  File "/data/build/odoo/addons/purchase/models/purchase_order.py", line 235, in _compute_tax_totals
    order.tax_totals['amount_total_cc'] = f"({formatLang(self.env, self.amount_total_cc, currency_obj=self.company_currency_id)})"
  File "/data/build/odoo/odoo/fields.py", line 1204, in __get__
    record.ensure_one()
  File "/data/build/odoo/odoo/models.py", line 5979, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: purchase.order(23, 22)

How to reproduce the issue:
Go to the purchase module, select POs with different currencies, try to print them in bulk.

The issue:
The `amount_total_cc` was computed using the `self` recordset instead of individual records.

opw-4292675

@robodoo fw=no
https://github.com/odoo/odoo/commit/d0e7be7832672d476f1b289af52d3a425990d719#diff-1281da5f4d0a3daaf162a2e6456469537d1b74b8034437783c9c717307aa8fcd changed the way the `_compute_tax_totals` works in 18.0