### PR TITLE
[IMP] event, event_sale, pos_event: share state between event and pos

### DIFF
--- a/addons/event_product/__manifest__.py
+++ b/addons/event_product/__manifest__.py
@@ -5,6 +5,7 @@
     'depends': ['event', 'product', 'account'],
     'data': [
         'views/event_ticket_views.xml',
+        'views/event_registration_views.xml',
         'data/event_product_data.xml',
     ],
     'demo': [

--- a/addons/event_product/models/__init__.py
+++ b/addons/event_product/models/__init__.py
@@ -3,3 +3,4 @@ from . import event_event_ticket
 from . import event_type_ticket
 from . import product_product
 from . import product_template
+from . import event_registration

--- a/addons/event_product/models/event_registration.py
+++ b/addons/event_product/models/event_registration.py
@@ -1,0 +1,24 @@
+from odoo import fields, models
+
+
+class EventRegistration(models.Model):
+    _inherit = ['event.registration']
+
+    sale_status = fields.Selection(string="Sale Status", selection=[
+            ('to_pay', 'Not Sold'),
+            ('sold', 'Sold'),
+            ('free', 'Free'),
+        ], compute="_compute_registration_status", compute_sudo=True, store=True, readonly=True, precompute=True)
+
+    def _has_order(self):
+        return False
+
+    # sale_status can be computed in pos_event and event_sale. We need to make it
+    # available in both modules, so its now in event module.
+    def _compute_registration_status(self):
+        if not self._has_order():
+            for reg in self:
+                if not reg.sale_status:
+                    reg.sale_status = 'free'
+                if not reg.state:
+                    reg.state = 'open'

--- a/addons/event_product/views/event_registration_views.xml
+++ b/addons/event_product/views/event_registration_views.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo><data>
+
+    <record id="view_event_registration_ticket_tree" model="ir.ui.view">
+        <field name="name">event.registration.list.inherit</field>
+        <field name="model">event.registration</field>
+        <field name="inherit_id" ref="event.view_event_registration_tree" />
+        <field name="arch" type="xml">
+            <field name="state" position="after">
+                <field name="sale_status" optional="show" widget="badge"
+                    decoration-success="sale_status == 'sold'"
+                    decoration-danger="sale_status == 'to_pay'"
+                    invisible="not sale_status" />
+            </field>
+        </field>
+    </record>
+
+    <record id="event_registration_view_graph" model="ir.ui.view">
+        <field name="name">event.registration.graph.inherit.event.sale</field>
+        <field name="model">event.registration</field>
+        <field name="inherit_id" ref="event.view_event_registration_graph"/>
+        <field name="arch" type="xml">
+            <field name="event_id" position="after">
+                <field name="sale_status" />
+            </field>
+        </field>
+    </record>
+
+    <record id="event_registration_ticket_view_form" model="ir.ui.view">
+        <field name="name">event.registration.form.inherit</field>
+        <field name="model">event.registration</field>
+        <field name="inherit_id" ref="event.view_event_registration_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group" position="before">
+                <widget name="web_ribbon" title="Sold" bg_color="text-bg-success"
+                    invisible="sale_status != 'sold'"/>
+                <widget name="web_ribbon" title="Not Sold" bg_color="text-bg-info"
+                    invisible="not sale_status or sale_status in ('sold', 'free') or not id"/>
+            </xpath>
+             <group name="utm_link" position="before">
+                <group string="Transaction" name="transaction" groups="base.group_no_one" />
+            </group>
+        </field>
+    </record>
+
+</data></odoo>

--- a/addons/event_sale/models/event_registration.py
+++ b/addons/event_sale/models/event_registration.py
@@ -11,11 +11,6 @@ class EventRegistration(models.Model):
     # TDE FIXME: maybe add an onchange on sale_order_id
     sale_order_id = fields.Many2one('sale.order', string='Sales Order', ondelete='cascade', copy=False)
     sale_order_line_id = fields.Many2one('sale.order.line', string='Sales Order Line', ondelete='cascade', copy=False)
-    sale_status = fields.Selection(string="Sale Status", selection=[
-            ('to_pay', 'Not Sold'),
-            ('sold', 'Sold'),
-            ('free', 'Free'),
-        ], compute="_compute_registration_status", compute_sudo=True, store=True, precompute=True)
     state = fields.Selection(default=None, compute="_compute_registration_status", store=True, readonly=False, precompute=True)
     utm_campaign_id = fields.Many2one(compute='_compute_utm_campaign_id', readonly=False,
         store=True, ondelete="set null")
@@ -23,6 +18,9 @@ class EventRegistration(models.Model):
         store=True, ondelete="set null")
     utm_medium_id = fields.Many2one(compute='_compute_utm_medium_id', readonly=False,
         store=True, ondelete="set null")
