### PR TITLE
[FIX] mail, tools: hide mention URLs in web notifications

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3769,7 +3769,7 @@ class MailThread(models.AbstractModel):
                 }
             }
         }
-        payload['options']['body'] = html2plaintext(body)
+        payload['options']['body'] = html2plaintext(body, include_references=False)
         payload['options']['body'] += self._generate_tracking_message(message)
 
         return payload

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -381,10 +381,12 @@ def create_link(url, label):
     return f'<a href="{url}" target="_blank" rel="noreferrer noopener">{label}</a>'
 
 
-def html2plaintext(html, body_id=None, encoding='utf-8'):
+def html2plaintext(html, body_id=None, encoding='utf-8', include_references=True):
     """ From an HTML text, convert the HTML to plain text.
     If @param body_id is provided then this is the tag where the
     body (not necessarily <body>) starts.
+    :param include_references: If False, numbered references and
+        URLs for links and images will not be included.
     """
     ## (c) Fry-IT, www.fry-it.com, 2007
     ## <peter@fry-it.com>
@@ -406,22 +408,23 @@ def html2plaintext(html, body_id=None, encoding='utf-8'):
 
     url_index = []
     i = 0
-    for link in tree.findall('.//a'):
-        url = link.get('href')
-        if url:
-            i += 1
-            link.tag = 'span'
-            link.text = '%s [%s]' % (link.text, i)
-            url_index.append(url)
+    if include_references:
+        for link in tree.findall('.//a'):
+            url = link.get('href')
+            if url:
+                i += 1
+                link.tag = 'span'
+                link.text = '%s [%s]' % (link.text, i)
+                url_index.append(url)
 
-    for img in tree.findall('.//img'):
-        src = img.get('src')
-        if src:
-            i += 1
-            img.tag = 'span'
-            img_name = re.search(r'[^/]+(?=\.[a-zA-Z]+(?:\?|$))', src)
-            img.text = '%s [%s]' % (img_name.group(0) if img_name else 'Image', i)
-            url_index.append(src)
+        for img in tree.findall('.//img'):
+            src = img.get('src')
+            if src:
+                i += 1
+                img.tag = 'span'
+                img_name = re.search(r'[^/]+(?=\.[a-zA-Z]+(?:\?|$))', src)
+                img.text = '%s [%s]' % (img_name.group(0) if img_name else 'Image', i)
+                url_index.append(src)
 
     html = ustr(etree.tostring(tree, encoding=encoding))
     # \r char is converted into &#13;, must remove it


### PR DESCRIPTION
Current behavior before PR:

When a user mentioned a channel or another user in a message, the web notification displayed the mention URL on the recipient’s side, causing a UI issue.
Before / After
<div style="display: flex;">
  <img src="https://github.com/user-attachments/assets/3e8d381a-5d08-4f43-89f4-382d7b9bcca1" width="48%" style="margin-right: 4%;" />
  <img src="https://github.com/user-attachments/assets/9abb168c-fe7d-4828-b55f-140219deb003" width="48%" />
</div>


Desired behavior after PR is merged:

This commit resolves the issue by hiding the mention URL in web notification when a user mentions a channel or another user in a message.

Task-4295310







---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
