### PR TITLE
[FIX] account: ensure registry is loaded

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -140,7 +140,7 @@ class AccountChartTemplate(models.AbstractModel):
             chart template.
         :type install_demo: bool
         """
-        if not self.env.registry.ready and not install_demo:
+        if not self.env.registry.loaded and not install_demo:
             _logger.warning('Incorrect usage of try_loading without a fully loaded registry. This could lead to issues.')
         if not company:
             return


### PR DESCRIPTION
During a major upgrade the registry my be `loaded` but not `ready`. https://github.com/odoo/odoo/blob/9918e8f3d627f3c52238d6b04bcd15c05d34e40c/odoo/modules/registry.py#L159-L160

This causes unnecessary warnings during upgrades (blocking the CI).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
