### PR TITLE
[PERF] base_automation: update date_automation_last after filtering trigger_field_ids

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -653,14 +653,13 @@ class BaseAutomation(models.Model):
             self = self.with_context(__action_done=automation_done)
             records = records.with_context(__action_done=automation_done)
 
-        # modify records
-        if 'date_automation_last' in records._fields:
-            records.date_automation_last = fields.Datetime.now()
-
         # we process the automation on the records for which any watched field
         # has been modified, and only mark the automation as done for those
         records = records.filtered(self._check_trigger_fields)
         automation_done[self] = records_done + records
+
+        if records and 'date_automation_last' in records._fields:
+            records.date_automation_last = fields.Datetime.now()
 
         # prepare the contexts for server actions
         contexts = [


### PR DESCRIPTION
### Analysis 
Before this commit, the `date_automation_last` was updated before checking the `trigger_field_ids`. This means that the `date_automation_last` field was updated even if the automation rule wasn't supposed to run - which, on the functional side, is a behavior we can argue on.

Moreover, this triggers a write on the records which is not necessary if the automation rule is not run and can increase the delay of the operation.

### Solution
In this commit, we update the `date_automation_last` after filtering the records by checking the `trigger_field_ids`.

## Benchmarks
Measuring `web_save` when updating the stage of a lead in the Kanban view of CRM:
| # `crm.lead `   | # `automation.rule` on crm.lead | Before | After | %
| -------------------- | -----| -- | ---------- | --------
|  970 records| 6 |  1.5s   | 0.3 s | - ~80%

### References
opw-4263443

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
