### PR TITLE
[IMP] website_sale: Google Merchant Center xml data feed

### DIFF
--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
@@ -69,9 +69,9 @@ export class CopyClipboardURLField extends CopyClipboardField {
 
 // ----------------------------------------------------------------------------
 
-function extractProps({ attrs }) {
+function extractProps({ string, attrs }) {
     return {
-        string: attrs.string,
+        string,
         disabledExpr: attrs.disabled,
     };
 }

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -29,6 +29,7 @@
 
         # QWeb templates
         'views/delivery_form_templates.xml',
+        'views/gmc_templates.xml',
         'views/templates.xml',
 
         # Model views.

--- a/addons/website_sale/const.py
+++ b/addons/website_sale/const.py
@@ -1,0 +1,26 @@
+import re
+
+GMC_SUPPORTED_UOM = {
+    'oz',
+    'lb',
+    'mg',
+    'g',
+    'kg',
+    'floz',
+    'pt',
+    'qt',
+    'gal',
+    'ml',
+    'cl',
+    'l',
+    'cbm',
+    'in',
+    'ft',
+    'yd',
+    'cm',
+    'm',
+    'sqft',
+    'sqm',
+}
+
+GMC_BASE_MEASURE = re.compile(r'(?P<base_count>\d+)?\s*(?P<base_unit>[a-z]+)')

--- a/addons/website_sale/controllers/__init__.py
+++ b/addons/website_sale/controllers/__init__.py
@@ -3,6 +3,7 @@
 from . import cart
 from . import combo_configurator
 from . import delivery
+from . import gmc
 from . import main
 from . import payment
 from . import product_configurator

--- a/addons/website_sale/controllers/gmc.py
+++ b/addons/website_sale/controllers/gmc.py
@@ -1,0 +1,68 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from urllib.parse import urljoin
+from werkzeug.exceptions import NotFound
+
+from odoo.http import Controller, request, route
+from odoo.osv import expression
+
+
+class GoogleMerchantCenter(Controller):
+
+    @route(
+        ['/gmc.xml', '/gmc-<pricelist_name_ilike>.xml'],
+        type='http',
+        auth='public',
+        website=True,
+        sitemap=False,
+    )
+    def gmc_data_source(self, pricelist_name_ilike=None):
+        """Generate a Google Merchant Center (GMC) data source/feed.
+
+        - The feed adapts to the context lang; product titles, descriptions, etc.
+        - By default, it uses the connected user's pricelist. A specific pricelist can be selected
+          by including its name or part in the URL. E.g., /gmc-christmas.xml or /gmc-christ.xml will
+          force the "christmas" pricelist as well as the pricelist's currency.
+          Note: All the product link will also force the pricelist to ensure the feed's
+          prices corresponds to the website's prices.
+
+        :param str pricelist_name_ilike: The name of the pricelist to use for the feed.
+        :return: The rendered GMC data source in XML.
+        :rtype: str
+        """
+        website = request.website
+        if not website.enabled_gmc_src or not website.has_ecommerce_access():
+            raise NotFound()
+
+        # Find the pricelist by name if specified.
+        if pricelist_name_ilike is not None:
+            pricelist_sudo = request.env['product.pricelist'].sudo().search(
+                expression.AND([
+                    [('name', 'ilike', pricelist_name_ilike)],
+                    request.env['product.pricelist']._get_website_pricelists_domain(website),
+                ]),
+                limit=1,
+            )
+            if not pricelist_sudo:
+                raise NotFound()
+            request.pricelist = pricelist_sudo
+
+        # Generate the GMC data source.
+        homepage_url = website.homepage_url or '/'
+        website_homepage = website._get_website_pages(
+            [('url', '=', homepage_url), ('website_id', '!=', False)], limit=1,
+        )
+        products = request.env['product.product'].search(expression.AND([
+            [('is_published', '=', True), ('type', 'in', ('consu', 'combo'))],
+            website.website_domain(),
+        ]))
+        gmc_data = {
+            'title': website_homepage.website_meta_title or website.name,
+            'link': urljoin(website.get_base_url(), request.env['ir.http']._url_lang(homepage_url)),
+            'description': website_homepage.website_meta_description,
+            'items': products._prepare_gmc_items(),
+        }
+        content = request.env['ir.ui.view'].sudo()._render_template(
+            'website_sale.gmc_xml', gmc_data,
+        )
+        return request.make_response(content, [('Content-Type', 'application/xml;charset=utf-8')])

--- a/addons/website_sale/models/delivery_carrier.py
+++ b/addons/website_sale/models/delivery_carrier.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from collections import defaultdict
+
 from odoo import fields, models
 
 
@@ -12,3 +14,55 @@ class DeliveryCarrier(models.Model):
         related='product_id.description_sale',
         readonly=False,
     )
+
+    def _prepare_best_delivery_by_country(self, product, pricelist_sudo, countries):
+        """ Compute the info for the best delivery per country this product can be shipped to.
+
+        :return: A dict per country the product can be shipped to. This dict uses the following
+            schema: {
+                'price': float, # the best possible price for the country
+                'delivery_method': 'delivery.carrier', # the delivery method that will ship this
+                                                       # product for the price
+                'currency': 'res.currency', # the price currency
+                'free_over_threshold': Optional[float], # optionnaly, the dict can contain the best
+                                                        # free over threshold for the country
+            }
+        :rtype: dict['res.country', dict[str, float | 'delivery.carrier']]
+        """
+        # Creates a temporary order with a temporary partner to compute the shipping rates.
+        tmp_partner = self.env['res.partner'].new({})
+        tmp_order = self.env['sale.order'].new({
+            'partner_id': tmp_partner.id,
+            'pricelist_id': pricelist_sudo.id,
+            'order_line': [{'product_id': product.id, 'product_uom_qty': 1.0}],
+        })
+
+        best_delivery_by_country = defaultdict(lambda: {
+            'price': float('inf'),
+            'currency': tmp_order.currency_id,
+        })
+        for dm in self:
+            if dm.country_ids:
+                filtered_countries = dm.country_ids & countries
+            else:
+                filtered_countries = countries
+            for country in filtered_countries:
+                tmp_partner.country_id = country
+                if not dm._match(tmp_partner, tmp_order):
+                    continue
+                shipment_rate = dm.rate_shipment(tmp_order)
+                if not shipment_rate['success']:
+                    continue
+                if shipment_rate['price'] < best_delivery_by_country[country]['price']:
+                    best_delivery_by_country[country].update(
+                        price=shipment_rate['price'], delivery_method=dm,
+                    )
+                if (
+                    dm.free_over
+                    and dm.amount < best_delivery_by_country[country].get(
+                        'free_over_threshold', float('inf'),
+                    )
+                ):
+                    best_delivery_by_country[country]['free_over_threshold'] = dm.amount
+
+        return best_delivery_by_country

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -504,6 +504,8 @@ class ProductTemplate(models.Model):
             'list_price': max(pricelist_price, price_before_discount),
             'price': pricelist_price,
             'has_discounted_price': has_discounted_price,
+            'discount_start_date': pricelist_item.date_start,
+            'discount_end_date': pricelist_item.date_end,
         }
 
         if (

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from urllib.parse import urljoin
+
 from odoo import _, api, fields, models
 
 
@@ -95,6 +97,12 @@ class ResConfigSettings(models.TransientModel):
                                                  compute='_compute_checkout_process_steps', readonly=False, store=True)
     enabled_buy_now_button = fields.Boolean(string="Buy Now",
                                             compute='_compute_checkout_process_steps', readonly=False, store=True)
