### PR TITLE
[FIX] account: convert `quick_encoding_vals` to a Json field

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -509,7 +509,7 @@ class AccountMove(models.Model):
         help='Use this field to encode the total amount of the invoice.\n'
              'Odoo will automatically create one invoice line with default values to match it.',
     )
-    quick_encoding_vals = fields.Binary(compute='_compute_quick_encoding_vals', exportable=False)
+    quick_encoding_vals = fields.Json(compute='_compute_quick_encoding_vals', exportable=False)
 
     # === Misc Information === #
     narration = fields.Html(


### PR DESCRIPTION
Currently, if the `quick_encoding_vals` field becomes visible in a view (e.g., by toggling "Show invisible elements" in Studio), the system crashes. This happens because the field is currently a Binary field that cannot be represented as a string.

### Fix

The `quick_encoding_vals` field is an **unstored computed** field that outputs a dictionary. To resolve the issue, we can safely convert it into a JSON field.

Note: Fix confirmed by WAN on the ticket.

opw-4241572