### PR TITLE
[17.0][ERROR] Multi Payment on POS

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -54,10 +54,14 @@ class AccountMove(models.Model):
                     reconciled_partials = move._get_all_reconciled_invoice_partials()
                     for i, reconciled_partial in enumerate(reconciled_partials):
                         counterpart_line = reconciled_partial['aml']
+                        # Check if there are multiple pos_payment records
                         pos_payment = counterpart_line.move_id.sudo().pos_payment_ids
-                        move.invoice_payments_widget['content'][i].update({
-                            'pos_payment_name': pos_payment.payment_method_id.name,
-                        })
+                        if pos_payment:
+                            # Handle multiple records by taking the first
+                            pos_payment_name = ', '.join(payment.payment_method_id.name for payment in pos_payment)
+                            move.invoice_payments_widget['content'][i].update({
+                                'pos_payment_name': pos_payment_name,
+                            })
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'


### PR DESCRIPTION
ValueError: Expected singleton: pos.payment.method(1, 4)

**Cause of the Error**
The ValueError: Expected singleton: pos.payment.method(1, 4) error is raised in Odoo when an operation intended for a single record (singleton) is instead applied to multiple records. In your code, pos_payment_ids is returning multiple payment methods for a single transaction because the customer has paid using multiple methods, like a mix of credit card, cash, and bank payments.

When you try to access pos_payment.payment_method_id.name, Odoo expects pos_payment_ids to contain only one record, but here it has more than one (IDs 1 and 4, for example). This is common in cases where a customer splits the payment across multiple methods, resulting in several pos.payment.method records associated with the transaction.

**Solution**
To handle multiple payment methods, you can modify the code to process all payment methods associated with a transaction instead of assuming there's only one. You can join the names of each payment method into a single string, which can then be displayed in the widget. Here’s the updated code to address this:

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
