### PR TITLE
[FIX] web_editor: toolbar stays aligned with selection while scrolling

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
@@ -29,6 +29,10 @@ patch(Wysiwyg.prototype, {
      **/
     async startEdition() {
         if (!this.options.inIframe) {
+            if (this.options.iframe) {
+                this.$iframe = $(this.options.iframe);
+                this.options.inIframe = true;
+            }
             return super.startEdition();
         } else {
             this.defAsset = this._getAssets();


### PR DESCRIPTION
**Current behavior before PR:**

- In web studio, when text is selected and the page is scrolled, the toolbar does not stay aligned with the selected text.

**Desired behavior after PR is merged:**

- Now, when scrolling in web studio, the toolbar remains fixed to the initial selection.

task-4317313
