### PR TITLE
[FIX] web: fix darkmode switch display

### DIFF
--- a/addons/web/static/src/webclient/burger_menu/burger_user_menu/burger_user_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/burger_user_menu/burger_user_menu.xml
@@ -9,7 +9,7 @@
               <CheckBox
                   t-if="element.type == 'switch'"
                   value="element.isChecked"
-                  className="'dropdown-item form-switch d-flex flex-row-reverse justify-content-between py-3 fs-4'"
+                  className="'dropdown-item form-switch d-flex flex-row-reverse justify-content-between py-3 fs-4 w-100'"
                   onChange="element.callback"
               >
                   <t t-out="element.description"/>

--- a/addons/web/static/src/webclient/user_menu/user_menu.xml
+++ b/addons/web/static/src/webclient/user_menu/user_menu.xml
@@ -18,7 +18,7 @@
                         <CheckBox
                             t-if="element.type == 'switch'"
                             value="element.isChecked"
-                            className="'form-switch d-flex flex-row-reverse justify-content-between p-0'"
+                            className="'form-switch d-flex flex-row-reverse justify-content-between p-0 w-100'"
                             onChange="element.callback"
                         >
                             <t t-out="element.description"/>


### PR DESCRIPTION
This commit resolves the overlap issue between the Dark Mode checkbox and its label in the User Menu on all screens.

Back-port of https://github.com/odoo/odoo/pull/132274, https://github.com/odoo/odoo/pull/132970

Before PR:

![2024-11-08_15-21](https://github.com/user-attachments/assets/9679d12e-4684-4641-a983-2ae10a37bb61)

After PR:

![image](https://github.com/user-attachments/assets/d1779346-3d67-4637-b270-d032fa48e7bb)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
