### PR TITLE
[FIX] purchase_stock: adjust button layout

### DIFF
--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -35,10 +35,12 @@
                 <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or forecasted_issue or product_type != 'product'"/>
             </xpath>
             <xpath expr="//div[@name='date_planned_div']" position="inside">
-                <button name="%(action_purchase_vendor_delay_report)d" class="oe_link" type="action" context="{'search_default_partner_id': partner_id}" invisible="state in ['purchase', 'done'] or not partner_id">
-                    <span invisible="on_time_rate &lt; 0"><field name="on_time_rate" widget="integer" class="oe_inline"/>% On-Time Delivery</span>
-                    <span invisible="on_time_rate &gt;= 0">No On-time Delivery Data</span>
-                </button>
+                <div>
+                    <button name="%(action_purchase_vendor_delay_report)d" class="oe_link" type="action" context="{'search_default_partner_id': partner_id}" invisible="state in ['purchase', 'done'] or not partner_id">
+                        <span invisible="on_time_rate &lt; 0"><field name="on_time_rate" widget="integer" class="oe_inline"/>% On-Time Delivery</span>
+                        <span invisible="on_time_rate &gt;= 0">No On-time Delivery Data</span>
+                    </button>
+                </div>
             </xpath>
             <xpath expr="//label[@for='receipt_reminder_email']" position="attributes">
                 <attribute name="invisible">effective_date</attribute>


### PR DESCRIPTION
In Odoo, an issue araised where the "Expected Arrival" date field was overlapped when zooming in. This was due to the button "action_purchase_vendor_delay_report".

To adress this, the related button was encapsulated within a <div> element. This change ensure that the layout remains consistent and the elements does not overlap regardless of the zoom level.

opw-4316093

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