+    enabled_gmc_src = fields.Boolean(
+        string="Google Merchant Center Data Source",
+        related='website_id.enabled_gmc_src',
+        readonly=False,
+    )
+    gmc_xml_url = fields.Char(compute='_compute_gmc_xml_url')
 
     #=== COMPUTE METHODS ===#
 
@@ -118,6 +126,13 @@ class ResConfigSettings(models.TransientModel):
             record.enabled_buy_now_button = website.is_view_active(
                 'website_sale.product_buy_now'
             )
+
+    @api.depends('website_domain')
+    def _compute_gmc_xml_url(self):
+        for config in self:
+            # Uses `config.get_base_url()` which fallbacks to `web․base․url` if `website_domain` is
+            # not set.
+            config.gmc_xml_url = urljoin(config.get_base_url(), '/gmc.xml')
 
     def _inverse_account_on_checkout(self):
         for record in self:

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -153,6 +153,8 @@ class Website(models.Model):
         default="Not Available For Sale",
     )
 
+    enabled_gmc_src = fields.Boolean(string="Google Merchant Center Data Source")
+
     currency_id = fields.Many2one(
         string="Default Currency",
         comodel_name='res.currency',
@@ -162,6 +164,11 @@ class Website(models.Model):
         string="Price list available for this Ecommerce/Website",
         comodel_name='product.pricelist',
         compute="_compute_pricelist_ids",
+    )
+
+    _check_gmc_ecommerce_access = models.Constraint(
+        'CHECK (NOT enabled_gmc_src OR ecommerce_access = \'everyone\')',
+        "eCommerce must be accessible to all users for Google Merchant Center to operate properly.",
     )
 
     #=== COMPUTE METHODS ===#

