### PR TITLE
[REF] mail: better attachment voice

### DIFF
--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -56,6 +56,7 @@ class AttachmentController(http.Controller):
         if thread_model == "discuss.channel" and not thread.allow_public_upload and not request.env.user._is_internal():
             raise AccessError(_("You are not allowed to upload attachments on this channel."))
         vals = {
+            "is_voice": kwargs.pop("voice", False),
             "name": ufile.filename,
             "raw": ufile.read(),
             "res_id": int(thread_id),

--- a/addons/mail/models/discuss/__init__.py
+++ b/addons/mail/models/discuss/__init__.py
@@ -2,6 +2,7 @@
 
 # mail
 from . import mail_message
+from . import mail_thread
 
 # discuss
 from . import discuss_channel_member

--- a/addons/mail/models/discuss/__init__.py
+++ b/addons/mail/models/discuss/__init__.py
@@ -9,7 +9,7 @@ from . import discuss_channel_member
 from . import discuss_channel_rtc_session
 from . import discuss_channel
 from . import discuss_gif_favorite
-from . import discuss_voice_metadata
+# from . import discuss_voice_metadata
 from . import mail_guest
 
 # odoo models

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -724,17 +724,6 @@ class DiscussChannel(models.Model):
         if not message.message_type == 'comment':
             raise UserError(_("Only messages type comment can have their content updated on model 'discuss.channel'"))
 
-    def _create_attachments_for_post(self, values_list, extra_list):
-        # Create voice metadata from meta information
-        attachments = super()._create_attachments_for_post(values_list, extra_list)
-        voice = attachments.env['ir.attachment']  # keep env, notably for potential sudo
-        for attachment, (_cid, _name, _token, info) in zip(attachments, extra_list):
-            if info.get('voice'):
-                voice += attachment
-        if voice:
-            voice._set_voice_metadata()
-        return attachments
-
     def _message_subscribe(self, partner_ids=None, subtype_ids=None, customer_ids=None):
         """ Do not allow follower subscription on channels. Only members are
         considered. """

--- a/addons/mail/models/discuss/ir_attachment.py
+++ b/addons/mail/models/discuss/ir_attachment.py
@@ -7,21 +7,21 @@ from odoo.addons.mail.tools.discuss import Store
 class IrAttachment(models.Model):
     _inherit = ["ir.attachment"]
 
-    is_voice = fields.Boolean("Is Voice", compute="_compute_is_voice", inverse="_inverse_is_voice")
-    voice_ids = fields.One2many("discuss.voice.metadata", "attachment_id")
+    is_voice = fields.Boolean("Is Voice")
+    # voice_ids = fields.One2many("discuss.voice.metadata", "attachment_id")
 
-    def _compute_is_voice(self):
-        voice_data = dict(self.env['discuss.voice.metadata'].sudo()._read_group(
-            [('attachment_id', 'in', self.ids)], groupby=['attachment_id'], aggregates=['id:recordset'],
-        )) if self else {}
-        for attachment in self:
-            attachment.is_voice = attachment in voice_data
+    # def _compute_is_voice(self):
+    #     voice_data = dict(self.env['discuss.voice.metadata'].sudo()._read_group(
+    #         [('attachment_id', 'in', self.ids)], groupby=['attachment_id'], aggregates=['id:recordset'],
+    #     )) if self else {}
+    #     for attachment in self:
+    #         attachment.is_voice = attachment in voice_data
 
-    def _inverse_is_voice(self):
-        todo = self.sudo().filtered(lambda a: a.is_voice and not a.voice_ids)
-        if todo:
-            self.env["discuss.voice.metadata"].create([{"attachment_id": att.id} for att in todo])
-        self.filtered(lambda a: not a.is_voice).sudo().voice_ids.unlink()
+    # def _inverse_is_voice(self):
+    #     todo = self.sudo().filtered(lambda a: a.is_voice and not a.voice_ids)
+    #     if todo:
+    #         self.env["discuss.voice.metadata"].create([{"attachment_id": att.id} for att in todo])
+    #     self.filtered(lambda a: not a.is_voice).sudo().voice_ids.unlink()
 
     def _bus_channel(self):
         self.ensure_one()

--- a/addons/mail/models/discuss/ir_attachment.py
+++ b/addons/mail/models/discuss/ir_attachment.py
@@ -7,7 +7,21 @@ from odoo.addons.mail.tools.discuss import Store
 class IrAttachment(models.Model):
     _inherit = ["ir.attachment"]
 
+    is_voice = fields.Boolean("Is Voice", compute="_compute_is_voice", inverse="_inverse_is_voice")
     voice_ids = fields.One2many("discuss.voice.metadata", "attachment_id")
+
+    def _compute_is_voice(self):
+        voice_data = dict(self.env['discuss.voice.metadata'].sudo()._read_group(
+            [('attachment_id', 'in', self.ids)], groupby=['attachment_id'], aggregates=['id:recordset'],
+        )) if self else {}
+        for attachment in self:
+            attachment.is_voice = attachment in voice_data
+
+    def _inverse_is_voice(self):
+        todo = self.sudo().filtered(lambda a: a.is_voice and not a.voice_ids)
+        if todo:
+            self.env["discuss.voice.metadata"].create([{"attachment_id": att.id} for att in todo])
+        self.filtered(lambda a: not a.is_voice).sudo().voice_ids.unlink()
 
     def _bus_channel(self):
         self.ensure_one()
@@ -24,12 +38,4 @@ class IrAttachment(models.Model):
             # TODO master: make a real computed / inverse field and stop propagating
             # kwargs through hook methods
             # sudo: discuss.voice.metadata - checking the existence of voice metadata for accessible attachments is fine
-            store.add(attachment, {"voice": bool(attachment.sudo().voice_ids)})
-
-    def _post_add_create(self, **kwargs):
-        super()._post_add_create(**kwargs)
-        if kwargs.get('voice'):
-            self._set_voice_metadata()
-
-    def _set_voice_metadata(self):
-        self.env["discuss.voice.metadata"].create([{"attachment_id": att.id} for att in self])
+            store.add(attachment, {"voice": attachment.is_voice})

--- a/addons/mail/models/discuss/mail_thread.py
+++ b/addons/mail/models/discuss/mail_thread.py
@@ -1,0 +1,8 @@
+from odoo import models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = ['mail.thread']
+
+    def _prepare_attachment_post_values(self, content, name, model, res_id, extra_info):
+        return dict(super()._prepare_attachment_post_values(content, name, model, res_id, extra_info), is_voice=(extra_info or {}).get('is_voice'))

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2349,6 +2349,7 @@ class MailThread(models.AbstractModel):
                     'description': name,
                     'res_model': model,
                     'res_id': res_id,
+                    **(info.get('extra_values') or {}),
                 }
                 token = False
                 if (cid and cid in body_cids) or (name and name in body_filenames):
