### PR TITLE
[FIX] mail: correct title display in web notifications for group chats

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1347,14 +1347,19 @@ class Channel(models.Model):
         payload = super()._notify_by_web_push_prepare_payload(message, msg_vals=msg_vals)
         payload['options']['data']['action'] = 'mail.action_discuss'
         record_name = msg_vals.get('record_name') if msg_vals and 'record_name' in msg_vals else message.record_name
+        author_id = [msg_vals.get('author_id')] if 'author_id' in msg_vals else message.author_id.ids
         if self.channel_type == 'chat':
-            author_id = [msg_vals.get('author_id')] if 'author_id' in msg_vals else message.author_id.ids
             payload['title'] = self.env['res.partner'].browse(author_id).name
             payload['options']['icon'] = '/discuss/channel/%d/partner/%d/avatar_128' % (message.res_id, author_id[0])
         elif self.channel_type == 'channel':
-            author_id = [msg_vals.get('author_id')] if 'author_id' in msg_vals else message.author_id.ids
             author_name = self.env['res.partner'].browse(author_id).name
             payload['title'] = "#%s - %s" % (record_name, author_name)
+        elif self.channel_type == 'group':
+            if not record_name:
+                member_names = self.channel_member_ids.mapped("partner_id.name")
+                record_name = f"{', '.join(member_names[:-1])} and {member_names[-1]}" if len(member_names) > 1 else member_names[0] if member_names else ""
+            author_name = self.env['res.partner'].browse(author_id).name
+            payload['title'] = "%s - %s" % (record_name, author_name)
         else:
             payload['title'] = "#%s" % (record_name)
         return payload

--- a/addons/test_mail_full/tests/test_web_push.py
+++ b/addons/test_mail_full/tests/test_web_push.py
@@ -51,6 +51,8 @@ class TestWebPushNotification(SMSCommon):
             'name': 'Direct Message',
         })
 
+        cls.group_chat_channel = channel.with_user(cls.user_email).create_group(partners_to=(cls.user_email + cls.user_inbox).partner_id.ids)
+
         cls.group_channel = cls.env['discuss.channel'].channel_create(name='Channel', group_id=None)
         cls.group_channel.add_members((cls.user_email + cls.user_inbox).partner_id.ids)
 
@@ -170,6 +172,19 @@ class TestWebPushNotification(SMSCommon):
         self._assert_notification_count_for_cron(0)
         push_to_end_point.assert_called_once()
         self.assertEqual(push_to_end_point.call_args.kwargs['device']['endpoint'], 'https://test.odoo.com/webpush/user2')
+
+        # Reset the mock counter
+        push_to_end_point.reset_mock()
+
+        # Test Group Chat
+        self.group_chat_channel.with_user(self.user_email).message_post(
+            body='Test', message_type='comment', subtype_xmlid='mail.mt_comment')
+
+        self._assert_notification_count_for_cron(0)
+        push_to_end_point.assert_called_once()
+        payload_value = json.loads(push_to_end_point.call_args.kwargs['payload'])
+        self.assertIn(self.user_email.name, payload_value['title'])
+        self.assertIn(self.user_inbox.name, payload_value['title'])
 
         # Reset the mock counter
         push_to_end_point.reset_mock()


### PR DESCRIPTION
Current behavior before PR:

When a user posted a message in a group chat, the web notification displayed `#False` as the title. This occurred because `record_name` was used as the title but it was empty for channels with `channel_type = 'group'`, as the displayName name is calculated on the UI side when displaying chat in Discuss.
Before / After
<div style="display: flex;">
  <img src="https://github.com/user-attachments/assets/7ad2de52-8cef-41a7-8d63-b19d718725ff" width="48%" style="margin-right: 4%;" />
  <img src="https://github.com/user-attachments/assets/452fac6e-3a79-4e53-a09c-4fad57b44856" width="48%" />
</div>


Desired behavior after PR is merged:

The title of the web notification now correctly displays the group chat name, ensuring recipients see accurate and complete group titles in notifications.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
