### PR TITLE
[FIX] pos_self_order: prevent missing payment step with slow internet

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -51,7 +51,11 @@ export class CartPage extends Component {
         const type = this.selfOrder.config.self_ordering_mode;
         const takeAway = this.selfOrder.currentOrder.take_away;
 
-        if (this.selfOrder.rpcLoading || !this.selfOrder.verifyCart()) {
+        if (
+            this.selfOrder.rpcLoading ||
+            !this.selfOrder.verifyCart() ||
+            !this.selfOrder.verifyPriceLoading()
+        ) {
             return;
         }
 

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -650,6 +650,16 @@ export class SelfOrder extends Reactive {
         return result;
     }
 
+    verifyPriceLoading() {
+        if (this.priceLoading) {
+            this.notification.add(_t("Please wait until the price is loaded"), {
+                type: "danger",
+            });
+            return false;
+        }
+        return true;
+    }
+
     getProductDisplayPrice(product) {
         if (this.currentOrder.take_away) {
             return product.price_info.display_price_alternative;

--- a/addons/pos_self_order/static/tests/tours/test_self_order_mobile.js
+++ b/addons/pos_self_order/static/tests/tours/test_self_order_mobile.js
@@ -242,6 +242,7 @@ registry.category("web_tour.tours").add("SelfOrderOrderNumberTour", {
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Coca-Cola"),
         Utils.clickBtn("Order"),
+        CartPage.checkProduct("Coca-Cola", "2.53", "1"),
         Utils.clickBtn("Pay"),
         Utils.clickBtn("Confirm"),
         Utils.clickBtn("Ok"),


### PR DESCRIPTION
Before this commit, with a slow internet connection, if a user added an item to the order and pressed the pay button very quickly (before completing the price loading), it would bypass the payment step and directly give the receipt.

opw-4305214

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
