### PR TITLE
[FIX] base,core: commit module load after marked installed

### DIFF
--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -19,6 +19,7 @@ from . import test_groups
 from . import test_http_case
 from . import test_i18n
 from . import test_image
+from . import test_install
 from . import test_avatar_mixin
 from . import test_ir_actions
 from . import test_ir_attachment

--- a/odoo/addons/base/tests/test_install.py
+++ b/odoo/addons/base/tests/test_install.py
@@ -1,0 +1,47 @@
+from unittest import SkipTest
+
+from odoo.tests.common import standalone
+from odoo.tests.test_module_operations import install
+from odoo.tools import mute_logger
+from odoo.tools.convert import ParseError
+
+
+@standalone('test_isolated_install')
+def test_isolated_install(env):
+    """ This test checks that a module failing to install has no side effect on
+    other modules.  In particular, the module that was installed just before is
+    correctly marked as 'installed'.
+    """
+    MODULE_NAMES = ['test_install_base', 'test_install_auto', 'test_install_fail']
+    modules = {
+        module.name: module
+        for module in env['ir.module.module'].search([('name', 'in', MODULE_NAMES)])
+    }
+    if len(modules) < 3:
+        raise SkipTest(f"Failed to find the required modules {MODULE_NAMES}")
+    if not all(module.state == 'uninstalled' for module in modules.values()):
+        raise SkipTest(f"The modules {MODULE_NAMES} should not be installed")
+
+    # now install test_install_fail, which should install test_install_base and
+    # test_install_auto just before it
+    try:
+        with mute_logger('odoo.modules.registry'):
+            install(env.cr.dbname, modules['test_install_fail'].id, 'test_install_fail')
+    except ParseError:
+        pass
+
+    # make sure to reset the transaction
+    env.cr.rollback()
+    env.transaction.reset()
+
+    # check the presence of the cron
+    cron = env['ir.cron'].search([('cron_name', '=', 'test_install_auto_cron')])
+    assert cron, "The cron 'test_install_auto_cron' has not been created"
+
+    # check the states of the modules
+    assert modules['test_install_base'].state == 'installed', "Module 'test_install_base' not installed"
+    assert modules['test_install_auto'].state == 'installed', "Module 'test_install_auto' not installed"
+    assert modules['test_install_fail'].state == 'uninstalled', "Module 'test_install_fail' should be uninstalled"
+
+    # check that test_install_auto's code is present
+    assert env['res.currency']._test_install_auto_cron() is True, "Cron code not working"

--- a/odoo/addons/base/tests/test_install_addons/test_install_auto/__init__.py
+++ b/odoo/addons/base/tests/test_install_addons/test_install_auto/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/odoo/addons/base/tests/test_install_addons/test_install_auto/__manifest__.py
+++ b/odoo/addons/base/tests/test_install_addons/test_install_auto/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    'name': 'test_install_auto',
+    'version': '1.0',
+    'category': 'Hidden/Tools',
+    'description': "",
+    'depends': ['test_install_base'],
+    'data': [
+        'data/ir_cron.xml',
+    ],
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/odoo/addons/base/tests/test_install_addons/test_install_auto/data/ir_cron.xml
+++ b/odoo/addons/base/tests/test_install_addons/test_install_auto/data/ir_cron.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="test_install_auto_cron" model="ir.cron">
+            <field name="name">test_install_auto_cron</field>
+            <field name="model_id" ref="base.model_res_currency"/>
+            <field name="state">code</field>
+            <field name="code">model._test_install_auto_cron()</field>
+            <field name="active" eval="True"/>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">12</field>
+            <field name="interval_type">hours</field>
+        </record>
+    </data>
+</odoo>

--- a/odoo/addons/base/tests/test_install_addons/test_install_auto/models/__init__.py
+++ b/odoo/addons/base/tests/test_install_addons/test_install_auto/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_currency

