### PR TITLE
[FIX] analytic: prevent dialog from closing when typing on mobile

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -8,6 +8,7 @@ import { usePosition } from "@web/core/position_hook";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { shallowEqual } from "@web/core/utils/arrays";
 import { roundDecimals } from "@web/core/utils/numbers";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
 import { useRecordObserver } from "@web/model/relational_model/utils";
 
@@ -629,7 +630,7 @@ export class AnalyticDistribution extends Component {
 
     onWindowResized() {
         // popup ui is ugly when window is resized, so close it
-        if (this.isDropdownOpen) {
+        if (this.isDropdownOpen && !isMobileOS()) {
             this.forceCloseEditor();
         }
     }


### PR DESCRIPTION
Steps to reproduce
==================

- Use a mobile device
- Enable analytic accounting
- Go to Expenses
- Open a record
- Click on the analytic field
- Search more on the project
- Click on the search input

=> The popup closes

Cause of the issue
==================

There is a resize handler that closes the popup.
When the keyboard appears, the window is resized to reserve space for it

Solution
========

Dont close the popup when we are using a mobile OS

opw-4174514