### PR TITLE
[FIX] web, portal, website, website_sale: `text-primary` readability

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -129,11 +129,11 @@
                 </a>
                 <div t-attf-class="dropdown-menu js_usermenu #{_dropdown_menu_class}" role="menu">
                     <a groups="base.group_user" href="/odoo" role="menuitem" class="dropdown-item ps-3" id="o_backend_user_dropdown_link">
-                        <i class="fa fa-fw fa-th me-1 small text-primary"/> Apps
+                        <i class="fa fa-fw fa-th me-1 small text-primary text-primary-emphasis"/> Apps
                     </a>
                     <div id="o_logout_divider" class="dropdown-divider"/>
                     <a t-attf-href="/web/session/logout?redirect=/" role="menuitem" id="o_logout" class="dropdown-item ps-3">
-                        <i class="fa fa-fw fa-sign-out me-1 small text-primary"/> Logout
+                        <i class="fa fa-fw fa-sign-out me-1 small text-primary text-primary-emphasis"/> Logout
                     </a>
                 </div>
             </li>
@@ -745,7 +745,7 @@
     <template id="my_account_link" name="Link to frontend portal" inherit_id="portal.user_dropdown">
         <xpath expr="//*[@id='o_logout_divider']" position="before">
             <a href="/my/home" role="menuitem" class="dropdown-item ps-3">
-                <i class="fa fa-fw fa-id-card-o me-1 small text-primary"/> My Account
+                <i class="fa fa-fw fa-id-card-o me-1 small text-primary text-primary-emphasis"/> My Account
             </a>
         </xpath>
     </template>

--- a/addons/web/static/src/scss/bootstrap_review_frontend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_frontend.scss
@@ -15,6 +15,11 @@
     @include text-emphasis-variant(".text-#{$color}", $value);
 }
 
