### PR TITLE
[FIX] web: editable list's buttons not displayed on small screen

### DIFF
--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -10,10 +10,11 @@
                             New
                         </button>
                     </t>
+                    <t t-if="env.isSmall" t-call="{{ props.buttonTemplate }}"/>
                 </t>
 
                 <t t-set-slot="layout-buttons">
-                    <t t-call="{{ props.buttonTemplate }}"/>
+                    <t t-if="!env.isSmall" t-call="{{ props.buttonTemplate }}"/>
                 </t>
                 <t t-set-slot="control-panel-always-buttons">
                     <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">


### PR DESCRIPTION
This commit fixes an issue where, in an editable list view on a small screen, once trying to modify a record the "Save" and "Discard" buttons doesn't appear. This is due to those buttons being put inside a dropdown... but hidden on small screen.

Steps to reproduce (on a small screen):
- Install CRM module
- Go to CRM > Configuration > Pipeline > Tags
- Try to modify one of the list's record

⇾ The "New" button disappears, but the "Save" and "Discard" buttons are not displayed

Note: reported during the mobile tests conversion to HOOT in master.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
