### PR TITLE
[FIX] hw_drivers: prevent loop of death on error in serial driver

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
@@ -102,15 +102,17 @@ class SerialDriver(Driver):
         :type data: string
         """
 
-        try:
-            with self._device_lock:
+        with self._device_lock:
+            try:
                 self._actions[data['action']](data)
                 time.sleep(self._protocol.commandDelay)
-        except Exception:
-            msg = _('An error occurred while performing action %s on %s') % (data, self.device_name)
-            _logger.exception(msg)
-            self._status = {'status': self.STATUS_ERROR, 'message_title': msg, 'message_body': traceback.format_exc()}
-            self._push_status()
+            except Exception:
+                msg = _(f'An error occurred while performing action "{data}" on "{self.device_name}"')
+                _logger.exception(msg)
+                self._status = {'status': self.STATUS_ERROR, 'message_title': msg, 'message_body': traceback.format_exc()}
+                self._push_status()
+            self._status = {'status': self.STATUS_CONNECTED, 'message_title': '', 'message_body': ''}
+            self.data['status'] = self._status
 
     def action(self, data):
         """Establish a connection with the device if needed and have it perform a specific action.


### PR DESCRIPTION
Before this commit, when an error happens on a serial device, the serial driver on the IoT box permanently sets its status to ERROR. This in turn leads to the user-facing app returning a failure status back to the user, even for sucessful subsequent operations.

This is particularly problematic, for example in the special case of BlackBox BE, where some points of sales have multiple checkouts using the same POS session and the same IoT Box + BlackBox. If at any point, a cashier sent an erroneous message to the IoT Box or to the Blackbox, all checkouts would become blocked, with the only alternative being to reload the handlers or restart the IoT Box. Furthermore, the subsequent actions appearing as refused may have executed successfully. Which means there would be a mismatch between the data stored in Odoo (multiple failed transactions) and the data sent to the SPF (one failed transaction, then many successful ones).

After this commit, the driver status is reset after being sent once. That way, when a new action is sent from the client to the IoT box, it's the status of the execution of this action and not the previous one that gets sent back to the client.

opw-4313538
opw-4182434
opw-4293988