### PR TITLE
[REF] mail, various: improve find / create partners in mail flows

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5965,35 +5965,34 @@ class AccountMove(models.Model):
             # Helper to know if the partner is an internal one.
             return partner == company.partner_id or (partner.user_ids and all(user._is_internal() for user in partner.user_ids))
 
-        extra_domain = False
-        if custom_values.get('company_id'):
-            extra_domain = ['|', ('company_id', '=', custom_values['company_id']), ('company_id', '=', False)]
+        def is_right_company(partner):
+            if custom_values.get('company_id'):
+                return partner.company_id in [False, custom_values['company_id']]
+            return True
 
         # Search for partners in copy.
         cc_mail_addresses = email_split(msg_dict.get('cc', ''))
-        followers = [partner for partner in self._mail_find_partner_from_emails(cc_mail_addresses, extra_domain=extra_domain) if partner]
+        followers = self._partner_find_from_emails_single(cc_mail_addresses, filter_found=is_right_company, no_create=True)
 
         # Search for partner that sent the mail.
         from_mail_addresses = email_split(msg_dict.get('from', ''))
-        senders = partners = [partner for partner in self._mail_find_partner_from_emails(from_mail_addresses, extra_domain=extra_domain) if partner]
+        senders = partners = self._partner_find_from_emails_single(from_mail_addresses, filter_found=is_right_company, no_create=True)
 
         # Search for partners using the user.
         if not senders:
             user_partners = self.env['res.users'].sudo().search(
                 [('email_normalized', 'in', from_mail_addresses)]
             ).mapped('partner_id')
-            senders = partners = list(self.env['res.partner'].search([('id', 'in', user_partners.ids)]))
+            senders = partners = self.env['res.partner'].search([('id', 'in', user_partners.ids)])
 
         if partners:
             # Check we are not in the case when an internal user forwarded the mail manually.
             if is_internal_partner(partners[0]):
                 # Search for partners in the mail's body.
                 body_mail_addresses = set(email_re.findall(msg_dict.get('body')))
-                partners = [
-                    partner
-                    for partner in self._mail_find_partner_from_emails(body_mail_addresses, extra_domain=extra_domain)
-                    if not is_internal_partner(partner) and partner.company_id.id in (False, company.id)
-                ]
+                partners = self._partner_find_from_emails_single(
+                    body_mail_addresses, filter_found=is_right_company, no_create=True
+                ).filtered(lambda p: not is_internal_partner(p))
         # Little hack: Inject the mail's subject in the body.
         if msg_dict.get('subject') and msg_dict.get('body'):
             msg_dict['body'] = Markup('<div><div><h3>%s</h3></div>%s</div>') % (msg_dict['subject'], msg_dict['body'])

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -360,22 +360,6 @@ class EventRegistration(models.Model):
             registration_id=self.id,
         )
 
-    def _message_get_suggested_recipients(self):
-        recipients = super()._message_get_suggested_recipients()
-        public_users = self.env['res.users'].sudo()
-        public_groups = self.env.ref("base.group_public", raise_if_not_found=False)
-        if public_groups:
-            public_users = public_groups.sudo().with_context(active_test=False).mapped("users")
-        try:
-            is_public = self.sudo().with_context(active_test=False).partner_id.user_ids in public_users if public_users else False
-            if self.partner_id and not is_public:
-                self._message_add_suggested_recipient(recipients, partner=self.partner_id, reason=_('Customer'))
-            elif self.email:
-                self._message_add_suggested_recipient(recipients, email=self.email, reason=_('Customer Email'))
-        except AccessError:     # no read access rights -> ignore suggested recipients
-            pass
-        return recipients
-
     def _message_get_default_recipients(self):
         # Prioritize registration email over partner_id, which may be shared when a single
         # partner booked multiple seats

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -77,7 +77,7 @@ class ThreadController(http.Controller):
     def mail_thread_partner_from_email(self, emails, additional_values=None):
         partners = [
             {"id": partner.id, "name": partner.name, "email": partner.email}
-            for partner in request.env["res.partner"]._find_or_create_from_emails(emails, additional_values)
+            for partner in request.env["res.partner"]._find_or_create_from_emails(emails, additional_values=additional_values)
         ]
         return partners
 
@@ -124,7 +124,7 @@ class ThreadController(http.Controller):
             partners |= request.env["res.partner"].browse(
                 partner.id
                 for partner in request.env["res.partner"]._find_or_create_from_emails(
-                    kwargs["partner_emails"], additional_values
+                    kwargs["partner_emails"], additional_values=additional_values,
                 )
             )
         if not request.env.user._is_internal():

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2004,63 +2004,75 @@ class MailThread(models.AbstractModel):
                 found_results[res_id] |= partner
         return found_results
 
-    def _message_add_suggested_recipient(self, result, partner=None, email=None, lang=None, reason=''):
+    def _message_add_suggested_recipient(self, recipients, partner=None, email=None, reason=''):
         """ Called by _message_get_suggested_recipients, to add a suggested
-            recipient as a dictionary in the result list """
+        recipient as a dictionary in the result list """
         self.ensure_one()
-        partner_info = {}
-        recipient_data = {'lang': lang, 'reason': reason}
+        recipient_data = {'create_values': {}, 'partner_id': False, 'reason': reason}
         if email and not partner:
-            # get partner info from email
-            partner_info = self._message_partner_info_from_emails([email])[0]
-            if partner_info.get('partner_id'):
-                partner = self.env['res.partner'].sudo().browse([partner_info['partner_id']])[0]
-        if email and email in [val['email'] for val in result if val.get('email')]:  # already existing email -> skip
-            return result
+            partner = self._partner_find_from_emails_single([email], no_create=True)
+            if partner:
+                recipient_data['name'] = partner.name
+
+        # check if already suggested
+        parse_name, email_normalized = parse_contact_from_email(email)
+        if email_normalized and email_normalized in {val['email'] for val in recipients}:  # already existing email -> skip
+            return recipients
         if partner and partner in self.message_partner_ids:  # recipient already in the followers -> skip
-            return result
-        if partner and partner.id in [val.get('partner_id', False) for val in result]:  # already existing partner ID -> skip
-            return result
-        if partner and partner.email:  # complete profile: id, name <email>
-            email_normalized = ','.join(email_normalize_all(partner.email))
-            recipient_data.update({'partner_id': partner.id, 'name': partner.name or '', 'email': email_normalized})
-        elif partner:  # incomplete profile: id, name
-            recipient_data.update({'partner_id': partner.id, 'name': partner.name})
+            return recipients
+        if partner and partner.id in {val['partner_id'] for val in recipients}:  # already existing partner ID -> skip
+            return recipients
+
+        if partner:
+            recipient_data.update({
+                'partner_id': partner.id, 'name': partner.name,
+                'email': ','.join(email_normalize_all(partner.email)) or partner.email,
+            })
         else:  # unknown partner, we are probably managing an email address
-            _, parsed_email_normalized = parse_contact_from_email(email)
-            partner_create_values = self._get_customer_information().get(parsed_email_normalized, {})
-            name = partner_create_values.get('name') or partner_info.get('full_name') or email
+            customer_values = self._get_customer_information().get(email_normalized) or {}
+            name = recipient_data.get('name') or customer_values.pop('name', False) or parse_name
             recipient_data.update({
                 'name': name,
-                'email': partner_info.get('full_name') or email,
-                'create_values': partner_create_values,
+                'email': email_normalized,
+                'create_values': customer_values,
             })
-        result.append(recipient_data)
-        return result
+        recipients.append(recipient_data)
+        return recipients
 
     def _message_get_suggested_recipients(self):
         """ Get suggested recipients to be managed by Chatter
 
         :returns: list of dictionaries (per suggested recipient) containing:
