### PR TITLE
[FIX] mrp: check also _origin.workorder state for duration compute

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -314,7 +314,7 @@ class MrpWorkorder(models.Model):
         for workorder in self:
             # Recompute the duration expected if the qty_producing has been changed:
             # compare with the origin record if it happens during an onchange
-            if workorder.state not in ['done', 'cancel'] and (workorder.qty_producing != workorder.qty_production
+            if workorder.state not in ['done', 'cancel'] and workorder._origin.state not in ['done', 'cancel'] and (workorder.qty_producing != workorder.qty_production
                 or (workorder._origin != workorder and workorder._origin.qty_producing and workorder.qty_producing != workorder._origin.qty_producing)):
                 workorder.duration_expected = workorder._get_duration_expected()
 


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
The duration_expected is computed also on "done" workorder on onchange (the issue happens on onchange)
### Current behavior before PR:
The duration expected is changing on done workorder
### Desired behavior after PR is merged:
The duration_expected is not changing on don workorder



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
