### PR TITLE
[IMP] point_of_sale: many2one_with_placeholder_field widget

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -75,6 +75,7 @@
             'point_of_sale/static/src/backend/tours/point_of_sale.js',
             'point_of_sale/static/src/backend/pos_kanban_view/*',
             'point_of_sale/static/src/app/hooks/hooks.js',
+            'point_of_sale/static/src/backend/many2one_with_placeholder_field/*',
         ],
         'web.assets_tests': [
             'barcodes/static/tests/legacy/helpers.js',

--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -46,6 +46,7 @@ class PosPaymentMethod(models.Model):
     open_session_ids = fields.Many2many('pos.session', string='Pos Sessions', compute='_compute_open_session_ids', help='Open PoS sessions that are using this payment method.')
     config_ids = fields.Many2many('pos.config', string='Point of Sale')
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company)
+    default_pos_receivable_account_name = fields.Char(related="company_id.account_default_pos_receivable_account_id.display_name", string="Default Receivable Account Name")
     use_payment_terminal = fields.Selection(selection=lambda self: self._get_payment_terminal_selection(), string='Use a Payment Terminal', help='Record payments with a terminal on this journal.')
     # used to hide use_payment_terminal when no payment interfaces are installed
     hide_use_payment_terminal = fields.Boolean(compute='_compute_hide_use_payment_terminal')

--- a/addons/point_of_sale/static/src/backend/many2one_with_placeholder_field/many2one_with_placeholder_field.js
+++ b/addons/point_of_sale/static/src/backend/many2one_with_placeholder_field/many2one_with_placeholder_field.js
@@ -1,0 +1,41 @@
+import { registry } from "@web/core/registry";
+import { Many2OneField, many2OneField } from "@web/views/fields/many2one/many2one_field";
+import { _t } from "@web/core/l10n/translation";
+
+export class Many2OneFieldWithPlaceholderField extends Many2OneField {
+    static props = {
+        ...Many2OneField.props,
+        placeholderField: { type: String, optional: true },
+    };
+
+    get Many2XAutocompleteProps() {
+        return {
+            ...super.Many2XAutocompleteProps,
+            placeholder:
+                this.props.record.data[this.props.placeholderField] || this.props.placeholder,
+        };
+    }
+}
+
+export const many2OneFieldWithPlaceholderField = {
+    ...many2OneField,
+    component: Many2OneFieldWithPlaceholderField,
+    supportedOptions: [
+        ...many2OneField.supportedOptions,
+        {
+            label: _t("Placeholder field"),
+            name: "placeholder_field",
+            type: "field",
+        },
+    ],
+    extractProps(params, dynamicInfo) {
+        return {
+            ...many2OneField.extractProps(params, dynamicInfo),
+            placeholderField: params.options.placeholder_field,
+        };
+    },
+};
+
+registry
+    .category("fields")
+    .add("many2one_with_placeholder_field", many2OneFieldWithPlaceholderField);

--- a/addons/point_of_sale/views/pos_payment_method_views.xml
+++ b/addons/point_of_sale/views/pos_payment_method_views.xml
@@ -9,6 +9,7 @@
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <field name="active" invisible="1"/>
                     <field name="type" invisible="1"/>
+                    <field name="default_pos_receivable_account_name" invisible="1" />
                     <div class="d-flex justify-content-between">
                         <div class="oe_title">
                             <label for="name"/>
@@ -21,7 +22,7 @@
                             <field name="split_transactions"/>
                             <field name="journal_id" required="not split_transactions" placeholder="Leave empty to use the receivable account of customer" />
                             <field name="outstanding_account_id" groups="account.group_account_readonly" invisible="type != 'bank'" required="type == 'bank'" placeholder="Selection of outstanding account is required" />
-                            <field name="receivable_account_id" groups="account.group_account_readonly" invisible="split_transactions" placeholder="Leave empty to use the default account from the company setting" />
+                            <field name="receivable_account_id" groups="account.group_account_readonly" invisible="split_transactions" widget="many2one_with_placeholder_field" options="{'placeholder_field': 'default_pos_receivable_account_name'}"/>
                             <field name="company_id" readonly="1" groups="base.group_multi_company" />
                         </group>
                         <group>


### PR DESCRIPTION
in this commit:
==============

This widget lets you specify another field that should act as the placeholder value for your many2one field.

Use it by specifying `widget="many2one_with_placeholder_field"` and `options="{'placeholder_field': <other field name>}"`

You should also ensure that the other field is present in the view in order for this to work.

Task - 4281382

