### PR TITLE
[CLN] various: rename tax_id to tax_ids on SOL

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -216,7 +216,7 @@ class SaleOrder(models.Model):
             'price_unit': price_unit,
             'product_uom_qty': 1,
             'product_id': carrier.product_id.id,
-            'tax_id': [(6, 0, taxes_ids)],
+            'tax_ids': [(6, 0, taxes_ids)],
             'is_delivery': True,
         }
         if carrier.free_over and self.currency_id.is_zero(price_unit) :

--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -424,7 +424,7 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
         delivery_line = sale_order.order_line.filtered(lambda l: l.is_delivery)
 
         # delivery line should have taxes from the branch company
-        self.assertRecordValues(delivery_line, [{'product_id': delivery_product.id, 'tax_id': tax_b.ids}])
+        self.assertRecordValues(delivery_line, [{'product_id': delivery_product.id, 'tax_ids': tax_b.ids}])
 
         # update delivery product by setting only the tax from parent company
         delivery_product.write({'taxes_id': [Command.set((tax_a).ids)]})
@@ -438,7 +438,7 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
         delivery_line = sale_order.order_line.filtered(lambda l: l.is_delivery)
 
         # delivery line should have taxes from the parent company as there is no tax from the branch company
-        self.assertRecordValues(delivery_line, [{'product_id': delivery_product.id, 'tax_id': tax_a.ids}])
+        self.assertRecordValues(delivery_line, [{'product_id': delivery_product.id, 'tax_ids': tax_a.ids}])
 
     def test_update_weight_in_shipping_when_change_quantity(self):
         product_test = self.env['product.product'].create({

--- a/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
+++ b/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
@@ -30,7 +30,7 @@ class TestPoSSaleL10NBe(TestPointOfSaleHttpCommon):
                 'product_id': self.product_a.id,
                 'product_uom_qty': 10,
                 'price_unit': 10,
-                'tax_id': False,
+                'tax_ids': False,
             })],
         })
 

--- a/addons/l10n_ec_sale/tests/test_l10n_ec_account_sale.py
+++ b/addons/l10n_ec_sale/tests/test_l10n_ec_account_sale.py
@@ -27,7 +27,7 @@ class TestL10nECAccountSale(TestSaleCommon):
                 Command.create({
                     'product_id': cls.company_data['product_order_no'].id,
                     'product_uom_qty': 5,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })

--- a/addons/l10n_hu_edi/tests/common.py
+++ b/addons/l10n_hu_edi/tests/common.py
@@ -168,7 +168,7 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
                     'product_id': self.product_a.id,
                     'product_uom_qty': 1,
                     'price_unit': 10000.0,
-                    'tax_id': [Command.set(self.tax_vat.ids)],
+                    'tax_ids': [Command.set(self.tax_vat.ids)],
                 })
             ]
         })

--- a/addons/l10n_in_sale_stock/models/stock_move.py
+++ b/addons/l10n_in_sale_stock/models/stock_move.py
@@ -26,6 +26,6 @@ class StockMove(models.Model):
         if line_id := self.sale_line_id:
             return {
                 'is_from_order': True,
-                'taxes': line_id.tax_id,
+                'taxes': line_id.tax_ids,
             }
         return super()._l10n_in_get_product_tax()

--- a/addons/l10n_it_edi_doi/models/sale_order.py
+++ b/addons/l10n_it_edi_doi/models/sale_order.py
@@ -163,12 +163,12 @@ class SaleOrder(models.Model):
             if not declaration_of_intent_tax:
                 continue
             declaration_tax_lines = order.order_line.filtered(
-                lambda line: declaration_of_intent_tax in line.tax_id
+                lambda line: declaration_of_intent_tax in line.tax_ids
             )
             if declaration_tax_lines and not order.l10n_it_edi_doi_id:
                 errors.append(_('Given the tax %s is applied, there should be a Declaration of Intent selected.',
                                 declaration_of_intent_tax.name))
-            if any(line.tax_id != declaration_of_intent_tax for line in declaration_tax_lines):
+            if any(line.tax_ids != declaration_of_intent_tax for line in declaration_tax_lines):
                 errors.append(_('A line using tax %s should not contain any other taxes',
                                 declaration_of_intent_tax.name))
         if errors:
@@ -240,7 +240,7 @@ class SaleOrder(models.Model):
             order_lines = order.order_line.filtered(
                 # The declaration tax cannot be used with other taxes on a single line
                 # (checked in `action_confirm`)
-                lambda line: line.tax_id.ids == tax.ids
+                lambda line: line.tax_ids.ids == tax.ids
             )
             order_not_yet_invoiced = 0
             for line in order_lines:

--- a/addons/l10n_it_edi_doi/tests/test_amounts_and_warnings.py
+++ b/addons/l10n_it_edi_doi/tests/test_amounts_and_warnings.py
@@ -93,7 +93,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
                 'product_id': self.product_1.id,
                 'price_unit': 1000.0,  # == declaration.threshold
                 'product_uom_qty': 2,
-                'tax_id': [Command.set(declaration_tax.ids)],
+                'tax_ids': [Command.set(declaration_tax.ids)],
             }),
         ])
 
@@ -217,13 +217,13 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
                 'name': 'declaration line',
                 'product_id': self.product_1.id,
                 'price_unit': 1000.0,  # == declaration.threshold
-                'tax_id': [Command.set(declaration_tax.ids)],
+                'tax_ids': [Command.set(declaration_tax.ids)],
             }),
             Command.create({
                 'name': 'not a declaration line',
                 'product_id': self.product_1.id,
                 'price_unit': 2000.0,  # > declaration.threshold; not counted
-                'tax_id': False,
+                'tax_ids': False,
             }),
         ])
 
@@ -313,13 +313,13 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
                 'name': 'declaration line',
                 'product_id': self.product_1.id,
                 'price_unit': 2000.0,  # > declaration.threshold
-                'tax_id': [Command.set(declaration_tax.ids)],
+                'tax_ids': [Command.set(declaration_tax.ids)],
             }),
             Command.create({
                 'name': 'not a declaration line',
                 'product_id': self.product_1.id,
                 'price_unit': 2000.0,  # > declaration.threshold; not counted
-                'tax_id': False,
+                'tax_ids': False,
             }),
         ])
         independent_order.action_confirm()
@@ -334,13 +334,13 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
                 'name': 'declaration line',
                 'product_id': self.product_1.id,
                 'price_unit': 1000.0,  # == declaration.threshold
-                'tax_id': [Command.set(declaration_tax.ids)],
+                'tax_ids': [Command.set(declaration_tax.ids)],
             }),
             Command.create({
                 'name': 'not a declaration line',
                 'product_id': self.product_1.id,
                 'price_unit': 2000.0,  # > declaration.threshold; not counted
-                'tax_id': False,
+                'tax_ids': False,
             }),
         ])
         order.action_confirm()
@@ -448,7 +448,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
                     'product_id': self.product_1.id,
                     'product_uom_qty': 2,
                     'price_unit': 2000.0,  # > declaration.threshold
-                    'tax_id': [Command.set(declaration_tax.ids)],
+                    'tax_ids': [Command.set(declaration_tax.ids)],
                 }),
             ]) for dummy in range(3)
         ])

--- a/addons/l10n_it_stock_ddt/tests/test_ddt.py
+++ b/addons/l10n_it_stock_ddt/tests/test_ddt.py
@@ -50,7 +50,7 @@ class TestDDT(TestSaleCommon):
                                    'product_id': p.id,
                                    'product_uom_qty': 5,
                                    'price_unit': p.list_price,
-                                   'tax_id': self.company_data['default_tax_sale']})
+                                   'tax_ids': self.company_data['default_tax_sale']})
                            for p in (
                     self.company_data['product_order_no'],
                     self.company_data['product_service_delivery'],
@@ -104,7 +104,7 @@ class TestDDT(TestSaleCommon):
                                    'product_id': self.product_a.id,
                                    'product_uom_qty': 3,
                                    'price_unit': self.product_a.list_price,
-                                   'tax_id': self.company_data['default_tax_sale']
+                                   'tax_ids': self.company_data['default_tax_sale']
                                    }
                             )],
             'pricelist_id': self.company_data['default_pricelist'].id,

--- a/addons/l10n_it_stock_ddt/tests/test_edi.py
+++ b/addons/l10n_it_stock_ddt/tests/test_edi.py
@@ -108,7 +108,7 @@ class TestItEdiDDT(TestItEdi):
                         'product_id': product.id,
                         'product_uom_qty': 5,
                         'price_unit': product.list_price,
-                        'tax_id': self.tax_22
+                        'tax_ids': self.tax_22
                     }) for product in self.products
                 ],
                 'pricelist_id': self.default_pricelist.id,

--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -70,7 +70,7 @@ class PosOrder(models.Model):
                     'product_id': line.product_id.id,
                     'price_unit': line.price_unit,
                     'product_uom_qty': 0,
-                    'tax_id': [(6, 0, line.tax_ids.ids)],
+                    'tax_ids': [(6, 0, line.tax_ids.ids)],
                     'is_downpayment': True,
                     'discount': line.discount,
                     'sequence': sale_lines and sale_lines[-1].sequence + 2 or 10,

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -73,7 +73,7 @@ class SaleOrderLine(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return ['discount', 'display_name', 'price_total', 'price_unit', 'product_id', 'product_uom_qty', 'qty_delivered',
-            'qty_invoiced', 'qty_to_invoice', 'display_type', 'name', 'tax_id', 'is_downpayment']
+            'qty_invoiced', 'qty_to_invoice', 'display_type', 'name', 'tax_ids', 'is_downpayment']
 
     @api.depends('pos_order_line_ids.qty')
     def _compute_qty_delivered(self):
@@ -88,7 +88,7 @@ class SaleOrderLine(models.Model):
             sale_line.qty_invoiced += sum([self._convert_qty(sale_line, pos_line.qty, 'p2s') for pos_line in sale_line.pos_order_line_ids], 0)
 
     def _get_sale_order_fields(self):
