### PR TITLE
[REF] mail: wrap attachment preview logic into a function

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -102,6 +102,10 @@ export class AttachmentList extends Component {
         });
     }
 
+    onClickAttachment(attachment) {
+        this.fileViewer.open(attachment, this.props.attachments);
+    }
+
     /**
      * @param {import("models").Attachment} attachment
      */

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -20,7 +20,7 @@
                      t-att-class="{ 'o-isUploading': attachment.uploading }"
                      tabindex="0"
                      t-att-data-mimetype="attachment.mimetype"
-                     t-on-click="() => this.fileViewer.open(attachment, props.attachments)"
+                     t-on-click="() => this.onClickAttachment(attachment)"
                      role="menuitem"
                 >
                     <img
@@ -50,7 +50,7 @@
                                }"
                     t-attf-class="bg-300"
                     t-att-title="attachment.name ? attachment.name : undefined" role="menu" t-att-aria-label="attachment.name"
-                    t-on-click="() => this.fileViewer.open(attachment, props.attachments)"
+                    t-on-click="() => this.onClickAttachment(attachment)"
                 >
                     <!-- o_image from mimetype.scss -->
                     <t t-ref="nonImageMain">

--- a/addons/mail/static/src/discuss/voice_message/common/attachment_list_patch.xml
+++ b/addons/mail/static/src/discuss/voice_message/common/attachment_list_patch.xml
@@ -9,7 +9,6 @@
         </xpath>
         <xpath expr="//div[hasclass('o-mail-AttachmentCard')]" position="attributes">
             <attribute name="t-attf-class" remove="bg-300" add="{{ attachment.voice ? 'bg-100' : 'bg-300'}}"/>
-            <attribute name="t-on-click">() => !attachment.voice ? this.fileViewer.open(attachment, props.attachments) : ""</attribute>
         </xpath>
         <xpath expr="//button[hasclass('o-mail-AttachmentCard-unlink')]" position="attributes">
             <attribute name="t-attf-class">{{ env.inComposer ? 'o-inComposer position-absolute btn-primary transition-base' : (attachment.voice ? 'bg-100' : 'bg-300') }}</attribute>

--- a/addons/mail/static/src/discuss/voice_message/common/attachment_model_patch.js
+++ b/addons/mail/static/src/discuss/voice_message/common/attachment_model_patch.js
@@ -12,5 +12,10 @@ const attachmentPatch = {
         }
         super.delete(...arguments);
     },
+    onClickAttachment(attachment) {
+        if (!attachment.voice) {
+            super.onClickAttachment(attachment);
+        }
+    },
 };
 patch(Attachment.prototype, attachmentPatch);


### PR DESCRIPTION
This commit is a first step to support opening and viewing  attachements
of type `application/o-spreadsheet` direclty from the attachment list
component. It wraps the attachement preview logic inside a separate functio
in order to be able to override it later and add viewing o-spreadsheet attachments
later.

task-3829519d:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
