### PR TITLE
[FIX] stock,repair: no longer break repair xpaths

### DIFF
--- a/addons/repair/views/stock_picking_views.xml
+++ b/addons/repair/views/stock_picking_views.xml
@@ -5,21 +5,23 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//label[@name='default_location_src_id_label']" position="before">
-                <field name="default_product_location_src_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
-                <field name="default_product_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
-            </xpath>
-            <xpath expr="//label[@name='default_location_src_id_label']" position="replace">
-                <label for="default_location_src_id" name="default_location_src_id_label" invisible="code == 'repair_operation'"/>
-                <label for="default_location_src_id" string="Component Source Location" invisible="code != 'repair_operation'"/>
-            </xpath>
-            <xpath expr="//label[@name='default_location_dest_id_label']" position="replace">
-                <label for="default_location_dest_id" name="default_location_dest_id_label" invisible="code == 'repair_operation'"/>
-                <label for="default_location_dest_id" string="Component Destination Location" invisible="code != 'repair_operation'"/>
-            </xpath>
-            <xpath expr="//div[@name='default_location_dest_id_div']" position="after">
-                <field name="default_remove_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
-                <field name="default_recycle_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
+            <xpath expr="//group[@name='locations']" position="replace">
+                <group string="Locations" groups="stock.group_stock_multi_locations" name="locations">
+                    <field name="default_product_location_src_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
+                    <field name="default_product_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
+                    <label for="default_location_src_id" name="default_location_src_id_label" invisible="code == 'repair_operation'"/>
+                    <label for="default_location_src_id" string="Component Source Location" invisible="code != 'repair_operation'"/>
+                    <div class="o_row" name="default_location_src_id_div">
+                        <field name="default_location_src_id" options="{'no_create': True}" required="1"/>
+                    </div>
+                    <label for="default_location_dest_id" name="default_location_dest_id_label" invisible="code == 'repair_operation'"/>
+                    <label for="default_location_dest_id" string="Component Destination Location" invisible="code != 'repair_operation'"/>
+                    <div class="o_row" name="default_location_dest_id_div">
+                        <field name="default_location_dest_id" options="{'no_create': True}" required="1"/>
+                    </div>
+                    <field name="default_remove_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
+                    <field name="default_recycle_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
+                </group>
             </xpath>
             <xpath expr="//group[@name='locations']" position="after">
                 <field name="return_type_of_ids" invisible="1"/>


### PR DESCRIPTION
Following https://github.com/odoo/odoo/pull/186831, the installation of the repair module would fail if
stock was previously installed without upgrading it first.

This is due to the new xpath defined in the repair module that reference the changed form in the stock module. However, if stock wasn't upgraded, then the new label / div don't exist yet, leading to an error as the xpaths link to something that doesn't exist yet.

This means that this patch needs to work with two possible versions of stock:
- The old one, with only <field> in the form
- The new one, with <field> and <label> in the form

Due to that singular situation, it made the declaration of xpath in repair impossible to have a proper target, as both versions of stock would require different targets and cannot co-exist.

To solve that situation, the choice was made to overwrite completely the common ancestor of the two versions (i.e. the locations <group>) and write it back in repair as if every previously declared xpath have been applied to it.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
