### PR TITLE
[IMP] mail_bot: replace html_escape

### DIFF
--- a/addons/mail_bot/models/mail_bot.py
+++ b/addons/mail_bot/models/mail_bot.py
@@ -5,7 +5,6 @@ import random
 
 from markupsafe import Markup
 from odoo import models, _
-from odoo.tools import html_escape
 
 
 class MailBot(models.AbstractModel):
@@ -61,23 +60,29 @@ class MailBot(models.AbstractModel):
             if odoobot_state == 'onboarding_emoji' and self._body_contains_emoji(body):
                 self.env.user.odoobot_state = "onboarding_command"
                 self.env.user.odoobot_failed = False
-                return html_escape(
-                    _("Great! 👍%(new_line)sTo access special commands, %(bold_start)sstart your sentence "
-                      "with%(bold_end)s %(command_start)s/%(command_end)s. Try getting help."
-                      )) % self._get_style_dict()
+                return self.env._(
+                    "Great! 👍%(new_line)sTo access special commands, %(bold_start)sstart your "
+                    "sentence with%(bold_end)s %(command_start)s/%(command_end)s. Try getting "
+                    "help.",
+                    **self._get_style_dict()
+                )
             elif odoobot_state == 'onboarding_command' and command == 'help':
                 self.env.user.odoobot_state = "onboarding_ping"
                 self.env.user.odoobot_failed = False
-                return html_escape(
-                    _("Wow you are a natural!%(new_line)sPing someone with @username to grab their attention. "
-                      "%(bold_start)sTry to ping me using%(bold_end)s %(command_start)s@OdooBot%(command_end)s"
-                      " in a sentence.")) % self._get_style_dict()
+                return self.env._(
+                    "Wow you are a natural!%(new_line)sPing someone with @username to grab their "
+                    "attention. %(bold_start)sTry to ping me using%(bold_end)s "
+                    "%(command_start)s@OdooBot%(command_end)s in a sentence.",
+                    **self._get_style_dict()
+                )
             elif odoobot_state == "onboarding_ping" and odoobot.id in values.get("partner_ids", []):
                 self.env.user.odoobot_state = "onboarding_attachement"
                 self.env.user.odoobot_failed = False
-                return html_escape(
-                    _("Yep, I am here! 🎉 %(new_line)sNow, try %(bold_start)ssending an attachment%(bold_end)s,"
-                      " like a picture of your cute dog...")) % self._get_style_dict()
+                return self.env._(
+                    "Yep, I am here! 🎉 %(new_line)sNow, try %(bold_start)ssending an "
+                    "attachment%(bold_end)s, like a picture of your cute dog...",
+                    **self._get_style_dict()
+                )
             elif odoobot_state == "onboarding_attachement" and values.get("attachment_ids"):
                 self.env["mail.canned.response"].create({
                     "source": source,
@@ -86,9 +91,11 @@ class MailBot(models.AbstractModel):
                 })
                 self.env.user.odoobot_failed = False
                 self.env.user.odoobot_state = "onboarding_canned"
-                return html_escape(
-                    _("Wonderful! 😇%(new_line)sTry typing %(command_start)s:%(command_end)s to use canned responses."
-                      " I've created a temporary one for you.")) % self._get_style_dict()
+                return self.env._(
+                    "Wonderful! 😇%(new_line)sTry typing %(command_start)s:%(command_end)s to use "
+                    "canned responses. I've created a temporary one for you.",
+                    **self._get_style_dict()
+                )
             elif odoobot_state == "onboarding_canned" and self.env.context.get("canned_response_ids"):
                 self.env["mail.canned.response"].search([
                     ("create_uid", "=", self.env.user.id),
@@ -97,18 +104,22 @@ class MailBot(models.AbstractModel):
                 ]).unlink()
                 self.env.user.odoobot_failed = False
                 self.env.user.odoobot_state = "idle"
-                return html_escape(
-                    _("Good, you can customize canned responses in the Discuss application."
-                      "%(new_line)s%(new_line)s%(bold_start)sIt's the end of this overview%(bold_end)s,"
-                      " you can now %(bold_start)sclose this conversation%(bold_end)s or start the tour again with"
-                      " typing %(command_start)sstart the tour%(command_end)s."
-                      " Enjoy discovering Odoo!")) % self._get_style_dict()
+                return self.env._(
+                    "Good, you can customize canned responses in the Discuss application."
+                    "%(new_line)s%(new_line)s%(bold_start)sIt's the end of this "
+                    "overview%(bold_end)s, you can now %(bold_start)sclose this "
+                    "conversation%(bold_end)s or start the tour again with typing "
+                    "%(command_start)sstart the tour%(command_end)s. Enjoy discovering Odoo!",
+                    **self._get_style_dict()
+                )
             # repeat question if needed
             elif odoobot_state == 'onboarding_canned' and not self._is_help_requested(body):
                 self.env.user.odoobot_failed = True
