### PR TITLE
[FIX] product,sale(_timesheet): use the expected UoM for new products

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -22,6 +22,12 @@ class ProductTemplate(models.Model):
     _check_company_auto = True
     _check_company_domain = models.check_company_domain_parent_of
 
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if 'uom_id' in fields_list and not res.get('uom_id'):
+            res['uom_id'] = self._get_default_uom_id().id
+        return res
+
     @tools.ormcache()
     def _get_default_category_id(self):
         # Deletion forbidden (at least through unlink)

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -422,7 +422,8 @@
                                                     'quantity': product_uom_qty,
                                                     'pricelist': parent.pricelist_id,
                                                     'uom': product_uom,
-                                                    'company_id': parent.company_id
+                                                    'company_id': parent.company_id,
+                                                    'default_uom_id': product_uom,
                                                 }"
                                                 readonly="not product_updatable"
                                                 required="not display_type and not is_downpayment"
@@ -533,6 +534,7 @@
                                         'uom':product_uom,
                                         'company_id': parent.company_id,
                                         'default_lst_price': price_unit,
+                                        'default_uom_id': product_uom,
                                     }"
                                     options="{
                                         'no_open': True,
@@ -551,6 +553,7 @@
                                         'uom':product_uom,
                                         'company_id': parent.company_id,
                                         'default_list_price': price_unit,
+                                        'default_uom_id': product_uom,
                                     }"
                                     options="{
                                         'no_open': True,

--- a/addons/sale_timesheet/models/product_product.py
+++ b/addons/sale_timesheet/models/product_product.py
@@ -11,6 +11,7 @@ class ProductProduct(models.Model):
 
     @tools.ormcache()
     def _get_default_uom_id(self):
+        # TODO remove me in master
         return self.env.ref('uom.product_uom_unit')
 
     def _is_delivered_timesheet(self):
@@ -27,7 +28,7 @@ class ProductProduct(models.Model):
             elif record._origin.uom_id:
                 record.uom_id = record._origin.uom_id
             else:
-                record.uom_id = self._get_default_uom_id()
+                record.uom_id = self.product_tmpl_id.default_get(['uom_id']).get('uom_id')
             record.uom_po_id = record.uom_id
 
     @api.onchange('service_policy')

--- a/addons/sale_timesheet/models/product_template.py
+++ b/addons/sale_timesheet/models/product_template.py
@@ -59,7 +59,7 @@ class ProductTemplate(models.Model):
             elif record._origin.uom_id:
                 record.uom_id = record._origin.uom_id
             else:
-                record.uom_id = self._get_default_uom_id()
+                record.uom_id = self.default_get(['uom_id']).get('uom_id')
             record.uom_po_id = record.uom_id
 
     def _get_service_to_general_map(self):

--- a/addons/sale_timesheet/tests/test_project.py
+++ b/addons/sale_timesheet/tests/test_project.py
@@ -186,6 +186,28 @@ class TestProject(TestCommonSaleTimesheet):
         ))
         self.assertEqual('delivered_timesheet', form.service_policy)
 
+    def test_open_product_form_with_default_uom_id(self):
+        """ Test default product uom fallback when product is not service type """
+        uom_dozen = self.env.ref('uom.product_uom_dozen')
+        product_form = Form(self.env['product.product'].with_context(
+            default_uom_id=uom_dozen.id,
+        ))
+        self.assertEqual(uom_dozen, product_form.uom_id, "Default uom should be Dozen")
+        product_form.type = 'service'
+        product_form.service_policy = 'delivered_timesheet'
+        uom_hour = self.env.ref('uom.product_uom_hour')
+        self.assertEqual(
+            uom_hour,
+            product_form.uom_id,
+            "Uom should be updated to Hour for service_type=`timesheet` product"
+        )
+        product_form.type = 'consu'
+        self.assertEqual(
+            uom_dozen,
+            product_form.uom_id,
+            "Uom should be updated to Dozen for `Goods` type product"
+        )
+
     def test_duplicate_project_allocated_hours(self):
         self.project_global.allocated_hours = 10
         self.assertEqual(self.project_global.copy().allocated_hours, 10)


### PR DESCRIPTION
Steps:
- Go to sales.
- Enable UOM from settings.
- Export Purchase EDI file with Dozens UOM on product in another DB.
- Import that file here in sales.
- Since that product is not created here in our db create product on fly from SOL.

Issue:
- Newly created product does not have Dozens UOM instead it set to Unit and update it in SOL so price on SOL and product is according to Dozens UOM and UOM set on product and SOL is Unit which can lead to issues.

Cause:
- Missing context to set default UOM from SOL to product.

Fix:
- Added `default_uom_id` context on product field on SOL view.
- Ensure that an uom is always provided to the creation values even if `default_uom_id` is set to `None` in the context, since `uom_id` is a required field on products.
- Updated sale_timesheet code to avoid overwriting default values when product is not a timesheet product

opw-4316426
