### PR TITLE
[IMP] hr_recruitment: add activities to the applicants list view

### DIFF
--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -16,6 +16,8 @@
                 <field name="candidate_id" optional="show"/>
                 <field name="application_status" optional="hide" invisible="application_status == 'ongoing'"/>
                 <field name="refuse_reason_id" optional='hide'/>
+                <field name="activity_ids" widget="list_activity" optional="hide"/>
+                <field name="activity_date_deadline" optional="hide"/>
                 <field name="priority" widget="priority" optional="show"/>
                 <field name="email_from" readonly="1" optional="hide"/>
                 <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show"/>


### PR DESCRIPTION
It is not possible at the moment to create activity for more than one applicant. This commit adds the activities column to the list view of `hr.applicant` so that it can be possible.

task-4316528



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
