### PR TITLE
[FIX] website: test_17_website_edit_menus tour

### DIFF
--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -9,6 +9,7 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('edit_menus', {
+    checkDelay: 100,
     url: '/',
 }, () => [
     // Add a megamenu item from the menu.


### PR DESCRIPTION
In this commit, we force checkDelay to 100ms (default is 500ms) to make the tour faster and avoid script timeout exceeded error.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
