### PR TITLE
[FIX] bus: log websocket session downgrade

### DIFF
--- a/addons/bus/tests/test_websocket_caryall.py
+++ b/addons/bus/tests/test_websocket_caryall.py
@@ -13,6 +13,7 @@ from weakref import WeakSet
 from odoo import http
 from odoo.api import Environment
 from odoo.tests import common, new_test_user
+from odoo.tools import mute_logger
 from .common import WebsocketCase
 from .. import websocket as websocket_module
 from ..models.bus import dispatch
@@ -262,7 +263,9 @@ class TestWebsocketCaryall(WebsocketCase):
             self.assertNotEqual(websocket._session.uid, user_session.uid)
             serve_forever_called_event.set()
 
-        with patch.object(WebsocketConnectionHandler, '_serve_forever', side_effect=serve_forever) as mock:
+        with patch.object(
+            WebsocketConnectionHandler, '_serve_forever', side_effect=serve_forever
+        ) as mock, mute_logger('odoo.addons.bus.websocket'):
             ws = self.websocket_connect(
                 cookie=f'session_id={user_session.sid};',
                 origin="http://example.com"

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -961,6 +961,14 @@ class WebsocketConnectionHandler:
         headers = request.httprequest.headers
         origin_url = urlparse(headers.get('origin'))
         if origin_url.netloc != headers.get('host') or origin_url.scheme != request.httprequest.scheme:
+            _logger.warning(
+                'Downgrading websocket session. Host=%(host)s, Origin=%(origin)s, Scheme=%(scheme)s.',
+                {
+                    'host': headers.get('host'),
+                    'origin': headers.get('origin'),
+                    'scheme': request.httprequest.scheme,
+                },
+            )
             session = root.session_store.new()
             session.update(get_default_session(), db=request.session.db)
             root.session_store.save(session)


### PR DESCRIPTION
Debugging websocket can be tough as we don't know
when a session is downgraded. Some messages can be
received, giving the impression that everything is
working fine while the socket is actually linked to
a public user.

This PR introduces some logs to help debugging this
scenario.

opw-4218953