### PR TITLE
[FIX] repair,stock: correct default src/dest loc labels

### DIFF
--- a/addons/repair/i18n/repair.pot
+++ b/addons/repair/i18n/repair.pot
@@ -293,7 +293,13 @@ msgid "Company"
 msgstr ""
 
 #. module: repair
+#: model_terms:ir.ui.view,arch_db:repair.repair_view_picking_type_form
+msgid "Component Destination Location"
+msgstr ""
+
+#. module: repair
 #: model:ir.model.fields,field_description:repair.field_repair_order__location_id
+#: model_terms:ir.ui.view,arch_db:repair.repair_view_picking_type_form
 msgid "Component Source Location"
 msgstr ""
 
@@ -381,36 +387,6 @@ msgstr ""
 #. module: repair
 #: model:ir.model.fields,field_description:repair.field_repair_order__search_date_category
 msgid "Date Category"
-msgstr ""
-
-#. module: repair
-#: model_terms:ir.ui.view,arch_db:repair.repair_view_picking_type_form
-msgid "Default Component Destination Location"
-msgstr ""
-
-#. module: repair
-#: model_terms:ir.ui.view,arch_db:repair.repair_view_picking_type_form
-msgid "Default Component Source Location"
-msgstr ""
-
-#. module: repair
-#: model:ir.model.fields,field_description:repair.field_stock_picking_type__default_product_location_dest_id
-msgid "Default Product Destination Location"
-msgstr ""
-
-#. module: repair
-#: model:ir.model.fields,field_description:repair.field_stock_picking_type__default_product_location_src_id
-msgid "Default Product Source Location"
-msgstr ""
-
-#. module: repair
-#: model:ir.model.fields,field_description:repair.field_stock_picking_type__default_recycle_location_dest_id
-msgid "Default Recycle Destination Location"
-msgstr ""
-
-#. module: repair
-#: model:ir.model.fields,field_description:repair.field_stock_picking_type__default_remove_location_dest_id
-msgid "Default Remove Destination Location"
 msgstr ""
 
 #. module: repair
@@ -880,6 +856,7 @@ msgstr ""
 
 #. module: repair
 #: model:ir.model.fields,field_description:repair.field_repair_order__product_location_dest_id
+#: model:ir.model.fields,field_description:repair.field_stock_picking_type__default_product_location_dest_id
 msgid "Product Destination Location"
 msgstr ""
 
@@ -900,6 +877,7 @@ msgstr ""
 
 #. module: repair
 #: model:ir.model.fields,field_description:repair.field_repair_order__product_location_src_id
+#: model:ir.model.fields,field_description:repair.field_stock_picking_type__default_product_location_src_id
 msgid "Product Source Location"
 msgstr ""
 
@@ -977,6 +955,11 @@ msgid "Recycle"
 msgstr ""
 
 #. module: repair
+#: model:ir.model.fields,field_description:repair.field_stock_picking_type__default_recycle_location_dest_id
+msgid "Recycle Destination Location"
+msgstr ""
+
+#. module: repair
 #: model:ir.model.fields,field_description:repair.field_repair_order__recycle_location_id
 msgid "Recycled Parts Destination Location"
 msgstr ""
@@ -984,6 +967,11 @@ msgstr ""
 #. module: repair
 #: model:ir.model.fields.selection,name:repair.selection__stock_move__repair_line_type__remove
 msgid "Remove"
+msgstr ""
+
+#. module: repair
+#: model:ir.model.fields,field_description:repair.field_stock_picking_type__default_remove_location_dest_id
+msgid "Remove Destination Location"
 msgstr ""
 
 #. module: repair
@@ -1318,8 +1306,8 @@ msgstr ""
 #. module: repair
 #: model:ir.model.fields,help:repair.field_stock_picking_type__default_product_location_dest_id
 msgid ""
-"This is the default destination location for product which come for the "
-"repair when you create a repair order with this operation type."
+"This is the default destination location for the product to be repaired in "
+"repair orders with this operation type."
 msgstr ""
 
 #. module: repair
