### PR TITLE
[FIX] web: fixed topbar actions not synchronising when switching views

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -502,7 +502,8 @@ export class ControlPanel extends Component {
             JSON.stringify(visibleEmbeddedActions)
         );
         browser.localStorage.setItem(this.embeddedOrderKey, JSON.stringify(order));
-        this.env.config.setCurrentEmbeddedAction(embeddedActionId);
+        this.env.config.setCurrentEmbeddedAction(embeddedActionId[0]);
+        this.env.config.setEmbeddedActions(this.state.embeddedInfos.embeddedActions);
         this.state.embeddedInfos.currentEmbeddedAction = enrichedNewEmbeddedAction;
         this.state.embeddedInfos.newActionName = `${newActionName} Custom`;
     }
@@ -540,6 +541,7 @@ export class ControlPanel extends Component {
         this.state.embeddedInfos.embeddedActions = embeddedActions.filter(
             ({ id }) => id !== action.id
         );
+        this.env.config.setEmbeddedActions(this.state.embeddedInfos.embeddedActions);
         await this.orm.unlink("ir.embedded.actions", [action.id]);
         if (action.id === currentEmbeddedAction?.id) {
             const { active_id, active_model } = this.env.searchModel.globalContext;

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -27,7 +27,7 @@ import {
     reactive,
 } from "@odoo/owl";
 import { downloadReport, getReportUrl } from "./reports/utils";
-import { omit, pick, shallowEqual } from "@web/core/utils/objects";
+import { omit, pick, shallowEqual, deepEqual } from "@web/core/utils/objects";
 import { zip } from "@web/core/utils/arrays";
 import { session } from "@web/session";
 
@@ -1481,6 +1481,24 @@ export function makeActionManager(env, router = _router) {
             newController,
             _getViewInfo(view, controller.action, controller.views, props)
         );
+
+        // Harmonizing the new controllers with old controller embedded actions
+        let oldControllerEmbeds = controller.embeddedActions;
+        if (!newController.config.parentActionId) {
+            oldControllerEmbeds = oldControllerEmbeds?.filter((embed) => embed.id);
+        }
+        if (controller.currentEmbeddedActionId) {
+            newController.config.currentEmbeddedActionId = controller.currentEmbeddedActionId;
+            newController.currentEmbeddedActionId = controller.currentEmbeddedActionId;
+        }
+        if (
+            oldControllerEmbeds?.length &&
+            newController.config.embeddedActions?.length &&
+            !deepEqual(newController.config.embeddedActions, oldControllerEmbeds)
+        ) {
+            newController.config.embeddedActions = oldControllerEmbeds;
+        }
+
         controller.action.controllers[viewType] = newController;
         let index;
         if (view.multiRecord) {


### PR DESCRIPTION
Steps to reproduce:

- Open a tasks in project
- Switch the view and create a custom topbar action
- Switch the view

Issue:

- The new custom topbar action is missing.

Reason:

- There is no mechanism to store the newly created custom action neither passed through the context to bring it back during switching views.

Fix:

- We store the embedded actions on to controller whenever we create a new embedded action and copy the embedded actions into new controller if the new controller misses the embedded actions.

task-4300986
