### PR TITLE
[FIX] pos_self_order: fix lang switch in self order

### DIFF
--- a/addons/pos_self_order/views/pos_self_order.index.xml
+++ b/addons/pos_self_order/views/pos_self_order.index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="pos_self_order.index" name="POS Self Order">&lt;!DOCTYPE html&gt;
-        <html>
+        <html t-att-lang="lang and lang.replace('_', '-')">
             <head>
                 <title>Odoo Self Order</title>
                 <meta http-equiv="X-UA-Compatible" content="IE=edge"/>


### PR DESCRIPTION
The lang switching wasn't working properly. The lang bundle was not reloaded when the lang was changed. This commit fixes the issue by adding lang attribute on html element.

opw-4246677

