### PR TITLE
[FIX] web_editor: kepp all border-width styles in to_inline

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -1646,13 +1646,6 @@ function _getMatchedCSSRules(node, cssRules, checkBlacklisted = false) {
         delete processedStyle['border-top-left-radius'];
         delete processedStyle['border-top-right-radius'];
     }
-    if (processedStyle['border-left-width']) {
-        processedStyle['border-width'] = processedStyle['border-left-width'];
-        delete processedStyle['border-right-width'];
-        delete processedStyle['border-bottom-width'];
-        delete processedStyle['border-top-width'];
-        delete processedStyle['border-left-width'];
-    }
 
     // If the border styling is initial we remove it to simplify the css tags
     // for compatibility. Also, since we do not send a css style tag, the

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -635,9 +635,9 @@ QUnit.module('convert_inline', {}, function () {
         // Some positional properties (eg., padding-right, margin-left) are not
         // concatenated (eg., as padding, margin) because they were defined with
         // variables (var) or calculated (calc).
-        const containerStyle = `border-width: 0px; border-radius: 0px; border-style: none; margin: 0px auto; box-sizing: border-box; max-width: 1320px; padding-left: 16px; padding-right: 16px; width: 100%;`;
-        const rowStyle = `border-width: 0px; border-radius: 0px; border-style: none; padding: 0px; box-sizing: border-box; margin-left: -16px; margin-right: -16px; margin-top: 0px;`;
-        const colStyle = `border-width: 0px; border-radius: 0px; border-style: none; box-sizing: border-box; margin-top: 0px; padding-left: 16px; padding-right: 16px; max-width: 100%; width: 100%;`;
+        const containerStyle = `border-radius: 0px; border-style: none; margin: 0px auto; box-sizing: border-box; border-width: 0px; max-width: 1320px; padding-left: 16px; padding-right: 16px; width: 100%;`;
+        const rowStyle = `border-radius: 0px; border-style: none; padding: 0px; box-sizing: border-box; border-width: 0px; margin-left: -16px; margin-right: -16px; margin-top: 0px;`;
+        const colStyle = `border-radius: 0px; border-style: none; box-sizing: border-box; border-width: 0px; margin-top: 0px; padding-left: 16px; padding-right: 16px; max-width: 100%; width: 100%;`;
         assert.strictEqual($editable.html(),
             `<div class="container" style="${containerStyle}" width="100%">` +
             `<div class="row" style="${rowStyle}">` +
@@ -1001,7 +1001,7 @@ QUnit.module('convert_inline', {}, function () {
         $iframeEditable.append(`<div class="o_layout" style="padding: 50px;"></div>`);
         convertInline.classToStyle($iframeEditable, convertInline.getCSSRules($iframeEditable[0].ownerDocument));
         assert.strictEqual($iframeEditable.html(),
-            `<div class="o_layout" style="border-width:0px;border-radius:0px;border-style:none;margin:0px;box-sizing:border-box;font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
+            `<div class="o_layout" style="border-radius:0px;border-style:none;margin:0px;box-sizing:border-box;border-left-width:0px;border-bottom-width:0px;border-right-width:0px;border-top-width:0px;font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
             "should have given all styles of body to .o_layout");
         styleSheet.deleteRule(0);
 


### PR DESCRIPTION
Steps to reproduce the issue:
=============================
- Go to any chatter
- Open email composer
- Add seperator
- Send
- The seperator doesn't appear

Origin of the issue:
====================
The issue was first introduced by [1] where we wanted to simplify the border-width to use only the style of 1 but it doesn't work correctly for `hr` element. We keep all border-with styles as grouping them all in one style can lead to very different ui.

opw-4300018

[1]: https://github.com/odoo/odoo/commit/3763d0e4c5cd97793721dc3404b403348ff2c2e8