### PR TITLE
[FIX] html_editor: ChatGPT alternatives dialog and insert fixups

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -163,6 +163,7 @@ export const editorCommands = {
         }
         const range = selection.getRangeAt(0);
         const block = closestBlock(selection.anchorNode);
+        const isInList = closestElement(selection.anchorNode, 'LI');
         const isSelectionAtStart = firstLeaf(block) === selection.anchorNode && selection.anchorOffset === 0;
         const isSelectionAtEnd = lastLeaf(block) === selection.focusNode && selection.focusOffset === nodeSize(selection.focusNode);
         if (range.startContainer.nodeType === Node.TEXT_NODE) {
@@ -352,7 +353,7 @@ export const editorCommands = {
             }
             // Ensure that all adjacent paragraph elements are converted to
             // <li> when inserting in a list.
-            if (block.nodeName === "LI" && paragraphRelatedElements.includes(nodeToInsert.nodeName)) {
+            if (isInList && paragraphRelatedElements.includes(nodeToInsert.nodeName)) {
                 setTagName(nodeToInsert, "LI");
             }
             // Contenteditable false property changes to true after the node is

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
@@ -170,6 +170,15 @@ describe('insert HTML', () => {
                 contentAfter: '<p>a<i class="fa fa-pastafarianism"></i>[]c<br></p>',
             });
         });
+        it('should delete selection and insert html in its place (3)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<ul><li><h1>[abc</h1></li><li><h1>def</h1></li><li>ghi]</li></ul>',
+                stepFunction: async editor => {
+                    await editor.execCommand('insert', parseHTML(editor.document, '<p>rst</p><p>uvw</p><p>xyz</p>'));
+                },
+                contentAfter: '<ul><li>rst</li><li>uvw</li><li>xyz[]</li></ul>',
+            });
+        });
         it('should remove a fully selected table then insert a span before it', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: unformat(

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_alternatives_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_alternatives_dialog.js
@@ -57,6 +57,11 @@ export class ChatGPTAlternativesDialog extends ChatGPTDialog {
         this.state.alternativesMode = ev.currentTarget.getAttribute('data-mode');
         this._generateAlternatives(1);
     }
+    preventDialogMousedown(ev) {
+        // Prevent the default behavior of a mousedown event on the dialog
+        // itself so it doesn't cancel the user's text selection in the editor.
+        ev.preventDefault();
+    }
 
     //--------------------------------------------------------------------------
     // Private

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_alternatives_dialog.xml
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_alternatives_dialog.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="web_edior.ChatGPTAlternativesDialog">
-    <Dialog size="'lg'" title="'AI Copywriter'">
+    <Dialog size="'lg'" title="'AI Copywriter'" t-on-mousedown="preventDialogMousedown">
         <div class="md-8">
             <div class="mb-3">
                 <t t-foreach="Object.entries(props.alternativesModes)"


### PR DESCRIPTION
Consider the following DOM:

```html
<ul>
    <li><h1>[test</h1></li>
    <li><h1>content]</h1></li>
</ul>
```

Inserting paragraphs there (say, `<p>test</p><p>content</p>`) resulted in the loss of the `li`s:

```html
<ul>
    <p>test</p>
    <p>content[]</p>
</ul>
```

This is because the `insert` function failed to check further than the text node's immediate parent when looking if it was in a `li`.

This PR also prevents the default behavior of a mousedown event on the ChatGPT alternatives dialog so it doesn't cancel the user's text selection in the editor. This way, like with every other dialog, whenever it's open nothing can happen in the background.

task-4258167

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
