### PR TITLE
[REF] event: move relevant code into event_sale

### DIFF
--- a/addons/event/static/src/client_action/event_registration_summary_dialog.js
+++ b/addons/event/static/src/client_action/event_registration_summary_dialog.js
@@ -44,11 +44,6 @@ export class EventRegistrationSummaryDialog extends Component {
             this.printSettings.iotPrinterId = this.registration.iot_printers[0].id;
         }
 
-        this.willAutoPrint = 
-            this.registration.status === 'confirmed_registration' &&
-            this.printSettings.autoPrint && this.useIotPrinter &&
-            this.hasSelectedPrinter() && !this.registration.has_to_pay;
-
         this.dialogState = useState({ isHidden: this.willAutoPrint });
 
         onMounted(() => {
@@ -75,6 +70,15 @@ export class EventRegistrationSummaryDialog extends Component {
 
     get needManualConfirmation() {
         return this.registrationStatus.value === "need_manual_confirmation";
+    }
+
+    get willAutoPrint() {
+        return (
+            this.registration.status === "confirmed_registration" &&
+            this.printSettings.autoPrint &&
+            this.useIotPrinter &&
+            this.hasSelectedPrinter()
+        );
     }
 
     async onRegistrationConfirm() {

--- a/addons/event/static/src/client_action/event_registration_summary_dialog.xml
+++ b/addons/event/static/src/client_action/event_registration_summary_dialog.xml
@@ -35,15 +35,10 @@
                 </div>
             </div>
             <div class="row fs-1">
-                <div class="col-lg-12 d-flex align-items-baseline gap-3">
+                <div id="registration_header" class="col-lg-12 d-flex align-items-baseline gap-3">
                     <t t-set="guest_label">Guest #</t>
                     <t t-if="registration.name" t-out="registration.name"/>
                     <t t-else="" t-out="guest_label + registration.id"/>
-                    <t t-if="registration.sale_status_value">
-                        <span class="badge rounded-pill" t-att-class="registration.has_to_pay ? 'text-bg-danger' : 'text-bg-success'">
-                            <t t-out="registration.sale_status_value"/>
-                        </span>
-                    </t>
                 </div>
             </div>
             <div id="registration_information" class="row mt-4">

--- a/addons/event_sale/static/src/client_action/event_registration_summary_dialog.js
+++ b/addons/event_sale/static/src/client_action/event_registration_summary_dialog.js
@@ -1,0 +1,8 @@
+import { patch } from "@web/core/utils/patch";
+import { EventRegistrationSummaryDialog } from "@event/client_action/event_registration_summary_dialog";
+
+patch(EventRegistrationSummaryDialog.prototype, {
+    get willAutoPrint() {
+        return super.willAutoPrint && !this.registration.has_to_pay;
+    },
+});

--- a/addons/event_sale/static/src/client_action/event_registration_summary_dialog.xml
+++ b/addons/event_sale/static/src/client_action/event_registration_summary_dialog.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t t-inherit="event.EventRegistrationSummaryDialog" t-inherit-mode="extension">
+        <xpath expr="//div[@id='registration_header']" position="inside">
+            <t t-if="registration.sale_status_value">
+                <span class="badge rounded-pill" t-out="registration.sale_status_value" t-att-class="registration.has_to_pay ? 'text-bg-danger' : 'text-bg-success'"/>
+            </t>
+        </xpath>
+    </t>
+
+</templates>


### PR DESCRIPTION
In a couple of places in
`EventRegistrationSummaryDialog`, fields from
`event_sale` were referenced even though it is
not necessarily installed. This PR moves the
relevant parts into the `event_sale` module.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
