### PR TITLE
[FIX] certificate: Handle subject parsing error

### DIFF
--- a/addons/certificate/models/certificate.py
+++ b/addons/certificate/models/certificate.py
@@ -185,22 +185,15 @@ class Certificate(models.Model):
 
                 try:
                     common_name = cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
+                    certificate.subject_common_name = common_name[0].value if common_name else ""
                 except ValueError:
-                    certificate.pem_certificate = None
                     certificate.subject_common_name = None
-                    certificate.content_format = None
-                    certificate.date_start = None
-                    certificate.date_end = None
-                    certificate.serial_number = None
-                    certificate.loading_error = _("The certificate subject field contains invalid characters. Make sure all characters are unicode valid.")
-                    continue
 
                 certificate.loading_error = ""
 
                 # Extract certificate data
                 certificate.pem_certificate = base64.b64encode(cert.public_bytes(Encoding.PEM))
                 certificate.serial_number = cert.serial_number
-                certificate.subject_common_name = common_name and common_name[0].value or ""
                 if parse_version(metadata.version('cryptography')) < parse_version('42.0.0'):
                     certificate.date_start = cert.not_valid_before
                     certificate.date_end = cert.not_valid_after


### PR DESCRIPTION
In version 42.0.0+ of the `cryptography` library, which we now use, certain special characters in the subject/issuer fields of certificates may cause parsing errors. While the certificates are recognized correctly, attempting to access a subject or issuer attribute with special characters sometimes throws an exception due to parsing issues.

### Fix

This issue appears to be specific to recent versions of `cryptography`, as the same certificate values can be successfully retrieved using `openssl`. Currently, we only access the `commonName` attribute from the subject field, which is not used in any critical way in our application.

Given this, and due to the blocking nature of this issue for customers requiring specific EDI setups (e.g., in Mexico), we have opted to bypass such cases for now by ignoring these parsing errors.

opw-4295754
opw-4293293