### PR TITLE
[FIX] mail: add capture to useDropzone utility listeners

### DIFF
--- a/addons/mail/static/src/core/common/dropzone_hook.js
+++ b/addons/mail/static/src/core/common/dropzone_hook.js
@@ -14,8 +14,8 @@ export function useDropzone(targetRef, onDrop, extraClass, isDropzoneEnabled = (
     let dragCount = 0;
     let hasTarget = false;
 
-    useExternalListener(document, "dragenter", onDragEnter);
-    useExternalListener(document, "dragleave", onDragLeave);
+    useExternalListener(document, "dragenter", onDragEnter, { capture: true });
+    useExternalListener(document, "dragleave", onDragLeave, { capture: true });
     // Prevents the browser to open or download the file when it is dropped
     // outside of the dropzone.
     useExternalListener(window, "dragover", (ev) => ev.preventDefault());
@@ -23,7 +23,7 @@ export function useDropzone(targetRef, onDrop, extraClass, isDropzoneEnabled = (
         ev.preventDefault();
         dragCount = 0;
         updateDropzone();
-    });
+    }, { capture: true });
 
     function updateDropzone() {
         const shouldDisplayDropzone = dragCount && hasTarget && isDropzoneEnabled();


### PR DESCRIPTION
This commit adds the capture parameter to events listeners in useDropzone utility function to make it work correctly in Documents App where the events weren't intercepted because of `stopPropagation()` call in others listeners.

Task-4314619





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
