### PR TITLE
[REF] *: add :not(:visible) to invisible trigger in tours

### DIFF
--- a/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
+++ b/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
@@ -20,7 +20,7 @@
             trigger: ".o_form_editable .o_field_widget[name=email_from] input",
         },
         {
-            trigger: '.o_form_button_save',
+            trigger: ".o_form_button_save:not(:visible)",
             content: 'Save the lead',
             run: 'click',
         },

--- a/addons/mail/static/tests/tours/mail_message_load_order_tour.js
+++ b/addons/mail/static/tests/tours/mail_message_load_order_tour.js
@@ -19,7 +19,8 @@ registry.category("web_tour.tours").add("mail_message_load_order_tour", {
             run: "click",
         },
         {
-            trigger: ".o-mail-MessageCard-jump",
+            content: "Click on invisible jump (should hover card to be visible)",
+            trigger: ".o-mail-MessageCard-jump:not(:visible)",
             run: "click",
         },
         {

--- a/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
@@ -147,6 +147,5 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
             content: "Make sure the floating toolbar is visible",
             trigger: '#toolbar.oe-floating[style*="visible"]',
         },
-        ...stepUtils.discardForm(),
-    ]
+    ],
 });

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -74,7 +74,8 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: ".o_project_task_kanban_view",
 },
 {
-    trigger: ".o_dropdown_kanban .btn.o-no-caret",
+    content: "Click on invisible caret. Should hover on card to be visible",
+    trigger: ".o_dropdown_kanban .btn.o-no-caret:not(:visible)",
     run: "click",
 }, {
     trigger: "a:contains('Set Cover Image')",

--- a/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
+++ b/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
@@ -53,7 +53,7 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
 },
 // Open the matrix through the pencil button next to the product in line edit mode.
 {
-    trigger: ".o_form_status_indicator_buttons.invisible", // wait for save to be finished
+    trigger: ".o_form_status_indicator_buttons:not(:visible)", // wait for save to be finished
 },
 {
     trigger: '.o_field_pol_product_many2one',
@@ -82,7 +82,7 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
 },
 // Ensures the matrix is opened with the values, when adding the same product.
 {
-    trigger: '.o_form_status_indicator_buttons.invisible',
+    trigger: ".o_form_status_indicator_buttons:not(:visible)",
 },
 {
     trigger: 'a:contains("Add a product")',

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
@@ -14,7 +14,7 @@ registry.category("web_tour.tours").add('sale_product_configurator_advanced_tour
         ...tourUtils.createNewSalesOrder(),
         ...tourUtils.selectCustomer("Tajine Saucisse"),
         {
-            trigger: ".o_field_widget[name=partner_shipping_id] .o_external_button", // Wait for onchange_partner_id
+            trigger: ".o_field_widget[name=partner_shipping_id] .o_external_button:not(:visible)", // Wait for onchange_partner_id
         },
         ...tourUtils.addProduct("Customizable Desk (TEST)"),
         ...configuratorTourUtils.selectAndSetCustomAttribute("Customizable Desk", "Legs", "Custom", "Custom 1"),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
@@ -39,7 +39,8 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
             run: "edit nice custom value && click .modal-body",
         },
         {
-            trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk")) label[style="background-color:#000000"] input',
+            trigger:
+                'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk")) label[style="background-color:#000000"] input:not(:visible)',
             run: "click",
         },
         {

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
@@ -27,14 +27,14 @@ registry.category("web_tour.tours").add('sale_product_configurator_tour', {
             trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td[name="price"] span:contains("800.40")',
         },
         {
-            trigger: 'label[style="background-color:#000000"] input',
+            trigger: 'label[style="background-color:#000000"] input:not(:visible)',
             run: "click",
         },
         {
             trigger: '.btn-primary:disabled:contains("Confirm")',
         },
         {
-            trigger: 'label[style="background-color:#FFFFFF"] input',
+            trigger: 'label[style="background-color:#FFFFFF"] input:not(:visible)',
             run: "click",
         },
         {

--- a/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
@@ -110,7 +110,7 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
         },
         // Open the matrix through the pencil button next to the product in line edit mode.
         {
-            trigger: ".o_form_status_indicator_buttons.invisible", // wait for save to be finished
+            trigger: ".o_form_status_indicator_buttons.invisible:not(:visible)", // wait for save to be finished
         },
         tourUtils.editLineMatching("Matrix (PAV11, PAV22, PAV31)", "PA4: PAV41"),
         tourUtils.editConfiguration(),
@@ -136,7 +136,7 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
         },
         // Ensures the matrix is opened with the values, when adding the same product.
         {
-            trigger: ".o_form_status_indicator_buttons.invisible",
+            trigger: ".o_form_status_indicator_buttons.invisible:not(:visible)",
         },
         ...tourUtils.addProduct("Matrix"),
         {

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -959,8 +959,9 @@ registerWebsitePreviewTour("website_form_editable_content", {
         content: "Check that the new text value was correctly set",
         trigger: ":iframe section.s_website_form h5:contains(/^ABC$/)",
     },
-    {   content: "Remove the dropped column",
-        trigger: ":iframe .oe_overlay.oe_active .oe_snippet_remove",
+    {
+        content: "Remove the dropped column",
+        trigger: ":iframe .oe_overlay.oe_active .oe_snippet_remove:not(:visible)",
         run: "click",
     },
     ...clickOnSave(),

--- a/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
+++ b/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
@@ -23,7 +23,7 @@
         run: "click",
     }, {
         content: 'Choose Booth',
-        trigger: '.o_wbooth_booths div:contains("OpenWood Demonstrator 2") input',
+        trigger: ".o_wbooth_booths div:contains(OpenWood Demonstrator 2) input:not(:visible)",
         run: "click",
     }, {
         content: "Validate attendees details",

--- a/addons/website_event_booth_sale/static/tests/tours/helpers/WebsiteEventBoothSaleTourMethods.js
+++ b/addons/website_event_booth_sale/static/tests/tours/helpers/WebsiteEventBoothSaleTourMethods.js
@@ -21,7 +21,7 @@
             },
             {
                 content: 'Select the booth',
-                trigger: '.o_wbooth_booths input[name="event_booth_ids"]',
+                trigger: ".o_wbooth_booths input[name=event_booth_ids]:not(:visible)",
                 run: function () {
                     document.querySelector('.o_wbooth_booths input[name="event_booth_ids"]:nth-child(1)').click();
                 },

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
@@ -17,7 +17,7 @@ registry.category("web_tour.tours").add('website_event_booth_tour', {
     run: "click",
 }, {
     content: 'Select the first two booths',
-    trigger: '.o_wbooth_booths input[name="event_booth_ids"]',
+    trigger: ".o_wbooth_booths input[name=event_booth_ids]:not(:visible)",
     run() {
         document.querySelectorAll('.o_wbooth_booths input[name="event_booth_ids"]')[0].click();
         document.querySelectorAll('.o_wbooth_booths input[name="event_booth_ids"]')[1].click();

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
@@ -20,7 +20,7 @@ registry.category("web_tour.tours").add('event_booth_sale_pricelists_different_c
     },
     {
         content: 'Select the booth',
-        trigger: '.o_wbooth_booths input[name="event_booth_ids"]:nth-child(1)',
+        trigger: ".o_wbooth_booths input[name=event_booth_ids]:nth-child(1):not(:visible)",
         run: "click",
     },
     {

--- a/addons/website_livechat/static/tests/tours/website_livechat_common.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_common.js
@@ -107,7 +107,7 @@ export const close = [
     },
     {
         content: "Check that the button is not displayed anymore",
-        trigger: ".o-livechat-root:shadow .o-mail-ChatHub",
+        trigger: ".o-livechat-root:shadow .o-mail-ChatHub:not(:visible)",
         run() {
             if (this.anchor.querySelectorAll(".o-livechat-livechatButton").length) {
                 console.error(`There should have no .o-livechat-livechatButton...`);

--- a/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
+++ b/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
@@ -43,7 +43,8 @@ registry.category("web_tour.tours").add('google_analytics_view_item', {
     },
     {
         content: 'select another variant',
-        trigger: 'ul.js_add_cart_variants ul.list-inline li:has(label.active) + li:has(label) input',
+        trigger:
+            "ul.js_add_cart_variants ul.list-inline li:has(label.active) + li:has(label) input:not(:visible)",
         run: "click",
     },
     {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_zoom.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_zoom.js
@@ -31,7 +31,7 @@ registry.category("web_tour.tours").add('shop_zoom', {
     },
     {
         content: "change variant",
-        trigger: 'input[data-attribute_name="Beautiful Color"][data-value_name="' + nameGreen + '"]',
+        trigger: `input[data-attribute_name='Beautiful Color'][data-value_name='${nameGreen}']:not(:visible)`,
         run: 'click',
     },
     {

--- a/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
@@ -70,7 +70,7 @@
     },
     {
         content: "select 2nd variant(Black Color)",
-        trigger: '.variant_attribute[data-attribute_name="Color"] input[data-value_name="Black"]',
+        trigger: ".variant_attribute[data-attribute_name=Color] input[data-value_name=Black]:not(:visible)",
         run: function (actions) {
           document.querySelector('img[class*="product_detail_img"]').setAttribute('data-image-to-change', 1);
           actions.click();

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
@@ -198,7 +198,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             trigger: '.my_wish_quantity:contains(1)',
         },
         {
-            trigger: '.oe_product_cart:contains("Bottle") .o_add_wishlist.disabled',
+            trigger: '.oe_product_cart:contains("Bottle") .o_add_wishlist.disabled:not(:visible)',
         },
         {
             content: "Click on product",
@@ -207,7 +207,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
         {
             content: "Select Bottle with second variant from /product",
-            trigger: '.js_variant_change[data-value_name="blue"]',
+            trigger: "input.js_variant_change[data-value_name=blue]:not(:visible)",
             run: "click",
         },
         {
@@ -220,7 +220,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
         {
             content: "Select Bottle with third variant from /product",
-            trigger: '.js_variant_change[data-value_name="black"]',
+            trigger: "input.js_variant_change[data-value_name=black]:not(:visible)",
             run: "click",
         },
         {
@@ -292,7 +292,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
         {
             content: "Check there is wishlist button on product from /shop",
-            trigger: '.oe_product_cart:contains("Bottle") .o_add_wishlist',
+            trigger: ".oe_product_cart:contains(Bottle) .o_add_wishlist:not(:visible)",
         },
         {
             content: "Click on product",
@@ -301,7 +301,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
         {
             content: "Select Bottle with first variant (red) from /product",
-            trigger: '.js_variant_change[data-value_name="red"]',
+            trigger: "input.js_variant_change[data-value_name=red]:not(:visible)",
             run: "click",
         },
         {
@@ -310,7 +310,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
         {
             content: "Select Bottle with second variant (blue) from /product",
-            trigger: '.js_variant_change[data-value_name="blue"]',
+            trigger: "input.js_variant_change[data-value_name=blue]:not(:visible)",
             run: "click",
         },
         {


### PR DESCRIPTION
In this commit, we add the pseudo selector :not(:visible) to invisible elements with the aim to remove _legacyVisible from findTrigger method in tour_step_automatic.js.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
