### PR TITLE
[FIX] website: url autocomplete in linktools

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -234,6 +234,7 @@
             'website/static/src/js/editor/editor.js',
             '/website/static/src/components/wysiwyg_adapter/toolbar_patch.js',
             'website/static/src/xml/web_editor.xml',
+            'website/static/src/js/editor/widget_link.js',
         ],
         'website.assets_wysiwyg': [
             ('include', 'web._assets_helpers'),


### PR DESCRIPTION
Issue:
======
url autocomplete doesn't work in mass mailing

Steps to reproduce the issue:
=============================
- Install website
- Create a new mass mailing
- Choose welcome message
- Select some text and click on the link icon on the toolbar in the snippets sidebar
- You will see the hint of `type / to search ....`
- If you type that nothing happens

Origin of the issue:
====================
The behavior of autocomplete was added only in website but the hint was added for the linkTools in general.

Solution:
=========
Patch linkTools to include the behavior too.

opw-4318224