### PR TITLE
[FIX] base: fix traceback when portal user tries to logout from all devices

### DIFF
--- a/addons/portal/static/src/xml/portal_security.xml
+++ b/addons/portal/static/src/xml/portal_security.xml
@@ -38,21 +38,4 @@
             </p>
         </div>
     </t>
-    <!-- Popup's view !-->
-    <t t-name="portal.revoke_all_devices_popup_template">
-        <section>
-            <div>
-                You are about to log out from all devices that currently have access to this user's account.
-            </div><br/>
-            <form action="/my/security" method="post" class="oe_reset_password_form" >
-                <div class="mb-3">
-                    <label for="current">Type in your password to confirm :</label>
-                    <input type="password" t-attf-class="form-control form-control-sm"
-                            id="current" name="password"
-                            autocomplete="current-password" required="required"/>
-                </div>
-                <input type="hidden" name="op" value="revoke"/>
-            </form>
-        </section>
-    </t>
 </templates>

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1143,7 +1143,9 @@ class Users(models.Model):
 
     @check_identity
     def action_revoke_all_devices(self):
-        return self._action_revoke_all_devices()
+        # self.env.user is sudo by default
+        # Need sudo to bypass access error for removing the devices of portal user
+        return (self.env.user if self.id == self.env.uid else self)._action_revoke_all_devices()
 
     def _action_revoke_all_devices(self):
         devices = self.env["res.device"].search([("user_id", "=", self.id)])


### PR DESCRIPTION
Currently, a traceback occurs when the portal user tries to `log out from all devices`.

To reproduce this issue:

1) Login as a portal user
2) In connection & security click logout from all devices

Error:-

```
The method 'revoke_all_devices' does not exist on the model 'res.users.identitycheck'
```

This error is occurring because the method `revoke_all_devices` is removed from the below commit

https://github.com/odoo/odoo/commit/0b5ea8e3b5321f4bbfc07651c6a8f666767904f8#diff-16e37db365c1ea1f2e6c79aeb60c80f68f1a5c75970e8e3f198eb18af56278ddL2138

But still, it is referenced in the orm call from the below line, which leads to the above traceback.

https://github.com/odoo/odoo/blob/640698c025d329d87467ef5c77a53b98c3590be8/addons/portal/static/src/js/portal_security.js#L139-L143

sentry-5662496036
