### PR TITLE
[FIX] point_of_sale, pos_hr: restrict product creation rights

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -35,6 +35,7 @@ import { ActionScreen } from "@point_of_sale/app/screens/action_screen";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 import { CashMovePopup } from "@point_of_sale/app/navbar/cash_move_popup/cash_move_popup";
 import { ClosePosPopup } from "../navbar/closing_popup/closing_popup";
+import { user } from "@web/core/user";
 
 const { DateTime } = luxon;
 
@@ -1771,6 +1772,9 @@ export class PosStore extends Reactive {
                 },
             }
         );
+    }
+    async allowProductCreation() {
+        return await user.hasGroup("base.group_system");
     }
     async orderDetails(order) {
         this.dialog.add(FormViewDialog, {

--- a/addons/pos_hr/static/src/overrides/models/pos_store.js
+++ b/addons/pos_hr/static/src/overrides/models/pos_store.js
@@ -142,4 +142,10 @@ patch(PosStore.prototype, {
         }
         return super.shouldShowOpeningControl(...arguments);
     },
+    async allowProductCreation() {
+        if (this.config.module_pos_hr) {
+            return this.employeeIsAdmin;
+        }
+        return await super.allowProductCreation();
+    },
 });


### PR DESCRIPTION
This commit allows to tell wether or not the current cashier has
the rights to create products from the store.

opw-4255570

Enterprise PR: https://github.com/odoo/enterprise/pull/72758