### PR TITLE
[FIX] web: not supported type on domain

### DIFF
--- a/addons/web/static/src/views/fields/domain/domain_field.js
+++ b/addons/web/static/src/views/fields/domain/domain_field.js
@@ -281,7 +281,7 @@ export const domainField = {
             type: "string",
         },
     ],
-    supportedTypes: ["char"],
+    supportedTypes: ["char", "text"],
     isEmpty: () => false,
     extractProps({ options }, dynamicInfo) {
         return {


### PR DESCRIPTION
Some domain fields in odoo uses 'Text' data type which is not supported in
domain widget, thus giving validation error.

By adding 'Text' type in supportedTypes of domain, we can avoid this error.

Closes https://github.com/odoo/enterprise/pull/73627

Task-4319471
