### PR TITLE
[IMP] point_of_sale: add offline tours tests

### DIFF
--- a/addons/point_of_sale/static/tests/generic_helpers/offline_util.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/offline_util.js
@@ -1,0 +1,33 @@
+import { run } from "@point_of_sale/../tests/generic_helpers/utils";
+import { ConnectionLostError } from "@web/core/network/rpc";
+
+const originalFetch = window.fetch;
+const originalSend = XMLHttpRequest.prototype.send;
+const originalConsoleError = console.error;
+
+export function setOfflineMode() {
+    return run(() => {
+        window.fetch = () => {
+            throw new ConnectionLostError();
+        };
+        XMLHttpRequest.prototype.send = () => {
+            throw new ConnectionLostError();
+        };
+        console.error = (...args) => {
+            const message = args[0] instanceof Error ? args[0].message : args[0];
+            if (typeof message === "string" && message.includes("ConnectionLostError")) {
+                console.info("Connection lost error handled in offline mode:", ...args);
+            } else {
+                originalConsoleError.apply(console, args);
+            }
+        };
+    }, "Offline mode is now enabled");
+}
+
+export function setOnlineMode() {
+    return run(() => {
+        window.fetch = originalFetch;
+        XMLHttpRequest.prototype.send = originalSend;
+        console.error = originalConsoleError;
+    }, "Offline mode is now disabled");
+}

--- a/addons/point_of_sale/static/tests/pos/tours/acceptance_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/acceptance_tour.js
@@ -5,12 +5,14 @@ import { inLeftSide, waitForLoading } from "@point_of_sale/../tests/pos/tours/ut
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
 
 registry.category("web_tour.tours").add("pos_basic_order_01_multi_payment_and_change", {
     steps: () =>
         [
             waitForLoading(),
             Chrome.startPoS(),
+            OfflineUtil.setOfflineMode(),
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1.0", "5.10"),
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "2.0", "10.20"),
             ProductScreen.clickPayButton(),
@@ -24,6 +26,7 @@ registry.category("web_tour.tours").add("pos_basic_order_01_multi_payment_and_ch
                 amount: "6.0",
                 change: "0.80",
             }),
+            OfflineUtil.setOnlineMode(),
             ProductScreen.finishOrder(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
@@ -4,11 +4,13 @@ import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
 import { registry } from "@web/core/registry";
+import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
 
 registry.category("web_tour.tours").add("PaymentScreenTour", {
     steps: () =>
         [
             Chrome.startPoS(),
+            OfflineUtil.setOfflineMode(),
             ProductScreen.addOrderline("Letter Tray", "10"),
             ProductScreen.clickPayButton(),
             PaymentScreen.emptyPaymentlines("52.8"),
@@ -57,6 +59,7 @@ registry.category("web_tour.tours").add("PaymentScreenTour", {
             PaymentScreen.validateButtonIsHighlighted(false),
             PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.0" }),
             PaymentScreen.validateButtonIsHighlighted(true),
+            OfflineUtil.setOnlineMode(),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/pos/tours/pricelist_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pricelist_tour.js
@@ -5,6 +5,7 @@ import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_uti
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Pricelist from "@point_of_sale/../tests/pos/tours/utils/pricelist_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
 
 registry.category("web_tour.tours").add("pos_pricelist", {
     steps: () =>
@@ -13,6 +14,7 @@ registry.category("web_tour.tours").add("pos_pricelist", {
             Pricelist.setUp(),
             Pricelist.waitForUnitTest(),
             Dialog.confirm("Open Register"),
+            OfflineUtil.setOfflineMode(),
             ProductScreen.clickPriceList("Fixed", true, "Public Pricelist"),
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("Deco Addict"),
@@ -41,6 +43,7 @@ registry.category("web_tour.tours").add("pos_pricelist", {
             ProductScreen.clickPriceList("Public Pricelist"),
             ...Order.hasTotal(`$ 8.96`),
             ProductScreen.clickPriceList("min_quantity ordering"),
+            OfflineUtil.setOnlineMode(),
             ProductScreen.closePos(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -11,6 +11,7 @@ import { back, inLeftSide, selectButton } from "@point_of_sale/../tests/pos/tour
 import { scan_barcode } from "@point_of_sale/../tests/generic_helpers/utils";
 import * as ProductConfiguratorPopup from "@point_of_sale/../tests/pos/tours/utils/product_configurator_util";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
+import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
 
 registry.category("web_tour.tours").add("ProductScreenTour", {
     checkDelay: 50,
@@ -19,6 +20,7 @@ registry.category("web_tour.tours").add("ProductScreenTour", {
             // Go by default to home category
 
             Chrome.startPoS(),
+            OfflineUtil.setOfflineMode(),
             ProductScreen.firstProductIsFavorite("Whiteboard Pen"),
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1.0", "5.10"),
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "2.0", "10.20"),
@@ -133,6 +135,7 @@ registry.category("web_tour.tours").add("ProductScreenTour", {
                 }),
             ]),
             ProductScreen.isShown(),
+            OfflineUtil.setOnlineMode(),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -8,6 +8,7 @@ import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import { registry } from "@web/core/registry";
 import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
+import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
 
 registry.category("web_tour.tours").add("ReceiptScreenTour", {
     checkDelay: 50,
@@ -15,6 +16,7 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
         [
             // press close button in receipt screen
             Chrome.startPoS(),
+            OfflineUtil.setOfflineMode(),
             ProductScreen.addOrderline("Letter Tray", "10", "5"),
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("Addison Olson"),
@@ -25,6 +27,7 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
             PaymentScreen.shippingLaterHighlighted(),
             PaymentScreen.clickValidate(),
             ReceiptScreen.receiptIsThere(),
+            Dialog.confirm("Continue with limited functionality"),
             //receipt had expected delivery printed
             ReceiptScreen.shippingDateExists(),
             ReceiptScreen.shippingDateIsToday(),
@@ -42,12 +45,14 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
             PaymentScreen.clickNumpad("0"),
             PaymentScreen.fillPaymentLineAmountMobile("Cash", "700"),
             PaymentScreen.changeIs("628.0"),
+            OfflineUtil.setOnlineMode(),
             PaymentScreen.clickValidate(),
             ReceiptScreen.receiptIsThere(),
             ReceiptScreen.totalAmountContains("72.0"),
             ReceiptScreen.setEmail("test@receiptscreen.com"),
             ReceiptScreen.clickSend(),
             ReceiptScreen.emailIsSuccessful(),
+            OfflineUtil.setOfflineMode(),
             ReceiptScreen.clickNextOrder(),
 
             // order with tip
@@ -98,6 +103,7 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
             Order.hasLine({ productName: "Desk Pad", priceNoDiscount: "20" }),
             ReceiptScreen.totalAmountContains("19.00"),
             ReceiptScreen.clickNextOrder(),
+            OfflineUtil.setOnlineMode(),
         ].flat(),
 });
 


### PR DESCRIPTION
- Create tour utils to enable/diable offline mode in order to test offline feature
- Use offline mode in some existing tours



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
