### PR TITLE
[FIX] mail: pass correct flag for regex

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -242,7 +242,7 @@ def html_normalize(src, filter_callback=None, output_method="html"):
         return src
 
     # html: remove encoding attribute inside tags
-    src = re.sub(r'(<[^>]*\s)(encoding=(["\'][^"\']*?["\']|[^\s\n\r>]+)(\s[^>]*|/)?>)', "", src, re.IGNORECASE | re.DOTALL)
+    src = re.sub(r'(<[^>]*\s)(encoding=(["\'][^"\']*?["\']|[^\s\n\r>]+)(\s[^>]*|/)?>)', "", src, flags=re.IGNORECASE | re.DOTALL)
 
     src = src.replace('--!>', '-->')
     src = re.sub(r'(<!-->|<!--->)', '<!-- -->', src)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Passing the regex flags in place of positional argument `count` generates a warning. Pass correct argument to `re.sub()`

Current behavior before PR:
Warning appears in log about incorrect use of positional parameter `count`.

Desired behavior after PR is merged:
No warning appears in log by `mail` addon due to usage of  `re.sub`.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
