### PR TITLE
[IMP] point_of_sale: implement global invoice like in sales

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -21,6 +21,8 @@
         'wizard/pos_payment.xml',
         'wizard/pos_close_session_wizard.xml',
         'wizard/pos_daily_sales_reports.xml',
+        'wizard/pos_confirmation_wizard.xml',
+        'wizard/pos_make_invoice.xml',
         'views/pos_assets_index.xml',
         'views/point_of_sale_report.xml',
         'views/point_of_sale_view.xml',

--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -13,6 +13,12 @@ class AccountMove(models.Model):
     reversed_pos_order_id = fields.Many2one('pos.order', string="Reversed POS Order",
         help="The pos order that was reverted after closing the session to create an invoice for it.")
     pos_session_ids = fields.One2many("pos.session", "move_id", "POS Sessions")
+    pos_order_count = fields.Integer(compute="_compute_origin_pos_count", string='POS Order Count')
+
+    @api.depends('pos_order_ids')
+    def _compute_origin_pos_count(self):
+        for move in self:
+            move.pos_order_count = len(move.sudo().pos_order_ids)
 
     def _stock_account_get_last_step_stock_moves(self):
         stock_moves = super(AccountMove, self)._stock_account_get_last_step_stock_moves()
@@ -71,7 +77,16 @@ class AccountMove(models.Model):
     def _compute_tax_totals(self):
         return super(AccountMove, self.with_context(linked_to_pos=bool(self.sudo().pos_order_ids)))._compute_tax_totals()
 
+    def action_view_source_pos_orders(self):
+        self.ensure_one()
+        action = self.env['ir.actions.act_window']._for_xml_id('point_of_sale.action_pos_pos_form')
 