--- a/odoo/addons/base/tests/test_install_addons/test_install_auto/models/res_currency.py
+++ b/odoo/addons/base/tests/test_install_addons/test_install_auto/models/res_currency.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class ResCurrency(models.Model):
+    _inherit = 'res.currency'
+
+    @api.model
+    def _test_install_auto_cron(self):
+        return True

--- a/odoo/addons/base/tests/test_install_addons/test_install_base/__manifest__.py
+++ b/odoo/addons/base/tests/test_install_addons/test_install_base/__manifest__.py
@@ -1,0 +1,9 @@
+{
+    'name': 'test_install_base',
+    'version': '1.0',
+    'category': 'Hidden/Tools',
+    'description': "",
+    'depends': ['base'],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/odoo/addons/base/tests/test_install_addons/test_install_fail/__manifest__.py
+++ b/odoo/addons/base/tests/test_install_addons/test_install_fail/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'test_install_fail',
+    'version': '1.0',
+    'category': 'Hidden/Tools',
+    'description': "",
+    'depends': ['test_install_base'],
+    'data': [
+        'views/res_currency_views.xml',
+    ],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/odoo/addons/base/tests/test_install_addons/test_install_fail/views/res_currency_views.xml
+++ b/odoo/addons/base/tests/test_install_addons/test_install_fail/views/res_currency_views.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <record id="view_currency_form_inherit_bad_module" model="ir.ui.view">
+        <field name="name">view.currency.form.inherit.bad.module</field>
+        <field name="model">res.currency</field>
+        <field name="inherit_id" ref="base.view_currency_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='ERROR']" position="after">
+                <h3>to fail</h3>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/odoo/addons/base/tests/test_install_addons/test_isolated_install.md
+++ b/odoo/addons/base/tests/test_install_addons/test_isolated_install.md
@@ -1,0 +1,19 @@
+### test_isolated_install
+
+Given the following package structure (where `\_` denotes a dependency)
+<pre>
+...
+    \_ test_install_base
+        \_ test_install_auto
+        \_ test_install_fail
+</pre>
+Given:
+* The auto-install module test_install_auto
+  * Has a model override of ResCurrency that defines a new method for the class
+  * Has some data that defines an IrCron record, which executes the method added in the override
+* The data error module test_install_fail:
+  * Has a view extension which has some bad syntax that will trigger a failure in load_data()
+
+We want to ensure each module is installed in an isolated manner, i.e., the
+failed installation of a module should not affect the state of another module
+which has been installed just before.

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -329,6 +329,7 @@ def load_module_graph(
                 if hasattr(package, kind):
                     delattr(package, kind)
             module.env.flush_all()
+            module.env.cr.commit()
 
         extra_queries = odoo.sql_db.sql_counter - module_extra_query_count - test_queries
         extras = []


### PR DESCRIPTION
Given the following module hierarchy:
<pre>
...
   \_ mid_level_module
                      \_ auto_install_module
                      \_ module_with_data_error
</pre>
Where:
* The auto install module has (for sake of example) some a model override of `ResCurrency` that defines a new method for the class. This module also has some data that defines an `IrCron` record, which executes the method added by the `ResCurrency` override within its own model files.

* The data error module has a view extension which has some bad syntax that will trigger a failure in `load_data()`.

Upon running an odoo instance with `-i module_with_data_error`, the module load will proceed until failing at this module- however the CRON data loaded from `auto_install_module` will be in the `ir_cron` postgres table, while its overridden method is not in the registry.

***

The problem occurs because a package's data/schema changes are committed prior to actually marking the module record as installed- so the mark install step doesn't get committed until the subsequent package data/schema changes are committed.

When the data_error module fails to have its data loaded, we will reset `to_install` modules as `uninstalled`- but because the module state changes from the prior package (auto_install) were not yet committed, it will not attempt to reinstall this package upon re-initialization (receiving a new request which un-rests the server).

So we are left with the CRON record which was committed already, without the actual model override required for the CRON to run.

***

If we modify the module state before committing, the issue is no longer present.