### PR TITLE
[IMP] html_editor: caption button for images

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -1216,7 +1216,7 @@ export class HistoryPlugin extends Plugin {
     }
 
     _onDocumentBeforeInput(ev) {
-        if (this.editable.contains(ev.targget)) {
+        if (this.editable.contains(ev.target)) {
             return;
         }
         if (["historyUndo", "historyRedo"].includes(ev.inputType)) {

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -264,10 +264,16 @@ export class ImagePlugin extends Plugin {
         if (!selectedImg) {
             return;
         }
+        let imageName;
+        // Keep the result from the first predicate that returns something.
+        this.getResource("image_name_predicates").find((p) => {
+            imageName = p(selectedImg);
+            return imageName;
+        });
         const fileModel = {
             isImage: true,
             isViewable: true,
-            name: selectedImg.src,
+            name: imageName || selectedImg.src,
             defaultSource: selectedImg.src,
             downloadUrl: selectedImg.src,
         };

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -36,6 +36,7 @@ const IMAGE_SIZE = [
 export class ImagePlugin extends Plugin {
     static id = "image";
     static dependencies = ["history", "link", "powerbox", "dom", "selection"];
+    static shared = ["getSelectedImage"];
     resources = {
         user_commands: [
             {
@@ -277,6 +278,9 @@ export class ImagePlugin extends Plugin {
     deleteImage() {
         const selectedImg = this.getSelectedImage();
         if (selectedImg) {
+            if (this.delegateTo("delete_image_handlers", selectedImg)) {
+                return;
+            }
             const cursors = this.dependencies.selection.preserveSelection();
             cursors.update(callbacksForCursorUpdate.remove(selectedImg));
             const parentEl = closestBlock(selectedImg);

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -144,6 +144,7 @@ export class MediaPlugin extends Plugin {
         // Collapse selection after the inserted/replaced element.
         const [anchorNode, anchorOffset] = rightPos(element);
         this.dependencies.selection.setSelection({ anchorNode, anchorOffset });
+        this.delegateTo("afer_save_media_dialog_handlers", element);
         this.dependencies.history.addStep();
     }
 

--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -76,7 +76,7 @@ export class SeparatorPlugin extends Plugin {
 
     handleSelectionInHr() {
         this.deselectHR();
-        const traversedNodes = this.dependencies.selection.getTraversedNodes({ deep: true });
+        const traversedNodes = this.dependencies.selection.getTraversedNodes();
         for (const node of traversedNodes) {
             if (node.nodeName === "HR") {
                 node.classList.toggle("o_selected_hr", true);

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -882,7 +882,7 @@ export class TablePlugin extends Plugin {
             .filter((node) => node.nodeName === "TABLE")
             .pop();
 
-        const traversedNodes = this.dependencies.selection.getTraversedNodes({ deep: true });
+        const traversedNodes = this.dependencies.selection.getTraversedNodes();
         if ((startTd !== endTd || selectSingleCell) && startTable === endTable) {
             if (!isProtected(startTable) && !isProtecting(startTable)) {
                 // The selection goes through at least two different cells ->

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -208,12 +208,15 @@ export class ToolbarPlugin extends Plugin {
         } else {
             // Mouse interaction behavior:
             // Close toolbar on mousedown and prevent it from opening until mouseup.
-            this.addDomListener(this.editable, "mousedown", () => {
-                this.overlay.close();
-                this.debouncedUpdateToolbar.cancel();
-                this.onSelectionChangeActive = false;
+            this.addGlobalDomListener("mousedown", (ev) => {
+                // Don't close if the mousedown is on an overlay.
+                if (!ev.target?.closest?.(".o-overlay-item")) {
+                    this.overlay.close();
+                    this.debouncedUpdateToolbar.cancel();
+                    this.onSelectionChangeActive = false;
+                }
             });
-            this.addDomListener(this.document, "mouseup", (ev) => {
+            this.addGlobalDomListener("mouseup", (ev) => {
                 if (ev.detail >= 2) {
                     // Delayed open, waiting for a possible triple click.
                     this.onSelectionChangeActive = true;

--- a/addons/html_editor/static/src/others/embedded_components/backend/caption/caption.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/caption/caption.js
@@ -1,0 +1,103 @@
+import {
+    applyObjectPropertyDifference,
+    getEmbeddedProps,
+    StateChangeManager,
+} from "@html_editor/others/embedded_component_utils";
+import { Component, useState, useRef, onMounted } from "@odoo/owl";
+
+export class EmbeddedCaptionComponent extends Component {
+    static template = "html_editor.EmbeddedCaption";
+
+    static props = {
+        image: { type: Element },
+        onUpdateCaption: { type: Function },
+        onEditorHistoryApply: { type: Function },
+        focusInput: { type: Boolean },
+        host: { type: Object },
+    };
+
+    setup() {
+        super.setup();
+        this.state = useState({
+            caption: "",
+            host: this.props.host,
+        });
+        this.captionInput = useRef("captionInput");
+        if (this.props.focusInput) {
+            onMounted(() => {
+                this.captionInput.el.focus();
+            });
+        }
+        // Ensure the state, the attribute and the placeholder are in sync.
+        this.updateCaption();
+        this.observer = new MutationObserver((mutations) => {
+            for (const mutation of mutations) {
+                if (mutation.type === "attributes" && mutation.attributeName === "data-caption") {
+                    this.updateCaption();
+                }
+            }
+        });
+        this.observer.observe(this.props.image, { attributes: true });
+    }
+
+    destroy() {
+        this.observer.disconnect();
+    }
+
+    updateCaption(caption = this.props.image.getAttribute("data-caption")) {
+        if (caption !== this.state.caption) {
+            this.state.caption = caption;
+            this.props.onUpdateCaption(caption);
+        }
+    }
+
+    onInputBlur() {
+        // This is triggered before the selection changes. Wait before updating
+        // so when the history step triggers a normalization, it restores that
+        // new selection and not the old one.
+        setTimeout(() => {
+            if (this.captionInput.el) {
+                this.updateCaption(this.captionInput.el.value || "");
+            }
+        });
+    }
+
+    onInputKeyup(ev) {
+        if (ev.key === "z" && ev.ctrlKey && !this._appliedNativeHistory) {
+            this.props.onEditorHistoryApply(ev.shiftKey);
+        }
+        this._appliedNativeHistory = false;
+    }
+
+    onInputBeforeInput(ev) {
+        this._appliedNativeHistory = false;
+        if (ev.inputType === "historyUndo" || ev.inputType === "historyRedo") {
+            // Input elements handle their own history, but this event is not
+            // triggered if no changes were made to the input. So we handle the
+            // editor history on keyup in those cases, but let the browser do
+            // its thing otherwise.
+            this._appliedNativeHistory = true;
+        }
+    }
+}
+
+export const captionEmbedding = {
+    name: "caption",
+    Component: EmbeddedCaptionComponent,
+    getProps: (host) => ({ host, ...getEmbeddedProps(host) }),
+    getStateChangeManager: (config) =>
+        new StateChangeManager(
+            Object.assign(config, {
+                propertyUpdater: {
+                    caption: (state, previous, next) => {
+                        applyObjectPropertyDifference(
+                            state,
+                            "caption",
+                            previous.caption,
+                            next.caption
+                        );
+                    },
+                },
+            })
+        ),
+};

--- a/addons/html_editor/static/src/others/embedded_components/backend/caption/caption.scss
+++ b/addons/html_editor/static/src/others/embedded_components/backend/caption/caption.scss
@@ -1,0 +1,3 @@
+figcaption {
+    color: #9e9d9a;
+}

--- a/addons/html_editor/static/src/others/embedded_components/backend/caption/caption.xml
+++ b/addons/html_editor/static/src/others/embedded_components/backend/caption/caption.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <!-- caption template -->
+    <t t-name="html_editor.EmbeddedCaption">
+        <input t-attf-class="border-0 p-0"
+            t-ref="captionInput" type="text" maxLength="100" t-att-placeholder="'Write your caption here'"
+            t-on-blur="onInputBlur" t-on-keydown.stop="" t-on-beforeinput="onInputBeforeInput" t-on-keyup="onInputKeyup"
+            t-att-value="state.caption"/>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/others/embedded_components/embedding_sets.js
+++ b/addons/html_editor/static/src/others/embedded_components/embedding_sets.js
@@ -1,4 +1,5 @@
 import { fileEmbedding } from "@html_editor/others/embedded_components/backend/file/file";
+import { captionEmbedding } from "@html_editor/others/embedded_components/backend/caption/caption";
 import { readonlyFileEmbedding } from "@html_editor/others/embedded_components/core/file/readonly_file";
 import {
     readonlyTableOfContentEmbedding,
@@ -12,6 +13,7 @@ export const MAIN_EMBEDDINGS = [
     tableOfContentEmbedding,
     toggleBlockEmbedding,
     videoEmbedding,
+    captionEmbedding,
 ];
 
 export const READONLY_MAIN_EMBEDDINGS = [
@@ -19,4 +21,5 @@ export const READONLY_MAIN_EMBEDDINGS = [
     readonlyTableOfContentEmbedding,
     toggleBlockEmbedding,
     videoEmbedding,
+    captionEmbedding,
 ];

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_blueprint.xml
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_blueprint.xml
@@ -1,0 +1,6 @@
+<templates>
+    <t t-name="html_editor.EmbeddedCaptionBlueprint">
+        <figcaption t-att-data-embedded-props="embeddedProps" data-embedded="caption"
+            data-oe-protected="true" contenteditable="false" class="mt-2"/>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -1,0 +1,244 @@
+import { Plugin } from "@html_editor/plugin";
+import { _t } from "@web/core/l10n/translation";
+import { closestBlock } from "@html_editor/utils/blocks";
+import { renderToElement } from "@web/core/utils/render";
+import { fillEmpty, unwrapContents } from "@html_editor/utils/dom";
+import { closestElement } from "@html_editor/utils/dom_traversal";
+import { boundariesOut, rightPos } from "@html_editor/utils/position";
+
+export class CaptionPlugin extends Plugin {
+    static id = "caption";
+    static dependencies = [
+        "image",
+        "split",
+        "history",
+        "embeddedComponents",
+        "selection",
+        "baseContainer",
+    ];
+    resources = {
+        user_commands: [
+            {
+                id: "toggleImageCaption",
+                title: _t("Add/remove a caption"),
+                run: this.toggleImageCaption.bind(this),
+            },
+        ],
+        toolbar_items: [
+            {
+                id: "image_caption",
+                description: _t("Add/remove a caption"),
+                groupId: "image_description",
+                commandId: "toggleImageCaption",
+                text: "Caption",
+                isActive: () => this.hasImageCaption(this.dependencies.image.getSelectedImage()),
+            },
+        ],
+        clean_for_save_handlers: this.cleanForSave.bind(this),
+        mount_component_handlers: this.setupNewCaption.bind(this),
+        delete_image_handlers: this.handleDeleteImage.bind(this),
+        afer_save_media_dialog_handlers: this.onImageReplaced.bind(this),
+        hints: [{ selector: "FIGCAPTION", text: _t("Write a caption...") }],
+        unsplittable_node_predicates: [
+            (node) => ["FIGURE", "FIGCAPTION"].includes(node.nodeName), // avoid merge
+        ],
+    };
+
+    setup() {
+        for (const figure of this.editable.querySelectorAll("figure")) {
+            // Embed the captions.
+            const image = figure.querySelector("img");
+            figure.before(image);
+            const caption = figure.querySelector("figcaption").textContent;
+            figure.remove();
+            this.addImageCaption(image, caption, false);
+        }
+    }
+
+    cleanForSave({ root }) {
+        for (const figure of root.querySelectorAll("figure")) {
+            figure.removeAttribute("contenteditable");
+            const image = figure.querySelector("img");
+            // Remove embedding and convert caption attribute to text.
+            figure.querySelector("figcaption").remove();
+            const caption = root.ownerDocument.createElement("figcaption");
+            caption.textContent = image.getAttribute("data-caption");
+            image.removeAttribute("data-caption");
+            image.removeAttribute("data-caption-id");
+            image.after(caption);
+        }
+    }
+
+    hasImageCaption(image) {
+        if (!image) {
+            return;
+        }
+        const block = closestBlock(image);
+        return (
+            block.nodeName === "FIGURE" && !!block.querySelector("[data-embedded='caption'] input")
+        );
+    }
+
+    toggleImageCaption(image = this.dependencies.image.getSelectedImage()) {
+        if (!image) {
+            return;
+        }
+        if (this.hasImageCaption(image)) {
+            this.removeImageCaption(image);
+        } else {
+            this.addImageCaption(image, image.getAttribute("data-caption") || "");
+        }
+    }
+
+    getCaptionId() {
+        return "" + Math.floor(Math.random() * Date.now());
+    }
+
+    addImageCaption(image, captionText = "", focusInput = true) {
+        this.captionsBeingAdded ||= new Set();
+        // Move the image within a figure element.
+        const figure = this.document.createElement("figure");
+        const link = image.parentElement.nodeName === "A" && image.parentElement;
+        if (link && (link.previousSibling || link.nextSibling)) {
+            // <p>wx<a><img/></a>yz</p> => <p>wx</p><p><a><img/></a></p><p>yz</p>
+            this.dependencies.split.splitAroundUntil(link, closestBlock(link));
+        } else if (
+            !link &&
+            (image.previousSibling || image.nextSibling) &&
+            closestBlock(image) !== this.editable
+        ) {
+            // <p>wx<img/>yz</p> => <p>wx</p><p><img/></p><p>yz</p>
+            this.dependencies.split.splitAroundUntil(image, closestBlock(image));
+        }
+        // => <p><figure><img/></figure></p>
+        // or <p><a><figure><img/></figure></a></p>
+        image.before(figure);
+        figure.append(image);
+        if (!link && figure.parentElement !== this.editable) {
+            // => <figure><img/></figure></p>
+            // but still <p><a><figure><img/></figure></p>
+            unwrapContents(figure.parentElement);
+        }
+        // Set the caption and its ID.
+        const captionId = this.getCaptionId();
+        this.captionsBeingAdded.add(captionId);
+        image.setAttribute("data-caption-id", captionId);
+        image.setAttribute("data-caption", captionText || "");
+        // Ensure it's not possible to write inside the figure.
+        figure.setAttribute("contenteditable", "false");
+        // Ensure it's possible to write before and after the figure.
+        const block = closestBlock(link || image);
+        if (!block.previousSibling) {
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            block.before(baseContainer);
+            fillEmpty(baseContainer);
+        }
+        if (!block.nextSibling) {
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            block.after(baseContainer);
+            fillEmpty(baseContainer);
+        }
+        // Add the caption component.
+        // => <p><figure><img/><figcaption>...</figcaption></figure></p>
+        // or <p><a><figure><img/><figcaption>...</figcaption></figure></a></p>
+        const caption = renderToElement("html_editor.EmbeddedCaptionBlueprint", {
+            embeddedProps: JSON.stringify({
+                id: captionId,
+                focusInput,
+            }),
+        });
+        figure.append(caption);
+        this.dependencies.history.addStep();
+        this.captionsBeingAdded.delete(captionId);
+    }
+
+    removeImageCaption(image) {
+        const figure = closestElement(image, "figure");
+        if (figure) {
+            figure.querySelector("figcaption").remove();
+            if (closestBlock(figure.parentElement) === this.editable) {
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                if (figure.parentElement.nodeName === "A") {
+                    figure.parentElement.before(baseContainer);
+                    baseContainer.append(figure.parentElement);
+                } else {
+                    figure.before(baseContainer);
+                    baseContainer.append(figure);
+                }
+            }
+            unwrapContents(figure);
+            image.removeAttribute("data-caption-id"); // (keep the data-caption for if we toggle again)
+            // Select the image.
+            const [anchorNode, anchorOffset, focusNode, focusOffset] = boundariesOut(image);
+            this.dependencies.selection.setSelection({
+                anchorNode,
+                anchorOffset,
+                focusNode,
+                focusOffset,
+            });
+            this.dependencies.selection.focusEditable();
+            this.dependencies.history.addStep();
+        }
+    }
+
+    setupNewCaption({ name, props }) {
+        if (name === "caption") {
+            const id = props.id;
+            delete props.id;
+            const image = this.editable.querySelector(`img[data-caption-id="${id}"]`);
+            Object.assign(props, {
+                image,
+                onUpdateCaption: (caption = "") => {
+                    const figcaption = image.parentElement.querySelector("figcaption");
+                    if (figcaption && figcaption.getAttribute("placeholder") !== caption) {
+                        // Adapt the figcaption element's placeholder to the new
+                        // caption for screen reader users.
+                        figcaption.setAttribute("placeholder", caption);
+                    }
+                    if (caption !== image.getAttribute("data-caption")) {
+                        image.setAttribute("data-caption", caption);
+                    }
+                    if (!this.captionsBeingAdded?.has(id)) {
+                        // If the caption is being added, we update without
+                        // adding a history step because it will be added at the
+                        // end of adding the caption, by `addImageCaption`.
+                        this.dependencies.history.addStep();
+                    }
+                },
+                onEditorHistoryApply: (redo = false) => {
+                    if (redo) {
+                        this.dependencies.history.redo();
+                    } else {
+                        this.dependencies.history.undo();
+                    }
+                },
+            });
+        }
+    }
+
+    onImageReplaced(media) {
+        const figure = closestElement(media, "figure");
+        if (media.nodeName === "IMG" && figure) {
+            const caption = figure.querySelector("[data-embedded='caption'] input")?.value;
+            if (caption) {
+                media.setAttribute("data-caption", caption);
+            }
+            const [anchorNode, anchorOffset] = rightPos(figure);
+            this.dependencies.selection.setSelection({ anchorNode, anchorOffset });
+        }
+    }
+
+    handleDeleteImage(image) {
+        const figure = closestElement(image, "figure");
+        if (figure) {
+            const sibling = figure.nextSibling || figure.previousSibling;
+            figure.remove();
+            this.dependencies.selection.setSelection({
+                anchorNode: sibling,
+                anchorOffset: 0,
+            });
+            this.dependencies.history.addStep();
+            return true;
+        }
+    }
+}

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -42,6 +42,7 @@ export class CaptionPlugin extends Plugin {
         unsplittable_node_predicates: [
             (node) => ["FIGURE", "FIGCAPTION"].includes(node.nodeName), // avoid merge
         ],
+        image_name_predicates: [this.getImageName.bind(this)],
     };
 
     setup() {
@@ -213,6 +214,12 @@ export class CaptionPlugin extends Plugin {
                     }
                 },
             });
+        }
+    }
+
+    getImageName(image) {
+        if (closestElement(image, "figure")) {
+            return image.getAttribute("data-caption");
         }
     }
 

--- a/addons/html_editor/static/src/plugin.js
+++ b/addons/html_editor/static/src/plugin.js
@@ -42,14 +42,39 @@ export class Plugin {
         return !isProtecting(ev.target) && (!isProtected(ev.target) || isUnprotecting(ev.target));
     }
 
-    addDomListener(target, eventName, fn, capture = false) {
+    /**
+     * Add an event listener on a given target, that will only be executed if
+     * the target is valid (unless `isGlobal` is true), and ensure it is removed
+     * when we destroy the editor.
+     *
+     * @param {Element} target
+     * @param {string} eventName
+     * @param {function(Event):void} fn
+     * @param {boolean} [capture=false] `useCapture` flag of `addEventListener`
+     * @param {boolean} [isGlobal=false] if true, don't check target validity
+     */
+    addDomListener(target, eventName, fn, capture = false, isGlobal = false) {
         const handler = (ev) => {
-            if (this.isValidTargetForDomListener(ev)) {
+            if (isGlobal || this.isValidTargetForDomListener(ev)) {
                 fn?.call(this, ev);
             }
         };
         target.addEventListener(eventName, handler, capture);
         this._cleanups.push(() => target.removeEventListener(eventName, handler, capture));
+    }
+
+    /**
+     * Add an event listener on the editor's document, and ensure it is removed
+     * when we destroy the editor.
+     *
+     * @todo Use this function to avoid iframe problems.
+     *
+     * @param {string} eventName
+     * @param {function(Event):void} fn
+     * @param {boolean} [capture=false] `useCapture` flag of `addEventListener`
+     */
+    addGlobalDomListener(eventName, fn, capture = false) {
+        this.addDomListener(this.document, eventName, fn, capture, true);
     }
 
     /**

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -63,6 +63,7 @@ import { EmbeddedComponentPlugin } from "./others/embedded_component_plugin";
 import { TableOfContentPlugin } from "@html_editor/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin";
 import { ToggleBlockPlugin } from "@html_editor/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin";
 import { VideoPlugin } from "@html_editor/others/embedded_components/plugins/video_plugin/video_plugin";
+import { CaptionPlugin } from "@html_editor/others/embedded_components/plugins/caption_plugin/caption_plugin";
 import { QWebPlugin } from "./others/qweb_plugin";
 import { EditorVersionPlugin } from "./core/editor_version_plugin";
 
@@ -178,6 +179,7 @@ export const EMBEDDED_COMPONENT_PLUGINS = [
     TableOfContentPlugin,
     ToggleBlockPlugin,
     VideoPlugin,
+    CaptionPlugin,
 ];
 
 export const DYNAMIC_PLACEHOLDER_PLUGINS = [DynamicPlaceholderPlugin, QWebPlugin];

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -510,3 +510,59 @@ test("replace an image with a caption", async () => {
         ),
     });
 });
+
+test("previewing an image with a caption shows the caption as title", async () => {
+    await setupEditorWithEmbeddedCaption(`<img class="img-fluid test-image" src="${base64Img}">`);
+
+    // Preview without a caption shows the file name.
+    await click("img");
+    await waitFor(".o-we-toolbar");
+    await click(".o-we-toolbar button[name='image_preview']");
+    await animationFrame();
+    let titleSpan = await queryOne(".o-FileViewer .o-FileViewer-header span.text-truncate");
+    expect(titleSpan.textContent).toBe(base64Img.replaceAll("\n", "%0A"));
+    await click(".o-FileViewer-headerButton[title='Close (Esc)']");
+    await animationFrame();
+
+    // Add a caption
+    await toggleCaption("Hello");
+
+    // Preview with a caption show the caption.
+    await click("img");
+    await waitFor(".o-we-toolbar button[name='image_preview']");
+    await click(".o-we-toolbar button[name='image_preview']");
+    await animationFrame();
+    titleSpan = await queryOne(".o-FileViewer .o-FileViewer-header span.text-truncate");
+    expect(titleSpan.textContent).toBe("Hello");
+});
+
+test("previewing an image without caption doesn't show the caption as title (even if data-caption exists)", async () => {
+    await setupEditorWithEmbeddedCaption(`<img class="img-fluid test-image" src="${base64Img}">`);
+
+    // Preview without a caption shows the file name.
+    await click("img");
+    await waitFor(".o-we-toolbar button[name='image_preview']");
+    await click(".o-we-toolbar button[name='image_preview']");
+    await animationFrame();
+    let titleSpan = await queryOne(".o-FileViewer .o-FileViewer-header span.text-truncate");
+    expect(titleSpan.textContent).toBe(base64Img.replaceAll("\n", "%0A"));
+    await click(".o-FileViewer-headerButton[title='Close (Esc)']");
+    await animationFrame();
+
+    // Add a caption
+    await toggleCaption("Hello");
+
+    // Remove the caption
+    await toggleCaption();
+    const image = await queryOne("img");
+    expect(image.getAttribute("data-caption")).toBe("Hello");
+    expect("figure").toHaveCount(0);
+
+    // Preview without a caption still shows the file name.
+    await click("img");
+    await waitFor(".o-we-toolbar button[name='image_preview']");
+    await click(".o-we-toolbar button[name='image_preview']");
+    await animationFrame();
+    titleSpan = await queryOne(".o-FileViewer .o-FileViewer-header span.text-truncate");
+    expect(titleSpan.textContent).toBe(base64Img.replaceAll("\n", "%0A"));
+});

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -1,0 +1,512 @@
+import { expect, test } from "@odoo/hoot";
+import { manuallyDispatchProgrammaticEvent, click, press, queryOne, waitFor } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import { makeMockEnv, onRpc } from "@web/../tests/web_test_helpers";
+import { CaptionPlugin } from "@html_editor/others/embedded_components/plugins/caption_plugin/caption_plugin";
+import { MAIN_PLUGINS, EMBEDDED_COMPONENT_PLUGINS } from "@html_editor/plugin_sets";
+import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
+import { closestElement } from "@html_editor/utils/dom_traversal";
+import { setupEditor, testEditor } from "./_helpers/editor";
+import { unformat } from "./_helpers/format";
+import { insertText } from "./_helpers/user_actions";
+import { cleanHints } from "./_helpers/dispatch";
+
+class CaptionPluginWithPredictableId extends CaptionPlugin {
+    getCaptionId() {
+        return "1";
+    }
+}
+const base64Img =
+    "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
+const configWithEmbeddedCaption = {
+    Plugins: [
+        ...MAIN_PLUGINS,
+        CaptionPluginWithPredictableId,
+        ...EMBEDDED_COMPONENT_PLUGINS.filter((plugin) => plugin.id !== "caption"),
+    ],
+    resources: {
+        embedded_components: [
+            CaptionPluginWithPredictableId,
+            ...MAIN_EMBEDDINGS.filter((plugin) => plugin.id !== "caption"),
+        ],
+    },
+};
+const setupEditorWithEmbeddedCaption = async (content) =>
+    await setupEditor(content, { config: configWithEmbeddedCaption });
+const toggleCaption = async (captionText) => {
+    await click("img");
+    await waitFor(".o-we-toolbar button[name='image_caption']");
+    await click("button[name='image_caption']");
+    if (captionText) {
+        await waitFor("figure > figcaption > input");
+        for (const char of captionText) {
+            if (char.toUpperCase() === char) {
+                await press(["Shift", char]);
+            } else {
+                await press(char);
+            }
+        }
+        const input = queryOne("input");
+        expect(input.value).toBe("Hello");
+    }
+};
+const objectToAttributesString = (attributes) =>
+    Object.entries(attributes)
+        .map(([k, v]) => (v.includes('"') ? `${k}='${v}'` : `${k}="${v}"`))
+        .join(" ");
+const getFigcaptionAttributes = (captionId, caption = "", focusInput = false) => {
+    const attributes = {
+        "data-embedded": "caption",
+        "data-oe-protected": "true",
+        contenteditable: "false",
+        class: "mt-2",
+        "data-embedded-props": `{"id":"${captionId}","focusInput":${focusInput}}`,
+    };
+    if (caption) {
+        attributes.placeholder = caption;
+    }
+    return objectToAttributesString(attributes);
+};
+const CAPTION_INPUT_ATTRIBUTES = objectToAttributesString({
+    type: "text",
+    maxlength: "100",
+    class: "border-0 p-0",
+    placeholder: "Write your caption here",
+});
+
+test.tags("focus required");
+test("add a caption to an image and focus it", async () => {
+    const captionId = 1;
+    await testEditor({
+        config: configWithEmbeddedCaption,
+        contentBefore: `<img class="img-fluid test-image" src="${base64Img}">`,
+        stepFunction: async (editor) => {
+            await toggleCaption();
+            await waitFor("figcaption > input");
+            const input = queryOne("figure > figcaption > input");
+            expect(input.value).toBe("");
+            expect(editor.document.activeElement).toBe(input);
+            expect(editor.document.getSelection().anchorNode.nodeName).toBe("FIGCAPTION");
+            // Remove the editor selection for the test because it's irrelevant
+            // since the focus is not in it.
+            const selection = editor.document.getSelection();
+            selection.removeAllRanges();
+            cleanHints(editor);
+        },
+        contentAfterEdit: unformat(
+            `<p><br></p>
+            <figure contenteditable="false">
+                <img class="img-fluid test-image" src="${base64Img}" data-caption-id="${captionId}" data-caption="">
+                <figcaption ${getFigcaptionAttributes(captionId, "", true)}>
+                    <input ${CAPTION_INPUT_ATTRIBUTES}>
+                </figcaption>
+            </figure>
+            <p><br></p>`
+        ),
+    });
+});
+
+test.tags("focus required");
+test("add a caption to an image surrounded by text and focus it", async () => {
+    const captionId = 1;
+    await testEditor({
+        config: configWithEmbeddedCaption,
+        contentBefore: `<p>ab<img class="img-fluid test-image" src="${base64Img}">cd</p>`,
+        stepFunction: async (editor) => {
+            await toggleCaption();
+            await waitFor("figcaption > input");
+            const input = queryOne("figure > figcaption > input");
+            expect(input.value).toBe("");
+            expect(editor.document.activeElement).toBe(input);
+            // Remove the editor selection for the test because it's irrelevant
+            // since the focus is not in it.
+            const selection = editor.document.getSelection();
+            selection.removeAllRanges();
+        },
+        contentAfterEdit: unformat(
+            `<p>ab</p>
+            <figure contenteditable="false">
+                <img class="img-fluid test-image" src="${base64Img}" data-caption-id="${captionId}" data-caption="">
+                <figcaption ${getFigcaptionAttributes(captionId, "", true)}>
+                    <input ${CAPTION_INPUT_ATTRIBUTES}>
+                </figcaption>
+            </figure>
+            <p>cd</p>`
+        ),
+    });
+});
+
+test("saving an image with a caption replaces the input with plain text", async () => {
+    const captionId = 1;
+    const caption = "Hello";
+    await testEditor({
+        config: configWithEmbeddedCaption,
+        contentBefore: unformat(
+            `<figure>
+                <img class="img-fluid test-image" src="${base64Img}">
+                <figcaption>${caption}</figcaption>
+            </figure>`
+        ),
+        contentBeforeEdit: unformat(
+            // Paragraphs get added to ensure we can write before/after the figure.
+            `<p><br></p>
+            <figure contenteditable="false">
+                <img class="img-fluid test-image" src="${base64Img}" data-caption-id="${captionId}" data-caption="${caption}">
+                <figcaption ${getFigcaptionAttributes(captionId, caption)}>
+                    <input ${CAPTION_INPUT_ATTRIBUTES}>
+                </figcaption>
+            </figure>
+            <p><br></p>`
+        ),
+        // Unchanged.
+        contentAfterEdit: unformat(
+            `<p><br></p>
+            <figure contenteditable="false">
+                <img class="img-fluid test-image" src="${base64Img}" data-caption-id="${captionId}" data-caption="${caption}">
+                <figcaption ${getFigcaptionAttributes(captionId, caption)}>
+                    <input ${CAPTION_INPUT_ATTRIBUTES}>
+                </figcaption>
+            </figure>
+            <p><br></p>`
+        ),
+        // Cleaned up for screen readers.
+        contentAfter: unformat(
+            `<p><br></p>
+            <figure>
+                <img class="img-fluid test-image" src="${base64Img}">
+                <figcaption>
+                    ${caption}
+                </figcaption>
+            </figure>
+            <p><br></p>`
+        ),
+    });
+});
+
+test.tags("focus required");
+test("loading an image with a caption embeds it", async () => {
+    const { editor } = await setupEditorWithEmbeddedCaption(`
+        <figure>
+            <img class="img-fluid test-image" src="${base64Img}">
+            <figcaption>Hello</figcaption>
+        </figure>
+    `);
+    const image = queryOne("img");
+    expect(image.getAttribute("data-caption")).toBe("Hello");
+    const input = queryOne("figure > figcaption > input");
+    expect(input.value).toBe("Hello");
+    // Do not focus the input when loading the page.
+    expect(editor.document.activeElement).not.toBe(input);
+});
+
+test.tags("focus required");
+test("clicking the caption button on an image with a caption removes the caption", async () => {
+    const caption = "Hello";
+    await testEditor({
+        config: configWithEmbeddedCaption,
+        contentBefore: unformat(
+            `<figure>
+                <img class="img-fluid test-image" src="${base64Img}">
+                <figcaption>${caption}</figcaption>
+            </figure>`
+        ),
+        stepFunction: async (editor) => {
+            const input = queryOne("figure > figcaption > input");
+            await toggleCaption();
+            expect(editor.document.activeElement).not.toBe(input);
+            expect(".o-we-toolbar").toHaveCount(1);
+        },
+        contentAfterEdit: unformat(
+            `<p><br></p>
+            <p>[<img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}">]</p>
+            <p><br></p>`
+        ),
+        // Unchanged
+        contentAfter: unformat(
+            `<p><br></p>
+            <p>[<img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}">]</p>
+            <p><br></p>`
+        ),
+    });
+});
+
+test.tags("focus required");
+test("leaving the caption persists its value", async () => {
+    const captionId = 1;
+    const caption = "Hello";
+    await testEditor({
+        config: configWithEmbeddedCaption,
+        contentBefore: `<p><img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}"></p><h1>Heading</h1>`,
+        stepFunction: async (editor) => {
+            await toggleCaption();
+            await waitFor("figcaption > input");
+            const input = queryOne("figure > figcaption > input");
+            expect(editor.document.activeElement).toBe(input);
+            await press("a");
+            await press("b");
+            await press("c");
+            await press("Backspace");
+            expect(input.value).toBe(`${caption}ab`);
+            expect(editor.document.activeElement).toBe(input);
+            const heading = queryOne("h1");
+            await click(heading);
+            expect(editor.document.activeElement).not.toBe(input);
+            await animationFrame(); // Wait for the selection to change.
+        },
+        contentAfterEdit: unformat(
+            `<p><br></p>
+            <figure contenteditable="false">
+                <img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}ab" data-caption-id="${captionId}">
+                <figcaption ${getFigcaptionAttributes(captionId, caption + "ab", true)}>
+                    <input ${CAPTION_INPUT_ATTRIBUTES}>
+                </figcaption>
+            </figure>
+            <h1>[]Heading</h1>`
+        ),
+        contentAfter: unformat(
+            `<p><br></p>
+            <figure>
+                <img class="img-fluid test-image" src="${base64Img}">
+                <figcaption>
+                    ${caption}ab
+                </figcaption>
+            </figure>
+            <h1>[]Heading</h1>`
+        ),
+    });
+});
+
+test.tags("focus required");
+test("can't use the powerbox in a caption", async () => {
+    await testEditor({
+        config: configWithEmbeddedCaption,
+        contentBefore: `<img class="img-fluid test-image" src="${base64Img}"><h1>Heading</h1>`,
+        stepFunction: async (editor) => {
+            await toggleCaption();
+            await waitFor("figcaption > input");
+            const input = queryOne("figure > figcaption > input");
+            expect(editor.document.activeElement).toBe(input);
+            await press("/");
+            await animationFrame();
+            expect(".o-we-powerbox").toHaveCount(0);
+            const heading = queryOne("h1");
+            await click(heading);
+            await animationFrame(); // Wait for the selection to change.
+        },
+        contentAfter: unformat(
+            `<p><br></p>
+            <figure>
+                <img class="img-fluid test-image" src="${base64Img}">
+                <figcaption>
+                    /
+                </figcaption>
+            </figure>
+            <h1>[]Heading</h1>`
+        ),
+    });
+});
+
+test.tags("desktop", "focus required");
+test("can't use the toolbar in a caption", async () => {
+    // TODO: The toolbar should not _always_ be usable in mobile!
+    await testEditor({
+        config: configWithEmbeddedCaption,
+        contentBefore: `<img class="img-fluid test-image" src="${base64Img}" data-caption="Hello"><h1>[]Heading</h1>`,
+        stepFunction: async (editor) => {
+            await toggleCaption();
+            await waitFor("figcaption > input");
+            const input = queryOne("figure > figcaption > input");
+            expect(editor.document.activeElement).toBe(input);
+            await animationFrame();
+            expect(".o-we-toolbar").toHaveCount(0);
+            input.select();
+            // Check that the contents of the input were indeed selected by
+            // inserting text.
+            editor.document.execCommand("insertText", false, "a");
+            expect(input.value).toBe("a");
+            await click("h1");
+            await animationFrame(); // Wait for the selection to change.
+        },
+        contentAfter: unformat(
+            `<p><br></p>
+            <figure>
+                <img class="img-fluid test-image" src="${base64Img}">
+                <figcaption>a</figcaption>
+            </figure>
+            <h1>[]Heading</h1>`
+        ),
+    });
+});
+
+test.tags("focus required");
+test("undo in a caption undoes the last caption action then returns to regular editor undo", async () => {
+    const caption = "Hello";
+    await testEditor({
+        config: configWithEmbeddedCaption,
+        contentBefore: `<p><img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}"></p><h1>[]Heading</h1>`,
+        stepFunction: async (editor) => {
+            await insertText(editor, "a");
+            const heading = queryOne("h1");
+            expect(heading.textContent).toBe("aHeading");
+            await toggleCaption();
+            await waitFor("figcaption > input");
+            const input = queryOne("figure > figcaption > input");
+            expect(editor.document.activeElement).toBe(input);
+            // Using native execCommand so the input's native history works.
+            await editor.document.execCommand("insertText", false, "b");
+            await editor.document.execCommand("insertText", false, "c");
+            await editor.document.execCommand("insertText", false, "d");
+            await editor.document.execCommand("delete", false, null); // Backspace.
+            expect(input.value).toBe(`${caption}bc`);
+
+            // We simulate undo with Ctrl+Z because we want to see how it
+            // interacts with native browser behavior.
+            const ctrlZ = async (target, shouldApplyNativeUndo) => {
+                const keydown = await manuallyDispatchProgrammaticEvent(target, "keydown", {
+                    key: "z",
+                    ctrlKey: true,
+                });
+                if (keydown.defaultPrevented) {
+                    return;
+                }
+                let valueBeforeUndo;
+                if (target === input) {
+                    valueBeforeUndo = input.value;
+                    // This is supposed to happen only after "beforeinput" but
+                    // beforeinput doesn't happen at all if there is nothing to
+                    // undo and this allows us to determine if that is the case.
+                    editor.document.execCommand("undo", false, null);
+                }
+                if (shouldApplyNativeUndo) {
+                    // The native undo should have changed the value of the
+                    // input.
+                    expect(input.value).not.toBe(valueBeforeUndo);
+                } else if (target === input) {
+                    // The native undo should not have changed the value of the input.
+                    expect(input.value).toBe(valueBeforeUndo);
+                }
+                if (target !== input || input.value !== valueBeforeUndo) {
+                    // The input events don't get triggered if the input has
+                    // nothing to undo.
+                    const beforeInput = await manuallyDispatchProgrammaticEvent(
+                        target,
+                        "beforeinput",
+                        {
+                            inputType: "historyUndo",
+                        }
+                    );
+                    // --> Here the editor should do its own UNDO.
+                    if (beforeInput.defaultPrevented) {
+                        return;
+                    }
+                    const inputEvent = await manuallyDispatchProgrammaticEvent(target, "input", {
+                        inputType: "historyUndo",
+                    });
+                    if (inputEvent.defaultPrevented) {
+                        return;
+                    }
+                }
+                await manuallyDispatchProgrammaticEvent(target, "keyup", {
+                    key: "z",
+                    ctrlKey: true,
+                });
+            };
+
+            // Native input undo undoes backspace in the input.
+            expect(editor.document.activeElement).toBe(input);
+            await ctrlZ(input, true);
+            expect(input.value).toBe(`${caption}bcd`);
+            expect(heading.textContent).toBe("aHeading");
+
+            // Native input undo undoes all the other key presses in the input.
+            expect(editor.document.activeElement).toBe(input);
+            await ctrlZ(input, true);
+            expect(input.value).toBe(caption);
+            expect(heading.textContent).toBe("aHeading");
+
+            // Editor undo removes the caption.
+            expect(editor.document.activeElement).toBe(input);
+            await ctrlZ(input, false);
+            expect(input.isConnected).toBe(false);
+            expect(heading.textContent).toBe("aHeading");
+
+            // Editor undo removes the key press in the heading.
+            expect(editor.document.activeElement).not.toBe(input);
+            const anchor = editor.document.getSelection().anchorNode;
+            await ctrlZ(closestElement(anchor), false);
+            expect(heading.textContent).toBe("Heading");
+        },
+        contentAfter: unformat(
+            `<p>
+                <img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}">
+            </p>
+            <h1>[]Heading</h1>`
+        ),
+    });
+});
+
+test("remove an image with a caption", async () => {
+    await testEditor({
+        config: configWithEmbeddedCaption,
+        contentBefore: unformat(
+            `<figure>
+                <img class="img-fluid test-image" src="${base64Img}">
+                <figcaption>Hello</figcaption>
+            </figure>
+            <h1>[]Heading</h1>`
+        ),
+        stepFunction: async () => {
+            await click("img");
+            await waitFor(".o-we-toolbar button[name='image_delete']");
+            await click(".o-we-toolbar button[name='image_delete']");
+        },
+        contentAfter: unformat(
+            `<p><br></p>
+            <h1>[]Heading</h1>`
+        ),
+    });
+});
+
+test("replace an image with a caption", async () => {
+    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => [
+        {
+            id: 1,
+            name: "logo",
+            mimetype: "image/png",
+            image_src: "/web/static/img/logo2.png",
+            access_token: false,
+            public: true,
+        },
+    ]);
+    const env = await makeMockEnv();
+    await testEditor({
+        env,
+        config: configWithEmbeddedCaption,
+        contentBefore: unformat(
+            `<figure>
+                <img src="/web/static/img/logo.png">
+                <figcaption>Hello</figcaption>
+            </figure>
+            <h1>[]Heading</h1>`
+        ),
+        stepFunction: async () => {
+            await click("img");
+            await waitFor(".o-we-toolbar button[name='replace_image']");
+            await click("button[name='replace_image']");
+            await waitFor(".o_select_media_dialog");
+            await click("img.o_we_attachment_highlight");
+            await animationFrame();
+            expect("img[src='/web/static/img/logo.png']").toHaveCount(0);
+            expect("img[src='/web/static/img/logo2.png']").toHaveCount(1);
+        },
+        // TODO: fix the weird final selection
+        contentAfter: unformat(
+            `<p><br></p>
+            <figure>
+                <img src="/web/static/img/logo2.png" alt="" class="img img-fluid o_we_custom_image">
+                <figcaption>Hello</figcaption>
+            </figure>
+            <h1>[]Heading</h1>`
+        ),
+    });
+});

--- a/addons/html_editor/static/tests/list/list_font_size.test.js
+++ b/addons/html_editor/static/tests/list/list_font_size.test.js
@@ -8,6 +8,7 @@ import {
 } from "../_helpers/user_actions";
 import { execCommand } from "../_helpers/userCommands";
 
+test.tags("font-dependent");
 test("should apply font-size to completely selected list item", async () => {
     await testEditor({
         contentBefore: "<ol><li>[abc]</li><li>def</li></ol>",
@@ -123,6 +124,7 @@ test("should carry font-size of list item to paragraph (4)", async () => {
     });
 });
 
+test.tags("font-dependent");
 test("should keep list item font-size on toggling list twice", async () => {
     await testEditor({
         contentBefore:
@@ -144,6 +146,7 @@ test("should change font-size of a list item", async () => {
     });
 });
 
+test.tags("font-dependent");
 test("should change font-size of a list item (2)", async () => {
     await testEditor({
         contentBefore:
@@ -182,6 +185,7 @@ test("should pad list based on font-size", async () => {
     });
 });
 
+test.tags("font-dependent");
 test("should pad list based on font-size (2)", async () => {
     await testEditor({
         contentBefore: `<span style="font-size: 56px;">[a]</span>`,

--- a/addons/html_editor/static/tests/list/outdent.test.js
+++ b/addons/html_editor/static/tests/list/outdent.test.js
@@ -5,6 +5,7 @@ import { bold, deleteBackward, keydownShiftTab } from "../_helpers/user_actions"
 import { getContent } from "../_helpers/selection";
 
 describe("Regular list", () => {
+    test.tags("font-dependent");
     test("should remove the list-style when outdent the list", async () => {
         await testEditor({
             contentBefore: unformat(`

--- a/addons/html_editor/static/tests/list/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/list/paragraph_break.test.js
@@ -382,6 +382,7 @@ describe("Selection collapsed", () => {
                 });
             });
 
+            test.tags("font-dependent");
             test("should keep the list-style when add li", async () => {
                 await testEditor({
                     contentBefore: unformat(`

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -7,18 +7,16 @@ import { getContent } from "./_helpers/selection";
 import { insertText } from "./_helpers/user_actions";
 
 test("Can replace an image", async () => {
-    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => {
-        return [
-            {
-                id: 1,
-                name: "logo",
-                mimetype: "image/png",
-                image_src: "/web/static/img/logo2.png",
-                access_token: false,
-                public: true,
-            },
-        ];
-    });
+    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => [
+        {
+            id: 1,
+            name: "logo",
+            mimetype: "image/png",
+            image_src: "/web/static/img/logo2.png",
+            access_token: false,
+            public: true,
+        },
+    ]);
     const env = await makeMockEnv();
     await setupEditor(`<p> <img class="img-fluid" src="/web/static/img/logo.png"> </p>`, { env });
     expect("img[src='/web/static/img/logo.png']").toHaveCount(1);
@@ -36,18 +34,16 @@ test("Can replace an image", async () => {
 
 test.tags("focus required");
 test("Selection is collapsed after the image after replacing it", async () => {
-    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => {
-        return [
-            {
-                id: 1,
-                name: "logo",
-                mimetype: "image/png",
-                image_src: "/web/static/img/logo2.png",
-                access_token: false,
-                public: true,
-            },
-        ];
-    });
+    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => [
+        {
+            id: 1,
+            name: "logo",
+            mimetype: "image/png",
+            image_src: "/web/static/img/logo2.png",
+            access_token: false,
+            public: true,
+        },
+    ]);
     const env = await makeMockEnv();
     const { el } = await setupEditor(
         `<p>abc<img class="img-fluid" src="/web/static/img/logo.png">def</p>`,
@@ -65,18 +61,16 @@ test("Selection is collapsed after the image after replacing it", async () => {
 
 test.tags("focus required");
 test("Can insert an image, and selection should be collapsed after it", async () => {
-    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => {
-        return [
-            {
-                id: 1,
-                name: "logo",
-                mimetype: "image/png",
-                image_src: "/web/static/img/logo2.png",
-                access_token: false,
-                public: true,
-            },
-        ];
-    });
+    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => [
+        {
+            id: 1,
+            name: "logo",
+            mimetype: "image/png",
+            image_src: "/web/static/img/logo2.png",
+            access_token: false,
+            public: true,
+        },
+    ]);
     const env = await makeMockEnv();
     const { editor, el } = await setupEditor("<p>a[]bc</p>", { env });
     await insertText(editor, "/image");
@@ -91,9 +85,7 @@ test("Can insert an image, and selection should be collapsed after it", async ()
 });
 
 test("press escape to close media dialog", async () => {
-    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => {
-        return [];
-    });
+    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => []);
     const env = await makeMockEnv();
     const { editor, el } = await setupEditor("<p>a[]bc</p>", { env });
     await insertText(editor, "/image");

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -133,6 +133,7 @@ describe("Html Paste cleaning - whitelist", () => {
         });
     });
 
+    test.tags("font-dependent");
     test("should remove b, keep p, and remove unwanted styles when pasting list from gdocs", async () => {
         await testEditor({
             contentBefore: "<p>[]<br></p>",
@@ -147,6 +148,7 @@ describe("Html Paste cleaning - whitelist", () => {
         });
     });
 
+    test.tags("font-dependent");
     test("should remove unwanted styles and keep tags when pasting list from gdoc", async () => {
         await testEditor({
             contentBefore: "<p>[]<br></p>",
@@ -2320,6 +2322,7 @@ describe("Special cases", () => {
             });
         });
 
+        test.tags("font-dependent");
         test("should paste checklist from gdoc", async () => {
             await testEditor({
                 contentBefore: "<p>[]<br></p>",

--- a/addons/html_editor/static/tests/utils/selection.test.js
+++ b/addons/html_editor/static/tests/utils/selection.test.js
@@ -140,7 +140,7 @@ describe("getTraversedNodes", () => {
                 const p2 = editable.lastChild;
                 const firstBr = p2.firstChild;
                 const cd = firstBr.nextSibling;
-                const result = editor.shared.selection.getTraversedNodes(editable);
+                const result = editor.shared.selection.getTraversedNodes();
                 expect(result).toEqual([p1, ab, p2, firstBr, cd]);
             },
         });
@@ -156,7 +156,7 @@ describe("getTraversedNodes", () => {
                 const br1 = p2.firstChild;
                 const cd = br1.nextSibling;
                 const br2 = cd.nextSibling;
-                const result = editor.shared.selection.getTraversedNodes(editable);
+                const result = editor.shared.selection.getTraversedNodes();
                 expect(result).toEqual([p1, ab, p2, br1, cd, br2]);
             },
         });
@@ -172,7 +172,7 @@ describe("getTraversedNodes", () => {
                 const br1 = p2.firstChild;
                 const cd = br1.nextSibling;
                 const br2 = cd.nextSibling;
-                const result = editor.shared.selection.getTraversedNodes(editable);
+                const result = editor.shared.selection.getTraversedNodes();
                 expect(result).toEqual([p1, ab, p2, br1, cd, br2]);
             },
         });
@@ -187,7 +187,7 @@ describe("getTraversedNodes", () => {
                 const p2 = editable.firstChild.nextSibling;
                 const cd = p2.firstChild;
                 const br1 = cd.nextSibling;
-                const result = editor.shared.selection.getTraversedNodes(editable);
+                const result = editor.shared.selection.getTraversedNodes();
                 expect(result).toEqual([p1, ab, p2, cd, br1]);
             },
         });
@@ -203,7 +203,7 @@ describe("getTraversedNodes", () => {
                 const cd = br.nextSibling;
                 const p2 = editable.lastChild;
                 const ef = p2.firstChild;
-                const result = editor.shared.selection.getTraversedNodes(editable);
+                const result = editor.shared.selection.getTraversedNodes();
                 expect(result).toEqual([p1, br, cd, p2, ef]);
             },
         });
@@ -219,7 +219,7 @@ describe("getTraversedNodes", () => {
                 const cd = br.nextSibling;
                 const p2 = editable.lastChild;
                 const ef = p2.firstChild;
-                const result = editor.shared.selection.getTraversedNodes(editable);
+                const result = editor.shared.selection.getTraversedNodes();
                 expect(result).toEqual([p1, ab, br, cd, p2, ef]);
             },
         });
@@ -231,7 +231,7 @@ describe("getTraversedNodes", () => {
                 const editable = editor.editable;
                 const p2 = editable.lastChild;
                 const cd = p2.firstChild;
-                const result = editor.shared.selection.getTraversedNodes(editable);
+                const result = editor.shared.selection.getTraversedNodes();
                 expect(result).toEqual([p2, cd]);
             },
         });
@@ -247,7 +247,7 @@ describe("getTraversedNodes", () => {
                 const cd = br.nextSibling;
                 const p2 = editable.lastChild;
                 const ef = p2.firstChild;
-                const result = editor.shared.selection.getTraversedNodes(editable);
+                const result = editor.shared.selection.getTraversedNodes();
                 expect(result).toEqual([p1, cd, p2, ef]);
             },
         });
@@ -264,7 +264,7 @@ describe("getTraversedNodes", () => {
                 const cd = br2.nextSibling;
                 const p2 = editable.firstChild.nextSibling;
                 const ef = p2.firstChild;
-                const result = editor.shared.selection.getTraversedNodes(editable);
+                const result = editor.shared.selection.getTraversedNodes();
                 expect(result).toEqual([p1, br2, cd, p2, ef]);
             },
         });
@@ -279,7 +279,7 @@ describe("getTraversedNodes", () => {
                 const abcde = td1.firstChild;
                 const td2 = td1.nextSibling;
                 const fg = td2.firstChild;
-                const result = editor.shared.selection.getTraversedNodes(editable);
+                const result = editor.shared.selection.getTraversedNodes();
                 expect(result).toEqual([td1, abcde, td2, fg]);
             },
         });
@@ -298,7 +298,7 @@ describe("getTraversedNodes", () => {
                 const e = br2.nextSibling;
                 const td2 = td1.nextSibling;
                 const fg = td2.firstChild;
-                const result = editor.shared.selection.getTraversedNodes(editable);
+                const result = editor.shared.selection.getTraversedNodes();
                 expect(result).toEqual([td1, abcd, br1, br2, e, td2, fg]);
             },
         });


### PR DESCRIPTION
### Purpose

For multiple reasons, users might want to add captions to images:

- **Improved accessibility**: captions add context for all users (cognitive help)
- **Clearer content**: captions help explain the image (more detailed than an alt or title attribute)
- **SEO benefits**: captions help search engines in indexing
- **Clearer design**: captions help keep text and images organized
- **Useful for various users**: such a feature fits different content needs

### Specification

- In the toolbar, when an image is selected, add a "Caption" button next to the "Description" button (in the same button group).
- When the "Caption" button is clicked, if the image has no caption yet, wrap the image in a `figure` element and add a `figcaption` element. The `figcaption` element is editable and focused, with the placeholder text "Write a caption..." (as a hint).
- If the image already has a caption, clicking the "Caption" button focuses the `figcaption` element and puts the caret at the end of its text.
- The `figcaption` element's text is gray.
- When editing the caption, users aren't allowed to add styles, use the toolbar or any Powerbox commands. Merging or splitting the caption is also prohibited. The caption is plain text. It behaves the same way as when editing the filename of a file block (`/file``).
- The feature is not available in the website builder, which will use its own plugin.
- Users can't write in the `figure` element, only in the `figcaption` element.
- When vizualizing the image with the FileViewer (double click on the image), the title shown is the caption when it exists.
- The `<figure><img/><figcaption>...</figcaption></figure>` structure is respected for accessibility purposes.

### Technical details

The caption feature is implemented as an embedded component so it can be completely loose from the editor. This way we ensure the caption remains plain text and can't be merged or split. The user writes in an `input` element in the `figcaption` element, to keep it as plain text. As the caption changes, the `placeholder` attribute of the image is adapted to reflect it. This way, screen readers will still read the caption when selecting the figure (tested with ChromeVox).

-----

In order to make this feature work as expected, this PR reintroduces the concept of editable media, which existed in
`web_editor` but was not moved over to `html_editor`. This is necessary in order for media to be editable when their parent has the `contenteditable` attribute set to `false`. There can be cases where we want to be able to edit an image but not to write in its container. This is the case for instance for the following common structure:

```html
<figure contenteditable="false">
    <img/>
    <figcaption contenteditable="true">Image caption</figcaption>
</figure>
```

We typically only want to write in the caption and not in the figure, but we want to be able to replace the image or transform it.

For such a case, we mark the image with the `o_editable_media` class.

task-4224709

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