+        if len(self.pos_order_ids) == 1:
+            action['views'] = [(self.env.ref('point_of_sale.view_pos_pos_form', False).id, 'form')]
+            action['res_id'] = self.pos_order_ids.id
+        else:
+            action['domain'] = [('id', 'in', self.pos_order_ids.ids)]
+        return action
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -180,14 +180,23 @@ class PosOrder(models.Model):
         :param sign: An optional parameter to force the sign of amounts.
         :return: A list of python dictionaries (see '_prepare_base_line_for_taxes_computation' in account.tax).
         """
-        self.ensure_one()
-        return self.lines._prepare_tax_base_line_values() or []
+        result = []
+        for order in self:
+            result.extend(order.lines._prepare_tax_base_line_values() or [])
+        return result
 
     @api.model
-    def _get_invoice_lines_values(self, line_values, pos_order_line):
+    def _get_invoice_lines_values(self, line_values, pos_line, move_type):
+        # correct quantity sign based on move type and if line is refund.
+        is_refund = line_values.get('is_refund', False)
+        qty_sign = -1 if (
+            (move_type == 'out_invoice' and is_refund)
+            or (move_type == 'out_refund' and not is_refund)
+        ) else 1
+
         return {
             'product_id': line_values['product_id'].id,
-            'quantity': line_values['quantity'],
+            'quantity': qty_sign * line_values['quantity'],
             'discount': line_values['discount'],
             'price_unit': line_values['price_unit'],
             'name': line_values['name'],
@@ -195,39 +204,41 @@ class PosOrder(models.Model):
             'product_uom_id': line_values['uom_id'].id,
         }
 
-    def _prepare_invoice_lines(self):
+    def _prepare_invoice_lines(self, move_type):
         """ Prepare a list of orm commands containing the dictionaries to fill the
         'invoice_line_ids' field when creating an invoice.
 
         :return: A list of Command.create to fill 'invoice_line_ids' when calling account.move.create.
         """
-        line_values_list = self.with_context(invoicing=True)._prepare_tax_base_line_values()
         invoice_lines = []
-        for line_values in line_values_list:
-            line = line_values['record']
-            invoice_lines_values = self._get_invoice_lines_values(line_values, line)
-            invoice_lines.append((0, None, invoice_lines_values))
-            is_percentage = self.pricelist_id and any(
-                self.pricelist_id.item_ids.filtered(
-                    lambda rule: rule.compute_price == "percentage")
-            )
-            if is_percentage and float_compare(line.price_unit, line.product_id.lst_price, precision_rounding=self.currency_id.rounding) < 0:
+        for order in self:
+            line_values_list = order.with_context(invoicing=True)._prepare_tax_base_line_values()
+            for line_values in line_values_list:
+                line = line_values['record']
+                invoice_lines_values = order._get_invoice_lines_values(line_values, line, move_type)
+                invoice_lines.append((0, None, invoice_lines_values))
+
+                is_percentage = order.pricelist_id and any(
+                    order.pricelist_id.item_ids.filtered(
+                        lambda rule: rule.compute_price == "percentage")
+                )
+                if is_percentage and float_compare(line.price_unit, line.product_id.lst_price, precision_rounding=order.currency_id.rounding) < 0:
+                    invoice_lines.append((0, None, {
+                        'name': _('Price discount from %(original_price)s to %(discounted_price)s',
+                                original_price=float_repr(line.product_id.lst_price, order.currency_id.decimal_places),
+                                discounted_price=float_repr(line.price_unit, order.currency_id.decimal_places)),
+                        'display_type': 'line_note',
+                    }))
+                if line.customer_note:
+                    invoice_lines.append((0, None, {
+                        'name': line.customer_note,
+                        'display_type': 'line_note',
+                    }))
+            if order.general_customer_note:
                 invoice_lines.append((0, None, {
-                    'name': _('Price discount from %(original_price)s to %(discounted_price)s',
-                              original_price=float_repr(line.product_id.lst_price, self.currency_id.decimal_places),
-                              discounted_price=float_repr(line.price_unit, self.currency_id.decimal_places)),
+                    'name': order.general_customer_note,
                     'display_type': 'line_note',
                 }))
-            if line.customer_note:
-                invoice_lines.append((0, None, {
-                    'name': line.customer_note,
-                    'display_type': 'line_note',
-                }))
-        if self.general_customer_note:
-            invoice_lines.append((0, None, {
-                'name': self.general_customer_note,
-                'display_type': 'line_note',
-            }))
         return invoice_lines
 
     def _get_pos_anglo_saxon_price_unit(self, product, partner_id, quantity):
@@ -588,14 +599,35 @@ class PosOrder(models.Model):
         return action
 
     def action_view_invoice(self):
+        invoices = self.account_move
+        if (len(invoices) == 1):
+            return {
+                'name': _('Customer Invoice'),
+                'view_mode': 'form',
+                'view_id': self.env.ref('account.view_move_form').id,
+                'res_model': 'account.move',
+                'context': "{'move_type':'out_invoice'}",
+                'type': 'ir.actions.act_window',
+                'res_id': self.account_move.id,
+            }
+        else:
+            return {
+                'name': _('Customer Invoices'),
+                'view_mode': 'list,form',
+                'res_model': 'account.move',
+                'type': 'ir.actions.act_window',
+                'domain': [('id', 'in', invoices.ids)],
+            }
+
+    def action_create_invoices(self):
         return {
-            'name': _('Customer Invoice'),
+            'name': _('Create Invoice(s)'),
             'view_mode': 'form',
-            'view_id': self.env.ref('account.view_move_form').id,
-            'res_model': 'account.move',
-            'context': "{'move_type':'out_invoice'}",
+            'view_id': self.env.ref('point_of_sale.view_pos_make_invoice').id,
+            'res_model': 'pos.make.invoice',
+            'target': 'new',
             'type': 'ir.actions.act_window',
-            'res_id': self.account_move.id,
+            'context': {'dialog_size': 'medium'}
         }
 
     # the refunded order is the order from which the items were refunded in this order
@@ -638,27 +670,32 @@ class PosOrder(models.Model):
 
     def _get_partner_bank_id(self):
         bank_partner_id = False
-        if self.amount_total <= 0 and self.partner_id.bank_ids:
+        amount_total = sum(order.amount_total for order in self)
+        if amount_total <= 0 and self.partner_id.bank_ids:
             bank_partner_id = self.partner_id.bank_ids[0].id
-        elif self.amount_total >= 0 and self.company_id.partner_id.bank_ids:
+        elif amount_total >= 0 and self.company_id.partner_id.bank_ids:
             bank_partner_id = self.company_id.partner_id.bank_ids[0].id
         return bank_partner_id
 
     def _create_invoice(self, move_vals):
-        self.ensure_one()
-        invoice = self.env['account.move'].sudo()\
+        AccountMove = self.env['account.move']
+
+        invoice = AccountMove.sudo()\
             .with_company(self.company_id)\
             .with_context(default_move_type=move_vals['move_type'], linked_to_pos=True)\
             .create(move_vals)
+        currency = self.currency_id
+        amount_total = sum(order.amount_total for order in self)
+        payment_total = sum(order.amount_paid for order in self)
 
         if self.config_id.cash_rounding:
             line_ids_commands = []
             rate = invoice.invoice_currency_rate
             sign = invoice.direction_sign
-            amount_paid = (-1 if self.amount_total < 0.0 else 1) * self.amount_paid
+            amount_paid = (-1 if amount_total < 0.0 else 1) * payment_total
             difference_currency = sign * (amount_paid - invoice.amount_total)
             difference_balance = invoice.company_currency_id.round(difference_currency / rate) if rate else 0.0
-            if not self.currency_id.is_zero(difference_currency):
+            if not currency.is_zero(difference_currency):
                 rounding_line = invoice.line_ids.filtered(lambda line: line.display_type == 'rounding' and not line.tax_line_id)
                 if rounding_line:
                     line_ids_commands.append(Command.update(rounding_line.id, {
@@ -685,9 +722,12 @@ class PosOrder(models.Model):
                     'amount_currency': existing_terms_line.amount_currency - difference_currency,
                     'balance': existing_terms_line.balance - difference_balance,
                 }))
-                with self.env['account.move']._check_balanced({'records': invoice}):
+                with AccountMove._check_balanced({'records': invoice}):
                     invoice.with_context(skip_invoice_sync=True).line_ids = line_ids_commands
-        invoice.message_post(body=_("This invoice has been created from the point of sale session: %s", self._get_html_link()))
+        body = _("This invoice has been created from the point of sale session:%s",
+                    Markup().join(Markup("%s ") % order._get_html_link() for order in self)
+                )
+        invoice.message_post(body=body)
         return invoice
 
     def action_pos_order_paid(self):
@@ -721,40 +761,53 @@ class PosOrder(models.Model):
         return True
 
     def _prepare_invoice_vals(self):
-        self.ensure_one()
+        """We have orders filtered by company > config > partners > fiscal_positions so it won't make any issue
+        when we access user, partner, bank or similar directly.
+        """
         timezone = pytz.timezone(self._context.get('tz') or self.env.user.tz or 'UTC')
-        invoice_date = fields.Datetime.now() if self.session_id.state == 'closed' else self.date_order
+        invoice_date = fields.Datetime.now()
+        is_single_order = len(self) == 1
+
+        if is_single_order and self.session_id.state != 'closed':
+            invoice_date = self.date_order
+
         pos_refunded_invoice_ids = []
         for orderline in self.lines:
             if orderline.refunded_orderline_id and orderline.refunded_orderline_id.order_id.account_move:
                 pos_refunded_invoice_ids.append(orderline.refunded_orderline_id.order_id.account_move.id)
 
+        fiscal_position = self.fiscal_position_id
+        pos_config = self.config_id
+        rounding_method = pos_config.rounding_method
+        amount_total = sum(order.amount_total for order in self)
+        move_type = 'out_invoice' if amount_total >= 0 else 'out_refund'
+
         vals = {
-            'invoice_origin': self.name,
+            'invoice_origin': ', '.join(ref or '' for ref in self.mapped('pos_reference')),
             'pos_refunded_invoice_ids': pos_refunded_invoice_ids,
             'pos_order_ids': self.ids,
-            'journal_id': self.session_id.config_id.invoice_journal_id.id,
-            'move_type': 'out_invoice' if self.amount_total >= 0 else 'out_refund',
-            'ref': self.name,
+            'journal_id': self.config_id.invoice_journal_id.id,
+            'move_type': move_type,
             'partner_id': self.partner_id.address_get(['invoice'])['invoice'],
             'partner_bank_id': self._get_partner_bank_id(),
             'currency_id': self.currency_id.id,
-            'invoice_user_id': self.user_id.id,
             'invoice_date': invoice_date.astimezone(timezone).date(),
-            'fiscal_position_id': self.fiscal_position_id.id,
-            'invoice_line_ids': self._prepare_invoice_lines(),
+            'invoice_user_id': self.user_id.id,
+            'fiscal_position_id': fiscal_position.id,
+            'invoice_line_ids': self._prepare_invoice_lines(move_type),
             'invoice_payment_term_id': self.partner_id.property_payment_term_id.id or False,
-            'invoice_cash_rounding_id': self.config_id.rounding_method.id,
+            'invoice_cash_rounding_id': rounding_method.id,
         }
-        if self.refunded_order_id.account_move:
+        if is_single_order and self.refunded_order_id.account_move:
             vals['ref'] = _('Reversal of: %s', self.refunded_order_id.account_move.name)
             vals['reversed_entry_id'] = self.refunded_order_id.account_move.id
-        if self.floating_order_name:
-            vals.update({'narration': self.floating_order_name})
+
+        if any(order.floating_order_name for order in self):
+            vals.update({'narration': ', '.join(self.filtered('floating_order_name').mapped('floating_order_name'))})
+
         return vals
 
     def _prepare_aml_values_list_per_nature(self):
-        self.ensure_one()
         AccountTax = self.env['account.tax']
         sign = 1 if self.amount_total < 0 else -1
         commercial_partner = self.partner_id.commercial_partner_id
@@ -888,10 +941,11 @@ class PosOrder(models.Model):
         return aml_vals_list_per_nature
 
     def _create_misc_reversal_move(self, payment_moves):
-        """ Create a misc move to reverse this POS order and "remove" it from the POS closing entry.
-        This is done by taking data from the order and using it to somewhat replicate the resulting entry in order to
-        reverse partially the movements done ine the POS closing entry.
+        """ Create a misc move to reverse POS orders and "remove" it from the POS closing entry.
+        This is done by taking data from the orders and using it to somewhat replicate the resulting entry in orders to
+        reverse partially the movements done in the POS closing entry.
         """
