### PR TITLE
[IMP] html_editor: improve look of table of contents

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.js
+++ b/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.js
@@ -9,7 +9,7 @@ export class EmbeddedTableOfContentComponent extends Component {
     };
 
     setup() {
-        this.state = useState({ toc: this.props.manager.structure });
+        this.state = useState({ toc: this.props.manager.structure, folded: false });
         onWillStart(async () => {
             await this.props.manager.batchedUpdateStructure();
         });

--- a/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.scss
+++ b/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.scss
@@ -8,13 +8,13 @@ $embedded-toc-bg--active: #1ba1e4;
     outline: 1px solid $o-gray-300;
     outline-offset: -1px;
     border-radius: 5px;
-    padding: 8px;
-    & > .o_embedded_toc_content {
+    background-color: $o-gray-100;
+    & .o_embedded_toc_content {
+        background-color: $o-view-background-color;
         @for $depth from 0 through 5 {
             a.o_embedded_toc_link_depth_#{$depth} {
                 padding-left: calc(5px + Min(30px, 10%) * #{$depth});
                 font-family: $font-family-base !important;
-                font-weight: $font-weight-bolder;
                 border-radius: 5px;
                 min-height: $line-height-base * $font-size-base;
                 border: transparent;
@@ -31,9 +31,11 @@ $embedded-toc-bg--active: #1ba1e4;
             }
         }
     }
-    & .o_embedded_toc_hint {
-        padding-left: 5px;
+
+    & .o_embedded_toc_label {
+        color: $o-gray-600;
     }
+
 }
 
 .o_field_html {

--- a/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.xml
+++ b/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.xml
@@ -1,16 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
 <t t-name="html_editor.EmbeddedTableOfContent">
-    <div class="o_embedded_toc_content">
-        <t t-foreach="this.state.toc.headings" t-as="heading" t-key="heading_index">
-            <a href="#" contenteditable="false"
-                t-out="heading.name"
-                t-on-click.prevent="() => this.onTocLinkClick(heading)"
-                t-attf-class="o_no_link_popover py-1 pe-1 d-block o_embedded_toc_link #{'o_embedded_toc_link_depth_' + heading.depth}"/>
-        </t>
+    <div class="px-1" t-att-class="{ 'pb-1' : !state.folded and state.toc.headings.length }">
+        <div class="d-flex align-items-center cursor-pointer user-select-none" t-on-click="() => { this.state.folded = !this.state.folded; }">
+            <div class="o_embedded_toc_label p-1 fw-bold">
+                Table of Contents
+                <i t-attf-class="align-self-center fa fa-fw fa-caret-#{ state.folded ? 'right' : 'down' }"/>
+            </div>
+        </div>
+        <div t-if="!state.folded" class="o_embedded_toc_content">
+            <t t-foreach="this.state.toc.headings" t-as="heading" t-key="heading_index">
+                <a href="#" contenteditable="false"
+                    t-out="heading.name"
+                    t-on-click.prevent="() => this.onTocLinkClick(heading)"
+                    t-attf-class="o_no_link_popover py-1 pe-1 d-block text-reset o_embedded_toc_link #{'o_embedded_toc_link_depth_' + heading.depth}"/>
+            </t>
+        </div>
     </div>
-    <i class="o_embedded_toc_hint" t-if="displayTocHint()">
-        Add headings in this field to fill the Table of Content
-    </i>
+    <div class="p-1" t-if="displayTocHint()">
+        <i class="o_embedded_toc_hint px-1">
+            Add headings to fill the Table of Contents
+        </i>
+    </div>
 </t>
 </templates>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
@@ -13,8 +13,8 @@ export class TableOfContentPlugin extends Plugin {
         user_commands: [
             {
                 id: "insertTableOfContent",
-                title: _t("Table Of Content"),
-                description: _t("Highlight the structure (headings) of this field"),
+                title: _t("Table of Contents"),
+                description: _t("Highlight the structure (headings)"),
                 icon: "fa-bookmark",
                 run: this.insertTableOfContent.bind(this),
             },


### PR DESCRIPTION
This commit updates the look of the table of content
embedded component in Odoo.
This component uses now the styling as the embedded
clipboard.
This also updates the name and description of the associated
command.

Task-4314480
