### PR TITLE
[FIX] hr_skills_survey: fix False in employee certificate

### DIFF
--- a/addons/hr_skills_survey/models/survey_user.py
+++ b/addons/hr_skills_survey/models/survey_user.py
@@ -27,7 +27,7 @@ class SurveyUserInput(models.Model):
                 'name': survey.title,
                 'date_start': fields.Date.today(),
                 'date_end': fields.Date.today(),
-                'description': html2plaintext(survey.description),
+                'description': html2plaintext(survey.description) if survey.description else '',
                 'line_type_id': line_type and line_type.id,
                 'display_type': 'certification',
                 'survey_id': survey.id


### PR DESCRIPTION
Current: Users go to Elearning > Certificates to create a test and do not fill in a description for the test.

After the employee finishes the test, they are given a certificate and it is displayed in the employee profile but it is displayed as "False" as shown in the image.

This PR fixes that error and fills it back as '' so that it does not display 'False' if the test does not have a description.
![Screenshot from 2024-11-07 10-42-28](https://github.com/user-attachments/assets/a26851e4-4fbc-46ea-849b-473f13866d6f)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