+        self.ensure_one()
         aml_values_list_per_nature = self._prepare_aml_values_list_per_nature()
         move_lines = []
         for aml_values_list in aml_values_list_per_nature.values():
@@ -930,40 +984,7 @@ class PosOrder(models.Model):
         self.write({'to_invoice': True})
         if self.company_id.anglo_saxon_accounting and self.session_id.update_stock_at_closing and self.session_id.state != 'closed':
             self._create_order_picking()
-        return self._generate_pos_order_invoice()
-
-    def _generate_pos_order_invoice(self):
-        moves = self.env['account.move']
-
-        for order in self:
-            # Force company for all SUPERUSER_ID action
-            if order.account_move:
-                moves += order.account_move
-                continue
-
-            if not order.partner_id:
-                raise UserError(_('Please provide a partner for the sale.'))
-
-            move_vals = order._prepare_invoice_vals()
-            new_move = order._create_invoice(move_vals)
-
-            order.state = 'done'
-            new_move.sudo().with_company(order.company_id).with_context(skip_invoice_sync=True)._post()
-
-            moves += new_move
-            payment_moves = order._apply_invoice_payments(order.session_id.state == 'closed')
-
-            # Send and Print
-            if self.env.context.get('generate_pdf', True):
-                new_move.with_context(skip_invoice_sync=True)._generate_and_send()
-
-            if order.session_id.state == 'closed':  # If the session isn't closed this isn't needed.
-                # If a client requires the invoice later, we need to revers the amount from the closing entry, by making a new entry for that.
-                order._create_misc_reversal_move(payment_moves)
-
-        if not moves:
-            return {}
-
+        move = self._generate_pos_order_invoice()
         return {
             'name': _('Customer Invoice'),
             'view_mode': 'form',
@@ -972,8 +993,47 @@ class PosOrder(models.Model):
             'context': "{'move_type':'out_invoice'}",
             'type': 'ir.actions.act_window',
             'target': 'current',
-            'res_id': moves and moves.ids[0] or False,
+            'res_id': move.id,
         }
