### PR TITLE
[FIX] pos_adyen: fix adyen callback

### DIFF
--- a/addons/pos_adyen/static/src/app/pos_bus.js
+++ b/addons/pos_adyen/static/src/app/pos_bus.js
@@ -9,9 +9,11 @@ patch(PosBus.prototype, {
         super.dispatch(...arguments);
 
         if (message.type === "ADYEN_LATEST_RESPONSE" && message.payload === this.pos.config.id) {
-            this.pos
-                .getPendingPaymentLine("adyen")
-                .payment_method.payment_terminal.handleAdyenStatusResponse();
+            const pendingLine = this.pos.getPendingPaymentLine("adyen");
+
+            if (pendingLine) {
+                pendingLine.payment_method.payment_terminal.handleAdyenStatusResponse();
+            }
         }
     },
 });


### PR DESCRIPTION
Add a check on adyen callback when paying. Verify if the pending payment line exist before processing the callback.

opw-4242322


