### PR TITLE
[FIX] hr_holidays: Add mail_activity_automation_skip check

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1556,6 +1556,9 @@ Attempting to double-book your time off won't magically make your vacation 2x be
         return responsible
 
     def activity_update(self):
+        if self.env.context.get('mail_activity_automation_skip'):
+            return False
+
         to_clean, to_do, to_do_confirm_activity = self.env['hr.leave'], self.env['hr.leave'], self.env['hr.leave']
         activity_vals = []
         today = fields.Date.today()


### PR DESCRIPTION
Since we moved away from activity_schedule in odoo/odoo#107804, the mail_activity_automation_skip context doesn't work anymore and activities get created regardless

We add a check at the beginning of the function to make the context flag work again


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
