### PR TITLE
[FIX] purchase_repair: add missing dependency

### DIFF
--- a/addons/purchase_repair/__manifest__.py
+++ b/addons/purchase_repair/__manifest__.py
@@ -6,7 +6,7 @@
     'version': '1.0',
     'category': 'Repair/Purchase',
     'license': 'LGPL-3',
-    'depends': ['repair', 'purchase'],
+    'depends': ['repair', 'purchase_stock'],
     'data': [
         'views/purchase_views.xml',
         'views/repair_views.xml',


### PR DESCRIPTION
The field [`purchase.order.repair_count`](https://github.com/odoo/odoo/blob/a4b21175dec1c09b0b02e31350de4b9848fa1728/addons/purchase_repair/models/purchase_order.py#L8-L13) depends on field `order_line.move_dest_ids.repair_id`, and [`move_dest_ids`](https://github.com/odoo/odoo/blob/a4b21175dec1c09b0b02e31350de4b9848fa1728/addons/purchase_stock/models/purchase_order_line.py#L28) is defined in module `purchase_stock`, but it is not an explicit dependency and the autoinstall does not guarantee the existence of the module.

Fixing the dependency to ensure the field `purchase.order.repair_count` can be computed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
