### PR TITLE
[FIX] website_sale: traceback when product has computed tax

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -280,7 +280,7 @@ class ProductTemplate(models.Model):
             base_price = None
             template_price_vals = {
                 'price_reduce': self._apply_taxes_to_price(
-                    pricelist_price, currency, product_taxes, taxes, self, website=website,
+                    pricelist_price, currency, product_taxes, taxes, template, website=website,
                 ),
             }
             if pricelist_rule_id:  # If a rule was applied, there might be a discount
@@ -296,7 +296,7 @@ class ProductTemplate(models.Model):
                 if float_compare(pricelist_base_price, pricelist_price, precision_rounding=currency.rounding) > 0:
                     base_price = pricelist_base_price
                     template_price_vals['base_price'] = self._apply_taxes_to_price(
-                        base_price, currency, product_taxes, taxes, self, website=website,
+                        base_price, currency, product_taxes, taxes, template, website=website,
                     )
 
             if not base_price and comparison_prices_enabled and template.compare_list_price:


### PR DESCRIPTION
Have a tax with Tax Computation set to 'Custom Formula', depending on a product.<product_field> (i.e. product.list_price)
Add that tax to a product shown in website shop
Access Ecommerce

Error
```
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
ValueError: Expected singleton: product.template(17, 18, 23, 8)
Template: website_sale.products_item
Path: /t/form/div[2]/div[2]/div[2]/span[1]
Node: <span class="h6 mb-0" t-if="template_price_vals[\'price_reduce\'] or not website.prevent_zero_price_sale" t-out="template_price_vals[\'price_reduce\']" t-options="{\'widget\': \'monetary\', \'display_currency\': website.currency_id}"/>
Compiled code:
code = None
template = 'website_sale.products_item'
```

This occurs because we call `compute_all` with multiple product templates

opw-4295796
