### PR TITLE
[FIX] maintenance: remove ischeck from tour

### DIFF
--- a/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
+++ b/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
@@ -71,7 +71,6 @@ registry.category("web_tour.tours").add("test_drag_and_drop_event_in_calendar", 
         },
         {
             trigger: '.fc-dayGridMonth-view',
-            isCheck: true,
         },
         {
             content: "Move event to 15th of the month",


### PR DESCRIPTION
`isCheck` is no longer supported in saas-17.4, removing it
previous commit introducing it: odoo/odoo@14bc358bef7f6f26f9596d4a1c1ed101f8648cbb

runbot-error-107508
