### PR TITLE
[FIX] mrp: fix traceback when the user tries to split multiple mrp orders

### DIFF
--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -47,13 +47,13 @@ class MrpProductionSplit(models.TransientModel):
             for _ in range(wizard.counter - 1):
                 commands.append(Command.create({
                     'quantity': quantity,
-                    'user_id': wizard.production_id.user_id,
+                    'user_id': wizard.production_id.user_id.id,
                     'date': wizard.production_id.date_start,
                 }))
                 remaining_quantity = float_round(remaining_quantity - quantity, precision_rounding=wizard.product_uom_id.rounding)
             commands.append(Command.create({
                 'quantity': remaining_quantity,
-                'user_id': wizard.production_id.user_id,
+                'user_id': wizard.production_id.user_id.id,
                 'date': wizard.production_id.date_start,
             }))
             wizard.production_detailed_vals_ids = commands


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to split multiple `mrp order` recordsets.

To reproduce this issue:
1) Install MRP
2) Open manufacturing orders list view from `mrp/operations` 
3) Select multiple recordsets and click the `split` from actions

Error:- 
```
ProgrammingError: can't adapt type 'res.users'
```

This error occurs because we used object `res.users` instead of id in the line below.
Which leads to the above traceback

https://github.com/odoo/odoo/blob/b3f8ba6260eacb117026930a3d4e09b34eea18ac/addons/mrp/wizard/mrp_production_split.py#L48-L51

We can resolve this issue by passing user id instead of an object

sentry-5766922041
