### PR TITLE
[FIX] fleet: track fields related to cost

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -45,7 +45,7 @@ class FleetVehicle(models.Model):
     country_code = fields.Char(related='country_id.code', depends=['country_id'])
     license_plate = fields.Char(tracking=True,
         help='License plate number of the vehicle (i = plate number for a car)')
-    vin_sn = fields.Char('Chassis Number', help='Unique number written on the vehicle motor (VIN/SN number)', copy=False)
+    vin_sn = fields.Char('Chassis Number', help='Unique number written on the vehicle motor (VIN/SN number)', tracking=True, copy=False)
     trailer_hook = fields.Boolean(default=False, string='Trailer Hitch', compute='_compute_model_fields', store=True, readonly=False)
     driver_id = fields.Many2one('res.partner', 'Driver', tracking=True, help='Driver address of the vehicle', copy=False)
     future_driver_id = fields.Many2one('res.partner', 'Future Driver', tracking=True, help='Next Driver Address of the vehicle', copy=False, check_company=True)
@@ -62,9 +62,10 @@ class FleetVehicle(models.Model):
     next_assignation_date = fields.Date('Assignment Date', help='This is the date at which the car will be available, if not set it means available instantly')
     order_date = fields.Date('Order Date')
     acquisition_date = fields.Date('Registration Date', required=False,
-        default=fields.Date.today, help='Date of vehicle registration')
+        default=fields.Date.today, tracking=True,
+        help='Date of vehicle registration')
     write_off_date = fields.Date('Cancellation Date', tracking=True, help="Date when the vehicle's license plate has been cancelled/removed.")
-    first_contract_date = fields.Date(string="First Contract Date", default=fields.Date.today)
+    first_contract_date = fields.Date(string="First Contract Date", default=fields.Date.today, tracking=True)
     color = fields.Char(help='Color of the vehicle', compute='_compute_model_fields', store=True, readonly=False)
     state_id = fields.Many2one('fleet.vehicle.state', 'State',
         default=_get_default_state, group_expand='_read_group_expand_full',
@@ -102,7 +103,7 @@ class FleetVehicle(models.Model):
          ('expired', 'Expired'),
          ('closed', 'Closed')
         ], string='Last Contract State', compute='_compute_contract_reminder', required=False)
-    car_value = fields.Float(string="Catalog Value (VAT Incl.)")
+    car_value = fields.Float(string="Catalog Value (VAT Incl.)", tracking=True)
     net_car_value = fields.Float(string="Purchase Value")
     residual_value = fields.Float()
     plan_to_change_car = fields.Boolean(related='driver_id.plan_to_change_car', store=True, readonly=False)

--- a/addons/fleet/models/fleet_vehicle_log_contract.py
+++ b/addons/fleet/models/fleet_vehicle_log_contract.py
@@ -17,7 +17,7 @@ class FleetVehicleLogContract(models.Model):
         start_date = fields.Date.from_string(strdate)
         return fields.Date.to_string(start_date + oneyear)
 
-    vehicle_id = fields.Many2one('fleet.vehicle', 'Vehicle', required=True, check_company=True)
+    vehicle_id = fields.Many2one('fleet.vehicle', 'Vehicle', required=True, check_company=True, tracking=True)
     cost_subtype_id = fields.Many2one('fleet.service.type', 'Type', help='Cost type purchased with this cost', domain=[('category', '=', 'contract')])
     amount = fields.Monetary('Cost', tracking=True)
     date = fields.Date(help='Date when the cost has been executed')
@@ -31,11 +31,12 @@ class FleetVehicleLogContract(models.Model):
         default=lambda self: self.env['fleet.vehicle'].browse(self._context.get('active_id')).manager_id,
         index=True)
     start_date = fields.Date(
-        'Contract Start Date', default=fields.Date.context_today,
+        'Contract Start Date', default=fields.Date.context_today, tracking=True,
         help='Date when the coverage of the contract begins')
     expiration_date = fields.Date(
         'Contract Expiration Date', default=lambda self:
         self.compute_next_year_date(fields.Date.context_today(self)),
+        tracking=True,
         help='Date when the coverage of the contract expirates (by default, one year after begin date)')
     days_left = fields.Integer(compute='_compute_days_left', string='Warning Date')
     expires_today = fields.Boolean(compute='_compute_days_left')
@@ -59,7 +60,7 @@ class FleetVehicleLogContract(models.Model):
         ('weekly', 'Weekly'),
         ('monthly', 'Monthly'),
         ('yearly', 'Yearly')
-        ], 'Recurring Cost Frequency', default='monthly', required=True)
+        ], 'Recurring Cost Frequency', default='monthly', required=True, tracking=True)
     service_ids = fields.Many2many('fleet.service.type', string="Included Services")
 
     @api.depends('vehicle_id.name', 'cost_subtype_id')


### PR DESCRIPTION
We've added tracking on some fields that are used to compute the cost of cars and also the serial number to know if it has been manually changed.

When the value or the cost of the car change, we want to know who modified it and when it has been done.

TASK-ID: 4306184




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
