### PR TITLE
[FIX] hr: fix badge id issue in employee profile

### DIFF
--- a/addons/hr/i18n/hr.pot
+++ b/addons/hr/i18n/hr.pot
@@ -2975,7 +2975,7 @@ msgstr ""
 #. module: hr
 #. odoo-python
 #: code:addons/hr/models/hr_employee.py:0
-msgid "The Badge ID must be a sequence of digits."
+msgid "The Badge ID must be alphanumeric without any accents and no longer than 18 characters."
 msgstr ""
 
 #. module: hr

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
+import re
 from pytz import timezone, UTC
 from datetime import datetime, time
 from random import choice
@@ -429,8 +430,9 @@ class HrEmployeePrivate(models.Model):
     @api.constrains('barcode')
     def _verify_barcode(self):
         for employee in self:
-            if employee.barcode and not employee.barcode.isdigit():
-                raise ValidationError(_("The Badge ID must be a sequence of digits."))
+            if employee.barcode:
+                if not (re.match(r'^[A-Za-z0-9]+$', employee.barcode) and len(employee.barcode) <= 18):
+                    raise ValidationError(_("The Badge ID must be alphanumeric without any accents and no longer than 18 characters."))
 
     @api.constrains('ssnid')
     def _check_ssnid(self):

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -422,3 +422,23 @@ class TestHrEmployee(TestHrCommon):
         employee_norbert = self.env['hr.employee'].create({'name': 'Norbert Employee', 'user_id': user_norbert.id})
         self.assertEqual(employee_norbert.image_1920, user_norbert.image_1920)
         self.assertEqual(employee_norbert.avatar_1920, user_norbert.avatar_1920)
+
+    def test_badge_validation(self):
+        # check employee's barcode should be a sequence of digits and alphabets
+        employee = self.env['hr.employee'].create({
+            'name': 'Badge Employee'
+        })
+
+        employee_form = Form(employee)
+        employee_form.barcode = 'Test@badge1'
+        with self.assertRaises(ValidationError):
+            employee_form.save()
+
+        employee_form.barcode = 'Testàë@badge'
+        with self.assertRaises(ValidationError):
+            employee_form.save()
+
+        employee_form.barcode = 'Testbadge2'
+        employee_form.save()
+
+        self.assertEqual(employee_form.barcode, 'Testbadge2')


### PR DESCRIPTION
**Steps:**
- Install the hr module
- Open the employee profile

-----

**Description of the issue/feature this PR addresses:**
In the employee profile, when entering letters with accents (é è à ë ...) in the badge ID, the barcode fails to print correctly, displaying the badge number as plain text instead.

-----

**Cause:**
The issue is due to barcode scanner limitations.

-----


**Fix:**
This PR resolves the issue by restricting the badge ID to alphanumeric characters without accents.

task-4316576
