### PR TITLE
[FIX] pos_self_order: fix test in pos_self_order

### DIFF
--- a/addons/pos_self_order/tests/test_self_order_common.py
+++ b/addons/pos_self_order/tests/test_self_order_common.py
@@ -50,26 +50,3 @@ class TestSelfOrderCommon(SelfOrderCommonTest):
         for mode in ("mobile", "consultation", "kiosk"):
             self.pos_config.write({"self_ordering_mode": mode})
             self.start_tour(self_route, "self_order_pos_is_closed")
-
-    def test_self_order_preparation_disabling_preparation_display(self):
-        """
-        This test ensures that the preparation display option can be disabled when the self_ordering_mode is set to 'nothing'.
-        It also tests that the preparation display option is enabled automatically when the self_ordering_mode is set to 'kiosk'.
-        """
-        self.pos_config.self_ordering_pay_after = 'each'
-
-        with odoo.tests.Form(self.env['res.config.settings']) as form:
-            with self.assertLogs(level="WARNING"):
-                form.module_pos_preparation_display = False
-
-            self.pos_config.write({
-                'self_ordering_mode': 'nothing',
-            })
-            form.pos_config_id = self.pos_config
-            self.assertEqual(form.module_pos_preparation_display, False)
-
-            self.pos_config.write({
-                'self_ordering_mode': 'kiosk',
-            })
-            form.pos_config_id = self.pos_config
-            self.assertEqual(form.module_pos_preparation_display, True)


### PR DESCRIPTION
The test `test_self_order_preparation_disabling_preparation_display` in `test_self_order_common` does not work when the `pos_preparation_display` module is not installed. This is because there is no warning message when `pos_preparation_display` is absent. This commit changes the test location to the module `pos_self_order_preparation_display`.