### PR TITLE
[FIX] pos_discount: correct tax group discount

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -342,17 +342,15 @@ export class PosOrder extends Base {
      * @param  {Orderline[]} lines an srray of Orderlines
      * @return {Number} the base amount on which we will apply a percentile reduction
      */
-    calculate_base_amount(tax_ids_array, lines) {
-        // Consider price_include taxes use case
-        const has_taxes_included_in_price = tax_ids_array.filter(
-            (tax_id) => this.models["account.tax"].get(tax_id).price_include
-        ).length;
-
+    calculate_base_amount(lines) {
         const base_amount = lines.reduce(
             (sum, line) =>
                 sum +
-                line.get_price_without_tax() +
-                (has_taxes_included_in_price ? line.get_total_taxes_included_in_price() : 0),
+                line.get_all_prices().priceWithTax -
+                line
+                    .get_all_prices()
+                    .taxesData.filter((tax) => !tax.price_include)
+                    .reduce((sum, tax) => (sum += tax.tax_amount_factorized), 0),
             0
         );
         return base_amount;

--- a/addons/pos_discount/__manifest__.py
+++ b/addons/pos_discount/__manifest__.py
@@ -25,6 +25,9 @@ discount to a customer.
         'point_of_sale._assets_pos': [
             'pos_discount/static/src/**/*',
         ],
+        'web.assets_tests': [
+            'pos_discount/static/tests/tours/**/*',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/pos_discount/static/src/overrides/components/control_buttons/control_buttons.js
+++ b/addons/pos_discount/static/src/overrides/components/control_buttons/control_buttons.js
@@ -47,7 +47,6 @@ patch(ControlButtons.prototype, {
                 .map((id) => Number(id));
 
             const baseToDiscount = order.calculate_base_amount(
-                tax_ids_array,
                 lines.filter((ll) => ll.isGlobalDiscountApplicable())
             );
 

--- a/addons/pos_discount/static/tests/tours/global_discount_tour.js
+++ b/addons/pos_discount/static/tests/tours/global_discount_tour.js
@@ -1,0 +1,27 @@
+import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("pos_global_discount_tax_group", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickDisplayedProduct("Test Product"),
+            ProductScreen.clickControlButton("Discount"),
+            Dialog.confirm(),
+            ProductScreen.totalAmountIs(90),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("pos_global_discount_tax_group_2", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickDisplayedProduct("Test Product"),
+            ProductScreen.clickControlButton("Discount"),
+            Dialog.confirm(),
+            ProductScreen.totalAmountIs(108),
+        ].flat(),
+});

--- a/addons/pos_discount/tests/__init__.py
+++ b/addons/pos_discount/tests/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_frontend

--- a/addons/pos_discount/tests/test_frontend.py
+++ b/addons/pos_discount/tests/test_frontend.py
@@ -1,0 +1,72 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import tagged
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+from odoo import Command
+
+
+@tagged('post_install', '-at_install')
+class TestUi(TestPointOfSaleHttpCommon):
+    def test_global_discount_tax_group_included(self):
+        tax_10 = self.env['account.tax'].create({
+            'name': "tax_10",
+            'amount_type': 'percent',
+            'amount': 10.0,
+            'type_tax_use': 'none',
+            'price_include': True
+        })
+        tax_20 = self.env['account.tax'].create({
+            'name': "tax_20",
+            'amount_type': 'percent',
+            'amount': 20.0,
+            'type_tax_use': 'none',
+            'price_include': True,
+        })
+        tax_group_10_20 = self.env['account.tax'].create({
+            'name': "tax_group_10_20",
+            'amount_type': 'group',
+            'children_tax_ids': [Command.set((tax_10 + tax_20).ids)],
+            'type_tax_use': 'sale',
+        })
+        self.env['product.product'].create({
+            'name': 'Test Product',
+            'lst_price': 100,
+            'taxes_id': [Command.set(tax_group_10_20.ids)],
+            'available_in_pos': True,
+        })
+
+        self.main_pos_config.module_pos_discount = True
+        self.main_pos_config.discount_product_id = self.env.ref("pos_discount.product_product_consumable", raise_if_not_found=False)
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'pos_global_discount_tax_group', login="pos_user")
+
+    def test_global_discount_tax_group_include_exclude(self):
+        tax_10 = self.env['account.tax'].create({
+            'name': "tax_10",
+            'amount_type': 'percent',
+            'amount': 10.0,
+            'type_tax_use': 'none',
+            'price_include': True
+        })
+        tax_20 = self.env['account.tax'].create({
+            'name': "tax_20",
+            'amount_type': 'percent',
+            'amount': 20.0,
+            'type_tax_use': 'none',
+        })
+        tax_group_10_20 = self.env['account.tax'].create({
+            'name': "tax_group_10_20",
+            'amount_type': 'group',
+            'children_tax_ids': [Command.set((tax_10 + tax_20).ids)],
+            'type_tax_use': 'sale',
+        })
+        self.env['product.product'].create({
+            'name': 'Test Product',
+            'lst_price': 100,
+            'taxes_id': [Command.set(tax_group_10_20.ids)],
+            'available_in_pos': True,
+        })
+
+        self.main_pos_config.module_pos_discount = True
+        self.main_pos_config.discount_product_id = self.env.ref("pos_discount.product_product_consumable", raise_if_not_found=False)
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'pos_global_discount_tax_group_2', login="pos_user")


### PR DESCRIPTION
When applying a global discount on an order that contains lines using tax group, the tax amount was always ignored by the discount.

Steps to reproduce:
-------------------
* Create a tax group with 2 taxes included in price (e.g 15% and 5%)
* Create a product with a price of 120€, the price without tax should be 99.38€
* Open PoS and add the product
* Add a global discount of 10%
> Observation: As all the taxes are included in price the discount
should be 12€ (10% of 120) but it is not

Why the fix:
------------
We now get the base by getting the total with tax of the line and substracting the tax amount that comes from that that are not included in price

opw-4289157