### PR TITLE
[FIX] tools: ensure banner appears on printed invoice

### DIFF
--- a/odoo/tools/pdf.py
+++ b/odoo/tools/pdf.py
@@ -140,6 +140,7 @@ def add_banner(pdf_stream, text=None, logo=False, thickness=2 * cm):
         width = float(abs(page.mediaBox.getWidth()))
         height = float(abs(page.mediaBox.getHeight()))
 
+        can.setPageSize((width, height))
         can.translate(width, height)
         can.rotate(-45)
 


### PR DESCRIPTION
The issue:
Starting with version 17.4, the Odoo banner displaying the invoice name on original bills is only added if the attached PDF uses US Letter paper size and is oriented vertically.

How to reproduce the issue:
-Upload any invoice with a non-standard format
-Print -> Original Bills

Explanation:
Since saas-17.4, the PyPDF2 library version was upgraded from 1.26.0 to 2.12.1. In version 1.26.0, the canvas dimensions were automatically adjusted when merging with non-standard page sizes. However, in version 2.12.1, this behavior no longer occurs, resulting in the banner not appearing correctly on non-standard formats.

opw-4278031

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
