### PR TITLE
[IMP] website, *: remove company-specific social media

### DIFF
--- a/addons/mass_mailing/models/res_company.py
+++ b/addons/mass_mailing/models/res_company.py
@@ -10,9 +10,9 @@ class ResCompany(models.Model):
     def _get_social_media_links(self):
         self.ensure_one()
         return {
-            'social_facebook': self.social_facebook,
-            'social_linkedin': self.social_linkedin,
-            'social_twitter': self.social_twitter,
-            'social_instagram': self.social_instagram,
-            'social_tiktok': self.social_tiktok,
+            'social_facebook': "https://www.facebook.com/Odoo",
+            'social_linkedin': "https://www.linkedin.com/company/odoo",
+            'social_twitter': "https://twitter.com/Odoo",
+            'social_instagram': "https://www.instagram.com/explore/tags/odoo/",
+            'social_tiktok': "https://www.tiktok.com/@odoo_official",
         }

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2546,6 +2546,7 @@ const ListUserValueWidget = UserValueWidget.extend({
      * @param {Event} ev
      */
     _onRemoveItemClick(ev) {
+        // For social media list, we allow to remove all elements.
         const minElements = this.el.dataset.allowEmpty ? 0 : 1;
         if (ev.target.closest('table').querySelectorAll('tr').length > minElements) {
             ev.target.closest('tr').remove();

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -413,7 +413,7 @@
     <!-- TODO probably review this system once the new editor is merged to not duplicate the selector, etc -->
     <div data-js="ReplaceMedia"
          data-selector="img, .media_iframe_video, span.fa, i.fa"
-         data-exclude="[data-oe-xpath], a[href^='/website/social/'] > i.fa, a[class*='s_share_'] > i.fa">
+         data-exclude="[data-oe-xpath], a[class^='s_social_media_'], a[class*='s_share_'] > i.fa">
         <we-row string="Media">
             <we-button class="o_we_bg_success" data-replace-media="true" data-no-preview="true">Replace</we-button>
             <div>

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -350,13 +350,6 @@ class Website(Home):
             action_url += '&step=' + str(step)
         return request.redirect(action_url)
 
-    @http.route(['/website/social/<string:social>'], type='http', auth="public", website=True, sitemap=False)
-    def social(self, social, **kwargs):
-        url = getattr(request.website, 'social_%s' % social, False)
-        if not url:
-            raise werkzeug.exceptions.NotFound()
-        return request.redirect(url, local=False)
-
     @http.route('/website/get_suggested_links', type='jsonrpc', auth="user", website=True, readonly=True)
     def get_suggested_link(self, needle, limit=10):
         current_website = request.website

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -132,39 +132,11 @@ class Website(models.Model):
         'List of blocked 3rd-party domains',
         compute='_compute_blocked_third_party_domains')
 
-    def _default_social_facebook(self):
-        return self.env.ref('base.main_company').social_facebook
-
-    def _default_social_github(self):
-        return self.env.ref('base.main_company').social_github
-
-    def _default_social_linkedin(self):
-        return self.env.ref('base.main_company').social_linkedin
-
-    def _default_social_youtube(self):
-        return self.env.ref('base.main_company').social_youtube
-
-    def _default_social_instagram(self):
-        return self.env.ref('base.main_company').social_instagram
-
-    def _default_social_twitter(self):
-        return self.env.ref('base.main_company').social_twitter
-
-    def _default_social_tiktok(self):
-        return self.env.ref('base.main_company').social_tiktok
-
     def _default_logo(self):
         with tools.file_open('website/static/src/img/website_logo.svg', 'rb') as f:
             return base64.b64encode(f.read())
 
     logo = fields.Binary('Website Logo', default=_default_logo, help="Display this logo on the website.")
-    social_twitter = fields.Char('X Account', default=_default_social_twitter)
-    social_facebook = fields.Char('Facebook Account', default=_default_social_facebook)
-    social_github = fields.Char('GitHub Account', default=_default_social_github)
-    social_linkedin = fields.Char('LinkedIn Account', default=_default_social_linkedin)
-    social_youtube = fields.Char('Youtube Account', default=_default_social_youtube)
-    social_instagram = fields.Char('Instagram Account', default=_default_social_instagram)
-    social_tiktok = fields.Char('TikTok Account', default=_default_social_tiktok)
     social_default_image = fields.Binary(string="Default Social Share Image", help="If set, replaces the website logo as the default social share image.")
     has_social_default_image = fields.Boolean(compute='_compute_has_social_default_image', store=True)
 

--- a/addons/website/static/src/snippets/s_facebook_page/options.js
+++ b/addons/website/static/src/snippets/s_facebook_page/options.js
@@ -18,7 +18,7 @@ options.registry.facebookPage = options.Class.extend({
         var defs = [this._super.apply(this, arguments)];
 
         var defaults = {
-            href: '',
+            href: "https://www.facebook.com/Odoo",
             id: '',
             height: 215,
             width: 350,
@@ -27,17 +27,6 @@ options.registry.facebookPage = options.Class.extend({
             hide_cover: "true",
         };
         this.fbData = Object.assign({}, defaults, pick(this.$target[0].dataset, ...Object.keys(defaults)));
-        if (!this.fbData.href) {
-            // Fetches the default url for facebook page from website config
-            var self = this;
-            defs.push(this.orm.searchRead("website", [], ["social_facebook"], {
-                limit: 1,
-            }).then(function (res) {
-                if (res) {
-                    self.fbData.href = res[0].social_facebook || '';
-                }
-            }));
-        }
 
         return Promise.all(defs).then(() => this._markFbElement()).then(() => this._refreshPublicWidgets());
     },

--- a/addons/website/static/src/snippets/s_instagram_page/options.js
+++ b/addons/website/static/src/snippets/s_instagram_page/options.js
@@ -28,8 +28,7 @@ options.registry.InstagramPage = options.Class.extend({
                     websiteId = ctx["website_id"];
                 },
             });
-            const values = await this.orm.read("website", [websiteId], ["social_instagram"]);
-            socialInstagram = values[0]["social_instagram"];
+            socialInstagram = "https://www.instagram.com/explore/tags/odoo/";
         }
         if (socialInstagram) {
             const pageName = this._getInstagramPageNameFromUrl(socialInstagram);

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -90,16 +90,11 @@ registerWebsitePreviewTour('snippet_social_media', {
     ...clickOnSnippet({id: 's_social_media', name: 'Social Media'}),
     ...addNewSocialNetwork(7, 7, 'https://www.youtu.be/y7TlnAv6cto'),
     {
-        content: 'Click on the toggle to hide Facebook',
-        trigger: 'we-list table we-button.o_we_user_value_widget',
-        run: 'click',
+        content: "Ensure facebook is first",
+        trigger: ':iframe .s_social_media:has(a:eq(0)[href="https://www.facebook.com/Odoo"])',
     },
     {
-        content: "Ensure twitter became first",
-        trigger: ':iframe .s_social_media:has(a:eq(0)[href="/website/social/twitter"])',
-    },
-    {
-        content: 'Drag the facebook link at the end of the list',
+        content: 'Drag the facebook link to the end of the list',
         trigger: 'we-list table we-button.o_we_drag_handle',
         tooltipPosition: 'bottom',
         run: "drag_and_drop we-list table tr:last-child",
@@ -110,21 +105,22 @@ registerWebsitePreviewTour('snippet_social_media', {
     },
     ...preventRaceConditionStep,
     // Create a Link for which we don't have an icon to propose.
-    ...addNewSocialNetwork(8, 7, 'https://whatever.it/1EdSw9X'),
+    ...addNewSocialNetwork(8, 8, 'https://whatever.it/1EdSw9X'),
     // Create a custom instagram link.
-    ...addNewSocialNetwork(9, 8, 'https://instagr.am/odoo.official/'),
+    ...addNewSocialNetwork(9, 9, 'https://instagr.am/odoo.official/'),
     {
         content: "Check if the result is correct before removing",
         trigger: ":iframe .s_social_media" +
-                 ":has(a:eq(0)[href='/website/social/twitter'])" +
-                 ":has(a:eq(1)[href='/website/social/linkedin'])" +
-                 ":has(a:eq(2)[href='/website/social/youtube'])" +
-                 ":has(a:eq(3)[href='/website/social/instagram'])" +
-                 ":has(a:eq(4)[href='/website/social/github'])" +
-                 ":has(a:eq(5)[href='/website/social/tiktok'])" +
-                 ":has(a:eq(6)[href='https://www.youtu.be/y7TlnAv6cto']:has(i.fa-youtube))" +
-                 ":has(a:eq(7)[href='https://whatever.it/1EdSw9X']:has(i.fa-pencil))" +
-                 ":has(a:eq(8)[href='https://instagr.am/odoo.official/']:has(i.fa-instagram))",
+                 ":has(a:eq(0)[href='https://twitter.com/Odoo'])" +
+                 ":has(a:eq(1)[href='https://www.linkedin.com/company/odoo'])" +
+                 ":has(a:eq(2)[href='https://www.youtube.com/user/OpenERPonline'])" +
+                 ":has(a:eq(3)[href='https://www.instagram.com/explore/tags/odoo/'])" +
+                 ":has(a:eq(4)[href='https://github.com/odoo'])" +
+                 ":has(a:eq(5)[href='https://www.tiktok.com/@odoo'])" +
+                 ":has(a:eq(6)[href='https://www.youtu.be/y7TlnAv6cto']:has(i.fa-youtube-play))" +
+                ":has(a:eq(7)[href='https://www.facebook.com/Odoo'])" +
+                 ":has(a:eq(8)[href='https://whatever.it/1EdSw9X']:has(i.fa-pencil))" +
+                 ":has(a:eq(9)[href='https://instagr.am/odoo.official/']:has(i.fa-instagram))",
     },
     // Create a custom link, not officially supported, ensure icon is found.
     {
@@ -145,23 +141,18 @@ registerWebsitePreviewTour('snippet_social_media', {
     },
     {
         content: "Ensure custom link was removed",
-        trigger: ':iframe .s_social_media:has(a:eq(6)[href="https://whatever.it/1EdSw9X"]:has(i.fa-pencil))',
-    },
-    {
-        content: 'Click on the toggle to show Facebook',
-        trigger: 'we-list table we-button.o_we_user_value_widget:not(.active)',
-        run: 'click',
+        trigger: ':iframe .s_social_media:has(a:eq(7)[href="https://whatever.it/1EdSw9X"]:has(i.fa-pencil))',
     },
     {
         content: "Check if the result is correct after removing",
         trigger: ":iframe .s_social_media" +
-                 ":has(a:eq(0)[href='/website/social/twitter'])" +
-                 ":has(a:eq(1)[href='/website/social/linkedin'])" +
-                 ":has(a:eq(2)[href='/website/social/youtube'])" +
-                 ":has(a:eq(3)[href='/website/social/instagram'])" +
-                 ":has(a:eq(4)[href='/website/social/github'])" +
-                 ":has(a:eq(5)[href='/website/social/tiktok'])" +
-                 ":has(a:eq(6)[href='/website/social/facebook'])" +
+                 ":has(a:eq(0)[href='https://www.linkedin.com/company/odoo'])" +
+                 ":has(a:eq(1)[href='https://www.youtube.com/user/OpenERPonline'])" +
+                 ":has(a:eq(2)[href='https://www.instagram.com/explore/tags/odoo/'])" +
+                 ":has(a:eq(3)[href='https://github.com/odoo'])" +
+                 ":has(a:eq(4)[href='https://www.tiktok.com/@odoo'])" +
+                 ":has(a:eq(5)[href='https://www.paypal.com/abc']:has(i.fa-paypal))" +
+                 ":has(a:eq(6)[href='https://www.facebook.com/Odoo'])" +
                  ":has(a:eq(7)[href='https://whatever.it/1EdSw9X']:has(i.fa-pencil))" +
                  ":has(a:eq(8)[href='https://instagr.am/odoo.official/']:has(i.fa-instagram))",
     },
@@ -190,13 +181,13 @@ registerWebsitePreviewTour('snippet_social_media', {
     {
         content: "Check if the result is correct after setting the icon",
         trigger: ":iframe .s_social_media" +
-                 ":has(a:eq(0)[href='/website/social/twitter'])" +
-                 ":has(a:eq(1)[href='/website/social/linkedin'])" +
-                 ":has(a:eq(2)[href='/website/social/youtube'])" +
-                 ":has(a:eq(3)[href='/website/social/instagram'])" +
-                 ":has(a:eq(4)[href='/website/social/github'])" +
-                 ":has(a:eq(5)[href='/website/social/tiktok'])" +
-                 ":has(a:eq(6)[href='/website/social/facebook'])" +
+                 ":has(a:eq(0)[href='https://www.linkedin.com/company/odoo'])" +
+                 ":has(a:eq(1)[href='https://www.youtube.com/user/OpenERPonline'])" +
+                 ":has(a:eq(2)[href='https://www.instagram.com/explore/tags/odoo/'])" +
+                 ":has(a:eq(3)[href='https://instagram.com/odoo.official/])" +
+                 ":has(a:eq(4)[href='https://www.tiktok.com/@odoo'])" +
+                 ":has(a:eq(5)[href='https://www.paypal.com/abc']:has(i.fa-paypal))" +
+                 ":has(a:eq(6)[href='https://www.facebook.com/Odoo'])" +
                  ":has(a:eq(7)[href='https://whatever.it/1EdSw9X']:has(i.fa-heart))" +
                  ":has(a:eq(8)[href='https://instagr.am/odoo.official/']:has(i.fa-instagram))",
     },
@@ -204,14 +195,35 @@ registerWebsitePreviewTour('snippet_social_media', {
     // the link (`replaceIcon` parameter set to `true`).
     ...addNewSocialNetwork(9, 9, "https://google.com", true),
     // Create a social network after replacing the first icon by an image.
-    ...replaceIconByImage("/website/social/twitter"),
+    ...replaceIconByImage("https://instagram.com/odoo.official/"),
     ...addNewSocialNetwork(10, 10, "https://facebook.com"),
     {
         content: "Check if the result is correct after adding images",
         trigger: ":iframe .s_social_media" +
-                 ":has(a:eq(0)[href='/website/social/twitter']:has(img))" +
+                 ":has(a:eq(3)[href='https://instagram.com/odoo.official/']:has(img))" +
                  ":has(a:eq(9)[href='https://google.com']:has(img))" +
-                 ":has(a:eq(10)[href='https://facebook.com']:has(img))",
+                 ":has(a:eq(10)[href='https://facebook.com'])",
+    },
+    // Additional test steps to check URL change and icon update
+    {
+        content: "Change Twitter URL to a different one",
+        trigger: "we-list table input:eq(0)",
+        run: "edit https://www.linkedin.com/company/odoo && click body",
+    },
+    {
+        content: "Ensure LinkedIn icon is found",
+        trigger: ":iframe .s_social_media" +
+                 ":has(a:eq(0)[href='https://www.linkedin.com/company/odoo']:has(i.fa-linkedin))",
+    },
+    {
+        content: "Change LinkedIn URL to a different one",
+        trigger: "we-list table input:eq(1)",
+        run: "edit https://www.instagram.com/explore/tags/odoo/ && click body",
+    },
+    {
+        content: "Ensure Instagram icon is found",
+        trigger: ":iframe .s_social_media" +
+                 ":has(a:eq(1)[href='https://www.instagram.com/explore/tags/odoo/']:has(i.fa-instagram))",
     },
     ...clickOnSave(),
 ]);

--- a/addons/website/tests/test_crawl.py
+++ b/addons/website/tests/test_crawl.py
@@ -25,16 +25,6 @@ class Crawler(HttpCaseWithUserDemo):
 
     def setUp(self):
         super(Crawler, self).setUp()
-        self.env.ref('website.default_website').write({
-            'social_facebook': "https://www.facebook.com/Odoo",
-            'social_twitter': 'https://twitter.com/Odoo',
-            'social_linkedin': 'https://www.linkedin.com/company/odoo',
-            'social_youtube': 'https://www.youtube.com/user/OpenERPonline',
-            'social_github': 'https://github.com/odoo',
-            'social_instagram': 'https://www.instagram.com/explore/tags/odoo/',
-            'social_tiktok': 'https://www.tiktok.com/@odoo',
-        })
-
         if hasattr(self.env['res.partner'], 'grade_id'):
             # Create at least one published parter, so that /partners doesn't
             # return a 404

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -56,22 +56,15 @@ class TestSnippets(HttpCase):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_countdown', login='admin')
 
     def test_05_social_media(self):
-        self.env.ref('website.default_website').write({
-            'social_facebook': "https://www.facebook.com/Odoo",
-            'social_twitter': 'https://twitter.com/Odoo',
-            'social_linkedin': 'https://www.linkedin.com/company/odoo',
-            'social_youtube': 'https://www.youtube.com/user/OpenERPonline',
-            'social_github': 'https://github.com/odoo',
-            'social_instagram': 'https://www.instagram.com/explore/tags/odoo/',
-            'social_tiktok': 'https://www.tiktok.com/@odoo',
-        })
         create_image_attachment(self.env, '/web/image/website.s_banner_default_image', 's_banner_default_image.jpg')
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_social_media', login="admin")
-        self.assertEqual(
-            self.env['website'].browse(1).social_instagram,
-            'https://instagram.com/odoo.official/',
-            'Social media should have been updated'
-        )
+
+        # Retrieve the social media snippet architecture
+        social_media_snippet = self.env['ir.ui.view'].search([('key', '=', 'website.s_social_media')], limit=1)
+        social_media_snippet_arch = social_media_snippet.arch
+
+        # Assert that the Instagram URL is present in the snippet architecture
+        self.assertIn('https://www.instagram.com/explore/tags/odoo/', social_media_snippet_arch)
 
     def test_06_snippet_popup_add_remove(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_add_remove', login='admin')

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -496,15 +496,6 @@ class TestUi(HttpCaseWithWebsiteUser):
         })
 
     def test_26_website_media_dialog_icons(self):
-        self.env.ref('website.default_website').write({
-            'social_twitter': 'https://twitter.com/Odoo',
-            'social_facebook': 'https://www.facebook.com/Odoo',
-            'social_linkedin': 'https://www.linkedin.com/company/odoo',
-            'social_youtube': 'https://www.youtube.com/user/OpenERPonline',
-            'social_github': 'https://github.com/odoo',
-            'social_instagram': 'https://www.instagram.com/explore/tags/odoo/',
-            'social_tiktok': 'https://www.tiktok.com/@odoo',
-        })
         self.start_tour("/", 'website_media_dialog_icons', login='admin')
 
     def test_27_website_clicks(self):

--- a/addons/website/views/snippets/s_company_team_detail.xml
+++ b/addons/website/views/snippets/s_company_team_detail.xml
@@ -16,15 +16,15 @@
                     <h4 class="h5-fs"><br/>James Mitchell</h4>
                     <p class="text-muted">Chief Technical Officer</p>
                     <p>James leads the tech strategy and innovation efforts at the company.</p>
-                    <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media">
+                    <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media"  data-vxml="001">
                         <h5 class="s_social_media_title d-none">Social Media</h5>
-                        <a href="/website/social/github" class="s_social_media_github" target="_blank" aria-label="GitHub">
+                        <a href="https://github.com/odoo" class="s_social_media_github" target="_blank" aria-label="GitHub">
                             <i class="fa fa-github o_editable_media fa-stack"/>
                         </a>
-                        <a href="/website/social/linkedin" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
+                        <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
                             <i class="fa fa-linkedin o_editable_media fa-stack"/>
                         </a>
-                        <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
+                        <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
                             <i class="fa fa-instagram o_editable_media fa-stack"/>
                         </a>
                     </div>
@@ -36,15 +36,15 @@
                     <h4 class="h5-fs"><br/>Sophia Benett</h4>
                     <p class="text-muted">Financial Analyst</p>
                     <p>Sophia evaluates financial data and provides strategic insights.</p>
-                    <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media">
+                    <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media"  data-vxml="001">
                         <h5 class="s_social_media_title d-none">Social Media</h5>
-                        <a href="/website/social/github" class="s_social_media_github" target="_blank" aria-label="GitHub">
+                        <a href="https://github.com/odoo" class="s_social_media_github" target="_blank" aria-label="GitHub">
                             <i class="fa fa-github o_editable_media fa-stack"/>
                         </a>
-                        <a href="/website/social/linkedin" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
+                        <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
                             <i class="fa fa-linkedin o_editable_media fa-stack"/>
                         </a>
-                        <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
+                        <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
                             <i class="fa fa-instagram o_editable_media fa-stack"/>
                         </a>
                     </div>
@@ -56,15 +56,15 @@
                     <h4 class="h5-fs"><br/>Olivia Reed</h4>
                     <p class="text-muted">Product Manager</p>
                     <p>Olivia oversees product development from concept to launch.</p>
-                    <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media">
+                    <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media"  data-vxml="001">
                         <h5 class="s_social_media_title d-none">Social Media</h5>
-                        <a href="/website/social/github" class="s_social_media_github" target="_blank" aria-label="GitHub">
+                        <a href="https://github.com/odoo" class="s_social_media_github" target="_blank" aria-label="GitHub">
                             <i class="fa fa-github o_editable_media fa-stack"/>
                         </a>
-                        <a href="/website/social/linkedin" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
+                        <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
                             <i class="fa fa-linkedin o_editable_media fa-stack"/>
                         </a>
-                        <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
+                        <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
                             <i class="fa fa-instagram o_editable_media fa-stack"/>
                         </a>
                     </div>
@@ -76,15 +76,15 @@
                     <h4 class="h5-fs"><br/>Emily Carter</h4>
                     <p class="text-muted">Human Resources Manager</p>
                     <p>Emily manages talent acquisition and workplace culture.</p>
-                    <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media">
+                    <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media"  data-vxml="001">
                         <h5 class="s_social_media_title d-none">Social Media</h5>
-                        <a href="/website/social/github" class="s_social_media_github" target="_blank" aria-label="GitHub">
+                        <a href="https://github.com/odoo" class="s_social_media_github" target="_blank" aria-label="GitHub">
                             <i class="fa fa-github o_editable_media fa-stack"/>
                         </a>
-                        <a href="/website/social/linkedin" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
+                        <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
                             <i class="fa fa-linkedin o_editable_media fa-stack"/>
                         </a>
-                        <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
+                        <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
                             <i class="fa fa-instagram o_editable_media fa-stack"/>
                         </a>
                     </div>
@@ -96,15 +96,15 @@
                     <h4 class="h5-fs"><br/>Alexander Rivera</h4>
                     <p class="text-muted">Marketing Director</p>
                     <p>Alexander drives our marketing campaigns and brand presence.</p>
-                    <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media">
+                    <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media"  data-vxml="001">
                         <h5 class="s_social_media_title d-none">Social Media</h5>
-                        <a href="/website/social/github" class="s_social_media_github" target="_blank" aria-label="GitHub">
+                        <a href="https://github.com/odoo" class="s_social_media_github" target="_blank" aria-label="GitHub">
                             <i class="fa fa-github o_editable_media fa-stack"/>
                         </a>
-                        <a href="/website/social/linkedin" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
+                        <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
                             <i class="fa fa-linkedin o_editable_media fa-stack"/>
                         </a>
-                        <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
+                        <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
                             <i class="fa fa-instagram o_editable_media fa-stack"/>
                         </a>
                     </div>
@@ -116,15 +116,15 @@
                     <h4 class="h5-fs"><br/>Daniel Foster</h4>
                     <p class="text-muted">Operations Manager</p>
                     <p>Daniel ensures efficient daily operations and process optimization.</p>
-                    <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media">
+                    <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media"  data-vxml="001">
                         <h5 class="s_social_media_title d-none">Social Media</h5>
-                        <a href="/website/social/github" class="s_social_media_github" target="_blank" aria-label="GitHub">
+                        <a href="https://github.com/odoo" class="s_social_media_github" target="_blank" aria-label="GitHub">
                             <i class="fa fa-github o_editable_media fa-stack"/>
                         </a>
-                        <a href="/website/social/linkedin" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
+                        <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
                             <i class="fa fa-linkedin o_editable_media fa-stack"/>
                         </a>
-                        <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
+                        <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
                             <i class="fa fa-instagram o_editable_media fa-stack"/>
                         </a>
                     </div>

--- a/addons/website/views/snippets/s_mega_menu_odoo_menu.xml
+++ b/addons/website/views/snippets/s_mega_menu_odoo_menu.xml
@@ -60,27 +60,27 @@
         <div class="container-fluid border-top s_mega_menu_odoo_menu_footer">
             <div class="row">
                 <div class="s_mega_menu_gray_area col-12 pt8 pb8">
-                    <div class="s_social_media text-center o_not_editable" data-snippet="s_social_media" data-name="Social Media" contenteditable="false">
+                    <div class="s_social_media text-center o_not_editable" data-snippet="s_social_media" data-name="Social Media" contenteditable="false" data-vxml="001">
                         <h5 class="s_social_media_title d-none" contenteditable="true">Follow us</h5>
-                        <a href="/website/social/facebook" class="s_social_media_facebook me-3 ms-3" target="_blank" aria-label="Facebook">
+                        <a href="https://www.facebook.com/Odoo" class="s_social_media_facebook me-3 ms-3" target="_blank" aria-label="Facebook">
                             <i class="fa fa-2x fa-facebook m-1 o_editable_media"/>
                         </a>
-                        <a href="/website/social/twitter" class="s_social_media_twitter me-3 ms-3" target="_blank" aria-label="X">
+                        <a href="https://twitter.com/Odoo" class="s_social_media_twitter me-3 ms-3" target="_blank" aria-label="X">
                             <i class="fa fa-2x fa-twitter m-1 o_editable_media"/>
                         </a>
-                        <a href="/website/social/linkedin" class="s_social_media_linkedin me-3 ms-3" target="_blank" aria-label="LinkedIn">
+                        <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin me-3 ms-3" target="_blank" aria-label="LinkedIn">
                             <i class="fa fa-2x fa-linkedin m-1 o_editable_media"/>
                         </a>
-                        <a href="/website/social/github" class="s_social_media_github me-3 ms-3" target="_blank" aria-label="GitHub">
+                        <a href="https://github.com/odoo" class="s_social_media_github me-3 ms-3" target="_blank" aria-label="GitHub">
                             <i class="fa fa-2x fa-github m-1 o_editable_media"/>
                         </a>
-                        <a href="/website/social/youtube" class="s_social_media_youtube me-3 ms-3" target="_blank" aria-label="YouTube">
-                            <i class="fa fa-2x fa-youtube m-1 o_editable_media"/>
+                        <a href="https://www.youtube.com/user/OpenERPonline" class="s_social_media_youtube me-3 ms-3" target="_blank" aria-label="YouTube">
+                            <i class="fa fa-2x fa-youtube-play m-1 o_editable_media"/>
                         </a>
-                        <a href="/website/social/instagram" class="s_social_media_instagram me-3 ms-3" target="_blank" aria-label="Instagram">
+                        <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram me-3 ms-3" target="_blank" aria-label="Instagram">
                             <i class="fa fa-2x fa-instagram m-1 o_editable_media"/>
                         </a>
-                        <a href="/website/social/tiktok" class="s_social_media_tiktok me-3 ms-3" target="_blank" aria-label="TikTok">
+                        <a href="https://www.tiktok.com/@odoo" class="s_social_media_tiktok me-3 ms-3" target="_blank" aria-label="TikTok">
                             <i class="fa fa-2x fa-tiktok m-1 o_editable_media"/>
                         </a>
                     </div>

--- a/addons/website/views/snippets/s_references_social.xml
+++ b/addons/website/views/snippets/s_references_social.xml
@@ -13,15 +13,15 @@
                     <img class="img img-fluid mx-auto" src="/web/image/website.s_reference_demo_image_1" alt=""/>
                     <h3 class="h5-fs" style="text-align: center;"><br/>Amsterdam</h3>
                     <p style="text-align: center;">Fruitful collaboration since 2014</p>
-                    <div class="s_social_media o_not_editable text-center no_icon_color" data-snippet="s_social_media" data-name="Social Media">
+                    <div class="s_social_media o_not_editable text-center no_icon_color" data-snippet="s_social_media" data-name="Social Media" data-vxml="001">
                         <h4 class="s_social_media_title d-none">Social Media</h4>
-                        <a href="/website/social/facebook" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
+                        <a href="https://www.facebook.com/Odoo" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
                             <i class="fa fa-facebook rounded shadow-sm o_editable_media"/>
                         </a>
-                        <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
+                        <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
                             <i class="fa fa-instagram rounded shadow-sm o_editable_media"/>
                         </a>
-                        <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank" aria-label="X">
+                        <a href="https://twitter.com/Odoo" class="s_social_media_twitter" target="_blank" aria-label="X">
                             <i class="fa fa-twitter rounded shadow-sm o_editable_media"/>
                         </a>
                     </div>
@@ -30,15 +30,15 @@
                     <img class="img img-fluid mx-auto" src="/web/image/website.s_reference_demo_image_2" alt=""/>
                     <h3 class="h5-fs" style="text-align: center;"><br/>Firenze</h3>
                     <p style="text-align: center;">Flourishing together since 2016</p>
-                    <div class="s_social_media o_not_editable text-center no_icon_color" data-snippet="s_social_media" data-name="Social Media">
+                    <div class="s_social_media o_not_editable text-center no_icon_color" data-snippet="s_social_media" data-name="Social Media" data-vxml="001">
                         <h4 class="s_social_media_title d-none">Social Media</h4>
-                        <a href="/website/social/facebook" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
+                        <a href="https://www.facebook.com/Odoo" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
                             <i class="fa fa-facebook rounded shadow-sm o_editable_media"/>
                         </a>
-                        <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
+                        <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
                             <i class="fa fa-instagram rounded shadow-sm o_editable_media"/>
                         </a>
-                        <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank" aria-label="X">
+                        <a href="https://twitter.com/Odoo" class="s_social_media_twitter" target="_blank" aria-label="X">
                             <i class="fa fa-twitter rounded shadow-sm o_editable_media"/>
                         </a>
                     </div>
@@ -47,15 +47,15 @@
                     <img class="img img-fluid mx-auto" src="/web/image/website.s_reference_demo_image_3" alt=""/>
                     <h3 class="h5-fs" style="text-align: center;"><br/>Nairobi</h3>
                     <p style="text-align: center;">Successful collaboration since 2019</p>
-                    <div class="s_social_media o_not_editable text-center no_icon_color" data-snippet="s_social_media" data-name="Social Media">
+                    <div class="s_social_media o_not_editable text-center no_icon_color" data-snippet="s_social_media" data-name="Social Media" data-vxml="001">
                         <h4 class="s_social_media_title d-none">Social Media</h4>
-                        <a href="/website/social/facebook" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
+                        <a href="https://www.facebook.com/Odoo" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
                             <i class="fa fa-facebook rounded shadow-sm o_editable_media"/>
                         </a>
-                        <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
+                        <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
                             <i class="fa fa-instagram rounded shadow-sm o_editable_media"/>
                         </a>
-                        <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank" aria-label="X">
+                        <a href="https://twitter.com/Odoo" class="s_social_media_twitter" target="_blank" aria-label="X">
                             <i class="fa fa-twitter rounded shadow-sm o_editable_media"/>
                         </a>
                     </div>
@@ -64,15 +64,15 @@
                     <img class="img img-fluid mx-auto" src="/web/image/website.s_reference_demo_image_4" alt=""/>
                     <h3 class="h5-fs" style="text-align: center;"><br/>Madrid</h3>
                     <p style="text-align: center;">Thriving partnership since 2021</p>
-                    <div class="s_social_media o_not_editable text-center no_icon_color" data-snippet="s_social_media" data-name="Social Media">
+                    <div class="s_social_media o_not_editable text-center no_icon_color" data-snippet="s_social_media" data-name="Social Media" data-vxml="001">
                         <h4 class="s_social_media_title d-none">Social Media</h4>
-                        <a href="/website/social/facebook" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
+                        <a href="https://www.facebook.com/Odoo" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
                             <i class="fa fa-facebook rounded shadow-sm o_editable_media"/>
                         </a>
-                        <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
+                        <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
                             <i class="fa fa-instagram rounded shadow-sm o_editable_media"/>
                         </a>
-                        <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank" aria-label="X">
+                        <a href="https://twitter.com/Odoo" class="s_social_media_twitter" target="_blank" aria-label="X">
                             <i class="fa fa-twitter rounded shadow-sm o_editable_media"/>
                         </a>
                     </div>

--- a/addons/website/views/snippets/s_social_media.xml
+++ b/addons/website/views/snippets/s_social_media.xml
@@ -6,27 +6,27 @@ For the moment we hack the contenteditable system so that the social media
 title stay editable after a save (see SOCIAL_MEDIA_TITLE_CONTENTEDITABLE).
 -->
 <template id="s_social_media" name="Social Media">
-    <div class="s_social_media text-start o_not_editable" contenteditable="false">
+    <div class="s_social_media text-start o_not_editable" contenteditable="false" data-vxml="001">
         <h4 class="s_social_media_title d-none" contenteditable="true">Social Media</h4>
-        <a href="/website/social/facebook" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
+        <a href="https://www.facebook.com/Odoo" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
             <i class="fa fa-facebook rounded shadow-sm o_editable_media"/>
         </a>
-        <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank" aria-label="X">
+        <a href="https://twitter.com/Odoo" class="s_social_media_twitter" target="_blank" aria-label="X">
             <i class="fa fa-twitter rounded shadow-sm o_editable_media"/>
         </a>
-        <a href="/website/social/linkedin" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
+        <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
             <i class="fa fa-linkedin rounded shadow-sm o_editable_media"/>
         </a>
-        <a href="/website/social/youtube" class="s_social_media_youtube" target="_blank" aria-label="YouTube">
-            <i class="fa fa-youtube rounded shadow-sm o_editable_media"/>
+        <a href="https://www.youtube.com/user/OpenERPonline" class="s_social_media_youtube" target="_blank" aria-label="YouTube">
+            <i class="fa fa-youtube-play rounded shadow-sm o_editable_media"/>
         </a>
-        <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
+        <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
             <i class="fa fa-instagram rounded shadow-sm o_editable_media"/>
         </a>
-        <a href="/website/social/github" class="s_social_media_github" target="_blank" aria-label="GitHub">
+        <a href="https://github.com/odoo" class="s_social_media_github" target="_blank" aria-label="GitHub">
             <i class="fa fa-github rounded shadow-sm o_editable_media"/>
         </a>
-        <a href="/website/social/tiktok" class="s_social_media_tiktok" target="_blank" aria-label="TikTok">
+        <a href="https://www.tiktok.com/@odoo" class="s_social_media_tiktok" target="_blank" aria-label="TikTok">
             <i class="fa fa-tiktok rounded shadow-sm o_editable_media"/>
         </a>
     </div>
@@ -40,7 +40,7 @@ title stay editable after a save (see SOCIAL_MEDIA_TITLE_CONTENTEDITABLE).
                 data-render-list-items="" data-has-default="multiple" data-name="social_media_list"
                 data-default-value="https://www.example.com" data-id-mode="name"
                 data-new-elements-not-toggleable="true" data-no-preview="true"
-                data-render-on-input-blur="true"/>
+                data-render-on-input-blur="true" data-allow-empty="true"/>
         </div>
     </xpath>
 </template>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1736,17 +1736,17 @@
                             </ul>
                             <div class="s_social_media text-start o_not_editable" data-snippet="s_social_media" data-name="Social Media" contenteditable="false">
                                 <h5 class="s_social_media_title d-none" contenteditable="true">Follow us</h5>
-                                <a href="/website/social/facebook" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
+                                <a href="https://www.facebook.com/Odoo" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
                                     <i class="fa fa-facebook rounded-circle shadow-sm o_editable_media"/>
                                 </a>
-                                <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank" aria-label="X">
+                                <a href="https://twitter.com/Odoo" class="s_social_media_twitter" target="_blank" aria-label="X">
                                     <i class="fa fa-twitter rounded-circle shadow-sm o_editable_media"/>
                                 </a>
-                                <a href="/website/social/linkedin" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
+                                <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
                                     <i class="fa fa-linkedin rounded-circle shadow-sm o_editable_media"/>
                                 </a>
-                                <a href="/" class="text-800" aria-label="Extra page">
-                                    <i class="fa fa-home rounded-circle shadow-sm o_editable_media"/>
+                                <a href="/" class="" aria-label="Extra page">
+                                    <i class="fa fa-pencil rounded-circle shadow-sm o_editable_media"/>
                                 </a>
                             </div>
                         </div>
@@ -1781,16 +1781,16 @@
                             </ul>
                             <div class="s_social_media text-start no_icon_color o_not_editable" data-snippet="s_social_media" data-name="Social Media" contenteditable="false">
                                 <h5 class="s_social_media_title d-none" contenteditable="true">Follow us</h5>
-                                <a href="/website/social/github" class="s_social_media_github" target="_blank">
+                                <a href="https://github.com/odoo" class="s_social_media_github" target="_blank">
                                     <i class="fa fa-2x fa-github m-1 o_editable_media"/>
                                 </a>
-                                <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank">
+                                <a href="https://twitter.com/Odoo" class="s_social_media_twitter" target="_blank">
                                     <i class="fa fa-2x fa-twitter m-1 o_editable_media"/>
                                 </a>
-                                <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank">
+                                <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank">
                                     <i class="fa fa-2x fa-instagram m-1 o_editable_media"/>
                                 </a>
-                                <a href="/website/social/linkedin" class="s_social_media_linkedin" target="_blank">
+                                <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin" target="_blank">
                                     <i class="fa fa-2x fa-linkedin m-1 o_editable_media"/>
                                 </a>
                             </div>
@@ -1809,13 +1809,13 @@
                 <div class="container s_allow_columns">
                     <div class="s_social_media text-center mb-4 o_not_editable" data-snippet="s_social_media" data-name="Social Media" contenteditable="false">
                         <h5 class="s_social_media_title d-none" contenteditable="true">Follow us</h5>
-                        <a href="/website/social/facebook" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
+                        <a href="https://www.facebook.com/Odoo" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
                             <i class="fa fa-facebook rounded-circle rounded shadow-sm o_editable_media"/>
                         </a>
-                        <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank" aria-label="X">
+                        <a href="https://twitter.com/Odoo" class="s_social_media_twitter" target="_blank" aria-label="X">
                             <i class="fa fa-twitter rounded-circle rounded shadow-sm o_editable_media"/>
                         </a>
-                        <a href="/website/social/linkedin" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
+                        <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
                             <i class="fa fa-linkedin rounded-circle rounded shadow-sm o_editable_media"/>
                         </a>
                     </div>
@@ -1872,10 +1872,10 @@
                         <div class="col-lg-2 pb16">
                             <h5>Follow us</h5>
                             <ul class="list-unstyled">
-                                <li class="py-1"><i class="fa fa-1x fa-fw fa-facebook-square me-2"/><a href="/website/social/facebook" target="_blank">Facebook</a></li>
-                                <li class="py-1"><i class="fa fa-1x fa-fw fa-twitter-square me-2"/><a href="/website/social/twitter" target="_blank">X</a></li>
-                                <li class="py-1"><i class="fa fa-1x fa-fw fa-linkedin-square me-2"/><a href="/website/social/linkedin" target="_blank">Linkedin</a></li>
-                                <li class="py-1"><i class="fa fa-1x fa-fw fa-instagram me-2"/><a href="/website/social/instagram" target="_blank">Instagram</a></li>
+                                <li class="py-1"><i class="fa fa-1x fa-fw fa-facebook-square me-2"/><a href="https://www.facebook.com/Odoo" target="_blank">Facebook</a></li>
+                                <li class="py-1"><i class="fa fa-1x fa-fw fa-twitter-square me-2"/><a href="https://twitter.com/Odoo" target="_blank">X</a></li>
+                                <li class="py-1"><i class="fa fa-1x fa-fw fa-linkedin-square me-2"/><a href="https://www.linkedin.com/company/odoo" target="_blank">Linkedin</a></li>
+                                <li class="py-1"><i class="fa fa-1x fa-fw fa-instagram me-2"/><a href="https://www.instagram.com/explore/tags/odoo/" target="_blank">Instagram</a></li>
                             </ul>
                         </div>
                         <div class="col-lg-3 pb16">
@@ -1922,13 +1922,13 @@
                         <div class="col-lg-3 pt16 pb16">
                             <div class="s_social_media text-end no_icon_color o_not_editable" data-snippet="s_social_media" data-name="Social Media" contenteditable="false">
                                 <h5 class="s_social_media_title d-none" contenteditable="true">Follow us</h5>
-                                <a href="/website/social/github" class="s_social_media_github" target="_blank">
+                                <a href="https://github.com/odoo" class="s_social_media_github" target="_blank">
                                     <i class="fa fa-2x fa-github m-1 o_editable_media"/>
                                 </a>
-                                <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank">
+                                <a href="https://twitter.com/Odoo" class="s_social_media_twitter" target="_blank">
                                     <i class="fa fa-2x fa-twitter m-1 o_editable_media"/>
                                 </a>
-                                <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank">
+                                <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank">
                                     <i class="fa fa-2x fa-instagram m-1 o_editable_media"/>
                                 </a>
                             </div>
@@ -1964,13 +1964,13 @@
                         <div class="col-lg-3 pt16 pb16">
                             <div class="s_social_media text-end no_icon_color o_not_editable" data-snippet="s_social_media" data-name="Social Media" contenteditable="false">
                                 <p class="s_social_media_title d-block mb-2" contenteditable="true">Follow us</p>
-                                <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank">
+                                <a href="https://twitter.com/Odoo" class="s_social_media_twitter" target="_blank">
                                     <i class="fa fa-twitter m-1 o_editable_media"/>
                                 </a>
-                                <a href="/website/social/linkedin" class="s_social_media_linkedin" target="_blank">
+                                <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin" target="_blank">
                                     <i class="fa fa-linkedin m-1 o_editable_media"/>
                                 </a>
-                                <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank">
+                                <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank">
                                     <i class="fa fa-instagram m-1 o_editable_media"/>
                                 </a>
                             </div>
@@ -2094,13 +2094,13 @@
                         <div class="col-lg-3 pb24">
                             <div class="s_social_media text-end o_not_editable" data-snippet="s_social_media" data-name="Social Media" contenteditable="false">
                                 <h5 class="s_social_media_title d-none" contenteditable="true">Follow Us</h5>
-                                <a href="/website/social/facebook" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
+                                <a href="https://www.facebook.com/Odoo" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
                                     <i class="fa fa-1x fa-facebook rounded-circle shadow-sm o_editable_media"/>
                                 </a>
-                                <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank" aria-label="X">
+                                <a href="https://twitter.com/Odoo" class="s_social_media_twitter" target="_blank" aria-label="X">
                                     <i class="fa fa-1x fa-twitter rounded-circle shadow-sm o_editable_media"/>
                                 </a>
-                                <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
+                                <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
                                     <i class="fa fa-1x fa-instagram rounded-circle shadow-sm o_editable_media"/>
                                 </a>
                             </div>
@@ -2944,16 +2944,16 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
             <div t-attf-class="o_header_social_links #{_div_class}">
                 <div class="s_social_media o_not_editable oe_unmovable oe_unremovable" data-snippet="s_social_media" data-name="Social Media">
                     <h5 class="s_social_media_title d-none">Follow us</h5>
-                    <a href="/website/social/facebook" class="s_social_media_facebook o_nav-link_secondary nav-link m-0 p-0 text-decoration-none" target="_blank" aria-label="Facebook">
+                    <a href="https://www.facebook.com/Odoo" class="s_social_media_facebook o_nav-link_secondary nav-link m-0 p-0 text-decoration-none" target="_blank" aria-label="Facebook">
                         <i class="fa fa-facebook fa-stack p-1 o_editable_media"/>
                     </a>
-                    <a href="/website/social/twitter" class="s_social_media_twitter o_nav-link_secondary nav-link m-0 p-0 text-decoration-none" target="_blank" aria-label="X">
+                    <a href="https://twitter.com/Odoo" class="s_social_media_twitter o_nav-link_secondary nav-link m-0 p-0 text-decoration-none" target="_blank" aria-label="X">
                         <i class="fa fa-twitter fa-stack p-1 o_editable_media"/>
                     </a>
-                    <a href="/website/social/linkedin" class="s_social_media_linkedin o_nav-link_secondary nav-link m-0 p-0 text-decoration-none" target="_blank" aria-label="LinkedIn">
+                    <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin o_nav-link_secondary nav-link m-0 p-0 text-decoration-none" target="_blank" aria-label="LinkedIn">
                         <i class="fa fa-linkedin fa-stack p-1 o_editable_media"/>
                     </a>
-                    <a href="/website/social/instagram" class="s_social_media_instagram o_nav-link_secondary nav-link m-0 p-0 text-decoration-none" target="_blank" aria-label="Instagram">
+                    <a href="https://www.instagram.com/explore/tags/odoo/" class="s_social_media_instagram o_nav-link_secondary nav-link m-0 p-0 text-decoration-none" target="_blank" aria-label="Instagram">
                         <i class="fa fa-instagram fa-stack p-1 o_editable_media"/>
                     </a>
                 </div>

--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -83,14 +83,6 @@ $o-wblog-loader-size: 50px;
         object-fit: cover;
     }
 
-    .o_wblog_social_links > a {
-        width: 3em;
-        height: 3em;
-        > i {
-            @include font-size(1.3em);
-        }
-    }
-
     // Blog Post Page
     // ==============================================
     #o_wblog_post_content {

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -193,13 +193,13 @@ Options:
             </div>
             <div class="o_wblog_social_links d-flex flex-wrap mx-n1 o_not_editable">
                 <t t-set="classes" t-translation="off">bg-100 border mx-1 mb-2 rounded-circle d-flex align-items-center justify-content-center text-decoration-none</t>
-                <a t-if="website.social_facebook" t-att-href="website.social_facebook" aria-label="Facebook" title="Facebook" t-att-class="classes"><i class="fa fa-facebook-square text-facebook"/></a>
-                <a t-if="website.social_twitter" t-att-href="website.social_twitter" t-att-class="classes"><i class="fa fa-twitter text-twitter" aria-label="X" title="X"/></a>
-                <a t-if="website.social_linkedin" t-att-href="website.social_linkedin" t-att-class="classes"><i class="fa fa-linkedin text-linkedin" aria-label="LinkedIn" title="LinkedIn"/></a>
-                <a t-if="website.social_youtube" t-att-href="website.social_youtube" t-att-class="classes"><i class="fa fa-youtube-play text-youtube" aria-label="Youtube" title="Youtube"/></a>
-                <a t-if="website.social_github" t-att-href="website.social_github" t-att-class="classes"><i class="fa fa-github text-github" aria-label="Github" title="Github"/></a>
-                <a t-if="website.social_instagram" t-att-href="website.social_instagram" t-att-class="classes"><i class="fa fa-instagram text-instagram" aria-label="Instagram" title="Instagram"/></a>
-                <a t-if="website.social_tiktok" t-att-href="website.social_tiktok" t-att-class="classes"><i class="fa fa-tiktok text-tiktok" aria-label="TikTok" title="TikTok"/></a>
+                <a t-att-href="https://www.facebook.com/Odoo" aria-label="Facebook" title="Facebook" t-att-class="classes"><i class="fa fa-facebook-square text-facebook"/></a>
+                <a t-att-href="https://twitter.com/Odoo" t-att-class="classes"><i class="fa fa-twitter text-twitter" aria-label="X" title="X"/></a>
+                <a t-att-href="https://www.linkedin.com/company/odoo" t-att-class="classes"><i class="fa fa-linkedin text-linkedin" aria-label="LinkedIn" title="LinkedIn"/></a>
+                <a t-att-href="https://www.youtube.com/user/OpenERPonline" t-att-class="classes"><i class="fa fa-youtube-play text-youtube" aria-label="Youtube" title="Youtube"/></a>
+                <a t-att-href="https://github.com/odoo" t-att-class="classes"><i class="fa fa-github text-github" aria-label="Github" title="Github"/></a>
+                <a t-att-href="https://www.instagram.com/explore/tags/odoo/" t-att-class="classes"><i class="fa fa-instagram text-instagram" aria-label="Instagram" title="Instagram"/></a>
+                <a t-att-href="https://www.tiktok.com/@odoo" t-att-class="classes"><i class="fa fa-tiktok text-tiktok" aria-label="TikTok" title="TikTok"/></a>
                 <a t-if="blog" t-att-href="'/blog/%s/feed' % slug(blog)" t-att-class="classes"><i class="fa fa-rss-square" aria-label="RSS" title="RSS"/></a>
             </div>
             <t t-call="website_mail.follow" t-if="blog">

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -187,21 +187,9 @@ Options:
 <!-- (Option) Sidebar Blog: Follow Us -->
 <template id="opt_sidebar_blog_index_follow_us" name="Follow Us" priority="1" inherit_id="website_blog.sidebar_blog_index" active="True">
     <xpath expr="//div[@id='o_wblog_sidebar']" position="inside">
-        <div class="o_wblog_sidebar_block pb-5">
-            <div>
-                <h6 class="text-uppercase pb-2 mb-4 border-bottom fw-bold">Follow Us</h6>
-            </div>
-            <div class="o_wblog_social_links d-flex flex-wrap mx-n1 o_not_editable">
-                <t t-set="classes" t-translation="off">bg-100 border mx-1 mb-2 rounded-circle d-flex align-items-center justify-content-center text-decoration-none</t>
-                <a t-att-href="https://www.facebook.com/Odoo" aria-label="Facebook" title="Facebook" t-att-class="classes"><i class="fa fa-facebook-square text-facebook"/></a>
-                <a t-att-href="https://twitter.com/Odoo" t-att-class="classes"><i class="fa fa-twitter text-twitter" aria-label="X" title="X"/></a>
-                <a t-att-href="https://www.linkedin.com/company/odoo" t-att-class="classes"><i class="fa fa-linkedin text-linkedin" aria-label="LinkedIn" title="LinkedIn"/></a>
-                <a t-att-href="https://www.youtube.com/user/OpenERPonline" t-att-class="classes"><i class="fa fa-youtube-play text-youtube" aria-label="Youtube" title="Youtube"/></a>
-                <a t-att-href="https://github.com/odoo" t-att-class="classes"><i class="fa fa-github text-github" aria-label="Github" title="Github"/></a>
-                <a t-att-href="https://www.instagram.com/explore/tags/odoo/" t-att-class="classes"><i class="fa fa-instagram text-instagram" aria-label="Instagram" title="Instagram"/></a>
-                <a t-att-href="https://www.tiktok.com/@odoo" t-att-class="classes"><i class="fa fa-tiktok text-tiktok" aria-label="TikTok" title="TikTok"/></a>
-                <a t-if="blog" t-att-href="'/blog/%s/feed' % slug(blog)" t-att-class="classes"><i class="fa fa-rss-square" aria-label="RSS" title="RSS"/></a>
-            </div>
+        <div class="o_wblog_sidebar_block pb-5" t-ignore="true">
+            <h6 class="text-uppercase pb-2 mb-4 border-bottom fw-bold">Follow Us</h6>
+            <t t-snippet-call="website.s_social_media"/>
             <t t-call="website_mail.follow" t-if="blog">
                 <t t-set="email" t-value="user_id.email"/>
                 <t t-set="object" t-value="blog"/>
@@ -284,17 +272,9 @@ Display a sidebar beside the post content.
 <!-- (Option) Post Sidebar: Share Links Display -->
 <template id="opt_blog_post_share_links_display" name="Share Links" inherit_id="website_blog.blog_post_sidebar" active="True" priority="2">
     <xpath expr="//div[@id='o_wblog_post_sidebar']" position="inside">
-        <div class="o_wblog_sidebar_block pb-5">
-            <div>
-                <h6 class="text-uppercase pb-3 mb-4 border-bottom fw-bold">Share this post</h6>
-            </div>
-
-            <div class="o_wblog_social_links d-flex flex-wrap mx-n1 o_not_editable">
-                <t t-set="classes" t-translation="off">bg-100 border mx-1 mb-2 rounded-circle d-flex align-items-center justify-content-center text-decoration-none</t>
-                <a href="#" aria-label="Facebook" title="Share on Facebook" t-attf-class="o_facebook #{classes}"><i class="fa fa-facebook-square text-facebook"/></a>
-                <a href="#" aria-label="Twitter" title="Share on X" t-attf-class="o_twitter #{classes}"><i class="fa fa-twitter text-twitter" aria-label="X" title="X"/></a>
-                <a href="#" aria-label="LinkedIn" title="Share on LinkedIn" t-attf-class="o_linkedin #{classes}"><i class="fa fa-linkedin text-linkedin" aria-label="LinkedIn" title="LinkedIn"/></a>
-            </div>
+        <div class="o_wblog_sidebar_block pb-5" t-ignore="true">
+            <h6 class="text-uppercase pb-3 mb-4 border-bottom fw-bold">Share this post</h6>
+            <t t-call="website.s_social_media"/>
         </div>
 
         <div class="oe_structure" id="oe_structure_blog_post_sidebar_3"/>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -448,19 +448,9 @@
 <!-- Index - Sidebar - Follow us -->
 <template id="index_sidebar_follow_us" inherit_id="website_event.index_sidebar" active="False" name="Follow us" priority="30">
     <xpath expr="//div[@id='o_wevent_index_sidebar']" position="inside">
-        <div class="o_wevent_sidebar_block">
-            <div>
-                <h6 class="o_wevent_sidebar_title">Follow Us</h6>
-            </div>
-            <div class="o_wevent_sidebar_social mx-n1">
-                <a t-att-href="https://www.facebook.com/Odoo" class="o_wevent_social_link"><i class="fa fa-facebook text-facebook" aria-label="Facebook" title="Facebook"/></a>
-                <a t-att-href="https://twitter.com/Odoo" class="o_wevent_social_link"><i class="fa fa-twitter text-twitter" aria-label="X" title="X"/></a>
-                <a t-att-href="https://www.linkedin.com/company/odoo" class="o_wevent_social_link"><i class="fa fa-linkedin text-linkedin" aria-label="LinkedIn" title="LinkedIn"/></a>
-                <a t-att-href="https://www.youtube.com/user/OpenERPonline" class="o_wevent_social_link"><i class="fa fa-youtube-play text-youtube" aria-label="Youtube" title="Youtube"/></a>
-                <a t-att-href="https://github.com/odoo" class="o_wevent_social_link"><i class="fa fa-github text-github" aria-label="Github" title="Github"/></a>
-                <a t-att-href="https://www.instagram.com/explore/tags/odoo/" class="o_wevent_social_link"><i class="fa fa-instagram text-instagram" aria-label="Instagram" title="Instagram"/></a>
-                <a t-att-href="https://www.tiktok.com/@odoo" class="o_wevent_social_link"><i class="fa fa-tiktok text-tiktok" aria-label="TikTok" title="TikTok"/></a>
-            </div>
+        <div class="o_wevent_sidebar_block" t-ignore="true">
+            <h6 class="o_wevent_sidebar_title">Follow Us</h6>
+            <t t-call="website.s_social_media"/>
         </div>
         <div id="oe_structure_website_event_follow_us_1" class="oe_structure"/>
     </xpath>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -453,13 +453,13 @@
                 <h6 class="o_wevent_sidebar_title">Follow Us</h6>
             </div>
             <div class="o_wevent_sidebar_social mx-n1">
-                <a t-if="website.social_facebook" t-att-href="website.social_facebook" class="o_wevent_social_link"><i class="fa fa-facebook text-facebook" aria-label="Facebook" title="Facebook"/></a>
-                <a t-if="website.social_twitter" t-att-href="website.social_twitter" class="o_wevent_social_link"><i class="fa fa-twitter text-twitter" aria-label="X" title="X"/></a>
-                <a t-if="website.social_linkedin" t-att-href="website.social_linkedin" class="o_wevent_social_link"><i class="fa fa-linkedin text-linkedin" aria-label="LinkedIn" title="LinkedIn"/></a>
-                <a t-if="website.social_youtube" t-att-href="website.social_youtube" class="o_wevent_social_link"><i class="fa fa-youtube-play text-youtube" aria-label="Youtube" title="Youtube"/></a>
-                <a t-if="website.social_github" t-att-href="website.social_github" class="o_wevent_social_link"><i class="fa fa-github text-github" aria-label="Github" title="Github"/></a>
-                <a t-if="website.social_instagram" t-att-href="website.social_instagram" class="o_wevent_social_link"><i class="fa fa-instagram text-instagram" aria-label="Instagram" title="Instagram"/></a>
-                <a t-if="website.social_tiktok" t-att-href="website.social_tiktok" class="o_wevent_social_link"><i class="fa fa-tiktok text-tiktok" aria-label="TikTok" title="TikTok"/></a>
+                <a t-att-href="https://www.facebook.com/Odoo" class="o_wevent_social_link"><i class="fa fa-facebook text-facebook" aria-label="Facebook" title="Facebook"/></a>
+                <a t-att-href="https://twitter.com/Odoo" class="o_wevent_social_link"><i class="fa fa-twitter text-twitter" aria-label="X" title="X"/></a>
+                <a t-att-href="https://www.linkedin.com/company/odoo" class="o_wevent_social_link"><i class="fa fa-linkedin text-linkedin" aria-label="LinkedIn" title="LinkedIn"/></a>
+                <a t-att-href="https://www.youtube.com/user/OpenERPonline" class="o_wevent_social_link"><i class="fa fa-youtube-play text-youtube" aria-label="Youtube" title="Youtube"/></a>
+                <a t-att-href="https://github.com/odoo" class="o_wevent_social_link"><i class="fa fa-github text-github" aria-label="Github" title="Github"/></a>
+                <a t-att-href="https://www.instagram.com/explore/tags/odoo/" class="o_wevent_social_link"><i class="fa fa-instagram text-instagram" aria-label="Instagram" title="Instagram"/></a>
+                <a t-att-href="https://www.tiktok.com/@odoo" class="o_wevent_social_link"><i class="fa fa-tiktok text-tiktok" aria-label="TikTok" title="TikTok"/></a>
             </div>
         </div>
         <div id="oe_structure_website_event_follow_us_1" class="oe_structure"/>

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -920,13 +920,13 @@
                                 <!-- Social media -->
                                 <div class="s_social_media text-start" data-name="Social Media" data-snippet="s_social_media">
                                     <h5 class="s_social_media_title d-none">Follow us</h5>
-                                    <a href="/website/social/facebook" class="s_social_media_facebook text-decoration-none" target="_blank" aria-label="Facebook">
+                                    <a href="https://www.facebook.com/Odoo" class="s_social_media_facebook text-decoration-none" target="_blank" aria-label="Facebook">
                                         <i class="fa fa-facebook rounded-empty-circle btn btn-outline-primary shadow-sm"></i>
                                     </a>
-                                    <a href="/website/social/twitter" class="s_social_media_twitter text-decoration-none" target="_blank" aria-label="X">
+                                    <a href="https://twitter.com/Odoo" class="s_social_media_twitter text-decoration-none" target="_blank" aria-label="X">
                                         <i class="fa fa-twitter rounded-empty-circle btn btn-outline-primary shadow-sm"></i>
                                     </a>
-                                    <a href="/website/social/linkedin" class="s_social_media_linkedin text-decoration-none" target="_blank" aria-label="LinkedIn">
+                                    <a href="https://www.linkedin.com/company/odoo" class="s_social_media_linkedin text-decoration-none" target="_blank" aria-label="LinkedIn">
                                         <i class="fa fa-linkedin rounded-empty-circle btn btn-outline-primary shadow-sm"></i>
                                     </a>
                                 </div>

--- a/addons/website_mass_mailing/models/res_company.py
+++ b/addons/website_mass_mailing/models/res_company.py
@@ -9,12 +9,11 @@ class ResCompany(models.Model):
 
     def _get_social_media_links(self):
         social_media_links = super()._get_social_media_links()
-        website_id = self.env['website'].get_current_website()
         social_media_links.update({
-            'social_facebook': website_id.social_facebook or social_media_links.get('social_facebook'),
-            'social_linkedin': website_id.social_linkedin or social_media_links.get('social_linkedin'),
-            'social_twitter': website_id.social_twitter or social_media_links.get('social_twitter'),
-            'social_instagram': website_id.social_instagram or social_media_links.get('social_instagram'),
-            'social_tiktok': website_id.social_tiktok or social_media_links.get('social_tiktok'),
+            'social_facebook': social_media_links.get('social_facebook'),
+            'social_linkedin': social_media_links.get('social_linkedin'),
+            'social_twitter': social_media_links.get('social_twitter'),
+            'social_instagram': social_media_links.get('social_instagram'),
+            'social_tiktok': social_media_links.get('social_tiktok'),
         })
         return social_media_links


### PR DESCRIPTION
This PR removes company-specific social media from the website module. The decision to remove these features was made to avoid confusion for users regarding which social media links are synchronized and which are not.

Key Changes:

* Resolved outdated social media routes in company data by mapping them to real values.
* Removed social media fields from website module, As it was no longer required.
* Adapted the cases for facebook and instagram snippet to have a default value that it was getting from the company data.
* Updated the FontAwesome fa-youtube icon to fa-youtube-play for better compatibility.
* Ensured social media icons dynamically update when the associated link changes.
* Fixed an issue where the social media icon was not visible in the social snippet section.
* Replace the fa-home icon wiht fa-pencil for footer as well.
* Added test cases to validate social media icon changes, ensuring functionality and maintainability.
* Added version control to the snippets to ensure that the snippet is always up to date.
* Added the upgrade script to remove those fields as well.

task-4297366