### PR TITLE
[FIX] website, html_editor: restore fuzzy page search for linkpopover url input

### DIFF
--- a/addons/html_editor/__manifest__.py
+++ b/addons/html_editor/__manifest__.py
@@ -22,6 +22,7 @@ This addon provides an extensible, maintainable editor.
         'web.assets_backend': [
             'html_editor/static/src/**/*',
             ('include', 'html_editor.assets_media_dialog'),
+            ('include', 'html_editor.assets_link_popover'),
             ('remove', 'html_editor/static/src/components/history_dialog/history_dialog.dark.scss'),
             ('remove', 'html_editor/static/src/main/toolbar/toolbar.dark.scss'),
         ],
@@ -41,6 +42,11 @@ This addon provides an extensible, maintainable editor.
         'html_editor.assets_image_cropper': [
             'html_editor/static/lib/cropperjs/cropper.css',
             'html_editor/static/lib/cropperjs/cropper.js',
+        ],
+        'html_editor.assets_link_popover': [
+            'html_editor/static/src/main/link/link_popover.js',
+            'html_editor/static/src/main/link/link_popover.xml',
+            'html_editor/static/src/main/link/utils.js',
         ],
     },
     'license': 'LGPL-3'

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -107,7 +107,6 @@ export class LinkPopover extends Component {
         this.state.url = deducedUrl
             ? this.correctLink(deducedUrl)
             : this.correctLink(this.state.url);
-        this.loadAsyncLinkPreview();
         this.props.onApply(this.state.url, this.state.label, this.state.classes);
     }
     onClickEdit() {

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -5,7 +5,7 @@
             <div t-if="state.editing" class="container-fluid d-flex vertical-center p-2" t-ref="editing-wrapper"  data-prevent-closing-overlay="true">
                 <div t-if="state.isImage" class="col p-2" style="max-width: 250px;">
                     <div class="input-group mb-1">
-                        <input t-ref="url" class="o_we_href_input_link form-control form-control-sm" t-model="state.url" title="URL" placeholder="Type your URL" t-on-keydown="onKeydownEnter"/>
+                        <input name="o_linkpopover_url_img" t-ref="url" class="o_we_href_input_link form-control form-control-sm" t-model="state.url" title="URL" placeholder="Type your URL" t-on-keydown="onKeydownEnter"/>
                         <button class="o_we_apply_link btn btn-sm btn-primary" t-att-class="{'mx-1': state.type ===  ''}" t-on-click="onClickApply">Apply</button>
                     </div>
                 </div>
@@ -15,7 +15,7 @@
                             <input t-ref="label" class="o_we_label_link form-control form-control-sm" t-model="state.label" title="Label" placeholder="Type your link label"/>
                         </div>
                         <div class="input-group mb-1">
-                            <input t-ref="url" class="o_we_href_input_link form-control form-control-sm" t-model="state.url" title="URL" placeholder="Type your URL" t-on-keydown="onKeydownEnter"/>
+                            <input name="o_linkpopover_url" t-ref="url" class="o_we_href_input_link form-control form-control-sm" t-model="state.url" title="URL" placeholder="Type your URL" t-on-keydown="onKeydownEnter"/>
                             <span class="ms-1" t-if="props.canUpload and !state.url">
                                 or <button class="btn btn-secondary btn-sm" t-on-click="uploadFile">Upload File</button>
                             </span>

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -11,6 +11,7 @@
         'digest',
         'web',
         'web_editor',
+        'html_editor',
         'http_routing',
         'portal',
         'social_media',
@@ -282,6 +283,9 @@
         'web.qunit_suite_tests': [
             'website/static/tests/redirect_field_tests.js',
         ],
+        'web.assets_unit_tests': [
+            'website/static/tests/website_html_editor.test.js',
+        ],
         'web.tests_assets': [
             'website/static/tests/website_service_mock.js',
         ],
@@ -293,6 +297,10 @@
             'website/static/src/xml/web_editor.xml',
             'website/static/src/js/editor/add_snippet_dialog.js',
             'website/static/src/js/editor/widget_link.js',
+        ],
+        'html_editor.assets_link_popover': [
+            'website/static/src/js/editor/html_editor.js',
+            'website/static/src/xml/html_editor.xml',
         ],
         'website.assets_wysiwyg': [
             ('include', 'web._assets_helpers'),

--- a/addons/website/static/src/components/autocomplete_with_pages/url_autocomplete.js
+++ b/addons/website/static/src/components/autocomplete_with_pages/url_autocomplete.js
@@ -4,6 +4,8 @@ import { Component } from "@odoo/owl";
 import { rpc } from "@web/core/network/rpc";
 import { AutoCompleteWithPages } from "@website/components/autocomplete_with_pages/autocomplete_with_pages";
 
+// TODO: we probably don't need it anymore after merging html_builder
+// see: https://github.com/odoo/odoo/pull/187091
 export class UrlAutoComplete extends Component {
     static props = {
         options: { type: Object },

--- a/addons/website/static/src/js/editor/html_editor.js
+++ b/addons/website/static/src/js/editor/html_editor.js
@@ -1,0 +1,173 @@
+import { LinkPopover } from "@html_editor/main/link/link_popover";
+import { rpc } from "@web/core/network/rpc";
+import { _t } from "@web/core/l10n/translation";
+import { AutoComplete } from "@web/core/autocomplete/autocomplete";
+import { patch } from "@web/core/utils/patch";
+import { useAutofocus, useChildRef } from "@web/core/utils/hooks";
+import wUtils from "@website/js/utils";
+
+/**
+ * The goal of this patch is to handle the URL autocomplete in the LinkPopover
+ * component. The URL autocomplete is used to suggest internal links, anchors.
+ * Before, the autocomplete was implemented as another OWL app. Now with this
+ * patch, URL autocomplete is implemented as a child component.
+ */
+
+/**
+ * this class is used to create a new autocomplete component that will be used
+ * in the LinkPopover component. Similar with AutoCompleteWithPages but it has
+ * two new props:
+ * - inputClass: to change the style of the input element in autocomplete
+ * - updateValue: to update the URL of the link element
+ */
+export class AutoCompleteInLinkPopover extends AutoComplete {
+    static props = {
+        ...AutoComplete.props,
+        inputClass: { type: String, optional: true },
+        updateValue: { type: Function, optional: true },
+    };
+    static template = "website.AutoCompleteInLinkPopover";
+
+    // overwrite the div class to avoid breaking the popover style
+    get autoCompleteRootClass() {
+        return `${super.autoCompleteRootClass} col`;
+    }
+
+    // apply classes on the input element in autocomplete
+    get inputClass() {
+        return this.props.inputClass || "o_input pe-3";
+    }
+
+    /**
+     * @param option
+     * @return {boolean}
+     */
+    isCategory(option) {
+        return !!option?.separator;
+    }
+
+    getOption(indices) {
+        const [sourceIndex, optionIndex] = indices;
+        return this.sources[sourceIndex]?.options[optionIndex];
+    }
+
+    /**
+     * @override
+     */
+    onOptionMouseEnter(indices) {
+        if (!this.isCategory(this.getOption(indices))) {
+            return super.onOptionMouseEnter(...arguments);
+        }
+    }
+
+    /**
+     * @override
+     */
+    onOptionMouseLeave(indices) {
+        if (!this.isCategory(this.getOption(indices))) {
+            return super.onOptionMouseLeave(...arguments);
+        }
+    }
+
+    isActiveSourceOption(indices) {
+        if (!this.isCategory(this.getOption(indices))) {
+            return super.isActiveSourceOption(...arguments);
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @override
+     */
+    selectOption(option) {
+        if (!this.isCategory(option)) {
+            const { value } = Object.getPrototypeOf(option);
+            this.targetDropdown.value = value;
+            return super.selectOption(...arguments);
+        }
+    }
+
+    /**
+     * @override
+     */
+    onInput() {
+        super.onInput();
+        this.props.updateValue(this.targetDropdown.value);
+    }
+}
+
+patch(LinkPopover, {
+    components: { ...LinkPopover.components, AutoCompleteInLinkPopover },
+    template: "website.linkPopover",
+});
+
+/* patch the LinkPopover component to maintain the option source for the
+ * AutoCompleteInLinkPopover component. Also we make sure state.url is updated
+ * when the user enters text in the autocomplete and selects an option from the
+ * autocomplete.
+ */
+patch(LinkPopover.prototype, {
+    setup() {
+        super.setup();
+        this.urlRef = useChildRef();
+        useAutofocus({
+            refName: this.state.isImage || this.state.label !== "" ? this.urlRef.name : "label",
+            mobile: true,
+        });
+    },
+
+    get sources() {
+        return [this.optionsSource];
+    },
+
+    get optionsSource() {
+        return {
+            placeholder: _t("Loading..."),
+            options: this.loadOptionsSource.bind(this),
+            optionTemplate: "website.AutoCompleteItem",
+        };
+    },
+
+    mapItemToSuggestion(item) {
+        return {
+            ...item,
+            classList: item.separator ? "ui-autocomplete-category" : "ui-autocomplete-item",
+        };
+    },
+
+    async loadOptionsSource(term) {
+        if (term[0] === "#") {
+            const anchors = await wUtils.loadAnchors(term, this.props.linkEl.ownerDocument.body);
+            return anchors.map((anchor) =>
+                this.mapItemToSuggestion({ label: anchor, value: anchor })
+            );
+        } else if (term.startsWith("http") || term.length === 0) {
+            // avoid useless call to /website/get_suggested_links
+            return [];
+        }
+        const res = await rpc("/website/get_suggested_links", {
+            needle: term,
+            limit: 15,
+        });
+        let choices = res.matching_pages;
+        res.others.forEach((other) => {
+            if (other.values.length) {
+                choices = choices.concat(
+                    [{ separator: other.title, label: other.title }],
+                    other.values
+                );
+            }
+        });
+        return choices.map(this.mapItemToSuggestion);
+    },
+
+    onSelect(selectedSubjection) {
+        const { value } = Object.getPrototypeOf(selectedSubjection);
+        this.state.url = value;
+    },
+
+    updateValue(val) {
+        this.state.url = val;
+    },
+});

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -16,32 +16,48 @@ import { UrlAutoComplete } from "@website/components/autocomplete_with_pages/url
  */
 function loadAnchors(url, body) {
     return new Promise(function (resolve, reject) {
-        if (url === window.location.pathname || url[0] === '#') {
+        if (url === window.location.pathname || url[0] === "#") {
             resolve(body ? body : document.body.outerHTML);
         } else if (url.length && !url.startsWith("http")) {
-            $.get(window.location.origin + url).then(resolve, reject);
-        } else { // avoid useless query
+            fetch(window.location.origin + url)
+                .then((response) => {
+                    return response.text();
+                })
+                .then((text) => {
+                    const parser = new DOMParser();
+                    const doc = parser.parseFromString(text, "text/html");
+                    return doc.body;
+                })
+                .then(resolve, reject);
+        } else {
+            // avoid useless query
             resolve();
         }
-    }).then(function (response) {
-        const anchors = $(response).find('[id][data-anchor=true], .modal[id][data-display="onClick"]').toArray().map((el) => {
-            return '#' + el.id;
+    })
+        .then(function (response) {
+            const anchors = Array.from(
+                response.querySelectorAll(
+                    '[id][data-anchor=true], .modal[id][data-display="onClick"]'
+                )
+            ).map((el) => {
+                return "#" + el.id;
+            });
+            // Always suggest the top and the bottom of the page as internal link
+            // anchor even if the header and the footer are not in the DOM. Indeed,
+            // the "scrollTo" function handles the scroll towards those elements
+            // even when they are not in the DOM.
+            if (!anchors.includes("#top")) {
+                anchors.unshift("#top");
+            }
+            if (!anchors.includes("#bottom")) {
+                anchors.push("#bottom");
+            }
+            return anchors;
+        })
+        .catch((error) => {
+            console.debug(error);
+            return [];
         });
-        // Always suggest the top and the bottom of the page as internal link
-        // anchor even if the header and the footer are not in the DOM. Indeed,
-        // the "scrollTo" function handles the scroll towards those elements
-        // even when they are not in the DOM.
-        if (!anchors.includes('#top')) {
-            anchors.unshift('#top');
-        }
-        if (!anchors.includes('#bottom')) {
-            anchors.push('#bottom');
-        }
-        return anchors;
-    }).catch(error => {
-        console.debug(error);
-        return [];
-    });
 }
 
 /**

--- a/addons/website/static/src/xml/html_editor.xml
+++ b/addons/website/static/src/xml/html_editor.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.AutoCompleteInLinkPopover" t-inherit="web.AutoComplete">
+    <xpath expr="//input[@t-ref='input']" position="attributes">
+        <attribute name="class" remove="o_input pe-3" separator=" "/>
+        <attribute name="t-attf-class" add="{{inputClass}}" separator=" "/>
+    </xpath>
+</t>
+
+<t t-name="website.AutoCompleteItem">
+    <div t-att-class="{
+        'fw-bold text-capitalize p-2': option.separator,
+    }">
+        <t t-if="option.icon and option.icon.length">
+            <img t-att-src="option.icon" width="24px" height="24px" class="me-2 rounded"/>
+        </t>
+        <t t-out="option.label"/>
+    </div>
+</t>
+
+<t t-name="website.InputURLAutoComplete">
+    <AutoCompleteInLinkPopover
+        sources="sources"
+        value="state.url"
+        input="urlRef"
+        onSelect.bind="onSelect"
+        dropdown="true"
+        autofocus="true"
+        placeholder.translate="Type your URL"
+        inputClass="'o_we_href_input_link form-control form-control-sm'"
+        t-on-keydown="onKeydownEnter"
+        updateValue.bind="updateValue"
+    />
+</t>
+
+<t t-name="website.linkPopover" t-inherit="html_editor.linkPopover" t-inherit-mode="primary">
+    <xpath expr="//input[@name='o_linkpopover_url']" position="replace">
+        <t t-call="website.InputURLAutoComplete"/>
+    </xpath>
+    <xpath expr="//input[@name='o_linkpopover_url_img']" position="replace">
+        <t t-call="website.InputURLAutoComplete"/>
+    </xpath>
+</t>
+
+</templates>

--- a/addons/website/static/tests/website_html_editor.test.js
+++ b/addons/website/static/tests/website_html_editor.test.js
@@ -1,0 +1,57 @@
+import { expect, test } from "@odoo/hoot";
+import { click, press, waitFor } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import { cleanLinkArtifacts } from "@html_editor/../tests/_helpers/format";
+import { getContent } from "@html_editor/../tests/_helpers/selection";
+import { setupEditor } from "@html_editor/../tests/_helpers/editor";
+import { contains, defineModels, onRpc } from "@web/../tests/web_test_helpers";
+import { mailModels } from "@mail/../tests/mail_test_helpers";
+
+defineModels(mailModels);
+
+test("autocomplete should shown and able to edit the link", async () => {
+    onRpc("/website/get_suggested_links", () => {
+        expect.step("/website/get_suggested_links");
+        return {
+            matching_pages: [
+                {
+                    value: "/contactus",
+                    label: "/contactus (Contact Us)",
+                },
+            ],
+            others: [
+                {
+                    title: "Apps url",
+                    values: [
+                        {
+                            value: "/contactus",
+                            icon: "/website_crm/static/description/icon.png",
+                            label: "/contactus (Contact Us)",
+                        },
+                    ],
+                },
+            ],
+        };
+    });
+
+    const { el } = await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
+
+    await waitFor(".o-we-linkpopover");
+    await click(".o_we_edit_link");
+    await animationFrame();
+    // the url input should be autocomplete
+    await contains(".o-autocomplete--input").focus();
+
+    // autocomplete dropdown should be there
+    await press(["ctrl", "a"]);
+    await press("c");
+    await waitFor(".o-autocomplete--dropdown-menu", { timeout: 3000 });
+    expect.verifySteps(["/website/get_suggested_links"]);
+
+    await click(".o-autocomplete--dropdown-item:first");
+    await click(".o_we_apply_link");
+    // the url should be applied after selecting a dropdown item
+    expect(cleanLinkArtifacts(getContent(el))).toBe(
+        '<p>this is a <a href="/contactus">li[]nk</a></p>'
+    );
+});


### PR DESCRIPTION
Steps to reproduce:
1. install website, add a link into an editing area in Todo app
2. at the url input, we don't have the internal link suggestion (fuzzy search)
when typing

The PR target to 18.0 because fuzzy page search is considered as a basic
function when website is installed. It's a functional fix for the html_editor

In this PR, we've updated the linkpopover component of the html_editor
to add a fuzzy page search feature to the URL input. Before 18.0, we
created another OWL app to load the page anchors. Here we do it by using
autocomplete component, users can now see and select from a dropdown of
relevant Odoo page anchors as they type in the URL input field.

To achieve this, we modified the popover template to include an
autocomplete field specifically designed for the link popover. In the
AutoCompleteInLinkpopover component, two new props were introduced:

1. inputClass: Allows customization of the input field's styling.
2. updateValue: Enables updating of the link popover's URL state when an
option is selected from the autocomplete dropdown.

We also remove the redundant linkpreview reload when clicking on apply,
cause the loadAsyncLinkPreview is already called at onMounted.

A unit test using hoot is added for testing the fuzzy page search in the
linkpopover.

task-4222657


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