--- a/addons/website_sale/static/tests/tours/website_sale_gmc_advertised_prices.js
+++ b/addons/website_sale/static/tests/tours/website_sale_gmc_advertised_prices.js
@@ -1,0 +1,38 @@
+import { registry } from '@web/core/registry';
+
+function check_price(price, currency) {
+    return [
+        {
+            content: 'Check price',
+            trigger: `span.oe_price:contains("${price}")`
+        },
+        {
+            content: 'Check currency',
+            trigger: `span.oe_price:contains("${currency}")`
+        },
+    ]
+}
+
+registry.category('web_tour.tours').add('website_sale_gmc_check_advertised_prices_red_sofa_default', {
+    steps: () => check_price('1,000.0', '$')
+});
+
+registry.category('web_tour.tours').add('website_sale_gmc_check_advertised_prices_blue_sofa_default', {
+    steps: () => check_price('1,200.0', '$')
+});
+
+registry.category('web_tour.tours').add('website_sale_gmc_check_advertised_prices_red_sofa_christmas', {
+    steps: () => check_price('990.0', '€') // 1000.0 * 1.1 (EUR rate) - 10% discount
+});
+
+registry.category('web_tour.tours').add('website_sale_gmc_check_advertised_prices_blue_sofa_christmas', {
+    steps: () => check_price('1,188.0', '€') // 1200.0 * 1.1 (EUR rate) - 10% discount
+});
+
+registry.category('web_tour.tours').add('website_sale_gmc_check_advertised_prices_red_sofa_tax_included', {
+    steps: () => check_price('1,150.0', '$') // 1000.0 + 15% tax
+});
+
+registry.category('web_tour.tours').add('website_sale_gmc_check_advertised_prices_blue_sofa_tax_included', {
+    steps: () => check_price('1,380.0', '$') // 1200.0 + 15% tax
+});

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -18,6 +18,7 @@ from . import test_website_sale_cart_notification
 from . import test_website_sale_cart_payment
 from . import test_website_sale_cart_recovery
 from . import test_website_sale_combo_configurator
+from . import test_website_sale_gmc
 from . import test_website_sale_image
 from . import test_website_sale_invoice
 from . import test_website_sale_mail