@@ -1339,8 +1327,8 @@ msgstr ""
 #. module: repair
 #: model:ir.model.fields,help:repair.field_stock_picking_type__default_product_location_src_id
 msgid ""
-"This is the default source location for product which come for the repair "
-"when you create a repair order with this operation type."
+"This is the default source location for the product to be repaired in repair"
+" orders with this operation type."
 msgstr ""
 
 #. module: repair

--- a/addons/repair/models/stock_picking.py
+++ b/addons/repair/models/stock_picking.py
@@ -25,22 +25,19 @@ class PickingType(models.Model):
         string="Number of Late Repair Orders", compute='_compute_count_repair')
 
     default_product_location_src_id = fields.Many2one(
-        'stock.location', 'Default Product Source Location', compute='_compute_default_product_location_id',
+        'stock.location', 'Product Source Location', compute='_compute_default_product_location_id',
         check_company=True, store=True, readonly=False, precompute=True,
-        help="This is the default source location for product which come for the repair when you create a repair order with this operation type.")
-
+        help="This is the default source location for the product to be repaired in repair orders with this operation type.")
     default_product_location_dest_id = fields.Many2one(
-        'stock.location', 'Default Product Destination Location', compute='_compute_default_product_location_id',
+        'stock.location', 'Product Destination Location', compute='_compute_default_product_location_id',
         check_company=True, store=True, readonly=False, precompute=True,
-        help="This is the default destination location for product which come for the repair when you create a repair order with this operation type.")
-
+        help="This is the default destination location for the product to be repaired in repair orders with this operation type.")
     default_remove_location_dest_id = fields.Many2one(
-        'stock.location', 'Default Remove Destination Location', compute='_compute_default_remove_location_dest_id',
+        'stock.location', 'Remove Destination Location', compute='_compute_default_remove_location_dest_id',
         check_company=True, store=True, readonly=False, precompute=True,
         help="This is the default remove destination location when you create a repair order with this operation type.")
-
     default_recycle_location_dest_id = fields.Many2one(
-        'stock.location', 'Default Recycle Destination Location', compute='_compute_default_recycle_location_dest_id',
+        'stock.location', 'Recycle Destination Location', compute='_compute_default_recycle_location_dest_id',
         check_company=True, store=True, readonly=False, precompute=True,
         help="This is the default recycle destination location when you create a repair order with this operation type.")
 

--- a/addons/repair/views/stock_picking_views.xml
+++ b/addons/repair/views/stock_picking_views.xml
@@ -5,18 +5,19 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='default_location_src_id']" position="attributes">
-                <attribute name="invisible">code=='repair_operation'</attribute>
-            </xpath>
-            <xpath expr="//field[@name='default_location_dest_id']" position="attributes">
-                <attribute name="string">Default Component Destination Location</attribute>
-            </xpath>
-            <xpath expr="//field[@name='default_location_dest_id']" position="before">
+            <xpath expr="//label[@name='default_location_src_id_label']" position="before">
                 <field name="default_product_location_src_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
-                <field name="default_location_src_id" string="Default Component Source Location" invisible="code != 'repair_operation'" options="{'no_create': True}" required="code in ('internal', 'outgoing')"/>
-            </xpath>
-            <xpath expr="//field[@name='default_location_dest_id']" position="after">
                 <field name="default_product_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
+            </xpath>
+            <xpath expr="//label[@name='default_location_src_id_label']" position="replace">
+                <label for="default_location_src_id" name="default_location_src_id_label" invisible="code == 'repair_operation'"/>
+                <label for="default_location_src_id" string="Component Source Location" invisible="code != 'repair_operation'"/>
+            </xpath>
+            <xpath expr="//label[@name='default_location_dest_id_label']" position="replace">
+                <label for="default_location_dest_id" name="default_location_dest_id_label" invisible="code == 'repair_operation'"/>
+                <label for="default_location_dest_id" string="Component Destination Location" invisible="code != 'repair_operation'"/>
+            </xpath>
+            <xpath expr="//div[@name='default_location_dest_id_div']" position="after">
                 <field name="default_remove_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
                 <field name="default_recycle_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
             </xpath>

