### PR TITLE
[FIX] web_editor, *: fix traceback when adding section background video

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -187,6 +187,7 @@ export class MediaDialog extends Component {
                     } else if ([TABS.VIDEOS.id, TABS.DOCUMENTS.id].includes(this.state.activeTab)) {
                         const parentEl = this.props.media.parentElement;
                         if (
+                            parentEl &&
                             parentEl.tagName === "A" &&
                             parentEl.children.length === 1 &&
                             this.props.media.tagName === "IMG"

--- a/addons/website/static/tests/tours/media_iframe_video.js
+++ b/addons/website/static/tests/tours/media_iframe_video.js
@@ -59,3 +59,43 @@ wTourUtils.registerWebsitePreviewTour(
         },
     ]
 );
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_snippet_background_video",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    [
+        wTourUtils.dragNDrop({
+            id: "s_text_block",
+            name: "Text",
+        }),
+        {
+            content: "Click on the text block.",
+            trigger: "iframe #wrap section.s_text_block",
+        },
+        {
+            content: "Click on the 'Background Video' button option.",
+            trigger: "we-button[data-name='bg_video_toggler_opt']",
+        },
+        {
+            content: "Click on the first sample video in the modal.",
+            trigger: "#video-suggestion .o_sample_video",
+        },
+        {
+            content: "Check the video is select.",
+            trigger: "textarea.is-valid",
+            run: () => {}, // This is a check.
+        },
+        {
+            content: "Click on the 'Add' button to apply the selected video as the background.",
+            trigger: ".modal-footer button.btn-primary",
+        },
+        {
+            content: "Verify that the video is set as the background of the snippet.",
+            trigger: "iframe #wrap section.o_background_video",
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -568,3 +568,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_media_iframe_video(self):
         self.start_tour("/", "website_media_iframe_video", login="admin")
+
+    def test_snippet_background_video(self):
+        self.start_tour("/", "website_snippet_background_video", login="admin")


### PR DESCRIPTION
Steps to reproduce:
1. Drag and drop a text snippet.
2. Select background video and insert the video in the mediaDialog.
3. Click on the add button.

Issue:
A traceback occurs due to the tag name not being found for an element. This issue was introduced in commit [1].
Issue link: https://github.com/odoo/odoo/issues/186874

Solution:
This PR resolves the traceback by adding a `parentEl` condition in the replace media on save function.
[1] : https://github.com/odoo/odoo/commit/36594d04a8909dd40ab6384f387c372ddae62345