--- a/addons/website_sale/tests/common_gmc.py
+++ b/addons/website_sale/tests/common_gmc.py
@@ -1,0 +1,102 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import base64
+import io
+from PIL import Image
+import time
+
+from odoo.fields import Command
+
+from odoo.addons.website_sale.controllers.gmc import GoogleMerchantCenter
+from odoo.addons.product.tests.common import ProductVariantsCommon
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
+
+
+class WebsiteSaleGMCCommon(ProductVariantsCommon, WebsiteSaleCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.WebsiteSaleGMCController = GoogleMerchantCenter()
+        cls.website.enabled_gmc_src = True
+
+        # Prepare products
+        cls.product_template_sofa.list_price = 1000.0
+        (cls.red_sofa, cls.blue_sofa) = cls.product_template_sofa.product_variant_ids[:2]
+        cls.red_sofa.default_code = 'SOFA-R'
+        cls.blue_sofa.product_template_attribute_value_ids.filtered(
+            lambda v: v.name == 'blue'
+        ).price_extra = 200.0
+        cls.blanket = cls._create_product(name="Blanket")
+        combos = cls.env['product.combo'].create([
+            {
+                'name': "Sofa Combo",
+                'combo_item_ids': [
+                    Command.create({'product_id': cls.red_sofa.id}),
+                    Command.create({'product_id': cls.blue_sofa.id})
+                ]
+            },
+            {
+                'name': "Blanket Combo",
+                'combo_item_ids': [
+                    Command.create({'product_id': cls.blanket.id}),
+                ]
+            }
+        ])
+        cls.sofa_bundle = cls._create_product(
+            name="Sofa + Blanket",
+            type='combo',
+            combo_ids=[Command.set(combos.ids)],
+            list_price=1099.0
+        )
+        cls.products = cls.red_sofa + cls.blue_sofa + cls.blanket + cls.sofa_bundle
+        cls.products.website_published = True
+
+        # Prepare pricelists
+        cls.eur_currency = cls.env.ref('base.EUR')
+        cls.eur_currency.write({
+            'active': True,
+            'rate_ids': [
+                Command.clear(),
+                Command.create({'name': time.strftime('%Y-%m-%d'),'rate': 1.1})
+            ],
+        })
+
+        # Prepare delivery methods
+        cls.delivery_countries = cls.env['res.country'].search([('code', 'in', ('BE', 'LU', 'GB'))])
+        cls.carrier.write({
+            'country_ids': [Command.set(cls.delivery_countries.ids)],  # limit computation overhead
+            'free_over': True,
+            'amount': 1200.0,
+            'website_published': True,
+        })
+        cls.carrier.product_id.list_price = 5.0
+
+    def update_items(self, website=None, pricelist=None, **ctx):
+        website = website or self.website
+        pricelist = pricelist or self.pricelist
+        with MockRequest(
+            self.env,
+            context=ctx,
+            website=website,
+            website_sale_current_pl=pricelist.id,
+        ):
+            self.items = self.products._prepare_gmc_items()
+        self.red_sofa_item = self.items[self.red_sofa]
+        self.blue_sofa_item = self.items[self.blue_sofa]
+
+    def _create_image(self, color):
+        f = io.BytesIO()
+        Image.new('RGB', (1920, 1080), color).save(f, 'JPEG')
+        f.seek(0)
+        return base64.b64encode(f.read())
+
+    def _create_public_category(self, list_vals):
+        """ Create a hierarchical chain of `public.product.category`
+
+        :return: the last category in the chain (leaf)
+        """
+        categs = self.env['product.public.category'].create(list_vals)
+        for i in range(0, len(categs) - 1):
+            categs[i].parent_id = categs[i + 1]
+        return categs[-1]

--- a/addons/website_sale/tests/test_website_sale_gmc.py
+++ b/addons/website_sale/tests/test_website_sale_gmc.py
@@ -1,0 +1,423 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime, timedelta
+from lxml import etree
+from werkzeug.exceptions import NotFound
+from urllib.parse import urlparse
+
+from odoo import Command
+from odoo.tests import HttpCase, tagged
+
+from odoo.addons.website_sale.tests.common import MockRequest
+from odoo.addons.website_sale.tests.common_gmc import WebsiteSaleGMCCommon
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleGMC(WebsiteSaleGMCCommon, HttpCase):
+
+    def test_gmc_xml_accessible_if_gmc_setting_enabled(self):
+        response = self.url_open('/gmc.xml')
+
+        self.assertEqual(200, response.status_code)
+
+    def test_gmc_xml_not_found_if_gmc_setting_disabled(self):
+        self.website.enabled_gmc_src = False
+
+        with self.assertRaises(NotFound), MockRequest(
+            self.env,
+            website=self.website,
+            website_sale_current_pl=self.pricelist.id,
+        ):
+            self.WebsiteSaleGMCController.gmc_data_source()
+
+    def test_gmc_xml_correct_xml_format(self):
+        response = self.url_open('/gmc.xml')
+
+        gmc_xml = etree.XML(response.content)  # assert valid xml
+        self.assertEqual(self.website.name, gmc_xml.xpath('//title')[0].text)
+        self.assertURLEqual('/', gmc_xml.xpath('//link')[0].text)
+        self.assertEqual(
+            'This is the homepage of the website',
+            gmc_xml.xpath('//description')[0].text,
+        )
+
+    def test_gmc_xml_localization(self):
+        fr_lang = self.env['res.lang']._activate_lang('fr_FR')
+        self.website.language_ids += fr_lang
+        self.red_sofa.with_context(lang=fr_lang.code).name = 'Canapé'
+        self.color_attribute_red.with_context(lang=fr_lang.code).name = 'rouge'
+
+        self.update_items(lang=fr_lang.code)
+
+        self.assertRegex(
+            self.parse_http_location(self.red_sofa_item['link']).path,
+            f'^\\/{fr_lang.url_code}.*',
+            'The links must redirect to the french website.',
+        )
+        self.assertEqual(
+            'Canapé (rouge)',
+            self.red_sofa_item['title'],
+        )
+
+    def test_gmc_xml_pricelist(self):
+        self._create_pricelist(
+            name="EUR",
+            currency_id=self.eur_currency.id,
+            selectable=True,
+        )
+        response = self.url_open('/gmc-eur.xml')
+        self.assertEqual(200, response.status_code)
+        gmc_xml = etree.XML(response.content)
+        self.assertEqual(
+            '1100.0 EUR',  # 1000.0 * 1.1 (EUR rate)
+            gmc_xml.xpath(
+                '//item[g:id="SOFA-R"]/g:price', namespaces={'g': 'http://base.google.com/ns/1.0'}
+            )[0].text
+        )
+
+    def test_gmc_items_required_fields(self):
+        self.update_items()
+
+        for item in self.items.values():
+            self.assertLessEqual(
+                {
+                    'id',
+                    'title',
+                    'description',
+                    'link',
+                    'image_link',
+                    'availability',
+                    'price',
+                    'identifier_exists',
+                    'shipping',
+                },
+                item.keys(),
+            )  # subseteq
+
+    def test_gmc_items_use_internal_reference_if_exists(self):
+        """Test prefer internal code to database id"""
+        # setup: red_sofa.code = 'SOFA-R', blue_sofa.code = False
+        self.update_items()
+
+        self.assertEqual(self.red_sofa.code, self.red_sofa_item['id'])
+        self.assertEqual(self.blue_sofa.id, self.blue_sofa_item['id'])
+
+    def test_gmc_items_link_redirects_to_correct_product(self):
+        self.update_items()
+
+        for product in self.red_sofa + self.blue_sofa:
+            response = self.url_open(self.items[product]['link'])
+
+            self.assertEqual(200, response.status_code)
+            url = urlparse(product.website_url)
+            self.assertURLEqual(
+                f'{url.path}?pricelist={self.pricelist.id}#{url.fragment}',
+                response.url,
+            )
+
+    def test_gmc_items_prices_match_website_prices_default(self):
+        self.update_items()
+
+        self.assertEqual('1000.0 USD', self.red_sofa_item['price'])
+        self.assertEqual('1200.0 USD', self.blue_sofa_item['price'])
+        self.start_tour(
+            self.red_sofa_item['link'],
+            'website_sale_gmc_check_advertised_prices_red_sofa_default',
+        )
+        self.start_tour(
+            self.blue_sofa_item['link'],
+            'website_sale_gmc_check_advertised_prices_blue_sofa_default',
+        )
+
+    def test_gmc_items_prices_match_website_prices_christmas(self):
+        self.christmas_pricelist = self._create_pricelist(
+            name="EUR Christmas Sales",
+            currency_id=self.eur_currency.id,
+            selectable=True,
+            item_ids=[
+                Command.create({
+                    'product_tmpl_id': self.product_template_sofa.id,
+                    'compute_price': 'percentage',
+                    'percent_price': 10.0,
+                    'date_start': datetime.now() - timedelta(1),
+                    'date_end': datetime.now() + timedelta(1),
+                }),
+                Command.create({
+                    'compute_price': 'percentage',
+                    'percent_price': 0.0,
+                }),
+            ],
+        )
+
+        self.update_items(pricelist=self.christmas_pricelist)
+
+        # 1000.0 (list_price) * 1.1 (EUR rate) - 10% (discount)
+        self.assertEqual('990.0 EUR', self.red_sofa_item['sale_price'])
+        # 1200.0 (list_price) * 1.1 (EUR rate) - 10% (discount)
+        self.assertEqual('1188.0 EUR', self.blue_sofa_item['sale_price'])
+        # 100.0 (list_price) * 1.1 (EUR rate)
+        self.assertEqual('110.0 EUR', self.items[self.blanket]['price'])
+        self.assertNotIn('sale_price', self.items[self.blanket])  # no discount
+        self.start_tour(
+            self.red_sofa_item['link'],
+            'website_sale_gmc_check_advertised_prices_red_sofa_christmas',
+        )
+        self.start_tour(
+            self.blue_sofa_item['link'],
+            'website_sale_gmc_check_advertised_prices_blue_sofa_christmas',
+        )
+
+    def test_gmc_items_prices_match_website_prices_tax_included(self):
+        # 15% taxes
+        self.website.show_line_subtotals_tax_selection = 'tax_included'
+
+        self.update_items()
+
+        self.assertEqual('1150.0 USD', self.red_sofa_item['price'])
+        self.assertEqual('1380.0 USD', self.blue_sofa_item['price'])
+        self.start_tour(
+            self.red_sofa_item['link'],
+            'website_sale_gmc_check_advertised_prices_red_sofa_tax_included',
+        )
+        self.start_tour(
+            self.blue_sofa_item['link'],
+            'website_sale_gmc_check_advertised_prices_blue_sofa_tax_included',
+        )
+
+    def test_gmc_items_additional_images_limit_to_10(self):
+        image = self._create_image('blue')
+        self.blue_sofa.write({
+            'product_variant_image_ids': [
+                Command.create({
+                    'name': f'image {i}',
+                    'image_1920': image,
+                })
+                for i in range(12)
+            ]
+        })
+
+        self.update_items()
+
+        self.assertEqual(10, len(self.blue_sofa_item['additional_image_link']))
+
+    def test_gmc_items_identifier_exists_iff_barcode_exists(self):
+        self.red_sofa.barcode = '0232344532564'
+
+        self.update_items()
+
+        self.assertEqual(self.red_sofa.barcode, self.red_sofa_item['gtin'])
+        self.assertEqual('yes', self.red_sofa_item['identifier_exists'])
+        self.assertNotIn('gtin', self.blue_sofa_item)
+        self.assertEqual('no', self.blue_sofa_item['identifier_exists'])
+
+    def test_gmc_items_sorted_types(self):
+        # Furnitures / Sofas
+        # Furnitures / Indoor Furnitures / Indoor Sofas
+        sofas_categ = self._create_public_category([
+            {'name': 'Furnitures'},
+            {'name': 'Sofas', 'sequence': 1},
+        ])
+        indoor_sofas_categ = self._create_public_category([
+            {'name': 'Furnitures'},
+            {'name': 'Indoor Furnitures'},
+            {'name': 'Indoor Sofas', 'sequence': 2},
+        ])
+        self.public_categories = sofas_categ + indoor_sofas_categ
+        self.product_template_sofa.public_categ_ids = self.public_categories
+
+        self.update_items()
+
+        self.assertListEqual(
+            list(
+                name.replace('/', '>')
+                for name in self.public_categories.sorted('sequence').mapped('display_name')
+            ),
+            self.red_sofa_item['product_type']
+        )
+
+    def test_gmc_items_types_limit_to_5(self):
+        self.product_template_sofa.write({
+            'public_categ_ids': [
+                Command.create({'name': f'Category {i}'}) for i in range(6)
+            ]
+        })
+
+        self.update_items()
+
+        self.assertEqual(5, len(self.red_sofa_item['product_type']))
+
+    def test_gmc_product_variants(self):
+        product_one_variant = self.env['product.template'].create({
+            'name': 'Test product',
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': attr.attribute_id.id,
+                    'value_ids': [Command.link(attr.id)],
+                })
+                for attr in (self.color_attribute_green + self.size_attribute_l)
+            ],
+            'list_price': 49.0,
+        }).product_variant_ids
+        self.products |= product_one_variant
+
+        self.update_items()
+
+        # same template
+        self.assertEqual(self.red_sofa_item['item_group_id'], self.blue_sofa_item['item_group_id'])
+        # no other variant
+        self.assertNotIn('item_group_id', self.items[product_one_variant])
+
+    def test_gmc_items_bundle_if_is_combo_product(self):
+        self.update_items()
+
+        self.assertEqual('yes', self.items[self.sofa_bundle]['is_bundle'])
+        self.assertEqual('no', self.red_sofa_item['is_bundle'])
+
+    def test_gmc_items_sorted_labels(self):
+        tags = [f'tag {i}' for i in range(3)]
+        self.product_template_sofa.write({
+            'product_tag_ids': [
+                Command.create({'name': tag, 'sequence': i})
+                for i, tag in enumerate(tags)
+            ]
+        })
+
+        self.update_items()
+
+        self.assertListEqual(tags, [name for _, name in self.red_sofa_item['custom_label']])
+
+    def test_gmc_items_tags_limit_to_5(self):
+        self.product_template_sofa.write({
+            'product_tag_ids': [
+                Command.create({'name': f"Tag {i}", 'sequence': i})
+                for i in range(10)
+            ]
+        })
+
+        self.update_items()
+
+        self.assertEqual(5, len(self.red_sofa_item['custom_label']))
+
+    def test_01_gmc_items_best_shipping_rate_per_country(self):
+        self._prepare_carrier(
+            self._prepare_carrier_product(list_price=2.99),
+            name="Local Shipping",
+            country_ids=[Command.set(self.country_be.ids)],
+            website_published=True,
+            fixed_price=2.99,
+        )
+
+        self.update_items()
+
+        # Red sofa only gets a reduced delivery for Belgium
+        self.assertDictEqual(
+            {rate['country']: rate['price'] for rate in self.red_sofa_item['shipping']},
+            {'BE': '2.99 USD', 'LU': '5.0 USD', 'GB': '5.0 USD'},
+        )
+        # Blue sofa price is $1200 -> free over
+        self.assertDictEqual(
+            {rate['country']: rate['price'] for rate in self.blue_sofa_item['shipping']},
+            {'BE': '0.0 USD', 'LU': '0.0 USD', 'GB': '0.0 USD'},
+        )
+
+    def test_02_gmc_items_best_shipping_rate_per_country(self):
+        self._prepare_carrier(
+            self._prepare_carrier_product(list_price=2.99),
+            name="Local Free above $100",
+            country_ids=[Command.set(self.country_be.ids)],
+            free_over=True,
+            amount=100.0,
+            max_weight=20.0,
+            website_published=True,
+        )
+        heavy_product = self._create_product(name="Heavy product", weight=100.0)
+        self.products += heavy_product
+
+        self.update_items()
+
+        # Free over in Belgium
+        self.assertDictEqual(
+            {rate['country']: rate['price'] for rate in self.red_sofa_item['shipping']},
+            {'BE': '0.0 USD', 'LU': '5.0 USD', 'GB': '5.0 USD'},
+        )
+        # Too heavy for free over in Belgium
+        self.assertDictEqual(
+            {rate['country']: rate['price'] for rate in self.items[heavy_product]['shipping']},
+            {'BE': '5.0 USD', 'LU': '5.0 USD', 'GB': '5.0 USD'},
+        )
+
+    def test_gmc_items_best_free_shipping_threshold(self):
+        self._prepare_carrier(
+            self._prepare_carrier_product(list_price=10.0),
+            name="Local Carrier",
+            country_ids=[Command.set(self.country_be.ids)],
+            free_over=True,
+            amount=100.0,
+            website_published=True,
+        )
+
+        self.update_items()
+
+        # In Belgium
+        self.assertListEqual(
+            ['100.0 USD', '100.0 USD'],
+            [
+                threshold['price_threshold']
+                for threshold in (
+                    self.red_sofa_item['free_shipping_threshold'][:1]
+                    + self.blue_sofa_item['free_shipping_threshold'][:1]
+                )
+            ],
+        )
+        # Outside Belgium
+        self.assertListEqual(
+            ['1200.0 USD', '1200.0 USD', '1200.0 USD', '1200.0 USD'],
+            [
+                threshold['price_threshold']
+                for threshold in (
+                    self.red_sofa_item['free_shipping_threshold'][1:]
+                    + self.blue_sofa_item['free_shipping_threshold'][1:]
+                )
+            ],
+        )
+
+    def test_gmc_items_default_availability_in_stock(self):
+        self.update_items()
+
+        self.assertEqual(
+            'in_stock',
+            self.red_sofa_item['availability'],
+        )
+
+    def _setup_6l_water_pack(self):
+        self.env.user.group_ids |= self.env.ref('uom.group_uom')
+        uom_litre = self.env.ref('uom.product_uom_pack_6')
+        base_unit_litre = self.env['website.base.unit'].create({'name': 'L'})
+        six_pack = self.env['product.product'].create([{
+            'name': 'Water Pack 6L',
+            'list_price': 12.0,
+            'uom_id': uom_litre.id,
+            'base_unit_count': 6.0,
+            'base_unit_id': base_unit_litre.id,
+        }])
+        self.products |= six_pack
+        return six_pack
+
+    def test_gmc_items_unit_pricing_iff_product_reference_enabled(self):
+        six_pack = self._setup_6l_water_pack()
+        self.update_items()
+        self.assertNotIn('unit_pricing_measure', self.items[six_pack])
+
+        # enable "Product Reference Price" setting
+        self.env.user.group_ids |= self.env.ref('website_sale.group_show_uom_price')
+        self.update_items()
+
+        self.assertEqual('6.0l', self.items[six_pack]['unit_pricing_measure'], '$12 / 6l')
+
+    def test_gmc_items_dont_send_unsupported_unit(self):
+        six_pack = self._setup_6l_water_pack()
+        six_pack.base_unit_id = False  # remove `L` alias -> falls back to `Pack of 6`
+
+        self.update_items()
+
+        self.assertNotIn('unit_pricing_measure', self.items[six_pack])

