### PR TITLE
[FIX] web_editor,website: fixing carousel traceback and transition issue

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2695,12 +2695,19 @@ var SnippetsMenu = Widget.extend({
         return exec(() => {
             return new Promise(resolve => {
                 if ($snippet && $snippet.length) {
-                    return this._createSnippetEditor($snippet).then(resolve);
+                    this._createSnippetEditor($snippet).then(resolve);
+                } else {
+                    resolve(null);
                 }
-                resolve(null);
             }).then(async editorToEnable => {
-                if (!previewMode && this._enabledEditorHierarchy[0] === editorToEnable
-                        || ifInactiveOptions && this._enabledEditorHierarchy.includes(editorToEnable)) {
+                if (editorToEnable && editorToEnable.$target && !editorToEnable.$target.closest('body').length) {
+                    await new Promise(requestAnimationFrame);
+                    if (!editorToEnable.$target.closest('body').length) {
+                        return null;
+                    }
+                }
+
+                if (this._enabledEditorHierarchy[0] === editorToEnable || ifInactiveOptions && this._enabledEditorHierarchy.includes(editorToEnable)) {
                     return editorToEnable;
                 }
 


### PR DESCRIPTION
Previously, when rapidly adding and removing slides in the Carousel
snippet (s_carousel), a JavaScript traceback would occur under certain
conditions.

Step to reproduce:

  1. Drag and Drop a Carousel Snippet (s_carousel) on the page.
  2. Rapidly `add -> remove -> add` slides button in editor.
  3. Traceback occurs.

Cause:

 - The issue occurred because the currently active slide was passed as
   the target to activate a snippet. During rapid DOM changes, the
   active slide could be destroyed or not yet rendered, resulting in a
   race condition and JavaScript error.

Solution:

 - Instead of targeting the individual active slide, we now pass the
   entire carousel element to the `activate_snippet` event. This avoids
   referencing DOM elements that may have been destroyed or are not yet
   stable.

task-4270369