### PR TITLE
[FIX] website_sale: reduce delay for marking products as recently viewed

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_recently_viewed.js
+++ b/addons/website_sale/static/src/js/website_sale_recently_viewed.js
@@ -8,7 +8,7 @@ publicWidget.registry.productsRecentlyViewedUpdate = publicWidget.Widget.extend(
     events: {
         'change input.product_id[name="product_id"]': '_onProductChange',
     },
-    debounceValue: 8000,
+    debounceValue: 500,
 
     /**
      * @constructor


### PR DESCRIPTION
When a user visits a product page, the product gets marked as "recently viewed"
after 8 seconds.

This delay is too long, as a user can realistically view the product and
navigate away before the 8 seconds have passed (in which case the product isn't
marked as recently viewed).

In particular, this is problematic when the website contains a "recently viewed
products" carousel, where the user expects to see all products they recently
viewed (even if they didn't stay on the product page for 8 seconds).

We decided to reduce the delay to 0.5 seconds, which is long enough to prevent
the product from being marked as "recently viewed" if the user visits a product
page by mistake and immediately navigates away, but short enough to prevent
problematic behaviors such as the one mentioned above.

opw-4114364