--- a/addons/website_sale/utils.py
+++ b/addons/website_sale/utils.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from pytz import UTC
+
+
+def gmc_format_price(price, currency):
+    return f'{currency.round(price)} {currency.name}'
+
+def gmc_format_date(dt):
+    return UTC.localize(dt).isoformat(timespec='minutes')

--- a/addons/website_sale/views/gmc_templates.xml
+++ b/addons/website_sale/views/gmc_templates.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="gmc_xml"><t t-translation="off">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</t>
+        <rss xmlns:g="http://base.google.com/ns/1.0" version="2.0">
+            <channel>
+                <title t-out="title"/>
+                <t t-translation="off">&lt;link&gt;<t t-out="link"/>&lt;/link&gt;</t>
+                <description t-out="description"/>
+                <t t-foreach="items.values()" t-as="item">
+                    <item>
+                        <!-- Required -->
+                        <g:id t-out="item['id']"/>
+                        <g:title t-out="item['title']"/>
+                        <g:description t-out="item['description']"/>
+                        <g:link t-out="item['link']"/>
+                        <g:image_link t-out="item['image_link']"/>
+                        <g:availability t-out="item['availability']"/>
+                        <g:price t-out="item['price']"/>
+                        <g:identifier_exists t-out="item['identifier_exists']"/>
+                        <g:gtin t-if="'gtin' in item" t-out="item['gtin']"/>
+                        <t t-foreach="item['shipping']" t-as="shipping">
+                            <g:shipping>
+                                <g:country t-out="shipping['country']"/>
+                                <g:service t-out="shipping['service']"/>
+                                <g:price t-out="shipping['price']"/>
+                            </g:shipping>
+                        </t>
+
+                        <!-- Optional -->
+                        <g:sale_price t-if="'sale_price' in item" t-out="item['sale_price']"/>
+                        <g:sale_price_effective_date
+                            t-if="'sale_price_effective_date' in item"
+                            t-out="item['sale_price_effective_date']"
+                        />
+                        <g:unit_pricing_measure
+                            t-if="'unit_pricing_measure' in item"
+                            t-out="item['unit_pricing_measure']"
+                        />
+                        <g:unit_pricing_base_measure
+                            t-if="'unit_pricing_base_measure' in item"
+                            t-out="item['unit_pricing_base_measure']"
+                        />
+                        <t t-foreach="item['custom_label']" t-as="tag_label">
+                            <t t-translation="off">
+                                &lt;g:<t t-out="tag_label[0]"/>&gt;
+                                    <t t-out="tag_label[1]"/>
+                                &lt;/g:<t t-out="tag_label[0]"/>&gt;
+                            </t>
+                        </t>
+                        <t t-foreach="item['additional_image_link']" t-as="link">
+                            <g:additional_image_link t-out="link"/>
+                        </t>
+                        <t t-foreach="item['product_type']" t-as="type">
+                            <g:product_type t-out="type"/>
+                        </t>
+                        <g:item_group_id
+                            t-if="'item_group_id' in item"
+                            t-out="item['item_group_id']"
+                        />
+                        <g:is_bundle t-out="item['is_bundle']"/>
+                        <t t-foreach="item['product_detail']" t-as="name_value">
+                            <g:product_detail>
+                                <g:attribute_name t-out="name_value[0]"/>
+                                <g:attribute_value t-out="name_value[1]"/>
+                            </g:product_detail>
+                        </t>
+                        <t name="shippings" t-foreach="item['free_shipping_threshold']" t-as="shipping">
+                            <g:free_shipping_threshold>
+                                <g:country t-out="shipping['country']"/>
+                                <g:price_threshold t-out="shipping['price_threshold']"/>
+                            </g:free_shipping_threshold>
+                        </t>
+                    </item>
+                </t>
+            </channel>
+        </rss>
+    </template>
+</odoo>

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -297,7 +297,21 @@
                     <field name="module_website_sale_autocomplete"/>
                 </setting>
             </setting>