+
+    def _generate_pos_order_invoice(self):
+        self.state = 'done'
+
+        company = self.company_id
+        invoice_vals = self._prepare_invoice_vals()
+        invoice = self._create_invoice(invoice_vals)
+        invoice.sudo().with_company(company).with_context(skip_invoice_sync=True)._post()
+
+        # invoice payments
+        payment_moves_from_closed_sessions = {}
+        all_payment_moves = self.env['account.move']
+        for session, orders in self.grouped('session_id').items():
+            is_session_closed = session.state == 'closed'
+            for order in orders:
+                order_payments = order.payment_ids.sudo().with_company(company)
+                payment_moves = order_payments._create_payment_moves(is_session_closed)
+                all_payment_moves |= payment_moves
+                if is_session_closed:
+                    payment_moves_from_closed_sessions[order] = payment_moves
+
+        self._reconcile_invoice_payments(invoice, all_payment_moves)
+
+        # reverse payment moves from closed sessions
+        for order, payment_moves in payment_moves_from_closed_sessions.items():
+            order._create_misc_reversal_move(payment_moves)
+
+        if self.env.context.get('generate_pdf', True):
+            invoice.with_context(skip_invoice_sync=True)._generate_and_send()
+
+        return invoice
+
+    def _reconcile_invoice_payments(self, invoice, payment_moves):
+        receivable_account = self.env["res.partner"]._find_accounting_partner(invoice.partner_id).with_company(self.company_id).property_account_receivable_id
+        if not receivable_account.reconcile:
+            return
+        payment_receivable_lines = payment_moves.pos_payment_ids._get_receivable_lines_for_invoice_reconciliation(receivable_account)
+        invoice_receivable_lines = invoice.line_ids.filtered(lambda line: line.account_id == receivable_account and not line.reconciled)
+        (payment_receivable_lines | invoice_receivable_lines).sudo().with_company(invoice.company_id).reconcile()
 
     def action_pos_order_cancel(self):
         if self.env.context.get('active_ids'):
