### PR TITLE
[FIX] web: focus the search input when pressing the search toggler

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -34,6 +34,10 @@ export class SearchBar extends Component {
                 "search-bar-additional-menu": { optional: true },
             },
         },
+        toggler: {
+            type: Object,
+            optional: true,
+        },
     };
     static defaultProps = {
         autofocus: true,
@@ -45,6 +49,8 @@ export class SearchBar extends Component {
         this.searchItemsFields = this.env.searchModel.getSearchItems((f) => f.type === "field");
         this.root = useRef("root");
         this.ui = useService("ui");
+
+        this.visibilityState = useState(this.props.toggler?.state || { showSearchBar: true });
 
         // core state
         this.state = useState({
@@ -67,7 +73,7 @@ export class SearchBar extends Component {
         this.inputRef =
             this.env.config.disableSearchBarAutofocus || !this.props.autofocus
                 ? useRef("autofocus")
-                : useAutofocus();
+                : useAutofocus({ mobile: this.props.toggler !== undefined }); // only force the focus on touch devices when the toggler is present on small devices
 
         useBus(this.env.searchModel, "focus-search", () => {
             this.inputRef.el.focus();

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -102,7 +102,7 @@
     </t>
 
     <t t-name="web.SearchBar">
-        <div class="o_cp_searchview d-flex input-group mt-1 mt-md-0" role="search" t-ref="root">
+        <div t-if="visibilityState.showSearchBar" class="o_cp_searchview d-flex input-group mt-1 mt-md-0" role="search" t-ref="root">
             <div class="o_searchview form-control d-print-contents d-flex align-items-center py-1 border-end-0"
                  role="search" aria-autocomplete="list">
                 <button class="d-print-none btn border-0 p-0"

--- a/addons/web/static/src/views/calendar/calendar_controller.xml
+++ b/addons/web/static/src/views/calendar/calendar_controller.xml
@@ -11,7 +11,7 @@
                     <t t-call="{{ props.buttonTemplate }}"/>
                 </t>
                 <t t-set-slot="layout-actions">
-                    <SearchBar t-if="searchBarToggler.state.showSearchBar"/>
+                    <SearchBar toggler="searchBarToggler"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
                     <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>

--- a/addons/web/static/src/views/graph/graph_controller.xml
+++ b/addons/web/static/src/views/graph/graph_controller.xml
@@ -58,7 +58,7 @@
                     <CogMenu/>
                 </t>
                 <t t-set-slot="layout-actions">
-                    <SearchBar t-if="searchBarToggler.state.showSearchBar"/>
+                    <SearchBar toggler="searchBarToggler"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
                     <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>

--- a/addons/web/static/src/views/kanban/kanban_controller.xml
+++ b/addons/web/static/src/views/kanban/kanban_controller.xml
@@ -34,7 +34,7 @@
                     <CogMenu/>
                 </t>
                 <t t-set-slot="layout-actions">
-                    <SearchBar t-if="searchBarToggler.state.showSearchBar"/>
+                    <SearchBar toggler="searchBarToggler"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
                     <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -34,7 +34,7 @@
                 </t>
 
                 <t t-set-slot="layout-actions">
-                    <SearchBar t-if="searchBarToggler.state.showSearchBar" autofocus="firstLoad"/>
+                    <SearchBar toggler="searchBarToggler" autofocus="firstLoad"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
                     <t t-if="!hasSelectedRecords" t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>

--- a/addons/web/static/src/views/pivot/pivot_controller.xml
+++ b/addons/web/static/src/views/pivot/pivot_controller.xml
@@ -26,7 +26,7 @@
                     <CogMenu/>
                 </t>
                 <t t-set-slot="layout-actions">
-                    <SearchBar t-if="searchBarToggler.state.showSearchBar"/>
+                    <SearchBar toggler="searchBarToggler"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
                     <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -41,6 +41,7 @@ import {
 import { browser } from "@web/core/browser/browser";
 import { pick } from "@web/core/utils/objects";
 import { SearchBar } from "@web/search/search_bar/search_bar";
+import { useSearchBarToggler } from "@web/search/search_bar/search_bar_toggler";
 class Partner extends models.Model {
     name = fields.Char();
     bar = fields.Many2one({ relation: "partner" });
@@ -195,6 +196,32 @@ test.tags`desktop`("navigation with facets (2)", async () => {
     await keyDown("ArrowRight");
     await animationFrame();
     expect(queryFirst`.o_searchview .o_searchview_facet:nth-child(1)`).toBeFocused();
+});
+
+test.tags("mobile");
+test("search input is focused when being toggled", async () => {
+    class Parent extends Component {
+        static template = xml`
+            <div>
+                <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
+                <SearchBar toggler="searchBarToggler"/>
+            </div>
+        `;
+        static components = { SearchBar };
+        static props = ["*"];
+        setup() {
+            this.searchBarToggler = useSearchBarToggler();
+        }
+    }
+    await mountWithSearch(Parent, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+    });
+    expect(".o_searchview input").toHaveCount(0);
+    await contains(`button .fa-search`).click();
+    expect(".o_searchview input").toHaveCount(1);
+    expect(queryFirst`.o_searchview input`).toBeFocused();
 });
 
 test("search date and datetime fields. Support of timezones", async () => {

--- a/addons/web_hierarchy/static/src/hierarchy_controller.xml
+++ b/addons/web_hierarchy/static/src/hierarchy_controller.xml
@@ -21,7 +21,7 @@
                     <t t-call="{{ props.buttonTemplate }}"/>
                 </t>
                 <t t-set-slot="layout-actions">
-                    <SearchBar t-if="searchBarToggler.state.showSearchBar"/>
+                    <SearchBar toggler="searchBarToggler"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
                     <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>


### PR DESCRIPTION
This commit fixes the desired behavior when touching the SearchBarToggler. Before the fix, the input was not focused, and the user had to touch the search input once after having touched the toggler, which makes one step
 redundant.

Now, the input is automatically focused when the search bar is mounted on small devices (the only one having the toggler), to keep the current behavior that don't focus the input on touch devices when using the medium/large UI.

task-4269494