### PR TITLE
[FIX] discuss: save threshold setting

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/call_settings.xml
@@ -51,7 +51,7 @@
                             </div>
                         </button>
                         <label class="w-100 d-flex ms-2" title="Voice detection sensitivity" aria-label="Voice detection sensitivity">
-                            <input class="o-Discuss-CallSettings-thresholdInput form-range rounded" t-attf-style="--volume: {{microphoneVolume.value * 100}}%;" type="range" min="0.001" max="1" step="0.001" t-model="store.settings.voiceActivationThreshold"/>
+                            <input class="o-Discuss-CallSettings-thresholdInput form-range rounded" t-attf-style="--volume: {{microphoneVolume.value * 100}}%;" type="range" min="0.001" max="1" step="0.001" t-model="store.settings.voiceActivationThreshold" t-on-input="store.settings.saveVoiceThresholdDebounce"/>
                         </label>
                     </div>
                 </t>

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -3,6 +3,7 @@ import {
     click,
     contains,
     defineMailModels,
+    editInput,
     openDiscuss,
     patchUiSize,
     SIZES,
@@ -11,6 +12,7 @@ import {
     step,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
+import { advanceTime } from "@odoo/hoot-mock";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 import { browser } from "@web/core/browser/browser";
@@ -124,4 +126,7 @@ test("local storage for call settings", async () => {
     await assertSteps(["mail_user_setting_show_only_video: false"]);
     await click("input[title='Blur video background']");
     await assertSteps(["mail_user_setting_use_blur: false"]);
+    await editInput(document.body, ".o-Discuss-CallSettings-thresholdInput", 0.3);
+    await advanceTime(2000); // threshold setting debounce timer
+    await assertSteps(["mail_user_setting_voice_threshold: 0.3"]);
 });

--- a/addons/mail/static/tests/mail_test_helpers_contains.js
+++ b/addons/mail/static/tests/mail_test_helpers_contains.js
@@ -263,9 +263,17 @@ export async function editInput(el, selector, value) {
         throw new Error("Only 'input' and 'textarea' elements can be edited with 'editInput'.");
     }
     if (
-        !["text", "textarea", "email", "search", "color", "number", "file", "tel"].includes(
-            input.type
-        )
+        ![
+            "text",
+            "textarea",
+            "email",
+            "search",
+            "color",
+            "number",
+            "file",
+            "tel",
+            "range",
+        ].includes(input.type)
     ) {
         throw new Error(`Type "${input.type}" not supported by 'editInput'.`);
     }


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/183969,
the threshold setting was not saved as we now use a t-model instead of a setter function (in which the setting save was made). This commit fixes this issue by calling the save function when the input is changed.