+// TODO: To be removed in master (18.1)
+// Define `text-primary-emphasis` class here in order to take priority when in
+// conjunction with other text-[x] classes
+@include text-emphasis-variant(".text-primary-emphasis", $primary-text-emphasis);
+
 // Cards
 
 .card {

--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -83,6 +83,13 @@ $link-hover-color: auto-contrast(darken($link-color, 15%), $body-bg, 'o-cc1-link
 $link-decoration: if(o-website-value('link-underline') == 'always', underline, none) !default;
 $link-hover-decoration: if(o-website-value('link-underline') != 'never', underline, none) !default;
 
+// Emphasis
+//
+// For higher contrast text. Not applicable for backgrounds.
+
+// Increase contrast when needed, otherwise fallback to BS default
+$primary-text-emphasis: if(not has-enough-contrast(o-color('primary'), $body-bg), increase-contrast(o-color('primary'), $body-bg), null) !default;
+
 // Grid
 $grid-gutter-width: 30px !default;
 
@@ -96,7 +103,7 @@ $border-color: var(--o-border-color) !default;
 // Note: for the 'active' color, color preset edition is not really flexible but
 // this could come in a future update.
 $component-active-bg: o-color('o-cc1-btn-primary') !default;
-$component-active-color: if($component-active-bg, color-contrast($component-active-bg), null) !default;
+$component-active-color: color-contrast($component-active-bg or o-color('primary')) !default;
 
 // Fonts
 //

--- a/addons/website/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website/static/src/snippets/s_searchbar/000.xml
@@ -48,7 +48,7 @@
         </div>
     </a>
     <t t-if="hasMoreResults">
-        <button type="submit" class="dropdown-item text-center text-primary">All results</button>
+        <button type="submit" class="dropdown-item text-center text-primary text-primary-emphasis">All results</button>
     </t>
 </div>
 

--- a/addons/website/tests/test_fuzzy.py
+++ b/addons/website/tests/test_fuzzy.py
@@ -162,7 +162,7 @@ class TestAutoComplete(TransactionCase):
 
     def _check_highlight(self, term, value):
         """ Verifies if a term is highlighted in a value """
-        self.assertTrue(f'<span class="text-primary">{term}</span>' in value.lower(),
+        self.assertTrue(f'<span class="text-primary text-primary-emphasis">{term}</span>' in value.lower(),
                         "Term must be highlighted")
 
     def test_01_few_results(self):

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2660,7 +2660,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 </template>
 
 <template id="search_text_with_highlight" name="Website Searchbox item highlight">
-    <span t-foreach="enumerate(parts)" t-as="part" t-att-class="'text-primary' if part[0] % 2 else None" t-esc="part[1]"/>
+    <span t-foreach="enumerate(parts)" t-as="part" t-att-class="'text-primary text-primary-emphasis' if part[0] % 2 else None" t-esc="part[1]"/>
 </template>
 
 <template id="list_website_public_pages" name="Website Pages">

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -213,7 +213,7 @@
             <div class="o_wsale_product_information position-relative d-flex flex-column flex-grow-1 flex-shrink-1">
                 <div class="o_wsale_product_information_text">
                     <h6 class="o_wsale_products_item_title mb-2 text-break">
-                        <a class="text-primary text-decoration-none" itemprop="name" t-att-href="product_href" t-att-content="product.name" t-field="product.name" />
+                        <a class="text-primary text-decoration-none text-primary-emphasis" itemprop="name" t-att-href="product_href" t-att-content="product.name" t-field="product.name" />
                         <a t-if="not product.website_published" role="button" t-att-href="product_href" class="btn btn-sm btn-danger" title="This product is unpublished.">
                             Unpublished
                         </a>


### PR DESCRIPTION
This PR normalizes rendering to improve readability for text elements using the `text-primary` class.

While links benefit from a contrast-check feature [1], elements using `text-primary` rely on `$primary` (color-1) directly, resulting in color inconsistencies between links and text, as well as readability issues.

The addition of "pastel palettes" [2] made this issue even more pronounced.

This PR:
- Adds `text-primary-emphasis` class to `text-primary` elements, taking priority.
- Introduces a contrast-check for `text-emphasis-*` colors, ensuring links and "primary text" share the same color in cases of low contrast. If contrast is sufficient, the default Bootstrap computation is used.
- Ensure that the `$component-active-color` contrast-check function has a color to compute against.

[1] https://github.com/odoo/odoo/pull/58739
[2] https://github.com/odoo/odoo/pull/172463

task-4332082


| `18.0` reference palette | `18.0` pastel palette | this PR pastel palette | . |
|--------|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/06b2e02a-673b-423c-a161-0bce6b09bc44) | ![image](https://github.com/user-attachments/assets/3682168d-9c46-4a32-a0c8-9557b14b1ba6) | ![image](https://github.com/user-attachments/assets/cfcf31ee-f894-459f-9488-77ad9be93951) | . |
| ![image](https://github.com/user-attachments/assets/ec262732-7271-4430-b5cb-69d6f244248d) | ![image](https://github.com/user-attachments/assets/60e5b6db-d88e-4f3e-998e-632477d6e362) | ![image](https://github.com/user-attachments/assets/f7633f8b-e9af-47ee-bf46-f4c42e411035) | . |
| ![image](https://github.com/user-attachments/assets/96f3034e-1c06-4068-82a1-0a404e9379d5) | ![image](https://github.com/user-attachments/assets/cad0d86e-83df-47f3-8a0f-0405613a6b06) | ![image](https://github.com/user-attachments/assets/0dc870c8-79a0-41fa-9810-ff9f7eea4773) | . |
| ![image](https://github.com/user-attachments/assets/3a1dfad8-2ed4-43f1-b503-627919dae5e1) | ![image](https://github.com/user-attachments/assets/8de26833-b4ad-4866-a5b4-19ae71b38164) | ![image](https://github.com/user-attachments/assets/c3544e3d-a60e-4f00-9ede-9a71b47a20b9) | . |
| ![image](https://github.com/user-attachments/assets/87f6eae1-156e-4291-b1c2-920dd2211b4c) | ![image](https://github.com/user-attachments/assets/22098e1f-43f3-40d1-bc7b-409730e6ada9) | ![image](https://github.com/user-attachments/assets/e88ddbcc-67db-4d43-acd7-f51101e9628e) | . |
| ![image](https://github.com/user-attachments/assets/52d565ba-886e-4b20-9f29-699d3ea6840f) | ![image](https://github.com/user-attachments/assets/1b961d5e-4366-46fd-aca2-4506f9351e18) | ![image](https://github.com/user-attachments/assets/eefeedf4-28b8-4855-b960-2ed7f5d58322) | . |

task-4332082


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
