### PR TITLE
[IMP] hr: add country code to departure reasons

### DIFF
--- a/addons/hr/data/hr_data.xml
+++ b/addons/hr/data/hr_data.xml
@@ -65,19 +65,19 @@
         <record id="departure_fired" model="hr.departure.reason">
             <field name="sequence">0</field>
             <field name="name">Fired</field>
-            <field name="reason_code">342</field>
+            <field name="country_id" eval="False"/>
         </record>
 
         <record id="departure_resigned" model="hr.departure.reason">
             <field name="sequence">1</field>
             <field name="name">Resigned</field>
-            <field name="reason_code">343</field>
+            <field name="country_id" eval="False"/>
         </record>
 
         <record id="departure_retired" model="hr.departure.reason">
             <field name="sequence">2</field>
             <field name="name">Retired</field>
-            <field name="reason_code">340</field>
+            <field name="country_id" eval="False"/>
         </record>
 
         <record id="contract_type_permanent" model="hr.contract.type">

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -95,5 +95,11 @@
         <field name="perm_read" eval="False"/>
     </record>
 
+    <record id="ir_rule_hr_departure_reason_multi_company" model="ir.rule">
+        <field name="name">Departure Reason: multi company</field>
+        <field name="model_id" ref="model_hr_departure_reason"/>
+        <field name="domain_force">[('country_code', 'in', user.env.companies.mapped('country_code') + [False])]</field>
+    </record>
+
 </data>
 </odoo>

--- a/addons/hr/views/hr_departure_reason_views.xml
+++ b/addons/hr/views/hr_departure_reason_views.xml
@@ -7,6 +7,7 @@
                 <list editable="bottom">
                     <field name="sequence" widget="handle" />
                     <field name="name" />
+                    <field name="country_code" optional="hide"/>
                 </list>
             </field>
         </record>
@@ -17,8 +18,9 @@
                 <form>
                     <group>
                         <group>
-                            <field name="sequence" />
-                            <field name="name" />
+                            <field name="sequence"/>
+                            <field name="name"/>
+                            <field name="country_code"/>
                         </group>
                     </group>
                 </form>


### PR DESCRIPTION
Add a `country_code` field to departure reasons to allow filtering
reasons that are relevant to the currently selected companies.

Move the `reason_code` field to localizations that actually use it.

task-4320913