### PR TITLE
[FIX] l10n_ar_website_sale: prevent error while opening account detail in portal

### DIFF
--- a/addons/l10n_ar_website_sale/controllers/portal.py
+++ b/addons/l10n_ar_website_sale/controllers/portal.py
@@ -27,6 +27,7 @@ class L10nARCustomerPortal(CustomerPortal):
             portal_layout_values.update({
                 'responsibility': partner.l10n_ar_afip_responsibility_type_id,
                 'identification': partner.l10n_latam_identification_type_id,
+                'partner_sudo': partner,
                 'responsibility_types': request.env['l10n_ar.afip.responsibility.type'].search([]),
                 'identification_types': request.env['l10n_latam.identification.type'].search(
                     ['|', ('country_id', '=', False), ('country_id.code', '=', 'AR')]),


### PR DESCRIPTION
Currently, an exception was generated when the user tries to open their account details in the portal (url: my/account)

error: `KeyError: 'partner_sudo'`

This error was generated because when the user tries to open their account detail in the portal, we do not have 'partner_sudo'.

Recentley refacto code with https://github.com/odoo/odoo/commit/453cfab758505ae15135703fb7be8bdb54981444 replaced `partner` with `partner_sudo` for the getting partner in the website sale address (`shop/address`) and we have the new key because the template 'partner_info' called from template 'address' see [1] and `partner_sudo` set from [2] for address. But when we call the 'partner_info' from template 'portal_my_details_fields' at [3], we do not have `partner_sudo`

This commit will fix the above issue by passing `partner_sudo` in the template at the time prepare value for opening account detail in portal.

[1] - https://github.com/odoo/odoo/blob/3ea0c936c01a7c55ee8fa6ee64fd8e89b2a04f5f/addons/l10n_ar_website_sale/views/templates.xml#L60
[2] - https://github.com/odoo/odoo/blob/3ea0c936c01a7c55ee8fa6ee64fd8e89b2a04f5f/addons/website_sale/controllers/main.py#L1119
[3] - https://github.com/odoo/odoo/blob/3ea0c936c01a7c55ee8fa6ee64fd8e89b2a04f5f/addons/l10n_ar_website_sale/views/templates.xml#L68

sentry-5725856236

