### PR TITLE
[FIX] mrp: setting workorder duration traceback

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1540,7 +1540,7 @@ class MrpProduction(models.Model):
         for workorder in final_workorders:
             workorder._plan_workorder(replan)
 
-        workorders = self.workorder_ids.filtered(lambda w: w.state not in ['done', 'cancel'])
+        workorders = self.workorder_ids.filtered(lambda w: w.state not in ['done', 'cancel'] and w.leave_id)
         if not workorders:
             return
 


### PR DESCRIPTION
Steps to recreate the issue:

- Create a MO with the SEC-ASSEM bill of materials and confirm it
- Unblock the Drill 1 workcenter
- Start working on the packing work order
- Modify the duration on the long time assembly work order
- Save

Current behavior before PR:
Traceback

Desired behavior after PR is merged:
No traceback

When a work order depends on a another workorder, setting the duration on the depending work order will trigger a call to `_plan_workorder`, but all workorders don't necessarily have a leave_id as their depending on a non-finished work order.
The `min` and `max` functions can't work with False values, triggering the traceback.

task-id: 4282910

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
