### PR TITLE
[PERF] mail: disable prefetcher during unlink

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -172,7 +172,7 @@ class MailMail(models.Model):
 
     def unlink(self):
         # cascade-delete the parent message for all mails that are not created for a notification
-        mail_msg_cascade_ids = [mail.mail_message_id.id for mail in self if not mail.is_notification]
+        mail_msg_cascade_ids = [mail.mail_message_id.id for mail in self.with_context(prefetch_fields=False) if not mail.is_notification]
         res = super(MailMail, self).unlink()
         if mail_msg_cascade_ids:
             self.env['mail.message'].browse(mail_msg_cascade_ids).unlink()


### PR DESCRIPTION
### Analysis
The prefetcher can be too aggressive and trigger a MemoryError when unlinking a lot of emails (e.g. when retrying a failed campaign).

### Solution
We disable the prefetcher during the `unlink()` to avoid this issue as we only need the `mail_message_ids` and `is_notification` to filter them before unlinking the parent message.

### References
opw-4315349 => 5K unsent emails during a campaign triggers a MemoryError when retrying so the client is blocked.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
