### PR TITLE
[FIX] point_of_sale, pos_restaurant: lines always set as dirty

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -148,8 +148,7 @@ export class PosOrder extends Base {
         this.amount_total = this.get_total_with_tax();
         this.amount_return = this.get_change();
         this.lines.forEach((line) => {
-            line.price_subtotal = line.get_price_without_tax();
-            line.price_subtotal_incl = line.get_price_with_tax();
+            line.setLinePrice();
         });
     }
 

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -189,7 +189,18 @@ export class PosOrderline extends Base {
 
         const disc = Math.min(Math.max(parsed_discount || 0, 0), 100);
         this.discount = disc;
+        this.order_id.recomputeOrderData();
         this.setDirty();
+    }
+
+    setLinePrice() {
+        const prices = this.get_all_prices();
+        if (this.price_subtotal !== prices.priceWithoutTax) {
+            this.price_subtotal = prices.priceWithoutTax;
+        }
+        if (this.price_subtotal_incl !== prices.priceWithTax) {
+            this.price_subtotal_incl = prices.priceWithTax;
+        }
     }
 
     // sets the qty of the product. The qty will be rounded according to the


### PR DESCRIPTION
Before this commit, lines was always set as dirty when synchronizing orders. This was due to the fact that the line was marked as dirty in the synchronization process, even if the line was not modified.

This commit fixes this issue by only marking the line as dirty if it has been modified.

taskId: 4314110
