### PR TITLE
[FIX] mrp: Fix rounding issue to get correct value

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -292,11 +292,11 @@ class ProductProduct(models.Model):
                         "free_qty": float_round(component.free_qty, precision_rounding=rounding),
                     }
                 )
-                ratios_virtual_available.append(component_res["virtual_available"] / qty_per_kit)
-                ratios_qty_available.append(component_res["qty_available"] / qty_per_kit)
-                ratios_incoming_qty.append(component_res["incoming_qty"] / qty_per_kit)
-                ratios_outgoing_qty.append(component_res["outgoing_qty"] / qty_per_kit)
-                ratios_free_qty.append(component_res["free_qty"] / qty_per_kit)
+                ratios_virtual_available.append(float_round(component_res["virtual_available"] / qty_per_kit, precision_rounding=rounding))
+                ratios_qty_available.append(float_round(component_res["qty_available"] / qty_per_kit, precision_rounding=rounding))
+                ratios_incoming_qty.append(float_round(component_res["incoming_qty"] / qty_per_kit, precision_rounding=rounding))
+                ratios_outgoing_qty.append(float_round(component_res["outgoing_qty"] / qty_per_kit, precision_rounding=rounding))
+                ratios_free_qty.append(float_round(component_res["free_qty"] / qty_per_kit, precision_rounding=rounding))
             if bom_sub_lines and ratios_virtual_available:  # Guard against all cnsumable bom: at least one ratio should be present.
                 res[product.id] = {
                     'virtual_available': float_round(min(ratios_virtual_available) * bom_kits[product].product_qty, precision_rounding=rounding) // 1,

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1321,22 +1321,30 @@ class TestBoM(TestMrpCommon):
         self.assertEqual(orderpoint.qty_to_order, 4000.0)
 
     def test_bom_kit_with_sub_kit(self):
-        p1, p2, p3, p4 = self.make_prods(4)
+        p1, p2, p3, p4, p5, p6 = self.make_prods(6)
         prod1, prod2 = self.make_prods(2)
         self.make_bom(p1, p2, p3)
         self.make_bom(p2, p3, p4)
         bom = self.make_bom(prod1, prod2)
         bom.product_qty = 100
 
+        bom = self.make_bom(p5, p6)
+        bom.bom_line_ids[0].product_qty = 0.1
+
         loc = self.env.ref("stock.stock_location_stock")
         self.env["stock.quant"]._update_available_quantity(p3, loc, 10)
         self.env["stock.quant"]._update_available_quantity(p4, loc, 10)
         self.env["stock.quant"]._update_available_quantity(prod2, loc, 5.57)
         self.env["stock.quant"]._update_available_quantity(prod2, loc, -5)
+        self.env["stock.quant"]._update_available_quantity(p6, loc, 5.5)
+        self.env["stock.quant"]._update_available_quantity(p6, loc, -5.2)
+
         self.assertEqual(p1.qty_available, 5.0)
         self.assertEqual(p2.qty_available, 10.0)
         self.assertEqual(p3.qty_available, 10.0)
         self.assertEqual(prod1.qty_available, 57.0)
+        self.assertEqual(p5.qty_available, 3.0)
+
 
     def test_operation_blocked_by_another_operation(self):
         """ Test that an operation is not blocked by another operation if the variant is different


### PR DESCRIPTION
Here is record is something like this
```py
(Pdb) 0.3/0.1
2.9999999999999996
```
after taking quotient becoming 2
```py
0.3
```
and after taking quotent it 3
```py
AssertionError: Lists differ: [[142[468 chars]63, '2'], [14264, '0.3'], [14265, '-37'], [142[12784 chars]-5']] != [[142[468 chars]63, '3'], [14264, '0.3'], [14265, '-37'], [142[12784 chars]-5']]

First differing element 27:
[14263, '2']
[14263, '3']
```
For resolving this Idea is to backport this fix

https://github.com/odoo/odoo/pull/182265

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
