### PR TITLE
[FIX] maintenance: remove ischeck from tour

### DIFF
--- a/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
+++ b/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
@@ -66,8 +66,8 @@ registry.category("web_tour.tours").add("test_drag_and_drop_event_in_calendar", 
             run: "click",
         },
         {
+            content: 'Wait for monthly view to load',
             trigger: '.fc-dayGridMonth-view',
-            isCheck: true,
         },
         {
             content: "Move event to 15th of the month",


### PR DESCRIPTION
`isCheck` is no longer supported in saas-17.4, removing it
previous commit introducing it: odoo/odoo@f39a05aa06b77379715a824c7ff36059d5bf565d

runbot-error-107508