### PR TITLE
[IMP] core: clear environment reset

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -179,8 +179,7 @@ class AccountChartTemplate(models.AbstractModel):
         module = self.env['ir.module.module'].search([('name', '=', module_name), ('state', '=', 'uninstalled')])
         if module:
             module.button_immediate_install()
-            self.env.reset()  # clear the envs with an old registry
-            self = self.env()['account.chart.template']  # create a new env with the new registry
+            self.env.transaction.reset()  # clear the transaction with an old registry
 
         # To be able to use code translation we load everything in 'en_US'
         # The demo data is still loaded "normally" since code translations cannot be used for them reliably.

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -859,9 +859,9 @@ class ResCompany(models.Model):
             # No automatic install during the loading of a chart_template
             return False
         if res := super().install_l10n_modules():
-            self.env.flush_all()
-            self.env.reset()     # clear the set of environments
-            env = self.env()     # get an environment that refers to the new registry
+            env = self.env
+            env.flush_all()
+            env.transaction.reset()
             for company in self.filtered(lambda c: c.country_id and not c.chart_template):
                 template_code = company.parent_id.chart_template or self.env['account.chart.template']._guess_chart_template(company.country_id)
                 if template_code != 'generic_coa':

--- a/addons/account/tests/test_account_all_l10n.py
+++ b/addons/account/tests/test_account_all_l10n.py
@@ -44,8 +44,7 @@ def test_all_l10n(env):
             _logger.warning("Demo data of module %s has failed: %s",
                 failure.module_id.name, failure.error)
 
-    env.reset()     # clear the set of environments
-    env = env()     # get an environment that refers to the new registry
+    env.transaction.reset()     # clear the set of environments
 
     # Install Charts of Accounts
     _logger.info('Loading chart of account')

--- a/addons/test_website/tests/test_views_during_module_operation.py
+++ b/addons/test_website/tests/test_views_during_module_operation.py
@@ -70,8 +70,7 @@ def test_01_cow_views_unlink_on_module_update(env):
     # Upgrade the module
     test_website_module = env['ir.module.module'].search([('name', '=', 'test_website')])
     test_website_module.button_immediate_upgrade()
-    env.reset()     # clear the set of environments
-    env = env()     # get an environment that refers to the new registry
+    env.transaction.reset()     # clear the set of environments
 
     # Ensure generic views got removed
     view = env.ref('test_website.update_module_view_to_be_t_called', raise_if_not_found=False)
@@ -180,8 +179,7 @@ def test_02_copy_ids_views_unlink_on_module_update(env):
 
     # Upgrade the module
     theme_default.button_immediate_upgrade()
-    env.reset()  # clear the set of environments
-    env = env()  # get an environment that refers to the new registry
+    env.transaction.reset()  # clear the set of environments
 
     # Ensure the theme.ir.ui.view got removed (since there is an IMD but not
     # present in XML files)
@@ -204,8 +202,7 @@ def test_02_copy_ids_views_unlink_on_module_update(env):
     # Upgrade the module
     with MockRequest(env, website=website_1):
         theme_default.button_immediate_upgrade()
-    env.reset()  # clear the set of environments
-    env = env()  # get an environment that refers to the new registry
+    env.transaction.reset()  # clear the set of environments
 
     # Ensure the theme.ir.ui.view got removed (since there is an IMD but not
     # present in XML files)

--- a/addons/website/tests/test_views_inherit_module_update.py
+++ b/addons/website/tests/test_views_inherit_module_update.py
@@ -42,8 +42,7 @@ def test_01_cow_views_inherit_on_module_update(env):
     # 3. Upgrade the module
     portal_module = env['ir.module.module'].search([('name', '=', 'portal')])
     portal_module.button_immediate_upgrade()
-    env.reset()     # clear the set of environments
-    env = env()     # get an environment that refers to the new registry
+    env.transaction.reset()     # clear the set of environments
 
     # 4. Ensure cow view also got its inherit_id updated
     expected_parent_view = env.ref('portal.frontend_layout')  # XML data
@@ -79,8 +78,7 @@ def test_02_cow_views_inherit_on_module_update(env):
     # 3. Upgrade the module
     portal_module = env['ir.module.module'].search([('name', '=', 'portal')])
     portal_module.button_immediate_upgrade()
-    env.reset()     # clear the set of environments
-    env = env()     # get an environment that refers to the new registry
+    env.transaction.reset()     # clear the set of environments
 
     # 4. Ensure cow view also got its inherit_id updated
     assert view_D.inherit_id == view_B, "Generic view security check."

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -553,8 +553,7 @@ class IrCron(models.Model):
         try:
             if self.pool != self.pool.check_signaling():
                 # the registry has changed, reload self in the new registry
-                self.env.reset()
-                self = self.env()[self._name]
+                self.env.transaction.reset()
 
             _logger.debug(
                 "cron.object.execute(%r, %d, '*', %r, %d)",

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -411,8 +411,7 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
         if installation_status or to_uninstall:
             # After the uninstall/install calls, the registry and environments
             # are no longer valid. So we reset the environment.
-            self.env.reset()
-            self = self.env()[self._name]
+            self.env.transaction.reset()
 
         # pylint: disable=next-method-called
         config = self.env['res.config'].next() or {}

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -765,14 +765,12 @@ class ResUsers(models.Model):
 
         if 'company_id' in values or 'company_ids' in values:
             # Reset lazy properties `company` & `companies` on all envs,
-            # and also their _cache_key, which may depend on them.
             # This is unlikely in a business code to change the company of a user and then do business stuff
             # but in case it happens this is handled.
             # e.g. `account_test_savepoint.py` `setup_company_data`, triggered by `test_account_invoice_report.py`
             for env in list(self.env.transaction.envs):
                 if env.user in self:
                     lazy_property.reset_all(env)
-                    env._cache_key.clear()
 
         # clear caches linked to the users
         if self.ids and 'groups_id' in values:

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -142,7 +142,7 @@ def retrying(func, env):
                 if env.cr._closed:
                     raise
                 env.cr.rollback()
-                env.reset()
+                env.transaction.reset()
                 env.registry.reset_changes()
                 if request:
                     request.session = request._get_session_and_dbname()[0]
@@ -168,7 +168,7 @@ def retrying(func, env):
             raise RuntimeError("unreachable")
 
     except Exception:
-        env.reset()
+        env.transaction.reset()
         env.registry.reset_changes()
         raise
 


### PR DESCRIPTION
Make the resetting simpler; most attributes are handled as lazy properties. This allows resetting an environment to be as simple as resetting all lazy properties.
We fix also all useless recreations of environments after resets. The `reset()` function that should be used is the one of the transaction.

task-4201974
odoo/design-themes#1008

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
