### PR TITLE
[FIX] mail: odoobot message remains unread

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -630,7 +630,8 @@ class Channel(models.Model):
         """
         Automatically set the message posted by the current user as seen for themselves.
         """
-        self._set_last_seen_message(message)
+        if message.is_current_user_or_guest_author:
+            self._set_last_seen_message(message)
         return super()._message_post_after_hook(message, msg_vals)
 
     def _check_can_update_message_content(self, message):

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -81,6 +81,7 @@ export class Thread extends Record {
                 "mainAttachment",
                 "message_unread_counter",
                 "message_needaction_counter",
+                "message_unread_counter_bus_id",
                 "name",
                 "seen_message_id",
                 "state",

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -119,6 +119,7 @@ class TestDiscussFullPerformance(HttpCase):
         self.users[0].notification_type = 'inbox'
         message = self.channel_channel_public_1.message_post(body='test', message_type='comment', author_id=self.users[2].partner_id.id, partner_ids=self.users[0].partner_id.ids)
         # add star
+        self.channel_channel_public_1.with_user(self.users[0])._set_last_seen_message(message)
         message.toggle_message_starred()
         self.env.company.sudo().name = 'YourCompany'
 


### PR DESCRIPTION
Before this commit, messages sent by OdooBot would remain unread.
1. Log in as demo user
2. Open OdooBot chat, remains unread

This happens because the `_set_last_seen_message` method called by the OdooBot reply logic sets the message as seen for the user. This results in the message being marked as read before it is received, preventing it to be marked as read by the client.
This commit fixes the issue by preventing the message to be mark as read if the author is not the current user.

Also added missing `message_unread_counter_bus_id` from `assignedDefined` that would prevent it to be set by record inserts.

task-4295630
opw-4316799