### PR TITLE
[FIX] web_editor, website: insert link in mass_mailing

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2868,13 +2868,18 @@ export class Wysiwyg extends Component {
             }
         }
     }
+
+    _getDelayBlurSelectors() {
+        return [".oe-toolbar", ".oe-powerbox-wrapper", ".o_we_crop_widget"];
+    }
+
     _onDocumentMousedown(e) {
         if (!e.target.classList.contains('o_editable_date_field_linked')) {
             this.$editable.find('.o_editable_date_field_linked').removeClass('o_editable_date_field_linked');
         }
         const closestDialog = e.target.closest('.o_dialog, .o_web_editor_dialog');
         if (
-            e.target.closest('.oe-toolbar,.oe-powerbox-wrapper,.o_we_crop_widget') ||
+            e.target.closest(this._getDelayBlurSelectors().join(",")) ||
             (closestDialog && closestDialog.querySelector('.o_select_media_dialog, .o_link_dialog'))
         ) {
             this._shouldDelayBlur = true;

--- a/addons/website/static/src/js/editor/widget_link.js
+++ b/addons/website/static/src/js/editor/widget_link.js
@@ -6,6 +6,7 @@ import { patch } from "@web/core/utils/patch";
 import { onWillStart, status, useEffect } from '@odoo/owl';
 import wUtils from "@website/js/utils";
 import { debounce } from "@web/core/utils/timing";
+import { Wysiwyg } from "@web_editor/js/wysiwyg/wysiwyg";
 
 const LINK_DEBOUNCE = 1000;
 
@@ -119,5 +120,14 @@ patch(LinkTools.prototype, {
             this.__onURLInput();
         }
         super._onPickSelectOption(...arguments);
+    },
+});
+
+patch(Wysiwyg.prototype, {
+    /**
+     * @override
+     */
+    _getDelayBlurSelectors() {
+        return super._getDelayBlurSelectors().concat([".ui-autocomplete"]);
     },
 });


### PR DESCRIPTION
Issue:
======
We can't insert a link with `/url` in mass mailing

Steps to reproduce the issue:
=============================
- Install website and email marketing
- Create a new mass mailing
- Add a button using `/button`
- Add a label
- Write `/` in url and choose any option make sure to click on it using the mouse
- Save
- The link isn't inserted

Origin of the issue:
====================
When we click to select an item, the event `mousedown` is triggered on the document which will force a wysiwyg blur. So the selection is no more in the editable and we can't insert the link.

Solution:
=========
To avoid the blur, we add the selector of the autocomplete to the selectors that delay the blur.

opw-4283325