### PR TITLE
[FIX] l10n_de: detach XML invoices

### DIFF
--- a/addons/l10n_de/models/ir_attachment.py
+++ b/addons/l10n_de/models/ir_attachment.py
@@ -36,7 +36,7 @@ class IrAttachment(models.Model):
         invoice_pdf_attachments = self.filtered(lambda attachment:
             attachment.res_model == 'account.move'
             and attachment.res_id
-            and attachment.res_field in ('invoice_pdf_report_file', 'ubl_cii_xml_id')
+            and attachment.res_field in ('invoice_pdf_report_file', 'ubl_cii_xml_file')
         )
         if invoice_pdf_attachments:
             # only detach the document from the field, but keep it in the database for the audit trail


### PR DESCRIPTION
Steps to reproduce:
Install the app l10n_de and switch to a German company Create an invoice
Send & Print the Invoice with XRechnung 
PDF and XML versions  are stored as attachments in the record (Chatter). Try to delete them form the chatter. When deleting them, the unlink function only removes the link to account.move fields and saves the attachment with a new name: "document detached by user on date". This works fine for the PDF version but not for XML one.

This is because `ir_attachment.res_field` is set to `ubl_cii_xml_file` for XML version of the attachment, but when filtering to detach them the filter looks for `ir_attachment.res_field` that are set to `ubl_cii_xml_id`.
opw-4273836


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
