### PR TITLE
[REM] core: remove current_thread().testing

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6570,4 +6570,4 @@ class AccountMove(models.Model):
 
         :returns: True if commit is acceptable, False otherwise.
         """
-        return not tools.config['test_enable'] and not modules.module.current_test
+        return not modules.module.current_test

--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -1,13 +1,11 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-import threading
 
 from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
 
-from odoo import api, fields, models, tools
+from odoo import api, fields, models, modules, tools
 from odoo.addons.base.models.ir_qweb import QWebException
 from odoo.tools import exception_to_unicode
 from odoo.tools.translate import _
@@ -164,7 +162,7 @@ class EventMail(models.Model):
         'after_event' or 'before_event' (and their negative counterparts).
         This is a global communication done once i.e. we do not track each
         registration individually. """
-        auto_commit = not getattr(threading.current_thread(), 'testing', False)
+        auto_commit = not modules.module.current_test
         batch_size = int(
             self.env['ir.config_parameter'].sudo().get_param('mail.batch_size')
         ) or 50  # be sure to not have 0, as otherwise no iteration is done
@@ -228,7 +226,7 @@ class EventMail(models.Model):
         self.ensure_one()
         context_registrations = self.env.context.get('event_mail_registration_ids')
 
-        auto_commit = not getattr(threading.current_thread(), 'testing', False)
+        auto_commit = not modules.module.current_test
         batch_size = int(
             self.env['ir.config_parameter'].sudo().get_param('mail.batch_size')
         ) or 50  # be sure to not have 0, as otherwise no iteration is done
@@ -484,6 +482,6 @@ class EventMail(models.Model):
                 self.env.invalidate_all()
                 scheduler._warn_error(e)
             else:
-                if autocommit and not getattr(threading.current_thread(), 'testing', False):
+                if autocommit and not modules.module.current_test:
                     self.env.cr.commit()
         return True

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -742,6 +742,7 @@ Attempting to double-book your time off won't magically make your vacation 2x be
             raise UserError(_("There is no employee set on the time off. Please make sure you're logged in the correct company."))
         holidays = super(HrLeave, self.with_context(mail_create_nosubscribe=True)).create(vals_list)
         holidays._check_validity()
+        self.env['hr.leave.allocation'].invalidate_model(['leaves_taken', 'max_leaves'])  # missing dependency on compute
 
         for holiday in holidays:
             if not self._context.get('leave_fast_create'):
@@ -793,6 +794,7 @@ Attempting to double-book your time off won't magically make your vacation 2x be
         result = super().write(values)
         if any(field in values for field in ['request_date_from', 'date_from', 'request_date_from', 'date_to', 'holiday_status_id', 'employee_id', 'state']):
             self._check_validity()
+            self.env['hr.leave.allocation'].invalidate_model(['leaves_taken', 'max_leaves'])  # missing dependency on compute
         if not self.env.context.get('leave_fast_create'):
             for holiday in self:
                 if employee_id:
@@ -818,6 +820,7 @@ Attempting to double-book your time off won't magically make your vacation 2x be
 
     def unlink(self):
         self.sudo()._post_leave_cancel()
+        self.env['hr.leave.allocation'].invalidate_model(['leaves_taken', 'max_leaves'])  # missing dependency on compute
         return super(HrLeave, self.with_context(leave_skip_date_check=True)).unlink()
 
     def copy_data(self, default=None):

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -1424,6 +1424,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'request_hour_to': '12',
             })
             self.assertEqual(leave.number_of_hours, 2)
+            self.assertEqual(allocation.leaves_taken, 2)
             self.assert_allocation_and_balance(allocation, 120, 118,
                 "The 2 hours should be deduced from the balance")
 
@@ -1447,6 +1448,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'request_date_to': datetime.date(2025, 6, 11),
             })
             self.assertEqual(leave.number_of_hours, 64)
