### PR TITLE
[FIX] quality_control: require quality check only for received products

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1685,6 +1685,8 @@ Please change the quantity done or the rounding precision of your unit of measur
                             break
 
                 if missing_reserved_quantity and move.product_id.tracking == 'serial' and (move.picking_type_id.use_create_lots or move.picking_type_id.use_existing_lots):
+                    # remove lines with a quantity of 0 to maintain the ratio of one move line to one move.
+                    move.move_line_ids.filtered(lambda ml: float_is_zero(ml.quantity, precision_rounding=ml.product_id.uom_id.rounding)).unlink()
                     for i in range(0, int(missing_reserved_quantity)):
                         move_line_vals_list.append(move._prepare_move_line_vals(quantity=1))
                 elif missing_reserved_quantity:


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a tracked product by SN: “P1.”
- Create a storable product: "P2."
- Create a receipt for one unit of P1 and P2.
- Mark it as "To Do."
- Set the done quantity of P1 to 0.
- Attempt to perform the quality check.

**Problem:**
You must perform a quality check for P1 even though it has yet to be received.

opw-4187521
