### PR TITLE
[FIX] Removed encode/decode in slugify after normalization to allow non ascii characters

### DIFF
--- a/doc/cla/individual/dabo-odoo.md
+++ b/doc/cla/individual/dabo-odoo.md
@@ -1,0 +1,11 @@
+Belgium, 2024-11-13
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Davide Bonetto dabo@odoo.com https://github.com/dabo-odoo

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -149,9 +149,16 @@ class IrHttp(models.AbstractModel):
                 return slugify_lib.slugify(value, max_length=max_length)
             except TypeError:
                 pass
-        uni = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
-        slug_str = re.sub(r'[\W_]+', '-', uni).strip('-').lower()
-        return slug_str[:max_length] if max_length > 0 else slug_str
+        uni = unicodedata.normalize('NFKD', value)
+        slugified_segments = []
+        for slug in re.split('-|_| ', uni):
+            slug = re.sub(r"[$&+,:;=?@#|'<>.^*()%!\-{}/\\\~]", '-', slug)
+            slug = re.sub(r'--+', '-', slug)
+            slug = re.sub(r'([^\w-])+', '', slug)
+            if (len(slug.strip('-')) > 0):
+                slugified_segments.append(slug.strip('-').lower())
+        slugified_str = ("-").join(slugified_segments)
+        return slugified_str[:max_length] if max_length > 0 else slugified_str
 
     @classmethod
     def _slugify(cls, value: str, max_length: int = 0, path: bool = False) -> str:

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -155,8 +155,9 @@ class IrHttp(models.AbstractModel):
             slug = re.sub(r"[$&+,:;=?@#|'<>.^*()%!\-{}/\\\~]", '-', slug)
             slug = re.sub(r'--+', '-', slug)
             slug = re.sub(r'([^\w-])+', '', slug)
-            if (len(slug.strip('-')) > 0):
-                slugified_segments.append(slug.strip('-').lower())
+            slug = slug.strip('-')
+            if (len(slug) > 0):
+                slugified_segments.append(slug.lower())
         slugified_str = ("-").join(slugified_segments)
         return slugified_str[:max_length] if max_length > 0 else slugified_str
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Any non-ascii character is removed from URLs.

Current behavior before PR:
If trying to create or navigate to a page in the website using URLs containing non ascii characters, the non ascii characters are removed from the URL, and if the URL was composed completely of non ascii characters, it gets replaced with -1,-2,-3...

Desired behavior after PR is merged:
The non ascii characters do not get removed from the URLs, allowing users to create and browse pages with URLs containing non ascii characters

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