+
+    def _has_order(self):
+        return super()._has_order() or self.sale_order_id
 
     @api.depends('sale_order_id.state', 'sale_order_id.currency_id', 'sale_order_id.amount_total')
     def _compute_registration_status(self):
@@ -39,6 +37,7 @@ class EventRegistration(models.Model):
                 (registrations - sold_registrations).sale_status = 'to_pay'
                 sold_registrations.filtered(lambda reg: not reg.state or reg.state in {'draft', 'cancel'}).state = "open"
                 (registrations - sold_registrations - cancelled_registrations).state = 'draft'
+        super()._compute_registration_status()
 
     @api.depends('sale_order_id')
     def _compute_utm_campaign_id(self):

--- a/addons/event_sale/views/event_registration_views.xml
+++ b/addons/event_sale/views/event_registration_views.xml
@@ -9,29 +9,13 @@
             <field name="event_id" position="after">
                 <field name="sale_order_id" optional="hide"/>
             </field>
-            <field name="state" position="after">
-                <field name="sale_status" optional="show" widget="badge"
-                    decoration-success="sale_status == 'sold'"
-                    decoration-danger="sale_status == 'to_pay'"/>
-            </field>
-        </field>
-    </record>
-
-    <record id="event_registration_view_graph" model="ir.ui.view">
-        <field name="name">event.registration.graph.inherit.event.sale</field>
-        <field name="model">event.registration</field>
-        <field name="inherit_id" ref="event.view_event_registration_graph"/>
-        <field name="arch" type="xml">
-            <field name="event_id" position="after">
-                <field name="sale_status"/>
-            </field>
         </field>
     </record>
 
     <record id="event_registration_ticket_view_form" model="ir.ui.view">
         <field name="name">event.registration.form.inherit</field>
         <field name="model">event.registration</field>
-        <field name="inherit_id" ref="event.view_event_registration_form" />
+        <field name="inherit_id" ref="event_product.event_registration_ticket_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button name="action_view_sale_order" type="object"
@@ -42,20 +26,10 @@
                             <span class="o_stat_text">Sale Order</span>
                         </div>
                 </button>
-                <field name="sale_order_id" invisible="1"/>
             </xpath>
-            <xpath expr="//group" position="before">
-                <field name="sale_status" invisible="1"/>
-                <widget name="web_ribbon" title="Sold" bg_color="text-bg-success"
-                    invisible="sale_status != 'sold'"/>
-                <widget name="web_ribbon" title="Not Sold" bg_color="text-bg-info"
-                    invisible="sale_status in ('sold', 'free') or not id"/>
-            </xpath>
-            <group name="utm_link" position="before">
-                <group string="Transaction" groups="base.group_no_one">
-                    <field name="sale_order_id"/>
-                    <field name="sale_order_line_id" readonly="1" invisible="not sale_order_id"/>
-                </group>
+            <group name="transaction" position="inside">
+                <field name="sale_order_id"/>
+                <field name="sale_order_line_id" readonly="1" invisible="not sale_order_id"/>
             </group>
         </field>
     </record>

