### PR TITLE
[FIX] mail_bot: fix html_escape in random choices

### DIFF
--- a/addons/mail_bot/models/mail_bot.py
+++ b/addons/mail_bot/models/mail_bot.py
@@ -146,7 +146,7 @@ class MailBot(models.AbstractModel):
                 return random.choice([
                     html_escape(
                         _("I'm not smart enough to answer your question.%(new_line)sTo follow my guide,"
-                          " ask: %(command_start)sstart the tour%(command_end)s.") % self._get_style_dict()),
+                          " ask: %(command_start)sstart the tour%(command_end)s.")) % self._get_style_dict(),
                     _("Hmmm..."),
                     _("I'm afraid I don't understand. Sorry!"),
                     html_escape(


### PR DESCRIPTION
Wrong closed parentheses in html_escape causes one of the OdooBot random responses to be rendered incorrectly.

![image](https://github.com/user-attachments/assets/6cfdbaa8-ba32-4c52-8b6e-370aa4fbd2dd)
