### PR TITLE
[IMP] point_of_sale, **: move fields for category timing

### DIFF
--- a/addons/point_of_sale/views/pos_category_view.xml
+++ b/addons/point_of_sale/views/pos_category_view.xml
@@ -19,6 +19,13 @@
                         <group name="sequence">
                             <field name="color" widget="color_picker" />
                         </group>
+                        <div name="available_between" class="row col-lg-12" invisible="1">
+                            <span class="text-900 fw-bold">Available between
+                                <span class="col-lg-4 o_light_label">
+                                    <a class="o-tooltip"><sup title="Only works for online and self order">?</sup></a>
+                                </span>
+                                <field name="hour_after" class="oe_inline text-center" widget="float_time"/> and <field name="hour_until" class="oe_inline text-center" widget="float_time"/></span>
+                        </div>
                     </group>
                 </sheet>
             </form>

--- a/addons/pos_self_order/models/pos_category.py
+++ b/addons/pos_self_order/models/pos_category.py
@@ -1,33 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.exceptions import ValidationError
-from odoo import models, fields, api, _
+from odoo import models, fields
 
 
 class PosCategory(models.Model):
     _inherit = "pos.category"
 
 
-    hour_until = fields.Float(string='Availability Until', default=24.0, help="The product will be available until this hour.")
-    hour_after = fields.Float(string='Availability After', default=0.0, help="The product will be available after this hour.")
     pos_config_ids = fields.Many2many('pos.config', string='Linked PoS Configurations')
-
-    @api.model
-    def _load_pos_data_fields(self, config_id):
-        fields = super()._load_pos_data_fields(config_id)
-        fields += ['hour_until', 'hour_after']
-        return fields
-
-    @api.constrains('hour_until', 'hour_after')
-    def _check_hour(self):
-        for category in self:
-            if category.hour_until and not (0.0 <= category.hour_until <= 24.0):
-                raise ValidationError(_('The Availability Until must be set between 00:00 and 24:00'))
-            if category.hour_after and not (0.0 <= category.hour_after <= 24.0):
-                raise ValidationError(_('The Availability After must be set between 00:00 and 24:00'))
-            if category.hour_until and category.hour_after and category.hour_until < category.hour_after:
-                raise ValidationError(_('The Availability Until must be greater than Availability After.'))
 
     def _can_return_content(self, field_name=None, access_token=None):
         if field_name in ["image_128", "image_512"]:

--- a/addons/pos_self_order/views/pos_category_views.xml
+++ b/addons/pos_self_order/views/pos_category_views.xml
@@ -5,14 +5,8 @@
         <field name="model">pos.category</field>
         <field name="inherit_id" ref="point_of_sale.product_pos_category_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='sequence']" position="after">
-                <div class="row col-lg-12">
-                    <span class="text-900 fw-bold">Available between
-                        <span class="col-lg-4 o_light_label">
-                            <a class="o-tooltip"><sup title="Only works for kiosk and mobile">?</sup></a>
-                        </span>
-                        <field name="hour_after" class="oe_inline text-center" widget="float_time"/> and <field name="hour_until" class="oe_inline text-center" widget="float_time"/></span>
-                </div>
+            <xpath expr="//div[@name='available_between']" position="attributes">
+                <attribute name="invisible">0</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
**: pos_self_order

In this commit:
===
- Moved the fields hour_after and hour_until from the pos_self_order module to the point_of_sale module in the pos.category model.

Related: https://github.com/odoo/enterprise/pull/73449

task-4319531

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
