### PR TITLE
[FIX] account_edi_ubl_cii: Fix patch in test

### DIFF
--- a/addons/account_edi_ubl_cii/tests/test_partner_peppol_fields.py
+++ b/addons/account_edi_ubl_cii/tests/test_partner_peppol_fields.py
@@ -101,10 +101,7 @@ class TestAccountUblCii(AccountTestInvoicingCommon):
             'name': "AU partner",
             'country_id': self.env.ref('base.au').id,
         })
-        with patch(
-                'odoo.addons.account_edi_ubl_cii.models.res_partner.ResPartner._get_ubl_cii_formats_info',
-                _get_ubl_cii_formats_info
-        ):
+        with patch.object(self.env.registry['res.partner'], '_get_ubl_cii_formats_info', _get_ubl_cii_formats_info):
             self.assertEqual(Partner._get_ubl_cii_formats(), ['ubl_no_country', 'peppol', 'cii'])
             self.assertEqual(Partner._get_ubl_cii_formats_by_country()['NZ'], ['peppol'])
             self.assertEqual(Partner._get_ubl_cii_formats_by_country()['AU'], ['peppol', 'cii'])


### PR DESCRIPTION
Fix a failing test that was incorrectly patching a class method, instead of patching
the base object.
Indeed, before this fix the test was only patching
`account_edi_ubl_cii._get_ubl_cii_formats_info()` and not extensions such as
`l10n_ro_edi._get_ubl_cii_formats_info()`).
Therefore extensions could add data to the returned value of the method, and
could make the test fail.

Related runbot error id: 104916
task-no
