### PR TITLE
[FIX] mail: is typing indicator stays long

### DIFF
--- a/addons/mail/static/src/discuss/typing/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/typing/common/composer_patch.js
@@ -3,6 +3,7 @@
 import { Composer } from "@mail/core/common/composer";
 import { Typing } from "@mail/discuss/typing/common/typing";
 
+import { onWillDestroy } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { patch } from "@web/core/utils/patch";
@@ -25,6 +26,9 @@ patch(Composer.prototype, {
         super.setup();
         this.typingNotified = false;
         this.stopTypingDebounced = useDebounced(this.stopTyping.bind(this), SHORT_TYPING);
+        onWillDestroy(() => {
+            this.stopTyping();
+        });
     },
     /**
      * Notify the server of the current typing status


### PR DESCRIPTION
When switching between threads, `composer.thread` changed but the func to remove the typing indicator was not called to the previous thread.

The fix is to call the func to remove the typing indicator when the thread changes.

task-4285488


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