-
+            <setting id="robots_setting" position="after">
+                <setting
+                    id="google_merchant_center_setting"
+                    help="Connect your eCommerce to Google Merchant Center via a product file."
+                    documentation="/applications/websites/ecommerce/products/catalog.html#multi-channel-promotion"
+                >
+                    <field name="enabled_gmc_src"/>
+                    <field
+                        name="gmc_xml_url"
+                        string="Copy file link"
+                        widget="CopyClipboardButton"
+                        invisible="not enabled_gmc_src"
+                    />
+                </setting>
+            </setting>
         </field>
     </record>
 </odoo>

--- a/addons/website_sale_stock/models/product_product.py
+++ b/addons/website_sale_stock/models/product_product.py
@@ -75,3 +75,14 @@ class ProductProduct(models.Model):
                 availability = 'https://schema.org/OutOfStock'
             markup_data['offers']['availability'] = availability
         return markup_data
+
+    def _prepare_gmc_stock_info(self):
+        """ Override of `website_sale` to check the stock level if the current product cannot be out
+        of stock.
+
+        Note: self.ensure_one()
+        """
+        gmc_info = super()._prepare_gmc_stock_info()
+        if self._is_sold_out():
+            gmc_info['availability'] = 'out_of_stock'
+        return gmc_info

