### PR TITLE
[FIX] mail: fix send email error

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -385,7 +385,11 @@ class MailTemplate(models.Model):
                         email_to_company[mail] = record_company
 
             if all_emails:
-                customers_information = ModelSudo.browse(res_ids)._get_customer_information()
+                if hasattr(ModelSudo, '_get_customer_information'):
+                    customers_information = ModelSudo.browse(res_ids)._get_customer_information()
+                else:
+                    customers_information = {}
+
                 partners = self.env['res.partner']._find_or_create_from_emails(
                     all_emails,
                     additional_values={

--- a/doc/cla/individual/willcoderwang.md
+++ b/doc/cla/individual/willcoderwang.md
@@ -1,0 +1,12 @@
+New Zealand, 2024-11-09
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Zhikun Wang wzk@disroot.org https://github.com/willcoderwang
+


### PR DESCRIPTION
fixes odoo/odoo#186233

Description of the issue/feature this PR addresses:
Fix the "AttributeError: 'res.users' object has no attribute '_get_customer_information'" error when sending email.

Current behavior before PR:
Get an exception.
Desired behavior after PR is merged:
No exception and email is sent.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
