### PR TITLE
[PERF] mail: speed up fetching of `avatar_128`

### DIFF
--- a/addons/mail/models/discuss/ir_binary.py
+++ b/addons/mail/models/discuss/ir_binary.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
+from odoo.osv.expression import OR
 
 
 class IrBinary(models.AbstractModel):
@@ -10,15 +11,16 @@ class IrBinary(models.AbstractModel):
         if record._name in ["res.partner", "mail.guest"] and field == "avatar_128":
             current_partner, current_guest = self.env["res.partner"]._get_current_persona()
             if current_partner or current_guest:
-                domain = []
+                member_lookup_domains = []
                 if record._name == "res.partner":
-                    domain.append(("channel_member_ids", "any", [("partner_id", "=", record.id)]))
+                    member_lookup_domains.append([("partner_id", "=", record.id)])
                 else:
-                    domain.append(("channel_member_ids", "any", [("guest_id", "=", record.id)]))
+                    member_lookup_domains.append([("guest_id", "=", record.id)])
                 if current_partner:
-                    domain.append(("channel_member_ids", "any", [("partner_id", "=", current_partner.id)]))
+                    member_lookup_domains.append([("partner_id", "=", current_partner.id)])
                 else:
-                    domain.append(("channel_member_ids", "any", [("guest_id", "=", current_guest.id)]))
+                    member_lookup_domains.append([("guest_id", "=", current_guest.id)])
+                domain = [('channel_member_ids', 'any', OR(member_lookup_domains))]
                 if self.env["discuss.channel"].search_count(domain, limit=1):
                     return record.sudo()
         return super()._find_record_check_access(record, access_token, field)


### PR DESCRIPTION
## Description
Following d6c6351c7f0b241578121d459943fdf2b305571e, the `ir.rule` related to discuss channels got more elaborated, with more subqueries. When loading an `avatar_128`, in an override of `_find_record_check_access`, a repetitive domain with an `any` operator on the same left leaf. This repetitive domain + the new `ir.rule` lead to a bad postgres plan, leading to a perf regression.

## Fix
Aggregate the right leaf of the domain in a disjonction, it's semantically equivalent, and leads to less subqueries in total for the final query. The plan is simpler and actually uses lazy merging nodes, which allows early exit with the `limit=1`, instead of hashjoins, which forces a total evaluation of the subplans (so `limit=1` is useless in that case).

## Benchmark
On next.odoo.com, loading an `avatar_128`, cache disabled in browser (simulating a first load)

|               | Before | After | Speed-up |
|---------------|--------|-------|----------|
| Timings (hot) | 3s     | 200ms | 15x      |


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
