### PR TITLE
[FIX] base: fix translation button for ir.ui.view.arch_base

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -633,22 +633,20 @@
     }
 
     .oe_no_translation_content {
-        // hide content but show the translate button
+        // hide content but show the translate button EN
         height: 0px;
 
-        div{
-            :not(.btn) {
-                display: none;
-            }
+        .o_field_translate:not(.o_field_input_buttons):not(.btn) {
+            display: none;
+        }
+        
+        .o_field_translate.btn {
+            // hide language button for current language
+            visibility: hidden !important;
+            margin-top: -10px;
 
-            .btn {
-                width: 100% !important;
-                margin-left: 0px;
-                visibility: hidden;
-            }
-
-            .btn:after {
-                // force the the translate button to EN
+            // force the the translate button to EN
+            &:after {
                 content: 'EN';
                 visibility: visible;
             }


### PR DESCRIPTION
The html structure translation button is changed in https://github.com/odoo/odoo/pull/184900

This commit fixes the hack for the translation button for ir.ui.view.arch_base


reproduce the bug
Settings -> Technical -> Views -> open any form view
![image](https://github.com/user-attachments/assets/9c07b8cd-282f-4dd0-8f42-713163d5de6c)


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
