### PR TITLE
[FIX] web: remove the error when a widget is used with the wrong field

### DIFF
--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -100,7 +100,7 @@ export function getFieldFromRegistry(fieldType, widget, viewType, jsClass) {
         const field = findInRegistry(widget);
         if (field) {
             if (field.supportedTypes && !field.supportedTypes?.includes(fieldType)) {
-                throw new Error(`The widget: ${widget} don't support the type ${fieldType}`);
+                console.warn(`The widget: ${widget} don't support the type ${fieldType}`);
             }
             return field;
         }


### PR DESCRIPTION
Since [1] a validation to check that a widget is used with the right field type was added. The issue with this validation is that it is not done when the view is created/modified but at runtime.

This commit, change the validation from error to a warning at runtime.