### PR TITLE
[REF] website(_*)_sale(_*): cart access

### DIFF
--- a/addons/sale/tests/test_sale_product_attribute_value_config.py
+++ b/addons/sale/tests/test_sale_product_attribute_value_config.py
@@ -18,7 +18,7 @@ class TestSaleProductAttributeValueCommon(AccountTestInvoicingCommon, TestProduc
         cls.computer.company_id = cls.env.company
         cls.computer = cls.computer.with_env(cls.env)
         cls.env['product.pricelist'].sudo().search([]).action_archive()
-        cls.env['product.pricelist'].create({'name': 'Base Pricelist'})
+        cls.pricelist = cls.env['product.pricelist'].create({'name': 'Base Pricelist'})
 
     @classmethod
     def _setup_currency(cls, currency_ratio=2):

--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -16,11 +16,9 @@ HOST = '127.0.0.1'
 
 @contextlib.contextmanager
 def MockRequest(
-        env, *, path='/mockrequest', routing=True, multilang=True,
-        context=frozendict(), cookies=frozendict(), country_code=None,
-        website=None, remote_addr=HOST, environ_base=None, url_root=None,
-        # website_sale
-        sale_order_id=None, website_sale_current_pl=None,
+    env, *, path='/mockrequest', routing=True, multilang=True,
+    context=frozendict(), cookies=frozendict(), country_code=None,
+    website=None, remote_addr=HOST, environ_base=None, url_root=None,
 ):
     # TODO move MockRequest to a package in addons/web/tests
     from odoo.tests.common import HttpCase  # noqa: PLC0415
@@ -56,8 +54,6 @@ def MockRequest(
         redirect=env['ir.http']._redirect,
         session=DotDict(
             odoo.http.get_default_session(),
-            sale_order_id=sale_order_id,
-            website_sale_current_pl=website_sale_current_pl,
             context={'lang': ''},
         ),
         geoip=odoo.http.GeoIP('127.0.0.1'),

--- a/addons/website_event_booth_sale/tests/test_website_event_booth_sale_pricelist.py
+++ b/addons/website_event_booth_sale/tests/test_website_event_booth_sale_pricelist.py
@@ -1,10 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.fields import Command
 from odoo.tests import tagged
 
 from odoo.addons.event_booth_sale.tests.common import TestEventBoothSaleCommon
 from odoo.addons.website_event_sale.tests.common import TestWebsiteEventSaleCommon
 from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.addons.website_sale.tests.common import MockRequest
 
 
 @tagged('post_install', '-at_install')
@@ -28,17 +30,11 @@ class TestWebsiteBoothPriceList(TestEventBoothSaleCommon, TestWebsiteEventSaleCo
         })
 
     def test_pricelist_different_currency(self):
-        self.env['product.pricelist'].search([('id', '!=', self.pricelist.id)]).action_archive()
-        self.pricelist.write({
-            'currency_id': self.env.company.currency_id.id,
-            'item_ids': [(5, 0, 0)],
-            'name': 'Test Pricelist (no discount)',
-        })
         so_line = self.env['sale.order.line'].create({
             'event_booth_category_id': self.event_booth_category_1.id,
             'event_booth_pending_ids': (self.booth_1 + self.booth_2).ids,
             'event_id': self.event.id,
-            'order_id': self.so.id,
+            'order_id': self.empty_cart.id,
             'product_id': self.event_booth_product.id,
         })
         self.assertEqual(so_line.price_reduce_taxexcl, 40)
@@ -46,12 +42,17 @@ class TestWebsiteBoothPriceList(TestEventBoothSaleCommon, TestWebsiteEventSaleCo
         # set pricelist to 10% - without discount
         pl2 = self.pricelist.copy({
             'currency_id': self.currency_test.id,
-            'item_ids': [(5, 0, 0), (0, 0, {
-                'applied_on': '3_global',
-                'compute_price': 'percentage',
-                'percent_price': 10,
-            })],
+            'item_ids': [
+                Command.create({
+                    'applied_on': '3_global',
+                    'compute_price': 'percentage',
+                    'percent_price': 10,
+                }),
+            ],
             'name': 'Test pricelist (with discount)',
+            'selectable': True,
         })
-        self.so._cart_update_pricelist(pricelist_id=pl2.id)
-        self.assertEqual(so_line.price_reduce_taxexcl, 360, 'Incorrect amount based on the pricelist "Without Discount" and its currency.')
+        with MockRequest(self.env, website=self.website, sale_order_id=self.empty_cart.id) as req:
+            self.assertEqual(req.pricelist, self.pricelist)
+            self.WebsiteSaleController.pricelist_change(pl2)
+            self.assertEqual(so_line.price_reduce_taxexcl, 360, 'Incorrect amount based on the pricelist "Without Discount" and its currency.')

--- a/addons/website_event_sale/controllers/main.py
+++ b/addons/website_event_sale/controllers/main.py
@@ -27,15 +27,11 @@ class WebsiteEventSaleController(WebsiteEventController):
             for event_ticket in request.env['event.event.ticket'].sudo().browse(event_ticket_ids)
         }
 
-        if all(event_ticket.price == 0 for event_ticket in event_ticket_by_id.values()) and not request.website.sale_get_order().id:
+        if all(event_ticket.price == 0 for event_ticket in event_ticket_by_id.values()) and not request.cart.id:
             # all chosen tickets are free AND no existing SO -> skip SO and payment process
             return super()._create_attendees_from_registration_post(event, registration_data)
 
-        order_sudo = request.website.sale_get_order(force_create=True)
-        if order_sudo.state != 'draft':
-            request.website.sale_reset()
-            order_sudo = request.website.sale_get_order(force_create=True)
-
+        order_sudo = request.cart or request.website._create_cart()
         tickets_data = defaultdict(int)
         for data in registration_data:
             event_ticket_id = data.get('event_ticket_id')
@@ -59,8 +55,6 @@ class WebsiteEventSaleController(WebsiteEventController):
                 data['sale_order_id'] = order_sudo.id
                 data['sale_order_line_id'] = cart_data[event_ticket_id]
 
-        request.session['website_sale_cart_quantity'] = order_sudo.cart_quantity
-
         return super()._create_attendees_from_registration_post(event, registration_data)
 
     @route()
@@ -68,9 +62,9 @@ class WebsiteEventSaleController(WebsiteEventController):
         res = super().registration_confirm(event, **post)
 
         registrations = self._process_attendees_form(event, post)
-        order_sudo = request.website.sale_get_order()
-        if not order_sudo.id:
-            # order does not contain any lines related to the event, meaning we are confirming only free tickets of this event
+        order_sudo = request.cart
+        if not any(line.event_ticket_id for line in order_sudo.order_line):
+            # order does not contain any tickets, meaning we are confirming a free event
             return res
 
         # we have at least one registration linked to a ticket -> sale mode activate
@@ -78,8 +72,8 @@ class WebsiteEventSaleController(WebsiteEventController):
             if order_sudo.amount_total:
                 request.session['sale_last_order_id'] = order_sudo.id
                 return request.redirect("/shop/checkout")
-            # free tickets -> order with amount = 0: auto-confirm, no checkout
-            elif order_sudo:
+            else:
+                # Free order -> auto confirmation without checkout
                 order_sudo.action_confirm()  # tde notsure: email sending ?
                 request.website.sale_reset()
 

--- a/addons/website_event_sale/tests/common.py
+++ b/addons/website_event_sale/tests/common.py
@@ -1,25 +1,23 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import timedelta
 
-from odoo.fields import Datetime
-from odoo.tests.common import TransactionCase
+from odoo.fields import Command, Datetime
+
+from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
 
 
-class TestWebsiteEventSaleCommon(TransactionCase):
+class TestWebsiteEventSaleCommon(WebsiteSaleCommon):
 
     @classmethod
     def setUpClass(cls):
-        super(TestWebsiteEventSaleCommon, cls).setUpClass()
+        super().setUpClass()
 
-        cls.env.company.country_id = cls.env.ref('base.us')
         cls.currency_test = cls.env['res.currency'].create({
             'name': 'eventX',
             'rounding': 0.01,
             'symbol': 'EX',
         })
-        cls.partner = cls.env['res.partner'].create({'name': 'test'})
         cls.env['res.currency.rate'].search([]).unlink()
         cls.rate = cls.env['res.currency.rate'].create({
             'company_id': cls.env.company.id,
@@ -40,7 +38,7 @@ class TestWebsiteEventSaleCommon(TransactionCase):
             'service_tracking': 'event',
             'list_price': 100,
             'name': 'Event Registration No Company Assigned',
-            'taxes_id': [(6, 0, cls.zero_tax.ids)],
+            'taxes_id': [Command.set(cls.zero_tax.ids)],
         })
 
         cls.event, cls.event_2 = cls.env['event.event'].create([
@@ -74,23 +72,16 @@ class TestWebsiteEventSaleCommon(TransactionCase):
             }
         ])
 
-        cls.current_website = cls.env['website'].get_current_website()
-        cls.pricelist = cls.env['product.pricelist'].create({'name': 'Base Pricelist'})
-
-        cls.so = cls.env['sale.order'].create({
-            'company_id': cls.env.company.id,
-            'partner_id': cls.partner.id,
-            'pricelist_id': cls.pricelist.id,
-        })
-
         def create_pricelist(currency, name):
             return cls.env['product.pricelist'].create({
                 'currency_id': currency.id,
-                'item_ids': [(5, 0, 0), (0, 0, {
-                    'applied_on': '3_global',
-                    'compute_price': 'percentage',
-                    'percent_price': 10,
-                })],
+                'item_ids': [
+                    Command.create({
+                        'applied_on': '3_global',
+                        'compute_price': 'percentage',
+                        'percent_price': 10,
+                    }),
+                ],
                 'name': name,
                 'selectable': True,
             })