-            * partner_id:       int: recipient partner id
-            * name:             str: name of the recipient
-            * email:            str: email of recipient
-            * lang:             str: language code
-            * reason:           str
-            * create_values:    dict: data for unknown partner
+            * partner_id:            int: recipient partner id
+            * name:                  str: name of the recipient
+            * email:                 str: email of recipient
+            * reason:                str
+            * new_partner_values:   dict: data for unknown partner
         """
         self.ensure_one()
-        result = []
+        recipients = []
+
+        # add responsible
         user_field = self._fields.get('user_id')
         if user_field and user_field.type == 'many2one' and user_field.comodel_name == 'res.users':
             thread = self.sudo()  # SUPERUSER because of a read on res.users that would crash otherwise
             if thread.user_id and thread.user_id.partner_id:
                 thread._message_add_suggested_recipient(
-                    result,
-                    partner=thread.user_id.partner_id,
-                    reason=self._fields['user_id'].string,
+                    recipients, partner=thread.user_id.partner_id, reason=self._fields['user_id'].string,
                 )
-        return result
+
+        # add customers
+        customers = self._mail_get_partners()[self.id]
+        for customer in customers.filtered(lambda p: not p.is_public):
+            self._message_add_suggested_recipient(recipients, partner=customer, reason=_('Customer'))
+
+        # add email
+        email_fname = self._mail_get_primary_email_field()
+        email_normalized = email_fname and email_normalize(self[email_fname], strict=False)
+        if email_normalized and email_normalized not in customers.mapped('email_normalized'):
+            self._message_add_suggested_recipient(recipients, email=self[email_fname], reason=_('Customer Email'))
+
+        return recipients
 
     def _mail_find_user_for_gateway(self, email_value, alias=None):
         """ Utility method to find user from email address that can create documents
@@ -2142,28 +2154,6 @@ class MailThread(models.AbstractModel):
                     self.env['res.partner']
                 ))
         return results
-
-    def _message_partner_info_from_emails(self, emails, link_mail=False):
-        """ Convert a list of emails into a list partner_ids and a list
-            new_partner_ids. The return value is non conventional because
-            it is meant to be used by the mail widget.
-
-            :return dict: partner_ids and new_partner_ids """
-        self.ensure_one()
-        MailMessage = self.env['mail.message'].sudo()
-        partners = self._mail_find_partner_from_emails(emails, records=self)
-        result = list()
-        for idx, contact in enumerate(emails):
-            partner = partners[idx]
-            partner_info = {'full_name': partner.email_formatted if partner else contact, 'partner_id': partner.id}
-            result.append(partner_info)
-            # link mail with this from mail to the new partner id
-            if link_mail and partner:
-                MailMessage.search([
-                    ('email_from', '=ilike', partner.email_normalized),
-                    ('author_id', '=', False)
-                ]).write({'author_id': partner.id})
-        return result
 
     def _get_customer_information(self):
         """ Get customer information that can be extracted from the records by

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -16,7 +16,7 @@ import re
 import time
 import threading
 
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 from collections.abc import Iterable
 from email import message_from_string
 from email.message import EmailMessage
@@ -1888,6 +1888,121 @@ class MailThread(models.AbstractModel):
     # ------------------------------------------------------
     # RECIPIENTS MANAGEMENT TOOLS
     # ------------------------------------------------------
+
+    def _partner_find_from_emails_single(self, emails, avoid_alias=True, filter_found=None, additional_values=None, no_create=False):
+        """ Shortcut version of '_partner_find_from_emails', two usages.
+
+        Either 'record._partner_find_from_emails_single([..])' on a singleton
+        recordset to skip dictionaries manipulation.
+        Either 'MailThread._partner_find_from_emails_single([..])' to use as a
+        generic tool method, without any record-based context values propagation. """
+        if self:  # void recordset allowed as tool mixin method
+            self.ensure_one()
+        return self._partner_find_from_emails(
+            {self: emails}, avoid_alias=avoid_alias, filter_found=filter_found, additional_values=additional_values, no_create=no_create
+        )[self.id]
+
+    def _partner_find_from_emails(self, records_emails, avoid_alias=True, filter_found=None, additional_values=None, no_create=False):
+        """ Find or create partners based on emails. Result is contextualized
+        based on records, calling 'Model._get_customer_information()' to populate
+        new partners data. It relies on 'ResPartner._find_or_create_from_emails()'
+        for name / email parsing and record creation.
+
+        :param dict records_emails: for each record in self, list of emails linked
+          to this record e.g. {<crm.lead, 4>: ['"Customer" <customer@test.example.com>']};
+        :param bool avoid_alias: skip link for any email matching existing aliases
+          notably to avoid creating contacts that could mess with mailgateway;
+        :param callable filter_found: if given, filters found partners based on emails;
+        :param dict additional_values: optional email-key based dict, giving
+          values to populate new partners. Added to default values coming from
+          'Model._get_customer_information()';
+        :param bool no_create: skip the 'create' part of 'find or create'. Allows
+          to use tool as 'find and sort' without adding new partners in db;
+
+        :return: for each record ID, a ResPartner recordset containing found
+            (or created) partners based on given emails. As emails are normalized
+            less partners maybe present compared to input if duplicates are
+            present;
+        :rtype: dict
+        """
+        if self and len(self) != len(records_emails):
+            raise ValueError('Invoke with either self maching records_emails, either on a void recordset.')
+        # when invoked through MailThread, ids may come from records_emails (not recommended tool usage)
+        res_ids = self.ids or [record.id for record in records_emails]
+        found_results = dict.fromkeys(res_ids, self.env['res.partner'])
+        # email_key is email_normalized, unless email is wrong and cannot be normalized
+        # in which case the raw input is used instead, to distinguish various wrong
+        # inputs
+        emails_all = []
+        emails_key_all = []
+        emails_key_company_id = {}
+        emails_key_res_ids = defaultdict(list)
+
+        # fetch company information (as sudo, as we should not crash for that)
+        records_company = self.sudo()._mail_get_companies()
+        # fetch model-related additional information
+        emails_normalized_info = self._get_customer_information()
+        for email_key, update in (additional_values or {}).items():
+            emails_normalized_info.setdefault(email_key, {}).update(**update)
+
+        # classify email / company and email / record IDs
+        for record, mails in records_emails.items():
+            mails = records_emails.get(record, [])
+            record_company = records_company.get(record.id, self.env['res.company'])
+            for mail in mails:
+                mail_normalized = email_normalize(mail, strict=False)
+                email_key = mail_normalized or mail
+                emails_key_res_ids[email_key].append(record.id)
+                if record_company and email_key:  # False is not interesting anyway
+                    emails_key_company_id[email_key] = record_company.id
+                emails_all.append(mail)
+                emails_key_all.append(email_key)
+        if not emails_all:  # early skip, no need to do searches / ...
+            return found_results
+
+        # fetch information used to find existing partners, beware portal/public who
+        # cannot read followers
+        followers = self.sudo().message_partner_ids
+        aliases = self.env['mail.alias'].sudo().search(
+            [('alias_full_name', 'in', emails_key_all)]
+        ) if avoid_alias else self.env['mail.alias'].sudo()
+        emails_ban = aliases.mapped('alias_full_name')
+
+        # inspired notably from odoo/odoo@80a0b45df806ffecfb068b5ef05ae1931d655810; final
+        # ordering is search order defined in '_find_or_create_from_emails', which is id ASC
+        def sort_key(p):
+            return (
+                p == self.env.user.partner_id,                      # prioritize user
+                p in followers,                                     # then followers
+                not p.partner_share,                                # prioritize internal users
+                bool(p.user_ids),                                   # prioritize portal users
+                p.company_id.id == emails_key_company_id.get(
+                    p.email_normalized, False
+                ),                                                  # then partner associated w/ record's company
+                not p.company_id,                                   # then company-agnostic to avoid issues
+            )
+
+        partners = self.env['res.partner']._find_or_create_from_emails(
+            emails_all,
+            additional_values={
+                mail_key: {
+                    'company_id': emails_key_company_id.get(mail_key, False),
+                    **emails_normalized_info.get(mail_key, {}),
+                } for mail_key in emails_key_all
+            },
+            ban_emails=emails_ban,
+            filter_found=filter_found,
+            no_create=no_create,
+            sort_key=sort_key,
+            sort_reverse=True,  # False < True, simplified writing sort
+        )
+
+        for mail, partner in zip(emails_all, partners):
+            mail_key = email_normalize(mail, strict=False) or mail
+            for res_id in emails_key_res_ids[mail_key]:
+                # use an "OR" to avoid duplicates in returned recordset
+                found_results[res_id] |= partner
+        return found_results
 
     def _message_add_suggested_recipient(self, result, partner=None, email=None, lang=None, reason=''):
         """ Called by _message_get_suggested_recipients, to add a suggested

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -110,34 +110,43 @@ class ResPartner(models.Model):
         return self.create(create_values)
 
     @api.model
