### PR TITLE
[FIX] html_editor: setContent move selection

### DIFF
--- a/addons/html_editor/static/tests/_helpers/selection.js
+++ b/addons/html_editor/static/tests/_helpers/selection.js
@@ -100,7 +100,10 @@ export function setContent(el, content) {
         textNode.textContent = textNode.textContent.replace("[", "").replace("]", "");
     }
     // remove extra empty text nodes
-    el.innerHTML = div.innerHTML;
+    const innerHTML = div.innerHTML;
+    if (el.innerHTML !== innerHTML) {
+        el.innerHTML = innerHTML;
+    }
 
     const configSelection = getSelection(el, content);
     if (configSelection) {


### PR DESCRIPTION
Before this commit, in the tests, when the setContent utils is used to move the selection, the entire html is recreated. This implies a set of unnecessary mutations in the dom.
This commit will therefore prevent the creation of all these mutations by checking if the ‘content’ is different from that in ‘el’.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
