### PR TITLE
[IMP] website: header & footer container width

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -318,7 +318,8 @@ const UserValueWidget = publicWidget.Widget.extend({
             this.illustrationEl = document.createElement('i');
             this.illustrationEl.classList.add('fa', this.options.dataAttributes.icon);
         }
-        if (this.options.dataAttributes.reload) {
+        // Set no-preview = true by default (avoid uncaught promise when not set)
+        if (this.options.dataAttributes.reload && !('noPreview' in this.options.dataAttributes)) {
             this.options.dataAttributes.noPreview = "true";
         }
     },
@@ -9216,7 +9217,7 @@ registry.ContainerWidth = SnippetOptionWidget.extend({
      */
     selectClass: async function (previewMode, widgetValue, params) {
         await this._super(...arguments);
-        if (previewMode === 'reset') {
+        if (previewMode === "reset" || !previewMode) {
             this.$target.removeClass('o_container_preview');
         } else if (previewMode) {
             this.$target.addClass('o_container_preview');

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -935,6 +935,47 @@ class Website(Home):
             'web.assets_frontend': request.env['ir.qweb']._get_asset_link_urls('web.assets_frontend', request.session.debug),
         }
 
+    @http.route(['/website/update_footer_template'], type='jsonrpc', auth='user', website=True)
+    def update_footer_template(self, template_key, possible_values):
+        """ Enables the footer template and its corresponding copyright template
+            on template change. The goal is to ensure that the content width of
+            the copyright aligns with the footer.
+        """
+
+        # Define templates views to enable/disable
+        views_enable = [template_key]
+        views_disable = self.theme_customize_data_get(possible_values, is_view_data=True)
+
+        # Define the possible footer classes and corresponding views
+        width_views = {
+            'container-fluid': 'website.footer_copyright_content_width_fluid',
+            'o_container_small': 'website.footer_copyright_content_width_small',
+        }
+
+        # Parse new footer template and get the content width
+        new_template = self._get_customize_data([template_key], is_view_data=True)
+        if not new_template or not new_template[0].arch:
+            return
+
+        tree = etree.HTML(new_template[0].arch)
+        container_classes = ['container', 'container-fluid', 'o_container_small']
+        classes_selector = ' or '.join([f"hasclass('{c}')" for c in container_classes])
+        res = tree.xpath(f"//div[{classes_selector}]")
+
+        # Define copyright views to enable/disable
+        if res:
+            classes = res[0].get('class').split()
+            width = next((c for c in container_classes if c in classes), False)
+            if width:
+                views_enable += [width_views.get(width)]
+                views_disable += [v for k, v in width_views.items() if k != width]
+
+        # Activate/Deactivate the computed views
+        self.theme_customize_data(is_view_data=True,
+                                  enable=views_enable,
+                                  disable=views_disable,
+                                  reset_view_arch=False)
+
     # ------------------------------------------------------
     # Server actions
     # ------------------------------------------------------

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -3055,6 +3055,55 @@ options.registry.HideFooter = VisibilityPageOptionUpdate.extend({
     shownValue: 'shown',
 });
 
+options.registry.FooterTemplateSelector = options.Class.extend({
+
+    //--------------------------------------------------------------------------
+    // Options
+    //--------------------------------------------------------------------------
+
+    /**
+     * Enables the footer view and its corresponding copyright view to match
+     * content width
+     *
+     * @override
+     */
+    customizeWebsiteViews: async function (previewMode, widgetValue, params) {
+        await rpc("/website/update_footer_template", {
+            'template_key': widgetValue,
+            'possible_values': this._getDataKeysFromPossibleValues(params.possibleValues),
+        });
+    },
+});
+
+options.registry.ContainerWidthFooter = options.registry.ContainerWidth.extend({
+    /**
+     * @override
+     */
+    start() {
+        this._copyrightAlreadyUpdated = false;
+        return this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Options
+    //--------------------------------------------------------------------------
+
+    /**
+     * Make sure views are enabled only once (required due to the apply-to).
+     *
+     * @override
+     */
+    async customizeWebsiteViews(previewMode, widgetValue, params) {
+        // TODO: When new API available, update 'data-apply-to' to avoid
+        // customize-website-views to be called for all elements, just once.
+        if (this._copyrightAlreadyUpdated || previewMode) {
+            return;
+        }
+        this._copyrightAlreadyUpdated = true;
+        return this._super(...arguments);
+    },
+});
+
 /**
  * Handles the edition of snippet's anchor name.
  */

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1198,6 +1198,20 @@
                        data-img="/website/static/src/img/snippets_options/header_template_sidebar.svg"/>
         </we-select>
 
+        <!-- Header Content Width - Options -->
+        <we-button-group string="Content Width" data-dependencies="!header_sidebar_opt"
+                         data-no-preview="true" data-reload="/">
+                <we-button title="Small"
+                           data-img="/website/static/src/img/snippets_options/content_width_small.svg"
+                           data-customize-website-views="website.header_width_small"/>
+                <we-button title="Regular"
+                           data-img="/website/static/src/img/snippets_options/content_width_normal.svg"
+                           data-customize-website-views=""/>
+                <we-button title="Full"
+                           data-img="/website/static/src/img/snippets_options/content_width_full.svg"
+                           data-customize-website-views="website.header_width_full"/>
+        </we-button-group>
+
         <!-- Header Sidebar Template - Options -->
         <we-input string="Width"
                   class="o_we_sublevel_1"
@@ -1563,6 +1577,7 @@
                        data-customize-website-variable="'headline'"
                        data-img="/website/static/src/img/snippets_options/footer_template_headline.svg"/>
         </we-select>
+
         <!-- Colors -->
         <we-colorpicker string="Colors"
                         data-customize-website-color="" data-color="footer"
@@ -1582,6 +1597,8 @@
                        data-customize-website-views="website.template_footer_slideout"
                        data-customize-website-variable="'slideout_shadow'"/>
         </we-select>
+
+        <!-- Copyright -->
         <we-checkbox string="Copyright"
                 data-name="footer_copyright_opt"
                 data-customize-website-views="website.footer_no_copyright|"

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1534,16 +1534,14 @@
                   data-dependencies="!header_effect_scroll_opt"/>
     </div>
 
-    <!-- Footer - Colors & Layouts -->
-    <div data-js="WebsiteLevelColor"
+    <!-- Footer - Layouts -->
+    <div data-js="FooterTemplateSelector"
          data-selector="#wrapwrap > footer"
          data-no-check="true"
          groups="website.group_website_designer">
-
-        <!-- Layouts -->
         <we-select string="Template"
-            data-variable="footer-template"
-            data-reload="/">
+                   data-variable="footer-template"
+                   data-reload="/">
             <we-button title="Default"
                        data-customize-website-views="website.footer_custom"
                        data-customize-website-variable="'default'"
@@ -1577,6 +1575,35 @@
                        data-customize-website-variable="'headline'"
                        data-img="/website/static/src/img/snippets_options/footer_template_headline.svg"/>
         </we-select>
+    </div>
+
+    <!-- Footer Content Width -->
+    <div data-js="ContainerWidthFooter"
+         data-selector="#wrapwrap > footer"
+         data-no-check="true"
+         groups="website.group_website_designer">
+        <we-button-group string="Content Width"
+                         data-reload="/" data-no-preview="false"
+                         data-apply-to="> #footer > section > .container, > #footer > section > .container-fluid, > #footer > section > .o_container_small, .o_footer_copyright > .container, .o_footer_copyright > .container-fluid, .o_footer_copyright > .o_container_small">
+            <we-button title="Small"
+                       data-img="/website/static/src/img/snippets_options/content_width_small.svg"
+                       data-select-class="o_container_small"
+                       data-customize-website-views="website.footer_copyright_content_width_small"/>
+            <we-button title="Regular"
+                       data-img="/website/static/src/img/snippets_options/content_width_normal.svg"
+                       data-select-class="container"/>
+            <we-button Title="Full"
+                       data-img="/website/static/src/img/snippets_options/content_width_full.svg"
+                       data-select-class="container-fluid"
+                       data-customize-website-views="website.footer_copyright_content_width_fluid"/>
+        </we-button-group>
+    </div>
+
+    <!-- Footer - Colors & Copyright -->
+    <div data-js="WebsiteLevelColor"
+         data-selector="#wrapwrap > footer"
+         data-no-check="true"
+         groups="website.group_website_designer">
 
         <!-- Colors -->
         <we-colorpicker string="Colors"
@@ -1600,10 +1627,10 @@
 
         <!-- Copyright -->
         <we-checkbox string="Copyright"
-                data-name="footer_copyright_opt"
-                data-customize-website-views="website.footer_no_copyright|"
-                data-no-preview="true"
-                data-reload="/"/>
+                     data-name="footer_copyright_opt"
+                     data-customize-website-views="website.footer_no_copyright|"
+                     data-no-preview="true"
+                     data-reload="/"/>
     </div>
 
     <!-- Footer - Borders & Shadows -->
@@ -1751,7 +1778,8 @@
 
     <!-- Stretch section -->
     <div data-js="ContainerWidth" data-selector="section, .s_carousel .carousel-item, .s_carousel_intro_item"
-        data-exclude="[data-snippet] :not(.oe_structure) > [data-snippet]" data-target="> .container, > .container-fluid, > .o_container_small">
+         data-exclude="[data-snippet] :not(.oe_structure) > [data-snippet], #footer > *"
+         data-target="> .container, > .container-fluid, > .o_container_small">
         <we-button-group string="Content Width">
             <we-button data-select-class="o_container_small"
                        data-img="/website/static/src/img/snippets_options/content_width_small.svg"

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -215,6 +215,7 @@
 
     <xpath expr="//header" position="before">
         <t t-set="cta_btn_text" t-value="False"/>
+        <t t-set="header_content_width" t-valuef="container"/>
         <t t-set="cta_btn_href">/contactus</t>
         <t t-set="extra_items_toggle_aria_label">Extra items button</t>
         <t t-set="primary_additional_colors" t-value="False"/>
@@ -529,7 +530,7 @@
         <t t-call="website.navbar">
             <t t-set="_navbar_classes" t-valuef="d-none d-lg-block shadow-sm"/>
 
-            <div id="o_main_nav" class="o_main_nav container">
+            <div id="o_main_nav" t-attf-class="o_main_nav #{header_content_width}">
                 <!-- Brand -->
                 <t t-call="website.placeholder_header_brand">
                     <t t-set="_link_class" t-valuef="me-4"/>
@@ -603,7 +604,7 @@
             <t t-set="_navbar_classes" t-valuef="d-none d-lg-block shadow-sm"/>
             <t t-set="_navbar_expand_class" t-valuef=""/>
 
-            <div id="o_main_nav" class="o_main_nav container d-grid py-0 o_grid_header_3_cols">
+            <div id="o_main_nav" t-attf-class="o_main_nav d-grid py-0 o_grid_header_3_cols #{header_content_width}">
                 <!-- Nav Toggler -->
                 <t t-call="website.navbar_toggler">
                     <t t-set="_toggler_class" t-valuef="btn me-auto p-2"/>
@@ -737,7 +738,7 @@
         <t t-call="website.navbar">
             <t t-set="_navbar_classes" t-valuef="d-none d-lg-block py-0 shadow-sm"/>
 
-            <div id="o_main_nav" class="o_main_nav container align-items-stretch">
+            <div id="o_main_nav" t-attf-class="o_main_nav align-items-stretch #{header_content_width}">
                 <!-- Brand -->
                 <t t-call="website.placeholder_header_brand">
                     <t t-set="_link_class" t-valuef="d-flex align-items-center me-4 p-2"/>
@@ -823,7 +824,7 @@
         <t t-call="website.navbar">
             <t t-set="_navbar_classes" t-valuef="d-none d-lg-block pt-3 shadow-sm"/>
 
-            <div id="o_main_nav" class="o_main_nav container flex-wrap">
+            <div id="o_main_nav" t-attf-class="o_main_nav flex-wrap #{header_content_width}">
                 <div class="o_header_hide_on_scroll d-grid align-items-center w-100 o_grid_header_3_cols pb-3">
                     <ul class="navbar-nav align-items-center gap-1">
                         <!-- Search bar -->
@@ -892,7 +893,7 @@
 
             <div id="o_main_nav" class="o_main_nav flex-wrap">
                 <div aria-label="Top" class="o_header_hide_on_scroll border-bottom o_border_contrast">
-                    <div class="container d-flex justify-content-between flex-wrap w-100">
+                    <div t-attf-class="#{header_content_width} d-flex justify-content-between flex-wrap w-100">
                         <ul class="o_header_search_left_col navbar-nav flex-wrap">
                             <!-- Language Selector -->
                             <t t-call="website.placeholder_header_language_selector">
@@ -924,7 +925,7 @@
                         </ul>
                     </div>
                 </div>
-                <div aria-label="Bottom" class="container d-grid align-items-center w-100 py-2 o_grid_header_3_cols">
+                <div aria-label="Bottom" t-attf-class="#{header_content_width} d-grid align-items-center w-100 py-2 o_grid_header_3_cols">
                     <!-- Navbar -->
                     <t t-call="website.navbar_nav">
                         <t t-set="_nav_class" t-valuef="me-4"/>
@@ -996,7 +997,7 @@
             <t t-set="_navbar_classes" t-valuef="o_header_force_no_radius d-none d-lg-block p-0 shadow-sm"/>
 
             <div id="o_main_nav" class="o_main_nav">
-                <div aria-label="Top" class="container d-flex align-items-center justify-content-between py-3">
+                <div aria-label="Top" t-attf-class="#{header_content_width} d-flex align-items-center justify-content-between py-3">
                     <!-- Brand -->
                     <t t-call="website.placeholder_header_brand">
                         <t t-set="_link_class" t-valuef="me-4"/>
@@ -1047,7 +1048,7 @@
                     </ul>
                 </div>
                 <div aria-label="Bottom" t-if="is_view_active('website.header_text_element') or is_view_active('website.header_social_links')" class="o_header_sales_one_bot o_header_hide_on_scroll gap-3 py-2">
-                    <ul class="navbar-nav container justify-content-between align-items-center">
+                    <ul t-attf-class="#{header_content_width} navbar-nav justify-content-between align-items-center">
                         <!-- Text element -->
                         <t t-call="website.placeholder_header_text_element">
                             <t t-set="_txt_elt_content" t-valuef="list"/>
@@ -1090,7 +1091,7 @@
             <div id="o_main_nav" class="o_main_nav">
                 <div class="o_header_hide_on_scroll">
                     <div aria-label="Top" t-if="is_view_active('website.header_text_element') or is_view_active('website.header_social_links') or is_view_active('website.header_language_selector')" class="o_header_sales_two_top py-1">
-                        <ul class="navbar-nav container d-grid h-100 px-3 o_grid_header_3_cols">
+                        <ul t-attf-class="#{header_content_width} navbar-nav d-grid h-100 px-3 o_grid_header_3_cols">
                             <!-- Return empty placeholder if the element is not active to keep the right layout -->
                             <li class="o_header_sales_two_lang_selector_placeholder" t-if="is_view_active('website.header_language_selector') == False"/>
                             <!-- Language Selector -->
@@ -1114,7 +1115,7 @@
                             </t>
                         </ul>
                     </div>
-                    <div aria-label="Middle" class="container d-flex justify-content-between align-items-center py-1">
+                    <div aria-label="Middle" t-attf-class="#{header_content_width} d-flex justify-content-between align-items-center py-1">
                         <!-- Brand -->
                         <t t-call="website.placeholder_header_brand">
                             <t t-set="_link_class" t-valuef="me-4"/>
@@ -1143,7 +1144,7 @@
                     </div>
                 </div>
                 <div aria-label="Bottom" class="border-top o_border_contrast">
-                    <div class="container d-flex justify-content-between">
+                    <div t-attf-class="#{header_content_width} d-flex justify-content-between">
                         <!-- Navbar -->
                         <t t-call="website.navbar_nav">
                             <t t-set="_nav_class" t-valuef="align-items-center me-4 py-1"/>
@@ -1194,7 +1195,7 @@
             <div id="o_main_nav" class="o_main_nav">
                 <div aria-label="Top" t-if="is_view_active('website.header_text_element') or is_view_active('website.header_social_links') or is_view_active('website.header_search_box') or is_view_active('website.header_call_to_action')"
                      class="o_header_sales_three_top o_header_hide_on_scroll position-relative border-bottom z-1 o_border_contrast">
-                    <div class="container d-flex justify-content-between gap-3 h-100">
+                    <div t-attf-class="#{header_content_width} d-flex justify-content-between gap-3 h-100">
                         <ul class="navbar-nav align-items-center gap-3 py-1">
                             <!-- Social -->
                             <t t-call="website.placeholder_header_social_links"/>
@@ -1220,7 +1221,7 @@
                         </ul>
                     </div>
                 </div>
-                <div aria-label="Bottom" class="container d-flex align-items-center py-2">
+                <div aria-label="Bottom" t-attf-class="#{header_content_width} d-flex align-items-center py-2">
                     <!-- Brand -->
                     <t t-call="website.placeholder_header_brand">
                         <t t-set="_link_class" t-valuef="me-4"/>
@@ -1283,7 +1284,7 @@
             <t t-set="_navbar_classes" t-valuef="o_header_sales_four_top o_header_force_no_radius d-none d-lg-block p-0 shadow-sm z-1"/>
 
             <div id="o_main_nav" class="o_main_nav">
-                <div aria-label="Top" class="container d-flex">
+                <div aria-label="Top" t-attf-class="#{header_content_width} d-flex">
                     <!-- Navbar -->
                     <t t-call="website.navbar_nav">
                         <t t-set="_nav_class" t-valuef="align-items-center me-auto pe-3"/>
@@ -1331,7 +1332,7 @@
                     </ul>
                 </div>
                 <div aria-label="Bottom" class="o_header_sales_four_bot o_header_hide_on_scroll z-0">
-                    <div class="container">
+                    <div t-attf-class="#{header_content_width}">
                         <ul class="navbar-nav d-grid align-items-center py-2 o_grid_header_3_cols">
                             <!-- Search bar -->
                             <li class="o_header_sales_four_search_placeholder" t-if="is_view_active('website.header_search_box') == False"/>
@@ -1505,11 +1506,11 @@
 <!-- "Rounded box" template -->
 <template id="template_header_boxed" inherit_id="website.layout" name="Template Header Rounded Box" active="False">
     <xpath expr="//header//nav" position="replace">
-        <div class="container py-3 px-0">
+        <div t-attf-class="#{header_content_width} py-3 px-0">
             <t t-call="website.navbar">
                 <t t-set="_navbar_classes" t-valuef="o_full_border d-none d-lg-block rounded-pill px-3 shadow-sm"/>
 
-                <div id="o_main_nav" class="o_main_nav container">
+                <div id="o_main_nav" t-attf-class="#{header_content_width} o_main_nav">
                     <!-- Brand -->
                     <t t-call="website.placeholder_header_brand">
                         <t t-set="_link_class" t-valuef="me-4"/>
@@ -1679,6 +1680,18 @@
 <template id="header_hoverable_dropdown" inherit_id="website.layout" name="Header Hoverable Dropdown" active="False">
     <xpath expr="//header" position="attributes">
         <attribute name="t-attf-class" add="o_hoverable_dropdown" separator=" "/>
+    </xpath>
+</template>
+
+<template id="header_width_small" inherit_id="website.layout" active="False">
+    <xpath expr="//t[@t-set='header_content_width']" position="attributes">
+        <attribute name="t-valuef">o_container_small</attribute>
+    </xpath>
+</template>
+
+<template id="header_width_full" inherit_id="website.layout" active="False">
+    <xpath expr="//t[@t-set='header_content_width']" position="attributes">
+        <attribute name="t-valuef">container-fluid</attribute>
     </xpath>
 </template>
 

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2134,6 +2134,19 @@
     </xpath>
 </template>
 
+<!-- Copyright Content Width -->
+<template id="footer_copyright_content_width_small" inherit_id="website.layout" name="Footer Copyright Width Small" active="False">
+    <xpath expr="//*[hasclass('o_footer_copyright')]/div" position="attributes">
+        <attribute name="class" remove="container" add="o_container_small" separator=" "/>
+    </xpath>
+</template>
+
+<template id="footer_copyright_content_width_fluid" inherit_id="website.layout" name="Footer Copyright Width Fluid" active="False">
+    <xpath expr="//*[hasclass('o_footer_copyright')]/div" position="attributes">
+        <attribute name="class" remove="container" add="container-fluid" separator=" "/>
+    </xpath>
+</template>
+
 <template id="footer_copyright_company_name" inherit_id="website.layout">
     <xpath expr="//footer//span[hasclass('o_footer_copyright_name')]" position="replace">
         <span class="o_footer_copyright_name me-2">Copyright &amp;copy; Company name</span>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1771,14 +1771,12 @@
 <template id="template_footer_descriptive" inherit_id="website.layout" name="Descriptive" active="False">
     <xpath expr="//div[@id='footer']" position="replace">
         <div id="footer" class="oe_structure oe_structure_solo" t-ignore="true" t-if="not no_footer">
-            <section class="s_title pt48 pb24" data-vcss="001" data-snippet="s_title">
-                <div class="container s_allow_columns">
-                    <h4><b>Designed</b> for companies</h4>
-                </div>
-            </section>
             <section class="s_text_block pb32" data-snippet="s_text_block" data-name="Text">
-                <div class="container">
+                <div class="container s_allow_columns">
                     <div class="row">
+                        <div class="col-lg-12 pt48 pb24">
+                            <h4><b>Designed</b> for companies</h4>
+                        </div>
                         <div class="col-lg-5">
                             <p>We are a team of passionate people whose goal is to improve everyone's life through disruptive products. We build great products to solve your business problems. Our products are designed for small to medium size companies willing to optimize their performance.</p>
                         </div>
@@ -1835,10 +1833,6 @@
                         <li class="list-inline-item mx-3"><i class="fa fa-1x fa-fw fa-phone me-2"/><span class="o_force_ltr"><a href="tel:+1 555-555-5556">+1 555-555-5556</a></span></li>
                         <li class="list-inline-item mx-3"><i class="fa fa-1x fa-fw fa-envelope me-2"/><span><a href="mailto:info@yourcompany.example.com">info@yourcompany.example.com</a></span></li>
                     </ul>
-                </div>
-            </section>
-            <section class="s_text_block pt16 pb16" data-snippet="s_text_block" data-name="Logo">
-                <div class="container">
                     <div class="row">
                         <div class="col-lg-2 offset-lg-5">
                             <a href="/" class="o_footer_logo logo">
@@ -1959,21 +1953,32 @@
         <div id="footer" class="oe_structure oe_structure_solo" t-ignore="true" t-if="not no_footer">
             <section class="s_text_block pt32 pb16" data-snippet="s_text_block" data-name="Text">
                 <div class="container">
-                    <div class="row">
-                        <div class="col-lg-3 pt16 pb16">
+                    <div class="row o_grid_mode">
+                        <div class="col-lg-3 pt16 pb16 o_grid_item g-col-lg-3 o_colored_level g-height-2"
+                             style="z-index: 1; grid-area: 1 / 1 / 3 / 4; --grid-item-padding-y: 0px; --grid-item-padding-x: 10px;">
                             <p class="mb-2">How can we help?</p>
                             <h4>Contact us anytime</h4>
                         </div>
-                        <div class="col-lg-3 pt16 pb16">
+                        <div class="col-lg-3 pt16 pb16 o_grid_item g-col-lg-3 o_colored_level g-height-2"
+                             style="z-index: 2; grid-area: 1 / 4 / 3 / 7; --grid-item-padding-y: 0px; --grid-item-padding-x: 10px;">
                             <p class="mb-2">Call us</p>
-                            <h5><span class="o_force_ltr"><a href="tel:+1 555-555-5556">+1 555-555-5556</a></span></h5>
+                            <h5>
+                                <span class="o_force_ltr">
+                                    <a href="tel:+1 555-555-5556">+1 555-555-5556</a>
+                                </span>
+                            </h5>
                         </div>
-                        <div class="col-lg-3 pt16 pb16">
+                        <div class="col-lg-3 pt16 pb16 o_grid_item g-col-lg-3 o_colored_level g-height-2"
+                             style="z-index: 3; grid-area: 1 / 7 / 3 / 10; --grid-item-padding-x: 0px; --grid-item-padding-y: 10px;">
                             <p class="mb-2">Send us a message</p>
-                            <h5><a href="mailto:hello@mycompany.com">hello@mycompany.com</a></h5>
+                            <h5>
+                                <a href="mailto:hello@mycompany.com">hello@mycompany.com</a>
+                            </h5>
                         </div>
-                        <div class="col-lg-3 pt16 pb16">
-                            <div class="s_social_media text-end no_icon_color o_not_editable" data-snippet="s_social_media" data-name="Social Media" contenteditable="false">
+                        <div class="col-lg-3 pt16 pb16 o_grid_item g-col-lg-3 o_colored_level g-height-2"
+                             style="z-index: 4; grid-area: 1 / 10 / 3 / 13; --grid-item-padding-y: 0px; --grid-item-padding-x: 10px;">
+                            <div class="s_social_media text-end no_icon_color o_not_editable"
+                                 data-snippet="s_social_media" data-name="Social Media" contenteditable="false">
                                 <p class="s_social_media_title d-block mb-2" contenteditable="true">Follow us</p>
                                 <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank">
                                     <i class="fa fa-twitter m-1 o_editable_media"/>
@@ -1986,37 +1991,43 @@
                                 </a>
                             </div>
                         </div>
-                    </div>
-                </div>
-            </section>
-            <section class="s_text_block" data-snippet="s_text_block" data-name="Text">
-                <div class="container allow_columns">
-                    <div class="s_hr pt16 pb16">
-                        <hr class="w-100 mx-auto" style="border-color: var(--600);"/>
-                    </div>
-                </div>
-            </section>
-            <section class="s_text_block" data-snippet="s_text_block" data-name="Text">
-                <div class="container">
-                    <div class="row align-items-center">
-                        <div class="col-lg-2 pb16">
+                        <div class="col-lg-12 pt16 pb16 o_grid_item g-col-lg-12 o_colored_level g-height-1"
+                             style="z-index: 5; grid-area: 3 / 1 / 4 / 13; --grid-item-padding-y: 0px; --grid-item-padding-x: 10px;">
+                            <div class="s_hr pt16 pb16">
+                                <hr class="w-100 mx-auto" style="border-color: var(--600);"/>
+                            </div>
+                        </div>
+                        <div class="col-lg-2 o_grid_item g-col-lg-2 o_grid_item_image o_colored_level o_grid_item_image_contain g-height-1"
+                             style="z-index: 6; grid-area: 4 / 1 / 5 / 3; --grid-item-padding-y: 0px; --grid-item-padding-x: 10px;">
                             <a href="/" class="o_footer_logo logo">
-                                <img src="/website/static/src/img/website_logo.svg" class="img-fluid" aria-label="Logo of MyCompany" title="MyCompany" role="img"/>
+                                <img src="/website/static/src/img/website_logo.svg" class="img-fluid"
+                                     aria-label="Logo of MyCompany" title="MyCompany" role="img"/>
                             </a>
                         </div>
-                        <div class="col-lg-10 pb16 text-end">
+                        <div class="col-lg-8 pt16 text-end o_colored_level o_grid_item g-col-lg-8 g-height-1"
+                             style="z-index: 7; grid-area: 4 / 5 / 5 / 13; --grid-item-padding-y: 0px; --grid-item-padding-x: 10px;">
                             <ul class="list-inline mb-0">
-                                <li class="list-inline-item"><a href="/">Home</a></li>
+                                <li class="list-inline-item">
+                                    <a href="/">Home</a>
+                                </li>
                                 <li class="list-inline-item">•</li>
-                                <li class="list-inline-item"><a href="#">About us</a></li>
+                                <li class="list-inline-item">
+                                    <a href="#">About us</a>
+                                </li>
                                 <li class="list-inline-item">•</li>
-                                <li class="list-inline-item"><a href="#">Products</a></li>
+                                <li class="list-inline-item">
+                                    <a href="#">Products</a>
+                                </li>
                                 <li class="list-inline-item">•</li>
-                                <li class="list-inline-item"><a href="#">Terms of Services</a></li>
+                                <li class="list-inline-item">
+                                    <a href="#">Terms of Services</a>
+                                </li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <t t-foreach="configurator_footer_links" t-as="link" class="list-inline-item">
                                     <li class="list-inline-item">•</li>
-                                    <li class="list-inline-item"><a t-att-href="link['href']" t-esc="link['text']"/></li>
+                                    <li class="list-inline-item">
+                                        <a t-att-href="link['href']" t-out="link['text']"/>
+                                    </li>
                                 </t>
                             </ul>
                         </div>
@@ -2027,37 +2038,30 @@
     </xpath>
 </template>
 
-<!-- Call-to-Action -->
 <template id="template_footer_call_to_action" inherit_id="website.layout" name="Call-to-Action" active="False">
     <xpath expr="//div[@id='footer']" position="replace">
         <div id="footer" class="oe_structure oe_structure_solo" t-ignore="true" t-if="not no_footer">
-            <section class="s_call_to_action pt64 pb64">
-                <div class="container">
-                    <div class="row">
-                        <div class="col-lg-9">
+            <section class="s_call_to_action" data-snippet="s_call_to_action" data-name="Text">
+                <div class="container s_allow_columns">
+                    <div class="row o_grid_mode" data-row-count="7">
+                        <div class="col-lg-9 pt64 pb56 o_grid_item g-col-lg-9 g-height-3" style="grid-area: 2 / 1 / 5 / 10; z-index: 1; --grid-item-padding-x: 10px; --grid-item-padding-y: 0px;">
                             <h3>50,000+ companies run Odoo to grow their businesses.</h3>
                             <p class="lead">Join us and make your company a better place.</p>
                         </div>
-                        <div class="col-lg-3">
-                            <a href="/contactus" class="btn btn-primary btn-lg btn-block">Start Button</a>
+                        <div class="col-lg-3 pt64 pb56 o_grid_item g-col-lg-3 g-height-3" style="text-align: right; grid-area: 2 / 10 / 5 / 13; z-index: 2; --grid-item-padding-x: 10px; --grid-item-padding-y: 0px;">
+                            <a href="/contactus" class="btn btn-primary btn-lg btn-block">Start
+                                Button
+                            </a>
                         </div>
-                    </div>
-                </div>
-            </section>
-            <section class="s_text_block" data-snippet="s_text_block" data-name="Text">
-                <div class="container s_allow_columns">
-                    <div class="s_hr pt16 pb16">
-                        <hr class="w-100 mx-auto" style="border-color: var(--600);"/>
-                    </div>
-                </div>
-            </section>
-            <section class="s_text_block" data-snippet="s_text_block" data-name="Text">
-                <div class="container">
-                    <div class="row">
-                        <div class="col-lg-9">
+                        <div class="col-lg-12 o_grid_item g-col-lg-12 g-height-1" style="grid-area: 5 / 1 / 6 / 13; z-index: 3; --grid-item-padding-x: 10px; --grid-item-padding-y: 0px;">
+                            <div class="s_hr pt16 pb16">
+                                 <hr class="w-100 mx-auto" style="border-color: var(--600);"/>
+                            </div>
+                        </div>
+                        <div class="col-lg-9 o_grid_item g-col-lg-9 g-height-1" style="grid-area: 6 / 1 / 7 / 10; z-index: 4; --grid-item-padding-x: 10px; --grid-item-padding-y: 0px;">
                             <p><i class="fa fa-1x fa-fw fa-map-marker me-2"/>250 Executive Park Blvd, Suite 3400 • San Francisco CA 94134 • United States</p>
                         </div>
-                        <div class="col-lg-3">
+                        <div class="col-lg-3 o_grid_item g-col-lg-3 g-height-1" style="grid-area: 6 / 10 / 7 / 13; z-index; --grid-item-padding-x: 10px; --grid-item-padding-y: 0px;">
                             <p><i class="fa fa-1x fa-fw fa-envelope me-2"/><a href="mailto:info@yourcompany.example.com">info@yourcompany.example.com</a></p>
                         </div>
                     </div>
@@ -2067,7 +2071,6 @@
     </xpath>
 </template>
 
-<!-- Headline -->
 <template id="template_footer_headline" inherit_id="website.layout" name="Headline" active="False">
     <xpath expr="//div[@id='footer']" position="replace">
         <div id="footer" class="oe_structure oe_structure_solo" t-ignore="true" t-if="not no_footer">
@@ -2080,12 +2083,6 @@
                         <div class="col-lg-9 pb24">
                             <p class="lead">We are a team of passionate people whose goal is to improve everyone's life.<br/>Our services are designed for small to medium size companies.</p>
                         </div>
-                    </div>
-                </div>
-            </section>
-            <section class="s_text_block" data-snippet="s_text_block" data-name="Text">
-                <div class="container">
-                    <div class="row align-items-center">
                         <div class="col-lg-3 pb24">
                             <ul class="ps-3 mb-0">
                                 <li><a href="/">Home</a></li>

--- a/doc/cla/individual/cove.md
+++ b/doc/cla/individual/cove.md
@@ -1,0 +1,11 @@
+Belgium, 2024-11-12
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Vermeulen Corentin cover4work@gmail.com https://github.com/ CorentinVermeulen


### PR DESCRIPTION
Currently, the user cannot adjust the width of the header content or the
 footer and copyright section.

This commit enhances the user experience by adding options to customize
the content width for both the header and the footer copyright.

task-4317645

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
