### PR TITLE
[FIX] account: round tax results when forcing price included

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1241,7 +1241,8 @@ class AccountTax(models.Model):
                     tax_amount = 0.0
                 tax_data['tax_amount'] = tax_amount
                 tax_data['tax_amount_factorized'] = tax_data['tax_amount'] * tax_data['_factor']
-                if rounding_method == 'round_per_line' or (not special_mode and tax_data['price_include'] and round_price_include):
+                if rounding_method == 'round_per_line' \
+                        or ((special_mode == 'total_included' or (not special_mode and tax_data['price_include'])) and round_price_include):
                     tax_data['tax_amount_factorized'] = float_round(tax_data['tax_amount_factorized'], precision_rounding=prec_rounding)
             elif quid == 'base':
                 extra_base = 0.0
@@ -1256,7 +1257,8 @@ class AccountTax(models.Model):
                     'extra_base': extra_base,
                     'total_tax_amount': total_tax_amount,
                 }))
-                if rounding_method == 'round_per_line' or (not special_mode and tax_data['price_include'] and round_price_include):
+                if rounding_method == 'round_per_line' \
+                        or ((special_mode == 'total_included' or (not special_mode and tax_data['price_include'])) and round_price_include):
                     tax_data['base'] = float_round(tax_data['base'], precision_rounding=prec_rounding)
                     tax_data['display_base'] = float_round(tax_data['display_base'], precision_rounding=prec_rounding)
 

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -479,7 +479,7 @@ export const accountTaxHelpers = {
                 tax_data.tax_amount_factorized = tax_data.tax_amount * tax_data._factor;
                 if (
                     rounding_method === "round_per_line" ||
-                    (!special_mode && tax_data.price_include && round_price_include)
+                    ((special_mode === 'total_included' || (!special_mode && tax_data.price_include)) && round_price_include)
                 ) {
                     tax_data.tax_amount_factorized = roundPrecision(
                         tax_data.tax_amount_factorized,
@@ -507,7 +507,7 @@ export const accountTaxHelpers = {
                 );
                 if (
                     rounding_method === "round_per_line" ||
-                    (!special_mode && tax_data.price_include && round_price_include)
+                    ((special_mode === 'total_included' || (!special_mode && tax_data.price_include)) && round_price_include)
                 ) {
                     tax_data.base = roundPrecision(tax_data.base, prec_rounding);
                     tax_data.display_base = roundPrecision(tax_data.display_base, prec_rounding);


### PR DESCRIPTION
In expenses, we want to keep the tax included in price. Even if the tax
is defined as not included in price we force the computation to be price
included. However, with specific combination of price and tax amount,
the computation result in amount not rounded correctly.
As result, users trying to post journal entry from expense report may face an
"Unbalanced Entry" error.
Steps to reproduce:
- With Canadian accounting set up in Canadian company
- Set rounding method to "Round globally"
- Create an expense:
  - Add total: 77.87 CAD
  - Use tax: 14.975 GST+QST
  - Paid By: Company
- Create Report > Submit to manager > Approve

Error will raise
```
The move (Draft Entry  (test)) is not balanced.
The total of debits equals 77.87 $ and the total of credits equals 77.87 $.
You might want to specify a default account on journal "Bank" to automatically balance each move.
```

In this specific configuration, we get tax values from unrounded computations, i.e. we set `amount_currency`
to 67.72776690584911, that will be stored as 67.73. However, from the expense report
we compute a (correct) balance of 67.72, when the move line is created the balance will be
updated from this amount (currency is company currency), so the move balance will be off, raising the error

opw-4148134