@@ -2359,7 +2360,7 @@ class MailThread(models.AbstractModel):
                 # keep cid, name list and token synced with attachement_values_list length to match ids latter
                 attachement_extra_list.append((cid, name, token, info))
 
-            new_attachments = self._create_attachments_for_post(attachement_values_list, attachement_extra_list)
+            new_attachments = self.env['ir.attachment'].sudo().create(attachement_values_list)
             attach_cid_mapping, attach_name_mapping = {}, {}
             for attachment, (cid, name, token, _info) in zip(new_attachments, attachement_extra_list):
                 if cid:
@@ -2387,12 +2388,6 @@ class MailThread(models.AbstractModel):
                     return_values['body'] = Markup(lxml.html.tostring(root, pretty_print=False, encoding='unicode'))
         return_values['attachment_ids'] = m2m_attachment_ids
         return return_values
-
-    def _create_attachments_for_post(self, values_list, extra_list):
-        """ Ease tweaking attachment creation when processing them in posting
-        process. Mainly meant for stable version, to be cleaned when reaching
-        master. """
-        return self.env['ir.attachment'].sudo().create(values_list)
 
     def _process_attachments_for_template_post(self, mail_template):
         """ Model specific management of attachments used with template attachments

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2342,15 +2342,7 @@ class MailThread(models.AbstractModel):
                     content = content.as_bytes()
                 elif content is None:
                     continue
-                attachement_values = {
-                    'name': name,
-                    'datas': base64.b64encode(content),
-                    'type': 'binary',
-                    'description': name,
-                    'res_model': model,
-                    'res_id': res_id,
-                    **(info.get('extra_values') or {}),
-                }
+                attachement_values = self._prepare_attachment_post_values(content, name, model, res_id, info)
                 token = False
                 if (cid and cid in body_cids) or (name and name in body_filenames):
                     token = self.env['ir.attachment']._generate_access_token()
@@ -2388,6 +2380,16 @@ class MailThread(models.AbstractModel):
                     return_values['body'] = Markup(lxml.html.tostring(root, pretty_print=False, encoding='unicode'))
         return_values['attachment_ids'] = m2m_attachment_ids
         return return_values
+
+    def _prepare_attachment_post_values(self, content, name, model, res_id, extra_info):
+        return {
+            'name': name,
+            'datas': base64.b64encode(content),
+            'type': 'binary',
+            'description': name,
+            'res_model': model,
+            'res_id': res_id,
+        }
 
     def _process_attachments_for_template_post(self, mail_template):
         """ Model specific management of attachments used with template attachments

