### PR TITLE
[FIX] html_editor: toolbar not getting opened on single selected cell

### DIFF
--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -8,6 +8,7 @@ import { registry } from "@web/core/registry";
 import { ToolbarMobile } from "./mobile_toolbar";
 import { debounce } from "@web/core/utils/timing";
 import { omit, pick } from "@web/core/utils/objects";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 
 /** @typedef { import("@html_editor/core/selection_plugin").EditorSelection } EditorSelection */
 /** @typedef { import("@html_editor/core/user_command_plugin").UserCommand } UserCommand */
@@ -304,7 +305,10 @@ export class ToolbarPlugin extends Plugin {
             return true;
         }
         const isCollapsed = selectionData.editableSelection.isCollapsed;
-        return !isCollapsed && this.getFilterTraverseNodes().length;
+        if (isCollapsed) {
+            return !!closestElement(selectionData.editableSelection.anchorNode, "td.o_selected_td");
+        }
+        return this.getFilterTraverseNodes().length;
     }
 
     shouldPreventClosing(selectionData) {

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -354,6 +354,46 @@ test("toolbar should not open on keypress tab inside table", async () => {
     expect(".o-we-toolbar").toHaveCount(0);
 });
 
+test("toolbar open on single selected cell in table", async () => {
+    const contentBefore = unformat(`
+        <table class="table table-bordered o_table">
+            <tbody>
+                <tr>
+                    <td><p>[]<br></p></td>
+                    <td><p><br></p></td>
+                </tr>
+                <tr>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                </tr>
+            </tbody>
+        </table>
+    `);
+
+    const { el } = await setupEditor(contentBefore);
+    const targetTd = el.querySelector("td");
+    const mouseDownPositionX = targetTd.getBoundingClientRect().left + 10;
+    const mouseDownPositionY = targetTd.getBoundingClientRect().top + 10;
+    const mouseMoveDiff = 40;
+    manuallyDispatchProgrammaticEvent(targetTd, "mousedown", {
+        clientX: mouseDownPositionX,
+        clientY: mouseDownPositionY,
+    });
+    // Simulate mousemove horizontally for 40px.
+    manuallyDispatchProgrammaticEvent(targetTd, "mousemove", {
+        clientX: mouseDownPositionX + mouseMoveDiff,
+        clientY: mouseDownPositionY,
+    });
+    manuallyDispatchProgrammaticEvent(targetTd, "mouseup", {
+        clientX: mouseDownPositionX + mouseMoveDiff,
+        clientY: mouseDownPositionY,
+    });
+    await animationFrame();
+    await tick();
+    expect(targetTd).toHaveClass("o_selected_td");
+    expect(".o-we-toolbar").toHaveCount(1);
+});
+
 test.tags("desktop");
 test("toolbar should close on keypress tab inside table", async () => {
     const contentBefore = unformat(`


### PR DESCRIPTION
**Before this PR:**

When trying to select single empty cell using mouse, toolbar is not getting opened. The reason is that `updateToolbar` gets called from mouseup event in `toolbar_plugin` but it fails to open toolbar because `shouldBeVisible` method returns false if selection is collapsed.

**Behaviour after PR:**

Now toolbar gets opened when selecting single empty cell.

task-4316754


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
