### PR TITLE
[FIX] l10n_ch: display bank partner name next to Swiss QRcode

### DIFF
--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -67,7 +67,7 @@
                                 <span t-field="o.partner_bank_id.acc_number" t-if="not o.partner_bank_id.l10n_ch_qr_iban"/>
                                 <span t-field="o.partner_bank_id.l10n_ch_qr_iban" t-if="o.partner_bank_id.l10n_ch_qr_iban"/>
                                 <br/>
-                                <span t-out="o.partner_bank_id.acc_holder_name or o.company_id.name"/><br/>
+                                <span t-out="o.partner_bank_id.partner_id.name or o.company_id.name"/><br/>
                                 <span t-field="o.company_id.street"/><br/>
                                 <span t-field="o.company_id.country_id.code"/>
                                 <span t-field="o.company_id.zip"/>
@@ -179,7 +179,7 @@
                                 <span t-field="o.partner_bank_id.acc_number" t-if="not o.partner_bank_id.l10n_ch_qr_iban"/>
                                 <span t-field="o.partner_bank_id.l10n_ch_qr_iban" t-if="o.partner_bank_id.l10n_ch_qr_iban"/>
                                 <br/>
-                                <span t-out="o.partner_bank_id.acc_holder_name or o.company_id.name"/><br/>
+                                <span t-out="o.partner_bank_id.partner_id.name or o.company_id.name"/><br/>
                                 <span t-field="o.company_id.street"/><br/>
                                 <span t-field="o.company_id.country_id.code"/>
                                 <span t-field="o.company_id.zip"/>


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_ch" and switch to the Swiss company
- In the Accounting settings activate the QRcodes on invoices
- Change the name of the Swiss company
- Create an invoice
- The old company name is still displayed next to the QR code

### Cause:
The field displayed is the field `account_holder_name` which is not updated when changing the company name.

Solution:
As the field `account_holder_name` is not supposed to be shown anymore in 18.0, we can display directly the partner name.

opw-4273688