--- a/addons/website_event_sale/tests/test_website_event_sale_pricelist.py
+++ b/addons/website_event_sale/tests/test_website_event_sale_pricelist.py
@@ -5,6 +5,7 @@ from odoo.tests import tagged
 
 from odoo.addons.website_event_sale.tests.common import TestWebsiteEventSaleCommon
 from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.addons.website_sale.tests.common import MockRequest
 
 
 @tagged('post_install', '-at_install')
@@ -27,7 +28,7 @@ class TestWebsiteEventPriceList(TestWebsiteEventSaleCommon):
             'event_id': self.event.id,
             'event_ticket_id': self.ticket.id,
             'name': self.event.name,
-            'order_id': self.so.id,
+            'order_id': self.empty_cart.id,
             'product_id': self.ticket.product_id.id,
             'product_uom_qty': 1,
         })
@@ -42,6 +43,9 @@ class TestWebsiteEventPriceList(TestWebsiteEventSaleCommon):
                 'percent_price': 10,
             })],
             'name': 'Percentage Discount',
+            'selectable': True,
         })
-        self.so._cart_update_pricelist(pricelist_id=pl2.id)
-        self.assertEqual(so_line.price_reduce_taxexcl, 900, 'Incorrect amount based on the pricelist and its currency.')
+        with MockRequest(self.env, website=self.website, sale_order_id=self.empty_cart.id) as req:
+            self.assertEqual(req.pricelist, self.pricelist)
+            self.WebsiteSaleController.pricelist_change(pl2)
+            self.assertEqual(so_line.price_reduce_taxexcl, 900, 'Incorrect amount based on the pricelist and its currency.')

--- a/addons/website_sale/controllers/payment.py
+++ b/addons/website_sale/controllers/payment.py
@@ -29,7 +29,8 @@ class PaymentPortal(payment_portal.PaymentPortal):
         :param dict kwargs: Locally unused data passed to `_create_transaction`
         :return: The mandatory values for the processing of the transaction
         :rtype: dict
