### PR TITLE
[FIX] stock: use reservation to increase move quantity

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1225,7 +1225,9 @@ class MrpProduction(models.Model):
                 continue
 
             new_qty = float_round((self.qty_producing - self.qty_produced) * move.unit_factor, precision_rounding=move.product_uom.rounding)
+            move.quantity = new_qty
             move._set_quantity_done(new_qty)
+
             if not move.manual_consumption:
                 move.picked = True
 

--- a/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
+++ b/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
@@ -25,7 +25,7 @@ registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_
             run: 'text 27',
         },
         { trigger: ".o_form_button_save" },
-        { trigger: ".o_data_row > td:contains('43')" },
+        { trigger: ".o_data_row > td:contains('27')" },
         {
             trigger: ".o_field_widget[name=quantity] input",
             run: 'text 7',
@@ -52,7 +52,7 @@ registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_
             run: 'text 7',
         },
         { trigger: ".o_form_button_save" },
-        { trigger: ".o_data_row > td:contains('10')" },
+        { trigger: ".o_data_row > td:contains('7')" },
         {
             trigger: ".o_field_widget[name=quantity] input",
             run: 'text 8',

--- a/addons/stock/static/src/views/picking_form/stock_move_one2many.js
+++ b/addons/stock/static/src/views/picking_form/stock_move_one2many.js
@@ -48,7 +48,7 @@ export class StockMoveX2ManyField extends X2ManyField {
     async openRecord(record) {
         if (this.canOpenRecord && !record.isNew) {
             const dirty = await record.isDirty();
-            if (dirty && 'quantity' in record._changes) {
+            if (await record._parentRecord.isDirty() || (dirty && 'quantity' in record._changes)) {
                 await record._parentRecord.save({ reload: true });
                 record = record._parentRecord.data[this.props.name].records.find(e => e.resId === record.resId);
                 if (!record) {

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -173,6 +173,24 @@ registry.category("web_tour.tours").add('test_onchange_twice_lot_ids', {
     ]
 });
 
+registry.category("web_tour.tours").add('test_edit_existing_lines_2', {
+    test: true,
+    steps: () => [
+        { trigger: ".o_data_row:has(.o_data_cell[data-tooltip='Product a']) .fa-list", run: 'click'},
+        { trigger: ".o_data_cell[name=lot_name]", run: 'click' },
+        { trigger: ".o_data_cell[name=lot_name] input", run: 'text SNa001'},
+        { trigger: ".o_form_view.modal-content .o_form_button_save", run: 'click'},
+        { trigger: "body:not(:has(div .modal-content))"},
+        { trigger: ".o_data_row:has(.o_data_cell[data-tooltip='Product b']) .fa-list", run: 'click' },
+        { trigger: ".o_data_cell[name=lot_name]", run: 'click' },
+        { trigger: ".o_data_cell[name=lot_name] input", run: 'text SNb001'},
+        { trigger: ".o_form_view.modal-content .o_form_button_save", run: 'click'},
+        { trigger: "body:not(:has(div .modal-content))"},
+        { trigger: ".o_form_view:not(.modal-content) .o_form_button_save", run: 'click' },
+        { trigger: ".o_form_renderer.o_form_saved" },
+    ]
+});
+
 registry.category("web_tour.tours").add("test_add_new_line_in_detailled_op", {
     test: true,
     steps: () => [

--- a/addons/stock/tests/test_picking_tours.py
+++ b/addons/stock/tests/test_picking_tours.py
@@ -165,6 +165,48 @@ class TestStockPickingTour(HttpCase):
         names = self.receipt.move_ids.move_line_ids.mapped('lot_name')
         self.assertEqual(names, ["one", "two"])
 
+    def test_edit_existing_lines_2(self):
+        self.uom_unit = self.env.ref('uom.product_uom_unit')
+        product_a, product_b = self.env["product.product"].create([
+            {
+                'name': 'Product a',
+                'is_storable': True,
+                'tracking': 'serial',
+            },
+            {
+                'name': 'Product b',
+                'is_storable': True,
+                'tracking': 'serial',
+            }
+        ])
+
+        self.receipt.write({
+            "move_ids": [
+                Command.create({
+                    "name": "Product a",
+                    "product_id": product_a.id,
+                    "location_id": self.receipt.location_id.id,
+                    "location_dest_id": self.receipt.location_dest_id.id,
+                    "product_uom_qty": 1,
+                }),
+                Command.create({
+                    "name": "Product b",
+                    "product_id": product_b.id,
+                    "location_id": self.receipt.location_id.id,
+                    "location_dest_id": self.receipt.location_dest_id.id,
+                    "product_uom_qty": 1,
+                }),
+            ]
+        })
+
+        self.receipt.action_confirm()
+
+        url = self._get_picking_url(self.receipt.id)
+        self.start_tour(url, 'test_edit_existing_lines_2', login='admin', timeout=60)
+
+        names = self.receipt.move_ids.move_line_ids.mapped('lot_name')
+        self.assertEqual(names, ["SNa001", "SNb001"])
+
     def test_onchange_serial_lot_ids(self):
         """
         Checks that onchange behaves correctly with respect to multiple unlinks

--- a/addons/stock/tests/test_picking_tours.py
+++ b/addons/stock/tests/test_picking_tours.py
@@ -170,12 +170,12 @@ class TestStockPickingTour(HttpCase):
         product_a, product_b = self.env["product.product"].create([
             {
                 'name': 'Product a',
-                'is_storable': True,
+                'type': 'product',
                 'tracking': 'serial',
             },
             {
                 'name': 'Product b',
-                'is_storable': True,
+                'type': 'product',
                 'tracking': 'serial',
             }
         ])

--- a/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
+++ b/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
@@ -35,7 +35,7 @@ registry.category("web_tour.tours").add('test_stock_picking_batch_sm_to_sml_sync
             run: 'text 27',
         },
         { trigger: ".o_form_button_save" },
-        { trigger: ".o_data_row > td:contains('47')" },
+        { trigger: ".o_data_row > td:contains('27')" },
         {
             trigger: ".o_field_widget[name=quantity] input",
             run: 'text 7',


### PR DESCRIPTION
This commit make use of `_action_assign()` to populate extra stock move
lines when increasing the quantity of a stock move. This feature was
available in v16 but lost from https://github.com/odoo-dev/odoo/commit/7dda6bb92715ea25b2818a62fec5e646f3678b81.

Also back-port https://github.com/odoo/odoo/commit/bf4bdbe775f8f49b2aaac069fc65bc03593b95df to make sure any change on `quantity` on stock move will trigger a `save` to update the stock move line accordingly at the openning of the detailed operations
Task : 4308181


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
