### PR TITLE
[FIX] hw_drivers: prevent loop of death on error in IoT box

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
@@ -111,6 +111,9 @@ class SerialDriver(Driver):
             _logger.exception(msg)
             self._status = {'status': self.STATUS_ERROR, 'message_title': msg, 'message_body': traceback.format_exc()}
             self._push_status()
+        finally:
+            self._status = {'status': self.STATUS_CONNECTED, 'message_title': '', 'message_body': ''}
+            self._push_status()
 
     def action(self, data):
         """Establish a connection with the device if needed and have it perform a specific action.


### PR DESCRIPTION
Before this commit, when an error happened on a serial device, the serial driver on the IoT box would permanently set its status to ERROR and not accept any additional request until reboot of the IoT box.

This causes confusion, among other things in the special case of BlackBox BE, where some points of sales have multiple checkouts using the same POs session and the same IoT Box + BlackBox. If at any point, a cashier sent an erroneous message to the IoT Box or to the Blackbox, all checkouts would become blocked, with the only alternative being to reload the handlers or restart the IoT Box.
Furthermore, as the action was executed correctly, this situation created a mismatch between the data stored in Odoo and the data logged to the BlackBox and sent to SPF.

After this commit, the driver status is reset after being sent once. That way, when a new action is sent from the client to the IoT box, it's the status of the execution of this action and not the previous one that gets sent back to the client.

opw-4313538
opw-4182434
opw-4293988