-        :raise: ValidationError if the invoice id or the access token is invalid
+        :raise: ValidationError if the access token is invalid or the order is not in the expected
+            state/configuration.
         """
         # Check the order id and the access token
         try:

--- a/addons/website_sale/controllers/product_configurator.py
+++ b/addons/website_sale/controllers/product_configurator.py
@@ -233,8 +233,7 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
             request.env.company
         )
         if product_taxes:
-            fiscal_position = request.website.fiscal_position_id.sudo()
-            taxes = fiscal_position.map_tax(product_taxes)
+            taxes = request.fiscal_position.map_tax(product_taxes)
             return request.env['product.template']._apply_taxes_to_price(
                 price, currency, product_taxes, taxes, product_or_template, website=request.website
             )

--- a/addons/website_sale/models/ir_http.py
+++ b/addons/website_sale/models/ir_http.py
@@ -2,6 +2,7 @@
 
 from odoo import api, models
 from odoo.http import request
+from odoo.tools import lazy
 
 
 class IrHttp(models.AbstractModel):
@@ -21,3 +22,13 @@ class IrHttp(models.AbstractModel):
             'add_to_cart_action': request.website.add_to_cart_action,
         })
         return session_info
+
+    @classmethod
+    def _frontend_pre_dispatch(cls):
+        super()._frontend_pre_dispatch()
+
+        # lazy to make sure those are only evaluated when requested
+        # All those records are sudoed !
+        request.cart = lazy(request.website._get_and_cache_current_cart)
+        request.fiscal_position = lazy(request.website._get_and_cache_current_fiscal_position)
+        request.pricelist = lazy(request.website._get_and_cache_current_pricelist)

--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -169,7 +169,7 @@ class ProductProduct(models.Model):
             'image': f'{base_url}{website.image_url(self, "image_1920")}',
             'offers': {
                 '@type': 'Offer',
-                'price': float_round(website.pricelist_id._get_product_price(
+                'price': float_round(request.pricelist._get_product_price(
                     self, quantity=1, target_currency=website.currency_id
                 ), 2),
                 'priceCurrency': website.currency_id.name,

--- a/addons/website_sale/models/res_partner.py
+++ b/addons/website_sale/models/res_partner.py
@@ -1,33 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models
-
-from odoo.addons.website.models import ir_http
+from odoo import _, api, models
 
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
-
-    last_website_so_id = fields.Many2one(
-        string="Last Online Sales Order",
-        comodel_name='sale.order',
-        compute='_compute_last_website_so_id',
-    )
-
-    def _compute_last_website_so_id(self):
-        SaleOrder = self.env['sale.order']
-        for partner in self:
-            is_public = partner.is_public
-            website = ir_http.get_request_website()
-            if website and not is_public:
-                partner.last_website_so_id = SaleOrder.search([
-                    ('partner_id', '=', partner.id),
-                    ('pricelist_id', '=', partner.property_product_pricelist.id),
-                    ('website_id', '=', website.id),
-                    ('state', '=', 'draft'),
-                ], order='write_date desc', limit=1)
-            else:
-                partner.last_website_so_id = SaleOrder  # Not in a website context or public User
 
     @api.onchange('property_product_pricelist')
     def _onchange_property_product_pricelist(self):

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -3,6 +3,7 @@
 from collections import Counter
 
 from odoo import _, api, fields, models
+from odoo.http import request
 from odoo.osv import expression
 
 
@@ -147,7 +148,7 @@ class WebsiteSnippetFilter(models.Model):
         products = self.env['product.product']
         visitor = self.env['website.visitor']._get_visitor_from_request()
         if visitor:
-            excluded_products = website.sale_get_order().order_line.product_id.ids
+            excluded_products = request.cart.order_line.product_id.ids
             tracked_products = self.env['website.track'].sudo()._read_group([
                 ('visitor_id', '=', visitor.id),
                 ('product_id', '!=', False),
@@ -187,7 +188,7 @@ class WebsiteSnippetFilter(models.Model):
                 ('order_line.product_id.product_tmpl_id', '=', current_template.id),
             ], limit=8, order='date_order DESC')
             if sale_orders:
-                cart_products = website.sale_get_order().order_line.product_id
+                cart_products = request.cart.order_line.product_id
                 excluded_products = cart_products.product_tmpl_id.product_variant_ids
                 excluded_products |= current_template.product_variant_ids
                 included_products = sale_orders.order_line.product_id
@@ -209,7 +210,7 @@ class WebsiteSnippetFilter(models.Model):
             product_template_id and int(product_template_id)
         ).exists()
         if current_template:
-            cart_products = website.sale_get_order().order_line.product_id
+            cart_products = request.cart.order_line.product_id
             excluded_products = cart_products.product_tmpl_id.product_variant_ids
             excluded_products |= current_template.product_variant_ids
             included_products = current_template._get_website_accessory_product()
@@ -233,7 +234,7 @@ class WebsiteSnippetFilter(models.Model):
             product_template_id and int(product_template_id)
         ).exists()
         if current_template:
-            cart_products = website.sale_get_order().order_line.product_id
+            cart_products = request.cart.order_line.product_id
             excluded_products = cart_products.product_tmpl_id.product_variant_ids
             excluded_products |= current_template.product_variant_ids
             alternative_products = current_template._get_website_alternative_product()

--- a/addons/website_sale/static/src/js/website_sale_reorder.js
+++ b/addons/website_sale/static/src/js/website_sale_reorder.js
@@ -149,13 +149,14 @@ export class ReorderDialog extends Component {
     }
 
     async addProductsToCart() {
-        let promises = [];
         for (const product of this.content.products) {
             if (!product.add_to_cart_allowed) {
                 continue;
             }
 
-            promises.push(this.cart.add({
+            // must be awaited to ensure that all the products are added to the same cart when it
+            // has to be created on the fly because there weren't any open one for the customer.
+            await this.cart.add({
                 productTemplateId: product.product_template_id,
                 productId: product.product_id,
                 quantity: product.qty,
@@ -165,8 +166,7 @@ export class ReorderDialog extends Component {
                 isBuyNow: true,
                 redirectToCart: false,
                 isConfigured: true,
-            }));
+            });
         }
-        return Promise.all(promises);
     }
 }

--- a/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
@@ -41,7 +41,7 @@ configuratorTourUtils.assertOptionalProductPrice("Conference Chair", "22.90"),
 configuratorTourUtils.selectAttribute("Conference Chair", "Legs", "Steel"),
 configuratorTourUtils.addOptionalProduct("Conference Chair"),
 configuratorTourUtils.addOptionalProduct("Chair floor protection"),
-configuratorTourUtils.assertPriceTotal("1,528.50"),
+configuratorTourUtils.assertPriceTotal("1,228.50"),
 {
     trigger: 'button:contains(Proceed to Checkout)',
     run: 'click',

--- a/addons/website_sale/tests/common.py
+++ b/addons/website_sale/tests/common.py
@@ -1,9 +1,38 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from contextlib import contextmanager
+
 from odoo.fields import Command
+from odoo.tools import lazy
 
 from odoo.addons.delivery.tests.common import DeliveryCommon
 from odoo.addons.product.tests.common import ProductCommon
+from odoo.addons.website.tools import MockRequest as websiteMockRequest
+from odoo.addons.website_sale.models.website import (
+    CART_SESSION_CACHE_KEY,
+    FISCAL_POSITION_SESSION_CACHE_KEY,
+    PRICELIST_SESSION_CACHE_KEY,
+)
+
+
+@contextmanager
+def MockRequest(
+    *args, sale_order_id=None, website_sale_current_pl=None, fiscal_position_id=None, **kwargs
+):
+    with websiteMockRequest(*args, **kwargs) as request:
+        if sale_order_id is not None:
+            request.session[CART_SESSION_CACHE_KEY] = sale_order_id
+        request.cart = lazy(request.website._get_and_cache_current_cart)
+
+        if website_sale_current_pl is not None:
+            request.session[PRICELIST_SESSION_CACHE_KEY] = website_sale_current_pl
+        request.pricelist = lazy(request.website._get_and_cache_current_pricelist)
+
+        if fiscal_position_id is not None:
+            request.session[FISCAL_POSITION_SESSION_CACHE_KEY] = fiscal_position_id
+        request.fiscal_position = lazy(request.website._get_and_cache_current_fiscal_position)
+
+        yield request
 
 
 class WebsiteSaleCommon(ProductCommon, DeliveryCommon):
@@ -15,8 +44,10 @@ class WebsiteSaleCommon(ProductCommon, DeliveryCommon):
 
         cls.website = cls.env.company.website_id
         if not cls.website:
-            cls.website = cls.env.ref('website.default_website')
-            cls.website.company_id = cls.env.company
+            cls.website = cls.env['website'].create({
+                'name': 'Test Website',
+                'company_id': cls.env.company.id,
+            })
 
         cls.public_user = cls.website.user_id
         cls.public_partner = cls.public_user.partner_id

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -4,13 +4,11 @@ from unittest.mock import patch
 
 from werkzeug.exceptions import Forbidden
 
-from odoo import api
 from odoo.fields import Command
 from odoo.tests import tagged
 
-from odoo.addons.website.tools import MockRequest
 from odoo.addons.website_sale.controllers.main import WebsiteSale
-from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 
 
 @tagged('post_install', '-at_install')
@@ -100,9 +98,8 @@ class TestCheckoutAddress(WebsiteSaleCommon):
         self._setUp_multicompany_env()
         so = self._create_so(partner_id=self.demo_partner.id)
 
-        env = api.Environment(self.env.cr, self.demo_user.id, {})
-        # change also website env for `sale_get_order` to not change order partner_id
-        with MockRequest(env, website=self.website.with_env(env), sale_order_id=so.id) as req:
+        website = self.website.with_user(self.demo_user).with_context({})
+        with MockRequest(website.env, website=website, sale_order_id=so.id) as req:
             req.httprequest.method = "POST"
 
             # 1. Logged in user, new shipping
@@ -123,9 +120,8 @@ class TestCheckoutAddress(WebsiteSaleCommon):
         self._setUp_multicompany_env()
         so = self._create_so(partner_id=self.website.user_id.partner_id.id)
 
-        env = api.Environment(self.env.cr, self.website.user_id.id, {})
-        # change also website env for `sale_get_order` to not change order partner_id
-        with MockRequest(env, website=self.website.with_env(env), sale_order_id=so.id) as req:
+        website = self.website.with_user(self.public_user).with_context({})
+        with MockRequest(website.env, website=website, sale_order_id=so.id) as req:
             req.httprequest.method = "POST"
 
             # 1. Public user, new billing
@@ -143,16 +139,23 @@ class TestCheckoutAddress(WebsiteSaleCommon):
     def test_03_carrier_rate_on_shipping_address_change(self):
         """ Test that when a shipping address is changed the price of delivery is recalculated
         and updated on the order."""
-        partner = self.env.user.partner_id
-        order = self._create_so()
-        order.carrier_id = self.carrier.id  # Set the carrier on the order.
-        shipping_partner_values = {'name': 'dummy', 'parent_id': partner.id, 'type': 'delivery'}
-        shipping_partner = self.env['res.partner'].create(shipping_partner_values)
-        order.partner_shipping_id = shipping_partner
-        with MockRequest(self.env, website=self.website, sale_order_id=order.id), patch(
-            'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
-            return_value={'success': True, 'price': 10, 'warning_message': ''}
-        ) as rate_shipment_mock:
+        shipping_partner = self.env['res.partner'].create({
+            'name': 'dummy',
+            'parent_id': self.partner.id,
+            'type': 'delivery',
+        })
+        self.cart.write({
+            'carrier_id': self.carrier.id,
+            'partner_shipping_id': shipping_partner.id
+        })
+        website = self.website.with_user(self.public_user).with_context({})
+        with (
+            MockRequest(website.env, website=website, sale_order_id=self.cart.id),
+            patch(
+                'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
+                return_value={'success': True, 'price': 10, 'warning_message': ''}
+            ) as rate_shipment_mock
+        ):
             # Change a shipping address of the order in the checkout.
             shipping_partner2 = shipping_partner.copy()
             self.WebsiteSaleController.shop_update_address(
@@ -164,7 +167,7 @@ class TestCheckoutAddress(WebsiteSaleCommon):
                 msg="The carrier rate must be recalculated when shipping address is changed.",
             )
             self.assertEqual(
-                order.order_line.filtered(lambda l: l.is_delivery)[0].price_unit,
+                self.cart.order_line.filtered('is_delivery')[0].price_unit,
                 10,
                 msg="The recalculated delivery price must be updated on the order.",
             )
@@ -205,15 +208,17 @@ class TestCheckoutAddress(WebsiteSaleCommon):
         self.assertEqual(so.pricelist_id, self.pricelist)
 
         with MockRequest(
-            self.env, website=self.website,
+            public_user_env,
+            website=self.website.with_env(public_user_env),
             sale_order_id=so.id,
             website_sale_current_pl=so.pricelist_id.id
-        ):
-            self.assertEqual(self.website.pricelist_id, self.pricelist)
-            order = self.website.with_env(public_user_env).sale_get_order()
+        ) as request:
+            self.assertEqual(request.pricelist, self.pricelist)
+            order = request.cart
             self.assertEqual(order, so)
             self.assertEqual(order.pricelist_id, self.pricelist)
-            order_b = self.website.with_user(test_user).sale_get_order()
+
+            order_b = request.website.with_user(test_user)._get_and_cache_current_cart()
             self.assertEqual(order, order_b)
             self.assertEqual(order_b.pricelist_id, pl_with_code)
 
@@ -245,9 +250,8 @@ class TestCheckoutAddress(WebsiteSaleCommon):
         self._setUp_multicompany_env()
         so = self._create_so(partner_id=self.portal_partner.id)
 
-        env = api.Environment(self.env.cr, self.portal_user.id, {})
-        # change also website env for `sale_get_order` to not change order partner_id
-        with MockRequest(env, website=self.website.with_env(env), sale_order_id=so.id) as req:
+        website = self.website.with_user(self.portal_user).with_context({})
+        with MockRequest(website.env, website=website, sale_order_id=so.id) as req:
             req.httprequest.method = "POST"
 
             # 1. Portal user, new shipping, same with the log in user
@@ -326,8 +330,8 @@ class TestCheckoutAddress(WebsiteSaleCommon):
             [90.91, 9.09, 100.0]
         )
 
-        env = api.Environment(self.env.cr, self.website.user_id.id, {})
-        with MockRequest(self.env, website=self.website.with_env(env), sale_order_id=so.id) as req:
+        website = self.website.with_user(self.public_user).with_context({})
+        with MockRequest(website.env, website=website, sale_order_id=so.id) as req:
             req.httprequest.method = "POST"
 
             self.WebsiteSaleController.shop_address_submit(**be_address_POST)
@@ -355,9 +359,8 @@ class TestCheckoutAddress(WebsiteSaleCommon):
         self._setUp_multicompany_env()
         so = self._create_so(partner_id=self.demo_partner.id)
 
-        env = api.Environment(self.env.cr, self.demo_user.id, {})
-        # change also website env for `sale_get_order` to not change order partner_id
-        with MockRequest(env, website=self.website.with_env(env), sale_order_id=so.id) as req:
+        website = self.website.with_user(self.demo_user).with_context({})
+        with MockRequest(website.env, website=website, sale_order_id=so.id) as req:
             req.httprequest.method = "POST"
 
             # check the default values
@@ -480,9 +483,8 @@ class TestCheckoutAddress(WebsiteSaleCommon):
         self.assertFalse(colleague._can_be_edited_by_current_customer(so, 'billing'))
         self.assertFalse(colleague._can_be_edited_by_current_customer(so, 'delivery'))
 
-        env = api.Environment(self.env.cr, user.id, {})
-        # change also website env for `sale_get_order` to not change order partner_id
-        with MockRequest(env, website=self.website.with_env(env), sale_order_id=so.id):
+        website = self.website.with_user(user).with_context({})
+        with MockRequest(website.env, website=website, sale_order_id=so.id):
 
             # Invalid addresses unaccessible to current customer
             with self.assertRaises(Forbidden):
@@ -601,8 +603,8 @@ class TestCheckoutAddress(WebsiteSaleCommon):
         so = self._create_so(partner_id=self.portal_partner.id)
         self.assertTrue(so.payment_term_id, "A payment term should be set by default on the sale order")
 
-        env = api.Environment(self.env.cr, self.portal_user.id, {})
-        with MockRequest(env, website=self.website.with_env(env).with_context(website_id=self.website.id)) as req:
+        website = self.website.with_user(self.portal_user).with_context({})
+        with MockRequest(website.env, website=website) as req:
             req.httprequest.method = "POST"
 
             self.default_address_values['partner_id'] = self.portal_partner.id

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -4,9 +4,7 @@ from odoo.fields import Command
 from odoo.tests import tagged
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo, HttpCaseWithUserPortal
-from odoo.addons.sale.tests.product_configurator_common import (
-    TestProductConfiguratorCommon,
-)
+from odoo.addons.sale.tests.product_configurator_common import TestProductConfiguratorCommon
 from odoo.addons.website.tests.common import HttpCaseWithWebsiteUser
 
 
@@ -60,10 +58,10 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
             else:
                 ptav.price_extra = 50.4
 
-        # Update the pricelist currency regarding env.company_id currency_id in case company has changed currency with COA installation.
-        website = cls.env['website'].get_current_website()
-        pricelist = website.pricelist_id
-        pricelist.write({'currency_id': cls.env.company.currency_id.id})
+        # Ensure that no pricelist is available during the test.
+        # This ensures that tours which triggers on the amounts will run properly, and that the
+        # currency will be the company currency.
+        cls.env['product.pricelist'].action_archive()
 
     def test_01_admin_shop_customize_tour(self):
         # Enable Variant Group
@@ -71,9 +69,6 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
         self.start_tour(self.env['website'].get_client_action_url('/shop?search=Test Product'), 'shop_customize', login="admin", timeout=120)
 
     def test_01_admin_shop_custom_attribute_value_tour(self):
-        # Ensure that no pricelist is available during the test.
-        # This ensures that tours which triggers on the amounts will run properly.
-        self.env['product.pricelist'].search([]).action_archive()
         self.start_tour("/", 'a_shop_custom_attribute_value', login="admin")
 
     def test_02_admin_shop_custom_attribute_value_tour(self):

--- a/addons/website_sale/tests/test_website_sale_cart_payment.py
+++ b/addons/website_sale/tests/test_website_sale_cart_payment.py
@@ -5,19 +5,16 @@ from odoo.tests.common import JsonRpcException, tagged
 from odoo.tools import mute_logger
 
 from odoo.addons.payment.tests.http_common import PaymentHttpCommon
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 
 
 @tagged('post_install', '-at_install')
-class WebsiteSaleCartPayment(PaymentHttpCommon):
+class WebsiteSaleCartPayment(PaymentHttpCommon, WebsiteSaleCommon):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.website = cls.env['website'].get_current_website()
-        with MockRequest(cls.env, website=cls.website):
-            cls.order = cls.website.sale_get_order(force_create=True)  # Create the cart to retrieve
         cls.tx = cls.env['payment.transaction'].create({
             'payment_method_id': cls.payment_method_id,
             'amount': cls.amount,
@@ -27,17 +24,17 @@ class WebsiteSaleCartPayment(PaymentHttpCommon):
             'operation': 'online_redirect',
             'partner_id': cls.partner.id,
         })
-        cls.order.write({'transaction_ids': [Command.set([cls.tx.id])]})
+        cls.cart.write({'transaction_ids': [Command.set([cls.tx.id])]})
 
     def test_unpaid_orders_can_be_retrieved(self):
         """ Test that fetching sales orders linked to a payment transaction in the states 'draft',
         'cancel', or 'error' returns the orders. """
         for unpaid_order_tx_state in ('draft', 'cancel', 'error'):
             self.tx.state = unpaid_order_tx_state
-            with MockRequest(self.env, website=self.website, sale_order_id=self.order.id):
+            with MockRequest(self.env, website=self.website, sale_order_id=self.cart.id) as request:
                 self.assertEqual(
-                    self.website.sale_get_order(),
-                    self.order,
+                    request.cart,
+                    self.cart,
                     msg=f"The transaction state '{unpaid_order_tx_state}' should not prevent "
                         f"retrieving the linked order.",
                 )
@@ -48,18 +45,18 @@ class WebsiteSaleCartPayment(PaymentHttpCommon):
         self.tx.provider_id.support_manual_capture = 'full_only'
         for paid_order_tx_state in ('pending', 'authorized', 'done'):
             self.tx.state = paid_order_tx_state
-            with MockRequest(self.env, website=self.website, sale_order_id=self.order.id):
+            with MockRequest(self.env, website=self.website, sale_order_id=self.cart.id) as request:
                 self.assertFalse(
-                    self.website.sale_get_order(),
+                    request.cart,
                     msg=f"The transaction state '{paid_order_tx_state}' should prevent retrieving "
                         f"the linked order.",
                 )
 
     @mute_logger('odoo.http')
     def test_transaction_route_rejects_unexpected_kwarg(self):
-        url = self._build_url(f'/shop/payment/transaction/{self.order.id}')
+        url = self._build_url(f'/shop/payment/transaction/{self.cart.id}')
         route_kwargs = {
-            'access_token': self.order._portal_ensure_token(),
+            'access_token': self.cart._portal_ensure_token(),
             'partner_id': self.partner.id,  # This should be rejected.
         }
         with self.assertRaises(JsonRpcException, msg='odoo.exceptions.ValidationError'):

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -1,21 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
-
 from datetime import datetime, timedelta
-from freezegun import freeze_time
 from unittest.mock import patch
+
+from freezegun import freeze_time
 
 from odoo.fields import Command
 from odoo.tests import tagged
 from odoo.tools import SQL
 
-from odoo.addons.base.tests.common import (
-    HttpCaseWithUserPortal,
-    TransactionCaseWithUserDemo,
-)
-from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
-
+from odoo.addons.base.tests.common import HttpCaseWithUserPortal, TransactionCaseWithUserDemo
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 
 r''' /!\/!\
 Calling `get_pricelist_available` after setting `property_product_pricelist` on
@@ -214,7 +209,7 @@ class TestWebsitePriceList(WebsiteSaleCommon):
             'list_price': 100,
             'taxes_id': False,
         })
-        self.website.pricelist_id.write({
+        self.pricelist.write({
             'item_ids': [Command.clear(), Command.create({
                 'applied_on': '1_product',
                 'product_tmpl_id': product.product_tmpl_id.id,
@@ -229,7 +224,7 @@ class TestWebsitePriceList(WebsiteSaleCommon):
                 'applied_on': '1_product',
                 'product_tmpl_id': product.product_tmpl_id.id,
                 'base': 'pricelist',
-                'base_pricelist_id': self.website.pricelist_id.id,
+                'base_pricelist_id': self.pricelist.id,
                 'compute_price': 'percentage',
                 'percent_price': 25,
             })]
@@ -237,6 +232,7 @@ class TestWebsitePriceList(WebsiteSaleCommon):
         so = self.env['sale.order'].create({
             'partner_id': self.env.user.partner_id.id,
             'website_id': self.website.id,
+            'pricelist_id': self.pricelist.id,
             'order_line': [Command.create({
                 'name': product.name,
                 'product_id': product.id,
@@ -259,7 +255,7 @@ class TestWebsitePriceList(WebsiteSaleCommon):
             'list_price': 0,
             'taxes_id': False,
         })
-        self.website.pricelist_id.write({
+        self.pricelist.write({
             'item_ids': [
                 Command.clear(),
                 Command.create({
@@ -274,7 +270,7 @@ class TestWebsitePriceList(WebsiteSaleCommon):
         so = self.env['sale.order'].create({
             'partner_id': self.env.user.partner_id.id,
             'website_id': self.website.id,
-            'pricelist_id': self.website.pricelist_id.id,
+            'pricelist_id': self.pricelist.id,
             'order_line': [Command.create({
                 'name': product.name,
                 'product_id': product.id,
@@ -313,28 +309,29 @@ class TestWebsitePriceList(WebsiteSaleCommon):
             'name': 'Product Template', 'list_price': 10.0, 'standard_price': 5.0
         })
         self.assertEqual(product_template.standard_price, 5)
-        # Hack to enforce the use of this pricelist in the call to `_get_sales_price`
-        self.website.pricelist_id = pricelist
-        price = product_template._get_sales_prices(self.website)[product_template.id]['price_reduce']
-        msg = "Template has no variants, the price should be computed based on the template's cost."
-        self.assertEqual(price, 4.5, msg)
+        with MockRequest(
+            self.env, website=self.website, website_sale_current_pl=pricelist.id
+        ) as request:
+            self.assertEqual(request.pricelist, pricelist)
+            price = product_template._get_sales_prices(self.website)[product_template.id]['price_reduce']
+            msg = "Template has no variants, the price should be computed based on the template's cost."
+            self.assertEqual(price, 4.5, msg)
 
-        product_template.attribute_line_ids = [Command.create({
-            'attribute_id': pa.id, 'value_ids': [Command.set([pav1.id, pav2.id])]
-        })]
-        msg = "Product template with variants should have no cost."
-        self.assertEqual(product_template.standard_price, 0, msg)
-        self.assertEqual(product_template.product_variant_ids[0].standard_price, 0)
+            product_template.attribute_line_ids = [Command.create({
+                'attribute_id': pa.id, 'value_ids': [Command.set([pav1.id, pav2.id])]
+            })]
+            msg = "Product template with variants should have no cost."
+            self.assertEqual(product_template.standard_price, 0, msg)
+            self.assertEqual(product_template.product_variant_ids[0].standard_price, 0)
 
-        self.website.pricelist_id = pricelist
-        price = product_template._get_sales_prices(self.website)[product_template.id]['price_reduce']
-        msg = "Template has variants, the price should be computed based on the 1st variant's cost."
-        self.assertEqual(price, 0, msg)
+            price = product_template._get_sales_prices(self.website)[product_template.id]['price_reduce']
+            msg = "Template has variants, the price should be computed based on the 1st variant's cost."
+            self.assertEqual(price, 0, msg)
 
-        product_template.product_variant_ids[0].standard_price = 20
-        self.website.pricelist_id = pricelist
-        price = product_template._get_sales_prices(self.website)[product_template.id]['price_reduce']
-        self.assertEqual(price, 18, msg)
+            product_template.product_variant_ids[0].standard_price = 20
+
+            price = product_template._get_sales_prices(self.website)[product_template.id]['price_reduce']
+            self.assertEqual(price, 18, msg)
 
     def test_base_price_with_discount_on_pricelist_tax_included(self):
         """
