### PR TITLE
[FIX] website_sale: display address fields on checkout

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2291,7 +2291,7 @@
             >
                 <!-- We don't allow public users to have multiple delivery addresses. -->
                 <t t-if="is_invoice">
-                    <t t-set="new_address_href" t-valuef="/shop/address?address_type=billing"/>
+                    <t t-set="new_address_href" t-valuef="/shop/address?address_type=billing&amp;use_delivery_as_billing={{use_delivery_as_billing}}"/>
                 </t>
                 <t t-else="">
                     <t


### PR DESCRIPTION
Steps to reproduce:
- Switch to CO Company
- Website > Configuration > Company = CO Company
- Home Page > Shop > Any product > Add to cart > Proceed to Checkout
- Checkout > Add address > Error occurs

Coupled with https://github.com/odoo/enterprise/pull/73734

Columbian localization is supposed to add fiscal regimen and obligation types to the form when Identification Type is NIT. The xpath is unstable as Identification Type is only displayed if the partner_id of the contact is the same as that of the order and the partner_id is only passed on redirections when the address is missing mandatory fields. Additionally, despite having an option to use the same address for billing and delivery being checked, those fields are inaccessible on the address form, showing up only on the billing address if the addresses are separate.

opw-4295936

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
