### PR TITLE
[IMP] http_routing, website, base: allow non-ascii characters in URLs

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -23,8 +23,8 @@ from odoo.osv import expression
 _logger = logging.getLogger(__name__)
 
 # NOTE: the second pattern is used for the ModelConverter, do not use nor flags nor groups
-_UNSLUG_RE = re.compile(r'(?:(\w{1,2}|\w[A-Za-z0-9-_]+?\w)-)?(-?\d+)(?=$|\/|#|\?)')
-_UNSLUG_ROUTE_PATTERN = r'(?:(?:\w{1,2}|\w[A-Za-z0-9-_]+?\w)-)?(?:-?\d+)(?=$|\/|#|\?)'
+_UNSLUG_RE = re.compile(r'(?:(\w{1,2}|\w[\w-]+?\w)-)?(-?\d+)(?=$|\/|#|\?)')
+_UNSLUG_ROUTE_PATTERN = r'(?:(?:\w{1,2}|\w[\w-]+?\w)-)?(?:-?\d+)(?=$|\/|#|\?)'
 
 
 class ModelConverter(ir_http.ModelConverter):

--- a/addons/website/tests/test_converter.py
+++ b/addons/website/tests/test_converter.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import threading
+import unicodedata
 
 from odoo.tests.common import BaseCase
 from odoo.modules.registry import Registry
@@ -84,8 +85,8 @@ class TestTitleToSlug(BaseCase):
 
     def test_special_chars(self):
         self.assertEqual(
-            "o-d-o-o",
-            self._slugify(r"o!#d{|\o/@~o&%^?")
+            "hello",
+            self._slugify("^h☺e$#!l(%l}o☞☞")
         )
 
     def test_str_to_unicode(self):
@@ -100,8 +101,26 @@ class TestTitleToSlug(BaseCase):
             self._slugify("Article 1")
         )
 
+    def test_non_ascii(self):
+        self.assertEqual(
+            "你好-再見",
+            self._slugify("你好 再見")
+        )
+
+    def test_multiple_dashes(self):
+        self.assertEqual(
+            "d-a-sh-e-s",
+            self._slugify("d-----a----sh--e-------s")
+        )
+
+    def test_leading_trailing_dashes_spaces_underscores(self):
+        self.assertEqual(
+            "mi-dd-le",
+            self._slugify("_-__   -- -mi-dd-le- -- _ _-_- - ")
+        )
+
     def test_all(self):
         self.assertEqual(
-            "do-you-know-martine-a-la-plage",
-            self._slugify("Do YOU know 'Martine à la plage' ?")
+            "do-you-know-馬丁娜-a-la-海灘",
+            self._slugify(" Do (YOU) ☞☞ know '馬丁娜 à la 海灘' ? ")
         )


### PR DESCRIPTION
Currently non-ascii characters in URLs get removed, meaning that for
example users in countries using alphabets composed of non-ascii
characters would be unable to create URLs in their native languages:
a user creating a page with URL .../امتحان would instead create a
page with URL .../-1.

Steps to reproduce:

- Open website app
- Create a new page using non-ascii characters as URL
- Check the URL of the created page

After the change non-ascii characters no longer get removed and
get slugified correctly, allowing users to create and browse pages
with non-ascii URLs.

task-3986492
Fixes https://github.com/odoo/odoo/issues/63563