### PR TITLE
[FIX] html_editor: apply fontsize in safari

### DIFF
--- a/addons/html_editor/static/src/main/font/font_selector.xml
+++ b/addons/html_editor/static/src/main/font/font_selector.xml
@@ -6,7 +6,7 @@
             </button>
             <t t-set-slot="content">
                 <t t-foreach="items" t-as="item" t-key="item_index">
-                    <DropdownItem class="'user-select-none'" onSelected="() => this.onSelected(item)">
+                    <DropdownItem onSelected="() => this.onSelected(item)" t-on-pointerdown.prevent="() => {}">
                         <t t-esc="item.name"/>
                     </DropdownItem>
                 </t>


### PR DESCRIPTION
Issue:
======
We can't change font size and font style in safari broswer.

Origin of the issue:
====================
In safari clicking in dropdown-item in the toolbar will produce the following flow:
- `pointerdown` event
- It will trigger the `blur` the event with null selection
- Since the item has the class `user-select-none` it will trigger the selectionchange with null selection too since we shouldn't select that element. In chrome here there is no selectionchange event because the element is not selectable so chrome doesn't care and do nothing.
- Now the selection is changed to null so the toolbar will appear and no `click` callback of the item is called because the element is already destroyed.

Solution:
=========
We add prevent on the `pointerdown` event so it doesn't trigger the blur and the selectionchange and we remove the `user-select-none` since it becomes useless.

opw-4299373