### PR TITLE
[FIX] discuss: use the guest's name in the welcome page

### DIFF
--- a/addons/mail/controllers/discuss/public_page.py
+++ b/addons/mail/controllers/discuss/public_page.py
@@ -98,6 +98,8 @@ class PublicPageController(http.Controller):
                 country_code=request.geoip.country_code,
                 timezone=request.env["mail.guest"]._get_timezone_from_request(request),
             )
+        if guest:
+            discuss_public_view_data["guest_name"] = guest.name
         if guest and not guest_already_known:
             discuss_public_view_data.update(
                 {
@@ -109,6 +111,9 @@ class PublicPageController(http.Controller):
 
     def _response_discuss_public_template(self, channel, discuss_public_view_data=None):
         discuss_public_view_data = discuss_public_view_data or {}
+        if "guest_name" not in discuss_public_view_data:
+            guest = request.env["mail.guest"]._get_guest_from_context()
+            discuss_public_view_data["guest_name"] = guest.name
         return request.render(
             "mail.discuss_public_channel_template",
             {

--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -3954,8 +3954,10 @@ msgid "Groups"
 msgstr ""
 
 #. module: mail
+#. odoo-javascript
 #. odoo-python
 #: code:addons/mail/controllers/discuss/public_page.py:0
+#: code:addons/mail/static/src/discuss/core/public/welcome_page.js:0
 #: model:ir.model,name:mail.model_mail_guest
 #: model:ir.model.fields,field_description:mail.field_bus_presence__guest_id
 #: model:ir.model.fields,field_description:mail.field_discuss_channel_member__guest_id

--- a/addons/mail/static/src/discuss/core/public/welcome_page.js
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.js
@@ -17,7 +17,7 @@ export class WelcomePage extends Component {
         this.rpc = useService("rpc");
         this.personaService = useService("mail.persona");
         this.state = useState({
-            userName: "Guest",
+            userName: this.props.data?.discussPublicViewData?.guest_name || _t("Guest"),
             audioStream: null,
             videoStream: null,
         });


### PR DESCRIPTION
Before this commit, the welcome page was using "Guest" as the default name, regardless of what the name was.
