### PR TITLE
[IMP] website_event: front end ticket creation

### DIFF
--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -18,7 +18,7 @@ function websiteCreateEventTourSteps() {
             tooltipPosition: "bottom",
             run: "click",
         }, {
-            trigger: ".modal-dialog div[name='name'] input",
+            trigger: '.modal-dialog .o_field_widget[name="name"] .o_input',
             content: "Create a name for your new event and click Continue. e.g: Technical Training",
             run: "edit Technical Training",
             tooltipPosition: "left",
@@ -34,6 +34,12 @@ function websiteCreateEventTourSteps() {
                 el2.dispatchEvent(new Event("change", {bubbles: true, cancelable: true}));
                 el1.click();
             }
+        },
+        {
+            trigger: '.modal-dialog div[name="event_ticket_ids"] .o_field_x2many_list_row_add a:contains("Add a line")',
+            content: "Click here to add a ticket",
+            tooltipPosition: "bottom",
+            run: "click",
         },
         {
             isActive: ["auto"],

--- a/addons/website_event/views/event_event_add.xml
+++ b/addons/website_event/views/event_event_add.xml
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-<record id="event_event_view_form_add" model="ir.ui.view">
-    <field name="name">event.event.view.form.add</field>
+<record id="event_event_view_form_website_create" model="ir.ui.view">
+    <field name="name">event.event.form.website_create</field>
     <field name="model">event.event</field>
+    <field name="mode">primary</field>
+    <field name="inherit_id" ref="event.view_event_form"/>
     <field name="arch" type="xml">
-        <form js_class="website_new_content_form">
-            <group>
-                <field name="website_url" invisible="1"/>
-                <field name="company_id" invisible="1"/>
-                <field name="name" placeholder="e.g. &quot;Conference for Architects&quot;" string="Event Name"/>
-                <field name="address_id" context="{'show_address': 1}"/>
-                <field name="date_begin" string="Start &#8594; End" widget="daterange" options="{'end_date_field': 'date_end'}" />
-                <field name="date_end" invisible="1" />
-            </group>
-        </form>
+        <xpath expr="//form" position="attributes">
+            <attribute name="js_class">website_new_content_form</attribute>
+        </xpath>
+        <xpath expr="//form" position="inside">
+            <!-- We need this for `computePath` used in `onAddContent` to redirect to the event after creation. -->
+            <field name="website_url" invisible="1"/>
+        </xpath>
+        <xpath expr="//header" position="replace"/>
+        <xpath expr="//div[hasclass('oe_button_box')]" position="replace"/>
+        <xpath expr="//field[@name='kanban_state']" position="replace"/>
     </field>
 </record>
 
@@ -23,7 +25,7 @@
     <field name="res_model">event.event</field>
     <field name="view_mode">form</field>
     <field name="target">new</field>
-    <field name="view_id" ref="event_event_view_form_add"/>
+    <field name="view_id" ref="event_event_view_form_website_create"/>
     <field name="context">{'default_address_id': False}</field>
 </record>
 


### PR DESCRIPTION
### Purpose
Allow users to create events fully from the website without having to navigate
from frontend to backend to create tickets, questions etc.

### Specifications
Open the event form view directly instead of the simplified view, so that users
can add event tickets, communication, questions etc.

This PR also fixes a minor tour trigger of `website_event_tour`.

Task-4256878
