### PR TITLE
[FIX] point_of_sale: add padding to pos receipt

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
@@ -129,6 +129,7 @@ odoo.define('point_of_sale.ReceiptScreen', function (require) {
             }
             async _sendReceiptToCustomer() {
                 const printer = new Printer(null, this.env.pos);
+                printer.isEmail = true;
                 const receiptString = this.orderReceipt.el.innerHTML;
                 const ticketImage = await printer.htmlToImg(receiptString);
                 const order = this.currentOrder;

--- a/addons/point_of_sale/static/src/js/printers.js
+++ b/addons/point_of_sale/static/src/js/printers.js
@@ -98,6 +98,9 @@ var PrinterMixin = {
     htmlToImg: function (receipt) {
         $('.pos-receipt-print').html(receipt);
         this.receipt = $('.pos-receipt-print>.pos-receipt');
+        if (this.isEmail) {
+            $('.pos-receipt-print .pos-receipt').css({ 'padding': '15px', 'padding-bottom': '30px'})
+        }
         // Odoo RTL support automatically flip left into right but html2canvas
         // won't work as expected if the receipt is aligned to the right of the
         // screen so we need to flip it back.


### PR DESCRIPTION
### Issue:
- In 16.0 only, When sending a POS receipt by email, the receipt displays correctly in the preview within the POS app. However, the attached receipt in the email appears cropped, and the company logo is not centered.

### Steps to reproduce:
1. On runbot, go to the POS app.
2. Start a session. add a product, a customer and pay.
3. Click on send by email arrow button.
4. check receipt on mailhog.

### Solution:
- I've wrapped the receipt content with a #receipt-wrapper div, allowing you to add a padding (margin).

opw-[4140950](https://www.odoo.com/web#id=4140950&view_type=form&model=project.task)

![image](https://github.com/user-attachments/assets/30dba206-9d41-4d45-bcd0-1ca0105d42f6)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