@@ -369,10 +366,12 @@ class TestWebsitePriceList(WebsiteSaleCommon):
                 'product_tmpl_id': product_tmpl.id,
             })],
         })
-        # Hack to enforce the use of this pricelist in the call to `_get_sales_price`
-        self.website.pricelist_id = self.pricelist
-        res = product_tmpl._get_sales_prices(self.website)
-        self.assertEqual(res[product_tmpl.id]['base_price'], 75)
+        with MockRequest(
+            self.website.env, website=self.website, website_sale_current_pl=self.pricelist.id
+        ) as request:
+            self.assertEqual(request.pricelist, self.pricelist)
+            res = product_tmpl._get_sales_prices(self.website)
+            self.assertEqual(res[product_tmpl.id]['base_price'], 75)
 
     def test_pricelist_item_validity_period(self):
         """ Test that if a cart was created before a validity period,
@@ -394,8 +393,6 @@ class TestWebsitePriceList(WebsiteSaleCommon):
             'list_price': 100,
             'taxes_id': False,
         })
-        current_website = self.env['website'].get_current_website()
-        current_website.pricelist_id = pricelist
         with freeze_time(today) as frozen_time:
             so = self.env['sale.order'].create({
                 'partner_id': self.env.user.partner_id.id,
@@ -407,7 +404,7 @@ class TestWebsitePriceList(WebsiteSaleCommon):
                     'product_uom_id': product.uom_id.id,
                     'price_unit': product.list_price,
                 })],
-                'website_id': current_website.id,
+                'website_id': self.website.id,
             })
             sol = so.order_line
             self.assertEqual(sol.price_total, 100.0)
@@ -613,8 +610,10 @@ class TestWebsitePriceListAvailableGeoIP(TestWebsitePriceListAvailable):
         pls_to_return += self.env.user.partner_id.property_product_pricelist
 
         current_pl = self.w1_pl_code
-        with patch('odoo.addons.website_sale.models.website.Website._get_geoip_country_code', return_value=self.BE.code), \
-            patch('odoo.addons.website_sale.models.website.Website._get_cached_pricelist_id', return_value=current_pl.id):
+        with (
+            patch('odoo.addons.website_sale.models.website.Website._get_geoip_country_code', return_value=self.BE.code),
+            MockRequest(self.env, website=self.website, website_sale_current_pl=current_pl.id),
+        ):
             pls = self.website.get_pricelist_available(show_visible=True)
         self.assertEqual(pls, pls_to_return + current_pl, "Only pricelists for BE, accessible en website and selectable should be returned. It should also return the applied promo pl")
 

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -6,7 +6,7 @@ from odoo.tests import tagged
 from odoo.addons.sale.tests.test_sale_product_attribute_value_config import (
     TestSaleProductAttributeValueCommon,
 )
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale.tests.common import MockRequest
 
 
 @tagged('post_install', '-at_install', 'product_attribute')
@@ -70,9 +70,6 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
 
     def test_get_combination_info_with_fpos(self):
         # Setup product.
-        current_website = self.env['website'].get_current_website()
-        pricelist = current_website._get_current_pricelist()
-        (self.env['product.pricelist'].search([]) - pricelist).write({'active': False})
         product = self.env['product.template'].create({
             'name': 'Test Product',
             'list_price': 2000,
@@ -89,7 +86,7 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
 
         # Setup pricelist: make sure the pricelist has a 10% discount
         self.env['product.pricelist'].search([]).action_archive()
-        pricelist = self.env['product.pricelist'].create({
+        self.env['product.pricelist'].create({
             'name': "test_get_combination_info",
             'company_id': self.env.company.id,
             'website_id': website.id,
@@ -135,7 +132,6 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
 
         # Now with fiscal position, taxes should be mapped
         self.env.user.partner_id.country_id = us_country
-        website.invalidate_recordset(['fiscal_position_id'])
         with MockRequest(product.env, website=website):
             combination_info = product._get_combination_info()
         self.assertEqual(combination_info['price'], 500, "500% + 0% tax (mapped from fp 15% -> 0%)")
@@ -146,7 +142,6 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
 
         # Reset / Safety check
         self.env.user.partner_id.country_id = None
-        website.invalidate_recordset(['fiscal_position_id'])
         with MockRequest(product.env, website=website):
             combination_info = product._get_combination_info()
         self.assertEqual(combination_info['price'], 500, "434.78$ + 15% tax")
@@ -154,7 +149,6 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
 
         # Now with fiscal position, taxes should be mapped
         self.env.user.partner_id.country_id = us_country.id
-        website.invalidate_recordset(['fiscal_position_id'])
         with MockRequest(product.env, website=website):
             combination_info = product._get_combination_info()
         self.assertEqual(round(combination_info['price'], 2), 434.78, "434.78$ + 0% tax (mapped from fp 15% -> 0%)")

--- a/addons/website_sale/tests/test_website_sale_product_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_product_configurator.py
@@ -7,11 +7,10 @@ from odoo.tests import tagged
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo, HttpCaseWithUserPortal
 from odoo.addons.sale.tests.product_configurator_common import TestProductConfiguratorCommon
-from odoo.addons.website.tools import MockRequest
 from odoo.addons.website_sale.controllers.product_configurator import (
     WebsiteSaleProductConfiguratorController,
 )
-from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 
 
 @tagged('post_install', '-at_install')
@@ -165,7 +164,7 @@ class TestWebsiteSaleProductConfigurator(
             'name': "Main product", 'website_published': True
         })
 
-        with (MockRequest(self.env, website=self.website)):
+        with MockRequest(self.env, website=self.website):
             show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
                 product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
             )
@@ -183,7 +182,7 @@ class TestWebsiteSaleProductConfigurator(
             'optional_product_ids': [Command.set(optional_product.ids)],
         })
 
-        with (MockRequest(self.env, website=self.website)):
+        with MockRequest(self.env, website=self.website):
             show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
                 product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
             )
@@ -207,7 +206,7 @@ class TestWebsiteSaleProductConfigurator(
             ],
         })
 
-        with (MockRequest(self.env, website=self.website)):
+        with MockRequest(self.env, website=self.website):
             show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
                 product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
             )
@@ -238,7 +237,7 @@ class TestWebsiteSaleProductConfigurator(
             ],
         })
 
-        with (MockRequest(self.env, website=self.website)):
+        with MockRequest(self.env, website=self.website):
             show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
                 product_template_id=main_product.id, ptav_ids=[], is_product_configured=True
             )
@@ -268,7 +267,7 @@ class TestWebsiteSaleProductConfigurator(
             ],
         })
 
-        with (MockRequest(self.env, website=self.website)):
+        with MockRequest(self.env, website=self.website):
             show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
                 product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
             )
@@ -298,7 +297,7 @@ class TestWebsiteSaleProductConfigurator(
             ],
         })
 
-        with (MockRequest(self.env, website=self.website)):
+        with MockRequest(self.env, website=self.website):
             show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
                 product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
             )
@@ -329,7 +328,7 @@ class TestWebsiteSaleProductConfigurator(
             ],
         })
 
-        with (MockRequest(self.env, website=self.website)):
+        with MockRequest(self.env, website=self.website):
             show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
                 product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
             )
@@ -349,7 +348,7 @@ class TestWebsiteSaleProductConfigurator(
             'optional_product_ids': [Command.set(optional_product.ids)],
         })
 
-        with (MockRequest(self.env, website=self.website)):
+        with MockRequest(self.env, website=self.website):
             show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
                 product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
             )
@@ -384,7 +383,7 @@ class TestWebsiteSaleProductConfigurator(
             'taxes_id': tax,
         })
 
-        with (MockRequest(self.env, website=self.website)):
+        with MockRequest(self.env, website=self.website):
             ptav_price_extra = self.pc_controller._get_ptav_price_extra(
                 product.attribute_line_ids.product_template_value_ids,
                 self.currency,
@@ -443,7 +442,9 @@ class TestWebsiteSaleProductConfigurator(
             'optional_product_ids': [Command.set(optional_product.ids)],
             'taxes_id': tax,
         })
-        self.website.pricelist_id.item_ids = [
+        # Make sure the custom pricelist from the product configurator common doesn't fail the test
+        self.custom_pricelist.action_archive()
+        self.pricelist.item_ids = [
             Command.create({
                 'applied_on': '1_product',
                 'percent_price': 50,
@@ -451,4 +452,4 @@ class TestWebsiteSaleProductConfigurator(
                 'product_tmpl_id': main_product.id,
             }),
         ]
-        self.start_tour('/', 'website_sale_product_configurator_strikethrough_price')
+        self.start_tour('/shop', 'website_sale_product_configurator_strikethrough_price')

--- a/addons/website_sale/tests/test_website_sale_product_filters.py
+++ b/addons/website_sale/tests/test_website_sale_product_filters.py
@@ -6,8 +6,7 @@ from odoo.tests import tagged
 from odoo.addons.sale.tests.test_sale_product_attribute_value_config import (
     TestSaleProductAttributeValueCommon,
 )
-from odoo.addons.website.tools import MockRequest
-from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 
 
 @tagged('post_install', '-at_install')
@@ -108,6 +107,7 @@ class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestSaleProductAttributeV
             with_variants = self.WebsiteSnippetFilter.with_context(
                 dynamic_filter=dyn_filter,
                 hide_variants=False,
+                website_id=self.website.id,
             )._get_products('latest_sold')
             self.assertSetEqual(
                 {p['product_id'] for p in with_variants},
@@ -123,6 +123,7 @@ class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestSaleProductAttributeV
             no_variants = self.WebsiteSnippetFilter.with_context(
                 dynamic_filter=dyn_filter,
                 hide_variants=True,
+                website_id=self.website.id,
             )._get_products('latest_sold')
             self.assertSetEqual(
                 {p['product_id'] for p in no_variants},
@@ -191,6 +192,7 @@ class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestSaleProductAttributeV
             with_variants = self.WebsiteSnippetFilter.with_context(
                 dynamic_filter=dyn_filter,
                 hide_variants=False,
+                website_id=self.website.id,
             )._get_products('recently_sold_with', product_template_id=str(self.computer.id))
             self.assertSetEqual(
                 {p['product_id'] for p in with_variants},
@@ -201,6 +203,7 @@ class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestSaleProductAttributeV
             no_variants = self.WebsiteSnippetFilter.with_context(
                 dynamic_filter=dyn_filter,
                 hide_variants=True,
+                website_id=self.website.id,
             )._get_products('recently_sold_with', product_template_id=str(self.computer.id))
             self.assertSetEqual(
                 {p['product_id'] for p in no_variants},

--- a/addons/website_sale/tests/test_website_sale_product_template.py
+++ b/addons/website_sale/tests/test_website_sale_product_template.py
@@ -5,8 +5,7 @@ from datetime import datetime
 from odoo.fields import Command
 from odoo.tests import tagged
 
-from odoo.addons.website.tools import MockRequest
-from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 
 
 @tagged('post_install', '-at_install')
@@ -47,11 +46,15 @@ class TestWebsiteSaleProductTemplate(WebsiteSaleCommon):
                 }),
             ],
         })
-        markup_data = product_template._to_markup_data(self.website)
+        website = self.website
+        with MockRequest(website.env, website=website):
+            markup_data = product_template._to_markup_data(self.website)
         self.assertEqual(markup_data['@type'], 'ProductGroup')
         self.assertEqual(len(markup_data['hasVariant']), 2)
 
     def test_markup_data_uses_product_schema_when_single_variant(self):
         product_template = self.env['product.template'].create({'name': 'Test product'})
-        markup_data = product_template._to_markup_data(self.website)
+        website = self.website
+        with MockRequest(website.env, website=website):
+            markup_data = product_template._to_markup_data(self.website)
         self.assertEqual(markup_data['@type'], 'Product')

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -10,7 +10,7 @@
            t-nocache-_text_class="_text_class"
            t-nocache-_item_class="_item_class"
            t-nocache-_link_class="_link_class">
-            <t t-set="website_sale_cart_quantity" t-value="request.session['website_sale_cart_quantity'] if 'website_sale_cart_quantity' in request.session else website.sale_get_order().cart_quantity or 0"/>
+            <t t-set="website_sale_cart_quantity" t-value="request.session.get('website_sale_cart_quantity', request.cart.cart_quantity) or 0"/>
             <t t-set="show_cart" t-value="website.has_ecommerce_access()"/>
             <li t-attf-class="#{_item_class} divider d-none"/> <!-- Make sure the cart and related menus are not folded (see autohideMenu) -->
             <li t-attf-class="o_wsale_my_cart #{not show_cart and 'd-none'} #{_item_class}">
@@ -316,7 +316,7 @@
     <template id="pricelist_list" name="Pricelists Dropdown">
         <t t-set="website_sale_pricelists" t-value="website_sale_pricelists or website.get_pricelist_available(show_visible=True)" />
         <t t-set="hasPricelistDropdown" t-value="hasPricelistDropdown or (website_sale_pricelists and len(website_sale_pricelists)&gt;1)"/>
-        <t t-set="pricelist" t-value="website.pricelist_id"/>
+        <t t-set="pricelist" t-value="request.pricelist"/>
         <div t-attf-class="o_pricelist_dropdown dropdown #{_classes if hasPricelistDropdown else 'd-none'}">
             <t t-cache="pricelist,website_sale_pricelists,navClass">
                 <a role="button" href="#" t-attf-class="dropdown-toggle btn btn-{{navClass}}" data-bs-toggle="dropdown">
@@ -683,7 +683,7 @@
                             <b>Pricelist</b>
                         </button>
                     </h2>
-                    <t t-set="curr_pl" t-value="website.pricelist_id"/>
+                    <t t-set="curr_pl" t-value="request.pricelist"/>
                     <div id="o_wsale_offcanvas_pricelist"
                         class="accordion-collapse collapse"
                         aria-labelledby="o_wsale_offcanvas_orderby_header">

--- a/addons/website_sale_collect/controllers/delivery.py
+++ b/addons/website_sale_collect/controllers/delivery.py
@@ -13,7 +13,7 @@ class InStoreDelivery(Delivery):
         order to retrieve pickup locations when called from the the product page.
         """
         if kwargs.get('product_id'):  # Called from the product page.