-        return ["product_id", "display_name", "price_unit", "product_uom_qty", "tax_id", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total", "is_downpayment"]
+        return ["product_id", "display_name", "price_unit", "product_uom_qty", "tax_ids", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total", "is_downpayment"]
 
     def read_converted(self):
         field_names = self._get_sale_order_fields()

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -98,9 +98,9 @@ patch(PosStore.prototype, {
                 price_unit: line.price_unit,
                 price_type: "automatic",
                 tax_ids:
-                    orderFiscalPos || !line.tax_id
+                    orderFiscalPos || !line.tax_ids
                         ? undefined
-                        : line.tax_id.map((t) => ["link", t]),
+                        : line.tax_ids.map((t) => ["link", t]),
                 sale_order_origin_id: sale_order,
                 sale_order_line_id: line,
                 customer_note: line.customer_note,
@@ -212,7 +212,7 @@ patch(PosStore.prototype, {
     async _createDownpaymentLines(sale_order, total_down_payment) {
         //This function will create all the downpaymentlines. We will create on downpayment line per unique tax combination
         const grouped = Object.groupBy(sale_order.order_line, (ol) => {
-            return ol.tax_id.map((tax_id) => tax_id.id).sort((a, b) => a - b);
+            return ol.tax_ids.map((tax_ids) => tax_ids.id).sort((a, b) => a - b);
         });
         Object.keys(grouped).forEach(async (key) => {
             const group = grouped[key];
@@ -223,7 +223,7 @@ patch(PosStore.prototype, {
             const down_payment_line_price = total_down_payment * ratio;
             // We apply the taxes and keep the same price
             const new_price = compute_price_force_price_include(
-                group[0].tax_id,
+                group[0].tax_ids,
                 down_payment_line_price,
                 this.config.down_payment_product_id,
                 this.config._product_default_values,
@@ -236,7 +236,7 @@ patch(PosStore.prototype, {
                 product_tmpl_id: this.config.down_payment_product_id.product_tmpl_id,
                 price_unit: new_price,
                 sale_order_origin_id: sale_order,
-                tax_ids: [["link", ...group[0].tax_id]],
+                tax_ids: [["link", ...group[0].tax_ids]],
                 down_payment_details: sale_order.order_line
                     .filter(
                         (line) =>

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -557,7 +557,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
                     'product_id': self.product_a.id,
                     'product_uom_qty': 10.0,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -662,7 +662,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
                     'product_id': self.product_a.id,
                     'product_uom_qty': 1.0,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()

--- a/addons/pos_sale/views/point_of_sale_report.xml
+++ b/addons/pos_sale/views/point_of_sale_report.xml
@@ -11,7 +11,7 @@
                         <t t-if="sale_orders">
                             <t t-set="sale_order" t-value="sale_orders[0]"/>
                             <t t-foreach="sale_order.order_line" t-as="sale_order_line">
-                                <t t-if="sale_order_line.product_id != down_payment_product and sale_order_line.tax_id == line.tax_ids">
+                                <t t-if="sale_order_line.product_id != down_payment_product and sale_order_line.tax_ids == line.tax_ids">
                                     <div>
                                         <span style="margin-right: 5px;"><t t-esc="int(sale_order_line.product_uom_qty)"/>x</span>
                                         <span t-esc="sale_order_line.name" />

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -72,7 +72,7 @@ class AccountMove(models.Model):
                 for l in so_dpl.invoice_lines
                 if l.move_id.state == 'posted' and l.move_id not in real_invoices  # don't recompute with the final invoice
             )
-            so_dpl.tax_id = so_dpl.invoice_lines.tax_ids
+            so_dpl.tax_ids = so_dpl.invoice_lines.tax_ids
 
         return res
 

--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -162,7 +162,7 @@ class AccountMoveLine(models.Model):
             'name': self.name,
             'sequence': last_sequence,
             'price_unit': price,
-            'tax_id': [x.id for x in taxes],
+            'tax_ids': [x.id for x in taxes],
             'discount': 0.0,
             'product_id': self.product_id.id,
             'product_uom_id': self.product_uom_id.id,

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1284,7 +1284,7 @@ class SaleOrder(models.Model):
 
     def _recompute_taxes(self):
         lines_to_recompute = self.order_line.filtered(lambda line: not line.display_type)
-        lines_to_recompute._compute_tax_id()
+        lines_to_recompute._compute_tax_ids()
         self.show_update_fpos = False
 
     def action_update_prices(self):

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -155,10 +155,10 @@ class SaleOrderLine(models.Model):
     combo_item_id = fields.Many2one(comodel_name='product.combo.item')
 
     # Pricing fields
-    tax_id = fields.Many2many(
+    tax_ids = fields.Many2many(
         comodel_name='account.tax',
         string="Taxes",
-        compute='_compute_tax_id',
+        compute='_compute_tax_ids',
         store=True, readonly=False, precompute=True,
         context={'active_test': False},
         check_company=True)
@@ -490,12 +490,12 @@ class SaleOrderLine(models.Model):
                 line.product_uom_id = line.product_id.uom_id
 
     @api.depends('product_id', 'company_id')
-    def _compute_tax_id(self):
+    def _compute_tax_ids(self):
         lines_by_company = defaultdict(lambda: self.env['sale.order.line'])
         cached_taxes = {}
         for line in self:
             if line.product_type == 'combo':
-                line.tax_id = False
+                line.tax_ids = False
                 continue
             lines_by_company[line.company_id] += line
         for company, lines in lines_by_company.items():
@@ -505,7 +505,7 @@ class SaleOrderLine(models.Model):
                     taxes = line.product_id.taxes_id._filter_taxes_by_company(company)
                 if not line.product_id or not taxes:
                     # Nothing to map
-                    line.tax_id = False
+                    line.tax_ids = False
                     continue
                 fiscal_position = line.order_id.fiscal_position_id
                 cache_key = (fiscal_position.id, company.id, tuple(taxes.ids))
@@ -516,7 +516,7 @@ class SaleOrderLine(models.Model):
                     result = fiscal_position.map_tax(taxes)
                     cached_taxes[cache_key] = result
                 # If company_id is set, always filter taxes by the company
-                line.tax_id = result
+                line.tax_ids = result
 
     def _get_custom_compute_tax_cache_key(self):
         """Hook method to be able to set/get cached taxes while computing them"""
@@ -747,7 +747,7 @@ class SaleOrderLine(models.Model):
         return self.env['account.tax']._prepare_base_line_for_taxes_computation(
             self,
             **{
-                'tax_ids': self.tax_id,
+                'tax_ids': self.tax_ids,
                 'quantity': self.product_uom_qty,
                 'partner_id': self.order_id.partner_id,
                 'currency_id': self.order_id.currency_id or self.order_id.company_id.currency_id,
@@ -756,7 +756,7 @@ class SaleOrderLine(models.Model):
             },
         )
 
-    @api.depends('product_uom_qty', 'discount', 'price_unit', 'tax_id')
+    @api.depends('product_uom_qty', 'discount', 'price_unit', 'tax_ids')
     def _compute_amount(self):
         for line in self:
             base_line = line._prepare_base_line_for_taxes_computation()
@@ -1038,11 +1038,11 @@ class SaleOrderLine(models.Model):
                 uom_qty_to_consider = line.qty_delivered if line.product_id.invoice_policy == 'delivery' else line.product_uom_qty
                 price_reduce = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
                 price_subtotal = price_reduce * uom_qty_to_consider
-                if len(line.tax_id.filtered(lambda tax: tax.price_include)) > 0:
+                if len(line.tax_ids.filtered(lambda tax: tax.price_include)) > 0:
                     # As included taxes are not excluded from the computed subtotal, `compute_all()` method
                     # has to be called to retrieve the subtotal without them.
                     # `price_reduce_taxexcl` cannot be used as it is computed from `price_subtotal` field. (see upper Note)
-                    price_subtotal = line.tax_id.compute_all(
+                    price_subtotal = line.tax_ids.compute_all(
                         price_reduce,
                         currency=line.currency_id,
                         quantity=uom_qty_to_consider,
@@ -1239,7 +1239,7 @@ class SaleOrderLine(models.Model):
         """
         return [
             'product_id', 'name', 'price_unit', 'product_uom_id', 'product_uom_qty',
-            'tax_id', 'analytic_distribution'
+            'tax_ids', 'analytic_distribution'
         ]
 
     def _update_line_quantity(self, values):
@@ -1334,7 +1334,7 @@ class SaleOrderLine(models.Model):
             'quantity': self.qty_to_invoice,
             'discount': self.discount,
             'price_unit': self.price_unit,
-            'tax_ids': [Command.set(self.tax_id.ids)],
+            'tax_ids': [Command.set(self.tax_ids.ids)],
             'sale_line_ids': [Command.link(self.id)],
             'is_downpayment': self.is_downpayment,
         }

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -119,7 +119,7 @@
                                 <td name="td_discount" t-if="display_discount" class="text-end">
                                     <span t-field="line.discount">-</span>
                                 </td>
-                                <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_id])"/>
+                                <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_ids])"/>
                                 <td name="td_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
                                     <span t-out="taxes">Tax 15%</span>
                                 </td>

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -68,7 +68,7 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
 
     isCellReadonly(column, record) {
         return super.isCellReadonly(column, record) || (
-            this.isComboItem(record) && column.name !== this.titleField && column.name !== 'tax_id'
+            this.isComboItem(record) && column.name !== this.titleField && column.name !== 'tax_ids'
         );
     }
 

--- a/addons/sale/tests/test_accrued_sale_orders.py
+++ b/addons/sale/tests/test_accrued_sale_orders.py
@@ -45,7 +45,7 @@ class TestAccruedSaleOrders(AccountTestInvoicingCommon):
                     'product_id': cls.product_a.id,
                     'product_uom_qty': 10.0,
                     'price_unit': cls.product_a.list_price,
-                    'tax_id': False,
+                    'tax_ids': False,
                     'analytic_distribution': {
                         cls.analytic_account_a.id : 80.0,
                         cls.analytic_account_b.id : 20.0,
@@ -56,7 +56,7 @@ class TestAccruedSaleOrders(AccountTestInvoicingCommon):
                     'product_id': cls.product_b.id,
                     'product_uom_qty': 10.0,
                     'price_unit': cls.product_b.list_price,
-                    'tax_id': False,
+                    'tax_ids': False,
                     'analytic_distribution': {
                         cls.analytic_account_b.id : 100.0,
                     },

--- a/addons/sale/tests/test_credit_limit.py
+++ b/addons/sale/tests/test_credit_limit.py
@@ -76,7 +76,7 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
                 'product_id': self.company_data['product_order_no'].id,
                 'product_uom_qty': 1,
                 'price_unit': 1000.0,
-                'tax_id': False,
+                'tax_ids': False,
             })]
         })
 
@@ -151,7 +151,7 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
                     'product_id': self.company_data['product_order_no'].id,
                     'product_uom_qty': 1,
                     'price_unit': 45.0,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })
             ]
         })
@@ -164,7 +164,7 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
                     'product_id': self.company_data['product_order_no'].id,
                     'product_uom_qty': 1,
                     'price_unit': 65.0,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })
             ],
         })

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -411,14 +411,14 @@ class TestSaleOrder(SaleCommon):
                     'product_uom_qty': 1,
                     'price_unit': 6.7,
                     'discount': 0,
-                    'tax_id': tax_a.ids,
+                    'tax_ids': tax_a.ids,
                 }),
                 Command.create({
                     'product_id': self.product.id,
                     'product_uom_qty': 1,
                     'price_unit': 6.7,
                     'discount': 0,
-                    'tax_id': tax_a.ids,
+                    'tax_ids': tax_a.ids,
                 }),
             ],
         })
@@ -434,14 +434,14 @@ class TestSaleOrder(SaleCommon):
                     'product_uom_qty': 1,
                     'price_unit': 6.7,
                     'discount': 0,
-                    'tax_id': tax_a.ids,
+                    'tax_ids': tax_a.ids,
                 }),
                 Command.create({
                     'product_id': self.product.id,
                     'product_uom_qty': 1,
                     'price_unit': 6.7,
                     'discount': 0,
-                    'tax_id': tax_a.ids,
+                    'tax_ids': tax_a.ids,
                 }),
             ],
         })
@@ -633,10 +633,10 @@ class TestSaleOrder(SaleCommon):
             line.product_id = product_no_tax
         so = so_form.save()
         self.assertRecordValues(so.order_line, [
-            {'product_id': product_all_taxes.id, 'tax_id': tax_xx.ids},
-            {'product_id': product_no_xx_tax.id, 'tax_id': tax_x.ids},
-            {'product_id': product_no_branch_tax.id, 'tax_id': (tax_a + tax_b).ids},
-            {'product_id': product_no_tax.id, 'tax_id': []},
+            {'product_id': product_all_taxes.id, 'tax_ids': tax_xx.ids},
+            {'product_id': product_no_xx_tax.id, 'tax_ids': tax_x.ids},
+            {'product_id': product_no_branch_tax.id, 'tax_ids': (tax_a + tax_b).ids},
+            {'product_id': product_no_tax.id, 'tax_ids': []},
         ])
 
 
@@ -803,11 +803,11 @@ class TestSalesTeam(SaleCommon):
             'name': product.name,
             'product_id': product.id,
             'order_id': sale_order.id,
-            'tax_id': tax_a,
+            'tax_ids': tax_a,
         })
 
         with self.assertRaises(UserError):
-            sol.tax_id = tax_b
+            sol.tax_ids = tax_b
 
     def test_assign_tax_multi_company(self):
         root_company = self.env['res.company'].create({'name': 'B0 company'})
@@ -848,15 +848,15 @@ class TestSalesTeam(SaleCommon):
             'name': product.name,
             'product_id': product.id,
             'order_id': sale_order.id,
-            'tax_id': tax_b1,
+            'tax_ids': tax_b1,
         })
 
         # should not raise anything
-        sol_b1.tax_id = tax_b0
-        sol_b1.tax_id = tax_b1
+        sol_b1.tax_ids = tax_b0
+        sol_b1.tax_ids = tax_b1
         # should raise (b2 is not on the same branch lineage as b1)
         with self.assertRaises(UserError):
-            sol_b1.tax_id = tax_b2
+            sol_b1.tax_ids = tax_b2
 
     def test_downpayment_amount_constraints(self):
         """Down payment amounts should be in the interval ]0, 1]."""

--- a/addons/sale/tests/test_sale_order_discount.py
+++ b/addons/sale/tests/test_sale_order_discount.py
@@ -28,7 +28,7 @@ class TestSaleOrderDiscount(SaleCommon):
         discount_line = self.sale_order.order_line[-1]
         self.assertEqual(discount_line.price_unit, -55)
         self.assertEqual(discount_line.product_uom_qty, 1.0)
-        self.assertFalse(discount_line.tax_id)
+        self.assertFalse(discount_line.tax_ids)
 
     def test_amount_with_manual_tax(self):
         self.tax_15pc_excl = self.env['account.tax'].create({
@@ -54,7 +54,7 @@ class TestSaleOrderDiscount(SaleCommon):
         self.assertEqual(len(solines), 2)
 
         # No taxes
-        solines.tax_id = [Command.clear()]
+        solines.tax_ids = [Command.clear()]
         self.wizard.write({
             'discount_percentage': 0.5,  # 50%
             'discount_type': 'so_discount',
@@ -63,31 +63,31 @@ class TestSaleOrderDiscount(SaleCommon):
 
         discount_line = self.sale_order.order_line[-1]
         self.assertAlmostEqual(discount_line.price_unit, -amount_before_discount * 0.5)
-        self.assertFalse(discount_line.tax_id)
+        self.assertFalse(discount_line.tax_ids)
         self.assertEqual(discount_line.product_uom_qty, 1.0)
 
         # One tax group
         discount_line.unlink()
         dumb_tax = self.env['account.tax'].create({'name': 'test'})
-        solines.tax_id = dumb_tax
+        solines.tax_ids = dumb_tax
         self.wizard.action_apply_discount()
 
         discount_line = self.sale_order.order_line - solines
         discount_line.ensure_one()
         self.assertAlmostEqual(discount_line.price_unit, -amount_before_discount * 0.5)
-        self.assertEqual(discount_line.tax_id, dumb_tax)
+        self.assertEqual(discount_line.tax_ids, dumb_tax)
         self.assertEqual(discount_line.product_uom_qty, 1.0)
 
         # Two tax groups
         discount_line.unlink()
-        solines[0].tax_id = [Command.clear()]
+        solines[0].tax_ids = [Command.clear()]
         self.wizard.action_apply_discount()
         discount_lines = self.sale_order.order_line - solines
         self.assertEqual(len(discount_lines), 2)
         self.assertEqual(discount_lines[0].price_unit, -solines[0].price_subtotal * 0.5)
         self.assertEqual(discount_lines[1].price_unit, -solines[1].price_subtotal * 0.5)
-        self.assertEqual(discount_lines[0].tax_id, solines[0].tax_id)
-        self.assertEqual(discount_lines[1].tax_id, solines[1].tax_id)
+        self.assertEqual(discount_lines[0].tax_ids, solines[0].tax_ids)
+        self.assertEqual(discount_lines[1].tax_ids, solines[1].tax_ids)
         self.assertTrue(all(line.product_uom_qty == 1.0 for line in discount_lines))
 
     def test_sol_discount(self):

--- a/addons/sale/tests/test_sale_order_down_payment.py
+++ b/addons/sale/tests/test_sale_order_down_payment.py
@@ -34,7 +34,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'product_uom_qty': 2,
             'price_unit': 100,
             'order_id': cls.sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol_serv_deliver = cls.env['sale.order.line'].create({
             'name': cls.company_data['product_service_delivery'].name,
@@ -42,7 +42,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'product_uom_qty': 2,
             'price_unit': 100,
             'order_id': cls.sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol_serv_order = cls.env['sale.order.line'].create({
             'name': cls.company_data['product_service_order'].name,
@@ -50,7 +50,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'product_uom_qty': 2,
             'price_unit': 100,
             'order_id': cls.sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol_product_deliver = cls.env['sale.order.line'].create({
             'name': cls.company_data['product_delivery_no'].name,
@@ -58,7 +58,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'product_uom_qty': 2,
             'price_unit': 100,
             'order_id': cls.sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
         cls.revenue_account = cls.company_data['default_account_revenue']
@@ -107,9 +107,9 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         income_acc_2 = self.revenue_account.copy()
         self.sale_order.order_line[1].product_id.product_tmpl_id.property_account_income_id = income_acc_2
 
-        self.sale_order.order_line[0].tax_id = self.tax_15 + self.tax_10
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = self.tax_15 + self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
         down_pay_amt = self.sale_order.amount_total / 2
@@ -168,7 +168,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
 
     def test_tax_with_diff_tax_on_invoice_breakdown(self):
         # if a generated invoice has it's taxes changed, this should not affect the next downpayment on an SO
-        self.sale_order.order_line[0].tax_id = self.tax_15
+        self.sale_order.order_line[0].tax_ids = self.tax_15
         (self.sale_order.order_line - self.sale_order.order_line[0]).unlink()
         self.make_downpayment(amount=25)
         first_invoice = self.sale_order.invoice_ids
@@ -192,9 +192,9 @@ class TestSaleOrderDownPayment(TestSaleCommon):
 
     def test_tax_breakdown_other_currency(self):
         self.sale_order.currency_id = self.other_currency  # rate = 2.0
-        self.sale_order.order_line[0].tax_id = self.tax_15 + self.tax_10
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = self.tax_15 + self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
         down_pay_amt = self.sale_order.amount_total / 2
@@ -215,9 +215,9 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_breakdown_fixed_payment_method(self):
-        self.sale_order.order_line[0].tax_id = self.tax_15 + self.tax_10
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = self.tax_15 + self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment(advance_payment_method='fixed', fixed_amount=222.5, amount=0)
         invoice = self.sale_order.invoice_ids
         down_pay_amt = 222.5
@@ -238,10 +238,10 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_breakdown_fixed_payment_method_with_taxes_on_all_lines(self):
-        self.sale_order.order_line[0].tax_id = self.tax_15
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
-        self.sale_order.order_line[3].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = self.tax_15
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
+        self.sale_order.order_line[3].tax_ids = self.tax_10
         self.make_downpayment(advance_payment_method='fixed', fixed_amount=222.5, amount=0)
         invoice = self.sale_order.invoice_ids
         down_pay_amt = 222.5
@@ -262,9 +262,9 @@ class TestSaleOrderDownPayment(TestSaleCommon):
 
     def test_tax_price_include_breakdown(self):
         tax_10_incl = self.create_tax(10, {'price_include_override': 'tax_included'})
-        self.sale_order.order_line[0].tax_id = tax_10_incl + self.tax_10
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = tax_10_incl + self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
         down_pay_amt = self.sale_order.amount_total / 2
@@ -287,9 +287,9 @@ class TestSaleOrderDownPayment(TestSaleCommon):
     def test_tax_price_include_include_base_amount_breakdown(self):
         tax_10_pi_ba = self.create_tax(10, {'price_include_override': 'tax_included', 'include_base_amount': True})
         self.tax_10.sequence = 2
-        self.sale_order.order_line[0].tax_id = tax_10_pi_ba + self.tax_10
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = tax_10_pi_ba + self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
         down_pay_amt = self.sale_order.amount_total / 2
@@ -310,10 +310,10 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_breakdown_with_discount(self):
-        self.sale_order.order_line[0].tax_id = self.tax_10
-        self.sale_order.order_line[1].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
         self.sale_order.order_line[1].discount = 25.0
-        self.sale_order.order_line[2].tax_id = self.tax_15
+        self.sale_order.order_line[2].tax_ids = self.tax_15
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
         down_pay_amt = self.sale_order.amount_total / 2
@@ -336,10 +336,10 @@ class TestSaleOrderDownPayment(TestSaleCommon):
     def test_tax_price_include_include_base_amount_breakdown_with_discount(self):
         tax_10_pi_ba = self.create_tax(10, {'price_include_override': 'tax_included', 'include_base_amount': True})
         self.tax_10.sequence = 2
-        self.sale_order.order_line[0].tax_id = tax_10_pi_ba + self.tax_10
+        self.sale_order.order_line[0].tax_ids = tax_10_pi_ba + self.tax_10
         self.sale_order.order_line[0].discount = 25.0
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
         down_pay_amt = self.sale_order.amount_total / 2
@@ -377,9 +377,9 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'children_tax_ids': [Command.set((tax_10_fix_c + tax_10_a).ids)],
             'type_tax_use': 'sale',
         })
-        self.sale_order.order_line[0].tax_id = tax_group_1
-        self.sale_order.order_line[1].tax_id = tax_group_2
-        self.sale_order.order_line[2].tax_id = tax_10_a
+        self.sale_order.order_line[0].tax_ids = tax_group_1
+        self.sale_order.order_line[1].tax_ids = tax_group_2
+        self.sale_order.order_line[2].tax_ids = tax_10_a
         self.make_downpayment()
 
         # Line 1: 200 + 80 = 284
@@ -419,7 +419,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
                     'product_id': self.company_data['product_order_no'].id,
                     'product_uom_qty': 1,
                     'price_unit': 1210,
-                    'tax_id': [Command.set((tax_fix + tax_percentage).ids)],
+                    'tax_ids': [Command.set((tax_fix + tax_percentage).ids)],
                 }),
             ],
         })
@@ -445,11 +445,11 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         analytic_plan = self.env['account.analytic.plan'].create({'name': 'Plan Test'})
         an_acc_01 = str(self.env['account.analytic.account'].create({'name': 'Account 01', 'plan_id': analytic_plan.id}).id)
         an_acc_02 = str(self.env['account.analytic.account'].create({'name': 'Account 02', 'plan_id': analytic_plan.id}).id)
-        self.sale_order.order_line[0].tax_id = self.tax_15 + self.tax_10
+        self.sale_order.order_line[0].tax_ids = self.tax_15 + self.tax_10
         self.sale_order.order_line[0].analytic_distribution = {an_acc_01: 100}
-        self.sale_order.order_line[1].tax_id = self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
         self.sale_order.order_line[1].analytic_distribution = {an_acc_01: 50, an_acc_02: 50}
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.sale_order.order_line[2].analytic_distribution = {an_acc_01: 100}
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
@@ -476,11 +476,11 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         analytic_plan = self.env['account.analytic.plan'].create({'name': 'Plan Test'})
         an_acc_01 = str(self.env['account.analytic.account'].create({'name': 'Account 01', 'plan_id': analytic_plan.id}).id)
         an_acc_02 = str(self.env['account.analytic.account'].create({'name': 'Account 02', 'plan_id': analytic_plan.id}).id)
-        self.sale_order.order_line[0].tax_id = self.tax_15
+        self.sale_order.order_line[0].tax_ids = self.tax_15
         self.sale_order.order_line[0].analytic_distribution = {an_acc_01: 50, an_acc_02: 50}
-        self.sale_order.order_line[1].tax_id = self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
         self.sale_order.order_line[1].analytic_distribution = {an_acc_01: 50, an_acc_02: 50}
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.sale_order.order_line[2].analytic_distribution = {an_acc_01: 50, an_acc_02: 50}
         self.sale_order.order_line[2].price_unit = - self.sale_order.order_line[1].price_unit
         self.make_downpayment()
@@ -522,10 +522,10 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'children_tax_ids': [Command.set((tax_10_fix_c + tax_10_a).ids)],
             'type_tax_use': 'sale',
         })
-        self.sale_order.order_line[0].tax_id = tax_group_1
+        self.sale_order.order_line[0].tax_ids = tax_group_1
         self.sale_order.order_line[0].analytic_distribution = {an_acc_01: 50, an_acc_02: 50}
-        self.sale_order.order_line[1].tax_id = tax_group_2
-        self.sale_order.order_line[2].tax_id = tax_10_a
+        self.sale_order.order_line[1].tax_ids = tax_group_2
+        self.sale_order.order_line[2].tax_ids = tax_10_a
 
         # Line 1: 200 + 80 = 284
         # Line 2: 200 + 40 = 240
@@ -559,15 +559,15 @@ class TestSaleOrderDownPayment(TestSaleCommon):
 
         self.sale_order.order_line[0].price_unit = 900
         self.sale_order.order_line[0].product_uom_qty = 1
-        self.sale_order.order_line[0].tax_id = tax_21
+        self.sale_order.order_line[0].tax_ids = tax_21
 
         self.sale_order.order_line[1].price_unit = 90
         self.sale_order.order_line[1].product_uom_qty = 2
-        self.sale_order.order_line[1].tax_id = tax_21
+        self.sale_order.order_line[1].tax_ids = tax_21
 
         self.sale_order.order_line[2].price_unit = 49
         self.sale_order.order_line[2].product_uom_qty = 4
-        self.sale_order.order_line[2].tax_id = tax_21
+        self.sale_order.order_line[2].tax_ids = tax_21
 
         self.sale_order.order_line[3].unlink()
         self.sale_order.action_confirm()
@@ -612,13 +612,13 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[0].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[0].product_uom_qty = 1
         self.sale_order.order_line[0].qty_delivered = 0
-        self.sale_order.order_line[0].tax_id = tax_21_a
+        self.sale_order.order_line[0].tax_ids = tax_21_a
         self.sale_order.order_line[0].price_unit = 1000
 
         self.sale_order.order_line[1].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[1].product_uom_qty = 1
         self.sale_order.order_line[1].qty_delivered = 0
-        self.sale_order.order_line[1].tax_id = tax_21_b
+        self.sale_order.order_line[1].tax_ids = tax_21_b
         self.sale_order.order_line[1].price_unit = 1000
 
         self.sale_order.order_line[2:].unlink()
@@ -718,13 +718,13 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[0].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[0].product_uom_qty = 1
         self.sale_order.order_line[0].qty_delivered = 0
-        self.sale_order.order_line[0].tax_id = tax_24_a
+        self.sale_order.order_line[0].tax_ids = tax_24_a
         self.sale_order.order_line[0].price_unit = 1000
 
         self.sale_order.order_line[1].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[1].product_uom_qty = 1
         self.sale_order.order_line[1].qty_delivered = 0
-        self.sale_order.order_line[1].tax_id = tax_24_b
+        self.sale_order.order_line[1].tax_ids = tax_24_b
         self.sale_order.order_line[1].price_unit = 1000
 
         self.sale_order.order_line[2:].unlink()
@@ -827,30 +827,30 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[0].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[0].product_uom_qty = 1
         self.sale_order.order_line[0].qty_delivered = 1
-        self.sale_order.order_line[0].tax_id = tax_21_a
+        self.sale_order.order_line[0].tax_ids = tax_21_a
         self.sale_order.order_line[0].price_unit = 1000
 
         self.sale_order.order_line[1].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[1].product_uom_qty = 1
         self.sale_order.order_line[1].qty_delivered = 1
-        self.sale_order.order_line[1].tax_id = tax_21_b
+        self.sale_order.order_line[1].tax_ids = tax_21_b
         self.sale_order.order_line[1].price_unit = 1000
 
         self.sale_order.order_line[2].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[2].product_uom_qty = 1
         self.sale_order.order_line[2].qty_delivered = 1
-        self.sale_order.order_line[2].tax_id = tax_25_a
+        self.sale_order.order_line[2].tax_ids = tax_25_a
         self.sale_order.order_line[2].price_unit = 968
 
         self.sale_order.order_line[3].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[3].product_uom_qty = 1
         self.sale_order.order_line[3].qty_delivered = 1
-        self.sale_order.order_line[3].tax_id = tax_25_b
+        self.sale_order.order_line[3].tax_ids = tax_25_b
         self.sale_order.order_line[3].price_unit = 968
 
         self.sale_order.order_line[3].copy({
             'order_id':self.sale_order.id,
-            'tax_id': tax_25_c,
+            'tax_ids': tax_25_c,
             'qty_delivered': 1,
         })
 
@@ -938,7 +938,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             self.sale_order.order_line[i].product_id = self.company_data['product_delivery_no'].id
             self.sale_order.order_line[i].product_uom_qty = 1
             self.sale_order.order_line[i].qty_delivered = 1
-            self.sale_order.order_line[i].tax_id = tax_20
+            self.sale_order.order_line[i].tax_ids = tax_20
             self.sale_order.order_line[i].price_unit = price_unit
 
         self.sale_order.order_line.qty_delivered_method = 'manual'
@@ -985,7 +985,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'product_id': self.company_data['product_order_no'].id,
             'product_uom_qty': 1,
             'price_unit': 100,
-            'tax_id': self.tax_15.ids,
+            'tax_ids': self.tax_15.ids,
             'order_id': sale_order.id,
         })
         sale_order.action_confirm()

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -610,7 +610,7 @@ class TestSalePrices(SaleCommon):
             "Wrong subtotal price computed for specified product & pricelist"
         )
         self.assertEqual(
-            self.empty_order.order_line.tax_id.id, tax_b.id,
+            self.empty_order.order_line.tax_ids.id, tax_b.id,
             "Wrong tax applied for specified product & pricelist"
         )
 
@@ -860,7 +860,7 @@ class TestSalePrices(SaleCommon):
             'product_id': self.product.id,
             'product_uom_qty': 1,
             'price_unit': 0.0,
-            'tax_id': [
+            'tax_ids': [
                 Command.set(taxes.ids),
             ],
         })]
@@ -888,11 +888,11 @@ class TestSalePrices(SaleCommon):
         }])
 
         # Apply taxes on the sale order lines
-        self.sale_order.order_line[0].write({'tax_id': [Command.link(tax_include.id)]})
-        self.sale_order.order_line[1].write({'tax_id': [Command.link(tax_exclude.id)]})
+        self.sale_order.order_line[0].write({'tax_ids': [Command.link(tax_include.id)]})
+        self.sale_order.order_line[1].write({'tax_ids': [Command.link(tax_exclude.id)]})
 
         for line in self.sale_order.order_line:
-            if line.tax_id.price_include:
+            if line.tax_ids.price_include:
                 price = line.price_unit * line.product_uom_qty - line.price_tax
             else:
                 price = line.price_unit * line.product_uom_qty
@@ -928,7 +928,7 @@ class TestSalePrices(SaleCommon):
         # Same with an included-in-price tax
         order = order.copy()
         line = order.order_line
-        line.tax_id = [Command.create({
+        line.tax_ids = [Command.create({
             'name': 'Super Tax',
             'amount_type': 'percent',
             'amount': 15.0,
@@ -979,7 +979,7 @@ class TestSalePrices(SaleCommon):
         # Same with an included-in-price tax
         order = order.copy()
         line = order.order_line
-        line.tax_id = [Command.create({
+        line.tax_ids = [Command.create({
             'name': 'Super Tax',
             'amount_type': 'percent',
             'amount': 10.0,

--- a/addons/sale/tests/test_sale_refund.py
+++ b/addons/sale/tests/test_sale_refund.py
@@ -23,22 +23,22 @@ class TestSaleRefund(TestSaleCommon):
                 Command.create({
                     'product_id': cls.company_data['product_order_no'].id,
                     'product_uom_qty': 5,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': cls.company_data['product_service_delivery'].id,
                     'product_uom_qty': 4,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': cls.company_data['product_service_order'].id,
                     'product_uom_qty': 3,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': cls.company_data['product_delivery_no'].id,
                     'product_uom_qty': 2,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -262,7 +262,7 @@ class TestSaleRefund(TestSaleCommon):
             'product_id': self.company_data['product_order_no'].id,
             'product_uom_qty': 5,
             'order_id': sale_order_refund.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
         self.assertRecordValues(sol_product, [{

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -26,22 +26,22 @@ class TestSaleToInvoice(TestSaleCommon):
                 Command.create({
                     'product_id': cls.company_data['product_order_no'].id,
                     'product_uom_qty': 5,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': cls.company_data['product_service_delivery'].id,
                     'product_uom_qty': 4,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': cls.company_data['product_service_order'].id,
                     'product_uom_qty': 3,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': cls.company_data['product_delivery_no'].id,
                     'product_uom_qty': 2,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -161,7 +161,7 @@ class TestSaleToInvoice(TestSaleCommon):
             'order_line': [Command.create({
                 'product_id': self.company_data['product_order_no'].id,
                 'product_uom_qty': 5,
-                'tax_id': False,
+                'tax_ids': False,
             }),]
         })
         # Confirm the SO
@@ -201,7 +201,7 @@ class TestSaleToInvoice(TestSaleCommon):
             'order_line': [Command.create({
                 'product_id': self.company_data['product_order_no'].id,
                 'product_uom_qty': 5,
-                'tax_id': False,
+                'tax_ids': False,
             }),]
         })
         # Confirm the SO
@@ -243,7 +243,7 @@ class TestSaleToInvoice(TestSaleCommon):
                 'product_id': self.company_data['product_order_no'].id,
                 'product_uom_qty': 5,
                 'price_unit': 0,
-                'tax_id': False,
+                'tax_ids': False,
             }), ]
         })
         sale_order.action_confirm()
@@ -504,7 +504,7 @@ class TestSaleToInvoice(TestSaleCommon):
             'product_id': self.company_data['product_order_no'].id,
             'product_uom_qty': 5,
             'order_id': sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
         # Confirm the SO
@@ -544,7 +544,7 @@ class TestSaleToInvoice(TestSaleCommon):
             'product_id': self.company_data['product_order_no'].id,
             'product_uom_qty': 5,
             'order_id': sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
         # Confirm the SO
@@ -750,7 +750,7 @@ class TestSaleToInvoice(TestSaleCommon):
             'product_uom_id': False,
             'price_unit': 0,
             'order_id': self.sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })]
 
         # confirm quotation
@@ -852,7 +852,7 @@ class TestSaleToInvoice(TestSaleCommon):
         })
         self.assertEqual(so_1.order_line.product_uom_qty, 1)
 
-        self.assertEqual(so_1.order_line.tax_id, self.company_data['default_tax_sale'],
+        self.assertEqual(so_1.order_line.tax_ids, self.company_data['default_tax_sale'],
             'Only taxes from the right company are put by default')
         so_1.action_confirm()
         # i'm not interested in groups/acls, but in the multi-company flow only
@@ -1028,7 +1028,7 @@ class TestSaleToInvoice(TestSaleCommon):
             'product_id': self.company_data['product_order_no'].id,
             'product_uom_qty': 5,
             'order_id': so.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
         so.action_confirm()

--- a/addons/sale/views/sale_order_line_views.xml
+++ b/addons/sale/views/sale_order_line_views.xml
@@ -78,7 +78,7 @@
                                    widget="monetary"
                                    invisible="company_price_include == 'tax_excluded'"
                                 />
-                            <field name="tax_id"
+                            <field name="tax_ids"
                                 widget="many2many_tags"
                                 options="{'no_create': True}"
                                 context="{'search_view_ref': 'account.account_tax_view_search'}"

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -470,7 +470,7 @@
                                         <field name="product_packaging_qty" invisible="not product_id or not product_packaging_id" groups="product.group_stock_packaging"/>
                                         <field name="product_packaging_id" invisible="not product_id" context="{'default_product_id': product_id, 'list_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" />
                                         <field name="price_unit"/>
-                                        <field name="tax_id" widget="many2many_tags" options="{'no_create': True}" context="{'search_view_ref': 'account.account_tax_view_search'}" domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
+                                        <field name="tax_ids" widget="many2many_tags" options="{'no_create': True}" context="{'search_view_ref': 'account.account_tax_view_search'}" domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
                                             readonly="qty_invoiced &gt; 0"/>
                                         <t groups="sale.group_discount_per_so_line">
                                             <label for="discount"/>
@@ -640,7 +640,7 @@
                                     readonly="qty_invoiced &gt; 0"/>
                                 <field name="technical_price_unit" column_invisible="1"/>
                                 <field
-                                    name="tax_id"
+                                    name="tax_ids"
                                     widget="many2many_tags"
                                     options="{'no_create': True}"
                                     domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -578,7 +578,7 @@
                                             </strong>
                                         </td>
                                         <td t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="taxes">
-                                            <span t-out="', '.join(map(lambda x: (x.name), line.tax_id))"/>
+                                            <span t-out="', '.join(map(lambda x: (x.name), line.tax_ids))"/>
                                         </td>
                                         <td t-if="not line.is_downpayment" class="text-end" id="subtotal">
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -239,7 +239,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
             AccountTax._add_tax_details_in_base_line(base_line_values, order.company_id)
             tax_details = base_line_values['tax_details']
 
-            taxes = line.tax_id.flatten_taxes_hierarchy()
+            taxes = line.tax_ids.flatten_taxes_hierarchy()
             fixed_taxes = taxes.filtered(lambda tax: tax.amount_type == 'fixed')
             down_payment_values.append([
                 taxes - fixed_taxes,
@@ -270,14 +270,14 @@ class SaleAdvancePaymentInv(models.TransientModel):
         downpayment_line_map = {}
         analytic_map = {}
         base_downpayment_lines_values = self._prepare_base_downpayment_line_values(order)
-        for tax_id, analytic_distribution, price_subtotal, account in down_payment_values:
+        for tax_ids, analytic_distribution, price_subtotal, account in down_payment_values:
             grouping_key = frozendict({
-                'tax_id': tuple(sorted(tax_id.ids)),
+                'tax_ids': tuple(sorted(tax_ids.ids)),
                 'account_id': account,
             })
             downpayment_line_map.setdefault(grouping_key, {
                 **base_downpayment_lines_values,
-                'tax_id': grouping_key['tax_id'],
+                'tax_ids': grouping_key['tax_ids'],
                 'product_uom_qty': 0.0,
                 'price_unit': 0.0,
             })

--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -62,7 +62,7 @@ class SaleOrderDiscount(models.TransientModel):
             'product_id': product.id,
             'sequence': 999,
             'price_unit': -amount,
-            'tax_id': [Command.set(taxes.ids)],
+            'tax_ids': [Command.set(taxes.ids)],
         }
         if description:
             # If not given, name will fallback on the standard SOL logic (cf. _compute_name)
@@ -112,7 +112,7 @@ class SaleOrderDiscount(models.TransientModel):
                 if not line.product_uom_qty or not line.price_unit:
                     continue
 
-                total_price_per_tax_groups[line.tax_id] += (line.price_unit * line.product_uom_qty)
+                total_price_per_tax_groups[line.tax_ids] += (line.price_unit * line.product_uom_qty)
 
             if not total_price_per_tax_groups:
                 # No valid lines on which the discount can be applied

--- a/addons/sale_edi_ubl/models/sale_edi_common.py
+++ b/addons/sale_edi_ubl/models/sale_edi_common.py
@@ -61,12 +61,11 @@ class SaleEdiCommon(models.AbstractModel):
             del line_values['quantity']
             if not line_values['product_id']:
                 logs += [_("Could not retrieve product for line '%s'", line_values['name'])]
-            # To do: rename tax_id field to `tax_ids` of sale.order.line
-            line_values['tax_id'], tax_logs = self._retrieve_taxes(
+            line_values['tax_ids'], tax_logs = self._retrieve_taxes(
                 order, line_values, 'sale',
             )
             logs += tax_logs
-            lines_values += self._retrieve_line_charges(order, line_values, line_values['tax_id'])
+            lines_values += self._retrieve_line_charges(order, line_values, line_values['tax_ids'])
             if not line_values['product_uom_id']:
                 line_values.pop('product_uom_id')  # if no uom, pop it so it's inferred from the product_id
             lines_values.append(line_values)

--- a/addons/sale_edi_ubl/models/sale_order.py
+++ b/addons/sale_edi_ubl/models/sale_order.py
@@ -55,5 +55,5 @@ class SaleOrder(models.Model):
             'name': name,
             'product_uom_qty': quantity,
             'price_unit': price_unit,
-            'tax_id': [Command.set(tax_ids)],
+            'tax_ids': [Command.set(tax_ids)],
         } for name, quantity, price_unit, tax_ids in lines_vals]

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -220,7 +220,7 @@ class SaleOrder(models.Model):
             'points_cost': cost,
             'reward_identifier_code': _generate_random_reward_code(),
             'sequence': max(self.order_line.filtered(lambda x: not x.is_reward_line).mapped('sequence'), default=10) + 1,
-            'tax_id': [(Command.CLEAR, 0, 0)] + [(Command.LINK, tax.id, False) for tax in taxes]
+            'tax_ids': [Command.clear()] + [Command.link(tax.id) for tax in taxes],
         }]
 
     def _discountable_amount(self, rewards_to_ignore):
@@ -244,7 +244,7 @@ class SaleOrder(models.Model):
             if not line.product_uom_qty or not line.price_unit:
                 # Ignore lines whose amount will be 0 (bc of empty qty or 0 price)
                 continue
-            tax_data = line.tax_id.compute_all(
+            tax_data = line.tax_ids.compute_all(
                 line.price_unit,
                 quantity=line.product_uom_qty,
                 product=line.product_id,
@@ -252,7 +252,7 @@ class SaleOrder(models.Model):
             )
             # To compute the discountable amount we get the subtotal and add
             # non-fixed tax totals. This way fixed taxes will not be discounted
-            taxes = line.tax_id.filtered(lambda t: t.amount_type != 'fixed')
+            taxes = line.tax_ids.filtered(lambda t: t.amount_type != 'fixed')
             discountable += tax_data['total_excluded'] + sum(
                 tax['amount'] for tax in tax_data['taxes'] if tax['id'] in taxes.ids
             )
@@ -356,7 +356,7 @@ class SaleOrder(models.Model):
         discountable_per_tax = defaultdict(int)
         for line in cheapest_line:
             discountable += line.price_total
-            taxes = line.tax_id.filtered(lambda t: t.amount_type != 'fixed')
+            taxes = line.tax_ids.filtered(lambda t: t.amount_type != 'fixed')
             discountable_per_tax[taxes] += line.price_unit * (1 - (line.discount or 0) / 100)
 
         return discountable, discountable_per_tax
@@ -425,21 +425,21 @@ class SaleOrder(models.Model):
             else:
                 non_common_lines = discounted_lines - lines_to_discount
                 # Fixed prices are per tax
-                discounted_amounts = {line.tax_id.filtered(lambda t: t.amount_type != 'fixed'): abs(line.price_total) for line in lines}
+                discounted_amounts = {line.tax_ids.filtered(lambda t: t.amount_type != 'fixed'): abs(line.price_total) for line in lines}
                 for line in itertools.chain(non_common_lines, common_lines):
                     # For gift card and eWallet programs we have no tax but we can consume the amount completely
                     if lines.reward_id.program_id.is_payment_program:
-                        discounted_amount = discounted_amounts[lines.tax_id.filtered(lambda t: t.amount_type != 'fixed')]
+                        discounted_amount = discounted_amounts[lines.tax_ids.filtered(lambda t: t.amount_type != 'fixed')]
                     else:
-                        discounted_amount = discounted_amounts[line.tax_id.filtered(lambda t: t.amount_type != 'fixed')]
+                        discounted_amount = discounted_amounts[line.tax_ids.filtered(lambda t: t.amount_type != 'fixed')]
                     if discounted_amount == 0:
                         continue
                     remaining = remaining_amount_per_line[line]
                     consumed = min(remaining, discounted_amount)
                     if lines.reward_id.program_id.is_payment_program:
-                        discounted_amounts[lines.tax_id.filtered(lambda t: t.amount_type != 'fixed')] -= consumed
+                        discounted_amounts[lines.tax_ids.filtered(lambda t: t.amount_type != 'fixed')] -= consumed
                     else:
-                        discounted_amounts[line.tax_id.filtered(lambda t: t.amount_type != 'fixed')] -= consumed
+                        discounted_amounts[line.tax_ids.filtered(lambda t: t.amount_type != 'fixed')] -= consumed
                     remaining_amount_per_line[line] -= consumed
 
         discountable = 0
@@ -450,7 +450,7 @@ class SaleOrder(models.Model):
             # line_discountable is the same as in a 'order' discount
             #  but first multiplied by a factor for the taxes to apply
             #  and then multiplied by another factor coming from the discountable
-            taxes = line.tax_id.filtered(lambda t: t.amount_type != 'fixed')
+            taxes = line.tax_ids.filtered(lambda t: t.amount_type != 'fixed')
             discountable_per_tax[taxes] += line_discountable *\
                 (remaining_amount_per_line[line] / line.price_total)
         return discountable, discountable_per_tax
@@ -470,7 +470,7 @@ class SaleOrder(models.Model):
         base_reward_line_values = {
             'product_id': reward_product.id,
             'product_uom_qty': 1.0,
-            'tax_id': [Command.clear()],
+            'tax_ids': [Command.clear()],
             'name': reward.description,
             'reward_id': reward.id,
             'coupon_id': coupon.id,
@@ -551,7 +551,7 @@ class SaleOrder(models.Model):
                     )
                     reward_line_values.update({
                         'price_unit': new_price,
-                        'tax_id': [Command.set(mapped_taxes.ids)],
+                        'tax_ids': [Command.set(mapped_taxes.ids)],
                     })
             return [reward_line_values]
 
@@ -569,7 +569,7 @@ class SaleOrder(models.Model):
                 # Check for any order line where its taxes exactly match reward_taxes
                 matching_lines = [
                     line for line in self.order_line
-                    if not line.is_delivery and set(line.tax_id) == set(mapped_taxes)
+                    if not line.is_delivery and set(line.tax_ids) == set(mapped_taxes)
                 ]
 
                 if not matching_lines:
@@ -582,7 +582,7 @@ class SaleOrder(models.Model):
                     reward_line_values['price_unit']
                 )
 
-                reward_line_values['tax_id'] = [Command.set(mapped_taxes.ids)]
+                reward_line_values['tax_ids'] = [Command.set(mapped_taxes.ids)]
 
             # Discount amount should not exceed the untaxed amount on the order
             if abs(reward_line_values['price_unit']) > self.amount_untaxed:
@@ -611,7 +611,7 @@ class SaleOrder(models.Model):
                 ) if mapped_taxes else reward.description,
                 'price_unit': -(price * discount_factor),
                 'points_cost': 0,
-                'tax_id': [Command.clear()] + [Command.link(tax.id) for tax in mapped_taxes]
+                'tax_ids': [Command.clear()] + [Command.link(tax.id) for tax in mapped_taxes]
             }
         # We only assign the point cost to one line to avoid counting the cost multiple times
         if reward_dict:

--- a/addons/sale_loyalty/models/sale_order_line.py
+++ b/addons/sale_loyalty/models/sale_order_line.py
@@ -26,9 +26,9 @@ class SaleOrderLine(models.Model):
         for line in self:
             line.is_reward_line = bool(line.reward_id)
 
-    def _compute_tax_id(self):
+    def _compute_tax_ids(self):
         reward_lines = self.filtered('is_reward_line')
-        super(SaleOrderLine, self - reward_lines)._compute_tax_id()
+        super(SaleOrderLine, self - reward_lines)._compute_tax_ids()
         # Discount reward line is split per tax, the discount is set on the line but not on the product
         # as the product is the generic discount line.
         # In case of a free product, retrieving the tax on the line instead of the product won't affect the behavior.
@@ -36,8 +36,8 @@ class SaleOrderLine(models.Model):
             line = line.with_company(line.company_id)
             fpos = line.order_id.fiscal_position_id or line.order_id.fiscal_position_id._get_fiscal_position(line.order_partner_id)
             # If company_id is set, always filter taxes by the company
-            taxes = line.tax_id.filtered(lambda r: not line.company_id or r.company_id == line.company_id)
-            line.tax_id = fpos.map_tax(taxes)
+            taxes = line.tax_ids.filtered(lambda r: not line.company_id or r.company_id == line.company_id)
+            line.tax_ids = fpos.map_tax(taxes)
 
     def _get_display_price(self):
         # A product created from a promotion does not have a list_price.

--- a/addons/sale_loyalty/tests/test_loyalty.py
+++ b/addons/sale_loyalty/tests/test_loyalty.py
@@ -351,7 +351,7 @@ class TestLoyalty(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -398,7 +398,7 @@ class TestLoyalty(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -439,11 +439,11 @@ class TestLoyalty(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': self.product_B.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -492,11 +492,11 @@ class TestLoyalty(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': self.product_B.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -523,7 +523,7 @@ class TestLoyalty(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -571,7 +571,7 @@ class TestLoyalty(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })

--- a/addons/sale_loyalty/tests/test_loyalty_history.py
+++ b/addons/sale_loyalty/tests/test_loyalty_history.py
@@ -61,7 +61,7 @@ class TestLoyaltyhistory(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -79,7 +79,7 @@ class TestLoyaltyhistory(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })

--- a/addons/sale_loyalty/tests/test_pay_with_gift_card.py
+++ b/addons/sale_loyalty/tests/test_pay_with_gift_card.py
@@ -199,8 +199,8 @@ class TestPayWithGiftCard(TestSaleCouponCommon):
         gift_card_line = order.order_line - sol
         self.assertAlmostEqual(gift_card_line.price_total, -100.0)
         self.assertAlmostEqual(order.amount_total, before_gift_card_payment - 100.0)
-        self.assertTrue(all(line.tax_id for line in order.order_line))
-        self.assertEqual(order.order_line.tax_id, self.tax_15pc_excl)
+        self.assertTrue(all(line.tax_ids for line in order.order_line))
+        self.assertEqual(order.order_line.tax_ids, self.tax_15pc_excl)
 
         # TAX INCL
         gift_card_line.unlink()  # Remove gift card
@@ -211,8 +211,8 @@ class TestPayWithGiftCard(TestSaleCouponCommon):
         gift_card_line = order.order_line - sol
         self.assertAlmostEqual(gift_card_line.price_total, -100.0)
         self.assertAlmostEqual(order.amount_total, before_gift_card_payment - 100.0)
-        self.assertTrue(all(line.tax_id for line in order.order_line))
-        self.assertEqual(gift_card_line.tax_id, self.tax_10pc_incl)
+        self.assertTrue(all(line.tax_ids for line in order.order_line))
+        self.assertEqual(gift_card_line.tax_ids, self.tax_10pc_incl)
 
         # TAX INCL + TAX EXCL
         gift_card_line.unlink()  # Remove gift card
@@ -223,5 +223,5 @@ class TestPayWithGiftCard(TestSaleCouponCommon):
         gift_card_line = order.order_line - sol
         self.assertAlmostEqual(gift_card_line.price_total, -100.0)
         self.assertAlmostEqual(order.amount_total, before_gift_card_payment - 100.0)
-        self.assertTrue(all(line.tax_id for line in order.order_line))
-        self.assertEqual(gift_card_line.tax_id, self.tax_10pc_incl + self.tax_15pc_excl)
+        self.assertTrue(all(line.tax_ids for line in order.order_line))
+        self.assertEqual(gift_card_line.tax_ids, self.tax_10pc_incl + self.tax_15pc_excl)

--- a/addons/sale_loyalty/tests/test_program_numbers.py
+++ b/addons/sale_loyalty/tests/test_program_numbers.py
@@ -126,8 +126,8 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
 
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(len(order.order_line.ids), 1, "We should not get the reduction line since we dont have 320$ tax excluded (cabinet is 320$ tax included)")
-        sol1.tax_id.price_include_override = 'tax_excluded'
-        sol1._compute_tax_id()
+        sol1.tax_ids.price_include_override = 'tax_excluded'
+        sol1._compute_tax_ids()
         self.env.flush_all()
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(len(order.order_line.ids), 2, "We should now get the reduction line since we have 320$ tax included (cabinet is 320$ tax included)")
@@ -372,7 +372,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self.assertEqual(len(order.order_line.ids), 12, "Order should contains 5 regular product lines, 3 free product lines and 4 discount lines (one for every tax)")
 
         # -- This is a test inside the test
-        order.order_line._compute_tax_id()
+        order.order_line._compute_tax_ids()
         self.assertRecordValues(order, [{
             'amount_total': 1711.0,
             'amount_untaxed': 1435.46,
@@ -532,7 +532,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'name': 'Drawer Black',
             'product_uom_qty': 1.0,
             'order_id': order.id,
-            'tax_id': [(4, self.tax_0pc_excl.id)]
+            'tax_ids': [(4, self.tax_0pc_excl.id)]
         })
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(order.amount_total, 0, "Total should be null. The fixed amount discount is higher than the SO total, it should be reduced to the SO total")
@@ -641,7 +641,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'price_unit': 100.0,
             'order_id': order.id,
-            'tax_id': [(6, 0, (self.tax_15pc_excl.id,))],
+            'tax_ids': [(6, 0, (self.tax_15pc_excl.id,))],
         },
         ])
 
@@ -743,7 +743,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'price_unit': 100.0,
             'order_id': order.id,
-            'tax_id': [(6, 0, (self.tax_15pc_excl.id,))],
+            'tax_ids': [(6, 0, (self.tax_15pc_excl.id,))],
         },
         {
             'product_id': self.pedalBin.id,
@@ -751,7 +751,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'price_unit': 100.0,
             'order_id': order.id,
-            'tax_id': [(6, 0, [])],
+            'tax_ids': [(6, 0, [])],
         },
         {
             'product_id': self.product_A.id,
@@ -759,7 +759,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'price_unit': 100.0,
             'order_id': order.id,
-            'tax_id': [(6, 0, [])],
+            'tax_ids': [(6, 0, [])],
         },
         ])
 
@@ -830,7 +830,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'price_unit': 100.0,
             'order_id': order.id,
-            'tax_id': [(6, 0, (self.tax_10pc_incl.id,))],
+            'tax_ids': [(6, 0, (self.tax_10pc_incl.id,))],
         },
         {
             'product_id': self.pedalBin.id,
@@ -838,7 +838,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'price_unit': 100.0,
             'order_id': order.id,
-            'tax_id': [(6, 0, [])],
+            'tax_ids': [(6, 0, [])],
         },
         {
             'product_id': self.product_A.id,
@@ -846,7 +846,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'price_unit': 100.0,
             'order_id': order.id,
-            'tax_id': [(6, 0, [])],
+            'tax_ids': [(6, 0, [])],
         },
         ])
 
@@ -956,7 +956,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'amount': 30,
             'price_include_override': 'tax_included',
         })
-        sol2.tax_id = percent_tax
+        sol2.tax_ids = percent_tax
 
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(len(order.order_line.ids), 4, "Conference Chair + Drawer Black + 20% on no TVA product (Conference Chair) + 20% on 15% tva product (Drawer Black)")
@@ -1111,7 +1111,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 14.0,
             'price_unit': 118.0,
             'order_id': order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(order.amount_total, 1486.80, "10% discount should be applied")
@@ -1534,26 +1534,26 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self.assertEqual(order.amount_total, 5, 'Price should be 10$ - 5$(discount) = 5$')
         self.assertEqual(order.amount_tax, 0, 'No taxes are applied yet')
 
-        sol.tax_id = self.tax_10pc_base_incl
+        sol.tax_ids = self.tax_10pc_base_incl
         self._auto_rewards(order, program)
 
         self.assertEqual(order.amount_total, 5, 'Price should be 10$ - 5$(discount) = 5$')
         self.assertEqual(float_compare(order.amount_tax, 5 / 11, precision_rounding=3), 0, '10% Tax included in 5$')
 
-        sol.tax_id = self.tax_10pc_excl
+        sol.tax_ids = self.tax_10pc_excl
         self._auto_rewards(order, program)
 
         # Value is 5.99 instead of 6 because you cannot have 6 with 10% tax excluded and a precision rounding of 2
         self.assertAlmostEqual(order.amount_total, 6, 1, msg='Price should be 11$ - 5$(discount) = 6$')
         self.assertEqual(float_compare(order.amount_tax, 6 / 11, precision_rounding=3), 0, '10% Tax included in 6$')
 
-        sol.tax_id = self.tax_20pc_excl
+        sol.tax_ids = self.tax_20pc_excl
         self._auto_rewards(order, program)
 
         self.assertEqual(order.amount_total, 7, 'Price should be 12$ - 5$(discount) = 7$')
         self.assertEqual(float_compare(order.amount_tax, 7 / 4, precision_rounding=3), 0, '20% Tax included on 7$')
 
-        sol.tax_id = self.tax_10pc_base_incl + self.tax_10pc_excl
+        sol.tax_ids = self.tax_10pc_base_incl + self.tax_10pc_excl
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 6, 1, msg='Price should be 11$ - 5$(discount) = 6$')
@@ -1596,21 +1596,21 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self.assertAlmostEqual(order.amount_total, 15, 1, msg='Price should be 20$ - 5$(discount) = 15$')
         self.assertEqual(order.amount_tax, 0, 'No taxes are applied yet')
 
-        sol1.tax_id = self.tax_10pc_base_incl
+        sol1.tax_ids = self.tax_10pc_base_incl
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 15, 1, msg='Price should be 20$ - 5$(discount) = 15$')
         self.assertEqual(float_compare(order.amount_tax, 5 / 11 + 0, precision_rounding=3), 0,
                          '10% Tax included in 5$ in sol1 (highest cost) and 0 in sol2')
 
-        sol2.tax_id = self.tax_10pc_excl
+        sol2.tax_ids = self.tax_10pc_excl
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 16, 1, msg='Price should be 21$ - 5$(discount) = 16$')
         # Tax amount = 10% in 10$ + 10% in 11$
         self.assertEqual(float_compare(order.amount_tax, 5 / 3, precision_rounding=3), 0)
 
-        sol2.tax_id = self.tax_10pc_base_incl + self.tax_10pc_excl
+        sol2.tax_ids = self.tax_10pc_base_incl + self.tax_10pc_excl
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 16, 1, msg='Price should be 21$ - 5$(discount) = 16$')
@@ -1626,7 +1626,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'order_id': order.id,
         })
-        sol3.tax_id = self.tax_10pc_excl
+        sol3.tax_ids = self.tax_10pc_excl
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 27, 1, msg='Price should be 32$ - 5$(discount) = 27$')
@@ -1860,6 +1860,6 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._auto_rewards(order, loyalty_program)
 
         self.assertEqual(len(order.order_line), 2, 'Promotion should add 1 line')
-        self.assertEqual(order.order_line[0].tax_id, tax_15pc_excl)
-        self.assertEqual(order.order_line[1].tax_id, tax_15pc_excl)
+        self.assertEqual(order.order_line[0].tax_ids, tax_15pc_excl)
+        self.assertEqual(order.order_line[1].tax_ids, tax_15pc_excl)
         self.assertEqual(order.amount_total, 156.0, '140$ + 15% - 5$ = 156$')

--- a/addons/sale_loyalty/views/sale_order_views.xml
+++ b/addons/sale_loyalty/views/sale_order_views.xml
@@ -27,7 +27,7 @@
             <xpath expr="//list//field[@name='price_unit']" position="attributes">
                 <attribute name="readonly" add="is_reward_line" separator=" or "/>
             </xpath>
-            <xpath expr="//list//field[@name='tax_id']" position="attributes">
+            <xpath expr="//list//field[@name='tax_ids']" position="attributes">
                 <attribute name="readonly" add="is_reward_line" separator=" or "/>
             </xpath>
             <group name="note_group" position="after">

--- a/addons/sale_loyalty_delivery/models/sale_order.py
+++ b/addons/sale_loyalty_delivery/models/sale_order.py
@@ -45,7 +45,7 @@ class SaleOrder(models.Model):
             'order_id': self.id,
             'is_reward_line': True,
             'sequence': max(self.order_line.filtered(lambda x: not x.is_reward_line).mapped('sequence'), default=0) + 1,
-            'tax_id': [(Command.CLEAR, 0, 0)] + [(Command.LINK, tax.id, False) for tax in taxes],
+            'tax_ids': [Command.clear()] + [Command.link(tax.id) for tax in taxes],
         }]
 
     def _get_reward_line_values(self, reward, coupon, **kwargs):

--- a/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
@@ -90,7 +90,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': self.kit_a.id,
                     'product_uom_qty': 1.0,
                     'price_unit': 1,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -251,7 +251,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': kit.id,
                     'product_uom_qty': 3.0,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -354,7 +354,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': kit.id,
                     'product_uom_qty': 3.0,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -446,7 +446,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': kit.id,
                     'product_uom_qty': 1.0,
                     'price_unit': 5,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -498,7 +498,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': kit.id,
                     'product_uom_qty': 2.0,
                     'price_unit': 5,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -596,7 +596,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': main_kit.id,
                     'product_uom_qty': 1.0,
                     'price_unit': 1,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -2313,7 +2313,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
                     'product_id': kit.id,
                     'product_uom_qty': 1.0,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -2378,7 +2378,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
                     'product_id': kit.id,
                     'product_uom_qty': 1.0,
                     'price_unit': 5,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -2400,7 +2400,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
                     'product_id': self.kit_1.id,
                     'product_uom_qty': 1.0,
                     'price_unit': 5,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         self.bom_kit_1.action_archive()

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -173,7 +173,7 @@ class TestSaleMrpKitBom(TransactionCase):
                     'product_id': self.kit.id,
                     'product_uom_qty': 10.0,
                     'price_unit': 1,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -237,7 +237,7 @@ class TestSaleMrpKitBom(TransactionCase):
                     'product_id': self.kitA.id,
                     'product_uom_qty': 1.0,
                     'price_unit': 1,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -290,7 +290,7 @@ class TestSaleMrpKitBom(TransactionCase):
                     'product_id': kitA.id,
                     'product_uom_qty': 1.0,
                     'price_unit': 1,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })]
         })
         so.action_confirm()
@@ -364,14 +364,14 @@ class TestSaleMrpKitBom(TransactionCase):
                     'product_id': kitAB.id,
                     'product_uom_qty': 1.0,
                     'price_unit': 1,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 (0, 0, {
                     'name': kitABC.name,
                     'product_id': kitABC.id,
                     'product_uom_qty': 1.0,
                     'price_unit': 1,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()

--- a/addons/sale_pdf_quote_builder/models/sale_pdf_form_field.py
+++ b/addons/sale_pdf_quote_builder/models/sale_pdf_form_field.py
@@ -150,7 +150,7 @@ class SalePdfFormField(models.Model):
                 "quantity": "product_uom_qty",
                 "tax_excl_price": "price_subtotal",
                 "tax_incl_price": "price_total",
-                "taxes": "tax_id",
+                "taxes": "tax_ids",
                 "uom": "product_uom_id.name",
                 "user_id__name": "salesman_id.name",
                 "validity_date": "order_id.validity_date",

--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -104,7 +104,7 @@ class TestPDFQuoteBuilder(HttpCase, SaleCommon):
         sol_1, sol_2 = self.sale_order.order_line
         sol_1.update({
             'discount': 4.99,
-            'tax_id': [
+            'tax_ids': [
                 Command.create({'name': "test tax1"}),
                 Command.create({'name': "test tax2"}),
             ],
@@ -122,7 +122,7 @@ class TestPDFQuoteBuilder(HttpCase, SaleCommon):
 
             new_form_field(name="one2many_test", path='order_id.order_line'),
             new_form_field(name="many2one_test", path='order_id.company_id'),
-            new_form_field(name="many2many_test", path='tax_id'),
+            new_form_field(name="many2many_test", path='tax_ids'),
         ])
         expected = {
             'boolean_test': "No",

--- a/addons/sale_project_stock/models/stock_move.py
+++ b/addons/sale_project_stock/models/stock_move.py
@@ -49,7 +49,7 @@ class StockMove(models.Model):
             'name': self.name,
             'sequence': last_sequence,
             'price_unit': price,
-            'tax_id': [x.id for x in taxes],
+            'tax_ids': [x.id for x in taxes],
             'discount': 0.0,
             'product_id': self.product_id.id,
             'product_uom_qty': self.product_uom_qty,

--- a/addons/sale_purchase/tests/test_access_rights.py
+++ b/addons/sale_purchase/tests/test_access_rights.py
@@ -42,7 +42,7 @@ class TestAccessRights(TestCommonSalePurchaseNoChart):
             'product_id': self.service_purchase_1.id,
             'product_uom_qty': 4,
             'order_id': sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
         # confirming SO will create the PO even if you don't have the rights

--- a/addons/sale_purchase/tests/test_sale_purchase.py
+++ b/addons/sale_purchase/tests/test_sale_purchase.py
@@ -37,19 +37,19 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
             'product_id': cls.company_data['product_service_delivery'].id,
             'product_uom_qty': 1,
             'order_id': cls.sale_order_1.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol1_product_order = cls.env['sale.order.line'].create({
             'product_id': cls.company_data['product_order_no'].id,
             'product_uom_qty': 2,
             'order_id': cls.sale_order_1.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol1_service_purchase_1 = cls.env['sale.order.line'].create({
             'product_id': cls.service_purchase_1.id,
             'product_uom_qty': 4,
             'order_id': cls.sale_order_1.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
         cls.sale_order_2 = SaleOrder.create({
@@ -62,19 +62,19 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
             'product_id': cls.company_data['product_delivery_no'].id,
             'product_uom_qty': 5,
             'order_id': cls.sale_order_2.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol2_service_order = cls.env['sale.order.line'].create({
             'product_id': cls.company_data['product_service_order'].id,
             'product_uom_qty': 6,
             'order_id': cls.sale_order_2.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol2_service_purchase_2 = cls.env['sale.order.line'].create({
             'product_id': cls.service_purchase_2.id,
             'product_uom_qty': 7,
             'order_id': cls.sale_order_2.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
     def test_sale_create_purchase(self):

--- a/addons/sale_purchase_stock/tests/test_access_rights.py
+++ b/addons/sale_purchase_stock/tests/test_access_rights.py
@@ -55,7 +55,7 @@ class TestAccessRights(TestCommonSalePurchaseNoChart):
             'product_id': product.id,
             'product_uom_qty': 1,
             'price_unit': product.list_price,
-            'tax_id': False,
+            'tax_ids': False,
             'order_id': so.id,
         }, {
             'name': 'Super Section',

--- a/addons/sale_purchase_stock/tests/test_lead_time.py
+++ b/addons/sale_purchase_stock/tests/test_lead_time.py
@@ -52,7 +52,7 @@ class TestLeadTime(TestCommonSalePurchaseNoChart):
             'product_id': product.id,
             'product_uom_qty': 1,
             'price_unit': product.list_price,
-            'tax_id': False,
+            'tax_ids': False,
             'order_id': so.id,
         })
         so.action_confirm()

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -36,7 +36,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': self.product.id,
                     'product_uom_qty': 2.0,
                     'price_unit': 12,
-                    'tax_id': False,  # no love taxes amls
+                    'tax_ids': False,  # no love taxes amls
                 })],
         })
         sale_order.flush_recordset()
@@ -922,7 +922,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': self.product.id,
                     'product_uom_qty': 10.0,
                     'price_unit': 12,
-                    'tax_id': False,  # no love taxes amls
+                    'tax_ids': False,  # no love taxes amls
                 })],
         })
         sale_order.action_confirm()
@@ -1011,7 +1011,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': self.product.id,
                     'product_uom_qty': 1,
                     'price_unit': 20,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         sale_order.action_confirm()
@@ -1029,7 +1029,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': self.product.id,
                     'product_uom_qty': 6,
                     'price_unit': 20,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         sale_order.action_confirm()
@@ -1073,7 +1073,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': self.product.id,
                     'product_uom_qty': 10.0,
                     'price_unit': 12,
-                    'tax_id': False,  # no love taxes amls
+                    'tax_ids': False,  # no love taxes amls
                 })],
         })
         sale_order.action_confirm()
@@ -1152,7 +1152,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': self.product.id,
                     'product_uom_qty': 1.0,
                     'price_unit': 12,
-                    'tax_id': False,  # no love taxes amls
+                    'tax_ids': False,  # no love taxes amls
                 })],
         })
         so_2.action_confirm()
@@ -1248,7 +1248,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 1,
                     'product_uom_id': unit_12.id,
                     'price_unit': 18,
-                    'tax_id': False,  # no love taxes amls
+                    'tax_ids': False,  # no love taxes amls
                 })],
         })
         so_1.action_confirm()
@@ -1308,7 +1308,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 1,
                     'product_uom_id': unit_12.id,
                     'price_unit': 18,
-                    'tax_id': False,  # no love taxes amls
+                    'tax_ids': False,  # no love taxes amls
                 })],
         })
         so_2.action_confirm()
@@ -1374,7 +1374,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': self.product.id,
                     'product_uom_qty': 3.0,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -1466,7 +1466,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': self.product.id,
                     'product_uom_qty': 3.0,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -1552,7 +1552,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': self.product.id,
                     'product_uom_qty': 3.0,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -1640,7 +1640,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': self.product.id,
                     'product_uom_qty': 1.0,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -1717,7 +1717,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_id': self.product.id,
                     'product_uom_qty': 10.0,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()

--- a/addons/sale_stock/tests/test_sale_stock_accrued_entries.py
+++ b/addons/sale_stock/tests/test_sale_stock_accrued_entries.py
@@ -28,7 +28,7 @@ class TestAccruedStockSaleOrders(AccountTestInvoicingCommon):
                     'product_id': cls.product_order.id,
                     'product_uom_qty': 10.0,
                     'price_unit': cls.product_order.list_price,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })
             ]
         })

--- a/addons/sale_timesheet/tests/test_sale_timesheet_report.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet_report.py
@@ -29,7 +29,7 @@ class TestSaleTimesheetReport(TestCommonSaleTimesheet):
             'product_uom_qty': 3,
             'order_id': sale_order.id,
             'price_unit': 10.0,
-            'tax_id': [Command.set(self.tax_sale_a.ids)],
+            'tax_ids': [Command.set(self.tax_sale_a.ids)],
         })
         sale_order.action_confirm()
         task = self.env['project.task'].search([('sale_line_id', '=', so_line.id)])

--- a/addons/stock_dropshipping/tests/test_stockvaluation.py
+++ b/addons/stock_dropshipping/tests/test_stockvaluation.py
@@ -45,7 +45,7 @@ class TestStockValuation(ValuationReconciliationTestCommon):
                 'product_id': self.product1.id,
                 'product_uom_qty': 1,
                 'price_unit': 12,
-                'tax_id': [(6, 0, [])],
+                'tax_ids': [(6, 0, [])],
             })],
             'picking_policy': 'direct',
         })

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -51,7 +51,7 @@ class SaleOrderLine(models.Model):
         show_tax = self.order_id.website_id.show_line_subtotals_tax_selection
         tax_display = 'total_excluded' if show_tax == 'tax_excluded' else 'total_included'
 
-        return self.tax_id.compute_all(
+        return self.tax_ids.compute_all(
             self.price_unit, self.currency_id, 1, self.product_id, self.order_partner_id,
         )[tax_display]
 

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -238,7 +238,7 @@ class TestWebsitePriceList(WebsiteSaleCommon):
                 'product_id': product.id,
                 'product_uom_qty': 1,
                 'price_unit': product.list_price,
-                'tax_id': False,
+                'tax_ids': False,
             })],
         })
         sol = so.order_line
@@ -276,7 +276,7 @@ class TestWebsitePriceList(WebsiteSaleCommon):
                 'product_id': product.id,
                 'product_uom_qty': 5,
                 'price_unit': product.list_price,
-                'tax_id': False,
+                'tax_ids': False,
             })]
         })
         sol = so.order_line

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -124,7 +124,7 @@ class SaleOrder(models.Model):
                     continue
                 new_lines += self.env['sale.order.line'].new({
                     'product_id': lines[0].product_id.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                     'price_unit': sum(lines.mapped('price_unit')),
                     'price_subtotal': sum(lines.mapped('price_subtotal')),
                     'price_total': sum(lines.mapped('price_total')),

--- a/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
@@ -113,7 +113,7 @@ registry.category("web_tour.tours").add('shop_sale_loyalty', {
             content: "check free product is removed",
             trigger: '#wrap:not(:has(div>strong:contains("Free Product - Small Cabinet")))',
         },
-        /* 4. Check /shop/payment does not break the `merged discount lines split per tax` (eg: with _compute_tax_id) */
+        /* 4. Check /shop/payment does not break the `merged discount lines split per tax` (eg: with _compute_tax_ids) */
         {
             content: "go to checkout",
             trigger: 'a[href="/shop/checkout?try_skip_step=true"]',


### PR DESCRIPTION
This commit rename `tax_id` field on sale.order.line to `tax_ids` to follow guidelines and have consistent name with other model specifically with account.move.line to have generic methods for both EDI without doing some ugly operations.

task-420635

See also
https://github.com/odoo/enterprise/pull/73624
https://github.com/odoo/upgrade/pull/6746