### PR TITLE
[IMP] website: Parallax Zoom In and Zoom Out effects

### DIFF
--- a/addons/website/static/tests/tours/parallax.js
+++ b/addons/website/static/tests/tours/parallax.js
@@ -23,7 +23,7 @@ registerWebsitePreviewTour("test_parallax", {
     trigger: ":iframe .s_cover span[data-gl-filter='blur']",
 },
     changeOption("Parallax", "we-toggler"),
-    changeOption("Parallax", 'we-button[data-select-data-attribute="0"]'),
+    changeOption("Parallax", 'we-button[data-set-parallax-type="none"]'),
 {
     content: "Check that the data related to the filter have been transferred to the new target",
     trigger: ":iframe .s_cover[data-gl-filter='blur']",
@@ -33,7 +33,7 @@ registerWebsitePreviewTour("test_parallax", {
     trigger: ":iframe .s_cover.o_modified_image_to_save",
 },
     changeOption("Parallax", "we-toggler"),
-    changeOption("Parallax", 'we-button[data-select-data-attribute="1"]'),
+    changeOption("Parallax", 'we-button[data-set-parallax-type="fixed"]'),
 {
     content: "Check that the 'o_modified_image_to_save' class has been deleted from the old target",
     trigger: ":iframe .s_cover:not(.o_modified_image_to_save)",
@@ -47,10 +47,16 @@ registerWebsitePreviewTour("test_parallax", {
     trigger: ":iframe span.s_parallax_bg[data-gl-filter='blur']",
 },
     changeOption("Parallax", "we-toggler"),
-    changeOption("Parallax", 'we-button[data-select-data-attribute="1.5"]'),
+    changeOption("Parallax", 'we-button[data-set-parallax-type="top"]'),
 {
     content: "Check that the option was correctly applied",
     trigger: ':iframe span.s_parallax_bg[style*=top][style*=bottom][style*=transform]',
+},
+    changeOption("Parallax", "we-toggler"),
+    changeOption("Parallax", 'we-button[data-set-parallax-type="zoom_in"]'),
+{
+    content: "Check that the option was correctly applied",
+    trigger: ':iframe span.s_parallax_bg[style*="transform: scale("]',
 },
     ...clickOnSave(),
     ...clickOnEditAndWaitEditMode(),

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -498,17 +498,17 @@
              t-att-data-selector="selector"
              t-att-data-exclude="exclude"
              t-att-data-target="target">
-            <we-select string="Parallax"
+            <we-select string="Scroll Effect"
                        class="o_we_sublevel_2"
-                       data-attribute-name="scrollBackgroundRatio"
-                       data-attribute-default-value="0"
                        data-parallax-type-opt="true"
                        data-no-preview="true"
                        data-dependencies="bg_image_opt">
-                <we-button data-name="parallax_none_opt" data-select-data-attribute="0">None</we-button>
-                <we-button data-select-data-attribute="1">Fixed</we-button>
-                <we-button data-name="parallax_top_opt" data-select-data-attribute="1.5">Bottom to Top</we-button>
-                <we-button data-name="parallax_bottom_opt" data-select-data-attribute="-1.5">Top to Bottom</we-button>
+                <we-button data-name="parallax_none_opt" data-set-parallax-type="none">None</we-button>
+                <we-button data-set-parallax-type="fixed">Fixed</we-button>
+                <we-button data-name="parallax_top_opt" data-set-parallax-type="top">Parallax to Top</we-button>
+                <we-button data-name="parallax_bottom_opt" data-set-parallax-type="bottom">Parallax to Bottom</we-button>
+                <we-button data-name="parallax_zoom_in_opt" data-set-parallax-type="zoom_in">Zoom In</we-button>
+                <we-button data-name="parallax_zoom_out_opt" data-set-parallax-type="zoom_out">Zoom Out</we-button>
             </we-select>
             <we-range string="Intensity"
                       class="o_we_sublevel_3"
@@ -530,6 +530,26 @@
                       data-min="0"
                       data-max="-3"
                       data-step="0.15"/> <!-- Make sure this cannot land on 1 -->
+            <we-range string="Intensity"
+                      class="o_we_sublevel_3"
+                      data-dependencies="parallax_zoom_in_opt"
+                      data-select-data-attribute=""
+                      data-attribute-name="scrollBackgroundRatio"
+                      data-attribute-default-value="0"
+                      data-no-preview="true"
+                      data-min="0"
+                      data-max="3"
+                      data-step="0.15"/> <!-- Make sure this cannot land on 1 -->
+            <we-range string="Intensity"
+                      class="o_we_sublevel_3"
+                      data-dependencies="parallax_zoom_out_opt"
+                      data-select-data-attribute=""
+                      data-attribute-name="scrollBackgroundRatio"
+                      data-attribute-default-value="0"
+                      data-no-preview="true"
+                      data-min="0"
+                      data-max="0.95"
+                      data-step="0.05"/>
         </div>
         <div data-js="BackgroundVideo"
              t-att-data-selector="selector"


### PR DESCRIPTION
For better customization I added the Zoom In and Zoom Out parallax effect on background images.

The parallax effect on background images before had only "None", "Fixed", "Bottom to Top" and "Top to Bottom"

Now the parallax effect has  "None", "Fixed", "Parallax to Top", "Parallax to Bottom", "Zoom In" and ''Zoom Out".
I also renamed "Parallax" to "Scroll Effect", "Bottom to Top" to "Parallax to Top", "Top to Bottom" to "Parallax to Bottom" to have a better naming for the options.

task-4317372

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
