### PR TITLE
[IMP] web: load native js modules using `loadJS` function

### DIFF
--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -26,8 +26,8 @@ class AssetsLoadingError extends Error {}
  * @param {string} url the url of the script
  * @returns {Promise<true>} resolved when the script has been loaded
  */
-export const _loadJS = (assets.loadJS = memoize(function loadJS(url) {
-    if (document.querySelector(`script[src="${url}"]`)) {
+export const _loadJS = (assets.loadJS = memoize(function loadJS(url, type="text/javascript") {
+    if (document.querySelector(`script[src="${url}"][type="${type}"]`)) {
         // Already in the DOM and wasn't loaded through this function
         // Unfortunately there is no way to check whether a script has loaded
         // or not (which may not be the case for async/defer scripts)
@@ -36,7 +36,7 @@ export const _loadJS = (assets.loadJS = memoize(function loadJS(url) {
     }
 
     const scriptEl = document.createElement("script");
-    scriptEl.type = "text/javascript";
+    scriptEl.type = type;
     scriptEl.src = url;
     document.head.appendChild(scriptEl);
     return new Promise((resolve, reject) => {
@@ -217,7 +217,7 @@ export const _loadBundle = (assets.loadBundle = async function loadBundle(desc) 
             }
         } else {
             // parallel loading
-            await Promise.all(urlData.map(loadJS));
+            await Promise.all(urlData.map(url => loadJS(url)));
         }
     }
 
@@ -247,8 +247,8 @@ export const _loadBundle = (assets.loadBundle = async function loadBundle(desc) 
     }
 });
 
-export const loadJS = function (url) {
-    return assets.loadJS(url);
+export const loadJS = function (url, type) {
+    return assets.loadJS(url, type);
 };
 export const loadCSS = function (url) {
     return assets.loadCSS(url);


### PR DESCRIPTION
This PR updates the `loadJS` function in `assets.js` to enable developers to seamlessly load any type of script into Odoo. One can, for instance, load a JS module by doing `loadJS(src, "module")`. This change will be helpful to load the new Firebase dependencies that are now distributed as standard JS module.

task-4247811

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
