### PR TITLE
[FIX] web: Many2ManyTagsField: do not lose default values

### DIFF
--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -348,8 +348,10 @@ export class Many2XAutocomplete extends Component {
                             e instanceof RPCError &&
                             e.exceptionName === "odoo.exceptions.ValidationError"
                         ) {
-                            const context = this.getCreationContext(request);
-                            return this.openMany2X({ context });
+                            return this.openMany2X({
+                                context: this.getCreationContext(request),
+                                nextRecordsContext: this.props.context,
+                            });
                         }
                         throw e;
                     }
@@ -378,11 +380,14 @@ export class Many2XAutocomplete extends Component {
         }
 
         if (request.length && canCreateEdit) {
-            const context = this.getCreationContext(request);
             options.push({
                 label: _t("Create and edit..."),
                 classList: "o_m2o_dropdown_option o_m2o_dropdown_option_create_edit",
-                action: () => this.openMany2X({ context }),
+                action: () =>
+                    this.openMany2X({
+                        context: this.getCreationContext(request),
+                        nextRecordsContext: this.props.context,
+                    }),
             });
         }
 
@@ -472,7 +477,7 @@ export function useOpenMany2XRecord({
     const orm = useService("orm");
 
     return async function openDialog(
-        { resId = false, forceModel = null, title, context },
+        { resId = false, forceModel = null, title, context, nextRecordsContext },
         immediate = false
     ) {
         const model = forceModel || resModel;
@@ -498,6 +503,7 @@ export function useOpenMany2XRecord({
                 preventEdit: !canWrite,
                 title,
                 context,
+                nextRecordsContext,
                 mode,
                 resId,
                 resModel: model,

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.js
@@ -13,6 +13,7 @@ export class FormViewDialog extends Component {
         resModel: String,
 
         context: { type: Object, optional: true },
+        nextRecordsContext: { type: Object, optional: true },
         mode: {
             optional: true,
             validate: (m) => ["edit", "readonly"].includes(m),
@@ -67,13 +68,8 @@ export class FormViewDialog extends Component {
                     this.currentResId = record.resId;
                     await this.props.onRecordSaved(record);
                     if (saveAndNew) {
-                        const context = Object.assign({}, this.props.context);
-                        Object.keys(context).forEach((k) => {
-                            if (k.startsWith("default_")) {
-                                delete context[k];
-                            }
-                        });
                         this.currentResId = false;
+                        const context = this.props.nextRecordsContext || this.props.context || {};
                         await record.model.load({ resId: false, context });
                     } else {
                         this.props.close();

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -938,10 +938,6 @@ test("Many2ManyTagsField: save&new in edit mode doesn't close edit window", asyn
         form: '<form><field name="name"/></form>',
     };
 
-    const nameSearchProm = new Deferred();
-    onRpc("name_search", () => {
-        nameSearchProm.resolve();
-    });
     await mountView({
         type: "form",
         resModel: "partner",
@@ -954,7 +950,6 @@ test("Many2ManyTagsField: save&new in edit mode doesn't close edit window", asyn
     });
 
     await contains(`div[name="timmy"] input`).edit("Ralts", { confirm: false });
-    await nameSearchProm;
     await runAllTimers();
     await clickFieldDropdownItem("timmy", "Create and edit...");
     //await testUtils.fields.many2one.createAndEdit("timmy", "Ralts");
@@ -975,34 +970,11 @@ test("Many2ManyTagsField: save&new in edit mode doesn't close edit window", asyn
 });
 
 test("Many2ManyTagsField: make tag name input field blank on Save&New", async () => {
-    expect.assertions(4);
-
     PartnerType._views = {
         form: '<form><field name="name"/></form>',
     };
 
-    let onchangeCalls = 0;
-    const nameSearchProm = new Deferred();
-    onRpc("onchange", (args) => {
-        if (onchangeCalls === 0) {
-            expect(args.kwargs.context).toEqual(
-                { allowed_company_ids: [1], default_name: "hello", lang: "en", tz: "taht", uid: 7 },
-                { message: "context should have default_name with 'hello' as value" }
-            );
-        }
-        if (onchangeCalls === 1) {
-            expect(args.kwargs.context).toEqual({
-                allowed_company_ids: [1],
-                lang: "en",
-                tz: "taht",
-                uid: 7,
-            });
-        }
-        onchangeCalls++;
-    });
-    onRpc("name_search", () => {
-        nameSearchProm.resolve();
-    });
+    onRpc("onchange", (args) => expect.step(args.kwargs.context));
     await mountView({
         type: "form",
         resModel: "partner",
@@ -1011,16 +983,75 @@ test("Many2ManyTagsField: make tag name input field blank on Save&New", async ()
     });
 
     await contains(".o_field_widget input").edit("hello", { confirm: false });
-    await nameSearchProm;
-    await animationFrame();
+    await runAllTimers();
     await clickFieldDropdownItem("timmy", "Create and edit...");
-    await animationFrame();
 
     expect(".modal .o_form_view input").toHaveValue("hello");
 
     // Create record with save & new
     await contains(".modal .btn-primary:nth-child(2)").click();
     expect(".modal .o_form_view input").toHaveValue("");
+
+    expect.verifySteps([
+        { allowed_company_ids: [1], default_name: "hello", lang: "en", tz: "taht", uid: 7 },
+        {
+            allowed_company_ids: [1],
+            lang: "en",
+            tz: "taht",
+            uid: 7,
+        },
+    ]);
+});
+
+test("Many2ManyTagsField: Save&New in many2many_tags with default_ keys in context", async () => {
+    PartnerType._views = {
+        form: `
+            <form>
+                <field name="name"/>
+                <field name="color"/>
+            </form>`,
+    };
+
+    onRpc("onchange", (args) => expect.step(args.kwargs.context));
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="timmy" widget="many2many_tags" context="{'default_color': 3}"/>
+            </form>`,
+        resId: 1,
+    });
+
+    await contains(".o_field_widget input").edit("hello", { confirm: false });
+    await runAllTimers();
+    await clickFieldDropdownItem("timmy", "Create and edit...");
+
+    expect(".modal .o_field_widget[name=name] input").toHaveValue("hello");
+    expect(".modal .o_field_widget[name=color] input").toHaveValue("3");
+
+    // Create record with save & new
+    await contains(".modal .btn-primary:nth-child(2)").click();
+    expect(".modal .o_field_widget[name=name] input").toHaveValue("");
+    expect(".modal .o_field_widget[name=color] input").toHaveValue("3");
+
+    expect.verifySteps([
+        {
+            allowed_company_ids: [1],
+            default_name: "hello",
+            default_color: 3,
+            lang: "en",
+            tz: "taht",
+            uid: 7,
+        },
+        {
+            allowed_company_ids: [1],
+            default_color: 3,
+            lang: "en",
+            tz: "taht",
+            uid: 7,
+        },
+    ]);
 });
 
 test("Many2ManyTagsField: conditional create/delete actions", async () => {
@@ -1037,10 +1068,6 @@ test("Many2ManyTagsField: conditional create/delete actions", async () => {
         search: "<search/>",
     };
 
-    let nameSearchProm = new Deferred();
-    onRpc("name_search", () => {
-        nameSearchProm.resolve();
-    });
     await mountView({
         type: "form",
         resModel: "turtle",
@@ -1057,7 +1084,6 @@ test("Many2ManyTagsField: conditional create/delete actions", async () => {
     expect(".o_field_many2many_tags.o_field_widget .badge .o_delete").toHaveCount(1);
 
     await clickFieldDropdown("partner_ids");
-    await nameSearchProm;
     await animationFrame();
     expect(
         ".o-autocomplete.dropdown li.o_m2o_start_typing a:contains(Start typing...)"
@@ -1070,14 +1096,10 @@ test("Many2ManyTagsField: conditional create/delete actions", async () => {
     await contains(".modal .modal-footer .o_form_button_cancel").click();
 
     // type something that doesn't exist
-    nameSearchProm = new Deferred();
     await contains(".o_field_many2many_tags input").edit("Something that does not exist", {
         confirm: false,
     });
-
-    await press("ArrowDown");
-    await nameSearchProm;
-    await animationFrame();
+    await runAllTimers();
 
     expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option").toHaveCount(2);
 
@@ -1088,10 +1110,8 @@ test("Many2ManyTagsField: conditional create/delete actions", async () => {
     // remove icon should still be there as it doesn't delete records but rather remove links
     expect(".o_field_many2many_tags.o_field_widget .badge .o_delete").toHaveCount(1);
 
-    nameSearchProm = new Deferred();
     await clickFieldDropdown("partner_ids");
-    await nameSearchProm;
-    await animationFrame();
+    await runAllTimers();
 
     // only Search More option should be available
     expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option").toHaveCount(1);
@@ -1106,14 +1126,8 @@ test("Many2ManyTagsField: conditional create/delete actions", async () => {
     await contains(".modal .modal-footer .o_form_button_cancel").click();
 
     // type something that does exist in multiple occurrences
-    // LPE: to check with AAB
-    nameSearchProm = new Deferred();
     await contains(".o_field_many2many_tags input").edit("Pa", { confirm: false });
-
-    await press("ArrowUp");
-    await animationFrame();
-    await nameSearchProm;
-    await animationFrame();
+    await runAllTimers();
 
     // only Search More option should be available
     expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option").toHaveCount(1);


### PR DESCRIPTION
Have a field with many2many_tags widget and a context containing `default_` keys (e.g. `{'default_product_id': 45}`). Type something in the input and click on "Create and edit". In the dialog, the name should be prefilled with the value you typed in the input. Moreover, the product should be set to product 45. Click on "Save & New". Before this commit, all fields were empty, because we removed from the context all `default_` keys.

This is correct to remove the `default_name` key, as we already created that record. However, we must keep the others.

This issue has been introduced with the wowl implementation of the Many2ManyTagsField/FormViewDialog.

task~4331742

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
