### PR TITLE
[IMP] mrp: move duration update in dedicated function that can be overriden

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1733,12 +1733,7 @@ class MrpProduction(models.Model):
                 if extra_vals:
                     move.move_line_ids.write(extra_vals)
             # workorder duration need to be set to calculate the price of the product
-            for workorder in order.workorder_ids:
-                if workorder.state not in ('done', 'cancel'):
-                    workorder.duration_expected = workorder._get_duration_expected()
-                if workorder.duration == 0.0:
-                    workorder.duration = workorder.duration_expected
-                    workorder.duration_unit = round(workorder.duration / max(workorder.qty_produced, 1), 2)
+            order.workorder_ids._update_duration()
             order._cal_price(moves_to_do_by_order[order.id])
         moves_to_finish = self.move_finished_ids.filtered(lambda x: x.state not in ('done', 'cancel'))
         moves_to_finish.picked = True

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -876,6 +876,14 @@ class MrpWorkorder(models.Model):
         if self.qty_producing:
             self.qty_producing = quantity
 
+    def _update_duration(self):
+        for workorder in self:
+            if workorder.state not in ('done', 'cancel'):
+                workorder.duration_expected = workorder._get_duration_expected()
+            if workorder.duration == 0.0:
+                workorder.duration = workorder.duration_expected
+                workorder.duration_unit = round(workorder.duration / max(workorder.qty_produced, 1), 2)
+
     def get_working_duration(self):
         """Get the additional duration for 'open times' i.e. productivity lines with no date_end."""
         self.ensure_one()


### PR DESCRIPTION
### Current behavior before PR:
The _post_inventory do everything in a big function

### Desired behavior after PR is merged:
The duration is updated using a separated function so can be overriden



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
