### PR TITLE
[IMP] spreadsheet: add @api.readonly to read-only methods

### DIFF
--- a/addons/spreadsheet/models/res_currency.py
+++ b/addons/spreadsheet/models/res_currency.py
@@ -4,6 +4,7 @@ from odoo import api, models
 class ResCurrency(models.Model):
     _inherit = ["res.currency"]
 
+    @api.readonly
     @api.model
     def get_company_currency_for_spreadsheet(self, company_id=None):
         """

--- a/addons/spreadsheet/models/res_currency_rate.py
+++ b/addons/spreadsheet/models/res_currency_rate.py
@@ -17,6 +17,7 @@ class ResCurrencyRate(models.Model):
         date = fields.Date.from_string(date) if date else fields.Date.context_today(self)
         return Currency._get_conversion_rate(currency_from, currency_to, company, date)
 
+    @api.readonly
     @api.model
     def get_rates_for_spreadsheet(self, requests):
         result = []

--- a/addons/spreadsheet/models/res_lang.py
+++ b/addons/spreadsheet/models/res_lang.py
@@ -11,6 +11,7 @@ from odoo.addons.spreadsheet.utils.formatting import (
 class ResLang(models.Model):
     _inherit = ["res.lang"]
 
+    @api.readonly
     @api.model
     def get_locales_for_spreadsheet(self):
         """Return the list of locales available for a spreadsheet."""

--- a/addons/spreadsheet/models/spreadsheet_mixin.py
+++ b/addons/spreadsheet/models/spreadsheet_mixin.py
@@ -99,6 +99,7 @@ class SpreadsheetMixin(models.AbstractModel):
     def _onchange_data_(self):
         self._check_spreadsheet_data()
 
+    @api.readonly
     @api.model
     def get_display_names_for_spreadsheet(self, args):
         ids_per_model = defaultdict(list)

--- a/addons/spreadsheet_account/models/account.py
+++ b/addons/spreadsheet_account/models/account.py
@@ -81,6 +81,7 @@ class AccountAccount(models.Model):
             )
         return domain
 
+    @api.readonly
     @api.model
     def spreadsheet_move_line_action(self, args):
         domain = self._build_spreadsheet_formula_domain(args)
@@ -94,6 +95,7 @@ class AccountAccount(models.Model):
             "name": _("Journal items for account prefix %s", ", ".join(args["codes"])),
         }
 
+    @api.readonly
     @api.model
     def spreadsheet_fetch_debit_credit(self, args_list):
         """Fetch data for ODOO.CREDIT, ODOO.DEBIT and ODOO.BALANCE formulas
@@ -118,6 +120,7 @@ class AccountAccount(models.Model):
 
         return results
 
+    @api.readonly
     @api.model
     def get_account_group(self, account_types):
         data = self._read_group(

--- a/addons/spreadsheet_account/models/res_company.py
+++ b/addons/spreadsheet_account/models/res_company.py
@@ -6,6 +6,7 @@ from odoo.tools import date_utils
 class ResCompany(models.Model):
     _inherit = ["res.company"]
 
+    @api.readonly
     @api.model
     def get_fiscal_dates(self, payload):
         companies = self.env["res.company"].browse(

--- a/addons/spreadsheet_dashboard/controllers/dashboards_controllers.py
+++ b/addons/spreadsheet_dashboard/controllers/dashboards_controllers.py
@@ -5,7 +5,12 @@ from odoo.http import request
 
 
 class DashboardDataRoute(http.Controller):
-    @http.route(['/spreadsheet/dashboard/data/<model("spreadsheet.dashboard"):dashboard>'], type='http', auth='user')
+    @http.route(
+        ['/spreadsheet/dashboard/data/<model("spreadsheet.dashboard"):dashboard>'],
+        type='http',
+        auth='user',
+        readonly=True
+    )
     def get_dashboard_data(self, dashboard):
         dashboard = dashboard.exists()
         if not dashboard:

--- a/addons/spreadsheet_dashboard/controllers/share.py
+++ b/addons/spreadsheet_dashboard/controllers/share.py
@@ -23,7 +23,7 @@ class DashboardShareRoute(http.Controller):
         )
 
     @http.route(["/dashboard/download/<int:share_id>/<token>"],
-                type='http', auth='public')
+                type='http', auth='public', readonly=True)
     def download(self, token=None, share_id=None):
         share = request.env["spreadsheet.dashboard.share"].sudo().browse(share_id)
         share._check_dashboard_access(token)
@@ -37,6 +37,7 @@ class DashboardShareRoute(http.Controller):
         type="http",
         auth="public",
         methods=["GET"],
+        readonly=True,
     )
     def get_shared_dashboard_data(self, share_id, token):
         share = (


### PR DESCRIPTION
## Description

Adds the `@api.readonly` decorator to methods that only perform data retrieval in spreadsheet-related models and controllers.

Task: [4317048](https://www.odoo.com/odoo/project/2328/tasks/4317048)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr