### PR TITLE
[FIX] mass_mailing: fix overlap issues with mass_mailing_html_field

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -473,8 +473,6 @@ export class MassMailingHtmlField extends HtmlField {
 
             const isSnippetsFolded = uiUtils.isSmall() || themeName === 'basic';
             this.wysiwyg.setSnippetsMenuFolded(isSnippetsFolded);
-            // Inform the iframe content of the snippets menu visibility
-            this.wysiwyg.$iframeBody.closest('body').toggleClass("has_snippets_sidebar", !isSnippetsFolded);
 
             this._switchImages(themeParams, $snippets);
 

--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -200,7 +200,7 @@ export class MassMailingHtmlField extends HtmlField {
      * @private
      */
     _updateIframe() {
-        const iframe = this.wysiwyg.$iframe[0];
+        const iframe = this.wysiwyg?.$iframe?.[0];
         if (!iframe || !iframe.contentDocument) {
             return;
         }

--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -264,7 +264,17 @@ export class MassMailingHtmlField extends HtmlField {
         const sidebar = document.querySelector("#oe_snippets");
         if (!sidebar) {
             return;
-        } else if (!this._isFullScreen()) {
+        } else if (this._isFullScreen()) {
+            sidebar.style.height = "";
+            sidebar.style.top = "0";
+        } else if (this.env.inDialog) {
+            const scrollableY = closestScrollableY(sidebar);
+            if (scrollableY) {
+                const rect = scrollableY.getBoundingClientRect();
+                sidebar.style.height = `${rect.height}px`;
+                sidebar.style.top = "0";
+            }
+        } else {
             const scrollableY = closestScrollableY(sidebar);
             const top = scrollableY
                 ? `${-1 * (parseInt(getComputedStyle(scrollableY).paddingTop) || 0)}px`
@@ -273,9 +283,6 @@ export class MassMailingHtmlField extends HtmlField {
             const offsetHeight = window.innerHeight - document.querySelector(".o_content").getBoundingClientRect().y;
             sidebar.style.height = `${Math.min(maxHeight, offsetHeight)}px`;
             sidebar.style.top = top;
-        } else {
-            sidebar.style.height = "";
-            sidebar.style.top = "0";
         }
     }
 

--- a/addons/mass_mailing/static/src/js/mass_mailing_wysiwyg.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_wysiwyg.js
@@ -71,6 +71,44 @@ export class MassMailingWysiwyg extends Wysiwyg {
     }
 
     /**
+     * Add or remove a class on the iframe body depending on the snippets menu
+     * folding state, in order to add/remove enough blank space for it.
+     *
+     * @override
+     */
+    handleSnippetsDisplay() {
+        super.handleSnippetsDisplay();
+        const iframe = this.$iframe?.[0];
+        if (!iframe || !iframe.isConnected) {
+            return;
+        }
+        const body = iframe.contentWindow.document.body;
+        body.classList.toggle(
+            "o_mass_mailing_iframe_body_with_snippets_sidebar",
+            this.isSnippetsMenuVisible
+        );
+    }
+
+    /**
+     * Apply style changes necessary to display the wysiwyg in fullscreen.
+     * The scrolling element used when dragging snippets must be changed
+     * because the form view scrollbar should not be used in fullscreen.
+     *
+     * @override
+     * @param {Boolean} isFullscreen
+     */
+    onToggleFullscreen(isFullscreen) {
+        super.onToggleFullscreen(isFullscreen);
+        const iframe = this.$iframe?.[0];
+        if (iframe && iframe.isConnected) {
+            const body = iframe.contentWindow.document.body;
+            const scrollingElement = isFullscreen ? body : iframe;
+            body.classList.toggle("o_mass_mailing_iframe_body_fullscreen", isFullscreen);
+            this.snippetsMenu?.draggableComponent?.update({ scrollingElement });
+        }
+    }
+
+    /**
      * @override
      */
     openMediaDialog() {
@@ -128,6 +166,19 @@ export class MassMailingWysiwyg extends Wysiwyg {
             }
         }
         return {...options, commands};
+    }
+    /**
+     * By default, an iframe is "scrollable", meaning that if the contents are
+     * bigger than the size of the iframe, scrollbars appear. This is
+     * undesirable in mass_mailing, because the scrolling is handled through
+     * an ancestor of the iframe in the form view.
+     *
+     * @override
+     */
+    _loadIframe() {
+        const promise = super._loadIframe();
+        this.$iframe[0].setAttribute("scrolling", "no");
+        return promise;
     }
     /**
      * @override

--- a/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
@@ -10,6 +10,19 @@ html:not(.o_mass_mailing_iframe), body:not(.o_mass_mailing_iframe), html.o_fulls
     overflow: visible !important;
 }
 
+html:has(body.o_mass_mailing_iframe_body_fullscreen) {
+    overflow-y: auto !important;
+}
+
+body {
+    &.o_mass_mailing_iframe_body_with_snippets_sidebar:not(.o_mass_mailing_iframe_body_fullscreen) {
+        padding-right: $o-we-sidebar-width !important;
+    }
+    &.o_mass_mailing_iframe_body_fullscreen {
+        overflow-y: auto !important;
+    }
+}
+
 #iframe_target:not(.o_fullscreen) {
     display: flex;
     flex-direction: column;
@@ -206,11 +219,6 @@ html:not(.o_mass_mailing_iframe), body:not(.o_mass_mailing_iframe), html.o_fulls
     .o_mail_template_preview {
         width: 50%!important;
     }
-}
-
-// Prevent the website snippets sidebar from overlapping the template
-body.has_snippets_sidebar .o_layout {
-    padding-right: $o-we-sidebar-width !important;
 }
 
 body.o_force_mail_theme_choice {

--- a/addons/mass_mailing/static/src/scss/mass_mailing.wysiwyg.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.wysiwyg.scss
@@ -29,6 +29,18 @@
     margin-left: 5px;
 }
 
+.o_field_mass_mailing_html {
+    .wysiwyg_iframe.o_iframe.has_snippets_sidebar {
+        border: none,
+    }
+    .o_form_fullscreen_ancestor {
+        // Prevent the website snippets sidebar from overlapping the template
+        .wysiwyg_iframe.o_iframe.has_snippets_sidebar {
+            padding-right: $o-we-sidebar-width !important;
+        }
+    }
+}
+
 .o_field_mass_mailing_html #oe_snippets {
     position: sticky;
     top: 0;

--- a/addons/web_editor/static/src/js/editor/drag_and_drop.js
+++ b/addons/web_editor/static/src/js/editor/drag_and_drop.js
@@ -104,7 +104,7 @@ const dragAndDropHookParams = {
         helper: [Function],
         extraWindow: [Object, Function],
     },
-    edgeScrolling: { enabled: true },
+    edgeScrolling: { enabled: true, speed: 20 },
     onComputeParams({ ctx, params }) {
         // The helper is mandatory and will follow the cursor instead
         ctx.followCursor = false;

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2254,6 +2254,7 @@ var SnippetsMenu = Widget.extend({
         this.el.classList.toggle('d-none', foldState);
         this.el.ownerDocument.body.classList.toggle('editor_has_snippets', !foldState);
         this.folded = !!foldState;
+        this.options.wysiwyg.onSnippetsFoldChange?.(this.folded);
     },
     /**
      * Get the editable area.


### PR DESCRIPTION
This PR fixes multiple issues related to the mass_mailing_html_field used
in `marketing_automation` and in `mass_mailing` modules.

1) The iframe scrollbar is hidden behind the snippets sidebar in fullscreen
mode
- concerns: mass_mailing, marketing_automation

2) In fullscreen mode, the iframe is not scrollable while dragging a snippet
from the sidebar
- concerns: mass_Mailing, marketing_automation

3) The snippets sidebar overlaps with the content
- concerns: mass_mailing, marketing_automation

4) The snippets sidebar height in a dialog is too big
- concerns: marketing_automation

See individual commits for further explanation.

task-4178640

Co-authored-by: Astik Singh <assi@odoo.com>
Co-authored-by: Damien Abeloos <abd@odoo.com>
Co-authored-by: Mahdi Cheikh Rouhou <macr@odoo.com>
Co-authored-by: Shubham Thanki <shut@odoo.com>