### PR TITLE
[IMP] mass_mailing, mail: remove checklist command

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -347,6 +347,9 @@ export const htmlField = {
         if ("allowFile" in options) {
             editorConfig.allowFile = Boolean(options.allowFile);
         }
+        if ("allowChecklist" in options) {
+            editorConfig.allowChecklist = Boolean(options.allowChecklist);
+        }
         if ("allowAttachmentCreation" in options) {
             editorConfig.allowImage = Boolean(options.allowAttachmentCreation);
             editorConfig.allowFile = Boolean(options.allowAttachmentCreation);

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -76,6 +76,9 @@ export class ListPlugin extends Plugin {
         "dom",
         "color",
     ];
+    static defaultConfig = {
+        allowChecklist: true,
+    };
     toolbarListSelectorKey = reactive({ value: 0 });
     resources = {
         user_commands: [
@@ -101,7 +104,8 @@ export class ListPlugin extends Plugin {
                 description: _t("Track tasks with a checklist"),
                 icon: "fa-check-square-o",
                 run: () => this.toggleListCommand({ mode: "CL" }),
-                isAvailable: this.canToggleList.bind(this),
+                isAvailable: (selection) =>
+                    this.config.allowChecklist && this.canToggleList(selection),
             },
         ],
         shortcuts: [
@@ -1280,14 +1284,18 @@ export class ListPlugin extends Plugin {
     }
 
     getListSelectorButtons() {
-        return listSelectorItems.map((item) => {
-            const command = this.resources.user_commands.find((cmd) => cmd.id === item.commandId);
-            const button = composeToolbarButton(command, item);
-            return {
-                ...pick(button, "id", "icon", "run", "mode"),
-                // We want short descriptions for these buttons.
-                description: command.title,
-            };
-        });
+        return listSelectorItems
+            .filter((item) => item.commandId != "toggleListCL" || this.config.allowChecklist)
+            .map((item) => {
+                const command = this.resources.user_commands.find(
+                    (cmd) => cmd.id === item.commandId
+                );
+                const button = composeToolbarButton(command, item);
+                return {
+                    ...pick(button, "id", "icon", "run", "mode"),
+                    // We want short descriptions for these buttons.
+                    description: command.title,
+                };
+            });
     }
 }

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -1502,6 +1502,41 @@ test("edit and save a html field in collaborative should keep the same wysiwyg",
     expect.verifySteps(["web_save"]);
 });
 
+test("'checklist' command is not available when 'allowChecklist' = false", async () => {
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html" options="{'allowChecklist': false}"/>
+            </form>`,
+    });
+    setSelectionInHtmlField();
+    await insertText(htmlEditor, "/chec");
+    await waitFor(".o-we-powerbox");
+    expect(queryAllTexts(".o-we-command-name")).not.toInclude("Checklist");
+});
+
+test("'checklist' toolbar option is not available when 'allowChecklist' = false", async () => {
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html" options="{'allowChecklist': false}"/>
+            </form>`,
+    });
+    const node = queryOne(".odoo-editor-editable p");
+    setSelection({ anchorNode: node, anchorOffset: 0, focusNode: node, focusOffset: 1 });
+    await waitFor(".o-we-toolbar");
+    await expandToolbar();
+    await contains(".o-we-toolbar button[name='list_selector']").click();
+    await waitFor(".o-we-toolbar-dropdown");
+    expect("button[name='checklist']").toHaveCount(0);
+});
+
 describe("sandbox", () => {
     const recordWithComplexHTML = {
         id: 1,

--- a/addons/mail/static/src/views/web/fields/html_mail_field/html_mail_field.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/html_mail_field.js
@@ -43,6 +43,7 @@ export const htmlMailField = {
     additionalClasses: ["o_field_html"],
     extractProps({ attrs, options }, dynamicInfo) {
         const props = htmlField.extractProps({ attrs, options }, dynamicInfo);
+        props.editorConfig.allowChecklist = false;
         props.embeddedComponents = false;
         return props;
     },

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -321,6 +321,7 @@ export const massMailingHtmlField = {
     component: MassMailingHtmlField,
     extractProps({ attrs, options }) {
         const props = htmlField.extractProps(...arguments);
+        props.editorConfig.allowChecklist = false;
         props.editorConfig.allowVideo = false;
         props.editorConfig.baseContainers = ["P"];
         Object.assign(props, {


### PR DESCRIPTION
This task focuses on the following improvements:
- removed /checklist command.
- removed checkbox option from snippet options.
- disabled checklist from toolbar items in mail composer.
- removed checklist from power buttons in mail composer.
- removed checklist from powerbox in mail composer.

Task-3107481