### PR TITLE
[FIX] stock_landed_costs: dont validate invalidated LC

### DIFF
--- a/addons/stock_landed_costs/i18n/stock_landed_costs.pot
+++ b/addons/stock_landed_costs/i18n/stock_landed_costs.pot
@@ -89,6 +89,15 @@ msgid "Additional Landed Cost"
 msgstr ""
 
 #. module: stock_landed_costs
+#. odoo-python
+#: code:addons/stock_landed_costs/models/stock_landed_cost.py:0
+#, python-format
+msgid ""
+"An inventory valuation operation occurred, making it impossible to validate "
+"this landed cost while linked to the following transfer: %s"
+msgstr ""
+
+#. module: stock_landed_costs
 #: model:ir.model.fields,field_description:stock_landed_costs.field_stock_landed_cost__target_model
 msgid "Apply On"
 msgstr ""

--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -148,6 +148,12 @@ class StockLandedCost(models.Model):
                     })
                     linked_layer.remaining_value += cost_to_add
                     valuation_layer_ids.append(valuation_layer.id)
+                # If there is product free but none in obtained above, some operation
+                # (i.e., costing method change) has left this LC in an illogical state.
+                elif line.product_id.free_qty:
+                    raise UserError(_('An inventory valuation operation occurred, making it '
+                                      'impossible to validate this landed cost while linked to the '
+                                      'following transfer: %s', line.move_id.picking_id.name))
                 # Update the AVCO/FIFO
                 product = line.move_id.product_id
                 if product.cost_method in ['average', 'fifo']:


### PR DESCRIPTION
*post costing method change*

**Current behavior:**
Creating a purchase order for some product that has standard, manual costing and receiving it, then switching the costing to non-standard, automatic and creating a bill with a landed cost linked to the receipt will not result in proper valuation.

**Expected behavior:**
Don't let this occur because it is an invalid series of operations.

**Steps to reproduce:**
1. Create a product with standard, manual valuation

2. Create a PO for the product, confirm, receive

3. Switch the product to FIFO, automatic valuation

4. Create a bill with a landed cost line, post it

5. Create the landed cost, link the receipt, vaidate

6. See that no stock valuation was created for the landed cost

**Cause of the issue:**
Changing the cost method empties the qty of the receipt as though it was already moved out of inventory, so no qty means no cost and subsequently no SVL.

**Fix:**
Don't validate landed costs that are linked to pickings with moves affected by such an operation.

opw-4218335