### PR TITLE
[FIX] web_editor: convert divs with inline content to `<p>` during paste

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -1864,6 +1864,18 @@ describe('Paste', () => {
             });
         });
     });
+    describe('Complex html div', () => {
+        const complexHtmlData = `<div><div><span style="color: #fb4934;">abc</span><span style="color: #ebdbb2;">def</span></div><div dir="rtl"><span style="color: #fb4934;">ghi</span><span style="color: #fe8019;">jkl</span></div><div><span style="color: #fb4934;">jkl</span><span style="color: #ebdbb2;">mno</span></div></div>`;
+        it('should convert div to p', async () =>{
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>[]<br></p>',
+                stepFunction: async editor => {
+                    await pasteHtml(editor, complexHtmlData);
+                },
+                contentAfter: '<p>abcdef</p><p dir="rtl">ghijkl</p><p>jklmno[]</p>',
+            });
+        });
+    });
     describe('Special cases', () => {
         describe('lists', async () => {
             it('should paste a list in a p', async () => {

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -648,6 +648,10 @@ blockquote {
 
 pre {
     white-space: pre-wrap;
+
+    p {
+        margin-bottom: 0px;
+    }
 }
 
 // Extend bootstrap to create background and text utilities for some colors


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

When pasting content containing `<div>` elements with inline child nodes, the `<div>` tags were unwrapped, causing all inline content within multiple `<div>` elements to merge into a single line.

Desired behavior after PR is merged:

`<div>` elements are now converted to `<p>` tags. This preserves the block structure and ensures inline content within each `<div>` remains in original format.

task-4309745

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
