### PR TITLE
[FIX] tools: suppor nav-tabs for index.html when viewing module info

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -51,6 +51,7 @@ safe_attrs = defs.safe_attrs | frozenset(
      'data-shape', 'data-shape-colors', 'data-file-name', 'data-original-mimetype',
      'data-behavior-props', 'data-prop-name',  # knowledge commands
      'data-mimetype-before-conversion',
+     'data-bs-toggle',  # support nav-tabs
      ])
 SANITIZE_TAGS = {
     # allow new semantic HTML5 tags


### PR DESCRIPTION
* Before: if we have a block contain multiple tab in index.html file we can not click on it to switch between tab, unlike the behiviour in odoo apps store description


https://github.com/user-attachments/assets/ab7f8213-2112-46e2-bb72-5e01cc1f7883


* After: Make the nav tabs work as it should be

https://github.com/user-attachments/assets/12c05abc-84f6-495e-ae5b-b6eca4d81a92


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
