### PR TITLE
[FIX] base: update ir_default when merging records

### DIFF
--- a/addons/account/tests/test_account_merge_wizard.py
+++ b/addons/account/tests/test_account_merge_wizard.py
@@ -271,3 +271,14 @@ class TestAccountMergeWizard(TestAccountMergeCommon):
         ]
 
         self.assertRecordValues(wizard.wizard_line_ids, expected_wizard_line_vals)
+
+    def test_merge_accounts_company_dependent_related(self):
+        payable_accounts = self.env['account.account'].search([('name', '=', 'Account Payable')])
+        self.assertEqual(len(payable_accounts), 2)
+        wizard = self._create_account_merge_wizard(payable_accounts)
+        wizard.action_merge()
+        payable_accounts = self.env['account.account'].search([('name', '=', 'Account Payable')])
+        self.assertEqual(len(payable_accounts), 1)
+        for company in self.env.companies:
+            partner_payable_account = self.partner_a.with_company(company).property_account_payable_id.exists()
+            self.assertEqual(partner_payable_account, payable_accounts)

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -234,6 +234,28 @@ class MergePartnerAutomatic(models.TransientModel):
                 dest_record_id=dst_record.id,
             ))
 
+        # merge the fallback values for company dependent many2one fields
+        self.env.cr.execute(SQL(
+            """
+            UPDATE ir_default
+            SET json_value =
+                CASE
+                    WHEN json_value::int IN %(src_record_ids)s
+                    THEN %(dest_record_id)s
+                    ELSE json_value
+                END
+            FROM ir_model_fields f
+            WHERE f.id = ir_default.field_id
+            AND f.company_dependent
+            AND f.relation = %(model_name)s
+            AND f.ttype = 'many2one'
+            AND json_value ~ '^[0-9]+$';
+            """,
+            src_record_ids=tuple(src_records.ids),
+            dest_record_id=str(dst_record.id),
+            model_name=dst_record._name,
+        ))
+
         self.env.flush_all()
 
         # company_dependent fields of merged records


### PR DESCRIPTION
When merging records that are related to company-dependent fields,
we update the company_dependent fields referring the merged records
but they are `null` if the user has never set them.
Therefore, we need to update the `ir_default` table, which stores
the default values.

Steps:

- Install stock_accountant
- Install the CoA on both companies
- Select both companies in company selector
- Go to charts of accounts and merge 'Stock Valuation accounts'
- Go to any Product Category for both companies, we get an error
  whith one of the companies because we're trying to
  access a record that has been deleted during the merge

opw-4245539
