### PR TITLE
[WIP] test

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -629,6 +629,8 @@ class MrpProduction(models.Model):
                 production.reservation_state = relevant_move_state
             else:
                 production.reservation_state = False
+            if production.workorder_ids:
+                production.workorder_ids.filtered(lambda wo: not wo.blocked_by_workorder_ids).write({'state': 'ready' if production.reservation_state == 'assigned' else 'waiting'})
 
     @api.depends('move_raw_ids', 'state', 'move_raw_ids.product_uom_qty')
     def _compute_unreserve_visible(self):

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -227,8 +227,9 @@ class MrpWorkorder(models.Model):
                 workorder.production_id.qty_producing = workorder.qty_producing
                 workorder.production_id._set_qty_producing()
 
-    @api.depends('state', 'production_state', 'qty_produced', 'qty_producing', 'qty_remaining', 'blocked_by_workorder_ids')
+    @api.depends('qty_produced', 'qty_producing', 'qty_remaining')
     def _compute_qty_ready(self):
+        # Dict on blocked_by_workorder_ids -> read state once
         for workorder in self:
             if workorder.production_state not in ('confirmed', 'progress') or workorder.state in ('cancel', 'done'):
                 workorder.qty_ready = 0

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -149,12 +149,8 @@ class MrpWorkorder(models.Model):
                                      domain="[('allow_workorder_dependencies', '=', True), ('id', '!=', id), ('production_id', '=', production_id)]",
                                      copy=False)
 
-    @api.depends('production_availability', 'blocked_by_workorder_ids.state', 'qty_ready')
+    @api.depends('blocked_by_workorder_ids.state', 'qty_ready')
     def _compute_state(self):
-        # Force to compute the production_availability right away.
-        # It is a trick to force that the state of workorder is computed at the end of the
-        # cyclic depends with the mo.state, mo.reservation_state and wo.state and avoid recursion error
-        self.mapped('production_availability')
         for workorder in self:
             if workorder.state not in ('pending', 'waiting', 'ready'):
                 continue
@@ -231,6 +227,7 @@ class MrpWorkorder(models.Model):
                 workorder.production_id.qty_producing = workorder.qty_producing
                 workorder.production_id._set_qty_producing()
 
+    @api.depends('state', 'production_state', 'qty_produced', 'qty_producing', 'qty_remaining', 'blocked_by_workorder_ids')
     def _compute_qty_ready(self):
         for workorder in self:
             if workorder.production_state not in ('confirmed', 'progress') or workorder.state in ('cancel', 'done'):


### PR DESCRIPTION
Limit 'Waiting for component' state to First WO Only, (the one that doesn't depend on any other WO).
Force write of waiting state on wo from mo _compute_reservation_state


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