@@ -989,22 +1049,6 @@ class PosOrder(models.Model):
         return {
             'pos.order': today_orders.read(self._load_pos_data_fields(self.config_id.ids[0]), load=False)
         }
-
-    def _apply_invoice_payments(self, is_reverse=False):
-        receivable_account = self.env["res.partner"]._find_accounting_partner(self.partner_id).with_company(self.company_id).property_account_receivable_id
-        payment_moves = self.payment_ids.sudo().with_company(self.company_id)._create_payment_moves(is_reverse)
-        if receivable_account.reconcile:
-            invoice_receivables = self.account_move.line_ids.filtered(lambda line: line.account_id == receivable_account and not line.reconciled)
-            if invoice_receivables:
-                credit_line_ids = payment_moves._context.get('credit_line_ids', None)
-                payment_receivables = payment_moves.mapped('line_ids').filtered(
-                    lambda line: (
-                        (credit_line_ids and line.id in credit_line_ids) or
-                        (not credit_line_ids and line.account_id == receivable_account and line.partner_id)
-                    )
-                )
-                (invoice_receivables | payment_receivables).sudo().with_company(self.company_id).reconcile()
-        return payment_moves
 
     def _get_open_order(self, order):
         return self.env["pos.order"].search([('uuid', '=', order.get('uuid'))], limit=1)

