### PR TITLE
[FIX] purchase_stock: use currency rate at bill date when invoice before receipt

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -86,8 +86,12 @@ class StockMove(models.Model):
             # in assigned state. However, the move date is the scheduled date until move is
             # done, then date of actual move processing. See:
             # https://github.com/odoo/odoo/blob/2f789b6863407e63f90b3a2d4cc3be09815f7002/addons/stock/models/stock_move.py#L36
+            convert_date = fields.Date.context_today(self)
+            # use currency rate at bill date when invoice before receipt
+            if float_compare(line.qty_invoiced, received_qty, precision_rounding=line.product_uom.rounding) > 0:
+                convert_date = max(line.sudo().invoice_lines.move_id.filtered(lambda m: m.state == 'posted').mapped('invoice_date'), default=convert_date)
             price_unit = order.currency_id._convert(
-                price_unit, order.company_id.currency_id, order.company_id, fields.Date.context_today(self), round=False)
+                price_unit, order.company_id.currency_id, order.company_id, convert_date, round=False)
         return price_unit
 
     def _generate_valuation_lines_data(self, partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, svl_id, description):

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -3032,6 +3032,97 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
             {'debit': 0,    'credit': 45,   'account_id': stock_in_id,  'reconciled': True, 'amount_currency': -90},
         ])
 
+    def test_invoice_first_receipt_later_with_multicurrency_different_dates(self):
+        """Ensure sure that use currency rate at bill date rather than the current date when invoice before receipt"""
+        company = self.env.user.company_id
+        company.anglo_saxon_accounting = False
+        company.currency_id = self.usd_currency
+
+        self.product1.detailed_type = 'product'
+        self.product1.purchase_method = 'purchase'
+
+        self.product1.with_company(company).categ_id.property_cost_method = 'fifo'
+        self.product1.with_company(company).categ_id.property_valuation = 'real_time'
+
+
+        po_date = '2023-10-01'
+        bill_date = '2023-10-15'
+        receipt_date = '2023-10-31'
+
+        po_rate = 0.8
+        bill_rate = 2.0
+        receipt_rate = 2.2
+
+        self.env['res.currency.rate'].search([]).unlink()
+        self.env['res.currency.rate'].create([
+            {
+                'name': po_date,
+                'rate': po_rate,
+                'currency_id': self.eur_currency.id,
+                'company_id': company.id,
+            },
+            {
+                'name': bill_date,
+                'rate': bill_rate,
+                'currency_id': self.eur_currency.id,
+                'company_id': company.id,
+            },
+            {
+                'name': receipt_date,
+                'rate': receipt_rate,
+                'currency_id': self.eur_currency.id,
+                'company_id': company.id,
+            },
+        ])
+
+        with freeze_time(po_date):
+            purchase_price = 100
+            po = self.env['purchase.order'].create({
+                'partner_id': self.partner_id.id,
+                'currency_id': self.eur_currency.id,
+                'order_line': [
+                    Command.create({
+                        'product_id': self.product1.id,
+                        'product_qty': 1.0,
+                        'price_unit': purchase_price,
+                        'taxes_id': False,
+                    }),
+                ]
+            })
+            po.button_confirm()
+
+        with freeze_time(bill_date):
+            po.action_create_invoice()
+            bill = po.invoice_ids
+            bill.invoice_date = bill_date
+            bill.action_post()
+
+        with freeze_time(receipt_date):
+            receipt = po.picking_ids
+            receipt.move_ids.write({'quantity_done': 1.0})
+            receipt.button_validate()
+
+        product_accounts = self.product1.product_tmpl_id.get_product_accounts()
+        payable_id = self.company_data['default_account_payable'].id
+        stock_in_id = product_accounts['stock_input'].id
+        expense_id = product_accounts['expense'].id
+        stock_valuation = product_accounts['stock_valuation'].id
+
+        # 1 Units invoiced at rate 2 and unit price 100 = 50
+        self.assertRecordValues(bill.line_ids, [
+            # pylint: disable=bad-whitespace
+            {'debit': 50.0,    'credit': 0,    'account_id': expense_id,   'reconciled': False,    'amount_currency':  100.0},
+            {'debit': 0,        'credit': 50.0,  'account_id': payable_id,   'reconciled': False,    'amount_currency': -100.0},
+        ])
+
+        layer_receipt = receipt.move_ids.stock_valuation_layer_ids
+
+        self.assertRecordValues(layer_receipt.account_move_id.line_ids, [
+            # pylint: disable=bad-whitespace
+            {'debit': 0,   'credit': 50.0,    'account_id': stock_in_id,  'reconciled': False, 'amount_currency': -110.0},
+            {'debit': 50.0,   'credit': 0,    'account_id': stock_valuation,  'reconciled': False, 'amount_currency': 110.0},
+        ])
+
     def test_analytic_distribution_propagation_with_exchange_difference(self):
         # Create 2 rates in order to generate an exchange difference later.
         eur = self.env.ref('base.EUR')


### PR DESCRIPTION
In some business case when the invoice is done before the receipt, the `stock.valuation.layer` currency rate will be taken on the bill rather than the current date.

To reproduce the issue:
(Need account_accountant)
1. Create a product category PC
   - Costing method: FIFO
   - Inventory valuation: Automated
2. Create a product P
   - Type: Storable
   - Category: PC
3. On 10/11/2024, confirm a PO with 1 x P at Є10
4. On 11/11/2024, bill it with currency rate of 1.06 at $10.6
4. On 12/11/2024, receive P with currency rate of 1.07 at $10.7

Errors: The price SVL is different from the bill

Solution: Use currency rate at bill date rather than the current date when invoice before receipt




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
