### PR TITLE
[IMP] sales_team: activate multi from form

### DIFF
--- a/addons/crm/views/crm_team_views.xml
+++ b/addons/crm/views/crm_team_views.xml
@@ -136,10 +136,10 @@
             <field name="inherit_id" ref="sales_team.crm_team_view_form"/>
             <field name="priority">12</field>
             <field name="arch" type="xml">
-                <xpath expr="//sheet" position="before">
+                <xpath expr="//form/*[1]" position="before">
                     <field name="use_leads" invisible="1"/>
                     <field name="use_opportunities" invisible="1"/>
-                    <header>
+                    <header invisible="not use_leads and not use_opportunities or not assignment_enabled">
                         <button name="action_assign_leads" type="object"
                             string="Assign Leads"
                             class="oe_highlight"

--- a/addons/sales_team/__manifest__.py
+++ b/addons/sales_team/__manifest__.py
@@ -27,7 +27,10 @@ Using this application you can manage Sales Teams with CRM and/or Sales
     'installable': True,
     'assets': {
         'web.assets_backend': [
-            'sales_team/static/**/*',
+            'sales_team/static/src/**/*',
+        ],
+        'web.assets_unit_tests': [
+            'sales_team/static/tests/**/*',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -164,18 +164,15 @@ class CrmTeam(models.Model):
             return
         # done in a loop, but to be used in form view only -> not optimized
         for team in self:
-            member_warning = False
             other_memberships = self.env['crm.team.member'].search([
                 ('crm_team_id', '!=', team._origin.id if team.ids else False),
                 ('user_id', 'in', team.member_ids.ids)
             ])
             if other_memberships:
-                member_warning = _("Adding %(user_names)s in this team will remove them from %(team_names)s.",
+                team.member_warning = _("%(user_names)s already in other teams (%(team_names)s).",
                                    user_names=", ".join(other_memberships.mapped('user_id.name')),
                                    team_names=", ".join(other_memberships.mapped('crm_team_id.name'))
                                   )
-            if member_warning:
-                team.member_warning = member_warning + " " + _("Working in multiple teams? Activate the option under Configuration>Settings.")
 
     def _search_member_ids(self, operator, value):
         return [('crm_team_member_ids.user_id', operator, value)]

--- a/addons/sales_team/models/crm_team_member.py
+++ b/addons/sales_team/models/crm_team_member.py
@@ -130,8 +130,7 @@ class CrmTeamMember(models.Model):
                 teams = user_mapping.get(member.user_id, self.env['crm.team'])
                 remaining = teams - (member.crm_team_id | member._origin.crm_team_id)
                 if remaining:
-                    member.member_warning = _("Adding %(user_name)s in this team will remove them from %(team_names)s. "
-                                              "Working in multiple teams? Activate the option under Configuration>Settings.",
+                    member.member_warning = _("%(user_name)s already in other teams (%(team_names)s).",
                                               user_name=member.user_id.name,
                                               team_names=", ".join(remaining.mapped('name'))
                                              )

--- a/addons/sales_team/static/src/js/crm_team_form.js
+++ b/addons/sales_team/static/src/js/crm_team_form.js
@@ -1,0 +1,51 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+import { formView } from "@web/views/form/form_view";
+import { FormController } from "@web/views/form/form_controller";
+import { registry } from "@web/core/registry";
+import { user } from "@web/core/user";
+import { useService } from "@web/core/utils/hooks";
+
+
+/**
+ * Controller used to directly activate the multi-team option
+ * via a button present in the crm team member alert.
+ *
+ * This alert is only displayed when a user is assigned to
+ * multiple teams but the multi-team option is deactivated.
+ */
+class CrmTeamFormController extends FormController {
+
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+    }
+
+    async beforeExecuteActionButton(clickParams) {
+        if (clickParams.name === "crm_team_activate_multi_membership") {
+            if (!user.hasGroup("sales_team.group_sale_manager")) {
+                return false;
+            }
+            const alert = document.querySelector(".alert");
+            try {
+                await this.orm.call("ir.config_parameter", "set_param", [
+                    "sales_team.membership_multi",
+                    true,
+                ]);
+                alert?.classList.add('d-none');
+            } catch {
+                if (alert) {
+                    alert.classList.replace("alert-info", "alert-danger");
+                    alert.textContent = _t("An error occurred while activating the Multi-Team option.");
+                }
+            }
+            return false;
+        }
+        return super.beforeExecuteActionButton(...arguments);
+    }
+}
+registry.category("views").add("crm_team_form", {
+    ...formView,
+    Controller: CrmTeamFormController,
+});

--- a/addons/sales_team/static/tests/crm_team_form.test.js
+++ b/addons/sales_team/static/tests/crm_team_form.test.js
@@ -1,0 +1,80 @@
+import { expect, test } from "@odoo/hoot";
+import { contains as webContains, onRpc } from "@web/../tests/web_test_helpers";
+import {
+    contains,
+    openFormView,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+
+import { defineCrmTeamModels } from "@sales_team/../tests/crm_team_test_helpers";
+
+defineCrmTeamModels();
+
+test("crm team form activate multi-team option via alert", async () => {
+    expect.assertions(7);
+
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Maria" });
+    const userId = pyEnv["res.users"].create({ partner_id: partnerId });
+    const [teamId_1] = pyEnv["crm.team"].create([
+        {
+            name: "Team1",
+            member_ids: [userId],
+        },
+        {
+            name: "Team2",
+            member_ids: [userId],
+        },
+    ]);
+
+    onRpc("has_group", ({ args }) => {
+        expect.step("has_group");
+        expect(args[1]).toBe("sales_team.group_sale_manager");
+        return true;
+    });
+    onRpc("set_param", ({ args }) => {
+        expect.step("set_param");
+        expect(args[0]).toBe("sales_team.membership_multi");
+        return true;
+    });
+
+    await start();
+    await openFormView("crm.team", teamId_1, {
+        arch: `<form js_class="crm_team_form">
+            <field name="is_membership_multi" invisible="1"/>
+            <field name="member_warning" invisible="1"/>
+            <div class="alert alert-info" invisible="is_membership_multi or not member_warning">
+                <field name="member_warning"/>
+                Working in multiple teams?
+                <button name="crm_team_activate_multi_membership" type="button">
+                    Activate "Multi-team"
+                </button>
+            </div>
+            <sheet>
+                <field name="member_ids">
+                    <kanban>
+                        <templates>
+                            <t t-name="card">
+                                <field name="name"/>
+                            </t>
+                        </templates>
+                    </kanban>
+                </field>
+            </sheet>
+        </form>`,
+    });
+
+    // Members list should have Maria which is already in Team2 => Alert should be shown
+    await expect(".o_field_widget[name='member_ids'] .o_kanban_record:visible").toHaveCount(1);
+    await expect(".o_field_widget[name='member_ids'] .o_kanban_record:visible").toHaveText("Maria");
+    await contains(".alert:visible", { count: 1 });
+
+    // Clicking on the button should update the multi-team option and remove the alert
+    await webContains(".alert button[name='crm_team_activate_multi_membership']").click();
+    await contains(".alert:visible", { count: 0 });
+    expect.verifySteps([
+        "has_group",
+        "set_param",
+    ]);
+});

--- a/addons/sales_team/static/tests/crm_team_test_helpers.js
+++ b/addons/sales_team/static/tests/crm_team_test_helpers.js
@@ -1,0 +1,9 @@
+import { defineModels } from "@web/../tests/web_test_helpers";
+import { mailModels } from "@mail/../tests/mail_test_helpers";
+
+import { CrmTeam } from "./mock_server/mock_models/crm_team";
+
+
+export function defineCrmTeamModels() {
+    return defineModels({ CrmTeam, ...mailModels });
+}

--- a/addons/sales_team/static/tests/mock_server/mock_models/crm_team.js
+++ b/addons/sales_team/static/tests/mock_server/mock_models/crm_team.js
@@ -1,0 +1,21 @@
+import { fields, models } from "@web/../tests/web_test_helpers";
+
+
+export class CrmTeam extends models.ServerModel {
+    _name = "crm.team";
+
+    name = fields.Char();
+    member_ids = fields.Many2many({ string: "Salespersons", relation: "res.users" });
+    is_membership_multi = fields.Boolean({ default: false });
+    member_warning = fields.Text({ compute: "_compute_member_warning" });
+
+    _compute_member_warning() {
+        for (const team of this) {
+            const other_memberships = this.env["crm.team"].search_count([
+                ["id", "!=", team.id],
+                ["member_ids", "in", team.member_ids]
+            ]);
+            team.member_warning = other_memberships ? "Users already in other teams." : false;
+        }
+    }
+}

--- a/addons/sales_team/views/crm_team_member_views.xml
+++ b/addons/sales_team/views/crm_team_member_views.xml
@@ -86,7 +86,7 @@
         <field name="name">crm.team.member.view.form</field>
         <field name="model">crm.team.member</field>
         <field name="arch" type="xml">
-            <form string="Sales Men">
+            <form string="Sales Men" js_class="crm_team_form">
                 <field name="active" invisible="1"/>
                 <field name="company_id" invisible="1"/>
                 <field name="is_membership_multi" invisible="1"/>
@@ -94,9 +94,13 @@
                 <field name="user_in_teams_ids" invisible="1"/>
                 <field name="user_company_ids" invisible="1"/>
                 <sheet>
-                    <div class="alert alert-info text-center" role="alert"
+                    <div class="alert alert-info text-center d-flex flex-wrap justify-content-center gap-1" role="alert"
                         invisible="not member_warning">
-                        <field name="member_warning"/>
+                        <field name="member_warning" class="w-auto"/>
+                        Working in multiple teams?
+                        <button name="crm_team_activate_multi_membership" type="button" class="btn btn-link p-0 lh-1">
+                            Activate "Multi-team"
+                        </button>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <field name="image_1920" widget='image' class="oe_avatar"

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -22,10 +22,14 @@
         <field name="name">crm.team.form</field>
         <field name="model">crm.team</field>
         <field name="arch" type="xml">
-            <form string="Sales Team" class="o_crm_team_form_view">
-                <div class="alert alert-info text-center" role="alert"
+            <form string="Sales Team" js_class="crm_team_form" class="o_crm_team_form_view">
+                <div class="alert alert-info text-center d-flex flex-wrap justify-content-center gap-1" role="alert"
                     invisible="is_membership_multi or not member_warning">
-                    <field name="member_warning"/>
+                    <field name="member_warning" class="w-auto"/>
+                    Working in multiple teams?
+                    <button name="crm_team_activate_multi_membership" type="button" class="btn btn-link p-0 lh-1">
+                        Activate "Multi-team"
+                    </button>
                 </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box"/>


### PR DESCRIPTION
Purpose
=======
Activate the multi team option in one click from the crm team
and crm team member form views.

Technical:
As the alert is displayed when the form isn't saved (computed text field),
adding the option link directly in the xml with a form controller to catch
the click and activate the option.

The "Configuration" menu in crm is only available if the user has the
"sales_team.group_sale_manager" group, the Multi-Team option in the settings
is also only accessible when having this group.
=> No need to add a group check on the button as people having access to the
form views also have the multi-team option right.
Just checking the group in the js form controller to make sure we only really try
to activate if the user has the right.

Adding an "invisible" attribute on the crm team form header to make sure the header
is present in the hierachy only if the action button is visible. Having an empty header
was adding a strange space on top of the form sheet which was misaligning it with the chatter.

Task-4283552

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
