### PR TITLE
[IMP] web: provide a way to execute code after env is ready

### DIFF
--- a/addons/web/static/src/env.js
+++ b/addons/web/static/src/env.js
@@ -28,8 +28,13 @@ import { session } from "@web/session";
  * @returns {OdooEnv}
  */
 export function makeEnv() {
+    const bus = new EventBus();
+    const prom = new Promise((resolve) => {
+        bus.addEventListener("SERVICES-LOADED", resolve, { once: true });
+    });
     return {
-        bus: new EventBus(),
+        bus,
+        isReady: prom,
         services: {},
         debug: odoo.debug,
         get isSmall() {
@@ -132,6 +137,7 @@ async function _startServices(env, toStart) {
         startServicesPromise = null;
     });
     await startServicesPromise;
+    env.bus.trigger("SERVICES-LOADED");
     if (toStart.size) {
         const missingDeps = new Set();
         for (const service of toStart.values()) {

--- a/addons/web/static/tests/env.test.js
+++ b/addons/web/static/tests/env.test.js
@@ -233,3 +233,26 @@ test(`mountComponent: can pass props to the root component`, async () => {
     });
     expect(getFixture()).toHaveText("text from props");
 });
+
+test(`env.isReady is resolved after services are loaded`, async () => {
+    const deferred = new Deferred();
+
+    registerService("test", [], async (env) => {
+        expect.step("before");
+        env.isReady.then(() => {
+            expect.step("env ready");
+        });
+
+        const result = await deferred;
+        expect.step("after");
+        return result;
+    });
+
+    const envCreationPromise = makeMockEnv();
+    await tick(); // wait for startServices
+    expect.verifySteps(["before"]);
+
+    deferred.resolve();
+    await envCreationPromise;
+    expect.verifySteps(["after", "env ready"]);
+});


### PR DESCRIPTION
It is useful to be able to run code after all services are ready. For example, a website service could wait for all other services to be ready, then start mounting interactions/components. If the service does that too quickly, some interactions or components could crash because a service could be missing.

Currently, there is no way to know that all services are ready from a service itself. It is not a problem in the web client: the code simply waits for all services before creating the root application. However, it feels like a limitation when working on a service that need to coordinate the start/destroy of components/interactions.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
