### PR TITLE
[FIX] survey: prevent error when question not found

### DIFF
--- a/addons/survey/controllers/survey_session_manage.py
+++ b/addons/survey/controllers/survey_session_manage.py
@@ -205,8 +205,8 @@ class UserInputSession(http.Controller):
             'is_first_question': is_first_question,
             'is_session_closed': not survey.session_state,
         }
-
-        values.update(self._prepare_question_results_values(survey, request.env['survey.user_input.line']))
+        if survey.session_question_id:
+            values.update(self._prepare_question_results_values(survey, request.env['survey.user_input.line']))
 
         return values
 

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -806,6 +806,7 @@ class Survey(models.Model):
         """
         if self.questions_layout == "one_page":
             return True
+        page_or_question = page_or_question or self.question_ids[-1]
         pages_or_questions = self._get_pages_or_questions(user_input)
         current_page_index = pages_or_questions.ids.index(page_or_question.id)
         next_page_or_question_candidates = pages_or_questions[current_page_index + 1:]


### PR DESCRIPTION
This error occurs when we create a live session, modify a question at the end of the survey, and then refresh the page.

Steps to reproduce:
---
- Install ``survey`` module
- Create new Survey > Add a question > Click on ``Create Live Session``
- Complete the survey(wait on Thank You page)
- Now go to the previous tab remove the question and add another question
- Now refresh another tab (Thank You page)

Traceback: 
---
``ValueError: False is not in list``

We encounter the error at [1] because ``page_or_question`` is empty. Its value comes from the ``_is_last_page_or_question`` method, where ``survey.session_question_id`` is also empty. This happens because when a question is removed, ``survey.session_question_id`` becomes empty, and when a new question is added, the ID for that question is not retrieved.

[1]- https://github.com/odoo/odoo/blob/e35d2a0c08f69ad1d122e07726786450e4c30b5a/addons/survey/models/survey_survey.py#L810

sentry-6043084559

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
