### PR TITLE
[FIX] point_of_sale: prevent error when adding customer account

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -114,7 +114,7 @@ export class PaymentScreen extends Component {
         if (
             paymentMethod.type === "pay_later" &&
             (!this.currentOrder.to_invoice ||
-                this.pos.data["ir.module.module"].find((m) => m.name === "pos_settle_due")
+                this.pos.models["ir.module.module"].find((m) => m.name === "pos_settle_due")
                     ?.state !== "installed")
         ) {
             this.notification.add(


### PR DESCRIPTION
Before this commit, if invoicing is enabled, adding a customer account payment would cause an error.

opw-4318917

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
