### PR TITLE
[FIX] base, website, *: Prevent `ir.model.fields` create

### DIFF
--- a/addons/base_sparse_field/views/views.xml
+++ b/addons/base_sparse_field/views/views.xml
@@ -10,7 +10,7 @@
                 <field name="related" position="before">
                     <field name="serialization_field_id"
                         domain="[('ttype','=','serialized'), ('model_id','=',parent.model)]"
-                        readonly="state == 'base'"/>
+                        readonly="state == 'base'" options="{'no_create': True}"/>
                 </field>
             </field>
         </record>
@@ -23,7 +23,7 @@
                 <field name="related" position="before">
                     <field name="serialization_field_id"
                         context="{'default_model_id': model_id, 'default_ttype': 'serialized'}"
-                        readonly="state == 'base'"/>
+                        readonly="state == 'base'" options="{'no_create': True}"/>
                 </field>
             </field>
         </record>

--- a/addons/gamification/views/gamification_goal_definition_views.xml
+++ b/addons/gamification/views/gamification_goal_definition_views.xml
@@ -62,7 +62,7 @@
                             <field name="batch_mode" />
                             <div colspan="2">In batch mode, the domain is evaluated globally. If enabled, do not use keyword 'user' in above filter domain.</div>
                             <field name="batch_distinctive_field" invisible="not batch_mode" required="batch_mode"
-                                domain="[('model_id', '=', model_id)]" class="oe_inline" />
+                                domain="[('model_id', '=', model_id)]" class="oe_inline" options="{'no_create': True}"/>
                             <field name="batch_user_expression" invisible="not batch_mode" required="batch_mode" class="oe_inline"
                                 placeholder="e.g. user.partner_id.id"/>
                         </group>

--- a/addons/website/views/ir_model_views.xml
+++ b/addons/website/views/ir_model_views.xml
@@ -11,7 +11,7 @@
                     <group>
                         <field name="website_form_access"/>
                         <field name="website_form_label"/>
-                        <field name="website_form_default_field_id"/>
+                        <field name="website_form_default_field_id" options="{'no_create': True}"/>
                     </group>
                 </page>
             </xpath>

--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -464,7 +464,7 @@
             <field name="arch" type="xml">
                 <list>
                     <field name="sequence" widget="handle"/>
-                    <field name="field_id"/>
+                    <field name="field_id" options="{'no_quick_create': True}"/>
                     <field name="value"/>
                     <field name="name"/>
                 </list>


### PR DESCRIPTION
\* = base_sparse_field, gamification

Quick create an `ir.model.fields` should not be possible in the UI,
This commit prevents it instead of raising an error

see https://github.com/odoo/odoo/pull/186295#pullrequestreview-2417762562
linked enterprise pr: https://github.com/odoo/enterprise/pull/73550