### PR TITLE
[FIX] web: avoid notification on unchanged invalid record

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -516,9 +516,9 @@ export class FormController extends Component {
     async afterExecuteActionButton(clickParams) {}
 
     async create() {
-        const canProceed = await this.model.root.save({
-            onError: this.onSaveError.bind(this),
-        });
+        const dirty = await this.model.root.isDirty();
+        const onError = this.onSaveError.bind(this);
+        const canProceed = !dirty || (await this.model.root.save({ onError }));
         // FIXME: disable/enable not done in onPagerUpdate
         if (canProceed) {
             await executeButtonCallback(this.ui.activeElement, () =>

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -237,7 +237,10 @@ export class ListController extends Component {
     }
 
     async openRecord(record) {
-        await record.save();
+        const dirty = await record.isDirty();
+        if (dirty) {
+            await record.save();
+        }
         if (this.archInfo.openAction) {
             this.actionService.doActionButton({
                 name: this.archInfo.openAction.action,

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -6005,6 +6005,32 @@ QUnit.module("Views", (hooks) => {
         assert.strictEqual(target.querySelector(".o_pager_counter").textContent, "1 / 2");
     });
 
+    QUnit.test("open a new record from an invalid one", async function (assert) {
+        // in this scenario, the record is already invalid in db, so we should be allowed to
+        // leave it
+        serverData.models.partner.records[0].foo = false;
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="foo" required="1"/>
+                </form>`,
+            resIds: [1],
+            resId: 1,
+        });
+
+        assert.strictEqual(target.querySelector(".o_breadcrumb").innerText, "first record");
+        assert.hasClass(target.querySelector(".o_field_widget[name=foo]"), "o_required_modifier");
+        await click(
+            target,
+            ".o_control_panel_main_buttons .d-none.d-xl-inline-flex .o_form_button_create"
+        );
+        assert.strictEqual(target.querySelector(".o_breadcrumb").innerText, "New");
+    });
+
     QUnit.test("keynav: switching to another record from a dirty one", async function (assert) {
         let nbWrite = 0;
         await makeView({

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -20902,4 +20902,35 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 3);
         assert.containsNone(target, ".o_group_header .o_pager");
     });
+    
+    QUnit.test("open record, with invalid record in list", async function (assert) {
+        // in this scenario, the record is already invalid in db, so we should be allowed to
+        // leave it
+        serverData.models.foo.records[0].foo = false;
+        serverData.views = {
+            "foo,false,form": `<form><field name="foo"/><field name="int_field"/></form>`,
+            "foo,false,list": `<tree><field name="foo" required="1"/><field name="int_field"/></tree>`,
+            "foo,false,search": `<search/>`,
+        };
+
+        const wc = await createWebClient({ serverData });
+        await doAction(wc, {
+            res_model: "foo",
+            type: "ir.actions.act_window",
+            views: [
+                [false, "list"],
+                [false, "form"],
+            ],
+        });
+
+        patchWithCleanup(wc.env.services.notification, {
+            add: () => {
+                throw new Error("should not display a notification");
+            },
+        });
+
+        await click(target.querySelector(".o_data_cell"));
+
+        assert.containsOnce(target, ".o_form_view");
+    });
 });


### PR DESCRIPTION
Before this commit, if an invalid record existed in db, and it was open
from a list, a notification was raised even if the user didn't modify
the record. Also, if an invalid record is open, and the user click to
create a new record, a notification is raised.

Now, the notifications only raise if the user modifies the record.

opw-3987849