### PR TITLE
[IMP] website_hr_recruitment : enhance remote job posting on google search

### DIFF
--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -126,9 +126,15 @@
                     <meta itemprop="name" t-att-content="job.company_id.name"/>
                     <meta itemprop="logo" t-attf-content="/logo.png?company=#{job.company_id.id}"/>
                 </span>
-                <span itemprop="jobLocation" itemscope="itemscope" itemtype="https://schema.org/Place">
+                <span t-if="job.address_id.sudo().contact_address" itemprop="jobLocation" itemscope="itemscope" itemtype="https://schema.org/Place">
                     <meta itemprop="address" t-att-content="job.address_id.sudo().contact_address"/>
                 </span>
+                <t t-else="">
+                    <meta itemprop="jobLocationType" content="TELECOMMUTE"/>
+                    <span itemprop="applicantLocationRequirements" itemscope="itemscope" itemtype="https://schema.org/Country">
+                        <meta itemprop="name" t-att-content="job.company_id.country_id.name"/>
+                    </span>
+                </t>
                 <!-- Job name -->
                 <section class="pb32">
                     <div class="container">

--- a/doc/cla/corporate/oerp.md
+++ b/doc/cla/corporate/oerp.md
@@ -19,3 +19,4 @@ Daryl Chen dc@oerp.ca https://github.com/dc-oerp
 Hetal Solanki hs@oerp.ca https://github.com/hs-oerp
 Foram Darji fd@oerp.ca https://github.com/fd-oerp
 Mitesh Savani ms@oerp.ca https://github.com/ms-oerp
+Helena Wong hw@oerp.ca https://github.com/hw-oerp


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Improve job posting structured data with modifying remote job specific XML tags when the job is a remote job, in order to match the requirements from [Google Search results Job Posting structured data document](https://developers.google.com/search/docs/appearance/structured-data/job-posting)

Currently Odoo website's job detail page with remote job is not passing the rich results test from [Google search rich result test](https://search.google.com/test/rich-results), as jobLocation will be empty content when it is a remote job. In order to be eligible in appear in google's enriched search result, jobLocation should not be used in a remote job, instead jobLocationtype & applicantLocationRequirements should be applied.

**Current behavior before PR:**
Empty jobLocation content when the job is a remote job. No jobLocationType & applicantLocationsRequirement tag for remote job which not matching with google search result's requirement.

**Desired behavior after PR is merged:**
jobLocation tag will be removed if the job is a remote job. jobLocationType will be appeared and the content will be TELECOMMUTE, and applicantLocationRequirements will be company's country.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