-    def _find_or_create_from_emails(self, emails, additional_values=None):
-        """ Based on a list of emails, find or create partners. Additional values
-        can be given to newly created partners. If an email is not unique (e.g.
-        multi-email input), only the first found email is considered.
+    def _find_or_create_from_emails(self, emails, filter_found=None,
+                                    additional_values=None,
+                                    sort_key=None, sort_reverse=True,
+                                    no_create=False):
+        """ Based on a list of emails, find or (optionally) create partners.
+        If an email is not unique (e.g. multi-email input), only the first found
+        valid email in input is considered. Filter and sort options allow to
+        tweak the way we link emails to partners (e.g. share partners only, ...).
 
-        Additional values allow to customize the created partner when context
-        allows to give more information. It data is based on email normalized
-        as it is the main information used in this method to distinguish or
-        find partners.
+        Optional additional values allow to customize the created partner. Data
+        are given per normalized email as it the creation criterion.
 
-        If no valid email is found for a given item, the given value is used to
-        find partners with same invalid email or create a new one with the wrong
-        value. It allows updating it afterwards. Notably with notifications
-        resend it is possible to update emails, if only a typo prevents from
-        having a real email for example.
+        When an email is invalid but not void, it is used for search or create.
+        It allows updating it afterwards e.g. with notifications resend which
+        allows fixing typos / wrong emails.
 
-        :param list emails: list of emails that may be formatted (each input
-          will be parsed and normalized);
-        :param dict additional_values: additional values per normalized email
-          given to create if the partner is not found. Typically used to
+        :param list emails: list of emails that can be formatted;
+        :param filter_found: if given, filters found partners based on emails;
+        :param dict additional_values: additional values per normalized or
+          raw invalid email given to partner creation. Typically used to
           propagate a company_id and customer information from related record.
-          Values for key 'False' are used when creating partner for invalid
-          emails;
+          If email cannot be normalized, raw value is used as dict key instead;
+        :param sort_key: an optional sorting key for sorting partners before
+          finding one with matching email normalized. When several partners
+          have the same email, users might want to give a preference based
+          on e.g. company, being a customer or not, ... Default ordering is
+          to use 'id ASC', which means older partners first as they are considered
+          as more relevant compared to default 'complete_name';
+        :param bool sort_reverse: given to sorted (see 'reverse' argument of sort);
+        :param bool no_create: skip the 'create' part of 'find or create'. Allows
+          to use tool as 'find and sort' without adding new partners in db;
 
