### PR TITLE
[IMP] core: SQL for negation

### DIFF
--- a/odoo/addons/test_new_api/tests/test_domain.py
+++ b/odoo/addons/test_new_api/tests/test_domain.py
@@ -143,6 +143,10 @@ class TestDomain(TransactionExpressionCase):
                     f"Incorrect result for search([('name', 'not in', {list(subset)})])",
                 )
 
+        # =like check
+        self.assertListEqual(self._search(EmptyChar, [('name', '=like', 'na%')]).mapped('name'), ['name'])
+        self.assertListEqual(self._search(EmptyChar, ['!', ('name', '=like', 'na%')]).mapped('name'), ['', False, False])
+
     def test_empty_translation(self):
         records_en = self.env['test_new_api.indexed_translation'].with_context(lang='en_US').create([
             {'name': 'English'},

--- a/odoo/addons/test_new_api/tests/test_search.py
+++ b/odoo/addons/test_new_api/tests/test_search.py
@@ -111,10 +111,10 @@ class TestSubqueries(TransactionCase):
                 ON ("test_new_api_multi"."partner" = "test_new_api_multi__partner"."id")
             WHERE (
                 "test_new_api_multi__partner"."id" IS NULL OR (
-                    NOT ((
+                    ((
                         ("test_new_api_multi__partner"."name" LIKE %s)
                         OR ("test_new_api_multi__partner"."phone" LIKE %s)
-                    ))
+                    )) IS NOT TRUE
                 )
             )
             ORDER BY "test_new_api_multi"."id"

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -971,7 +971,7 @@ class expression(object):
 
             if is_operator(leaf):
                 if leaf == NOT_OPERATOR:
-                    push_result(SQL("(NOT (%s))", pop_result()))
+                    push_result(SQL("((%s) IS NOT TRUE)", pop_result()))
                 elif leaf == AND_OPERATOR:
                     push_result(SQL("(%s AND %s)", pop_result(), pop_result()))
                 else:


### PR DESCRIPTION
Negating arbitrary SQL is now done using `x IS NOT TRUE` instead of `NOT x`. This handles correctly the complement when the value of `x` is null.

The goal is to translate correctly operators that do not have a negative version. The negation of `x like 'test'` is `x not like 'test' or x is null`; to handle the generic case efficiently and evaluate `x` once, `(x like 'test') IS NOT TRUE` is correct where `NOT (x like 'test')` does not handle null values correctly.

task-4067946


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