--- a/addons/point_of_sale/security/ir.model.access.csv
+++ b/addons/point_of_sale/security/ir.model.access.csv
@@ -63,3 +63,7 @@ access_pos_note,pos.note.user,model_pos_note,point_of_sale.group_pos_user,1,0,0,
 access_pos_note_manager,pos.note.manager,model_pos_note,point_of_sale.group_pos_manager,1,1,1,1
 access_pos_preset,pos.preset.user,model_pos_preset,point_of_sale.group_pos_user,1,0,0,0
 access_pos_preset_manager,pos.preset.manager,model_pos_preset,point_of_sale.group_pos_manager,1,1,1,1
+access_pos_make_invoice,pos.make.invoice.user,model_pos_make_invoice,point_of_sale.group_pos_user,1,1,1,0
+access_pos_make_invoice_manager,pos.make.invoice.manager,model_pos_make_invoice,point_of_sale.group_pos_manager,1,1,1,1
+access_pos_confirmation_wizard,pos.confirmation.wizard.user,model_pos_confirmation_wizard,point_of_sale.group_pos_user,1,1,1,1
+access_pos_confirmation_wizard_manager,pos.confirmation.wizard.manager,model_pos_confirmation_wizard,point_of_sale.group_pos_manager,1,1,1,1

--- a/addons/point_of_sale/views/account_move_views.xml
+++ b/addons/point_of_sale/views/account_move_views.xml
@@ -5,6 +5,15 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button class="oe_stat_button"
+                        name="action_view_source_pos_orders"
+                        type="object"
+                        icon="fa-pencil-square-o"
+                        invisible="pos_order_count == 0 or move_type not in ('out_invoice', 'out_refund')">
+                    <field string="POS Orders" name="pos_order_count" widget="statinfo"/>
+                </button>
+            </xpath>
             <xpath expr="//field[@name='tax_cash_basis_origin_move_id']" position="before">
                 <field name="reversed_pos_order_id" readonly="True" invisible="not reversed_pos_order_id"/>
             </xpath>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -287,6 +287,9 @@
         <field name="model">pos.order</field>
         <field name="arch" type="xml">
             <list string="POS Orders" create="0" sample="1" decoration-info="state == 'draft'" decoration-muted="state == 'cancel'" duplicate="0">
+                <header>
+                    <button name="action_create_invoices" type="object" string="Create Invoices"/>
+                </header>
                 <field name="currency_id" column_invisible="True"/>
                 <field name="name" decoration-bf="1"/>
                 <field name="session_id"  readonly="state != 'draft'"/>

--- a/addons/point_of_sale/wizard/__init__.py
+++ b/addons/point_of_sale/wizard/__init__.py
@@ -5,3 +5,5 @@ from . import pos_details
 from . import pos_payment
 from . import pos_close_session_wizard
 from . import pos_daily_sales_reports
+from . import pos_confirmation_wizard
+from . import pos_make_invoice

--- a/addons/point_of_sale/wizard/pos_confirmation_wizard.py
+++ b/addons/point_of_sale/wizard/pos_confirmation_wizard.py
@@ -1,0 +1,31 @@
+from odoo import models, fields, api, _
+
+class PosConfirmationWizard(models.TransientModel):
+    _name = 'pos.confirmation.wizard'
+    _description = 'Confirmation Wizard'
+
+    def get_selected_orders(self):
+        selected_orders = self.env.context.get('orders')
+        return self.env['pos.order'].browse(selected_orders)
+
+    def _default_message(self):
+        selected_orders = self.get_selected_orders()
+        customer_name = selected_orders.partner_id.name
+        message = _("It seems that the POS order(s) %(order_ref)s do not have a customer.\n\nWould you like to set %(customer_name)s as the customer for the selected POS order(s)?", order_ref= ', '.join(selected_orders.filtered(lambda o: not o.partner_id).mapped('name')), customer_name=customer_name)
+        return message
+
+    message = fields.Text(default=_default_message, readonly=True)
+
+    def action_confirm(self):
+        selected_orders = self.get_selected_orders()
+        selected_orders.write({'partner_id': selected_orders.partner_id.id})
+        return {
+            'name': _('Create Invoice(s)'),
+            'view_mode': 'form',
+            'view_id': self.env.ref('point_of_sale.view_pos_make_invoice').id,
+            'res_model': 'pos.make.invoice',
+            'target': 'new',
+            'type': 'ir.actions.act_window',
+            'context': {'active_ids': selected_orders.ids},
+        }
+

