### PR TITLE
[IMP] hr{_contract}: add list view to reduce code duplication

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -293,6 +293,21 @@
             </field>
         </record>
 
+        <record id="hr_employee_list_view" model="ir.ui.view">
+            <field name="name">hr.employee.list</field>
+            <field name="model">hr.employee</field>
+            <field name="arch" type="xml">
+                <list string="Employees" multi_edit="1" editable="bottom" sample="1" js_class="hr_employee_list">
+                    <field name="name" readonly="1"/>
+                    <field name="company_id" optional="hide"/>
+                    <field name="department_id" optional="hide"/>
+                    <field name="job_id" context="{'default_no_of_recruitment': 0, 'default_is_favorite': False}" optional="hide"/>
+                    <field name="parent_id" widget="many2one_avatar_user" optional="hide"/>
+                    <field name="resource_calendar_id" optional="show"/>
+                </list>
+            </field>
+        </record>
+
         <record id="hr_kanban_view_employees" model="ir.ui.view">
             <field name="name">hr.employee.kanban</field>
             <field name="model">hr.employee</field>

--- a/addons/hr_contract/views/hr_employee_views.xml
+++ b/addons/hr_contract/views/hr_employee_views.xml
@@ -25,6 +25,17 @@
         </field>
     </record>
 
+    <record id="hr_contract_employee_list_inherit" model="ir.ui.view">
+        <field name="name">hr.contract.employee.list.inherit</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.hr_employee_list_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='resource_calendar_id']" position="before">
+                <field name="first_contract_date" optional="hide"/>
+            </xpath>
+        </field>
+    </record>
+
     <record id="hr_employee_view_graph_inherit_hr_contract" model="ir.ui.view">
         <field name="name">hr.employee.view.graph</field>
         <field name="inherit_id" ref="hr.hr_employee_view_graph"/>


### PR DESCRIPTION
This commit adds a new list view for `hr.employee` model to use it
inside an action displayed in timesheets setting (enterprise feature) to
only have the fields needed in that use case.

task-4179246