### PR TITLE
[FIX] account: skip manual attachment in send&print wizard

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -494,7 +494,7 @@ class AccountMoveSend(models.TransientModel):
         seen_attachment_ids = set()
         to_exclude = {x['name'] for x in mail_attachments_widget if x.get('skip')}
         for attachment_data in self._get_invoice_extra_attachments_data(move) + mail_attachments_widget:
-            if attachment_data['name'] in to_exclude:
+            if attachment_data['name'] in to_exclude and not attachment_data.get('manual'):
                 continue
 
             try:


### PR DESCRIPTION
The Send & Print dialog will not consider attachments that have the same name as removed ones, example:

- Create an invoice
- Confirm it
- From the action menu: `Print` > `Invoice`
- Download the file to disk - e.g. `INV_2024_00001.pdf`
- Open the `Send & Print` dialog
- Select `Email` only
- Remove the generated attachment `INV_2024_00001.pdf` (on the dialog)
- Add the `INV_2024_00001.pdf` attachment (the one on disk)
- Send the email

The invoice will not be attached to the email, you can check in the chatter.
This occurs because we filter out attachments by checking their names, and the name is the same as the auto-generated one.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4260237)
opw-4260237