### PR TITLE
[FIX] web: do not retain elements in tooltip service

### DIFF
--- a/addons/web/static/src/core/tooltip/tooltip_service.js
+++ b/addons/web/static/src/core/tooltip/tooltip_service.js
@@ -51,15 +51,18 @@ export const tooltipService = {
         let closeTooltip;
         let target = null;
         let touchPressed;
-        const elementsWithTooltips = new Map();
+        const elementsWithTooltips = new WeakMap();
 
         /**
          * Closes the currently opened tooltip if any, or prevent it from opening.
          */
         function cleanup() {
+            target = null;
             browser.clearTimeout(openTooltipTimeout);
+            openTooltipTimeout = null;
             if (closeTooltip) {
                 closeTooltip();
+                closeTooltip = null;
             }
         }
 
@@ -97,12 +100,12 @@ export const tooltipService = {
          *  open
          */
         function openTooltip(el, { tooltip = "", template, info, position, delay = OPEN_DELAY }) {
-            target = el;
             cleanup();
             if (!tooltip && !template) {
                 return;
             }
 
+            target = el;
             openTooltipTimeout = browser.setTimeout(() => {
                 // verify that the element is still in the DOM
                 if (target.isConnected) {


### PR DESCRIPTION
Before this commit, elements on which tooltip were attached were used in a `Map` as keys. That caused the elements to be retained even after being detached from DOM. This commit changes the `Map` to a `WeakMap` to not keep the element's reference and clears properties that kept an element when the tooltip is closed.