### PR TITLE
[FIX] point_of_sale: correctly format auto fill

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
@@ -39,7 +39,8 @@ export class ClosePosPopup extends Component {
     }
     autoFillCashCount() {
         const count = this.props.default_cash_details.amount;
-        this.state.payments[this.props.default_cash_details.id].counted = count.toString();
+        this.state.payments[this.props.default_cash_details.id].counted =
+            this.env.utils.formatCurrency(count, false);
         this.setManualCashInput(count);
     }
     get cashMoveData() {

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -392,3 +392,24 @@ registry.category("web_tour.tours").add("PosCategoriesOrder", {
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("AutofillCashCount", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Test Expensive"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+            ProductScreen.isShown(),
+            Chrome.clickMenuOption("Close Register"),
+            {
+                trigger: ".fa-clone.btn-secondary",
+                run: "click",
+            },
+            ProductScreen.cashDifferenceIs(0),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1533,6 +1533,22 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosCategoriesOrder', login="pos_admin")
 
+    def test_autofill_cash_count(self):
+        """Make sure that when the decimal separator is a comma, the shown orderline price is correct.
+        """
+        lang = self.env['res.lang'].search([('code', '=', self.pos_user.lang)])
+        lang.write({'thousands_sep': '.', 'decimal_point': ','})
+        self.env["product.product"].create(
+            {
+                "available_in_pos": True,
+                "list_price": 123456,
+                "name": "Test Expensive",
+                "taxes_id": False
+            }
+        )
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, "AutofillCashCount", login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
When using the new auto fill cash count button, the amount filled in was not using the correct separator. That leads to wrong closing amounts

Steps to reproduce:
-------------------
* Change the language to a one that use different separator (Dutch)
* Open PoS and make some sales (atleast 100€)
* Close the session and click on the copy button that will autofill the closing amount.
> Observation: The amount would be wrongly filled. If the amount to fill
was 120,20 € it would become 12020 €

Why the fix:
------------
To fix this we just use the correct helpers to format currencies

opw-4265952