### PR TITLE
[FIX] web: X2ManyField.rendererProps bound to the component

### DIFF
--- a/addons/web/static/src/views/fields/x2many/x2many_field.xml
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.xml
@@ -17,8 +17,8 @@
                     <Pager t-if="props.value.count > props.value.limit" t-props="pagerProps"/>
                 </div>
             </div>
-            <ListRenderer t-if="viewMode === 'list'" t-props="rendererProps" />
-            <KanbanRenderer t-elif="viewMode" t-props="rendererProps" />
+            <ListRenderer t-if="viewMode === 'list'" t-props="this.rendererProps" />
+            <KanbanRenderer t-elif="viewMode" t-props="this.rendererProps" />
         </div>
     </t>
 


### PR DESCRIPTION
rendererProps was not called on the component.

This causes issues when assigning a variable on `this` and referencing
it later.

See:
https://github.com/odoo/owl/commit/df59ec49aefce2e0913fdc1792d42b9680fb28b6
https://github.com/odoo/odoo/commit/f76955a5615cf7950c014c4f7a64d8f3aeafdda0