### PR TITLE
[FIX] web_editor: preserve cropper size when rotating an image

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop_widget.js
@@ -240,7 +240,6 @@ const ImageCropWidget = Widget.extend({
                 break;
             case 'rotate':
                 this.$cropperImage.cropper(action, value);
-                this._resetCropBox();
                 break;
             case 'flip': {
                 const amount = this.$cropperImage.cropper('getData')[scaleDirection] * -1;

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -45,7 +45,7 @@ safe_attrs = defs.safe_attrs | frozenset(
     ['style',
      'data-o-mail-quote', 'data-o-mail-quote-node',  # quote detection
      'data-oe-model', 'data-oe-id', 'data-oe-field', 'data-oe-type', 'data-oe-expression', 'data-oe-translation-initial-sha', 'data-oe-nodeid',
-     'data-last-history-steps',
+     'data-last-history-steps', 'data-width', 'data-height', 'data-scale-x', 'data-scale-y', 'data-x', 'data-y',
      'data-publish', 'data-id', 'data-res_id', 'data-interval', 'data-member_id', 'data-scroll-background-ratio', 'data-view-id',
      'data-class', 'data-mimetype', 'data-original-src', 'data-original-id', 'data-gl-filter', 'data-quality', 'data-resize-width',
      'data-shape', 'data-shape-colors', 'data-file-name', 'data-original-mimetype',


### PR DESCRIPTION
**Current behavior before PR:**

- Rotating a cropped image reset the cropper to cover the entire image.

- When saving the record, all attributes not in the safe_attrs list were
  sanitized. As a result, if the record contained a cropped image, its
  crop-related attributes were also sanitized. Consequently, when the cropper
  was reopened, the container displayed the entire image instead of the cropped
  version.

**Desired behavior after PR is merged:**

- The cropper now retains its size when rotating a cropped image, maintaining the original crop area.

- Image attributes such as data-width, data-height, data-scale-x, data-scale-y,
  data-x, and data-y are no longer sanitized during the save process. This
  ensures that when the cropper is reopened for a cropped image, the container
  correctly displays only the cropped portion of the image, rather than the
  entire image.

task-4290693
