### PR TITLE
[FIX] test_lint : add support for SQL wrapper in the wrapper constructor

### DIFF
--- a/odoo/addons/test_lint/tests/_odoo_checker_sql_injection.py
+++ b/odoo/addons/test_lint/tests/_odoo_checker_sql_injection.py
@@ -107,6 +107,8 @@ class OdooBaseChecker(BaseChecker):
 
     def _evaluate_function_call(self, node, args_allowed, position):
         name = node.func.attrname if isinstance(node.func, astroid.Attribute) else node.func.name
+        if name == 'SQL':
+            return True
         if isinstance(node.scope(), astroid.GeneratorExp):
             return True
         if name == node.scope().name:


### PR DESCRIPTION
Before this commit, the tester did not account for the use of an SQL wrapper inside of the constructor of an other SQL wrapper,

This lead to a RecusionError when trying to infer the value of the Call node.

This simple fix prevent the check of an other SQL wrapper during the classical call node analysis. This Call node would be analysed anyway during the visit_call function.