--- a/addons/point_of_sale/wizard/pos_confirmation_wizard.xml
+++ b/addons/point_of_sale/wizard/pos_confirmation_wizard.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="point_of_sale.view_confirm_action_wizard" model="ir.ui.view">
+        <field name="name">pos.confirmation.wizard.form</field>
+        <field name="model">pos.confirmation.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Warning" width="500px">
+                <group>
+                    <field name="message" nolabel="1" readonly="1"/>
+                </group>
+                <footer>
+                    <button name="action_confirm" string="Confirm" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_confirm_action_wizard" model="ir.actions.act_window">
+        <field name="name">Confirm Action</field>
+        <field name="res_model">pos.confirmation.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="point_of_sale.view_confirm_action_wizard"/>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/addons/point_of_sale/wizard/pos_make_invoice.py
+++ b/addons/point_of_sale/wizard/pos_make_invoice.py
@@ -1,0 +1,74 @@
+from odoo import models, fields, _
+from odoo.exceptions import UserError
+
+
+class PosMakeInvoice(models.TransientModel):
+    _name = 'pos.make.invoice'
+    _description = 'Multiple order invoice creation'
+
+    consolidated_billing = fields.Boolean(
+        string="Consolidated Billing", default=True,
+        help="Create one invoice for all orders related to same customer and same invoicing address"
+    )
+    count = fields.Integer(string="Order Count", compute='_compute_order_count')
+
+    def _compute_order_count(self):
+        for wizard in self:
+            wizard.count = len(self.env.context.get('active_ids', []))
+
+    def action_create_invoices(self):
+        self.ensure_one()
+        selected_orders = self.env['pos.order'].browse(self.env.context.get('active_ids'))
+        is_single_order = len(selected_orders) == 1
+
+        uninvoiceable_orders = selected_orders.filtered(lambda o: o.invoice_status != 'to_invoice' or o.state == 'draft' or o.state == 'cancel' )
+        if uninvoiceable_orders:
+            order_names = "\n".join(uninvoiceable_orders.mapped('pos_reference'))
+            raise UserError(_(
+                "Unable to create consolidated invoice/s because the following orders can't be invoiced.\n\n%s",
+                order_names
+            ))
+
+        invalid_refund_orders = selected_orders.filtered(lambda o: o.refunded_order_id.account_move)
+        if (not is_single_order) and invalid_refund_orders:
+            # Normally it can't be encountered because when paying a refund order,
+            # if the original order is invoiced, the refund order is required by the UI to be invoiced.
+            order_names = "\n".join([f"{o.name} ({o.pos_reference})" for o in invalid_refund_orders])
+            raise UserError(_("The following refund orders can't be part of a consolidated invoice because they refunded invoiced orders. Each refund order should be handled separately.\n\n%s", order_names))
+
+        invoices = self.env['account.move']
+
+        if not self.consolidated_billing or len(selected_orders) == 1:
+            for order in selected_orders:
+                invoices |= order._generate_pos_order_invoice()
+        else:
+            configs = selected_orders.config_id
+            partners = selected_orders.partner_id
+            some_order_has_no_partner = any(not o.partner_id for o in selected_orders)
+            if len(configs) == 1 and len(partners) == 1 and some_order_has_no_partner:
+                # When all the orders belong to one config and there is only one customer but some orders have no partner,
+                # we can proceed but we ask the user if we proceed by setting that one customer to all the orders.
+                return {
+                    'name': _('Warning'),
+                    'view_mode': 'form',
+                    'view_id': self.env.ref('point_of_sale.view_confirm_action_wizard').id,
+                    'res_model': 'pos.confirmation.wizard',
+                    'target': 'new',
+                    'type': 'ir.actions.act_window',
+                    'context': {'orders': selected_orders.ids, 'dialog_size': 'medium'},
+                }
+
+            grouped_orders = []
+            for config, config_orders in selected_orders.grouped('config_id').items():
+                for partner, partner_orders in config_orders.grouped('partner_id').items():
+                    if not partner:
+                        raise UserError(_("Kindly ensure that each order contains a customer."))
+
+                    for fiscal_position, fiscal_position_orders in partner_orders.grouped('fiscal_position_id').items():
+                        grouped_orders.append(((config, partner, fiscal_position), fiscal_position_orders))
+
+            for _key, orders in grouped_orders:
+                invoices |= orders._generate_pos_order_invoice()
+
+        if invoices:
+            return selected_orders.action_view_invoice()

