### PR TITLE
[FIX] pos_sale: Fix quotation from repair

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_order_line.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_order_line.js
@@ -47,8 +47,10 @@ patch(PosOrderline.prototype, {
      * Set quantity based on the give sale order line.
      * @param {'sale.order.line'} saleOrderLine
      */
-    setQuantityFromSOL(saleOrderLine) {
-        if (
+    async setQuantityFromSOL(saleOrderLine) {
+        if (!saleOrderLine.has_valued_move_ids) {
+            this.set_quantity(saleOrderLine.product_uom_qty);
+        } else if (
             this.product_id.type === "service" &&
             !["sent", "draft"].includes(this.sale_order_origin_id.state)
         ) {

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -134,6 +134,12 @@ patch(PosStore.prototype, {
                     });
                 }
             }
+
+            line.has_valued_move_ids = await this.data.call(
+                "sale.order.line",
+                "has_valued_move_ids",
+                [line.id]
+            );
             newLine.setQuantityFromSOL(line);
             newLine.set_unit_price(line.price_unit);
             newLine.set_discount(line.discount);

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -341,3 +341,13 @@ registry.category("web_tour.tours").add("PosSettleOrder4", {
             ReceiptScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosRepairSettleOrder", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.settleNthOrder(1),
+            ProductScreen.selectedOrderlineHas("Test Product", 1),
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -916,3 +916,33 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.assertEqual(sale_order.picking_ids.state, 'cancel')
         self.assertEqual(sale_order.pos_order_line_ids.order_id.picking_ids.state, 'assigned')
         self.assertEqual(self.env['purchase.order.line'].search_count([('product_id', '=', product_a.id)]), 1)
+
+    def test_pos_repair(self):
+        if self.env['ir.module.module']._get('repair').state != 'installed':
+            self.skipTest("Repair module is required for this test")
+
+        self.product_1 = self.env['product.product'].create({
+            'name': 'Test product 1'
+        })
+        self.stock_warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        self.repair1 = self.env['repair.order'].create({
+            'product_id': self.product_1.id,
+            'product_uom': self.env.ref('uom.product_uom_unit').id,
+            'picking_type_id': self.stock_warehouse.repair_type_id.id,
+            'move_ids': [
+                (0, 0, {
+                    'product_id': self.product_1.id,
+                    'product_uom_qty': 1.0,
+                    'state': 'draft',
+                    'repair_line_type': 'add',
+                    'company_id': self.env.company.id,
+                })
+            ],
+            'partner_id': self.env['res.partner'].create({'name': 'Partner 1'}).id
+        })
+        self.repair1._action_repair_confirm()
+        self.repair1.action_repair_start()
+        self.repair1.action_repair_end()
+        self.repair1.action_create_sale_order()
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosRepairSettleOrder', login="pos_user")


### PR DESCRIPTION
When opening a quotation created from a repair order in the PoS the
quantity of the products would always be 0.

Steps to reproduce:
-------------------
* Create a repair order for whatever product
* Add some product to the list with the "Add" option
* Start and End the reparation
* Create a quotation for the repair order
* Open the quotation in the PoS
> Observation: The quantity of the product in the pos is 0

Why the fix:
------------
If the sale order line has no `valued_move_ids` it means that it's
linked to a repair. In this case we take the product_uom_qty into
account for the pos order line quantity.

opw-4261097