### PR TITLE
[PERF] base: restore previous res.users display name search behavior

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -826,7 +826,8 @@ class Users(models.Model):
         domain = super()._search_display_name(operator, value)
         if operator in ('=', 'ilike') and value:
             name_domain = [('login', '=', value)]
-            domain = expression.OR([name_domain, domain])
+            if users := self.search(name_domain):
+                domain = [('id', 'in', users.ids)]
         return domain
 
     def copy_data(self, default=None):


### PR DESCRIPTION
After removal of _name_search(), the res.users `_search_display_name()` has been rewritten to use an `OR` to match either exactly the login or part of the name; this make the query very inefficient as it prevent PostgreSQL to use the index an any of the two fields.

This commit re-introduce the previous behavior: we first check for an exact users match on the login or (if none) we fallback to standard display name search (for `name`).

With a database will multiple millions of users:

Before:
```
In [1]: %time env["res.users"].search([('display_name', 'ilike', 'OdooBot')])
CPU times: user 2.03 ms, sys: 8 µs, total: 2.04 ms
Wall time: 16.8 s
```

After:
```
In [1]: %time env["res.users"].search([('display_name', 'ilike', 'OdooBot')])
CPU times: user 1.21 ms, sys: 1.87 ms, total: 3.08 ms
Wall time: 6.69 ms
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