--- a/addons/point_of_sale/wizard/pos_make_invoice.xml
+++ b/addons/point_of_sale/wizard/pos_make_invoice.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="point_of_sale.view_pos_make_invoice" model="ir.ui.view">
+        <field name="name">Create Invoice(s)</field>
+        <field name="model">pos.make.invoice</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="count"/>
+                    <field name="consolidated_billing" invisible="count == 1"/>
+                </group>
+                <footer>
+                    <button name="action_create_invoices" type="object"
+                        string="Create"
+                        class="btn-primary" data-hotkey="q"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/pos_sale/models/account_move.py
+++ b/addons/pos_sale/models/account_move.py
@@ -8,11 +8,12 @@ class AccountMove(models.Model):
         if self.env.user.has_group('point_of_sale.group_pos_user'):
             for invoice in self:
                 for pos_order_line in invoice.pos_order_ids.mapped('lines'):
-                    if isCancelled and "(Cancelled)" not in pos_order_line.sale_order_line_id.name:
-                        name = _("%(old_name)s (Cancelled)", old_name=pos_order_line.sale_order_line_id.name)
-                        pos_order_line.sale_order_line_id.name = name
-                    elif not isCancelled:
-                        pos_order_line.sale_order_line_id.name = pos_order_line.sale_order_line_id.name.replace(" (Cancelled)", "")
+                    if pos_order_line.sale_order_line_id:
+                        if isCancelled and "(Cancelled)" not in pos_order_line.sale_order_line_id.name:
+                            name = _("%(old_name)s (Cancelled)", old_name=pos_order_line.sale_order_line_id.name)
+                            pos_order_line.sale_order_line_id.name = name
+                        elif not isCancelled and "(Cancelled)" in pos_order_line.sale_order_line_id.name:
+                            pos_order_line.sale_order_line_id.name = pos_order_line.sale_order_line_id.name.replace(" (Cancelled)", "")
 
     def button_cancel(self):
         res = super().button_cancel()

--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -166,8 +166,8 @@ class PosOrder(models.Model):
             }
         return order_line
 
-    def _get_invoice_lines_values(self, line_values, pos_line):
-        inv_line_vals = super()._get_invoice_lines_values(line_values, pos_line)
+    def _get_invoice_lines_values(self, line_values, pos_line, move_type):
+        inv_line_vals = super()._get_invoice_lines_values(line_values, pos_line, move_type)
 
         if pos_line.sale_order_origin_id:
             origin_line = pos_line.sale_order_line_id


### PR DESCRIPTION
In this commit:
-------------------
- A new wizard is created to facilitate making multiple invoices at the same time
- If consolidated billing is checked, the common invoice will be grouped by partner and config_id; if not, an individual invoice will be created per order.
- Now, the invoice form view has a smart button to navigate connected pos orders Also, navigate orders from the chatter.

Task: 4256209