### PR TITLE
[FIX] account_payment: Fix overdue payment issues for portal users

### DIFF
--- a/addons/account_payment/controllers/portal.py
+++ b/addons/account_payment/controllers/portal.py
@@ -83,12 +83,15 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
         total_amount = sum(overdue_invoices.mapped('amount_total'))
         amount_residual = sum(overdue_invoices.mapped('amount_residual'))
         batch_name = company.get_next_batch_payment_communication() if len(overdue_invoices) > 1 else first_invoice.name
-        values['payment'] = {
-            'date': fields.Date.today(),
-            'reference': batch_name,
+        values.update({
+            'payment': {
+                'date': fields.Date.today(),
+                'reference': batch_name,
+                'amount': total_amount,
+                'currency': currency,
+            },
             'amount': total_amount,
-            'currency': currency,
-        }
+        })
 
         common_view_values = self._get_common_page_view_values(
             invoices_data={

--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -169,8 +169,10 @@ class PaymentTransaction(models.Model):
             **extra_create_values,
         }
 
-        if self.invoice_ids:
-            next_payment_values = self.invoice_ids._get_invoice_next_payment_values()
+        for invoice in self.invoice_ids:
+            if invoice.state != 'posted':
+                continue
+            next_payment_values = invoice._get_invoice_next_payment_values()
             if next_payment_values['installment_state'] == 'epd' and self.amount == next_payment_values['amount_due']:
                 aml = next_payment_values['epd_line']
                 epd_aml_values_list = [({
@@ -183,8 +185,9 @@ class PaymentTransaction(models.Model):
                 for aml_values_list in early_payment_values.values():
                     if (aml_values_list):
                         aml_vl = aml_values_list[0]
-                        aml_vl['partner_id'] = self.partner_id.id
+                        aml_vl['partner_id'] = invoice.partner_id.id
                         payment_values['write_off_line_vals'] += [aml_vl]
+                break
 
         payment = self.env['account.payment'].create(payment_values)
         payment.action_post()

--- a/addons/account_payment/static/src/js/payment_form.js
+++ b/addons/account_payment/static/src/js/payment_form.js
@@ -28,4 +28,17 @@ PaymentForm.include({
         }
         await this._super(...arguments);
     },
+
+        /**
+     * Prepare the params for the RPC to the transaction route.
+     *
+     * @override method from payment.payment_form
+     * @private
+     * @return {object} The transaction route params.
+     */
+        _prepareTransactionRouteParams() {
+            const transactionRouteParams =  this._super(...arguments);
+            transactionRouteParams.payment_reference = this.paymentContext.paymentReference;
+            return transactionRouteParams;
+        },
 });


### PR DESCRIPTION
Currently, multiple tracebacks are occurring when the portal user tries to pay the overdue amount.

**To reproduce this issue:**

1) In accounting create multiple invoices with the customer as a portal user 
2) Make sure to give the due date as past date while creating the invoices 
3) Now login with portal user and try to pay the due amount in the batch

**Error:-**
```
PaymentPortal.overdue_invoices_transaction() missing 1 required positional argument: 'payment_reference'
```

This error occurs because we didn't provide the `payment_reference` in `_prepareTransactionRouteParams`. 
when executing the `overdue_invoices_transaction()` transaction route.

We can resolve this issue by providing the required arguments in the ` _prepareTransactionRouteParams() ` by overriding it in the account payment

**Note:-**

After resolving the above bug, we are encountering two more bugs.

**Bug 1:-**

When making a batch payment, we are getting an ensure_one() error if the due amount spans multiple invoices.

This occurs from the following line:

https://github.com/odoo/odoo/blob/65811ebaf309c462bf918b01d4401695d87b44d6/addons/account_payment/models/payment_transaction.py#L172-L173

**Bug 2:-**

After resolving Bug 1, when we try to make a payment, the amount appears as 0.0

This is because we are passing the amount value in a dictionary with the key as `payment`. 
while rendering the `portal_overdue_invoices_page`.

https://github.com/odoo/odoo/blob/65811ebaf309c462bf918b01d4401695d87b44d6/addons/account_payment/controllers/portal.py#L63

https://github.com/odoo/odoo/blob/65811ebaf309c462bf918b01d4401695d87b44d6/addons/account_payment/controllers/portal.py#L86-L90

While rendering the `payment.form` template from `portal_overdue_invoices_page`, 
the amount value is missing in `this.paymentContext`, resulting in the amount being null.

https://github.com/odoo/odoo/blob/65811ebaf309c462bf918b01d4401695d87b44d6/addons/payment/static/src/js/payment_form.js#L414-L415

This leads to a successful payment with the amount as 0.0.

sentry-5741581459

