### PR TITLE
[FIX] purchase_requisition: copy blanket order lines' custom description to purchase order

### DIFF
--- a/addons/purchase_requisition/models/purchase.py
+++ b/addons/purchase_requisition/models/purchase.py
@@ -294,7 +294,7 @@ class PurchaseOrderLine(models.Model):
                     name = pol._get_product_purchase_description(pol.product_id.with_context(product_ctx))
                     if line.product_description_variants:
                         name += '\n' + line.product_description_variants
-                    pol.name = name
+                    pol.name = (pol.name or name) if pol.order_id.requisition_id.type_id.line_copy == 'copy' else name
                     break
         super(PurchaseOrderLine, po_lines_without_requisition)._compute_price_unit_and_date_planned_and_name()
 


### PR DESCRIPTION

**Issue:**
When a purchase order is made from a blanket order, even with the line copying option activated, the custom description is replaced.

**Expected:**
From a blanket order with Line copying activated (`Use lines of agreement`), the blanket order's lines' content should be copied and pasted identically on the purchase order.

**Steps to reproduce:**
- Activate Purchase app and activate Purchase Agreements in the settings;
- Create a Blanket Order with at least 2 identical products;
- Insert a Custom Description for each line;
- Create a New Quotation from the Blanket Order and read the Custom Description column content.

**Cause:**
Product description manually entered is replaced on PO creation. https://github.com/odoo/odoo/blob/16.0/addons/purchase_requisition/models/purchase.py#L297

**Fix:**
Copy product description variant if line copying is activated.

opw-4230676

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
