### PR TITLE
[PERF] pos_loyalty: make product addition to cart faster

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/data_service_options.js
+++ b/addons/pos_loyalty/static/src/overrides/models/data_service_options.js
@@ -8,7 +8,9 @@ patch(DataServiceOptions.prototype, {
             name: "loyalty.card",
             key: "id",
             condition: (record) => {
-                return record.models["pos.order.line"].find((l) => l.coupon_id?.id === record.id);
+                return record["<-pos.order.line.coupon_id"].find(
+                    (l) => l.order_id?.finalized && typeof l.order_id.id === "number"
+                );
             },
         });
         return data;


### PR DESCRIPTION
Before this commit, adding products to the cart would become slow when there were several loyalty.card records and several pos.order.line records.

opw-4317125

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
