### PR TITLE
[IMP] stock: remove product tracking constraint

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -926,21 +926,6 @@ class ProductTemplate(models.Model):
 
         if 'is_storable' in vals and not vals['is_storable'] and sum(self.mapped('nbr_reordering_rules')) != 0:
             raise UserError(_('You still have some active reordering rules on this product. Please archive or delete them first.'))
-        if any('is_storable' in vals and vals['is_storable'] != prod_tmpl.is_storable for prod_tmpl in self):
-            existing_done_move_lines = self.env['stock.move.line'].sudo().search([
-                ('product_id', 'in', self.with_context(active_test=False).mapped('product_variant_ids').ids),
-                ('state', '=', 'done'),
-            ], limit=1)
-            if existing_done_move_lines:
-                raise UserError(_("You can not change the inventory tracking of a product that was already used."))
-            existing_reserved_move_lines = self.env['stock.move.line'].sudo().search([
-                ('product_id', 'in', self.with_context(active_test=False).mapped('product_variant_ids').ids),
-                ('state', 'in', ['partially_available', 'assigned']),
-            ], limit=1)
-            if existing_reserved_move_lines:
-                raise UserError(_("You can not change the inventory tracking of a product that is currently reserved on a stock move. If you need to change the inventory tracking, you should first unreserve the stock move."))
-        if 'is_storable' in vals and not vals['is_storable'] and any(p.is_storable and not float_is_zero(p.qty_available, precision_rounding=p.uom_id.rounding) for p in self):
-            raise UserError(_("Available quantity should be set to zero before changing inventory tracking"))
         return super().write(vals)
 
     def copy(self, default=None):

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -368,11 +368,6 @@ class TestVirtualAvailable(TestStockCommon):
         # At this point product_3 should have the quantity reserved
         self.product_3.active = False
 
-        # Should not be possible to change the product type when quantities are reserved
-        with self.assertRaises(UserError):
-            self.product_3.write({'is_storable': False})
+        self.product_3.write({'is_storable': False})
 
-        # Should not be possible to change the product type when moves are done.
         self.picking_out.button_validate()
-        with self.assertRaises(UserError):
-            self.product_3.write({'is_storable': False})


### PR DESCRIPTION
This commit removes the product tracking constraints to prevent errors 
when users change product tracking after initial setup. 
It will not affect existing quants or valuations.

Task: 4189728

