### PR TITLE
[IMP] point_of_sale: allow search with barcode

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -199,7 +199,7 @@ export class ProductProduct extends Base {
     }
 
     get searchString() {
-        const fields = ["display_name", "description_sale", "description", "default_code"];
+        const fields = ["display_name", "description_sale", "description"];
         return fields
             .map((field) => this[field] || "")
             .filter(Boolean)

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -77,7 +77,7 @@ export class PartnerList extends Component {
     getPartners() {
         const searchWord = unaccent((this.state.query || "").trim(), false);
         const partners = this.pos.models["res.partner"].getAll();
-        const exactMatches = partners.filter((product) => product.exactMatch(searchWord));
+        const exactMatches = partners.filter((partner) => partner.exactMatch(searchWord));
 
         if (exactMatches.length > 0) {
             return exactMatches;

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -358,9 +358,17 @@ export class ProductScreen extends Component {
     }
 
     getProductsBySearchWord(searchWord) {
-        return fuzzyLookup(unaccent(searchWord, false), this.products, (product) =>
+        const exactMatches = this.products.filter((product) => product.exactMatch(searchWord));
+
+        if (exactMatches.length > 0 && searchWord.length > 2) {
+            return exactMatches;
+        }
+
+        const fuzzyMatches = fuzzyLookup(unaccent(searchWord, false), this.products, (product) =>
             unaccent(product.searchString, false)
         );
+
+        return Array.from(new Set([...exactMatches, ...fuzzyMatches]));
     }
 
     addMainProductsToDisplay(products) {

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -12,6 +12,7 @@ import {
     inLeftSide,
     selectButton,
     scan_barcode,
+    negateStep,
 } from "@point_of_sale/../tests/tours/utils/common";
 import * as ProductConfiguratorPopup from "@point_of_sale/../tests/tours/utils/product_configurator_util";
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
@@ -411,5 +412,36 @@ registry.category("web_tour.tours").add("AutofillCashCount", {
                 run: "click",
             },
             ProductScreen.cashDifferenceIs(0),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("ProductSearchTour", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.searchProduct("Test Product"),
+            ProductScreen.productIsDisplayed("Apple").map(negateStep),
+            ProductScreen.productIsDisplayed("Test Product 1"),
+            ProductScreen.productIsDisplayed("Test Product 2"),
+            ProductScreen.searchProduct("Apple"),
+            ProductScreen.productIsDisplayed("Test Product 1").map(negateStep),
+            ProductScreen.productIsDisplayed("Test Product 2").map(negateStep),
+            ProductScreen.searchProduct("Test Produt"), // typo to test the fuzzy search
+            ProductScreen.productIsDisplayed("Test Product 1"),
+            ProductScreen.productIsDisplayed("Test Product 2"),
+            ProductScreen.searchProduct("1234567890123"),
+            ProductScreen.productIsDisplayed("Test Product 2").map(negateStep),
+            ProductScreen.productIsDisplayed("Test Product 1"),
+            ProductScreen.searchProduct("1234567890124"),
+            ProductScreen.productIsDisplayed("Test Product 1").map(negateStep),
+            ProductScreen.productIsDisplayed("Test Product 2"),
+            ProductScreen.searchProduct("TESTPROD1"),
+            ProductScreen.productIsDisplayed("Test Product 2").map(negateStep),
+            ProductScreen.productIsDisplayed("Test Product 1"),
+            ProductScreen.searchProduct("TESTPROD2"),
+            ProductScreen.productIsDisplayed("Test Product 1").map(negateStep),
+            ProductScreen.productIsDisplayed("Test Product 2"),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -427,6 +427,21 @@ export function productIsDisplayed(name, position = -1) {
         },
     ];
 }
+export function searchProduct(string) {
+    return [
+        {
+            isActive: ["mobile"],
+            content: `Click search field`,
+            trigger: `.fa-search`,
+            run: `click`,
+        },
+        {
+            content: "Search for a product using the search bar",
+            trigger: ".pos-rightheader .form-control > input",
+            run: `edit ${string}`,
+        },
+    ];
+}
 export function totalAmountIs(amount) {
     return inLeftSide(...Order.hasTotal(amount));
 }

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1561,6 +1561,37 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'LotTour', login="pos_user")
 
+    def test_product_search(self):
+        """Verify that the product search works correctly"""
+        self.env['product.product'].create([
+            {
+                'name': 'Test Product 1',
+                'list_price': 100,
+                'taxes_id': False,
+                'available_in_pos': True,
+                'barcode': '1234567890123',
+                'default_code': 'TESTPROD1',
+            },
+            {
+                'name': 'Test Product 2',
+                'list_price': 100,
+                'taxes_id': False,
+                'available_in_pos': True,
+                'barcode': '1234567890124',
+                'default_code': 'TESTPROD2',
+            },
+            {
+                'name': 'Apple',
+                'list_price': 100,
+                'taxes_id': False,
+                'available_in_pos': True,
+            },
+        ])
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ProductSearchTour', login="pos_user")
+
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Before this commit, searching with the barcode of
a product would not show any results.

opw-4330143

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
