### PR TITLE
[FIX] website: prevent logo overflow in header

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1271,6 +1271,12 @@ header {
             }
         }
     }
+} @else if o-website-value('header-template') == 'boxed' { // TODO: Adapt in master, just add ps-3 class in xml
+    @include media-breakpoint-down(sm) {
+        nav.rounded-pill {
+            padding-left: 1rem !important;
+        }
+    }
 }
 
 .o_grid_header_3_cols {


### PR DESCRIPTION
Specification:
This update ensures that the logo remains contained within the header, preventing overflow when certain templates are applied.

Steps to Reproduce:

1. Go to the website and enter Edit Mode.
2. Upload a logo and select the "Rounded Box Menu" header template.
3. Save the changes or switch to mobile view.
4. Observe that the logo overflows from the header.

Solution:
This commit adjusts the UI styling to keep the logo within header bounds, especially in mobile view.

task-4310456