-            order_sudo = request.website.sale_get_order(force_create=True)
+            order_sudo = request.cart or request.website._create_cart()
             in_store_dm = request.website.sudo().in_store_dm_id
             if order_sudo.carrier_id.delivery_type != 'in_store':
                 order_sudo.set_delivery_line(in_store_dm, in_store_dm.product_id.list_price)
@@ -29,7 +29,7 @@ class InStoreDelivery(Delivery):
         :param str pickup_location_data: The JSON-formatted pickup location data.
         :return: None
         """
-        order_sudo = request.website.sale_get_order()
+        order_sudo = request.cart
         if order_sudo.carrier_id.delivery_type != 'in_store':
             in_store_dm = request.website.sudo().in_store_dm_id
             order_sudo.set_delivery_line(in_store_dm, in_store_dm.product_id.list_price)

--- a/addons/website_sale_collect/controllers/main.py
+++ b/addons/website_sale_collect/controllers/main.py
@@ -12,7 +12,7 @@ class WebsiteSaleCollect(WebsiteSale):
         """ Override of `website_sale` to include the selected pickup location and zip code. """
         res = super()._prepare_product_values(product, category, search, **kwargs)
         if request.website.sudo().in_store_dm_id:
-            order_sudo = request.website.sale_get_order()
+            order_sudo = request.cart
             if (
                 order_sudo.carrier_id.delivery_type == 'in_store'
                 and order_sudo.pickup_location_data

--- a/addons/website_sale_collect/models/delivery_carrier.py
+++ b/addons/website_sale_collect/models/delivery_carrier.py
@@ -70,7 +70,7 @@ class DeliveryCarrier(models.Model):
         partner_address.geo_localize()  # Calculate coordinates.
 
         pickup_locations = []
-        order_sudo = request.website.sale_get_order()
+        order_sudo = request.cart
         for wh in self.warehouse_ids:
             # Prepare the stock data based on either the product or the order.
             if product:  # Called from the product page.

--- a/addons/website_sale_collect/models/product_template.py
+++ b/addons/website_sale_collect/models/product_template.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
+from odoo.http import request
 
 from odoo.addons.website_sale_collect import utils
 
@@ -20,7 +21,7 @@ class ProductTemplate(models.Model):
             and product_or_template.is_storable
         ):
             res['show_click_and_collect_availability'] = True
-            order_sudo = website.sale_get_order()
+            order_sudo = request.cart
             if (
                 order_sudo
                 and order_sudo.carrier_id.delivery_type == 'in_store'

--- a/addons/website_sale_loyalty/controllers/cart.py
+++ b/addons/website_sale_loyalty/controllers/cart.py
@@ -9,13 +9,9 @@ class Cart(WebsiteSaleCart):
 
     @route()
     def cart(self, **post):
-        order = request.website.sale_get_order()
-        if order and order.state != 'draft':
-            request.session['sale_order_id'] = None
-            order = request.website.sale_get_order()
-        if order:
-            order._update_programs_and_rewards()
-            order._auto_apply_rewards()
+        if order_sudo := request.cart:
+            order_sudo._update_programs_and_rewards()
+            order_sudo._auto_apply_rewards()
         return super().cart(**post)
 
     @route()

--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -13,10 +13,9 @@ class WebsiteSale(main.WebsiteSale):
 
     @route()
     def pricelist(self, promo, **post):
-        order = request.website.sale_get_order()
-        if not order:
+        if not (order_sudo := request.cart):
             return request.redirect('/shop')
-        coupon_status = order._try_apply_code(promo)
+        coupon_status = order_sudo._try_apply_code(promo)
         if coupon_status.get('not_found'):
             return super().pricelist(promo, **post)
         elif coupon_status.get('error'):
@@ -26,7 +25,7 @@ class WebsiteSale(main.WebsiteSale):
             if len(coupon_status) == 1:
                 coupon, rewards = next(iter(coupon_status.items()))
                 if request.env.context.get('product_id') or (len(rewards) == 1 and not rewards.multi_product):
-                    reward_successfully_applied = self._apply_reward(order, rewards, coupon)
+                    reward_successfully_applied = self._apply_reward(order_sudo, rewards, coupon)
 
             if reward_successfully_applied:
                 request.session['successful_code'] = promo
@@ -34,10 +33,9 @@ class WebsiteSale(main.WebsiteSale):
 
     @route()
     def shop_payment(self, **post):
-        order = request.website.sale_get_order()
-        if order:
-            order._update_programs_and_rewards()
-            order._auto_apply_rewards()
+        if order_sudo := request.cart:
+            order_sudo._update_programs_and_rewards()
+            order_sudo._auto_apply_rewards()
         return super().shop_payment(**post)
 
     @route(['/coupon/<string:code>'], type='http', auth='public', website=True, sitemap=False)
@@ -49,9 +47,8 @@ class WebsiteSale(main.WebsiteSale):
         code = code.strip()
 
         request.session['pending_coupon_code'] = code
-        order = request.website.sale_get_order()
-        if order:
-            result = order._try_pending_coupon()
+        if order_sudo := request.cart:
+            result = order_sudo._try_pending_coupon()
             if isinstance(result, dict) and 'error' in result:
                 url_query['coupon_error'] = result['error']
             else:
@@ -64,9 +61,8 @@ class WebsiteSale(main.WebsiteSale):
 
     @route('/shop/claimreward', type='http', auth='public', website=True, sitemap=False)
     def claim_reward(self, reward_id, code=None, **post):
-        order_sudo = request.website.sale_get_order()
         redirect = post.get('r', '/shop/cart')
-        if not order_sudo:
+        if not (order_sudo := request.cart):
             return request.redirect(redirect)
 
         try:

--- a/addons/website_sale_loyalty/tests/test_apply_pending_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_apply_pending_coupon.py
@@ -1,26 +1,23 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import http
-from odoo.tests import HttpCase, tagged
+from odoo.tests import tagged
 
 from odoo.addons.sale_loyalty.tests.common import TestSaleCouponNumbersCommon
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 from odoo.addons.website_sale_loyalty.controllers.cart import Cart
 from odoo.addons.website_sale_loyalty.controllers.main import WebsiteSale
 
 
 @tagged('-at_install', 'post_install')
-class TestSaleCouponApplyPending(HttpCase, TestSaleCouponNumbersCommon):
+class TestSaleCouponApplyPending(TestSaleCouponNumbersCommon, WebsiteSaleCommon):
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.WebsiteSaleController = WebsiteSale()
-        self.WebsiteSaleCartController = Cart()
-
-        self.website = self.env['website'].browse(1)
-        self.global_program = self.p1
-        self.coupon_program = self.env['loyalty.program'].create({
+        cls.global_program = cls.p1
+        cls.coupon_program = cls.env['loyalty.program'].create({
             'name': 'One Free Product',
             'program_type': 'coupons',
             'rule_ids': [(0, 0, {
@@ -28,28 +25,31 @@ class TestSaleCouponApplyPending(HttpCase, TestSaleCouponNumbersCommon):
             })],
             'reward_ids': [(0, 0, {
                 'reward_type': 'product',
-                'reward_product_id': self.largeCabinet.id,
+                'reward_product_id': cls.largeCabinet.id,
             })]
         })
-        self.env['loyalty.generate.wizard'].with_context(active_id=self.coupon_program.id).create({
+        cls.env['loyalty.generate.wizard'].with_context(active_id=cls.coupon_program.id).create({
             'coupon_qty': 1,
             'points_granted': 1,
         }).generate_coupons()
-        self.coupon = self.coupon_program.coupon_ids[0]
-        installed_modules = set(self.env['ir.module.module'].search([
+        cls.coupon = cls.coupon_program.coupon_ids[0]
+        installed_modules = set(cls.env['ir.module.module'].search([
             ('state', '=', 'installed'),
         ]).mapped('name'))
         for _ in http._generate_routing_rules(installed_modules, nodb_only=False):
             pass
 
+    def setUp(self):
+        super().setUp()
+
+        self.WebsiteSaleController = WebsiteSale()
+        self.WebsiteSaleCartController = Cart()
+
     def test_01_activate_coupon_with_existing_program(self):
-        order = self.empty_order
+        order = self.empty_cart
         self.env['product.pricelist.item'].search([]).unlink()
 
-        with MockRequest(
-                self.env,
-                website=self.website, sale_order_id=order.id, website_sale_current_pl=1
-            ) as request:
+        with MockRequest(self.env, website=self.website, sale_order_id=order.id) as request:
             self.WebsiteSaleCartController.add_to_cart(
                 product_template_id=self.largeCabinet.product_tmpl_id,
                 product_id=self.largeCabinet.id,
@@ -85,13 +85,10 @@ class TestSaleCouponApplyPending(HttpCase, TestSaleCouponNumbersCommon):
             )
 
     def test_02_pending_coupon_with_existing_program(self):
-        order = self.empty_order
+        order = self.empty_cart
         self.env['product.pricelist.item'].search([]).unlink()
 
-        with MockRequest(
-            self.env,
-            website=self.website, sale_order_id=order.id, website_sale_current_pl=1
-        ) as request:
+        with MockRequest(self.env, website=self.website, sale_order_id=order.id) as request:
             self.WebsiteSaleCartController.add_to_cart(
                 product_template_id=self.largeCabinet.product_tmpl_id,
                 product_id=self.largeCabinet.id,

--- a/addons/website_sale_loyalty/tests/test_ewallet.py
+++ b/addons/website_sale_loyalty/tests/test_ewallet.py
@@ -4,8 +4,7 @@ from odoo import http
 from odoo.fields import Command
 from odoo.tests import HttpCase, tagged
 
-from odoo.addons.website.tools import MockRequest
-from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 from odoo.addons.website_sale_loyalty.controllers.cart import Cart
 from odoo.addons.website_sale_loyalty.controllers.main import WebsiteSale
 
@@ -19,7 +18,6 @@ class TestEwallet(HttpCase, WebsiteSaleCommon):
 
         cls.WebsiteSaleController = WebsiteSale()
         cls.WebsiteSaleCartController = Cart()
-        cls.website = cls.env['website'].browse(1)
 
         cls.product.write({'taxes_id': [Command.clear()]})
 

--- a/addons/website_sale_loyalty/tests/test_free_product_reward.py
+++ b/addons/website_sale_loyalty/tests/test_free_product_reward.py
@@ -1,66 +1,55 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import http
-from odoo.tests import tagged
-from odoo.tests.common import HttpCase
+from odoo.fields import Command
+from odoo.tests import HttpCase, tagged
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 from odoo.addons.website_sale_loyalty.controllers.cart import Cart
 from odoo.addons.website_sale_loyalty.controllers.main import WebsiteSale
 
 
 @tagged('post_install', '-at_install')
-class TestFreeProductReward(HttpCase):
+class TestFreeProductReward(HttpCase, WebsiteSaleCommon):
 
     def setUp(self):
         super().setUp()
 
         self.WebsiteSaleController = WebsiteSale()
         self.WebsiteSaleCartController = Cart()
-        self.website = self.env['website'].browse(1)
-
-        self.sofa = self.env['product.product'].create({
-            'name': 'Test Sofa',
-            'list_price': 2950.0,
-            'website_published': True,
-        })
-
-        self.carpet = self.env['product.product'].create({
-            'name': 'Test Carpet',
-            'list_price': 500.0,
-            'website_published': True,
-        })
 
         # Disable any other program
         self.program = self.env['loyalty.program'].search([]).write({'active': False})
 
+        self.sofa, self.carpet = self.env['product.product'].create([
+            {
+                'name': 'Test Sofa',
+                'list_price': 2950.0,
+                'website_published': True,
+            }, {
+                'name': 'Test Carpet',
+                'list_price': 500.0,
+                'website_published': True,
+            },
+        ])
         self.program = self.env['loyalty.program'].create({
             'name': 'Get a product for free',
             'program_type': 'promotion',
             'applies_on': 'current',
             'trigger': 'auto',
-            'rule_ids': [(0, 0, {
+            'rule_ids': [Command.create({
                 'minimum_qty': 1,
                 'minimum_amount': 0.00,
                 'reward_point_amount': 1,
                 'reward_point_mode': 'order',
                 'product_ids': self.sofa,
             })],
-            'reward_ids': [(0, 0, {
+            'reward_ids': [Command.create({
                 'reward_type': 'product',
                 'reward_product_id': self.carpet.id,
                 'reward_product_qty': 1,
                 'required_points': 1,
             })],
-        })
-
-        self.steve = self.env['res.partner'].create({
-            'name': 'Steve Bucknor',
-            'email': 'steve.bucknor@example.com',
-        })
-
-        self.empty_order = self.env['sale.order'].create({
-            'partner_id': self.steve.id
         })
 
         installed_modules = set(self.env['ir.module.module'].search([
@@ -72,8 +61,8 @@ class TestFreeProductReward(HttpCase):
     def test_add_product_to_cart_when_it_exist_as_free_product(self):
         # This test the flow when we claim a reward in the cart page and then we
         # want to add the product again
-        order = self.empty_order
-        with MockRequest(self.env, website=self.website, sale_order_id=order.id, website_sale_current_pl=1):
+        order = self.empty_cart
+        with MockRequest(self.env, website=self.website, sale_order_id=order.id):
             self.WebsiteSaleCartController.add_to_cart(
                 product_template_id=self.sofa.product_tmpl_id,
                 product_id=self.sofa.id,

--- a/addons/website_sale_loyalty/tests/test_sale_coupon_multiwebsite.py
+++ b/addons/website_sale_loyalty/tests/test_sale_coupon_multiwebsite.py
@@ -4,7 +4,7 @@ from odoo.exceptions import UserError
 from odoo.tests import tagged
 
 from odoo.addons.sale_loyalty.tests.common import TestSaleCouponNumbersCommon
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale.tests.common import MockRequest
 
 
 @tagged('-at_install', 'post_install')

--- a/addons/website_sale_loyalty/tests/test_website_sale_auto_invoice.py
+++ b/addons/website_sale_loyalty/tests/test_website_sale_auto_invoice.py
@@ -3,22 +3,17 @@
 from odoo.fields import Command
 from odoo.tests import tagged
 
-from odoo.addons.website.tools import MockRequest
 from odoo.addons.website_sale.controllers.main import WebsiteSale
-from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 
 
 @tagged('post_install', '-at_install')
 class TestWebsiteSaleAutoInvoice(WebsiteSaleCommon):
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.Controller = WebsiteSale()
-
     def test_automatic_invoice_on_zero_amount(self):
         # Set automatic invoice
         self.env['ir.config_parameter'].sudo().set_param('sale.automatic_invoice', 'True')
+        Controller = WebsiteSale()
 
         # Create a discount code
         program = self.env['loyalty.program'].sudo().create({
@@ -35,15 +30,14 @@ class TestWebsiteSaleAutoInvoice(WebsiteSaleCommon):
                     'discount': 100,
                 })
             ]
-            }
-        )
+        })
 
         # Apply discount
         self.cart._try_apply_code("100code")
         self.cart._apply_program_reward(program.reward_ids, program.coupon_ids)
 
-        with MockRequest(self.env, sale_order_id=self.cart.id, website=self.website):
-            self.Controller.shop_payment_validate()
+        with MockRequest(self.env, website=self.website, sale_order_id=self.cart.id):
+            Controller.shop_payment_validate()
         self.assertTrue(
             self.cart.invoice_ids, "Invoices should be generated for orders with zero total amount",
         )

--- a/addons/website_sale_loyalty/tests/test_website_sale_loyalty_delivery.py
+++ b/addons/website_sale_loyalty/tests/test_website_sale_loyalty_delivery.py
@@ -4,11 +4,8 @@ from odoo.fields import Command
 from odoo.tests import HttpCase, tagged
 
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
-from odoo.addons.website.tools import MockRequest
-from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
-from odoo.addons.website_sale_loyalty.controllers.delivery import (
-    WebsiteSaleLoyaltyDelivery,
-)
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
+from odoo.addons.website_sale_loyalty.controllers.delivery import WebsiteSaleLoyaltyDelivery
 
 
 @tagged('post_install', '-at_install')

--- a/addons/website_sale_stock/models/product_product.py
+++ b/addons/website_sale_stock/models/product_product.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields, _
-from odoo.http import request
 
 
 class ProductProduct(models.Model):
@@ -14,14 +13,9 @@ class ProductProduct(models.Model):
         self.ensure_one()
         return partner in self.stock_notification_partner_ids
 
-    def _get_cart_qty(self, website=None):
-        if not self.allow_out_of_stock_order:
-            website = website or self.env['website'].get_current_website()
-            # When the cron is run manually, request has no attribute website, and that would cause a crash
-            # so we check for it
-            cart = website and request and hasattr(request, 'website') and website.sale_get_order() or None
-            if cart:
-                return sum(cart._get_common_product_lines(product=self).mapped('product_uom_qty'))
+    def _get_cart_qty(self, order_sudo):
+        if order_sudo and not self.allow_out_of_stock_order:
+            return sum(order_sudo._get_common_product_lines(product=self).mapped('product_uom_qty'))
         return 0
 
     def _is_sold_out(self):

--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -50,7 +50,7 @@ class ProductTemplate(models.Model):
             stock_notification_email = request and request.session.get('stock_notification_email', '')
             res.update({
                 'free_qty': free_qty,
-                'cart_qty': product_sudo._get_cart_qty(website),
+                'cart_qty': product_sudo._get_cart_qty(request.cart),
                 'uom_name': product_sudo.uom_id.name,
                 'uom_rounding': product_sudo.uom_id.rounding,
                 'show_availability': product_sudo.show_availability,
@@ -94,7 +94,7 @@ class ProductTemplate(models.Model):
                 product_or_template.sudo(), **kwargs
             ) if product_or_template.is_product_variant else 0
             cart_quantity = product_or_template._get_cart_qty(
-                website
+                request.cart
             ) if product_or_template.is_product_variant else 0
             data['free_qty'] = available_qty - cart_quantity
         return data

--- a/addons/website_sale_stock/models/sale_order_line.py
+++ b/addons/website_sale_stock/models/sale_order_line.py
@@ -15,4 +15,4 @@ class SaleOrderLine(models.Model):
         return self.shop_warning
 
     def _get_max_available_qty(self):
-        return self.product_id.free_qty - self.product_id._get_cart_qty()
+        return self.product_id.free_qty - self.product_id._get_cart_qty(order_sudo=self.order_id)

--- a/addons/website_sale_stock/tests/test_website_sale_stock_delivery.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_delivery.py
@@ -4,40 +4,35 @@ from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 
 from odoo.addons.payment.tests.common import PaymentCommon
-from odoo.addons.sale.tests.common import SaleCommon
-from odoo.addons.website.tools import MockRequest
 from odoo.addons.website_sale.controllers.cart import Cart
 from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 
 
 @tagged('post_install', '-at_install')
-class TestWebsiteSaleStockDeliveryController(PaymentCommon, SaleCommon):
-    def setUp(self):
-        super().setUp()
-        self.website = self.env.ref('website.default_website')
-        self.WebsiteSaleCartController = Cart()
-        self.WebsiteSaleController = WebsiteSale()
+class TestWebsiteSaleStockDeliveryController(PaymentCommon, WebsiteSaleCommon):
 
     def test_validate_payment_with_no_available_delivery_method(self):
         """
         An error should be raised if you try to validate an order with a storable
         product without any delivery method available
         """
-        storable_product = self.env['product.product'].create({
+        storable_product = self.env['product.product'].create([{
             'name': 'Storable Product',
             'sale_ok': True,
             'is_storable': True,
             'website_published': True,
-        })
+        }])
         carriers = self.env['delivery.carrier'].search([])
         carriers.write({'website_published': False})
 
+        WebsiteSaleCartController = Cart()
+        WebsiteSaleController = WebsiteSale()
         with MockRequest(self.env, website=self.website):
-            self.website.sale_get_order(force_create=True)
-            self.WebsiteSaleCartController.add_to_cart(
+            WebsiteSaleCartController.add_to_cart(
                 product_template_id=storable_product.product_tmpl_id,
                 product_id=storable_product.id,
                 quantity=1,
             )
             with self.assertRaises(ValidationError):
-                self.WebsiteSaleController.shop_payment_validate()
+                WebsiteSaleController.shop_payment_validate()

--- a/addons/website_sale_stock/tests/test_website_sale_stock_product_template.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_product_template.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from odoo.tests import tagged
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale.tests.common import MockRequest
 from odoo.addons.website_sale_stock.tests.common import WebsiteSaleStockCommon
 
 

--- a/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
@@ -4,7 +4,7 @@
 from odoo.tests import tagged
 
 from odoo.addons.sale.tests.test_sale_product_attribute_value_config import TestSaleProductAttributeValueCommon
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale.tests.common import MockRequest
 
 
 @tagged('post_install', '-at_install')
@@ -88,6 +88,7 @@ class TestWebsiteSaleStockProductWarehouse(TestSaleProductAttributeValueCommon):
         be returned and the quantity updated to its maximum. """
 
         so = self.env['sale.order'].create({
+            'website_id': self.website.id,
             'partner_id': self.env.user.partner_id.id,
             'order_line': [(0, 0, {
                 'name': self.product_A.name,
@@ -97,8 +98,9 @@ class TestWebsiteSaleStockProductWarehouse(TestSaleProductAttributeValueCommon):
             })]
         })
 
