### PR TITLE
[FIX] base: MX address formatting

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -1006,7 +1006,7 @@
             <field name="currency_id" ref="MXN" />
             <field eval="52" name="phone_code" />
             <field name="vat_label">RFC</field>
-            <field eval="'%(street)s %(street2)s\n%(zip)s %(city)s, %(state_code)s\n%(country_name)s'"  name="address_format" />
+            <field eval="'%(street)s\n%(street2)s\n%(zip)s %(city)s, %(state_code)s\n%(country_name)s'"  name="address_format" />
         </record>
         <record id="my" model="res.country">
             <field name="name">Malaysia</field>


### PR DESCRIPTION
Issue:

When printing the PDF of a Purchase Order, if the company has multiple address, those appear on the same line.

Steps to reproduce:

- Create a Mexican Company with 2 address lines
- Create a Purchase Order
- Print the PDF of the Purchase Order

Cause:

The separator between the 2 address lines in the address format is set as a blank space.

Solution:

Replace the blank space separator with a new line.

Ticket:

4221771

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
