### PR TITLE
[FIX] hr_holidays: restrcit access to leaves in overview

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -35,7 +35,7 @@ class LeaveReportCalendar(models.Model):
 
     is_absent = fields.Boolean(related='employee_id.is_absent')
     leave_manager_id = fields.Many2one(related='employee_id.leave_manager_id')
-    leave_id = fields.Many2one(comodel_name='hr.leave', readonly=True)
+    leave_id = fields.Many2one(comodel_name='hr.leave', readonly=True, groups='hr_holidays.group_hr_holidays_user')
     is_manager = fields.Boolean("Manager", compute="_compute_is_manager")
 
     def init(self):


### PR DESCRIPTION
In the overview, any user with no time off rights can go to the custom groupby filter "Leave" and see the time off type of other users. This commit hides this filter to prevent access.

task-4241846



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
