### PR TITLE
[FIX] mail: prevent access error for non-admin users leaving group chats

### DIFF
--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -168,7 +168,8 @@ export class DiscussCoreCommon {
         if (
             !channel.isCorrespondentOdooBot &&
             channel.channel_type !== "channel" &&
-            this.store.self.type === "partner"
+            this.store.self.type === "partner" &&
+            channel.selfMember
         ) {
             // disabled on non-channel threads and
             // on "channel" channels for performance reasons


### PR DESCRIPTION
**Current behavior before PR:**

When a user leaves a group chat from the Discuss sidebar, an `AccessError` occurs because `thread.delete()` is not called, allowing `thread.markAsFetched()` to run even though the user is no longer a member.
**Desired behavior after PR is merged:**

This commit resolves the issue by ensuring that no access error occurs when a non-admin user leaves a group chat.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