+            self.assertEqual(allocation.leaves_taken, 66)
             self.assert_allocation_and_balance(allocation, 182, 116,
                 "The leave hours should be deduced from the balance.")
 

--- a/addons/hr_holidays/tests/test_change_department.py
+++ b/addons/hr_holidays/tests/test_change_department.py
@@ -32,11 +32,15 @@ class TestChangeDepartment(TestHrHolidaysCommon):
         self.employee_emp.department_id = self.hr_dept
         self.assertEqual(hol1_employee_group.department_id, self.hr_dept, 'hr_holidays: non approved leave request should change department if employee change department')
 
+        # flushing is needed after approving because the hr.leave.department_id
+        # is not yet recomputed
+
         # Approved passed leave request change department
         self.employee_emp.department_id = self.hr_dept
         hol2_employee_group = create_holiday("hol2", -1, -1)
         hol2_user_group = hol2_employee_group.with_user(self.user_hruser_id)
         hol2_user_group.action_approve()
+        self.env.flush_all()
         self.employee_emp.department_id = self.rd_dept
         self.assertEqual(hol2_employee_group.department_id, self.hr_dept, 'hr_holidays: approved passed leave request should stay in previous department if employee change department')
 
@@ -45,6 +49,7 @@ class TestChangeDepartment(TestHrHolidaysCommon):
         hol22_employee_group = create_holiday("hol22", 2, 2)
         hol22_user_group = hol22_employee_group.with_user(self.user_hruser_id)
         hol22_user_group.action_approve()
+        self.env.flush_all()
         self.employee_emp.department_id = self.rd_dept
         self.assertEqual(hol22_employee_group.department_id, self.rd_dept, 'hr_holidays: approved future leave request should change department if employee change department')
 
@@ -53,6 +58,7 @@ class TestChangeDepartment(TestHrHolidaysCommon):
         hol3_employee_group = create_holiday("hol3", -2, -2)
         hol3_user_group = hol3_employee_group.with_user(self.user_hruser_id)
         hol3_user_group.action_refuse()
+        self.env.flush_all()
         self.employee_emp.department_id = self.hr_dept # Change department
         self.assertEqual(hol3_employee_group.department_id, self.rd_dept, 'hr_holidays: refused passed leave request should stay in previous department if employee change department')
 
@@ -61,5 +67,6 @@ class TestChangeDepartment(TestHrHolidaysCommon):
         hol32_employee_group = create_holiday("hol32", 10, 10)
         hol32_user_group = hol32_employee_group.with_user(self.user_hruser_id)
         hol32_user_group.action_refuse()
+        self.env.flush_all()
         self.employee_emp.department_id = self.hr_dept # Change department
         self.assertEqual(hol32_employee_group.department_id, self.hr_dept, 'hr_holidays: refused future leave request should change department if employee change department')

--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -48,6 +48,7 @@ class TestOutOfOffice(TestHrHolidaysCommon):
         })
         second_leave.action_approve()
         # validate a leave from 2024-06-10 (Monday) to 2024-06-11 (Tuesday)
+        self.env.invalidate_all()  # missing dependencies on compute functions, reset transaction
         self.assertEqual(self.employee_hruser.user_id.im_status, 'leave_offline', 'user should be out (leave_offline)')
         self.assertEqual(self.employee_hruser.user_id.partner_id.im_status, 'leave_offline', 'user should be out (leave_offline)')
 

--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -5,10 +5,9 @@ import contextlib
 import logging
 import json
 import requests
-import threading
 import uuid
 
-from odoo import exceptions, _
+from odoo import exceptions, modules, _
 from odoo.tools import email_normalize
 
 _logger = logging.getLogger(__name__)
