### PR TITLE
[IMP] base,l10n_us: Replace aba_routing with generalized clearing_number field in res.partner.bank

### DIFF
--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -38,6 +38,7 @@ class ResPartnerBank(models.Model):
     active = fields.Boolean(tracking=True)
     acc_number = fields.Char(tracking=True)
     acc_holder_name = fields.Char(tracking=True)
+    clearing_number = fields.Char(tracking=True)
     partner_id = fields.Many2one(tracking=True)
     user_has_group_validate_bank_account = fields.Boolean(compute='_compute_user_has_group_validate_bank_account')
     allow_out_payment = fields.Boolean(

--- a/addons/l10n_us/models/res_partner_bank.py
+++ b/addons/l10n_us/models/res_partner_bank.py
@@ -2,17 +2,25 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
-from odoo import fields, models, api, _
+from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 
 
 class ResPartnerBank(models.Model):
     _inherit = 'res.partner.bank'
 
-    aba_routing = fields.Char(string="ABA/Routing", help="American Bankers Association Routing Number")
+    show_aba_routing = fields.Boolean(compute="_compute_show_aba_routing")
 
-    @api.constrains('aba_routing')
-    def _check_aba_routing(self):
+    @api.depends('country_code', 'acc_type')
+    def _compute_show_aba_routing(self):
         for bank in self:
-            if bank.aba_routing and not re.match(r'^\d{1,9}$', bank.aba_routing):
-                raise ValidationError(_('ABA/Routing should only contains numbers (maximum 9 digits).'))
+            if bank.country_code == 'US' and bank.acc_type != 'iban':
+                bank.show_aba_routing = True
+            else:
+                bank.show_aba_routing = False
+
+    @api.constrains('clearing_number')
+    def _check_clearing_number_us(self):
+        for bank in self:
+            if bank.country_code == 'US' and bank.clearing_number and not re.match(r'^\d{1,9}$', bank.clearing_number):
+                raise ValidationError(_('ABA/Routing should only contain numbers (maximum 9 digits).'))

--- a/addons/l10n_us/views/res_partner_bank_views.xml
+++ b/addons/l10n_us/views/res_partner_bank_views.xml
@@ -5,8 +5,12 @@
         <field name="model">res.partner.bank</field>
         <field name="inherit_id" ref="base.view_partner_bank_form"/>
         <field name="arch" type="xml">
-            <field name="bank_id" position="after">
-                <field name="aba_routing" invisible="acc_type == 'iban'"/>
+            <xpath expr="//field[@name='clearing_number']" position="attributes">
+                <attribute name="nolabel">1</attribute>
+            </xpath>
+            <field name="clearing_number" position="before">
+                <label for="clearing_number" invisible="show_aba_routing"/>
+                <label for="clearing_number" string="ABA/Routing" invisible="not show_aba_routing"/>
             </field>
         </field>
     </record>

--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -74,6 +74,7 @@ class ResPartnerBank(models.Model):
     active = fields.Boolean(default=True)
     acc_type = fields.Selection(selection=lambda x: x.env['res.partner.bank'].get_supported_account_types(), compute='_compute_acc_type', string='Type', help='Bank account type: Normal or IBAN. Inferred from the bank account number.')
     acc_number = fields.Char('Account Number', required=True)
+    clearing_number = fields.Char('Clearing Number')
     sanitized_acc_number = fields.Char(compute='_compute_sanitized_acc_number', string='Sanitized Account Number', readonly=True, store=True)
     acc_holder_name = fields.Char(string='Account Holder Name', help="Account holder name, in case it is different than the name of the Account Holder", compute='_compute_account_holder_name', readonly=False, store=True)
     partner_id = fields.Many2one('res.partner', 'Account Holder', ondelete='cascade', index=True, domain=['|', ('is_company', '=', True), ('parent_id', '=', False)], required=True)

--- a/odoo/addons/base/views/res_bank_views.xml
+++ b/odoo/addons/base/views/res_bank_views.xml
@@ -85,6 +85,7 @@
                         <group>
                             <field name="acc_number"/>
                             <field name="bank_id"/>
+                            <field name="clearing_number"/>
                             <field name="partner_id"/>
                         </group>
                         <group>


### PR DESCRIPTION
The ABA number is the clearing number of banks in the US, while some countries in EU still use clearing number for international purposes. So we can generalize the Clearing Number by adding it to res.partner.bank in base and removing the aba_routing from l10n_us.

The Clearing Number label is dependent on the country: for the US, it's ABA/Routing.

Enterprise: https://github.com/odoo/enterprise/pull/73681
Upgrade: https://github.com/odoo/upgrade/pull/6758

task-4307862


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
