### PR TITLE
[IMP] website: change "Steps" snippet arrow direction for RTL languages

### DIFF
--- a/addons/website/static/src/snippets/s_process_steps/002.scss
+++ b/addons/website/static/src/snippets/s_process_steps/002.scss
@@ -21,8 +21,20 @@
         .s_process_step_connector {
             height: $process-step-number-size;
             width: calc(100% - #{$process-step-number-size});
-            left: calc(50% + #{$process-step-number-size / 2});
+            left: calc(50% + #{$process-step-number-size / 2} + 16px);
 
+            transform: unset;
+            // `o_up_curve` uses to indicate the up side curves arrows, as a
+            // helper to switch the direction for the `rtl` languages.
+            &.o_up_curve {
+                transform: scale(1, -1);
+            }
+            .o_rtl & {
+                transform: scale(-1, 1);
+                &.o_up_curve {
+                    transform: scale(-1, -1);
+                }
+            }
             path {
                 stroke: $border-color;
                 fill: transparent;
@@ -31,12 +43,6 @@
 
         &:last-child .s_process_step_connector {
             display: none;
-        }
-    }
-
-    &.s_process_steps_connector_curved_arrow {
-        .s_process_step:nth-child(odd) .s_process_step_connector {
-            transform: scale(1, -1);
         }
     }
 

--- a/addons/website/static/src/snippets/s_process_steps/options.js
+++ b/addons/website/static/src/snippets/s_process_steps/options.js
@@ -109,7 +109,6 @@ options.registry.StepsConnector = options.Class.extend({
             this.hCurrentStepIconHeight = stepMainElementRect.height / 2;
             this.hNextStepIconHeight = nextStepMainElementRect.height / 2;
 
-            connectorEl.style.left = `calc(50% + ${stepMainElementRect.width / 2}px + 16px)`;
             connectorEl.style.height = `${
                 stepMainElementRect.height + Math.abs(stepHeightDifference)
             }px`;
@@ -127,11 +126,12 @@ options.registry.StepsConnector = options.Class.extend({
             connectorEl.style.display = 'block';
             const {height, width} = connectorEl.getBoundingClientRect();
             connectorEl.style.removeProperty('display');
-            if (type === "s_process_steps_connector_curved_arrow" && i % 2 === 0) {
-                connectorEl.style.transform = stepHeightDifference ? "unset" : "scale(1, -1)";
-            } else {
-                connectorEl.style.transform = "unset";
-            }
+            const isEvenUpperCurve = (
+                type === "s_process_steps_connector_curved_arrow" &&
+                i % 2 === 0 &&
+                !stepHeightDifference
+            );
+            connectorEl.classList.toggle("o_up_curve", isEvenUpperCurve);
             connectorEl.setAttribute('viewBox', `0 0 ${width} ${height}`);
             connectorEl
                 .querySelector("path")


### PR DESCRIPTION
Steps to Reproduce:
1. Install an RTL language (e.g., Arabic (Syria)).
2. Drag and drop the steps snippet on the website.
3. Switch the website language to the installed RTL language.
> Observe that the arrows do not follow the correct RTL flow.

This commit resolves the issue by ensuring the arrows adjust correctly
in RTL layouts using appropriate `transform` and `scale` properties.

task-4286249