### PR TITLE
[FIX] purchase: Correct display in purchase report

### DIFF
--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -88,7 +88,7 @@
                                     <span class="text-align-bottom"><span t-field="line.discount"/>%</span>
                                 </td>
                                 <td class="text-end">
-                                    <span t-esc="', '.join([(tax.invoice_label or tax.name) for tax in line.taxes_id])"/>
+                                    <span t-out="', '.join([(tax.invoice_label or tax.name) for tax in line.taxes_id])"/>
                                 </td>
                                 <td class="text-end">
                                     <span t-field="line.price_subtotal"
@@ -113,7 +113,7 @@
                                 <td colspan="99" id="subtotal">
                                     <strong class="mr16">Subtotal</strong>
                                     <span
-                                        t-esc="current_subtotal"
+                                        t-out="current_subtotal"
                                         t-options='{"widget": "monetary", "display_currency": o.currency_id}'
                                     />
                                 </td>


### PR DESCRIPTION
Changed the tax display in the purchase order template from `t-esc` to `t-out` to ensure proper HTML rendering of tax labels. This adjustment is necessary to display the tax descriptions correctly without escaping HTML content, which was causing display issues in the rendered document.

This change addresses the need for accurate representation of tax information in purchase orders, improving the clarity and correctness of the document output.

opw-4313981

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