--- a/addons/website_sale_stock/tests/__init__.py
+++ b/addons/website_sale_stock/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_website_sale_stock_multilang
 from . import test_website_sale_stock_product_template
 from . import test_website_sale_stock_product_warehouse
 from . import test_website_sale_stock_delivery
+from . import test_website_sale_stock_gmc
 from . import test_website_sale_stock_stock_notification
 from . import test_website_sale_stock_reorder_from_portal
 from . import test_website_sale_stock_stock_message

--- a/addons/website_sale_stock/tests/test_website_sale_stock_gmc.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_gmc.py
@@ -1,0 +1,47 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+
+from odoo.addons.website_sale.tests.common_gmc import WebsiteSaleGMCCommon
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleStockGMC(WebsiteSaleGMCCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.website.warehouse_id = cls.env.ref('stock.warehouse0')
+        cls.stock_loc = cls.website.warehouse_id.lot_stock_id
+        cls.supplier_loc = cls.env.ref('stock.stock_location_suppliers')
+        (cls.blue_sofa + cls.red_sofa + cls.blanket).write({
+            'is_storable': True,
+            'allow_out_of_stock_order': False,
+        })
+        cls.red_sofa.allow_out_of_stock_order = True
+        cls.env['stock.quant'].create({
+            'product_id': cls.blue_sofa.id,
+            'quantity': 10.0,
+            'location_id': cls.stock_loc.id,
+        })
+
+    def test_gmc_items_availability_check_stock(self):
+        self.update_items()
+
+        self.assertEqual('in_stock', self.blue_sofa_item['availability'])
+        self.assertEqual('out_of_stock', self.items[self.blanket]['availability'])
+        self.assertEqual('in_stock', self.red_sofa_item['availability']) # allow_out_of_stock_order
+
+    def test_gmc_items_keep_website_stock_separate(self):
+        self.blue_sofa.allow_out_of_stock_order = False
+        # setup second website with seperate stock
+        website_2_warehouse = self.env['stock.warehouse'].create({'name': 'Stock 2', 'code': 'WH2'})
+        website_2 = self.env['website'].create({
+            'name': 'Website Test 2',
+            'domain': 'https://my-website.net',
+            'warehouse_id': website_2_warehouse.id,
+        })
+
+        self.update_items(website=website_2)
+
+        self.assertEqual('out_of_stock', self.red_sofa_item['availability'])


### PR DESCRIPTION
To ensure the multi-channel promotion of products through various platforms (e.g., Google, Meta, Pinterest, TikTok), we need to provide data feeds so that our users can easily input their catalog into these platforms.

This commit introduces a new route (/gmc.xml) for Google Merchant Center. This XML file serves as a product feed to Google, ensuring synchronization between our platform and Google's services.

The product feed can be configured to utilize a pricelist and can be translated to target different locations. For instance, if the French language is installed and there exists a pricelist named "UE" with the currency EUR, then "/fr/gmc-UE.xml" represents a feed in French, where all prices are displayed in EUR and computed according to the UE pricelist.

Docs: https://github.com/odoo/documentation/pull/12754

task-4319930

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
