### PR TITLE
[FIX] mrp: avoid undesired splitting in shopfloor step

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -610,7 +610,7 @@ class MrpProduction(models.Model):
             if production.state in ('draft', 'done', 'cancel'):
                 production.reservation_state = False
                 continue
-            relevant_move_state = production.move_raw_ids._get_relevant_state_among_moves()
+            relevant_move_state = production.move_raw_ids.filtered(lambda m: not m.picked)._get_relevant_state_among_moves()
             # Compute reservation state according to its component's moves.
             if relevant_move_state == 'partially_available':
                 if production.workorder_ids.operation_id and production.bom_id.ready_to_produce == 'asap':


### PR DESCRIPTION
### Steps to reproduce:

- Create 2 storable products: Final product (FP) and Component (COMP)
- Put 10 units of COMP in stock
- Create a Bill of Material for FP:
  - raw move: 10 x COMP
  - 1 operation: "Register COMP"
  - Add an instruction on your operation:
    - type: "Register consumed component"
    - Product To Register: COMP
- Create and confirm an MO for 1 Unit of FP
- Go to the shopfloor > "Register COMP"
- Change the quantity to 3 > Validate
#### > Go back to the MO the quantity of the raw move is still 10

### Cause of the issue:

Clicking on "Validate" as well as on "Continue consumption" will trigger a call of the `_next` method with `continue_production=False` and `True` respectively:
https://github.com/odoo/enterprise/blob/e86b97f57e2388b3b65326cecedd3c14ca02ddb1/mrp_workorder/models/quality.py#L346-L352 However, if you underconsume, a new move line will be created for the remaining quantity in both cases and it should only when you `Continue consumption`.

### Note:

If you underconsume, and change the quantity of the raw move without changing its original demand. As such, its state will itself change. Hence, if you come back to the MO, the reservation sate of the MO will be recomputed and be updated from assigned to confirmed. However, as the raw move is picked it should not alter the reservation state of the MO anymore:
https://github.com/odoo/odoo/blob/9918e8f3d627f3c52238d6b04bcd15c05d34e40c/addons/mrp/models/mrp_production.py#L613 This is the purpose of the community PR.

opw-4216910
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
