### PR TITLE
[FIX] analytic: add a default plan in account node field to allow quick create

### DIFF
--- a/addons/analytic/models/analytic_line.py
+++ b/addons/analytic/models/analytic_line.py
@@ -77,6 +77,9 @@ class AnalyticPlanFields(models.AbstractModel):
     def _get_plan_domain(self, plan):
         return [('plan_id', 'child_of', plan.id)]
 
+    def _get_account_node_context(self, plan):
+        return {'default_plan_id': plan.id}
+
     @api.constrains(lambda self: self._get_plan_fnames())
     def _check_account_id(self):
         fnames = self._get_plan_fnames()
@@ -114,6 +117,7 @@ class AnalyticPlanFields(models.AbstractModel):
 
             # If there is a main node, append the ones for other plans
             if account_node is not None or account_filter_node is not None:
+                account_node.set('context', repr(self._get_account_node_context(project_plan)))
                 for plan in other_plans[::-1]:
                     fname = plan._column_name()
                     if account_node is not None:
@@ -121,7 +125,8 @@ class AnalyticPlanFields(models.AbstractModel):
                             'optional': 'show',
                             **account_node.attrib,
                             'name': fname,
-                            'domain': repr(self._get_plan_domain(plan))
+                            'domain': repr(self._get_plan_domain(plan)),
+                            'context': repr(self._get_account_node_context(plan)),
                         }))
                     if account_filter_node is not None:
                         account_filter_node.addnext(E.filter(name=fname, context=f"{{'group_by': '{fname}'}}"))


### PR DESCRIPTION
We add by default the plan of the current node in the context, allowing to create new analytic plans on the fly.

task-4221324
version-18.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
