### PR TITLE
[FIX] spreadsheet: do not translate value of quarters in filters

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
@@ -10,7 +10,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { sprintf } from "@web/core/utils/strings";
 import { Domain } from "@web/core/domain";
-import { constructDateRange, getPeriodOptions, QUARTER_OPTIONS } from "@web/search/utils/dates";
+import { constructDateRange, QUARTER_OPTIONS } from "@web/search/utils/dates";
 
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { CommandResult } from "@spreadsheet/o_spreadsheet/cancelled_reason";
@@ -271,11 +271,10 @@ export class GlobalFiltersUIPlugin extends spreadsheet.UIPlugin {
                 if (!value || value.yearOffset === undefined) {
                     return [[{ value: "" }]];
                 }
-                const periodOptions = getPeriodOptions(DateTime.local());
                 const year = String(DateTime.local().year + value.yearOffset);
-                const period = periodOptions.find(({ id }) => value.period === id);
-                let periodStr = period && period.description;
-                // Named months aren't in getPeriodOptions
+                const period = QUARTER_OPTIONS[value.period];
+                let periodStr = period && "Q" + period.setParam.quarter; // we do not want the translated value (like T1 in French)
+                // Named months aren't in QUARTER_OPTIONS
                 if (!period) {
                     periodStr =
                         MONTHS[value.period] && String(MONTHS[value.period].value).padStart(2, "0");


### PR DESCRIPTION
Currently, when using a language that translates the abbreviation of quarters (Q) to anything else, the formula `=filter.value(...)` would return the translated version, which then could not be used on other formulas like `=odoo.balance`, this can be observed by opening the Finance/accounting dashboard while in french and selecting a filter in quarter.

After this fix, the formula filter.value will always return Q1 to Q4 for quarter names.

Task: 4274741




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
