### PR TITLE
[FIX] pos: prevent reuse of serial numbers from active orders

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1388,7 +1388,7 @@ class PosOrderLine(models.Model):
             filtered(lambda q: float_compare(q.quantity, 0, precision_rounding=q.product_id.uom_id.rounding) > 0).\
             mapped('lot_id')
 
-        return available_lots.read(['id', 'name'])
+        return available_lots.read(['id', 'name', 'product_qty'])
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_order_state(self):

--- a/addons/point_of_sale/static/src/app/store/select_lot_popup/select_lot_popup.js
+++ b/addons/point_of_sale/static/src/app/store/select_lot_popup/select_lot_popup.js
@@ -45,11 +45,13 @@ export class EditListPopup extends Component {
         options: { type: Array, optional: true },
         customInput: { type: Boolean, optional: true },
         uniqueValues: { type: Boolean, optional: true },
+        isLotNameUsed: { type: Function, optional: true },
     };
     static defaultProps = {
         options: [],
         customInput: true,
         uniqueValues: true,
+        isLotNameUsed: () => false,
     };
 
     /**
@@ -121,6 +123,7 @@ export class EditListPopup extends Component {
     }
     hasValidValue(itemId, text) {
         return (
+            !this.props.isLotNameUsed(text) &&
             (this.props.customInput || this.props.options.includes(text)) &&
             (!this.props.uniqueValues ||
                 !this.state.array.some((elem) => elem._id !== itemId && elem.text === text))
@@ -186,6 +189,7 @@ export class EditListPopup extends Component {
                     const itemValue = item.text.trim();
                     const isValidValue =
                         itemValue !== "" &&
+                        !this.props.isLotNameUsed(itemValue) &&
                         (this.props.customInput || this.props.options.includes(itemValue));
                     if (!isValidValue) {
                         return false;

--- a/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
@@ -269,5 +269,13 @@ registry.category("web_tour.tours").add("LotTour", {
             inLeftSide({
                 trigger: ".info-list:contains('SN 3')",
             }),
+
+            // Verify if the serial number can be reused for the current order
+            Chrome.createFloatingOrder(),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            ProductScreen.enterLastLotNumber("3"),
+            inLeftSide({
+                trigger: ".info-list:not(:contains('SN 3'))",
+            }),
         ].flat(),
 });


### PR DESCRIPTION
Steps:
- Open the POS.
- Add a product with serial number tracking to the order line.
- Create a new order.
- Add the same product to the new order

Issue:
- it is possible to select the same serial number that was previously used in another order.

Fix:
- Hide serial numbers that are being used in active orders

Task - 3944652

