### PR TITLE
[FIX] project_mrp_account: put the cost from MO into the correct section in project update

### DIFF
--- a/addons/project_mrp_account/models/stock_move.py
+++ b/addons/project_mrp_account/models/stock_move.py
@@ -12,6 +12,12 @@ class StockMove(models.Model):
         distribution = self.raw_material_production_id.project_id._get_analytic_distribution()
         return distribution or super()._get_analytic_distribution()
 
+    def _prepare_analytic_line_values(self, account_field_values, amount, unit_amount):
+        res = super()._prepare_analytic_line_values(account_field_values, amount, unit_amount)
+        if self.raw_material_production_id:
+            res['category'] = 'manufacturing_order'
+        return res
+
     def _prepare_analytic_lines(self):
         res = super()._prepare_analytic_lines()
         if res and self.raw_material_production_id:


### PR DESCRIPTION

This commit's purpose is to remove the cost from the aal of manufacturing order from the 'other cost' section and put it inside the 'manufacturing order' section. This section currently contains only the MO linked to a work order.

task - 4184226

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
