### PR TITLE
[FIX] account_peppol: Create res_partner via API.

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -171,6 +171,7 @@ class ResPartner(models.Model):
         self._update_peppol_state_per_company(vals=vals)
         return res
 
+    @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)
         if res:


### PR DESCRIPTION
The issue:
When account_peppol is installed, we are not able to create a res_partner via XML-RPC. Got this error : `TypeError: ResPartner.create() missing 1 required positional argument: vals_list`

How to reproduce the issue:
1. Install 'account_peppol'
2. Setup API with Python
3. Execute : `id = models.execute_kw(db, uid, password, 'res.partner', 'create', [{'name': "New Partner"}])`

opw-4291258
opw-4321674
