### PR TITLE
[FIX] point_of_sale: wrong Payments in Cash in POS when session closing

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -548,7 +548,7 @@ class PosSession(models.Model):
         pay_later_payments = orders.payment_ids - payments
         cash_payment_method_ids = self.payment_method_ids.filtered(lambda pm: pm.type == 'cash')
         default_cash_payment_method_id = cash_payment_method_ids[0] if cash_payment_method_ids else None
-        total_default_cash_payment_amount = sum(payments.filtered(lambda p: p.payment_method_id == default_cash_payment_method_id).mapped('amount')) if default_cash_payment_method_id else 0
+        total_default_cash_payment_amount = sum(payments.filtered(lambda p: p.payment_method_id == default_cash_payment_method_id and not p.is_change).mapped('amount')) if default_cash_payment_method_id else 0
         other_payment_method_ids = self.payment_method_ids - default_cash_payment_method_id if default_cash_payment_method_id else self.payment_method_ids
         cash_in_count = 0
         cash_out_count = 0


### PR DESCRIPTION
When a customer pays $100 in cash and receives $44 as change, the system erroneously calculates the total cash payment as $12. This fix adjusts the logic to ensure the correct cash total reflects the actual cash transactions, calculating it as $56 ($100 received - $44 returned).





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