-                return html_escape(
-                    _("Not sure what you are doing. Please, type %(command_start)s:%(command_end)s and wait for the"
-                      " propositions. Select one of them and press enter.")) % self._get_style_dict()
+                return self.env._(
+                    "Not sure what you are doing. Please, type %(command_start)s:%(command_end)s "
+                    "and wait for the propositions. Select one of them and press enter.",
+                    **self._get_style_dict()
+                )
             elif odoobot_state in (False, "idle", "not_initialized") and (_('start the tour') in body.lower()):
                 self.env.user.odoobot_state = "onboarding_emoji"
                 return _("To start, try to send me an emoji :)")
@@ -119,44 +130,63 @@ class MailBot(models.AbstractModel):
                 return _("That's not nice! I'm a bot but I have feelings... 💔")
             # help message
             elif self._is_help_requested(body) or odoobot_state == 'idle':
-                return html_escape(
-                    _("Unfortunately, I'm just a bot 😞 I don't understand! If you need help discovering our product, "
-                      "please check %(document_link_start)sour documentation%(document_link_end)s or"
-                      " %(slides_link_start)sour videos%(slides_link_end)s.")) % self._get_style_dict()
+                return self.env._(
+                    "Unfortunately, I'm just a bot 😞 I don't understand! If you need help "
+                    "discovering our product, please check %(document_link_start)sour "
+                    "documentation%(document_link_end)s or %(slides_link_start)sour "
+                    "videos%(slides_link_end)s.",
+                    **self._get_style_dict()
+                )
             else:
                 # repeat question
                 if odoobot_state == 'onboarding_emoji':
                     self.env.user.odoobot_failed = True
-                    return (html_escape(
-                        _("Not exactly. To continue the tour, send an emoji:"
-                          " %(bold_start)stype%(bold_end)s%(command_start)s :)%(command_end)s and press enter."))
-                            % self._get_style_dict())
+                    return self.env._(
+                        "Not exactly. To continue the tour, send an emoji:"
+                        " %(bold_start)stype%(bold_end)s%(command_start)s :)%(command_end)s and "
+                        "press enter.",
+                        **self._get_style_dict()
+                    )
                 elif odoobot_state == 'onboarding_attachement':
                     self.env.user.odoobot_failed = True
-                    return html_escape(
-                        _("To %(bold_start)ssend an attachment%(bold_end)s, click on the %(paperclip_icon)s icon and"
-                          " select a file.")) % self._get_style_dict()
+                    return self.env._(
+                        "To %(bold_start)ssend an attachment%(bold_end)s, click on the "
+                        "%(paperclip_icon)s icon and select a file.",
+                        **self._get_style_dict()
+                    )
                 elif odoobot_state == 'onboarding_command':
                     self.env.user.odoobot_failed = True
-                    return html_escape(
-                        _("Not sure what you are doing. Please, type %(command_start)s/%(command_end)s and wait for the propositions."
-                          " Select %(command_start)shelp%(command_end)s and press enter.")) % self._get_style_dict()
+                    return self.env._(
+                        "Not sure what you are doing. Please, type "
+                        "%(command_start)s/%(command_end)s and wait for the propositions."
+                        " Select %(command_start)shelp%(command_end)s and press enter.",
+                        **self._get_style_dict()
+                    )
                 elif odoobot_state == 'onboarding_ping':
                     self.env.user.odoobot_failed = True
-                    return html_escape(
-                        _("Sorry, I am not listening. To get someone's attention, %(bold_start)sping him%(bold_end)s."
-                          " Write %(command_start)s@OdooBot%(command_end)s and select me.")) % self._get_style_dict()
-                return random.choice([
-                    html_escape(
-                        _("I'm not smart enough to answer your question.%(new_line)sTo follow my guide,"
-                          " ask: %(command_start)sstart the tour%(command_end)s.")) % self._get_style_dict(),
-                    _("Hmmm..."),
-                    _("I'm afraid I don't understand. Sorry!"),
-                    html_escape(
-                        _("Sorry I'm sleepy. Or not! Maybe I'm just trying to hide my unawareness of human language..."
-                          "%(new_line)sI can show you features if you write: %(command_start)sstart the"
-                          " tour%(command_end)s.")) % self._get_style_dict()
-                ])
+                    return self.env._(
+                        "Sorry, I am not listening. To get someone's attention, %(bold_start)sping "
+                        "him%(bold_end)s. Write %(command_start)s@OdooBot%(command_end)s and select"
+                        " me.",
+                        **self._get_style_dict()
+                    )
+                return random.choice(
+                    [
+                        self.env._(
+                            "I'm not smart enough to answer your question.%(new_line)sTo follow my "
+                            "guide, ask: %(command_start)sstart the tour%(command_end)s.",
+                            **self._get_style_dict()
+                        ),
+                        self.env._("Hmmm..."),
+                        self.env._("I'm afraid I don't understand. Sorry!"),
+                        self.env._(
+                            "Sorry I'm sleepy. Or not! Maybe I'm just trying to hide my unawareness"
+                            " of human language...%(new_line)sI can show you features if you write:"
+                            " %(command_start)sstart the tour%(command_end)s.",
+                            **self._get_style_dict()
+                        ),
+                    ]
+                )
         return False
 
     def _body_contains_emoji(self, body):


### PR DESCRIPTION
Since escaping html in translations is now built in, this commit replaces the `html_escape` use cases with `env._`.