-        :return: res.partner records in a list, following order of emails. It
-          is not a recordset, to keep Falsy values.
+        :return: res.partner records in a list, following order of emails. Using
+          a list allows to to keep Falsy values when no match;
+        :rtype: list
         """
-        additional_values = additional_values if additional_values else {}
+        additional_values = additional_values or {}
         partners, tocreate_vals_list = self.env['res.partner'], []
         name_emails = [tools.parse_contact_from_email(email) for email in emails]
 
@@ -159,43 +168,48 @@ class ResPartner(models.Model):
                 domains.append([('email_normalized', 'in', list(emails_normalized))])
             if names:
                 domains.append([('email', 'in', list(names))])
-            partners += self.search(expression.OR(domains))
+            partners += self.search(expression.OR(domains), order='id ASC')
+            if filter_found:
+                partners = partners.filtered(filter_found)
 
-        # create partners for valid email without any existing partner. Keep
-        # only first found occurrence of each normalized email, aka: ('Norbert',
-        # 'norbert@gmail.com'), ('Norbert With Surname', 'norbert@gmail.com')'
-        # -> a single partner is created for email 'norbert@gmail.com'
-        seen = set()
-        notfound_emails = (emails_normalized - set(partners.mapped('email_normalized'))) if partners else emails_normalized
-        notfound_name_emails = [
-            name_email
-            for name_email in name_emails
-            if name_email[1] in notfound_emails and name_email[1] not in seen
-               and not seen.add(name_email[1])
-        ]
-        tocreate_vals_list += [
-            {
-                self._rec_name: name or email_normalized,
-                'email': email_normalized,
-                **additional_values.get(email_normalized, {}),
-            }
-            for name, email_normalized in notfound_name_emails
-        ]
+        if not no_create:
+            # create partners for valid email without any existing partner. Keep
+            # only first found occurrence of each normalized email, aka: ('Norbert',
+            # 'norbert@gmail.com'), ('Norbert With Surname', 'norbert@gmail.com')'
+            # -> a single partner is created for email 'norbert@gmail.com'
+            seen = set()
+            notfound_emails = emails_normalized - set(partners.mapped('email_normalized'))
+            notfound_name_emails = [
+                name_email
+                for name_email in name_emails
+                if name_email[1] in notfound_emails and name_email[1] not in seen
+                and not seen.add(name_email[1])
+            ]
+            tocreate_vals_list += [
+                {
+                    self._rec_name: name or email_normalized,
+                    'email': email_normalized,
+                    **additional_values.get(email_normalized, {}),
+                }
+                for name, email_normalized in notfound_name_emails
+            ]
+            # create partners for invalid emails (aka name and not email_normalized)
+            # without any existing partner
+            tocreate_vals_list += [
+                {
+                    self._rec_name: name,
+                    'email': name,
+                    **additional_values.get(name, {}),
+                }
+                for name in names if name not in partners.mapped('email')
+            ]
+            # create partners once
+            if tocreate_vals_list:
+                partners += self.create(tocreate_vals_list)
 
-        # create partners for invalid emails (aka name and not email_normalized)
-        # without any existing partner
-        tocreate_vals_list += [
-            {
-                self._rec_name: name,
-                'email': name,
-                **additional_values.get(False, {}),
-            }
-            for name in names if name not in partners.mapped('email')
-        ]
-
-        # create partners once
-        if tocreate_vals_list:
-            partners += self.create(tocreate_vals_list)
+        # sort partners (already ordered based on search)
+        if sort_key:
+            partners = partners.sorted(key=sort_key, reverse=sort_reverse)
 
         return [
             next(

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -493,14 +493,13 @@ export class Composer extends Component {
             );
             if (newPartners.length !== 0) {
                 const recipientEmails = [];
-                const recipientAdditionalValues = {};
                 newPartners.forEach((recipient) => {
                     recipientEmails.push(recipient.email);
-                    recipientAdditionalValues[recipient.email] = recipient.create_values || {};
                 });
                 const partners = await rpc("/mail/partner/from_email", {
+                    thread_model: this.thread.model,
+                    thread_id: this.thread.id,
                     emails: recipientEmails,
-                    additional_values: recipientAdditionalValues,
                 });
                 for (const index in partners) {
                     const partnerData = partners[index];

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -455,7 +455,6 @@ export class Store extends BaseStore {
         });
         const partner_ids = validMentions?.partners.map((partner) => partner.id) ?? [];
         const recipientEmails = [];
-        const recipientAdditionalValues = {};
         if (!isNote) {
             const recipientIds = thread.suggestedRecipients
                 .filter((recipient) => recipient.persona && recipient.checked)
@@ -464,7 +463,6 @@ export class Store extends BaseStore {
                 .filter((recipient) => recipient.checked && !recipient.persona)
                 .forEach((recipient) => {
                     recipientEmails.push(recipient.email);
-                    recipientAdditionalValues[recipient.email] = recipient.create_values;
                 });
             partner_ids.push(...recipientIds);
         }
@@ -500,7 +498,6 @@ export class Store extends BaseStore {
         if (recipientEmails.length) {
             Object.assign(params, {
                 partner_emails: recipientEmails,
-                partner_additional_values: recipientAdditionalValues,
             });
         }
         return params;

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -640,7 +640,6 @@ export async function mail_message_post(request) {
         thread_id,
         thread_model,
         partner_emails,
-        partner_additional_values,
         canned_response_ids,
     } = await parseRequestParams(request);
     if (canned_response_ids) {
@@ -658,7 +657,7 @@ export async function mail_message_post(request) {
                 post_data.partner_ids.push(partner[0].id);
             } else {
                 const partner_id = ResPartner.create(
-                    Object.assign({ email }, partner_additional_values[email] || {})
+                    Object.assign({ email })
                 );
                 post_data.partner_ids.push(partner_id);
             }
@@ -784,7 +783,9 @@ async function mail_thread_partner_from_email(request) {
     /** @type {import("mock_models").ResPartner} */
     const ResPartner = this.env["res.partner"];
 
-    const { emails, additional_values = {} } = await parseRequestParams(request);
+    const { thread_model, thread_id, emails } = await parseRequestParams(request);
+    // use variables, but don't actually implement py in JS, much effort for nothing
+    this.env[thread_model].browse(thread_id);
     const partners = emails.map((email) => ResPartner.search([["email", "=", email]])[0]);
     for (const index in partners) {
         if (!partners[index]) {
@@ -792,7 +793,6 @@ async function mail_thread_partner_from_email(request) {
             partners[index] = ResPartner.create({
                 email,
                 name: email,
-                ...(additional_values[email] || {}),
             });
         }
     }

--- a/addons/mail/tests/discuss/test_discuss_thread_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_thread_controller.py
@@ -79,6 +79,7 @@ class TestDiscussThreadController(MailControllerThreadCommon):
             {"name": "Public Channel", "group_public_id": None}
         )
         no_emails = []
+        existing_emails = [self.user_employee.email]
         partner_emails = [self.user_employee.email, "test@example.com"]
 
         def test_emails(user, allowed, exp_emails, exp_author=None):
@@ -96,8 +97,8 @@ class TestDiscussThreadController(MailControllerThreadCommon):
                 test_emails(self.user_public, True, no_emails),
                 test_emails(self.guest, True, no_emails),
                 test_emails(self.user_portal, True, no_emails),
-                # restricted because not base.group_partner_manager
-                test_emails(self.user_employee_nopartner, True, no_emails),
+                # restricted because not base.group_partner_manager: find existing only
+                test_emails(self.user_employee_nopartner, True, existing_emails),
                 test_emails(self.user_employee, True, partner_emails),
                 test_emails(self.user_admin, True, partner_emails),
             ),

--- a/addons/mail/tests/test_mail_tools.py
+++ b/addons/mail/tests/test_mail_tools.py
@@ -150,10 +150,11 @@ class TestMailTools(MailCommon):
         company_id. """
         Partner = self.env['res.partner']
         self.test_partner.company_id = self.company_2
+        self.test_partner.write({'name': 'Original - Company2'})
 
-        test_partner_no_company = self.test_partner.copy({'company_id': False})
+        test_partner_no_company = self.test_partner.copy({'name': 'NoCompany', 'company_id': False})
         test_partner_company_2 = self.test_partner