--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -9017,17 +9017,17 @@ msgstr ""
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking_type__default_location_dest_id
 msgid ""
-"This is the default destination location when you create a picking manually "
-"with this operation type. It is possible however to change it or that the "
-"routes put another location."
+"This is the default destination location when this operation is manually "
+"created. However, it is possible to change it afterwards or that the routes "
+"use another one by default."
 msgstr ""
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking_type__default_location_src_id
 msgid ""
-"This is the default source location when you create a picking manually with "
-"this operation type. It is possible however to change it or that the routes "
-"put another location."
+"This is the default source location when this operation is manually created."
+" However, it is possible to change it afterwards or that the routes use "
+"another one by default."
 msgstr ""
 
 #. module: stock

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -33,11 +33,11 @@ class PickingType(models.Model):
     default_location_src_id = fields.Many2one(
         'stock.location', 'Source Location', compute='_compute_default_location_src_id',
         check_company=True, store=True, readonly=False, precompute=True, required=True,
-        help="This is the default source location when you create a picking manually with this operation type. It is possible however to change it or that the routes put another location.")
+        help="This is the default source location when this operation is manually created. However, it is possible to change it afterwards or that the routes use another one by default.")
     default_location_dest_id = fields.Many2one(
         'stock.location', 'Destination Location', compute='_compute_default_location_dest_id',
         check_company=True, store=True, readonly=False, precompute=True, required=True,
-        help="This is the default destination location when you create a picking manually with this operation type. It is possible however to change it or that the routes put another location.")
+        help="This is the default destination location when this operation is manually created. However, it is possible to change it afterwards or that the routes use another one by default.")
     code = fields.Selection([('incoming', 'Receipt'), ('outgoing', 'Delivery'), ('internal', 'Internal Transfer')], 'Type of Operation', default='incoming', required=True)
     return_picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type for Returns',

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -119,8 +119,15 @@
                                     picking type with the code 'Internal', which make sense, but as the field 'code' on picking
                                     types can't be partially hidden, you can still select the code internal in the form view -->
                                 <group string="Locations" groups="stock.group_stock_multi_locations" name="locations">
-                                    <field name="default_location_src_id" options="{'no_create': True}" required="1"/>
-                                    <field name="default_location_dest_id" options="{'no_create': True}" required="1"/>
+                                    <!-- Labels = hack to handle field location string changes in repair -->
+                                    <label for="default_location_src_id" name="default_location_src_id_label"/>
+                                    <div class="o_row" name="default_location_src_id_div">
+                                        <field name="default_location_src_id" options="{'no_create': True}" required="1"/>
+                                    </div>
+                                    <label for="default_location_dest_id" name="default_location_dest_id_label"/>
+                                    <div class="o_row" name="default_location_dest_id_div">
+                                        <field name="default_location_dest_id" options="{'no_create': True}" required="1"/>
+                                    </div>
                                 </group>
                             </group>
                         </page>


### PR DESCRIPTION
Followup to task: 4028900

Fixes the following issues:
- The label of "Default Component Destination Location" was applied to all operation types, not just `repair_operation`. This resulted in confusing labeling for all the other operation types when Repair was installed
- The "help" of `default_location_src_id` and `default_location_dest_id` referred to stock pickings, but these fields are also used for MRP and Repair. So the help has been updated to be more generic to avoid confusion
- Task: 4034713 removed the "Default" from the label of the default location fields for picking types, therefore we remove them from the repair ones for consistency
- cleaned up the inheritance of the picking type form view in repair so that the `default_location_src_id` field isn't in the same view twice (or have inconsistent attributes)
- reordered the Repair default locations to follow a more logic ordering


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
