### PR TITLE
[IMP] bus: clean unused update presence parameter

### DIFF
--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -43,10 +43,10 @@ class WebsocketController(Controller):
         return {"channels": channels_with_db, "notifications": notifications}
 
     @route('/websocket/update_bus_presence', type='jsonrpc', auth='public', cors='*')
-    def update_bus_presence(self, inactivity_period, im_status_ids_by_model):
+    def update_bus_presence(self, inactivity_period):
         if 'is_websocket_session' not in request.session:
             raise SessionExpiredException()
-        request.env['ir.websocket']._update_bus_presence(int(inactivity_period), im_status_ids_by_model)
+        request.env['ir.websocket']._update_bus_presence(int(inactivity_period))
         return {}
 
     @route("/websocket/on_closed", type="jsonrpc", auth="public", cors="*")

--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -119,7 +119,7 @@ class IrWebsocket(models.AbstractModel):
         if bus_target := self._get_missed_presences_bus_target():
             data["missed_presences"]._send_presence(bus_target=bus_target)
 
-    def _update_bus_presence(self, inactivity_period, im_status_ids_by_model):
+    def _update_bus_presence(self, inactivity_period):
         if self.env.user and not self.env.user._is_public():
             self.env['bus.presence'].update_presence(
                 inactivity_period,

--- a/addons/bus/static/src/im_status_service.js
+++ b/addons/bus/static/src/im_status_service.js
@@ -26,10 +26,7 @@ export const imStatusService = {
         const updateBusPresence = () => {
             lastSentInactivity = presence.getInactivityPeriod();
             startAwayTimeout();
-            bus_service.send("update_presence", {
-                inactivity_period: lastSentInactivity,
-                im_status_ids_by_model: {},
-            });
+            bus_service.send("update_presence", { inactivity_period: lastSentInactivity });
         };
         this.updateBusPresence = updateBusPresence;
 

--- a/addons/bus/static/tests/legacy/helpers/mock_server.js
+++ b/addons/bus/static/tests/legacy/helpers/mock_server.js
@@ -66,10 +66,7 @@ patch(MockServer.prototype, {
      * @param {any} [message.data]
      */
     _performWebsocketRequest({ event_name, data }) {
-        if (event_name === "update_presence") {
-            const { inactivity_period, im_status_ids_by_model } = data;
-            this._mockIrWebsocket__updatePresence(inactivity_period, im_status_ids_by_model);
-        } else if (event_name === "subscribe") {
+        if (event_name === "subscribe") {
             const { channels } = data;
             this.channelsByUser[this.pyEnv?.currentUser] = this.pyEnv
                 ? this._mockIrWebsocket__buildBusChannelList(channels)

--- a/addons/bus/static/tests/legacy/helpers/mock_server/models/ir_websocket.js
+++ b/addons/bus/static/tests/legacy/helpers/mock_server/models/ir_websocket.js
@@ -5,44 +5,6 @@ import { MockServer } from "@web/../tests/helpers/mock_server";
 
 patch(MockServer.prototype, {
     /**
-     * Simulates `_update_presence` on `ir.websocket`.
-     *
-     * @param inactivityPeriod
-     * @param imStatusIdsByModel
-     */
-    _mockIrWebsocket__updatePresence(inactivityPeriod, imStatusIdsByModel) {
-        const imStatusNotifications = this._mockIrWebsocket__getImStatus(imStatusIdsByModel);
-        if (Object.keys(imStatusNotifications).length > 0) {
-            this._mockBusBus__sendone(
-                this.pyEnv.currentPartner,
-                "mail.record/insert",
-                imStatusNotifications
-            );
-        }
-    },
-    /**
-     * Simulates `_get_im_status` on `ir.websocket`.
-     *
-     * @param {Object} imStatusIdsByModel
-     * @param {Number[]|undefined} res.partner ids of res.partners whose im_status
-     * should be monitored.
-     */
-    _mockIrWebsocket__getImStatus(imStatusIdsByModel) {
-        const imStatus = {};
-        const { "res.partner": partnerIds } = imStatusIdsByModel;
-        if (partnerIds) {
-            imStatus["res.partner"] = this.mockSearchRead(
-                "res.partner",
-                [[["id", "in", partnerIds]]],
-                {
-                    context: { active_test: false },
-                    fields: ["im_status"],
-                }
-            ).map((p) => ({ id: p.id, im_status: p.im_status }));
-        }
-        return imStatus;
-    },
-    /**
      * Simulates `_build_bus_channel_list` on `ir.websocket`.
      */
     _mockIrWebsocket__buildBusChannelList(channels = []) {

--- a/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
+++ b/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
@@ -40,8 +40,7 @@ export class BusBus extends models.Model {
         const IrWebSocket = this.env["ir.websocket"];
 
         if (event_name === "update_presence") {
-            const { inactivity_period, im_status_ids_by_model } = data;
-            IrWebSocket._update_presence(inactivity_period, im_status_ids_by_model);
+            IrWebSocket._update_presence(data.inactivity_period);
         } else if (event_name === "subscribe") {
             const { channels } = data;
             this.channelsByUser[this.env?.uid] = channels;

--- a/addons/bus/static/tests/mock_server/mock_models/ir_websocket.js
+++ b/addons/bus/static/tests/mock_server/mock_models/ir_websocket.js
@@ -5,9 +5,8 @@ export class IrWebSocket extends models.ServerModel {
 
     /**
      * @param {number} inactivityPeriod
-     * @param {number[]} imStatusIdsByModel
      */
-    _update_presence(inactivityPeriod, imStatusIdsByModel) {}
+    _update_presence(inactivityPeriod) {}
 
     /**
      * @returns {string[]}

--- a/addons/hr_presence/models/ir_websocket.py
+++ b/addons/hr_presence/models/ir_websocket.py
@@ -11,8 +11,8 @@ from odoo.addons.bus.websocket import wsrequest
 class IrWebsocket(models.AbstractModel):
     _inherit = ['ir.websocket']
 
-    def _update_bus_presence(self, inactivity_period, im_status_ids_by_model):
-        super()._update_bus_presence(inactivity_period, im_status_ids_by_model)
+    def _update_bus_presence(self, inactivity_period):
+        super()._update_bus_presence(inactivity_period)
         #  This method can either be called due to an http or a
         #  websocket request. The request itself is necessary to
         #  retrieve the current guest. Let's retrieve the proper

--- a/addons/mail/models/discuss/ir_websocket.py
+++ b/addons/mail/models/discuss/ir_websocket.py
@@ -83,8 +83,8 @@ class IrWebsocket(models.AbstractModel):
         return super()._build_bus_channel_list(channels)
 
     @add_guest_to_context
-    def _update_bus_presence(self, inactivity_period, im_status_ids_by_model):
-        super()._update_bus_presence(inactivity_period, im_status_ids_by_model)
+    def _update_bus_presence(self, inactivity_period):
+        super()._update_bus_presence(inactivity_period)
         if not self.env.user or self.env.user._is_public():
             guest = self.env["mail.guest"]._get_guest_from_context()
             if not guest:

--- a/addons/mail/static/tests/mock_server/mock_models/ir_websocket.js
+++ b/addons/mail/static/tests/mock_server/mock_models/ir_websocket.js
@@ -1,42 +1,9 @@
 import { busModels } from "@bus/../tests/bus_test_helpers";
 
-import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
-
 import { makeKwArgs } from "@web/../tests/web_test_helpers";
 import { isIterable } from "@web/core/utils/arrays";
 
 export class IrWebSocket extends busModels.IrWebSocket {
-    /**
-     * @override
-     * @type {typeof busModels.WebSocket["prototype"]["_get_im_status"]}
-     */
-    _im_status_to_store(store, imStatusIdsByModel) {
-        /** @type {import("mock_models").MailGuest} */
-        const MailGuest = this.env["mail.guest"];
-        /** @type {import("mock_models").ResPartner} */
-        const ResPartner = this.env["res.partner"];
-
-        const { "mail.guest": guestIds, "res.partner": partnerIds } = imStatusIdsByModel;
-        if (guestIds) {
-            store.add(
-                "mail.guest",
-                MailGuest.browse(guestIds).map((guest) => ({
-                    id: guest.id,
-                    im_status: guest.im_status,
-                }))
-            );
-        }
-        if (partnerIds) {
-            store.add(
-                "res.partner",
-                ResPartner.browse(partnerIds).map((partner) => ({
-                    id: partner.id,
-                    im_status: partner.im_status,
-                }))
-            );
-        }
-    }
-
     /**
      * @override
      * @type {typeof busModels.IrWebSocket["prototype"]["_build_bus_channel_list"]}
@@ -95,26 +62,5 @@ export class IrWebSocket extends busModels.IrWebSocket {
             }
         }
         return channels;
-    }
-    /**
-     * @param {number} inactivityPeriod
-     * @param {number[]} imStatusIdsByModel
-     */
-    _update_presence(inactivityPeriod, imStatusIdsByModel) {
-        super._update_presence(inactivityPeriod, imStatusIdsByModel);
-
-        /** @type {import("mock_models").BusBus} */
-        const BusBus = this.env["bus.bus"];
-        /** @type {import("mock_models").ResPartner} */
-        const ResPartner = this.env["res.partner"];
-
-        const store = new mailDataHelpers.Store();
-        this._im_status_to_store(store, imStatusIdsByModel);
-        if (Object.keys(store.get_result()).length > 0) {
-            if (this.env.user) {
-                const [partner] = ResPartner.read(this.env.user.partner_id);
-                BusBus._sendone(partner, "mail.record/insert", store.get_result());
-            }
-        }
     }
 }


### PR DESCRIPTION
Since [1], the `im_status_ids_by_model` parameter is unused by the `IrWebsocket.update_presence` handler. This PR removes it.

[1]: https://github.com/odoo/odoo/pull/175462