### PR TITLE
[FIX] website_project: test_admin_task_submission no-demo

### DIFF
--- a/addons/website_project/tests/test_website_project.py
+++ b/addons/website_project/tests/test_website_project.py
@@ -53,7 +53,9 @@ class TestWebsiteProject(HttpCase):
         self.assertTrue(task.exists())
         self.assertEqual(task.partner_id, self.test_partner, "Partner id should not be False")
         self.assertFalse(task.email_cc, "email_cc field should be empty")
-        self.assertIn('This Task was submitted by Mitchell Admin (admin@yourcompany.example.com) on behalf of test@partner.com', html2plaintext(task.description), "Warning message should be displayed in description of task")
+        admin_user = self.env.ref('base.user_admin')
+        asserttext = '%s (%s)' % (admin_user.name, admin_user.email)
+        self.assertIn('This Task was submitted by %s on behalf of test@partner.com' % asserttext, html2plaintext(task.description), "Warning message should be displayed in description of task")
 
-        mail_message = task.message_ids.filtered(lambda m: m.body == '<div class="alert alert-info">This Task was submitted by Mitchell Admin (admin@yourcompany.example.com) on behalf of test@partner.com</div>')
+        mail_message = task.message_ids.filtered(lambda m: m.body == '<div class="alert alert-info">This Task was submitted by %s on behalf of test@partner.com</div>' % asserttext)
         self.assertEqual(len(mail_message), 1, "Alert message should be displayed in the chatter of the task created.")


### PR DESCRIPTION
When we do not activate demo data, name of the administrator is Administrator and not Mitchell Admin. Because of that, test fails. This fix checks the username of administrator and generates assert texts based on that.

[broken build errors](https://runbot.odoo.com/web#id=105350&menu_id=424&cids=1&action=573&model=runbot.build.error&view_type=form)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
