### PR TITLE
[FIX] account_payment: allow internal users to change a payment provider

### DIFF
--- a/addons/account_payment/models/account_payment.py
+++ b/addons/account_payment/models/account_payment.py
@@ -111,12 +111,12 @@ class AccountPayment(models.Model):
             self.payment_token_id = False
             return
 
-        self.payment_token_id = self.env['payment.token'].search([
+        self.payment_token_id = self.env['payment.token'].sudo().search([
             *self.env['payment.token']._check_company_domain(self.company_id),
             ('partner_id', '=', self.partner_id.id),
             ('provider_id.capture_manually', '=', False),
             ('provider_id', '=', self.payment_method_line_id.payment_provider_id.id),
-         ], limit=1)
+         ], limit=1)  # In sudo mode to read the provider fields.
 
     #=== ACTION METHODS ===#
 


### PR DESCRIPTION
**Issue:**
An employee can't modify a `Payment Method` (other than "Manual" on a new payment entry).

**Expected:**
An employee should be able to change the payment provider to register a customer payment.

**Steps to reproduce:**
- Activate Accounting app and go to Configuration > Online Payments > Payment Providers;
- Install any of these providers, configure it, activate the test mode and publish it;
- Go to Customers Payments > Payments;
- Open or create a payement record;
- Try to change the Payment Method field for .

**Cause:**
No rights have been given to users on the payment provider data lookup.
https://github.com/odoo/odoo/blob/18.0/addons/payment/security/ir.model.access.csv

**Fix:**
Give temporary rights on payment provider token lookup.

opw-4270781

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
