### PR TITLE
[IMP] base: update IDR currency decimal rounding

### DIFF
--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -134,7 +134,7 @@
             <field name="iso_numeric">360</field>
             <field name="full_name">Indonesian rupiah</field>
             <field name="symbol">Rp</field>
-            <field name="rounding">0.01</field>
+            <field name="rounding">1</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rupiah</field>


### PR DESCRIPTION
In Indonesia, general transactions don't involve decimal places because the amount is too small (1 USD is around 15700 IDR). This change is also aligned with our integrations to Xendit (`payment_xendit`), QRIS (`l10n_id`) as they only accept integer amount through API. Similarly to how we implement e-Faktur (`l10n_id_efaktur`), we always use integer amount.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
