### PR TITLE
[FIX] point_of_sale: set default contact values to false

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerDetailsEdit.js
+++ b/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerDetailsEdit.js
@@ -14,18 +14,18 @@ odoo.define("point_of_sale.PartnerDetailsEdit", function (require) {
             this.intFields = ["country_id", "state_id", "property_product_pricelist"];
             const partner = this.props.partner;
             this.changes = useState({
-                name: partner.name || "",
-                street: partner.street || "",
-                city: partner.city || "",
-                zip: partner.zip || "",
+                name: partner.name || false,
+                street: partner.street || false,
+                city: partner.city || false,
+                zip: partner.zip || false,
                 state_id: partner.state_id && partner.state_id[0],
                 country_id: partner.country_id && partner.country_id[0],
-                lang: partner.lang || "",
-                email: partner.email || "",
-                phone: partner.phone || "",
-                mobile: partner.mobile || "",
-                barcode: partner.barcode || "",
-                vat: partner.vat || "",
+                lang: partner.lang || false,
+                email: partner.email || false,
+                phone: partner.phone || false,
+                mobile: partner.mobile || false,
+                barcode: partner.barcode || false,
+                vat: partner.vat || false,
                 property_product_pricelist: this.getDefaultPricelist(partner),
             });
 


### PR DESCRIPTION
Creating new customers inside a pos session without all fields filled, in the backend those fields would be marked as set

Steps to reproduce:
-------------------
* Create a new customer in the shop and only fill out its name
* In the backend, go in the **Contact** App
* Create a filter: Tax Id is not set
> Observation: The customer just created does not appear in that filter.
It is considered as having a tax id (vat) set.

Why the fix:
------------
When we take a look at the record raw data the vat is set to `""` which is considered as set.

Comparing this with a contact created from the contact app, the only fields that are set to `""` are the computed fields relying on data which is set to false. Everything else is just set to false.

opw-4276003