-        with MockRequest(self.env, website=self.website, sale_order_id=so.id):
-            website_so = self.website.sale_get_order()
+        with MockRequest(self.env, website=self.website, sale_order_id=so.id) as req:
+            website_so = req.cart
+            self.assertEqual(website_so, so)
             self.assertEqual(
                 website_so.order_line.product_id.virtual_available,
                 25,

--- a/addons/website_sale_wishlist/controllers/main.py
+++ b/addons/website_sale_wishlist/controllers/main.py
@@ -9,8 +9,6 @@ class WebsiteSaleWishlist(Controller):
 
     @route('/shop/wishlist/add', type='jsonrpc', auth='public', website=True)
     def add_to_wishlist(self, product_id, **kw):
-        website = request.website
-        pricelist = website.pricelist_id
         product = request.env['product.product'].browse(product_id)
 
         price = product._get_combination_info_variant()['price']
@@ -23,8 +21,8 @@ class WebsiteSaleWishlist(Controller):
             partner_id = request.env.user.partner_id.id
 
         wish = Wishlist._add_to_wishlist(
-            pricelist.id,
-            pricelist.currency_id.id,
+            request.pricelist.id,
+            request.website.currency_id.id,
             request.website.id,
             price,
             product_id,


### PR DESCRIPTION
In all ecommerce flows, the cart was found, and created through the `sale_get_order` util, which not only found the cart, but also updated it according to the current request configuration.

This led recently to a big issue where all the ecommerce orders became assigned to the superuser (aka OdooBot) because the method was called with a modified environment, with the superuser.

This big issue highlighted once again this method, which doesn't work as you'd expect it to and was one of the cornerstones of the ecommerce flows that needed to be adapted to avoid such issues, clarify its uses, ...

The first idea was to follow the existing approach done for the pricelist and the fiscal_position, through computed fields on the website, as a form of 'request cache', but as the field result cannot be sudoed by default like the result of `sale_get_order` was, this means all code would have to be aware of it to avoid forgetting to sudo the field result.

> request.website.sale_order_id.sudo()

After more thoughts, inspiration came from the existing `website` attribute on the request, since the order (and pricelist) are cached in the request session, and are not expected to change during most requests (except specific ones).

> request.cart (sudo)
> request.pricelist (sudo)
> request.fiscal_position (sudo)

All three records can be empty, if a cart is needed, it must be created clearly through the `_create_cart` method, replacing the previous `force_create` argument of `sale_get_order`.

This new approach:
* provides a clear single access to the existing cart (if any)
* ensures that the cart checks and automatic updates (update the address after login, removing archived products, ...) are only done once by request, with the request environment. Local updates to the environment in routes won't trigger unexpected changes to the cart.
Routes and method overrides won't trigger the check again when fetching the cart, like it was the case previously with calls to `sale_get_order`
* improves performance
   * only search once for a previous cart in case of logged in customers
   * cache the fiscal position id in the session (like it was done previously for the pricelist and cart)
   * differentiate the presence of a pricelist key in the session, even if its value is Falsy, from the absence of the key in the session.  Having the key there means that no pricelist was available for the customer, and he should have the default prices in the company currency.
* drops the 'confusing' fields on the `website`, which were dependent on the request (and session)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
