### PR TITLE
[FIX] sale_timesheet: fix multicompany access error on timesheet on task

### DIFF
--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -213,7 +213,7 @@ class AccountAnalyticLine(models.Model):
 
     def _timesheet_preprocess_get_accounts(self, vals):
         so_line = self.env['sale.order.line'].browse(vals.get('so_line'))
-        if not (so_line and (distribution := so_line.analytic_distribution)):
+        if not (so_line and (distribution := so_line.sudo().analytic_distribution)):
             return super()._timesheet_preprocess_get_accounts(vals)
 
         company = self.env['res.company'].browse(vals.get('company_id'))

--- a/addons/sale_timesheet/tests/common.py
+++ b/addons/sale_timesheet/tests/common.py
@@ -46,12 +46,14 @@ class TestCommonSaleTimesheet(TestSaleProjectCommon):
             'name': 'Gregor Clegane',
             'user_id': cls.user_employee_company_B.id,
             'hourly_cost': 15,
+            'company_id': cls.company_data_2['company'].id, # user and employee are assigned to different companies. That's why we have set them to the same company.
         })
 
         cls.manager_company_B = cls.env['hr.employee'].create({
             'name': 'Cersei Lannister',
             'user_id': cls.user_manager_company_B.id,
             'hourly_cost': 45,
+            'company_id': cls.company_data_2['company'].id,
         })
 
         # Account and project

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -1185,3 +1185,25 @@ class TestSaleTimesheetAnalyticPlan(TestCommonSaleTimesheet):
             'employee_id': self.employee_manager.id,
             'so_line': so_line.id,
         })
+
+    def test_sol_and_analytic_distribution_access_multi_company(self):
+        """
+        Step:
+            1) Create two companies and two users with employees.
+            2) Create a sale order with Company A.
+            3) Confirm the sale order.
+            4) Remove the company_id from the project.
+            5) Select the default company B and remove Company A.
+            6) Add a timesheet to the task.
+        """
+        self.so.project_id.company_id = False
+        self.user_employee_company_B.groups_id += self.env.ref('hr_timesheet.group_timesheet_manager')
+        timesheet = self.env['account.analytic.line'].with_user(self.user_employee_company_B).create({
+            'name': 'Task with SOL',
+            'project_id': self.so.project_id.id,
+            'task_id': self.so.tasks_ids[1].id,
+            'employee_id': self.user_employee_company_B.employee_id.id,
+            'so_line': self.so.tasks_ids[1].sale_line_id.id,
+        })
+        self.assertEqual({str(timesheet.account_id.id): 100}, self.so.tasks_ids[1].sale_line_id.analytic_distribution,
+                        "The timesheet should have the same accounts as in the analytic distribution of the so_line")


### PR DESCRIPTION
Steps to reproduce:
----------------------------------
   1) Create two companies and two users with employees.
   2) Create a sale order with Company A.
   3) Confirm the sale order.
   4) Remove the company_id from the project.
   5) Select the default company B and remove Company A.
   6) Add a timesheet to the task.
 
Issue:
------------------------
 - When we try to add the timesheet for company 2 an access error will appears

Cause:
------------------
 - Currently, when we remove the company from the project, the project and task become
  accessible to all companies.The sale line item reference is not removed from the task,
  so when creating the timesheet, the sale item reference is passed. The user can access
  the sale order, but the analytic distribution is not accessible, causing an access error.
  If we remove the sale item from the task, there will be no access error. However,
  doing so is not preferable, which is why we applied sudo.

Fix:
-------------------------
 - In this commit to resolved access error by adding `sudo()` to bypass record rules when retrieving `analytic_distribution` from `sale.order.line`.
  
task-4206915