### PR TITLE
[FIX] mail: do not show unread indicator on muted notifications

### DIFF
--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -12,7 +12,7 @@
             'px-3 py-2': !ui.isSmall,
             'o-active': props.isActive,
         }">
-            <span class="o-mail-NotificationItem-unreadIndicator position-absolute opacity-50" t-att-class="{ 'opacity-0': props.muted }"><i class="fa fa-circle"/></span>
+            <span class="o-mail-NotificationItem-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': props.muted, 'opacity-50': !props.muted }"><i class="fa fa-circle"/></span>
             <div class="position-relative bg-inherit m-1 flex-shrink-0" style="width:40px;height:40px;">
                 <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>


### PR DESCRIPTION
There was `opacity-0` on muted item, but due to `opacity-50` being mistakenly present at all time, it had precedence over the `opacity-0` thus the unread indicator was always visible.

![Screenshot 2024-11-08 at 19 10 03](https://github.com/user-attachments/assets/f7253df8-c3e9-46e6-a109-114370a9de7d)
