### PR TITLE
[FIX] point_of_sale: ensure new order lines are added to pending orders

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -638,6 +638,7 @@ export class PosStore extends Reactive {
         if (!order) {
             order = this.add_new_order();
         }
+        this.addPendingOrder([order.id]);
         return await this.addLineToOrder(vals, order, opts, configure);
     }
 


### PR DESCRIPTION
Before this commit, when adding a new line to the order, it wasn't added to the pending order. If you clicked back to the floor screen, you might miss the added line. For example, adding a global discount would be missing in that case.

opw-4322621

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
