### PR TITLE
[IMP] sale_pdf_quote_builder: default quote headers/footers

### DIFF
--- a/addons/sale/tests/common.py
+++ b/addons/sale/tests/common.py
@@ -47,6 +47,18 @@ class SaleCommon(
     def _enable_discounts(cls):
         cls.env.user.groups_id += cls.group_discount_per_so_line
 
+    def _create_so(self, **values):
+        default_values = {
+            'partner_id': self.partner.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product.id,
+                }),
+            ],
+            **values
+        }
+        return self.env['sale.order'].create(default_values)
+
 
 class TestSaleCommon(AccountTestInvoicingCommon):
 

--- a/addons/sale_pdf_quote_builder/models/quotation_document.py
+++ b/addons/sale_pdf_quote_builder/models/quotation_document.py
@@ -48,6 +48,11 @@ class QuotationDocument(models.Model):
         compute='_compute_form_field_ids',
         store=True,
     )
+    add_by_default = fields.Boolean(
+        string="Add By Default",
+        help="If checked, this header or footer will be added by default on new quotes.",
+        default=False,
+    )
 
     # === CONSTRAINT METHODS ===#
 

--- a/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
+++ b/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
@@ -38,6 +38,7 @@
                                 options="{'no_create': True}"
                                 widget="many2many_tags"
                             />
+                            <field name="add_by_default"/>
                         </group>
                     </group>
                     <group string="Attached To" groups="base.group_multi_company,base.group_no_one">
@@ -122,6 +123,7 @@
                 <field name="name"/>
                 <field name="document_type"/>
                 <field name="quotation_template_ids" widget="many2many_tags"/>
+                <field name="add_by_default" widget="boolean_toggle" optional="show"/>
                 <field name="company_id" groups="base.group_multi_company" optional="show"/>
             </list>
         </field>
@@ -147,6 +149,7 @@
                     />
                     <filter name="all" string="All"/>
                     <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
+                    <filter name="add_by_default" string="Add By Default" domain="[('add_by_default', '=', True)]"/>
                 </group>
             </search>
         </field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Spare a couple of clicks when selecting the headers and footers of the quotation builder.

Current behavior before PR:
User have to select the quote documents they want to add for each of their quotation.

Desired behavior after PR is merged:
User can set quote documents as `add_by_default` which, when enabled, selects the quote document by default in the quote builder of a new sale quotation. If the `add_by_default` field is modified, any previously created quote should not be affected.

task-4307011

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
