### PR TITLE
[REF] hr_holidays: return newly created leaves after splitting

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1321,6 +1321,8 @@ Attempting to double-book your time off won't magically make your vacation 2x be
 
         split_leaves.filtered(lambda l: l.state in 'validate')._validate_leave_request()
 
+        return split_leaves
+
     def action_validate(self):
         current_employee = self.env.user.employee_id
         leaves = self._get_leaves_on_public_holiday()


### PR DESCRIPTION
Return newly created leaves after calling `hr.leave._split_leaves()` to improve inheritability by other modules


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
