### PR TITLE
[FIX] account_peppol: resolve conflict with duplicate publicwidget name

### DIFF
--- a/addons/account_peppol/static/src/js/portal.js
+++ b/addons/account_peppol/static/src/js/portal.js
@@ -2,16 +2,15 @@
 
 import publicWidget from "@web/legacy/js/public/public_widget";
 
-publicWidget.registry.portalDetails = publicWidget.Widget.extend({
-    selector: '.o_portal_details',
-    events: {
-        'change select[name="invoice_sending_method"]': '_onSendingMethodChange',
-    },
+publicWidget.registry.portalDetails.include({
+    events: Object.assign({}, publicWidget.registry.portalDetails.prototype.events, {
+        "change select[name='invoice_sending_method']": "_onSendingMethodChange",
+    }),
 
     start() {
         this._showPeppolConfig();
         this.orm = this.bindService("orm");
-        return this._super.apply(this, arguments);
+        return this._super(...arguments);
     },
 
     _showPeppolConfig() {
@@ -19,9 +18,9 @@ publicWidget.registry.portalDetails = publicWidget.Widget.extend({
         const divToToggle = document.querySelectorAll(".portal_peppol_toggle");
         for (const peppolDiv of divToToggle) {
             if (method === "peppol") {
-                peppolDiv.classList.remove("d-none")
+                peppolDiv.classList.remove("d-none");
             } else {
-                peppolDiv.classList.add("d-none")
+                peppolDiv.classList.add("d-none");
             }
         }
     },


### PR DESCRIPTION
Steps to reproduce:
1. Go to website > My Account > Edit information
2. Change the country from say India to United States
3. Click on the state drop down, which then appears blank.

The issue occurs because the `account_peppol` module extends the public
widget by using the same name as the existing `portalDetails` public
widget from the portal module, effectively overriding it. This causes
certain functionalities to be lost when `account_peppol` is installed.

This commit modifies the `account_peppol` module to extend the existing
portalDetails widget instead of overriding it.

Issue introduced in commit: https://github.com/odoo/odoo/commit/857b9a188c77cef2e3cd8a1c6b3035e7cd8d1305

task-4310315



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
