### PR TITLE
[FIX] pos_mrp: Correct total cost when kit products share components

### DIFF
--- a/addons/pos_mrp/models/pos_order.py
+++ b/addons/pos_mrp/models/pos_order.py
@@ -8,12 +8,14 @@ class PosOrderLine(models.Model):
 
     def _get_stock_moves_to_consider(self, stock_moves, product):
         self.ensure_one()
-        bom = product.env['mrp.bom']._bom_find(product, company_id=stock_moves.company_id.id, bom_type='phantom')[product]
+        bom = product.env['mrp.bom']._bom_find(product, company_id=stock_moves.company_id.id, bom_type='phantom').get(product)
         if not bom:
             return super()._get_stock_moves_to_consider(stock_moves, product)
-        _dummy, components = bom.explode(product, self.qty)
+        boms, components = bom.explode(product, self.qty)
         ml_product_to_consider = (product.bom_ids and [comp[0].product_id.id for comp in components]) or [product.id]
-        return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and ml.bom_line_id)
+        if len(boms) > 1:
+            return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and ml.bom_line_id)
+        return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and (ml.bom_line_id in bom.bom_line_ids))
 
 class PosOrder(models.Model):
     _inherit = "pos.order"

--- a/addons/pos_mrp/tests/test_pos_mrp_flow.py
+++ b/addons/pos_mrp/tests/test_pos_mrp_flow.py
@@ -332,3 +332,116 @@ class TestPosMrp(TestPointOfSaleCommon):
         self.assertEqual(expense_line.filtered(lambda l: l.product_id == self.kit).debit, 6000.0)
         interim_line = order.account_move.line_ids.filtered(lambda l: l.account_id.id == accounts['stock_output'].id)
         self.assertEqual(interim_line.filtered(lambda l: l.product_id == self.kit).credit, 6000.0)
+
+    def test_bom_kit_order_total_cost_with_shared_component(self):
+        category = self.env['product.category'].create({
+            'name': 'Category for average cost',
+            'property_cost_method': 'average',
+        })
+
+        kit_1 = self.env['product.product'].create({
+            'name': 'Kit Product 1',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 30.0,
+            'categ_id': category.id,
+        })
+
+        kit_2 = self.env['product.product'].create({
+            'name': 'Kit Product 2',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 200.0,
+            'categ_id': category.id,
+        })
+
+        shared_component_a = self.env['product.product'].create({
+            'name': 'Shared Comp A',
+            'type': 'product',
+            'available_in_pos': True,
+            'lst_price': 10.0,
+            'standard_price': 5.0,
+
+        })
+
+        other_component_a = self.env['product.product'].create({
+            'name': 'Other Comp A',
+            'type': 'product',
+            'available_in_pos': True,
+            'lst_price': 20.0,
+            'standard_price': 10.0,
+        })
+
+        other_component_b = self.env['product.product'].create({
+            'name': 'Other Comp B',
+            'type': 'product',
+            'available_in_pos': True,
+            'lst_price': 30.0,
+            'standard_price': 20.0,
+        })
+
+        bom_product_form = Form(self.env['mrp.bom'])
+        bom_product_form.product_id = kit_1
+        bom_product_form.product_tmpl_id = kit_1.product_tmpl_id
+        bom_product_form.product_qty = 1.0
+        bom_product_form.type = 'phantom'
+        with bom_product_form.bom_line_ids.new() as bom_line:
+            bom_line.product_id = shared_component_a
+            bom_line.product_qty = 1.0
+        with bom_product_form.bom_line_ids.new() as bom_line:
+            bom_line.product_id = other_component_a
+            bom_line.product_qty = 1.0
+        self.bom_a = bom_product_form.save()
+
+        bom_product_form = Form(self.env['mrp.bom'])
+        bom_product_form.product_id = kit_2
+        bom_product_form.product_tmpl_id = kit_2.product_tmpl_id
+        bom_product_form.product_qty = 1.0
+        bom_product_form.type = 'phantom'
+        with bom_product_form.bom_line_ids.new() as bom_line:
+            bom_line.product_id = shared_component_a
+            bom_line.product_qty = 10.0
+        with bom_product_form.bom_line_ids.new() as bom_line:
+            bom_line.product_id = other_component_b
+            bom_line.product_qty = 5.0
+        self.bom_b = bom_product_form.save()
+
+        self.pos_config.open_ui()
+        order = self.env['pos.order'].create({
+            'session_id': self.pos_config.current_session_id.id,
+            'lines': [(0, 0, {
+                'name': kit_1.name,
+                'product_id': kit_1.id,
+                'price_unit': kit_1.lst_price,
+                'qty': 1,
+                'tax_ids': [[6, False, []]],
+                'price_subtotal': kit_1.lst_price,
+                'price_subtotal_incl': kit_1.lst_price,
+            }), (0, 0, {
+                'name': kit_2.name,
+                'product_id': kit_2.id,
+                'price_unit': kit_2.lst_price,
+                'qty': 1,
+                'tax_ids': [[6, False, []]],
+                'price_subtotal': kit_2.lst_price,
+                'price_subtotal_incl': kit_2.lst_price,
+            })],
+            'pricelist_id': self.pos_config.pricelist_id.id,
+            'amount_paid': kit_1.lst_price + kit_2.lst_price,
+            'amount_total': kit_1.lst_price + kit_2.lst_price,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': False,
+        })
+        payment_context = {"active_ids": order.ids, "active_id": order.id}
+        order_payment = self.PosMakePayment.with_context(**payment_context).create({
+            'amount': order.amount_total,
+            'payment_method_id': self.cash_payment_method.id
+        })
+        order_payment.with_context(**payment_context).check()
+        self.pos_config.current_session_id.action_pos_session_closing_control()
+        pos_order = self.env['pos.order'].search([], order='id desc', limit=1)
+        self.assertRecordValues(pos_order.lines, [
+            {'product_id': kit_1.id, 'total_cost': 15.0},
+            {'product_id': kit_2.id, 'total_cost': 150.0},
+        ])


### PR DESCRIPTION
**Current behavior:**
When computing the total cost for a kit product in a POS order, extra stock moves are included if another POS order line has a product that shares the same components. This results in an incorrect total cost displayed on the POS order, which does not match the computed price from the BOM shown on the product page.

**Expected behavior:**
The total cost for the POS order should match the computed BOM price shown on the product page.

**Steps to reproduce:**

1. Create two products: Product 1 and Product 2.
2. Set both products to be tracked by "quantity" or make them "storable" and assign them to a product category with "average cost" as the costing method (instead of "standard price").
3. Create a Bill of Materials for each product, ensuring they share at least one component. Make sure BoM Type is 'kit'
   - Tip: For better visibility of the error, assign a quantity of 10 or more to the shared component in Product 2's BOM, and set the shared component’s `standard_price` (cost) to 5 or higher. This will make the discrepancy in the total cost more apparent.
4. Create the shared component as a new product and assign it a price.
5. Open a new POS order, add Product 1 and Product 2, and close the order.
6. Locate the order and observe that the "total cost" is incorrect.

**Cause of the issue:**
The stock move filter does not consider that stock moves for BOM lines need to belong to the current product. As a result, if two kit products share components, the stock moves for one product are mistakenly included in the calculation for the other, leading to an incorrect total cost.

**Fix:**
When filtering out the stock moves, ensure they are correctly associated with the current product by verifying that each stock move’s BOM line belongs specifically to the current product and does not include nested BOMs.

opw-4274532

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
