### PR TITLE
[FIX] html_editor: add preview for Solid and Custom colors in table

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -66,7 +66,7 @@ export class ColorPlugin extends Plugin {
     setup() {
         this.selectedColors = reactive({ color: "", backgroundColor: "" });
         this.previewableApplyColor = this.dependencies.history.makePreviewableOperation(
-            (color, mode) => this._applyColor(color, mode)
+            (color, mode, previewMode) => this._applyColor(color, mode, previewMode)
         );
     }
 
@@ -128,7 +128,8 @@ export class ColorPlugin extends Plugin {
      * @param {string} param.mode 'color' or 'backgroundColor'
      */
     applyColorPreview({ color, mode }) {
-        this.previewableApplyColor.preview(color, mode);
+        // Preview the color before applying it.
+        this.previewableApplyColor.preview(color, mode, true);
         this.updateSelectedColor();
     }
     /**
@@ -170,9 +171,10 @@ export class ColorPlugin extends Plugin {
      *
      * @param {string} color hexadecimal or bg-name/text-name class
      * @param {string} mode 'color' or 'backgroundColor'
+     * @param {boolean} [previewMode=false] true - apply color in preview mode
      */
-    _applyColor(color, mode) {
-        if (this.delegateTo("color_apply_overrides", color, mode)) {
+    _applyColor(color, mode, previewMode = false) {
+        if (this.delegateTo("color_apply_overrides", color, mode, previewMode)) {
             return;
         }
         let selection = this.dependencies.selection.getEditableSelection();

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -699,11 +699,15 @@ export class TablePlugin extends Plugin {
         return didDeselectTable;
     }
 
-    applyTableColor(color, mode) {
+    applyTableColor(color, mode, previewMode) {
         const selectedTds = [...this.editable.querySelectorAll("td.o_selected_td")].filter(
             (node) => node.isContentEditable
         );
         if (selectedTds.length && mode === "backgroundColor") {
+            if (previewMode) {
+                // Temporarily remove backgroundColor applied by "o_selected_td" class with !important.
+                selectedTds.forEach((td) => td.classList.remove("o_selected_td"));
+            }
             for (const td of selectedTds) {
                 this.dependencies.color.colorElement(td, color, mode);
             }

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -467,4 +467,128 @@ describe("color preview", () => {
         execCommand(editor, "historyUndo");
         expect("font").toHaveCount(0);
     });
+
+    test("should preview color in table on hover in solid tab", async () => {
+        const { el } = await setupEditor(`
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td>
+                            <p>[<br></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p>]<br></p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        `);
+        await waitFor(".o-we-toolbar");
+        await animationFrame();
+        await click(".o-select-color-background");
+        await animationFrame();
+        // Hover a color
+        await hover(queryOne("button[data-color='#CE0000']"));
+        expect(getContent(el)).toBe(`
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr>
+                        <td class="" style="background-color: rgb(206, 0, 0);">
+                            <p>[<br></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="" style="background-color: rgb(206, 0, 0);">
+                            <p>]<br></p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        `);
+        // Hover out
+        await hover(queryOne(".o-we-toolbar .o-select-color-foreground"));
+        await animationFrame();
+        expect(getContent(el)).toBe(`
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr>
+                        <td class="o_selected_td">
+                            <p>[<br></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="o_selected_td">
+                            <p>]<br></p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        `);
+        expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+    });
+
+    test("should preview color in table on hover in custom tab", async () => {
+        const { el } = await setupEditor(`
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td>
+                            <p>[<br></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p><br>]</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        `);
+        await waitFor(".o-we-toolbar");
+        await animationFrame();
+        await click(".o-select-color-background");
+        await animationFrame();
+        await click(".btn:contains('Custom')");
+        await animationFrame();
+        // Hover a color
+        await hover(queryOne("button[data-color='black']"));
+        expect(getContent(el)).toBe(`
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr>
+                        <td class="bg-black">
+                            <p>[<br></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="bg-black">
+                            <p>]<br></p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        `);
+        // Hover out
+        await hover(queryOne(".o-we-toolbar .o-select-color-foreground"));
+        await animationFrame();
+        expect(getContent(el)).toBe(`
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr>
+                        <td class="o_selected_td">
+                            <p>[<br></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="o_selected_td">
+                            <p>]<br></p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        `);
+        expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+    });
 });


### PR DESCRIPTION
### Steps to reproduce:

- Open a table (e.g., /table) and select a cell to apply backgroundColor.
- Hover over a color in the Gradient tab to see the preview update.
- Hover over a color in the Solid or Custom tab — no preview appears.

### Approach:

Setting previewMode to true in `onColorHover` temporarily removes `o_selected_td` class in applyTableColor, clearing backgroundColor to allow preview of the hovered color. `COLOR_RESET_PREVIEW` is dispatched on `onColorHoverOut`, reapplying o_selected_td.

### Description of the issue/feature this PR addresses:

- Only Gradient tab colors preview on hover in table cells.
- Solid and Custom tab colors do not trigger a preview.

### Desired behavior after PR is merged:

- Colors from the Solid and Custom tabs now preview on hover in table cells.

task-4320353