### PR TITLE
[FIX] base: prevent iOS Safari schema parsing issue

### DIFF
--- a/odoo/addons/base/views/ir_qweb_widget_templates.xml
+++ b/odoo/addons/base/views/ir_qweb_widget_templates.xml
@@ -36,6 +36,8 @@
             </div>
             <div t-if="phone and 'phone' in fields"><i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-phone fa-fw' role="img" aria-label="Phone" title="Phone"/> <span class="o_force_ltr" itemprop="telephone" t-esc="phone"/></div>
             <div t-if="mobile and 'mobile' in fields"><i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-mobile fa-fw' role="img" aria-label="Mobile" title="Mobile"/> <span class="o_force_ltr" itemprop="telephone" t-esc="mobile"/></div>
+            <!-- Prevent issue with iOS Safari parsing of schema data without telephone itemprops -->
+            <div t-elif="not (phone and 'phone' in fields)" itemprop="telephone"/>
             <div t-if="website and 'website' in fields">
                 <i t-if="not options.get('no_marker')" class='fa fa-globe' role="img" aria-label="Website" title="Website"/>
                 <a t-att-href="website and '%s%s' % ('http://' if '://' not in website else '',website)"><span itemprop="website" t-esc="website"/></a>


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps (17.0+)
-------------
1. Create a Sale Order for a new contact without phone number;
2. disable online signature;
3. add a deliverable product to the SO;
4. hit "Send by Email";
5. open the sent mail (e.g. via Mailhog);
6. copy the payment link;
7. open in Safari on iOS;
8. pay the sales order.

Issue
-----
> ```
>TypeError: Attempted to assign to readonly property.
>   extractFilteredSchemaValuesFromMicroData@https...
>   extractSchemaValuesFromSchemaOrg@https...
>   global code@https...
>  ```

Cause
-----
`extractFilteredSchemaValuesFromMicroData` is a function internal to iOS Safari. It is bugged in that it tries to reassign a `const` in some scenarios where no elements with `itemprop="telephone"` attributes are found.

More details in this comment: https://github.com/odoo/odoo/pull/187143#issuecomment-2475934797

Solution
--------
If the contact doesn't have a mobile or phone number, add an empty `div` with `itemprop="telephone"`.

> [!note]
> I've also reported the bug to Apple, but who knows when/if they'll fix it.

Related issue: https://github.com/odoo/odoo/issues/162145

opw-4072838