### PR TITLE
[FIX] pos_loyalty: take into account discount proportions

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -1278,7 +1278,8 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                             lineReward.all_discount_product_ids.has(product) &&
                             applicableProducts.has(product)
                         ) &&
-                        lineReward.reward_type === 'discount'
+                        lineReward.reward_type === 'discount' &&
+                        lineReward.discount_mode != 'percent'
                     )
                 ) {
                     linesToDiscount.push(line);
@@ -1306,24 +1307,19 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
             if (!discountedLines.length) {
                 continue;
             }
-            const commonLines = linesToDiscount.filter((line) => discountedLines.includes(line));
-            const nonCommonLines = discountedLines.filter((line) => !linesToDiscount.includes(line));
-            const discountedAmounts = lines.reduce((map, line) => {
-                map[line.get_taxes().map((t) => t.id)];
-                return map;
-            }, {});
-            const process = (line) => {
-                const key = line.get_taxes().map((t) => t.id);
-                if (!discountedAmounts[key] || line.reward_id) {
-                    return;
+            if (lineReward.discount_mode === 'percent') {
+                const discount = lineReward.discount / 100;
+                for (const line of discountedLines) {
+                    if (line.reward_id) {
+                        continue;
+                    }
+                    if (lineReward.discount_applicability === 'cheapest') {
+                        remainingAmountPerLine[line.cid] *= (1 - (discount / line.get_quantity()))
+                    } else {
+                        remainingAmountPerLine[line.cid] *= (1 - discount);
+                    }
                 }
-                const remaining = remainingAmountPerLine[line.cid];
-                const consumed = Math.min(remaining, discountedAmounts[key]);
-                discountedAmounts[key] -= consumed;
-                remainingAmountPerLine[line.cid] -= consumed;
-            }
-            nonCommonLines.forEach(process);
-            commonLines.forEach(process);
+            } 
         }
 
         let discountable = 0;

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
@@ -420,3 +420,17 @@ ProductScreen.check.selectedOrderlineHas('Test Product A', '1.00', '100.00');
 PosLoyalty.exec.finalizeOrder("Cash");
 
 Tour.register('PosLoyaltyArchivedRewardProductsActive', {test: true, url: '/pos/web'}, getSteps());
+
+startSteps();
+
+ProductScreen.do.confirmOpeningPopup();
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer("partner_a");
+
+ProductScreen.exec.addOrderline("Test Product A", "5"),
+ProductScreen.do.clickDisplayedProduct('Test Product B');
+PosLoyalty.check.hasRewardLine('10% on your order', '-3.00');
+PosLoyalty.check.hasRewardLine('10% on Test Product B', '-0.45');
+PosLoyalty.exec.finalizeOrder("Cash");
+
+Tour.register('PosLoyalty2DiscountsSpecificGlobal', {test: true, url: '/pos/web'}, getSteps());

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -946,6 +946,81 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour('/pos/web?config_id=%d' % self.main_pos_config.id, 'PosLoyaltySpecificDiscountWithFreeProductTour', login='accountman')
+
+    def test_2_discounts_specific_global(self):
+        LoyaltyProgram = self.env['loyalty.program']
+        (LoyaltyProgram.search([])).write({'pos_ok': False})
+
+        product_category = self.env['product.category'].create({
+            'name': 'Discount category',
+        })
+
+        self.product_a = self.env['product.product'].create({
+            'name': 'Test Product A',
+            'type': 'product',
+            'list_price': 5,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+        self.product_b = self.env['product.product'].create({
+            'name': 'Test Product B',
+            'type': 'product',
+            'list_price': 5,
+            'available_in_pos': True,
+            'taxes_id': False,
+            'categ_id': product_category.id,
+        })
+
+        self.env['loyalty.program'].create({
+            'name': 'Discount 10%',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [(0, 0, {
+                'reward_point_mode': 'order',
+                'reward_point_amount': 1,
+                'minimum_amount': 1,
+                'minimum_qty': 5,
+            })],
+            'reward_ids': [(0, 0, {
+                'reward_type': 'discount',
+                'required_points': 1,
+                'discount': 10,
+                'discount_mode': 'percent',
+                'discount_applicability': 'order',
+            })],
+            'pos_config_ids': [Command.link(self.main_pos_config.id)],
+        })
+
+        self.env['loyalty.program'].create({
+            'name': 'Discount on category',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [(0, 0, {
+                'reward_point_mode': 'order',
+                'reward_point_amount': 1,
+                'minimum_amount': 1,
+                'minimum_qty': 1,
+            })],
+            'reward_ids': [(0, 0, {
+                'reward_type': 'discount',
+                'required_points': 1,
+                'discount': 10,
+                'discount_mode': 'percent',
+                'discount_applicability': 'specific',
+                'discount_product_category_id': product_category.id,
+            })],
+            'pos_config_ids': [Command.link(self.main_pos_config.id)],
+        })
+
+        self.main_pos_config.open_ui()
+        self.start_tour(
+            '/pos/web?config_id=%d' % self.main_pos_config.id,
+            'PosLoyalty2DiscountsSpecificGlobal',
+            login='accountman',
+        )
+
     def test_point_per_money_spent(self):
         """Test the point per $ spent feature"""
         LoyaltyProgram = self.env['loyalty.program']


### PR DESCRIPTION
Currently when multiple discounts are applied with loyalty rewards, the proportion applied to each line is not computed and lead to incoherant values for the next discount applied.

Steps to reproduce:
-------------------
* Create a promotion program rewarding 20% on the order for a minimum of 5 products
* Create a promotion program rewarding 20% on a product category C1 for a minimum of 1 product
* Create 2 products of 1$, one of them with the catgory C1
* Open shop session
* Add 5 products (not C1)
* Add 1 product (with C1)
> Observation: -1.2$ in discount for the 6 products and +0.08$ for the
products in category C1

Why the fix:
------------
After this fix https://github.com/odoo/odoo/commit/85047eca7c0f28e3b174ba166c0d7a1d9965b6b8 all discounts were taken into account when added to `linesToDiscount`.

Since it was now counted we had remove this part to not count the discount twice:
```python
if (lineReward.discount_mode === 'percent') {
    const discount = lineReward.discount / 100;
    for (const line of discountedLines) {
        if (line.reward_id) {
            continue;
        }
        if (lineReward.discount_applicability === 'cheapest') {
            remainingAmountPerLine[line.cid] *= (1 - (discount / line.get_quantity()))
        } else {
            remainingAmountPerLine[line.cid] *= (1 - discount);
        }
    }
}
```

However when they were added to `linesToDiscount` the whole discount was taken into account, and not just the portion that applies on the order line.

We revert part of the previous fix but we modify the added part to only apply on rewards that have fixed amounts.

opw-4284817