### PR TITLE
[PERF] mail: speed up fetching of `avatar_128`

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -59,7 +59,7 @@ class Channel(models.Model):
         compute='_compute_channel_partner_ids', inverse='_inverse_channel_partner_ids',
         search='_search_channel_partner_ids')
     channel_member_ids = fields.One2many('discuss.channel.member', 'channel_id', string='Members')
-    parent_channel_id = fields.Many2one("discuss.channel", help="Parent channel", ondelete="cascade", index=True, readonly=True)
+    parent_channel_id = fields.Many2one("discuss.channel", help="Parent channel", ondelete="cascade", index=True, auto_join=True, readonly=True)
     sub_channel_ids = fields.One2many("discuss.channel", "parent_channel_id", string="Sub Channels", readonly=True)
     from_message_id = fields.Many2one("mail.message", help="The message the channel was created from.", readonly=True)
     pinned_message_ids = fields.One2many('mail.message', 'res_id', domain=[('model', '=', 'discuss.channel'), ('pinned_at', '!=', False)], string='Pinned Messages')

--- a/addons/mail/models/discuss/ir_binary.py
+++ b/addons/mail/models/discuss/ir_binary.py
@@ -1,13 +1,26 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
+from odoo.exceptions import AccessError, MissingError
 
 
 class IrBinary(models.AbstractModel):
     _inherit = "ir.binary"
 
     def _find_record_check_access(self, record, access_token, field):
-        if record._name in ["res.partner", "mail.guest"] and field == "avatar_128":
+        if not (record._name in ["res.partner", "mail.guest"] and field == "avatar_128"):
+            return super()._find_record_check_access(record, access_token, field)
+
+        # implement fallback permission checks for avatar visibility, based on channel membership, but
+        # *always* try calling super() first, because the fallback checks are not cheap! In many cases
+        # the user has direct access to the avatar, without requiring specific channel membership.
+        #
+        # TODO: in master this complexity could be avoided by using a specific route for accessing
+        #  channel avatars, based on the channel ID. This way we won't need to search all channels
+        #  for a possible membership, when no direct access is granted.
+        try:
+            return super()._find_record_check_access(record, access_token, field)
+        except (AccessError, MissingError) as e:
             current_partner, current_guest = self.env["res.partner"]._get_current_persona()
             if current_partner or current_guest:
                 domain = []
@@ -21,4 +34,4 @@ class IrBinary(models.AbstractModel):
                     domain.append(("channel_member_ids", "any", [("guest_id", "=", current_guest.id)]))
                 if self.env["discuss.channel"].search_count(domain, limit=1):
                     return record.sudo()
-        return super()._find_record_check_access(record, access_token, field)
+            raise e


### PR DESCRIPTION
## Description
Following d6c6351c7f0b241578121d459943fdf2b305571e, the `ir.rule` related to discuss channels got more elaborated, with more subqueries. When loading an `avatar_128`, in an override of `_find_record_check_access`, a repetitive domain with an `any` operator on the same left leaf. This repetitive domain + the new `ir.rule` lead to a bad postgres plan, leading to a perf regression.

## Fix
We add an `auto_join=True` on `parent_channel_id` to avoid doing an additional nested sub-query coming from the `ir.rule`. This change is safe, as the comodel is the same model as the current one, and an user that has access to a subchannel, should probably already have access to its parent channel.
The other improvement is an optimistic early `super()` call, which should not raise any issue for internal employees, who already should have access to the avatar. In case of an access violation, we fallback on the previous behaviour.

## Benchmark
On a large database, loading an `avatar_128`, cache disabled in browser (simulating a first load) for an internal non-privileged user.

|                      | Timings   |
|----------------------|-----------|
| Before               | 300~400ms |
| `auto_join=True`     | 20~25ms   |
| + `super()` shortcut | 13~23ms   |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
