### PR TITLE
[FIX] tests: lower failed to fetch messages

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1213,6 +1213,10 @@ class ChromeBrowser:
 
         log_type = type
         _logger = self._logger.getChild('browser')
+        if self._result.done() and "Failed to fetch" in message and log_type in ('warning', 'error'):
+            # lower down Failed to fetch error message
+            log_type = 'info'
+
         _logger.log(
             self._TO_LEVEL.get(log_type, logging.INFO),
             "%s%s",


### PR DESCRIPTION
The failed to fetch message can be related to any request being stoped by the Chrome stoploading.  It is the cause of many random errors occuring after test successfull builds.

https://runbot.odoo.com/runbot/build/67702421
https://runbot.odoo.com/runbot/build/70277206
https://runbot.odoo.com/runbot/build/69086069

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
