### PR TITLE
[FIX] website_blog: remove border on last entry

### DIFF
--- a/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
+++ b/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
@@ -205,6 +205,11 @@
         .o_container_small .s_blog_posts_post_cover_col {
             display: none;
         }
+
+        // SCSS Fix for stable, to be removed on master.
+        div.dynamic_snippet_template div.row:last-child div.border-bottom {
+            border-bottom: none !important;
+        }
     }
 
     &.s_blog_post_card {

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -56,7 +56,7 @@
 <template id="dynamic_filter_template_blog_post_horizontal" name="Horizontal">
     <div t-foreach="records" t-as="data" class="s_blog_posts_post w-100" data-number-of-elements="1">
         <t t-set="record" t-value="data['_record']"/>
-        <div t-attf-class="pb-4 {{record_last and 'border-0' or 'border-bottom'}}">
+        <div t-attf-class="pb-4 {{not data_last and 'border-bottom'}}">
             <div class="row flex-md-nowrap">
                 <div class="s_blog_posts_post_cover_col col mb-2 mb-md-0">
                     <a class="d-block h-100 text-decoration-none" t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']">


### PR DESCRIPTION
`s_dynamic_snippet_blog_posts` in the horizontal layout is displaying a border on the last entry while it should not.

This is due to the `record_last` instead of `data_last` introduced in https://github.com/odoo/odoo/commit/dbb72d1f68cf7f462e1d6bdf8998f29627ccc2f0

Steps to reproduce:
- Add a blog post snippet `s_blog_posts` in the page
- Change the template option to "Horizontal" in the editor
- Scroll to the last entry, it shouldn't have a border


task-4182265

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
