### PR TITLE
[IMP] mail, web: add dropzone on full mail composer

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -7,8 +7,9 @@ import { SuggestedRecipientsList } from "@mail/core/web/suggested_recipient_list
 import { FollowerList } from "@mail/core/web/follower_list";
 import { isDragSourceExternalFile } from "@mail/utils/common/misc";
 import { useAttachmentUploader } from "@mail/core/common/attachment_uploader_hook";
-import { useDropzone } from "@web/core/dropzone/dropzone_hook";
+import { useCustomDropzone } from "@web/core/dropzone/dropzone_hook";
 import { useHover, useMessageHighlight } from "@mail/utils/common/hooks";
+import { MailAttachmentDropzone } from "@mail/core/common/mail_attachment_dropzone";
 import { SearchMessageInput } from "@mail/core/common/search_message_input";
 import { SearchMessageResult } from "@mail/core/common/search_message_result";
 
@@ -94,9 +95,10 @@ patch(Chatter.prototype, {
         this.followerListDropdown = useDropdownState();
         /** @type {number|null} */
         this.loadingAttachmentTimeout = null;
-        useDropzone(
-            this.rootRef,
-            async (ev) => {
+        useCustomDropzone(this.rootRef, MailAttachmentDropzone, {
+            extraClass: "o-mail-Chatter-dropzone",
+            /** @param {Event} ev */
+            onDrop: async (ev) => {
                 if (this.state.composerType) {
                     return;
                 }
@@ -117,9 +119,8 @@ patch(Chatter.prototype, {
                     );
                     this.state.isAttachmentBoxOpened = true;
                 }
-            },
-            "o-mail-Chatter-dropzone"
-        );
+            }
+        });
         useEffect(
             () => {
                 if (!this.state.thread) {

--- a/addons/mail/static/src/core/common/attachment_uploader_hook.js
+++ b/addons/mail/static/src/core/common/attachment_uploader_hook.js
@@ -2,7 +2,7 @@ import { useState } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 
-function dataUrlToBlob(data, type) {
+export function dataUrlToBlob(data, type) {
     const binData = window.atob(data);
     const uiArr = new Uint8Array(binData.length);
     uiArr.forEach((_, index) => (uiArr[index] = binData.charCodeAt(index)));

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -1,7 +1,8 @@
 import { AttachmentList } from "@mail/core/common/attachment_list";
 import { useAttachmentUploader } from "@mail/core/common/attachment_uploader_hook";
-import { useDropzone } from "@web/core/dropzone/dropzone_hook";
+import { useCustomDropzone } from "@web/core/dropzone/dropzone_hook";
 import { Picker, usePicker } from "@mail/core/common/picker";
+import { MailAttachmentDropzone } from "@mail/core/common/mail_attachment_dropzone";
 import { MessageConfirmDialog } from "@mail/core/common/message_confirm_dialog";
 import { NavigableList } from "@mail/core/common/navigable_list";
 import { useSuggestion } from "@mail/core/common/suggestion_hook";
@@ -133,12 +134,10 @@ export class Composer extends Component {
         });
         useExternalListener(window, "beforeunload", this.saveContent.bind(this));
         if (this.props.dropzoneRef) {
-            useDropzone(
-                this.props.dropzoneRef,
-                this.onDropFile,
-                "o-mail-Composer-dropzone",
-                () => this.allowUpload
-            );
+            useCustomDropzone(this.props.dropzoneRef, MailAttachmentDropzone, {
+                extraClass: "o-mail-Composer-dropzone",
+                onDrop: this.onDropFile,
+            }, () => this.allowUpload);
         }
         if (this.props.messageEdition) {
             this.props.messageEdition.composerOfThread = this;

--- a/addons/mail/static/src/core/common/mail_attachment_dropzone.js
+++ b/addons/mail/static/src/core/common/mail_attachment_dropzone.js
@@ -1,0 +1,8 @@
+import { Component } from "@odoo/owl";
+import { Dropzone } from "@web/core/dropzone/dropzone";
+
+export class MailAttachmentDropzone extends Component {
+    static template = "mail.MailAttachmentDropzone";
+    static components = { Dropzone };
+    static props = Dropzone.props;
+}

--- a/addons/mail/static/src/core/common/mail_attachment_dropzone.xml
+++ b/addons/mail/static/src/core/common/mail_attachment_dropzone.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.MailAttachmentDropzone">
+        <Dropzone t-props="this.props">
+            <h4>Drop Files here <i class="fa fa-paperclip"/></h4>
+        </Dropzone>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/web/mail_composer_attachment_list.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_list.js
@@ -1,4 +1,5 @@
 import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
 import {
     many2ManyBinaryField,
     Many2ManyBinaryField
@@ -6,6 +7,21 @@ import {
 
 export class MailComposerAttachmentList extends Many2ManyBinaryField {
     static template = "mail.MailComposerAttachmentList";
+    /** @override */
+    setup() {
+        super.setup();
+        this.mailStore = useService("mail.store");
+        this.attachmentUploadService = useService("mail.attachment_upload");
+    }
+    /**
+     * @override
+     * @param {integer} fileId
+     */
+    async onFileRemove(fileId) {
+        super.onFileRemove(fileId);
+        const attachment = this.mailStore.Attachment.get(fileId);
+        await this.attachmentUploadService.unlink(attachment);
+    }
 }
 
 export const mailComposerAttachmentList = {

--- a/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
@@ -1,36 +1,36 @@
-import { _t } from "@web/core/l10n/translation";
+import { dataUrlToBlob } from "@mail/core/common/attachment_uploader_hook";
 import { registry } from "@web/core/registry";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { useService } from "@web/core/utils/hooks";
 import { useX2ManyCrud } from "@web/views/fields/relational_utils";
 
 import { Component } from "@odoo/owl";
-import { FileInput } from "@web/core/file_input/file_input";
+import { FileUploader } from "@web/views/fields/file_handler";
 
 
 export class MailComposerAttachmentSelector extends Component {
     static template = "mail.MailComposerAttachmentSelector";
-    static components = { FileInput };
+    static components = { FileUploader };
     static props = { ...standardFieldProps };
 
     setup() {
-        this.notification = useService("notification");
+        this.mailStore = useService("mail.store");
+        this.attachmentUploadService = useService("mail.attachment_upload");
         this.operations = useX2ManyCrud(() => {
             return this.props.record.data["attachment_ids"];
         }, true);
     }
 
-    /** @param {Array[Object]} files */
-    async onFileUploaded(files) {
-        for (const file of files) {
-            if (file.error) {
-                return this.notification.add(file.error, {
-                    title: _t("Uploading error"),
-                    type: "danger",
-                });
-            }
-            await this.operations.saveRecord([file.id]);
-        }
+    /** @param {Object} data */
+    async onFileUploaded({ data, name, type }) {
+        const resIds = JSON.parse(this.props.record.data.res_ids);
+        const thread = await this.mailStore.Thread.insert({
+            model: this.props.record.data.model,
+            id: resIds[0],
+        });
+        const file = new File([dataUrlToBlob(data, type)], name, { type });
+        const attachment = await this.attachmentUploadService.upload(thread, thread.composer, file);
+        await this.operations.saveRecord([attachment.id]);
     }
 }
 

--- a/addons/mail/static/src/core/web/mail_composer_attachment_selector.xml
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_selector.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates>
     <t t-name="mail.MailComposerAttachmentSelector">
-        <FileInput
-            multiUpload="true"
-            onUpload.bind="onFileUploaded"
-            resModel="props.record.resModel"
-            resId="props.record.resId or 0">
-            <button class="btn btn-light w-auto" data-hotkey="a">
-                <i class="fa fa-fw fa-paperclip"/>
-            </button>
-        </FileInput>
+        <FileUploader multiUpload="true" onUploaded.bind="onFileUploaded">
+            <t t-set-slot="toggler">
+                <button class="btn btn-light w-auto" data-hotkey="a">
+                    <i class="fa fa-fw fa-paperclip"/>
+                </button>
+            </t>
+        </FileUploader>
     </t>
 </templates>

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -1,5 +1,5 @@
 import { registry } from "@web/core/registry";
-import { contains, inputFiles } from "@web/../tests/utils";
+import { contains, dragenterFiles, dropFiles, inputFiles } from "@web/../tests/utils";
 
 /**
  * This tour depends on data created by python test in charge of launching it.
@@ -35,8 +35,8 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
             content: "Add one file in composer",
             trigger: ".o-mail-Composer button[aria-label='Attach files']",
             async run() {
-                const text = new File(["hello, world"], "text.txt", { type: "text/plain" });
-                await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text]);
+                const files = [new File(["hello, world"], "file1.txt", { type: "text/plain" })];
+                await inputFiles(".o-mail-Composer-coreMain .o_input_file", files);
             },
         },
         {
@@ -54,7 +54,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         },
         {
             content: "Check the earlier provided attachment is listed",
-            trigger: ".o_field_mail_composer_attachment_list a:contains(text.txt)",
+            trigger: ".o_field_mail_composer_attachment_list a:contains(file1.txt)",
         },
         {
             content: "Check subject is autofilled",
@@ -91,6 +91,19 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
             },
         },
         {
+            content: "Drop a file on the full composer",
+            trigger: ".o_mail_composer_form_view",
+            async run() {
+                const files = [new File(["hi there"], "file2.txt", { type: "text/plain" })];
+                await dragenterFiles(".o_mail_composer_form_view .o_form_renderer", files);
+                await dropFiles(".o-Dropzone", files);
+            }
+        },
+        {
+            content: "Check the attachment is listed",
+            trigger: ".o_field_mail_composer_attachment_list a:contains(file2.txt)",
+        },
+        {
             content: "Click on the mail template selector",
             trigger: ".mail-composer-template-dropdown-btn",
             run: "click",
@@ -121,8 +134,12 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
             trigger: ".o-mail-MessageNotificationPopover:contains('Not A Demo User\nJane')",
         },
         {
-            content: "Check message contains the attachment",
-            trigger: '.o-mail-Message .o-mail-AttachmentCard:contains("text.txt")',
+            content: "Check message contains the first attachment",
+            trigger: '.o-mail-Message .o-mail-AttachmentCard:contains("file1.txt")',
+        },
+        {
+            content: "Check message contains the second attachment",
+            trigger: '.o-mail-Message .o-mail-AttachmentCard:contains("file2.txt")',
         },
         // Test the full composer input text is kept on closing
         {

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -283,4 +283,7 @@ class TestMailComposerUI(MailCommon, HttpCase):
             )
         message = self._new_msgs.filtered(lambda message: message.author_id == self.user_employee.partner_id)
         self.assertEqual(len(message), 1)
+        self.assertEqual(
+            sorted(message.attachment_ids.mapped('raw')),
+            sorted([b'hello, world', b'hi there']))
         self.assertIn(user.partner_id, message.partner_ids)

--- a/addons/web/static/src/core/dropzone/dropzone.js
+++ b/addons/web/static/src/core/dropzone/dropzone.js
@@ -5,6 +5,7 @@ export class Dropzone extends Component {
         extraClass: { type: String, optional: true },
         onDrop: { type: Function, optional: true },
         ref: Object,
+        slots: { type: Object, optional: true },
     };
     static template = "web.Dropzone";
 

--- a/addons/web/static/src/core/dropzone/dropzone.xml
+++ b/addons/web/static/src/core/dropzone/dropzone.xml
@@ -10,7 +10,9 @@
         t-on-drop="props.onDrop"
         t-ref="root"
     >
-        <h4>Drag Files Here <i class="fa fa-download"/></h4>
+        <t t-slot="default">
+            <h4>Drag Files Here <i class="fa fa-download"/></h4>
+        </t>
     </div>
 </t>
 

--- a/addons/web/static/src/core/dropzone/dropzone_hook.js
+++ b/addons/web/static/src/core/dropzone/dropzone_hook.js
@@ -2,8 +2,13 @@ import { Dropzone } from "@web/core/dropzone/dropzone";
 import { useEffect, useExternalListener } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
-
-export function useDropzone(targetRef, onDrop, extraClass, isDropzoneEnabled = () => true) {
+/**
+ * @param {Ref} targetRef - Element on which to place the dropzone.
+ * @param {Class} dropzoneComponent - Class used to instantiate the dropzone component.
+ * @param {Object} dropzoneComponentProps - Props given to the instantiated dropzone component.
+ * @param {function} isDropzoneEnabled - Function that determines whether the dropzone should be enabled.
+ */
+export function useCustomDropzone(targetRef, dropzoneComponent, dropzoneComponentProps, isDropzoneEnabled = () => true) {
     const overlayService = useService("overlay");
     const uiService = useService("ui");
 
@@ -28,10 +33,9 @@ export function useDropzone(targetRef, onDrop, extraClass, isDropzoneEnabled = (
         const shouldDisplayDropzone = dragCount && hasTarget && isTargetInActiveElement && isDropzoneEnabled();
 
         if (shouldDisplayDropzone && !hasDropzone) {
-            removeDropzone = overlayService.add(Dropzone, {
-                extraClass,
-                onDrop,
-                ref: targetRef
+            removeDropzone = overlayService.add(dropzoneComponent, {
+                ref: targetRef,
+                ...dropzoneComponentProps
             });
         }
         if (!shouldDisplayDropzone && hasDropzone) {
@@ -61,4 +65,16 @@ export function useDropzone(targetRef, onDrop, extraClass, isDropzoneEnabled = (
         },
         () => [targetRef.el]
     );
+}
+
+/**
+ * @param {Ref} targetRef - Element on which to place the dropzone.
+ * @param {function} onDrop - Callback function called when the user drops a file on the dropzone.
+ * @param {string} extraClass - Classes that will be added to the standard `Dropzone` component.
+ * @param {function} isDropzoneEnabled - Function that determines whether the dropzone should be enabled.
+ */
+export function useDropzone(targetRef, onDrop, extraClass, isDropzoneEnabled = () => true) {
+    const dropzoneComponent = Dropzone;
+    const dropzoneComponentProps = { extraClass, onDrop };
+    useCustomDropzone(targetRef, dropzoneComponent, dropzoneComponentProps, isDropzoneEnabled);
 }


### PR DESCRIPTION
This PR allows users to add new attachments to an email by dragging and dropping a file onto the full mail composer. This change will make the process of attaching new files simpler for the end-user. To ensure that the dropzones will be visible on the modals, we will add the dropzone components to the overlay layer.

Task-4273520