### PR TITLE
[FIX] im_livechat: typo in chatbot.script.step to_store

### DIFF
--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -372,7 +372,7 @@ class ChatbotScriptStep(models.Model):
         if fields is None:
             fields = ["answer_ids", "message", "type"]
         for step in self:
-            data = self._read_format(
+            data = step._read_format(
                 [f for f in fields if f not in {"answer_ids", "message", "type"}], load=False
             )[0]
             if "answer_ids" in fields:


### PR DESCRIPTION
This PR fixes a typo introduced by this commit ce0f8d9e608acdcc6fd8495e7b9cd8f7d2757349.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
