### PR TITLE
[FIX] web_editor, website: prevent tab duplication

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1587,7 +1587,7 @@ export function isUnbreakable(node) {
                 node.getAttribute('t-value') ||
                 node.getAttribute('t-out') ||
                 node.getAttribute('t-raw'))) ||
-        node.classList.contains('oe_unbreakable')
+        node.matches(".oe_unbreakable, a.btn, a[role='tab'], a[role='button']")
     );
 }
 


### PR DESCRIPTION
Steps To Reproduce:
-> Go to Edit mode.
-> Drag & Drop Tabs Snippet.
-> Click in middle of tab's text and press "Enter".
-> Tab is split and and new Tab is created.

Issue Reason:
As tab's element fails `isUnbreakable()` check for `Keydown`(Enter) event
which makes it possible to split the element. And issue is not specific
to Tab snippet but in other snippets where `anchor tag` and elements with
`btn` class or role attribute is `button`.

Solution:
By modifying checks in `isUnbreakable()` for handling elements with `anchor
tags` and elements with `btn` class or role attribute is `button`.

This PR solves the issue of tab duplication in Tab Snippet and few snippets in which there is already button and the said behavior is observed are : `Cover` , `Text - Image` , `Image - Text `, `Carousel `, `Donate
Now ( Button )` where anchor tag and elements with 'btn' class or role attribute is 'button', in `Masonry` and `Carousel` snippet which adds button
through `Add Element` option and also when we add a button using `/button` command in any snippets.

task-4316648