### PR TITLE
[REF] event: remove OXP badge printer hacks

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -787,9 +787,4 @@ class EventEvent(models.Model):
             'timeframe': self._get_event_timeframe_string(),
             'address': self.address_id.name if self.address_id else None,
             'logo': self.company_id.logo,
-            'sponsor_text': self._get_printing_sponsor_text()
         }
-
-    def _get_printing_sponsor_text(self):
-        sponsor_text = self.env['ir.config_parameter'].sudo().get_param('event.badge_printing_sponsor_text')
-        return sponsor_text or "Powered by Odoo"

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -443,7 +443,6 @@ class EventRegistration(models.Model):
             'name': self.name,
             'ticket_name': self.event_ticket_id.name if self.event_ticket_id else None,
             'ticket_color': self.event_ticket_id.color if self.event_ticket_id else None,
-            'ticket_text_color': self.event_ticket_id._get_ticket_printing_color() if self.event_ticket_id else None,
             'registration_answers': self.registration_answer_choice_ids.mapped('display_name'),
             'company_name': self.company_name
         }

--- a/addons/event/models/event_ticket.py
+++ b/addons/event/models/event_ticket.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import json
-
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools.misc import formatLang
@@ -201,15 +199,3 @@ class EventEventTicket(models.Model):
             raise UserError(_(
                 "The following tickets cannot be deleted while they have one or more registrations linked to them:\n- %s",
                 '\n- '.join(self.mapped('name'))))
-
-    def _get_ticket_printing_color(self):
-        self.ensure_one()
-        default_color = '#000000'
-        color_overrides_json = self.env['ir.config_parameter'].sudo().get_param('event.ticket_text_colors')
-        if color_overrides_json:
-            try:
-                color_overrides = json.loads(color_overrides_json)
-                return color_overrides.get(self.name, default_color)
-            except (json.JSONDecodeError, AttributeError):
-                pass
-        return default_color

--- a/addons/event/tools/esc_label_tools.py
+++ b/addons/event/tools/esc_label_tools.py
@@ -406,14 +406,6 @@ def print_event_template(event: dict, layout: dict, flip=False):
         command.print_image("LOGOFLIP" if flip else "LOGO", (logo_x_pos, logo_y_pos))
 
     command.set_color(layout["secondary_text_color"], alpha=layout["secondary_text_alpha"])
-    print_centered_text(
-        layout,
-        text=event["sponsor_text"],
-        y_position=layout["custom_text_y_pos"],
-        font_size=layout["details_font_size"],
-        command=command,
-        flip=flip
-    )
 
     return command
 
@@ -483,7 +475,6 @@ def print_attendee_badge(attendee: dict, layout: dict, flip=False):
             .set_color(color=attendee["ticket_color"], bg_color=attendee["ticket_color"], bg_alpha=255)
             .print_box(position=(0, ticket_bg_y_pos), size=(layout["print_width"], layout["ticket_bg_height"]))
             )
-        command.set_color(attendee["ticket_text_color"])
         print_centered_text(
             layout,
             text=attendee["ticket_name"],
@@ -533,7 +524,6 @@ layout_96x82 = {
     "answers_y_pos": 1120,
     "logo_y_pos": 1200,
     "ticket_text_y_pos": 1780,
-    "custom_text_y_pos": 1550,
     "secondary_text_color": "#374151",
     "secondary_text_alpha": 200
 }


### PR DESCRIPTION
In the lead-up to OXP 2024, some less-than-ideal
hacks were introduced specifically for the needs
of the OXP. These are not needed now, and so
can be removed.
If similar requirements are needed in the future
they will be deployed internally and not merged.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
