### PR TITLE
[FIX] stock_delivery: do not lowercase the tracking link

### DIFF
--- a/addons/stock_delivery/models/delivery_carrier.py
+++ b/addons/stock_delivery/models/delivery_carrier.py
@@ -245,7 +245,7 @@ class DeliveryCarrier(models.Model):
 
     def fixed_get_tracking_link(self, picking):
         if self.tracking_url and picking.carrier_tracking_ref:
-            return self.tracking_url.lower().replace("<shipmenttrackingnumber>", picking.carrier_tracking_ref)
+            return self.tracking_url.replace("<shipmenttrackingnumber>", picking.carrier_tracking_ref)
         return False
 
     def fixed_cancel_shipment(self, pickings):
@@ -267,7 +267,7 @@ class DeliveryCarrier(models.Model):
 
     def base_on_rule_get_tracking_link(self, picking):
         if self.tracking_url and picking.carrier_tracking_ref:
-            return self.tracking_url.lower().replace("<shipmenttrackingnumber>", picking.carrier_tracking_ref)
+            return self.tracking_url.replace("<shipmenttrackingnumber>", picking.carrier_tracking_ref)
         return False
 
     def base_on_rule_cancel_shipment(self, pickings):


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product P1
- Go to the delivery method
    - Select the Standard delivery
    - Add this tracking link: “https://iel.co.th/tracking/?trackingNo=<shipmenttrackingnumber>”
- Create a delivery for one unit of P1
- Go to the additional information:
    - carrier: Standard delivery
    - Tracking Reference: 1234

- Mark as todo
- Click on the racking smartbutton

Problem:
The link is lowercase, so its become not valid (some URLs are CASE-sensitiv)

![2024-11-12_09-42](https://github.com/user-attachments/assets/3dbb226c-37d2-4c74-8e67-a41d1cf13f8e)
![2024-11-12_09-41](https://github.com/user-attachments/assets/674b1c9c-16d4-49bf-b502-d6f075247043)



opw-4296872
