### PR TITLE
[FIX] point_of_sale: fix order reference in qr code payment

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1655,8 +1655,8 @@ export class PosStore extends Reactive {
             qr = await this.data.call("pos.payment.method", "get_qr_code", [
                 [payment.payment_method_id.id],
                 payment.amount,
-                payment.pos_order_id.name,
-                payment.pos_order_id.name,
+                payment.pos_order_id.name + " " + payment.pos_order_id.tracking_number,
+                "",
                 this.currency.id,
                 payment.pos_order_id.partner_id?.id,
             ]);


### PR DESCRIPTION
To be compliant with belgium we need to fix the reference of the order in the qr code payment.

If we have 12 digits at the end of the reference, it considers it as a structured reference but isn't. So we also add the tracking number at the end of the reference.

opw-4285530

