### PR TITLE
[FIX] hr: update `distance_from_work` on `km_home_work` changes

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -242,7 +242,7 @@ class HrEmployeePrivate(models.Model):
 
     def _inverse_km_home_work(self):
         for employee in self:
-            employee.distance_home_work = employee.km_home_work / 1.609 if employee.distance_home_work_unit == "miles" else employee.distance_home_work
+            employee.distance_home_work = employee.km_home_work / 1.609 if employee.distance_home_work_unit == "miles" else employee.km_home_work
 
     def _get_partner_count_depends(self):
         return ['user_id']


### PR DESCRIPTION
To reproduce, sign a new contract in the salary configurator with a different home to work distance. Check the employee's private info and the distance is not updated.

The issue happens because the salary configurator works on the field `km_home_work` while there is also `distance_home_work` that works with either miles or kilometers. An inverse was introduced in:  https://github.com/odoo/odoo/pull/178160 but it used the wrong field when computing `distance_from_work`.

task-4306551

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
