### PR TITLE
[FIX] base_import: use correct value and unit for batch size

### DIFF
--- a/addons/base_import/static/src/import_model.js
+++ b/addons/base_import/static/src/import_model.js
@@ -429,7 +429,7 @@ export class BaseImportModel {
             const parameters = {
                 tracking_disable: this.importOptions.tracking_disable,
                 delayAfterEachBatch: this.binaryFilesParams.delayAfterEachBatch.value,
-                maxSizePerBatch: this.binaryFilesParams.maxSizePerBatch.value,
+                maxBatchSize: this.binaryFilesParams.maxSizePerBatch.value * 1024 * 1024,
             };
 
             if (!this.binaryFilesParams.binaryFiles) {


### PR DESCRIPTION
This commit fixes the parameters send to the BinaryFileManager. There was a typo `maxBatchSize` and not `maxSizePerBatch` also has the unit on the web interface is in mega we should multiply the unit by 1024 ^ 2 to have the correct value.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
