### PR TITLE
[FIX] mail: enable push notifications in iOS PWA

### DIFF
--- a/addons/mail/static/src/core/web/messaging_menu.js
+++ b/addons/mail/static/src/core/web/messaging_menu.js
@@ -4,7 +4,7 @@ import { onExternalClick, useDiscussSystray } from "@mail/utils/common/hooks";
 
 import { Component, useState } from "@odoo/owl";
 
-import { hasTouch, isIOS } from "@web/core/browser/feature_detection";
+import { hasTouch, isDisplayStandalone, isIOS, isIosApp } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { _t } from "@web/core/l10n/translation";
@@ -233,7 +233,11 @@ export class MessagingMenu extends Component {
     }
 
     get shouldAskPushPermission() {
-        return this.notification.permission === "prompt" && !isIOS();
+        if (isIOS() && !isDisplayStandalone() && !isIosApp()) {
+            // iOS browser apps do not have push notifications: Only PWA and apps have them.
+            return false;
+        }
+        return this.notification.permission === "prompt";
     }
 }
 


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/178057

PR above fixed an issue of persistent notification in messaging menu in iOS, due to push notifications being only available through PWA.

At the time of the fix, installing PWA apps on iOS had necessarily push notification enabled. However this no longer seems to be the case: PWA apps on iOS must now explicitly asks for enabling push notifications. This is also a necessary step in order for the PWA apps to be shown in iOS Settings > Notifications.

This commit fixes the issue by not showing button to enable push notifications specifically on iOS outside of app. That way there's no persistent notification on Safari while push notifications can still be enabled.

Extra notes:
- iOS requests for push notifications seem to require HTTPS, otherwise they are necessarily blocked.
- iOS 17 does not show the dialog to accept or deny push notifications. This is likely an iOS bug that has apparently been fixed with iOS 18.