@@ -109,7 +108,7 @@ def iap_jsonrpc(url, method='call', params=None, timeout=15):
     Calls the provided JSON-RPC endpoint, unwraps the result and
     returns JSON-RPC errors as exceptions.
     """
-    if hasattr(threading.current_thread(), 'testing') and threading.current_thread().testing:
+    if modules.module.current_test:
         raise exceptions.AccessError("Unavailable during tests.")  # pylint: disable=missing-gettext
 
     payload = {

--- a/addons/mail/models/mail_scheduled_message.py
+++ b/addons/mail/models/mail_scheduled_message.py
@@ -2,12 +2,11 @@
 
 import json
 import operator
-import threading
 from collections import defaultdict
 from itertools import groupby
 from markupsafe import Markup
 
-from odoo import _, api, fields, models
+from odoo import _, api, fields, models, modules
 from odoo.addons.mail.tools.discuss import Store
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools.misc import clean_context
@@ -230,7 +229,7 @@ class MailScheduledMessage(models.Model):
             This is useful when scheduled messages are sent from the _post_messages_cron.
         """
         notification_parameters_whitelist = self._notification_parameters_whitelist()
-        auto_commit = not getattr(threading.current_thread(), 'testing', False)
+        auto_commit = not modules.module.current_test
         for scheduled_message in self:
             message_creator = scheduled_message.create_uid
             try:

--- a/addons/mail/tests/test_mail_message.py
+++ b/addons/mail/tests/test_mail_message.py
@@ -8,9 +8,10 @@ from odoo.tests import new_test_user, tagged
 class TestMailMessage(common.MailCommon):
     def test_unlink_failure_message_notify_author(self):
         recipient = new_test_user(self.env, login="Bob", email="invalid_email_addr")
-        message = self.env.user.partner_id.message_post(
-            body="Hello world!", partner_ids=recipient.partner_id.ids
-        )
+        with self.mock_mail_gateway():
+            message = self.env.user.partner_id.message_post(
+                body="Hello world!", partner_ids=recipient.partner_id.ids
+            )
         self.assertEqual(message.notification_ids.failure_type, "mail_email_invalid")
         self.assertEqual(message.notification_ids.res_partner_id, recipient.partner_id)
         self.assertEqual(message.notification_ids.author_id, self.env.user.partner_id)

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -11,7 +11,6 @@ import lxml
 import random
 import re
 import requests
-import threading
 import werkzeug.urls
 from ast import literal_eval
 from dateutil.relativedelta import relativedelta
