### PR TITLE
[FIX] mrp: don't write on invisible field

### DIFF
--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -29,7 +29,6 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         product_form = Form(cls.env['product.product'])
         product_form.name = 'Stick'
         product_form.uom_id = cls.uom_unit
-        product_form.uom_po_id = cls.uom_unit
         product_form.is_storable = True
         product_form.route_ids.clear()
         product_form.route_ids.add(cls.warehouse.manufacture_pull_id.route_id)
@@ -41,7 +40,6 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         product_form.name = 'Raw Stick'
         product_form.is_storable = True
         product_form.uom_id = cls.uom_unit
-        product_form.uom_po_id = cls.uom_unit
         cls.raw_product = product_form.save()
 
         # Create bom for manufactured product
@@ -405,7 +403,6 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         product_form.name = 'Wood'
         product_form.is_storable = True
         product_form.uom_id = self.uom_unit
-        product_form.uom_po_id = self.uom_unit
         self.wood_product = product_form.save()
 
         # Create bom for manufactured product


### PR DESCRIPTION
`uom_po_id` is invisible in the product view in 2 scenarios. the uom group is not activated or the product cannot be bought. As we are setting the default value anyway in those tests, it's better to not give a particular value to avoid error about writing into invisible field

runbot error : 65999

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
