### PR TITLE
[FIX] point_of_sale: manage timezones for invoice requests

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -111,8 +111,8 @@ class PosController(PortalAccount):
                 date_order = datetime(*[int(i) for i in form_values['date_order'].split('-')])
                 order = request.env['pos.order'].sudo().search([
                     ('pos_reference', '=like', '%' + form_values['pos_reference'].replace('%', r'\%').replace('_', r'\_')),
-                    ('date_order', '>=', date_order),
-                    ('date_order', '<', date_order + timedelta(days=1)),
+                    ('date_order', '>=', date_order - timedelta(days=1)),
+                    ('date_order', '<', date_order + timedelta(days=2)),
                     ('ticket_code', '=', form_values['ticket_code']),
                 ], limit=1)
                 if order:


### PR DESCRIPTION
Steps to reproduce:
[point_of_sale]
- activate "Generate a code on ticket" option in PoS settings.
- have a PoS session in GMT-6 and create an order after 6pm local time.
- go to /pos/ticket, enter the order information and the date that appears on the ticket
- ** No sale order found **

Cause
The `date_order` of the sale order is stored in UTC while the date displayed on the ticket is in local time.

Change
This commit makes the search domain bigger to account for orders made in different timezones.

opw-4311152
