### PR TITLE
[FIX] l10n_bg: set default pos receivable account

### DIFF
--- a/addons/l10n_bg/data/account.account.template.csv
+++ b/addons/l10n_bg/data/account.account.template.csv
@@ -101,6 +101,7 @@
 "l10n_bg_406","Settlements with related parties for purchases","406","liability_current","l10n_bg.l10n_bg_chart_template","","False"
 "l10n_bg_409","Other settlements with suppliers","409","liability_current","l10n_bg.l10n_bg_chart_template","","False"
 "l10n_bg_411","Customers","411","asset_receivable","l10n_bg.l10n_bg_chart_template","","True"
+"l10n_bg_4111","Customers (PoS)","4111","asset_receivable","l10n_bg.l10n_bg_chart_template","","True"
 "l10n_bg_412","Clients on advances","412","asset_current","l10n_bg.l10n_bg_chart_template","","False"
 "l10n_bg_413","Clients on trade credits","413","asset_current","l10n_bg.l10n_bg_chart_template","","False"
 "l10n_bg_414","Sales customers under certain conditions","414","asset_current","l10n_bg.l10n_bg_chart_template","","False"

--- a/addons/l10n_bg/data/l10n_bg_chart_data.xml
+++ b/addons/l10n_bg/data/l10n_bg_chart_data.xml
@@ -12,5 +12,6 @@
         <field name="property_tax_receivable_account_id" ref="l10n_bg_4538"/>
         <field name="default_cash_difference_income_account_id" ref="l10n_bg_791001"/>
         <field name="default_cash_difference_expense_account_id" ref="l10n_bg_691001"/>
+        <field name="default_pos_receivable_account_id" ref="l10n_bg_4111"/>
     </record>
 </odoo>


### PR DESCRIPTION
Currently, customers are unable to invoice orders through a pos session if they use the Bulgarian localization.

Steps to reproduce:
-------------------
* Install **point_of_sale** and **l10n_bg**
* Change the current company to the Bulgarian one
* Set up a shop and open it
* Make an order, select any customer
* Select payment
* Select the invoice option
* Select payment method and validate
> Observation: Traceback appears

psycopg2.errors.CheckViolation: new row for relation "account_move_line" violates check constraint "account_move_line_check_accountable_required_fields"

Why the fix:
------------
The constraints is violated because the value for account_id does not exist. https://github.com/odoo/odoo/blob/4601acea15feea4780269b4a333f18435904b684/addons/point_of_sale/models/pos_payment.py#L115-L117

We observe that `self.company_id.account_default_pos_receivable_account_id.id` is not set. This field belogns to the `account` module but can only be modified if the module `account_accountant` because of the group `group_account_readonly`. https://github.com/odoo/odoo/blob/4601acea15feea4780269b4a333f18435904b684/addons/point_of_sale/views/res_config_settings_views.xml#L163-L167

Other localizations do not have the issue as they set the default account through the data in `account`module.
https://github.com/odoo/odoo/blob/4601acea15feea4780269b4a333f18435904b684/addons/l10n_au/data/account_chart_template_data.xml#L14 https://github.com/odoo/odoo/blob/4601acea15feea4780269b4a333f18435904b684/addons/l10n_au/data/account.account.template.csv#L8

opw-4279804