--- a/addons/pos_event/__manifest__.py
+++ b/addons/pos_event/__manifest__.py
@@ -3,12 +3,14 @@
 {
     'name': "POS - Event",
     'category': "Technical",
+    'version': "1.0",
     'summary': 'Link module between Point of Sale and Event',
     'depends': ['point_of_sale', 'event_product'],
     'data': [
         'security/ir.model.access.csv',
         'data/point_of_sale_data.xml',
         'data/event_product_data.xml',
+        'views/event_registration_views.xml',
         'views/event_event_views.xml',
         'views/pos_order_views.xml',
     ],

--- a/addons/pos_event/models/event_registration.py
+++ b/addons/pos_event/models/event_registration.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import fields, models, api
+from odoo.tools import float_is_zero
 
 
 class EventRegistration(models.Model):
@@ -8,6 +9,24 @@ class EventRegistration(models.Model):
 
     pos_order_id = fields.Many2one(related='pos_order_line_id.order_id', string='PoS Order')
     pos_order_line_id = fields.Many2one('pos.order.line', string='PoS Order Line', ondelete='cascade', copy=False)
+
+    def _has_order(self):
+        return super()._has_order() or self.pos_order_id
+
+    @api.depends('pos_order_id.state', 'pos_order_id.currency_id', 'pos_order_id.amount_total')
+    def _compute_registration_status(self):
+        if self.pos_order_id:
+            for registration in self:
+                if registration.pos_order_id.state == 'cancel':
+                    registration.state = 'cancel'
+                elif float_is_zero(registration.pos_order_id.amount_total, precision_rounding=registration.pos_order_id.currency_id.rounding):
+                    registration.sale_status = 'free'
+                    registration.state = 'open'
+                else:
+                    registration.sale_status = 'sold'
+                    registration.state = 'open'
+
+        super()._compute_registration_status()
 
     @api.model
     def _load_pos_data_domain(self, data):
@@ -33,3 +52,9 @@ class EventRegistration(models.Model):
         session_ids = self.env['pos.session'].sudo().search([("state", "!=", "closed")])
         if len(session_ids) > 0:
             session_ids.config_id._update_events_seats(self.event_id)
+
+    def action_view_pos_order(self):
+        action = self.env["ir.actions.actions"]._for_xml_id("point_of_sale.action_pos_pos_form")
+        action['views'] = [(False, 'form')]
+        action['res_id'] = self.pos_order_id.id
+        return action

--- a/addons/pos_event/static/src/app/services/pos_store.js
+++ b/addons/pos_event/static/src/app/services/pos_store.js
@@ -51,6 +51,14 @@ patch(PosStore.prototype, {
                 taxes_id: taxeIds.map((tax) => ["link", tax]),
                 _event_id: event.id,
             });
+
+            // Disable products
+            for (const ticket of event.event_ticket_ids) {
+                const productTmpl = ticket.product_id.product_tmpl_id;
+                if (productTmpl) {
+                    productTmpl.available_in_pos = false;
+                }
+            }
         }
     },
 });

--- a/addons/pos_event/views/event_registration_views.xml
+++ b/addons/pos_event/views/event_registration_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo><data>
+    <record id="event_registration_ticket_view_form" model="ir.ui.view">
+        <field name="name">event.registration.form.inherit</field>
+        <field name="model">event.registration</field>
+        <field name="inherit_id" ref="event_product.event_registration_ticket_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_view_pos_order" type="object"
+                        class="oe_stat_button" icon="fa-usd"
+                        groups="point_of_sale.group_pos_user"
+                        invisible="not pos_order_id">
+                        <div class="o_stat_info">
+                            <span class="o_stat_text">PoS Order</span>
+                        </div>
+                </button>
+            </xpath>
+            <group name="transaction" position="inside">
+                <field name="pos_order_id" invisible="not pos_order_id" />
+            </group>
+        </field>
+    </record>
+</data></odoo>


### PR DESCRIPTION
Before the `state` fields was only managed with event_sale. But since we are able to sell tickets from the POS, we need to share the state between these modules to have a coherent state.

This commit adds the `state` field to the `event.registration` model directly in `event` module. This way, the state is shared between `event`, `event_sale` and `pos_event`.

This commit also add a `oe_stat_button` to the `event.registration` form view to be able to access to its pos_order directly.

taskId-4330905

