### PR TITLE
[FIX] l10n_sa_edi: fix company credentials on API call

### DIFF
--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -546,7 +546,7 @@ class AccountJournal(models.Model):
         """
             Helper function to make api calls to the ZATCA API Endpoint
         """
-        api_url = ZATCA_API_URLS[self.env.company.l10n_sa_api_mode]
+        api_url = ZATCA_API_URLS[self.company_id.l10n_sa_api_mode]
         request_url = urljoin(api_url, request_url)
         try:
             request_response = requests.request(method, request_url, data=request_data.get('body'),


### PR DESCRIPTION
Credentials used for making API calls related to the ZATCA edi were reliant on the company available through the context. This caused issues when using multi_company and having invoices created through different companies, as the system would try to submit invoices of some companies using the credentials of the company running at the moment of execution of the EDI scheduled action, which usually means the default company.

Description of the issue/feature this PR addresses:
When using multi_company, Invoices of additional companies would get sent with the credentials of the default company when submitted through the EDI scheduled action, as they would rely on `self.env.company` instead of `self.company_id` available through the journal.

Current behavior before PR:
When using multi_company, Invoices of additional companies would get sent with the credentials of the default company when submitted through the EDI scheduled action, as they would rely on `self.env.company` instead of `self.company_id` available through the journal.

Desired behavior after PR is merged:
Invoices always get the submission credentials linked to the journal on which they were created. 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
