### PR TITLE
[FIX] web: separate toggle button from dark mode text in user menu

### DIFF
--- a/addons/web/static/src/webclient/burger_menu/burger_user_menu/burger_user_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/burger_user_menu/burger_user_menu.xml
@@ -9,7 +9,7 @@
               <CheckBox
                   t-if="element.type == 'switch'"
                   value="element.isChecked"
-                  className="'dropdown-item form-switch d-flex flex-row-reverse justify-content-between py-3 fs-4'"
+                  className="'dropdown-item form-switch d-flex flex-row-reverse justify-content-between py-3 fs-4 w-100'"
                   onChange="element.callback"
               >
                   <t t-out="element.description"/>

--- a/addons/web/static/src/webclient/user_menu/user_menu.xml
+++ b/addons/web/static/src/webclient/user_menu/user_menu.xml
@@ -18,7 +18,7 @@
                         <CheckBox
                             t-if="element.type == 'switch'"
                             value="element.isChecked"
-                            className="'form-switch d-flex flex-row-reverse justify-content-between p-0'"
+                            className="'form-switch d-flex flex-row-reverse justify-content-between p-0 w-100'"
                             onChange="element.callback"
                         >
                             <t t-out="element.description"/>


### PR DESCRIPTION
Previously in user menu 'Dark Mode' text was getting merged 
with toggle checkbox button becasue of width: fit-content 
was set to checkbox.

After this commit the toggle button will be seperated from 
dark mode text.

Task-4315881

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
