### PR TITLE
[FIX] hr,hr_skills,resource_mail: prevent component destruction

### DIFF
--- a/addons/hr/models/resource.py
+++ b/addons/hr/models/resource.py
@@ -34,4 +34,4 @@ class ResourceResource(models.Model):
             if is_hr_user:
                 resource.avatar_128 = employee[0].avatar_128
             else:
-                resource.avatar_128 = avatar_per_employee_id[employee[0].id]
+                resource.avatar_128 = avatar_per_employee_id[employee[0].id] if employee else False

--- a/addons/hr_skills/static/tests/many2one_avatar_employee.test.js
+++ b/addons/hr_skills/static/tests/many2one_avatar_employee.test.js
@@ -1,5 +1,5 @@
 import { click, contains, start, startServer } from "@mail/../tests/mail_test_helpers";
-import { mountView } from "@web/../tests/web_test_helpers";
+import { mountView, onRpc } from "@web/../tests/web_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
 import { queryAttribute } from "@odoo/hoot-dom";
 import { defineHrSkillModels } from "@hr_skills/../tests/hr_skills_test_helpers";
@@ -27,6 +27,21 @@ test("many2one_avatar_employee widget in kanban view with skills on avatar card"
     });
     pyEnv["m2o.avatar.employee"].create([{ employee_id: pierreEid }]);
     await start();
+
+    onRpc("resource.resource", "get_avatar_card_data", (params) => {
+        const resourceIdArray = params.args[0];
+        const resourceId = resourceIdArray[0];
+        const resources = pyEnv['hr.employee.public'].read([resourceId]);
+        const result = resources.map(resource => ({
+            name: resource.name,
+            role_ids: resource.role_ids,
+            email:resource.email,
+            phone: resource.phone,
+            user_id: resource.user_id,
+            employee_skill_ids: resource.employee_skill_ids
+        }));
+        return result;
+    });
     await mountView({
         type: "kanban",
         resModel: "m2o.avatar.employee",

--- a/addons/resource_mail/models/resource_resource.py
+++ b/addons/resource_mail/models/resource_resource.py
@@ -8,3 +8,6 @@ class ResourceResource(models.Model):
     _inherit = 'resource.resource'
 
     im_status = fields.Char(related='user_id.im_status')
+
+    def get_avatar_card_data(self, fields):
+        return self._read_format(fields)

--- a/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.js
+++ b/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.js
@@ -29,7 +29,7 @@ export class AvatarCardResourcePopover extends AvatarCardPopover {
     }
 
     async onWillStart() {
-        [this.record] = await this.orm.read(this.props.recordModel, [this.props.id], this.fieldNames);
+        [this.record] = await this.orm.call('resource.resource', 'get_avatar_card_data', [[this.props.id], this.fieldNames], {});
         await Promise.all(this.loadAdditionalData());
     }
 

--- a/addons/resource_mail/static/tests/many2many_avatar_resource.test.js
+++ b/addons/resource_mail/static/tests/many2many_avatar_resource.test.js
@@ -9,6 +9,7 @@ import {
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { queryAll } from "@odoo/hoot-dom";
 import { defineResourceMailModels } from "./resource_mail_test_helpers";
+import { onRpc } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 const data = {};
@@ -66,6 +67,20 @@ beforeEach(async () => {
     data.task1Id = pyEnv["resource.task"].create({
         display_name: "Task with three resources",
         resource_ids: [data.resourceComputerId, data.resourceMarieId, data.resourcePierreId],
+    });
+
+    onRpc("resource.resource", "get_avatar_card_data", (params) => {
+        const resourceIdArray = params.args[0];
+        const resourceId = resourceIdArray[0];
+        const resources = pyEnv['resource.resource'].read([resourceId]);
+        const result = resources.map(resource => ({
+            name: resource.name,
+            role_ids: resource.role_ids,
+            email:resource.email,
+            phone: resource.phone,
+            user_id: resource.user_id,
+        }));
+        return result;
     });
 });
 test("many2many_avatar_resource widget in form view", async () => {

--- a/addons/resource_mail/static/tests/many2one_avatar_resource.test.js
+++ b/addons/resource_mail/static/tests/many2one_avatar_resource.test.js
@@ -9,6 +9,7 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
+import { onRpc } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 const data = {};
@@ -80,6 +81,20 @@ beforeEach(async () => {
             resource_type: "user",
         },
     ]);
+    onRpc("resource.resource", "get_avatar_card_data", (params) => {
+        const resourceIdArray = params.args[0];
+        const resourceId = resourceIdArray[0];
+        const resources = pyEnv['resource.resource'].read([resourceId]);
+        const result = resources.map(resource => ({
+            name: resource.name,
+            role_ids: resource.role_ids,
+            email:resource.email,
+            phone: resource.phone,
+            user_id: resource.user_id,
+        }));
+        return result;
+    });
+
 });
 
 test("many2one_avatar_resource widget in form view", async () => {


### PR DESCRIPTION
Steps to Reproduce:
- Open the Planning app.
- Click on the avatar of a resource.
- Refresh the page, then click on the avatar of a resource again.

Issue:
- A traceback error occurs when clicking on the avatar after a page refresh, likely due to component destruction or incomplete 
  loading.

Solution:
- Consolidated multiple RPC calls into a single method in the parent component to avoid issues with component destruction 
  during super.onWillStart.
- Modified onWillStart to ensure hr_access data is fetched without risking lifecycle conflicts.

task-4210513

