### PR TITLE
[FIX] mail: load more on chatter search panel randomly works

### DIFF
--- a/addons/mail/static/src/core/common/message_card_list.xml
+++ b/addons/mail/static/src/core/common/message_card_list.xml
@@ -13,7 +13,7 @@
                     <Message hasActions="false" message="message" thread="props.thread" messageSearch="props.messageSearch"/>
                 </div>
             </div>
-            <span t-if="props.loadMore" t-ref="load-more"/>
+            <span t-if="props.loadMore" class="mb-1" t-ref="load-more"/>
             <p t-if="props.showEmpty !== undefined ? props.showEmpty : props.messages.length === 0" t-esc="emptyText" class="text-center fst-italic text-500 fs-6"/>
         </div>
     </t>


### PR DESCRIPTION
Load more on search panel works based on the visibility of a span at the bottom of the panel when scrolling down. Depending on the height of the messages and probably change of the height of other elements on the page, since this element has zero height, it could happen that it's not visible when scrolling to the bottom.
This commit adds a minimum margin to the element to make sure it always has a small height and it's visible regardless of other elements when it should be.

