### PR TITLE
[FIX] l10n_eu_oss: don't ref inexistent tag

### DIFF
--- a/addons/l10n_eu_oss/models/res_company.py
+++ b/addons/l10n_eu_oss/models/res_company.py
@@ -150,6 +150,12 @@ class Company(models.Model):
             country = self.account_fiscal_country_id
         chart_template = self.env['account.chart.template']._guess_chart_template(country)
 
+        # If that l10n module isn't installed, it means the company doesn't use any tax report for that country
+        # and thus hasn't nor need those tax report tag
+        is_coa_module_installed = self.env['account.chart.template']._get_chart_template_mapping()[chart_template]['installed']
+        if not is_coa_module_installed:
+            chart_template = None
+
         tag_for_country = EU_TAG_MAP.get(chart_template, {
             'invoice_base_tag': None,
             'invoice_tax_tag': None,


### PR DESCRIPTION
The aim of this commit is to prevent traceback when mapping local and
eu taxes to oss taxes.

Before the commit:
If the company chart template to use resolves to a CoA coming from a
module not installed, it will crash when trying to resolve the xml_id
for that specific localization.

After the commit:
If the l10n module isn't installed, it won't try to reference any
tax tag as the tax report line wouldn't be there anyway

Note:
1) This case is unlikely as if the customer has a vat number for a specific
country, it means they have a tax report to fill and thus must have
installed the related localization either as main CoA or as a foreing
fiscal position.
2) This was spotted through a runbot single l10n build error.

Nevertheless, it is something that is possible and thus should be
working smoothly.

runbot-100532