### PR TITLE
[FIX] hr_expense: fix typo in hr.expense.attachment_ids domain

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -80,7 +80,7 @@ class HrExpense(models.Model):
     attachment_ids = fields.One2many(
         comodel_name='ir.attachment',
         inverse_name='res_id',
-        domain="[('res_model', '=', 'hr.expense')]",
+        domain=[('res_model', '=', 'hr.expense')],
         string="Attachments",
     )
     state = fields.Selection(


### PR DESCRIPTION
### Steps to reproduce the issue:

1. With studio, add a signature field to the Expense Form
2. Create a new expense with a signature
3. Receive the following error:

>       File "[...]/odoo/addons/hr_expense/models/hr_expense.py", line 459, in _compute_same_receipt_expense_ids
>         same_receipt_ids.update(expenses_groupby_checksum[attachment.checksum])
>     KeyError: <string of letters and numbers>

### Explanation:

When a Binary field is assigned a value.`ir.attachment` is automatically created and linked to said field through `res_field`. https://github.com/odoo/odoo/blob/9b440d5b07d9683d7f051baa98476b2977acba0f/odoo/fields.py#L2514-L2522 In the database, when retrieving attachments, those with `res_field` assigned are discarded from the query. https://github.com/odoo/odoo/blob/bfd7945d634bd4d46c4d62e93061581c6c5b09c1/odoo/addons/base/models/ir_attachment.py#L520-L526 During the creation of `hr.expense`, `attachment_ids` is assigned all attachments created and linked to it, in the cache, through `res_id`. https://github.com/odoo/odoo/blob/9b440d5b07d9683d7f051baa98476b2977acba0f/odoo/fields.py#L3290 Since saas-17.4, the compute method `_compute_same_receipt_expense_ids` has been added with a dependency on `attachment_ids`. If, during the creation, a Binary field has been assigned a value and `ir.attachment` created, the latter will still be linked to `attachment_ids` in the cache and found in the `filtered` method, while the `_read_group`, checking the database, will discard it due to `res_field` having a value. https://github.com/odoo/odoo/blob/6b8e07e36c6e6e283d21c2b5abd9a9dabf10fa4a/addons/hr_expense/models/hr_expense.py#L445-L454 Due to that difference between the cache and the database, an issue occurs when trying to retrieve the value from `ir.attachment`.

### Fix reasoning:

`attachment_ids` has a domain attribute, but it is not correctly assigned. The value should be a List instead of a String. https://github.com/odoo/odoo/blob/9b440d5b07d9683d7f051baa98476b2977acba0f/odoo/fields.py#L2991 While this specific domain is not necessary for One2Many fields since it is already covered by the override in `get_domain_list`. https://github.com/odoo/odoo/blob/9b440d5b07d9683d7f051baa98476b2977acba0f/odoo/fields.py#L4497-L4498 We will keep it to make sure the cache is invalidated and `attachment_ids` is retrieved from the database. https://github.com/odoo/odoo/blob/bde4952255987cd21ceaabdf13f0a271b6ab10fa/odoo/models.py#L6889-L6894

opw-4293803