-        test_partner_company_3 = test_partner_no_company.copy({'company_id': self.company_3.id})
+        test_partner_company_3 = test_partner_no_company.copy({'name': 'Company3', 'company_id': self.company_3.id})
         records = [
             None,
             *Partner.create([
@@ -168,9 +169,10 @@ class TestMailTools(MailCommon):
             (test_partner_company_3, "Prefer same company as reference record."),
             (test_partner_no_company, "Prefer non-specific partner for non-specific records."),
         ]
-        for record, (expected_partner, msg) in zip(records, expected_partners):
-            found = Partner._mail_find_partner_from_emails([self._test_email], records=record)
-            self.assertEqual(found, [expected_partner], msg)
+        for record, (expected, msg) in zip(records, expected_partners):
+            with self.subTest(record=record.name if record else 'NoRecord'):
+                found = Partner._mail_find_partner_from_emails([self._test_email], records=record)
+                self.assertEqual(found, [expected], f'Found {found[0].name} instead of {expected[0].name}: {msg}')
 
 
 @tagged('mail_tools', 'mail_init')

--- a/addons/mail/tests/test_mail_tools.py
+++ b/addons/mail/tests/test_mail_tools.py
@@ -45,9 +45,6 @@ class TestMailTools(MailCommon):
         # test with wildcard "_"
         found = Partner._mail_find_partner_from_emails(['alfred_astaire@test.example.com'])
         self.assertEqual(found, [self.env['res.partner']])
-        # sub-check: this search does not consider _ as a wildcard
-        found = Partner._mail_search_on_partner(['alfred_astaire@test.example.com'])
-        self.assertEqual(found, self.env['res.partner'])
 
         # test partners with encapsulated emails
         # ------------------------------------------------------------
@@ -69,9 +66,6 @@ class TestMailTools(MailCommon):
         # test with wildcard "_"
         found = Partner._mail_find_partner_from_emails(['alfred_astaire@test.example.com'])
         self.assertEqual(found, [self.env['res.partner']])
-        # sub-check: this search does not consider _ as a wildcard
-        found = Partner._mail_search_on_partner(['alfred_astaire@test.example.com'])
-        self.assertEqual(found, self.env['res.partner'])
 
     @users('employee')
     def test_mail_find_partner_from_emails_followers(self):

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -278,10 +278,10 @@ class TestPartner(MailCommon):
             partners = self.env['res.partner'].with_context(lang='en_US')._find_or_create_from_emails(
                 all_emails,
                 additional_values={
-                    tools.email_normalize(email): {
+                    tools.email_normalize(email) or email: {
                         'company_id': self.env.company.id,
                     }
-                    for email in all_emails
+                    for email in all_emails if email and email.strip()
                 },
             )
         self.assertEqual(len(partners), len(new_samples))

--- a/addons/mail_group/controllers/portal.py
+++ b/addons/mail_group/controllers/portal.py
@@ -345,9 +345,8 @@ class PortalMailGroup(http.Controller):
         if not group:
             return request.render('mail_group.invalid_token_subscription')
 
-        partners = request.env['mail.thread'].sudo()._mail_find_partner_from_emails([email])
-        partner_id = partners[0].id if partners else None
-        group._join_group(email, partner_id)
+        partner = request.env['mail.thread'].sudo()._partner_find_from_emails_single([email], no_create=True)
+        group._join_group(email, partner.id)
 
         return request.render('mail_group.confirmation_subscription', {
             'group': group,

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1686,13 +1686,6 @@ class ProjectTask(models.Model):
         self.message_subscribe(partner_ids)
         return super().message_update(msg, update_vals=update_vals)
 
-    def _message_get_suggested_recipients(self):
-        recipients = super()._message_get_suggested_recipients()
-        if self.partner_id:
-            reason = _('Customer Email') if self.partner_id.email else _('Customer')
-            self._message_add_suggested_recipient(recipients, partner=self.partner_id, reason=reason)
-        return recipients
-
     def _notify_by_email_get_headers(self, headers=None):
         headers = super()._notify_by_email_get_headers(headers=headers)
         if self.project_id:

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1645,12 +1645,6 @@ class ProjectTask(models.Model):
                 self.with_context(lang=user.lang)._get_default_personal_stage_create_vals(user.id)
             )
 
-    def task_email_split(self, msg):
-        email_list = tools.email_split((msg.get('to') or '') + ',' + (msg.get('cc') or ''))
-        # check left-part is not already an alias
-        aliases = self.mapped('project_id.alias_name')
-        return [x for x in email_list if x.split('@')[0] not in aliases]
-
     @api.model
     def message_new(self, msg, custom_values=None):
         # remove default author when going through the mail gateway. Indeed we
@@ -1675,13 +1669,13 @@ class ProjectTask(models.Model):
         defaults.update(custom_values)
 
         task = super(ProjectTask, self.with_context(create_context)).message_new(msg, custom_values=defaults)
-        partners = task._partner_find_from_emails_single(task.task_email_split(msg), no_create=True)
+        partners = task._partner_find_from_emails_single(tools.email_split((msg.get('to') or '') + ',' + (msg.get('cc') or '')), no_create=True)
         task.message_subscribe(partners.ids)
         return task
 
     def message_update(self, msg, update_vals=None):
         for task in self:
-            partners = task._partner_find_from_emails_single(task.task_email_split(msg), no_create=True)
+            partners = task._partner_find_from_emails_single(tools.email_split((msg.get('to') or '') + ',' + (msg.get('cc') or '')), no_create=True)
             task.message_subscribe(partners.ids)
         return super().message_update(msg, update_vals=update_vals)
 

--- a/addons/project/tests/test_project_base.py
+++ b/addons/project/tests/test_project_base.py
@@ -13,6 +13,7 @@ class TestProjectCommon(TransactionCase):
         super(TestProjectCommon, cls).setUpClass()
         cls.env.company.resource_calendar_id.tz = "Europe/Brussels"
 
+        user_group_partner_manager = cls.env.ref('base.group_partner_manager')
         user_group_employee = cls.env.ref('base.group_user')
         user_group_project_user = cls.env.ref('project.group_project_user')
         user_group_project_manager = cls.env.ref('project.group_project_manager')
@@ -48,13 +49,13 @@ class TestProjectCommon(TransactionCase):
             'login': 'armandel',
             'password': 'armandel',
             'email': 'armande.projectuser@example.com',
-            'groups_id': [(6, 0, [user_group_employee.id, user_group_project_user.id])]
+            'groups_id': [(6, 0, [user_group_employee.id, user_group_project_user.id, user_group_partner_manager.id])]
         })
         cls.user_projectmanager = Users.create({
             'name': 'Bastien ProjectManager',
             'login': 'bastien',
             'email': 'bastien.projectmanager@example.com',
-            'groups_id': [(6, 0, [user_group_employee.id, user_group_project_manager.id])]})
+            'groups_id': [(6, 0, [user_group_employee.id, user_group_project_manager.id, user_group_partner_manager.id])]})
 
         # Test 'Pigs' project
         cls.project_pigs = cls.env['project.project'].with_context({'mail_create_nolog': True}).create({

--- a/addons/project/tests/test_project_mail_features.py
+++ b/addons/project/tests/test_project_mail_features.py
@@ -3,7 +3,6 @@ from odoo.addons.project.tests.test_project_base import TestProjectCommon
 from odoo.addons.test_mail.data.test_mail_data import MAIL_TEMPLATE
 from odoo.tests import tagged, users
 from odoo.tools import formataddr, mute_logger
-from odoo.tools.mail import email_normalize
 
 
 @tagged('post_install', '-at_install', 'mail_flow', 'mail_tools')
@@ -280,9 +279,9 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                 expected_all = [
                     {  # mail.thread.cc: email_cc field
                         'create_values': {},
-                        'email': '"New Cc" <new.cc@test.agrolait.com>',
-                        'lang': None,
-                        'name': '"New Cc" <new.cc@test.agrolait.com>',
+                        'email': 'new.cc@test.agrolait.com',
+                        'name': 'New Cc',
+                        'partner_id': False,
                         'reason': 'CC Email',
                     },
                     # other CC (partner_2) and customer (partner_id) already follower
@@ -290,7 +289,8 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                 for suggested, expected in zip(suggested_all, expected_all):
                     self.assertDictEqual(suggested, expected)
                 # check recipients, which creates them (simulating discuss in a quick way)
-                task.with_user(self.user_projectuser)._partner_find_from_emails_single([sug['email'] for sug in suggested_all])
+                task.with_user(self.user_projectuser)._partner_find_from_emails_single(
+                    [formataddr((sug['name'], sug['email'])) for sug in suggested_all])
                 new_partner_cc = self.env['res.partner'].search([('email_normalized', '=', 'new.cc@test.agrolait.com')])
                 self.assertEqual(new_partner_cc.email, 'new.cc@test.agrolait.com')
                 self.assertEqual(new_partner_cc.name, 'New Cc')

--- a/addons/project/tests/test_project_mail_features.py
+++ b/addons/project/tests/test_project_mail_features.py
@@ -290,10 +290,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                 for suggested, expected in zip(suggested_all, expected_all):
                     self.assertDictEqual(suggested, expected)
                 # check recipients, which creates them (simulating discuss in a quick way)
-                self.env["res.partner"]._find_or_create_from_emails(
-                    [sug['email'] for sug in suggested_all],
-                    additional_values={email_normalize(sug['email']): sug.get('create_values') or {} for sug in suggested_all},
-                )
+                task.with_user(self.user_projectuser)._partner_find_from_emails_single([sug['email'] for sug in suggested_all])
                 new_partner_cc = self.env['res.partner'].search([('email_normalized', '=', 'new.cc@test.agrolait.com')])
                 self.assertEqual(new_partner_cc.email, 'new.cc@test.agrolait.com')
                 self.assertEqual(new_partner_cc.name, 'New Cc')

--- a/addons/project/tests/test_project_mail_features.py
+++ b/addons/project/tests/test_project_mail_features.py
@@ -6,7 +6,7 @@ from odoo.tools import formataddr, mute_logger
 from odoo.tools.mail import email_normalize
 
 
-@tagged('post_install', '-at_install', 'mail_flow')
+@tagged('post_install', '-at_install', 'mail_flow', 'mail_tools')
 class TestProjectMailFeatures(TestProjectCommon, MailCommon):
 
     @classmethod
@@ -292,7 +292,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                 # check recipients, which creates them (simulating discuss in a quick way)
                 self.env["res.partner"]._find_or_create_from_emails(
                     [sug['email'] for sug in suggested_all],
-                    {email_normalize(sug['email']): sug.get('create_values') or {} for sug in suggested_all},
+                    additional_values={email_normalize(sug['email']): sug.get('create_values') or {} for sug in suggested_all},
                 )
                 new_partner_cc = self.env['res.partner'].search([('email_normalized', '=', 'new.cc@test.agrolait.com')])
                 self.assertEqual(new_partner_cc.email, 'new.cc@test.agrolait.com')

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1766,14 +1766,6 @@ class SaleOrder(models.Model):
             return self.env.ref('sale.mt_order_sent')
         return super()._track_subtype(init_values)
 
-    def _message_get_suggested_recipients(self):
-        recipients = super()._message_get_suggested_recipients()
-        if self.partner_id:
-            self._message_add_suggested_recipient(
-                recipients, partner=self.partner_id, reason=_("Customer")
-            )
-        return recipients
-
     # PAYMENT #
 
     def _force_lines_to_invoice_policy_order(self):

--- a/addons/survey/models/survey_user_input.py
+++ b/addons/survey/models/survey_user_input.py
@@ -670,16 +670,6 @@ class SurveyUser_Input(models.Model):
     # MESSAGING
     # ------------------------------------------------------------
 
-    def _message_get_suggested_recipients(self):
-        recipients = super()._message_get_suggested_recipients()
-        if self.partner_id:
-            self._message_add_suggested_recipient(
-                recipients,
-                partner=self.partner_id,
-                reason=_('Survey Participant')
-            )
-        return recipients
-
     def _notify_new_participation_subscribers(self):
         subtype_id = self.env.ref('survey.mt_survey_survey_user_input_completed', raise_if_not_found=False)
         if not self.ids or not subtype_id:

--- a/addons/test_mail/models/mail_test_access.py
+++ b/addons/test_mail/models/mail_test_access.py
@@ -1,4 +1,4 @@
-from odoo import exceptions, fields, models
+from odoo import exceptions, fields, models, tools
 
 
 class MailTestAccess(models.Model):
@@ -71,7 +71,20 @@ class MailTestAccessPublic(models.Model):
 
     name = fields.Char("Name")
     customer_id = fields.Many2one('res.partner', 'Customer')
+    email = fields.Char('Email')
+    mobile = fields.Char('Mobile')
     is_locked = fields.Boolean()
 
     def _mail_get_partner_fields(self):
         return ['customer_id']
+
+    def _get_customer_information(self):
+        email_key_to_values = super()._get_customer_information()
+        for record in self.filtered('email'):
+            # do not fill Falsy with random data, unless monorecord (= always correct)
+            if not tools.email_normalize(record.email) and len(self) > 1:
+                continue
+            values = email_key_to_values.setdefault(record.email, {})
+            if not values.get('mobile'):
+                values['mobile'] = record.mobile
+        return email_key_to_values

--- a/addons/test_mail/models/mail_test_lead.py
+++ b/addons/test_mail/models/mail_test_lead.py
@@ -46,10 +46,10 @@ class MailTestTLead(models.Model):
         lang_code = self.env['res.lang']._get_data(code=self.lang_code).code or None
         if self.partner_id:
             self._message_add_suggested_recipient(
-                recipients, partner=self.partner_id, lang=lang_code, reason=_('Customer'))
+                recipients, partner=self.partner_id, reason=_('Customer'))
         elif self.email_from:
             self._message_add_suggested_recipient(
-                recipients, email=self.email_from, lang=lang_code, reason=_('Customer Email'))
+                recipients, email=self.email_from, reason=_('Customer Email'))
         return recipients
 
     def _message_post_after_hook(self, message, msg_vals):

--- a/addons/test_mail/models/mail_test_ticket.py
+++ b/addons/test_mail/models/mail_test_ticket.py
@@ -100,25 +100,6 @@ class MailTestTicket(models.Model):
                 values['phone'] = ticket.phone_number
         return email_keys_to_values
 
-    def _message_get_suggested_recipients(self):
-        recipients = super()._message_get_suggested_recipients()
-        if self.customer_id:
-            self._message_add_suggested_recipient(
-                recipients,
-                partner=self.customer_id,
-                lang=None,
-                reason=_('Customer'),
-            )
-        elif self.email_from:
-            self._message_add_suggested_recipient(
-                recipients,
-                partner=None,
-                email=self.email_from,
-                lang=None,
-                reason=_('Customer Email'),
-            )
-        return recipients
-
 
 class MailTestTicketEl(models.Model):
     """ Just mail.test.ticket, but exclusion-list enabled. Kept as different

--- a/addons/test_mail/models/mail_test_ticket.py
+++ b/addons/test_mail/models/mail_test_ticket.py
@@ -86,18 +86,19 @@ class MailTestTicket(models.Model):
         return super(MailTestTicket, self)._track_subtype(init_values)
 
     def _get_customer_information(self):
-        email_normalized_to_values = super()._get_customer_information()
+        email_keys_to_values = super()._get_customer_information()
 
-        for record in self.filtered('email_from'):
-            email_from_normalized = email_normalize(record.email_from)
-            if not email_from_normalized:  # do not fill Falsy with random data
+        for ticket in self:
+            email_key = email_normalize(ticket.email_from) or ticket.email_from
+            # do not fill Falsy with random data, unless monorecord (= always correct)
+            if not email_key and len(self) > 1:
                 continue
-            values = email_normalized_to_values.setdefault(email_from_normalized, {})
+            values = email_keys_to_values.setdefault(email_key, {})
             if not values.get('mobile'):
-                values['mobile'] = record.mobile_number
+                values['mobile'] = ticket.mobile_number
             if not values.get('phone'):
-                values['phone'] = record.phone_number
-        return email_normalized_to_values
+                values['phone'] = ticket.phone_number
+        return email_keys_to_values
 
     def _message_get_suggested_recipients(self):
         recipients = super()._message_get_suggested_recipients()
@@ -152,6 +153,19 @@ class MailTestTicketMc(models.Model):
 
     company_id = fields.Many2one('res.company', 'Company', default=lambda self: self.env.company)
     container_id = fields.Many2one('mail.test.container.mc', tracking=True)
+
+    def _get_customer_information(self):
+        email_keys_to_values = super()._get_customer_information()
+
+        for ticket in self:
+            email_key = email_normalize(ticket.email_from) or ticket.email_from
+            # do not fill Falsy with random data, unless monorecord (= always correct)
+            if not email_key and len(self) > 1:
+                continue
+            values = email_keys_to_values.setdefault(email_key, {})
+            if not values.get('company_id'):
+                values['company_id'] = ticket.company_id.id
+        return email_keys_to_values
 
     def _notify_get_reply_to(self, default=None):
         # Override to use alias of the parent container

--- a/addons/test_mail/tests/test_mail_flow.py
+++ b/addons/test_mail/tests/test_mail_flow.py
@@ -165,31 +165,30 @@ class TestMailFlow(MailCommon, TestRecipients):
         # ------------------------------------------------------------
         suggested_all = lead_as_emp._message_get_suggested_recipients()
         expected_all = [
-            {  # mail.thread.cc: email_cc field
-                'create_values': {},
-                'email': 'pay@zboing.com',
-                'lang': None,
-                'name': 'pay@zboing.com',
-                'reason': 'CC Email',
-            },
-            {  # mail.thread.cc: email_cc field (linked to partner)
-                'email': 'portal@zboing.com',
-                'lang': None,
-                'name': 'Portal Zboing',
-                'reason': 'CC Email',
-                'partner_id': self.customer_portal_zboing.id,
-            },
-            {  # then primary emailadditional_values
+            {  # first primary email
                 'create_values': {
                     'lang': 'fr_FR',
                     'mobile': False,
-                    'name': 'Sylvie Lelitre (Zboing)',
                     'phone': '+32455001122',
                 },
-                'email': '"Sylvie Lelitre" <sylvie.lelitre@zboing.com>',
-                'lang': None,
+                'email': 'sylvie.lelitre@zboing.com',
                 'name': 'Sylvie Lelitre (Zboing)',
+                'partner_id': False,
                 'reason': 'Customer Email',
+            },
+            {  # mail.thread.cc: email_cc field
+                'create_values': {},
+                'email': 'pay@zboing.com',
+                'name': '',
+                'partner_id': False,
+                'reason': 'CC Email',
+            },
+            {  # mail.thread.cc: email_cc field (linked to partner)
+                'create_values': {},
+                'email': 'portal@zboing.com',
+                'name': 'Portal Zboing',
+                'reason': 'CC Email',
+                'partner_id': self.customer_portal_zboing.id,
             },
         ]
         for suggested, expected in zip(suggested_all, expected_all):

--- a/addons/test_mail/tests/test_mail_flow.py
+++ b/addons/test_mail/tests/test_mail_flow.py
@@ -197,7 +197,7 @@ class TestMailFlow(MailCommon, TestRecipients):
         # check recipients, which creates them (simulating discuss in a quick way)
         self.env["res.partner"]._find_or_create_from_emails(
             [sug['email'] for sug in suggested_all],
-            {email_normalize(sug['email']): sug.get('create_values') or {} for sug in suggested_all},
+            additional_values={email_normalize(sug['email']): sug.get('create_values') or {} for sug in suggested_all},
         )
         partner_sylvie = self.env['res.partner'].search(
             [('email_normalized', '=', 'sylvie.lelitre@zboing.com')]

--- a/addons/test_mail/tests/test_mail_flow.py
+++ b/addons/test_mail/tests/test_mail_flow.py
@@ -195,10 +195,7 @@ class TestMailFlow(MailCommon, TestRecipients):
         for suggested, expected in zip(suggested_all, expected_all):
             self.assertDictEqual(suggested, expected)
         # check recipients, which creates them (simulating discuss in a quick way)
-        self.env["res.partner"]._find_or_create_from_emails(
-            [sug['email'] for sug in suggested_all],
-            additional_values={email_normalize(sug['email']): sug.get('create_values') or {} for sug in suggested_all},
-        )
+        lead_as_emp._partner_find_from_emails_single([sug['email'] for sug in suggested_all])
         partner_sylvie = self.env['res.partner'].search(
             [('email_normalized', '=', 'sylvie.lelitre@zboing.com')]
         )

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -443,7 +443,7 @@ class TestMailgateway(MailGatewayCommon):
         })
 
         record = self.format_and_process(MAIL_TEMPLATE, from_1.email_formatted, f'groups@{self.alias_domain}')
-        self.assertFalse(record.message_ids[0].author_id)
+        self.assertFalse(record.message_ids[0].author_id, f'Should not link a partner, especially not {from_1}')
         self.assertEqual(record.message_ids[0].email_from, from_1.email_formatted)
 
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.addons.mail.models.mail_thread', 'odoo.models')

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -405,8 +405,8 @@ class TestAPI(MailCommon, TestRecipients):
         suggestions = ticket._message_get_suggested_recipients()
         self.assertEqual(len(suggestions), 2)
         for suggestion, expected in zip(suggestions, [{
+            'create_values': {},
             'email': self.user_employee.email_normalized,
-            'lang': None,
             'name': self.user_employee.name,
             'partner_id': self.partner_employee.id,
             'reason': 'Responsible',
@@ -416,9 +416,9 @@ class TestAPI(MailCommon, TestRecipients):
                 'mobile': '+32455998877',
                 'phone': 'wrong',
             },
-            'email': '"Paulette Vachette" <paulette@test.example.com>',
-            'lang': None,
-            'name': '"Paulette Vachette" <paulette@test.example.com>',
+            'email': 'paulette@test.example.com',
+            'name': 'Paulette Vachette',
+            'partner_id': False,
             'reason': 'Customer Email',
         }]):
             self.assertDictEqual(suggestion, expected)
@@ -442,13 +442,17 @@ class TestAPI(MailCommon, TestRecipients):
                 self.assertDictEqual(
                     suggestions[0],
                     {
+                        'create_values': {},
                         'email': self.test_partner.email_normalized,
-                        'lang': None,
                         'name': self.test_partner.name,
                         'partner_id': self.test_partner.id,
                         'reason': 'Customer Email',
                     }
                 )
+
+        # do not propose public partners
+        ticket_public = self.env['mail.test.ticket.mc'].create({'customer_id': self.user_public.partner_id.id})
+        self.assertFalse(ticket_public._message_get_suggested_recipients())
 
     @mute_logger('openerp.addons.mail.models.mail_mail')
     @users('employee')

--- a/addons/test_mail/tests/test_mail_thread_mixins.py
+++ b/addons/test_mail/tests/test_mail_thread_mixins.py
@@ -79,7 +79,7 @@ class TestMailThread(MailCommon, TestRecipients):
                 bl_record.unlink()
 
 
-@tagged('mail_thread', 'mail_thread_cc')
+@tagged('mail_thread', 'mail_thread_cc', 'mail_tools')
 class TestMailThreadCC(MailCommon):
 
     @users("employee")
@@ -91,28 +91,17 @@ class TestMailThreadCC(MailCommon):
             'email_cc': 'cc1@example.com, cc2@example.com, cc3 <cc3@example.com>',
         })
         suggestions = record._message_get_suggested_recipients()
-        self.assertItemsEqual(
-            suggestions,
-            [
-                {
-                    'lang': None,
-                    'reason': 'CC Email',
-                    'name': 'cc1@example.com',
-                    'email': 'cc1@example.com',
-                    'create_values': {},
-                }, {
-                    'lang': None,
-                    'reason': 'CC Email',
-                    'name': 'cc2@example.com',
-                    'email': 'cc2@example.com',
-                    'create_values': {},
-                }, {
-                    'lang': None,
-                    'reason': 'CC Email',
-                    'name': '"cc3" <cc3@example.com>',
-                    'email': '"cc3" <cc3@example.com>',
-                    'create_values': {},
-                },
-            ],
-            'cc should be in suggestions',
-        )
+        expected_list = [
+            {
+                'name': '', 'email': 'cc1@example.com',
+                'reason': 'CC Email', 'partner_id': False, 'create_values': {},
+            }, {
+                'name': '', 'email': 'cc2@example.com',
+                'reason': 'CC Email', 'partner_id': False, 'create_values': {},
+            }, {
+                'name': 'cc3', 'email': 'cc3@example.com',
+                'reason': 'CC Email', 'partner_id': False, 'create_values': {},
+            }]
+        self.assertEqual(len(suggestions), len(expected_list))
+        for suggestion, expected in zip(suggestions, expected_list):
+            self.assertDictEqual(suggestion, expected)

--- a/addons/website_event_booth/controllers/event_booth.py
+++ b/addons/website_event_booth/controllers/event_booth.py
@@ -118,13 +118,14 @@ class WebsiteEventBoothController(WebsiteEventController):
 
     def _prepare_booth_registration_partner_values(self, event, kwargs):
         if request.env.user._is_public():
-            conctact_email_normalized = tools.email_normalize(kwargs['contact_email'])
-            contact_name_email = tools.formataddr((kwargs['contact_name'], conctact_email_normalized))
-            partner = request.env['res.partner'].sudo().find_or_create(contact_name_email)
-            if not partner.name and kwargs.get('contact_name'):
-                partner.name = kwargs['contact_name']
-            if not partner.phone and kwargs.get('contact_phone'):
-                partner.phone = kwargs['contact_phone']
+            contact_email_normalized = tools.email_normalize(kwargs['contact_email'])
+            partner = request.env['res.partner'].sudo()._find_or_create_from_emails(
+                [contact_email_normalized],
+                additional_values={contact_email_normalized: {
+                    'phone': kwargs.get('contact_phone'),
+                    'name': kwargs.get('contact_name'),
+                }}
+            )[0]
         else:
             partner = request.env.user.partner_id
         return {

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -246,22 +246,9 @@ class EventSponsor(models.Model):
         return self.env.ref('event.event_main_menu').id
 
     # ------------------------------------------------------------
-    # MESSAGING
-    # ------------------------------------------------------------
-
-    def _message_get_suggested_recipients(self):
-        recipients = super()._message_get_suggested_recipients()
-        if self.partner_id:
-            self._message_add_suggested_recipient(
-                recipients,
-                partner=self.partner_id,
-                reason=_('Sponsor')
-            )
-        return recipients
-
-    # ------------------------------------------------------------
     # Misc
     # ------------------------------------------------------------
+
     def get_base_url(self):
         """As website_id is not defined on this record, we rely on event website_id for base URL."""
         return self.event_id.get_base_url()

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -482,10 +482,7 @@ class EventTrack(models.Model):
 
     def _message_get_suggested_recipients(self):
         recipients = super()._message_get_suggested_recipients()
-        if self.partner_id:
-            if self.partner_id not in recipients:
-                self._message_add_suggested_recipient(recipients, partner=self.partner_id, reason=_('Contact'))
-        else:
+        if not self.partner_id:
             #  Priority: contact information then speaker information
             if self.contact_email and self.contact_email != self.partner_id.email:
                 self._message_add_suggested_recipient(recipients, email=self.contact_email, reason=_('Contact Email'))

--- a/addons/website_mail/controllers/main.py
+++ b/addons/website_mail/controllers/main.py
@@ -23,11 +23,13 @@ class WebsiteMail(http.Controller):
             partner_ids = request.env.user.partner_id.ids
         else:
             # mail_thread method
-            partner_ids = [p.id for p in request.env['mail.thread'].sudo()._mail_find_partner_from_emails([email], records=record.sudo()) if p]
-            if not partner_ids or not partner_ids[0]:
+            try:
                 self.env['ir.http']._verify_request_recaptcha_token('website_mail_follow')
-                name = email.split('@')[0]
-                partner_ids = request.env['res.partner'].sudo().create({'name': name, 'email': email}).ids
+            except Exception:
+                no_create = True
+            else:
+                no_create = False
+            partner_ids = record.sudo()._partner_find_from_emails_single([email], no_create=no_create).ids
         # add or remove follower
         if is_follower:
             record.sudo().message_unsubscribe(partner_ids)

--- a/addons/website_project/controllers/main.py
+++ b/addons/website_project/controllers/main.py
@@ -30,8 +30,7 @@ class WebsiteForm(form.WebsiteForm):
     def extract_data(self, model_sudo, values):
         data = super().extract_data(model_sudo, values)
         if model_sudo.model == 'project.task' and values.get('email_from'):
-            partners_list = request.env['mail.thread'].sudo()._mail_find_partner_from_emails([values['email_from']])
-            partner = partners_list[0] if partners_list else self.env['res.partner']
+            partner = request.env['mail.thread'].sudo()._partner_find_from_emails_single([values['email_from']], no_create=True)
             data['record']['partner_id'] = partner.id
             data['record']['email_from'] = values['email_from']
             if partner:

--- a/addons/website_sale_stock/controllers/main.py
+++ b/addons/website_sale_stock/controllers/main.py
@@ -11,12 +11,12 @@ class WebsiteSaleStock(Controller):
 
     @route('/shop/add/stock_notification', type='jsonrpc', auth='public', website=True)
     def add_stock_email_notification(self, email, product_id):
+        # TDE FIXME: seems a bit open
         if not email_re.match(email):
             raise BadRequest(_("Invalid Email"))
 
         product = request.env['product.product'].browse(int(product_id))
-        partners = request.env['res.partner'].sudo()._mail_find_partner_from_emails([email], force_create=True)
-        partner = partners[0]
+        partner = request.env['mail.thread'].sudo()._partner_find_from_emails_single([email])
 
         if not product._has_stock_notification(partner):
             product.sudo().stock_notification_partner_ids += partner

--- a/addons/website_sale_stock/tests/test_website_sale_stock_stock_notification.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_stock_notification.py
@@ -35,8 +35,7 @@ class TestStockNotificationProduct(HttpCase):
     def test_back_in_stock_notification_product(self):
         self.start_tour("/", 'back_in_stock_notification_product')
 
-        partner_ids = self.env['res.partner']._mail_find_partner_from_emails(['test@test.test'])
-        partner = partner_ids[0]
+        partner = self.env['mail.thread']._partner_find_from_emails_single(['test@test.test'], no_create=True)
         ProductProduct = self.env['product.product']
         product = ProductProduct.browse(self.product.id)
         self.assertTrue(product._has_stock_notification(partner))

--- a/addons/website_sale_stock_wishlist/tests/test_website_sale_stock_wishlist_stock_notification.py
+++ b/addons/website_sale_stock_wishlist/tests/test_website_sale_stock_wishlist_stock_notification.py
@@ -41,8 +41,7 @@ class TestStockNotificationWishlist(HttpCaseWithWebsiteUser):
     def test_stock_notification_wishlist(self):
         self.start_tour("/", 'stock_notification_wishlist', login="website_user")
 
-        partner_ids = self.env['res.partner']._mail_find_partner_from_emails(['test@test.test'])
-        partner = partner_ids[0]
+        partner = self.env['mail.thread']._partner_find_from_emails_single(['test@test.test'], no_create=True)
         ProductProduct = self.env['product.product']
         product = ProductProduct.browse(self.product.id)
         self.assertTrue(product._has_stock_notification(partner))


### PR DESCRIPTION
In order to unify methods searching or creating partners, let us create
yet another one. Introducing '_partner_find_from_emails' that should
act as the main find, sort and create partner record-based tool method.

It relies on 'Partner._find_or_create_from_emails()' for finding and
creating, as it is already covering a lot of use cases (parsing name
and email, multi-email input, ...). It is improved to support a sorting
key so that it is now possible to choose which partner matches a given
input when multiple results match. Sorting can be used notably for multi
company environment, filtering out non users, ... depending on the actual
business flow.

Created partners benefit from 'Model._get_customer_information()' that
models can override to add business-specific information. It is also
cleaned, notably to be sure data is managed based on normalized emails.

Compared to original computation, contains the following fix-imps:

 * less queries for finding: original searches on users, then partners;
   new one does a single search;
 * less queries when creating: create is now done in batch while it
   was sequential in old one;
 * better support partner creation, as it calls the complete tool instead
   of the quick 'name_create';
 * support record-based customer information e.g. lead population customer
   fields based on lead information, while it was not the case before;
 * when searching, choosing the right partner based on criterions is
   better (follower, internal then portal user, same company, ...) and
   customizable;

This new tool is going to replace old pseudo-generic tool method
'_mail_find_partner_from_emails'. This allows to improve and simplify
'_message_get_suggested_recipients', various code managing partners
in mail and addons, and globally remove duplicated or old code that
can now be managed through generic mail tools and helpers. See
individual commits for more details.

This PR belongs to a group of PRs that aim at improving mail flow
in Odoo so that it looks more like traditional email flows:
 * odoo/odoo#184824
 * odoo/odoo#187024
 * odoo/odoo#191213
 * odoo/odoo#185240
 * odoo/odoo#191358
 * odoo/odoo#188642 : Final branch

Task-4332797: [mail] Partner from emails 3.0
Prepares Task-4273479: [mail] Email-like recipients