### PR TITLE
[FIX] mail : Prevent changing the alias_domain_id if already exist

### DIFF
--- a/addons/mail/models/mail_alias_mixin_optional.py
+++ b/addons/mail/models/mail_alias_mixin_optional.py
@@ -68,7 +68,7 @@ class AliasMixinOptional(models.AbstractModel):
                 alias_vals, record_vals = self._alias_filter_fields(vals)
                 # generate record-agnostic base alias values
                 alias_vals.update(self.env[self._name].with_context(
-                    default_alias_domain_id=company.alias_domain_id.id,
+                    default_alias_domain_id=alias_vals.get('alias_domain_id', company.alias_domain_id.id),
                 )._alias_get_creation_values())
                 alias_vals_list.append(alias_vals)
                 record_vals_list.append(record_vals)

--- a/addons/test_mail/tests/test_mail_alias.py
+++ b/addons/test_mail/tests/test_mail_alias.py
@@ -804,6 +804,13 @@ class TestMailAliasMixin(TestMailAliasCommon):
         with self.assertRaises(exceptions.ValidationError):
             record.write({'alias_defaults': "{'custom_field': brokendict"})
 
+        rec = self.env['mail.test.container'].create({
+            'name': 'Test Record2',
+            'alias_name': 'alias.test',
+            'alias_domain_id': self.mail_alias_domain_c2.id,
+        })
+        self.assertEqual(rec.alias_id.alias_domain_id, self.mail_alias_domain_c2, "Should use the provided alias domain in priority")
+
     @users('erp_manager')
     def test_alias_mixin_alias_email(self):
         """ Test 'alias_email' mixin field computation and search capability """


### PR DESCRIPTION
### Steps to reproduce:
	- Create two alias domains
	- Create a Helpdesk team with alias name 'test' for example and with one of the alias domains created in the first step
	- Create another helpdesk team with the same alias name but with the other alias domain created in the first step
	- Notice the 'Invalid operation' pop-up that will be shown

### Current behavior before PR:
This is happening because when creating the helpdesk team we should get the alias creation values but when getting those values we are passing a default value for the alias_domain_id in the context https://github.com/odoo/odoo/blob/17.0/addons/mail/models/mail_alias_mixin_optional.py#L70:L72 which change the alias_domain_id value that will be used for the helpdesk team creation.

### Desired behavior after PR is merged:
We are checking if the alias_domain_id is present in the vals_list or not and if it does exist we don't change it.

opw-4286060