### PR TITLE
[FIX] hr: make civil status translatable.

### DIFF
--- a/addons/hr/i18n/hr.pot
+++ b/addons/hr/i18n/hr.pot
@@ -1090,6 +1090,12 @@ msgid ""
 msgstr ""
 
 #. module: hr
+#. odoo-python
+#: code:addons/hr/models/hr_employee.py:0
+msgid "Divorced"
+msgstr ""
+
+#. module: hr
 #: model:ir.model.fields.selection,name:hr.selection__hr_employee__certificate__doctor
 msgid "Doctor"
 msgstr ""
@@ -1817,6 +1823,12 @@ msgid "Lead the entire sales cycle"
 msgstr ""
 
 #. module: hr
+#. odoo-python
+#: code:addons/hr/models/hr_employee.py:0
+msgid "Legal Cohabitant"
+msgstr ""
+
+#. module: hr
 #: model_terms:ir.actions.act_window,help:hr.action_hr_job
 msgid "Let's create a job position."
 msgstr ""
@@ -1899,6 +1911,12 @@ msgstr ""
 #. module: hr
 #: model:hr.job,name:hr.job_marketing
 msgid "Marketing and Community Manager"
+msgstr ""
+
+#. module: hr
+#. odoo-python
+#: code:addons/hr/models/hr_employee.py:0
+msgid "Married"
 msgstr ""
 
 #. module: hr
@@ -2771,6 +2789,12 @@ msgid "Show employees"
 msgstr ""
 
 #. module: hr
+#. odoo-python
+#: code:addons/hr/models/hr_employee.py:0
+msgid "Single"
+msgstr ""
+
+#. module: hr
 #: model:ir.model.fields,field_description:hr.field_res_config_settings__module_hr_skills
 msgid "Skills Management"
 msgstr ""
@@ -3235,6 +3259,12 @@ msgstr ""
 msgid ""
 "Whether the employee is a member of the active user's department or one of "
 "it's child department."
+msgstr ""
+
+#. module: hr
+#. odoo-python
+#: code:addons/hr/models/hr_employee.py:0
+msgid "Widower"
 msgstr ""
 
 #. module: hr

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -610,11 +610,11 @@ class HrEmployeePrivate(models.Model):
 
     def _get_marital_status_selection(self):
         return [
-            ('single', 'Single'),
-            ('married', 'Married'),
-            ('cohabitant', 'Legal Cohabitant'),
-            ('widower', 'Widower'),
-            ('divorced', 'Divorced')
+            ('single', _('Single')),
+            ('married', _('Married')),
+            ('cohabitant', _('Legal Cohabitant')),
+            ('widower', _('Widower')),
+            ('divorced', _('Divorced')),
         ]
 
     # ---------------------------------------------------------


### PR DESCRIPTION
In the employees module, the civil status field in the private information section has terms that are always in English. These terms were not exported to be translated. This commit makes them translatable and exports them to the translators.

Opw-4292046
Opw-4278798

Enterprise: https://github.com/odoo/enterprise/pull/73406
