### PR TITLE
[FIX] base_geolocalize: wrong value for lat, long reset

### DIFF
--- a/addons/base_geolocalize/models/res_partner.py
+++ b/addons/base_geolocalize/models/res_partner.py
@@ -16,8 +16,8 @@ class ResPartner(models.Model):
         if any(field in vals for field in ['street', 'zip', 'city', 'state_id', 'country_id']) \
                 and not all('partner_%s' % field in vals for field in ['latitude', 'longitude']):
             vals.update({
-                'partner_latitude': 0.0,
-                'partner_longitude': 0.0,
+                'partner_latitude': False,
+                'partner_longitude': False,
             })
         return super().write(vals)
 


### PR DESCRIPTION
As zero is valid for latitude and longitude, False should be used instead





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
