### PR TITLE
[FIX] various: not supported field type

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -286,7 +286,7 @@ export class HtmlField extends Component {
 export const htmlField = {
     component: HtmlField,
     displayName: _t("Html"),
-    supportedTypes: ["html"],
+    supportedTypes: ["html", "text"],
     extractProps({ attrs, options }, dynamicInfo) {
         const editorConfig = {
             mediaModalParams: {

--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -58,7 +58,7 @@ class SnailmailLetter(models.Model):
              "If the letter is correctly sent, the status goes in 'Sent',\n"
              "If not, it will got in state 'Error' and the error message will be displayed in the field 'Error Message'.")
     error_code = fields.Selection([(err_code, err_code) for err_code in ERROR_CODES], string="Error")
-    info_msg = fields.Char('Information')
+    info_msg = fields.Html('Information')
 
     reference = fields.Char(string='Related Record', compute='_compute_reference', readonly=True, store=False)
 

--- a/odoo/addons/base/models/ir_profile.py
+++ b/odoo/addons/base/models/ir_profile.py
@@ -39,7 +39,7 @@ class IrProfile(models.Model):
     entry_count = fields.Integer('Entry count')
 
     speedscope = fields.Binary('Speedscope', compute='_compute_speedscope')
-    speedscope_url = fields.Text('Open', compute='_compute_speedscope_url')
+    speedscope_url = fields.Char('Open', compute='_compute_speedscope_url')
 
     @api.autovacuum
     def _gc_profile(self):


### PR DESCRIPTION
Some fields in odoo uses Different type which is not supported in
widget, thus giving validation error.

- Mail, text type in html
- Snailmail, char type in html
- Ir profile, text type in url

### Changes:

[**Mail**] Added 'text' type in supportedTypes of html widget for mail
[**Snailmail**] Changed type of `info_msg` field to Html supported in html widget
[**Ir profile**] Changed type of `speedscope_url` field to Char supported in url widget

Task-4325985
