### PR TITLE
[FIX] account: correct visibility of status bar for secured entries

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -777,7 +777,9 @@
                                 invisible="checked or state == 'draft'" data-hotkey="k" />
                         <field name="state" widget="statusbar" statusbar_visible="draft,posted"
                                groups="!account.group_account_secured"/>
-                        <field name="state" widget="account_move_statusbar_secured" statusbar_visible="draft,posted"
+                        <field name="state" invisible="not secured and not restrict_mode_hash_table" widget="account_move_statusbar_secured" statusbar_visible="draft,posted"
+                               groups="account.group_account_secured"/>
+                        <field name="state" invisible="restrict_mode_hash_table or secured" widget="statusbar" statusbar_visible="draft,posted"
                                groups="account.group_account_secured"/>
                     </header>
                     <div class="alert alert-warning w-100 d-flex align-items-center gap-1" invisible="state != 'draft' or not duplicated_ref_ids"  role="alert">


### PR DESCRIPTION
Before this **PR**:
Since the visibility of the status bar for secured entries was controlled by the security group 'Show Inalterability Features', once assigned to a user, it would make the status bar visible indefinitely, regardless of whether the "Secure Posted Entries with Hash" option was activated or not.

After this **PR**:
The status bar for secured entries is now displayed only for entries that are already secured or belong to journals where the "Secure Posted Entries with Hash" option is enabled.

**task**-4314073