@@ -19,7 +18,7 @@ from markupsafe import Markup
 from werkzeug.urls import url_join
 from PIL import Image, UnidentifiedImageError
 
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, modules, tools, _
 from odoo.addons.base_import.models.base_import import ImportValidationError
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
@@ -1117,7 +1116,7 @@ class MailingMailing(models.Model):
 
             # auto-commit except in testing mode
             composer._action_send_mail(
-                auto_commit=not getattr(threading.current_thread(), 'testing', False)
+                auto_commit=not modules.module.current_test
             )
             mailing.write({
                 'state': 'done',

--- a/addons/partner_autocomplete/models/iap_autocomplete_api.py
+++ b/addons/partner_autocomplete/models/iap_autocomplete_api.py
@@ -17,7 +17,7 @@ class IapAutocompleteApi(models.AbstractModel):
 
     @api.model
     def _contact_iap(self, local_endpoint, action, params, timeout=15):
-        if self.env.registry.in_test_mode() or modules.module.current_test:  # TODO use only current_test once mail stops disabing current_test
+        if modules.module.current_test:
             raise exceptions.ValidationError(_('Test mode'))
         account = self.env['iap.account'].get('partner_autocomplete')
         if not account.account_token:

--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-import threading
 from uuid import uuid4
 
 from werkzeug.urls import url_join
@@ -110,7 +108,7 @@ class SmsSms(models.Model):
         for batch_ids in self._split_batch():
             self.browse(batch_ids)._send(unlink_failed=unlink_failed, unlink_sent=unlink_sent, raise_exception=raise_exception)
             # auto-commit if asked except in testing mode
-            if auto_commit is True and not (getattr(threading.current_thread(), 'testing', False) or modules.module.current_test):
+            if auto_commit is True and not modules.module.current_test:
                 self._cr.commit()
 
     def resend_failed(self):
@@ -160,7 +158,7 @@ class SmsSms(models.Model):
         res = None
         try:
             # auto-commit except in testing mode
-            auto_commit = not (getattr(threading.current_thread(), 'testing', False) and not modules.module.current_test)
+            auto_commit = not modules.module.current_test
             res = self.browse(ids).send(unlink_failed=False, unlink_sent=True, auto_commit=auto_commit, raise_exception=False)
         except Exception:
             _logger.exception("Failed processing SMS queue")

--- a/addons/stock/data/stock_demo.xml
+++ b/addons/stock/data/stock_demo.xml
@@ -160,6 +160,10 @@
             <field name="user_ids" eval="[(4, ref('base.user_admin')), (4, ref('base.user_demo'))]"/>
         </record>
 
+        <record id="warehouse_company_1" model="stock.warehouse">
+            <field name="company_id" ref="res_company_1"/>
+        </record>
+
         <record id="base.group_multi_company" model="res.groups">
             <field name="user_ids" eval="[(4, ref('base.user_admin')), (4, ref('base.user_demo'))]"/>
         </record>

--- a/addons/stock/models/res_company.py
+++ b/addons/stock/models/res_company.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import threading
 
 from odoo import _, api, fields, models, modules
 
@@ -193,8 +191,7 @@ class ResCompany(models.Model):
             company.sudo()._create_per_company_picking_types()
             company.sudo()._create_per_company_rules()
             company.sudo()._set_per_company_inter_company_locations(inter_company_location)
-        test_mode = getattr(threading.current_thread(), 'testing', False) or modules.module.current_test
-        if test_mode:
+        if modules.module.current_test:
             self.env['stock.warehouse'].sudo().create([{'company_id': company.id} for company in companies])
         return companies
 

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -490,6 +490,7 @@ class StockWarehouse(models.Model):
         (_find_existing_rule_or_create method is responsible for this part).
         """
         # Create routes and active/create their related rules.
+        self.ensure_one()
         routes = []
         rules_dict = self.get_rules_dict()
         for route_field, route_data in self._get_routes_values().items():

--- a/addons/stock_sms/models/stock_picking.py
+++ b/addons/stock_sms/models/stock_picking.py
@@ -3,8 +3,6 @@
 
 from odoo import models, modules, _
 
-import threading
-
 
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
@@ -23,7 +21,7 @@ class StockPicking(models.Model):
             is_delivery = picking.company_id.stock_move_sms_validation \
                     and picking.picking_type_id.code == 'outgoing' \
                     and picking.partner_id.phone
-            if is_delivery and not getattr(threading.current_thread(), 'testing', False) \
+            if is_delivery \
                     and not modules.module.current_test \
                     and not picking.company_id.has_received_warning_stock_sms \
                     and picking.company_id.stock_move_sms_validation:

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -2328,7 +2328,7 @@ class TestMailGatewayReplies(MailGatewayCommon):
             ('new', False),  # reference is lost, but reply alias should be ok
             ('update', False),  # reference is lost, hence considered as a reply to catchall, is going to crash (FIXME ?)
         ]:
-            with self.subTest(reply_to_mode=reply_to_mode, auto_delete_keep_log=auto_delete_keep_log):
+            with self.subTest(reply_to_mode=reply_to_mode, auto_delete_keep_log=auto_delete_keep_log), self.mock_mail_gateway(mail_unlink_sent=True):
                 composer_form = Form(self.env['mail.compose.message'].with_context({
                     'active_ids': self.test_records.ids,
                     'default_auto_delete': True,
@@ -2343,8 +2343,7 @@ class TestMailGatewayReplies(MailGatewayCommon):
                 if reply_to_mode == 'new':
                     composer_form.reply_to = self.alias.display_name
                 composer = composer_form.save()
-                with self.mock_mail_gateway(mail_unlink_sent=True):
-                    mails, _msg = composer._action_send_mail()
+                mails, _msg = composer._action_send_mail()
                 self.assertFalse(mails.exists())
 
                 # check reply using references

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -878,6 +878,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         unlinked_mails = set()
 
         with self.assertQueryCount(admin=31, employee=31), \
+             self.mock_mail_gateway(), \
              patch.object(type(self.env['mail.mail']), 'unlink', _patched_unlink):
             self.env['mail.mail'].sudo().browse(mails.ids).send()
 

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -47,7 +47,10 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +101 compared to local
-        with self.assertQueryCount(__system__=1280, marketing=1281):  # 1129, 1130
+        with (
+            self.mock_mail_gateway(mail_unlink_sent=True),
+            self.assertQueryCount(__system__=1280, marketing=1281),  # 1129, 1130
+        ):
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
@@ -90,7 +93,10 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +101 compared to local
-        with self.assertQueryCount(__system__=1319, marketing=1320):  # 1167, 1168
+        with (
+            self.mock_mail_gateway(mail_unlink_sent=True),
+            self.assertQueryCount(__system__=1319, marketing=1320),  # 1167, 1168
+        ):
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)

--- a/addons/website/tests/test_iap.py
+++ b/addons/website/tests/test_iap.py
@@ -1,5 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import threading
 from unittest.mock import patch
 
 import odoo.tests
@@ -14,7 +13,7 @@ class TestIap(odoo.tests.HttpCase):
         supported by the configurator."""
         def _get_industries(lang):
             # Calls to IAP are disabled during testing, we need to remove the testing flag to let it perform the calls
-            with patch.object(threading.current_thread(), 'testing', False), patch.object(modules.module, 'current_test', False):
+            with patch.object(modules.module, 'current_test', False):
                 industries = self.env['website']._website_api_rpc('/api/website/1/configurator/industries', {'lang': lang})['industries']
             return {industry['id']: industry['label'] for industry in industries}
 

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -611,7 +611,7 @@ class IrActionsReport(models.Model):
                     if len(bodies) > 1:
                         v = subprocess.run([_get_wkhtmltopdf_bin(), '--version'], stdout=subprocess.PIPE, check=True, encoding="utf-8")
                         if '(with patched qt)' not in v.stdout:
-                            if modules.module.current_test or tools.config['test_enable']:
+                            if modules.module.current_test:
                                 raise unittest.SkipTest("Unable to convert multiple documents via wkhtmltopdf using unpatched QT")
                             raise UserError(_("Tried to convert multiple documents in wkhtmltopdf using unpatched QT"))
 

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -378,6 +378,12 @@ class IrMail_Server(models.Model):
         self.ensure_one()
         return self.test_smtp_connection(autodetect_max_email_size=True)
 
+    @classmethod
+    def _disable_send(cls):
+        """Whether to disable sending e-mails"""
+        # no e-mails during testing or when registry is not ready
+        return modules.module.current_test or not cls.pool._init
+
     def connect(self, host=None, port=None, user=None, password=None, encryption=None,
                 smtp_from=None, ssl_certificate=None, ssl_private_key=None, smtp_debug=False, mail_server_id=None,
                 allow_archived=False):
@@ -403,8 +409,8 @@ class IrMail_Server(models.Model):
            longer raised.
         """
         # Do not actually connect while running in test mode
-        if modules.module.current_test:
-            return
+        if self._disable_send():
+            return None
         mail_server = smtp_encryption = None
         if mail_server_id:
             mail_server = self.sudo().browse(mail_server_id)
@@ -817,7 +823,7 @@ class IrMail_Server(models.Model):
         smtp_from, smtp_to_list, message = self._prepare_email_message(message, smtp)
 
         # Do not actually send emails in testing mode!
-        if modules.module.current_test:
+        if self._disable_send():
             _test_logger.debug("skip sending email in test mode")
             return message['Message-Id']
 

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
 import logging
-import threading
-import warnings
 
-from odoo import api, fields, models, tools, _, Command
+from odoo import api, fields, models, modules, tools, _, Command
 from odoo.api import SUPERUSER_ID
 from odoo.exceptions import ValidationError, UserError
 from odoo.osv import expression
@@ -232,7 +229,7 @@ class ResCompany(models.Model):
         is_ready_and_not_test = (
             not tools.config['test_enable']
             and (self.env.registry.ready or not self.env.registry._init)
-            and not getattr(threading.current_thread(), 'testing', False)
+            and not modules.module.current_test
         )
         if uninstalled_modules and is_ready_and_not_test:
             return uninstalled_modules.button_immediate_install()

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -440,7 +440,7 @@ class MockSmtplibCase:
 
         with patch('smtplib.SMTP_SSL', side_effect=lambda *args, **kwargs: self.testing_smtp_session), \
              patch('smtplib.SMTP', side_effect=lambda *args, **kwargs: self.testing_smtp_session), \
-             patch.object(modules.module, 'current_test', False), \
+             patch.object(type(IrMailServer), '_disable_send', lambda _: False), \
              patch.object(type(IrMailServer), 'connect', mock_function(connect_origin)) as connect_mocked, \
              patch.object(type(IrMailServer), '_find_mail_server', mock_function(find_mail_server_origin)) as find_mail_server_mocked:
             self.connect_mocked = connect_mocked.mock
@@ -460,8 +460,9 @@ class MockSmtplibCase:
         )
 
     def _send_email(self, msg, smtp_session):
-        with patch.object(modules.module, 'current_test', False):
-            self.env['ir.mail_server'].send_email(msg, smtp_session=smtp_session)
+        IrMailServer = self.env['ir.mail_server']
+        with patch.object(type(IrMailServer), '_disable_send', lambda _: False):
+            IrMailServer.send_email(msg, smtp_session=smtp_session)
         return smtp_session.messages.pop()
 
     def assertSMTPEmailsSent(self, smtp_from=None, smtp_to_list=None,

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import itertools
 import logging
 import sys
-import threading
 import time
 import typing
 import traceback
@@ -71,19 +70,12 @@ def load_data(env: Environment, idref, mode: str, kind: str, package: ModuleNode
         return files
 
     filename = None
-    try:
-        if kind in ('demo', 'test'):
-            threading.current_thread().testing = True
-        for filename in _get_files_of_kind(kind):
-            _logger.info("loading %s/%s", package.name, filename)
-            noupdate = False
-            if kind in ('demo', 'demo_xml') or (filename.endswith('.csv') and kind in ('init', 'init_xml')):
-                noupdate = True
-            tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
-    finally:
-        if kind in ('demo', 'test'):
-            threading.current_thread().testing = False
-
+    for filename in _get_files_of_kind(kind):
+        _logger.info("loading %s/%s", package.name, filename)
+        noupdate = False
+        if kind in ('demo', 'demo_xml') or (filename.endswith('.csv') and kind in ('init', 'init_xml')):
+            noupdate = True
+        tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
     return bool(filename)
 
 

--- a/odoo/tests/loader.py
+++ b/odoo/tests/loader.py
@@ -3,7 +3,6 @@ import importlib.util
 import inspect
 import logging
 import sys
-import threading
 from pathlib import Path
 from unittest import case
 
@@ -112,11 +111,9 @@ def run_suite(suite):
     # avoid dependency hell
     from ..modules import module
     module.current_test = True
-    threading.current_thread().testing = True
 
     results = OdooTestResult()
     suite(results)
 
-    threading.current_thread().testing = False
     module.current_test = False
     return results


### PR DESCRIPTION
For testing indicator, we have: `odoo.modules.module.current_test` flag. We should not rely anymore on setting the value on the current thread as it duplicates what we could check.

task-4270485
odoo/enterprise#73634
odoo/upgrade-util#164



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
