### PR TITLE
[FIX] stock: handle domain starting with non-string

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -179,7 +179,7 @@ class StockQuant(models.Model):
 
     def _search(self, domain, *args, **kwargs):
         domain = [
-            line if not isinstance(line, (list, tuple)) or not line[0].startswith('lot_properties.')
+            line if not isinstance(line, (list, tuple)) or not (isinstance(line[0], str) and line[0].startswith('lot_properties.'))
             else ['lot_id', 'any', [line]]
             for line in domain
         ]


### PR DESCRIPTION
It is possible for a domain to have a non-string as its first element, for example `[(0, '=', 1)]` (as produced by Odoo's [`expression.OR()`](https://github.com/odoo/odoo/blob/bb40cf9efc87929e16671538aa68b191dffd06b3/odoo/osv/expression.py#L305) if given an empty domain).

Any call to stock_quant's [`_search()`](https://github.com/odoo/odoo/blob/bb40cf9efc87929e16671538aa68b191dffd06b3/addons/stock/models/stock_quant.py#L182-L184) with such a domain would fail with an `AttributeError` when attempting to call `startswith` on an integer.

We need to check if the first domain element is a string first.