--- a/addons/mail/security/ir.model.access.csv
+++ b/addons/mail/security/ir.model.access.csv
@@ -57,7 +57,6 @@ access_mail_template_reset,access.mail.template.reset,model_mail_template_reset,
 ir_actions_report_access_user,ir.actions.report.access.user,base.model_ir_actions_report,base.group_user,1,0,0,0
 access_mail_link_preview_admin,mail.link.preview.admin,model_mail_link_preview,base.group_erp_manager,1,1,1,1
 access_discuss_gif_favorite,discuss.gif.favorite,model_discuss_gif_favorite,base.group_user,1,1,1,1
-access_discuss_voice_metadata_user,discuss.voice.metadata.user,model_discuss_voice_metadata,base.group_system,1,1,1,1
 access_mail_push_system,access.mail.push.system,mail.model_mail_push,base.group_system,1,1,1,1
 access_mail_push_device_system,access.mail.push.device.system,mail.model_mail_push_device,base.group_system,1,1,1,1
 access_mail_message_translation_system,mail.message.translation,model_mail_message_translation,base.group_system,1,1,1,1

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -468,9 +468,9 @@ class TestChannelInternals(MailCommon, HttpCase):
     def test_channel_message_post_with_voice_attachment(self):
         """ Test 'voice' info being supported to create voice metadata. """
         channel = self.env['discuss.channel'].create({'name': 'channel_1'})
-        channel.message_post(attachments=[('audio', b'OggS\x00\x02', {'extra_values': {'is_voice': True}})])
+        channel.message_post(attachments=[('audio', b'OggS\x00\x02', {'is_voice': True})])
         attachment = channel.message_ids.attachment_ids
-        self.assertTrue(attachment.voice_ids, "message's attachment should have voice metadata")
+        # self.assertTrue(attachment.voice_ids, "message's attachment should have voice metadata")
         self.assertTrue(attachment.is_voice, "message's attachment should be flagged as voice")
 
         # revert is_voice flag

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -475,7 +475,7 @@ class TestChannelInternals(MailCommon, HttpCase):
 
         # revert is_voice flag
         attachment.is_voice = False
-        self.assertFalse(self.env["discuss.voice.metadata"].search([("attachment_id", "in", attachment.ids)]))
+        # self.assertFalse(self.env["discuss.voice.metadata"].search([("attachment_id", "in", attachment.ids)]))
 
     @mute_logger('odoo.models.unlink')
     def test_channel_unsubscribe_auto(self):


### PR DESCRIPTION
Use a real compute / inverse field, allowing to remove override of '_post_add_create' for that purpose. It should be used only for post upload specific management, not model related manipulation.

Task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
