### PR TITLE
[FIX] website_sale: allow filtering with more than one attribute

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -310,6 +310,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
         url = '/shop'
         if search:
             post['search'] = search
+        if attrib_list:
+            post['attribute_value'] = attrib_list
 
         options = self._get_search_options(
             category=category,


### PR DESCRIPTION
If user wanted to filter products by more than one attribute, after going to the next page, second attribute filter was deleted.

opw-4191891
