### PR TITLE
[FIX] cli: obfuscate partner complete name

### DIFF
--- a/odoo/cli/obfuscate.py
+++ b/odoo/cli/obfuscate.py
@@ -163,7 +163,7 @@ class Obfuscate(Command):
                             ('mail_tracking_value', 'new_value_char'),
                             ('mail_tracking_value', 'new_value_text'),
                             ('res_partner', 'name'),
-                            ('res_partner', 'display_name'),
+                            ('res_partner', 'complete_name'),
                             ('res_partner', 'email'),
                             ('res_partner', 'phone'),
                             ('res_partner', 'mobile'),


### PR DESCRIPTION
before this commit, for obfuscating data in the
res.partner model, the display_name field is used, which is non stored field and thus in the log,
an error/warning is shown as follows while
running obfuscate command

odoo.cli.obfuscate: Invalid fields: res_partner.display_name

the invalid warning is raised as the field is not
a stored field and thus removing it from the
obfuscation

even though, the res.partner name field is obfuscated, the same data is remaining in the complete_name
field, so adding this field to obfuscating field list

after this commit, the log will not show the
invalid field warning and complete name also
will be obfuscated

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
