### PR TITLE
[IMP] mail, im_livechat: simplify fetch message params

### DIFF
--- a/addons/im_livechat/controllers/cors/channel.py
+++ b/addons/im_livechat/controllers/cors/channel.py
@@ -7,9 +7,9 @@ from odoo.addons.im_livechat.tools.misc import force_guest_env
 
 class LivechatChannelController(ChannelController):
     @route("/im_livechat/cors/channel/messages", methods=["POST"], type="jsonrpc", auth="public", cors="*")
-    def livechat_channel_messages(self, guest_token, channel_id, before=None, after=None, limit=30, around=None):
+    def livechat_channel_messages(self, guest_token, channel_id, fetch_params=None):
         force_guest_env(guest_token)
-        return self.discuss_channel_messages(channel_id, before, after, limit, around)
+        return self.discuss_channel_messages(channel_id, fetch_params)
 
     @route("/im_livechat/cors/channel/mark_as_read", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_channel_mark_as_read(self, guest_token, **kwargs):

--- a/addons/mail/controllers/mailbox.py
+++ b/addons/mail/controllers/mailbox.py
@@ -7,9 +7,9 @@ from odoo.addons.mail.tools.discuss import Store
 
 class MailboxController(http.Controller):
     @http.route("/mail/inbox/messages", methods=["POST"], type="jsonrpc", auth="user", readonly=True)
-    def discuss_inbox_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
+    def discuss_inbox_messages(self, fetch_params=None):
         domain = [("needaction", "=", True)]
-        res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
+        res = request.env["mail.message"]._message_fetch(domain, **(fetch_params or {}))
         messages = res.pop("messages")
         return {
             **res,
@@ -18,9 +18,9 @@ class MailboxController(http.Controller):
         }
 
     @http.route("/mail/history/messages", methods=["POST"], type="jsonrpc", auth="user", readonly=True)
-    def discuss_history_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
+    def discuss_history_messages(self, fetch_params=None):
         domain = [("needaction", "=", False)]
-        res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
+        res = request.env["mail.message"]._message_fetch(domain, **(fetch_params or {}))
         messages = res.pop("messages")
         return {
             **res,
@@ -29,9 +29,9 @@ class MailboxController(http.Controller):
         }
 
     @http.route("/mail/starred/messages", methods=["POST"], type="jsonrpc", auth="user", readonly=True)
-    def discuss_starred_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
+    def discuss_starred_messages(self, fetch_params=None):
         domain = [("starred_partner_ids", "in", [request.env.user.partner_id.id])]
-        res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
+        res = request.env["mail.message"]._message_fetch(domain, **(fetch_params or {}))
         messages = res.pop("messages")
         return {
             **res,

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -24,13 +24,13 @@ class ThreadController(http.Controller):
         return Store(thread, as_thread=True, request_list=request_list).get_result()
 
     @http.route("/mail/thread/messages", methods=["POST"], type="jsonrpc", auth="user")
-    def mail_thread_messages(self, thread_model, thread_id, search_term=None, before=None, after=None, around=None, limit=30):
+    def mail_thread_messages(self, thread_model, thread_id, fetch_params=None):
         domain = [
             ("res_id", "=", int(thread_id)),
             ("model", "=", thread_model),
             ("message_type", "!=", "user_notification"),
         ]
-        res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
+        res = request.env["mail.message"]._message_fetch(domain, **(fetch_params or {}))
         messages = res.pop("messages")
         if not request.env.user._is_public():
             messages.set_message_done()

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -650,8 +650,10 @@ export class Store extends BaseStore {
     async searchMessagesInThread(searchTerm, thread, before = false) {
         const { count, data, messages } = await rpc(thread.getFetchRoute(), {
             ...thread.getFetchParams(),
-            search_term: await prettifyMessageContent(searchTerm), // formatted like message_post
-            before,
+            fetch_params: {
+                search_term: await prettifyMessageContent(searchTerm), // formatted like message_post
+                before,
+            },
         });
         this.insert(data, { html: true });
         return {

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -567,10 +567,13 @@ export class Thread extends Record {
         // ordered messages received: newest to oldest
         return await rpc(this.getFetchRoute(), {
             ...this.getFetchParams(),
-            limit: !around && around !== 0 ? this.store.FETCH_LIMIT : this.store.FETCH_LIMIT * 2,
-            after,
-            around,
-            before,
+            fetch_params: {
+                limit:
+                    !around && around !== 0 ? this.store.FETCH_LIMIT : this.store.FETCH_LIMIT * 2,
+                after,
+                around,
+                before,
+            },
         });
     }
 

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -54,7 +54,7 @@ test("simple chatter on a record", async () => {
     await contains(".o-mail-Thread");
     await waitForSteps([
         `/mail/thread/data - {"request_list":["activities","attachments","followers","scheduledMessages","suggestedRecipients"],"thread_id":${partnerId},"thread_model":"res.partner"}`,
-        `/mail/thread/messages - {"thread_id":${partnerId},"thread_model":"res.partner","limit":30}`,
+        `/mail/thread/messages - {"thread_id":${partnerId},"thread_model":"res.partner","fetch_params":{"limit":30}}`,
     ]);
 });
 

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -60,7 +60,7 @@ test("can create a new channel", async () => {
             channels_as_member: true,
             context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
         })}`,
-        '/mail/inbox/messages - {"limit":30}',
+        '/mail/inbox/messages - {"fetch_params":{"limit":30}}',
     ]);
     await contains(".o-mail-Discuss");
     await contains(".o-mail-DiscussSidebar-item", { text: "abc", count: 0 });
@@ -89,7 +89,7 @@ test("can create a new channel", async () => {
             method: "channel_create",
             model: "discuss.channel",
         })}`,
-        `/discuss/channel/messages - {"channel_id":${channelId},"limit":60,"around":${selfMember.new_message_separator}}`,
+        `/discuss/channel/messages - {"channel_id":${channelId},"fetch_params":{"limit":60,"around":${selfMember.new_message_separator}}}`,
     ]);
 });
 
@@ -129,7 +129,7 @@ test("can make a DM chat", async () => {
             channels_as_member: true,
             context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
         })}`,
-        '/mail/inbox/messages - {"limit":30}',
+        '/mail/inbox/messages - {"fetch_params":{"limit":30}}',
     ]);
     await contains(".o-mail-Discuss");
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario", count: 0 });
@@ -157,7 +157,7 @@ test("can make a DM chat", async () => {
             method: "channel_get",
             model: "discuss.channel",
         })}`,
-        `/discuss/channel/messages - {"channel_id":${channelId},"limit":60,"around":0}`,
+        `/discuss/channel/messages - {"channel_id":${channelId},"fetch_params":{"limit":60,"around":0}}`,
     ]);
 });
 

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -61,7 +61,7 @@ test("sanity check", async () => {
             channels_as_member: true,
             context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
         })}`,
-        '/mail/inbox/messages - {"limit":30}',
+        '/mail/inbox/messages - {"fetch_params":{"limit":30}}',
     ]);
     await contains(".o-mail-DiscussSidebar");
     await contains("h4:contains(Your inbox is empty)");
@@ -310,7 +310,7 @@ test("No load more when fetch below fetch limit of 60", async () => {
     }
     onRpcBefore("/discuss/channel/messages", (args) => {
         asyncStep("/discuss/channel/messages");
-        expect(args.limit).toBe(60);
+        expect(args.fetch_params.limit).toBe(60);
     });
     await start();
     await openDiscuss(channelId);
@@ -674,7 +674,7 @@ test("initially load messages from inbox", async () => {
     });
     onRpcBefore("/mail/inbox/messages", (args) => {
         asyncStep("/discuss/inbox/messages");
-        expect(args.limit).toBe(30);
+        expect(args.fetch_params.limit).toBe(30);
     });
     await start();
     await openDiscuss();

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -305,23 +305,16 @@ async function discuss_channel_messages(request) {
     /** @type {import("mock_models").MailMessage} */
     const MailMessage = this.env["mail.message"];
 
-    const {
-        after,
-        around,
-        before,
-        channel_id,
-        limit = 30,
-        search_term,
-    } = await parseRequestParams(request);
+    const { channel_id, fetch_params = {} } = await parseRequestParams(request);
     const domain = [
         ["res_id", "=", channel_id],
         ["model", "=", "discuss.channel"],
         ["message_type", "!=", "user_notification"],
     ];
-    const res = MailMessage._message_fetch(domain, search_term, before, after, around, limit);
+    const res = MailMessage._message_fetch(domain, makeKwArgs(fetch_params));
     const { messages } = res;
     delete res.messages;
-    if (!around) {
+    if (!fetch_params.around) {
         MailMessage.set_message_done(messages.map((message) => message.id));
     }
     return {
@@ -495,9 +488,9 @@ async function discuss_history_messages(request) {
     /** @type {import("mock_models").MailNotification} */
     const MailNotification = this.env["mail.notification"];
 
-    const { after, around, before, limit = 30, search_term } = await parseRequestParams(request);
+    const { fetch_params = {} } = await parseRequestParams(request);
     const domain = [["needaction", "=", false]];
-    const res = MailMessage._message_fetch(domain, search_term, before, after, around, limit);
+    const res = MailMessage._message_fetch(domain, makeKwArgs(fetch_params));
     const { messages } = res;
     delete res.messages;
     const messagesWithNotification = messages.filter((message) => {
@@ -524,9 +517,9 @@ async function discuss_inbox_messages(request) {
     /** @type {import("mock_models").MailMessage} */
     const MailMessage = this.env["mail.message"];
 
-    const { after, around, before, limit = 30, search_term } = await parseRequestParams(request);
+    const { fetch_params = {} } = await parseRequestParams(request);
     const domain = [["needaction", "=", true]];
-    const res = MailMessage._message_fetch(domain, search_term, before, after, around, limit);
+    const res = MailMessage._message_fetch(domain, makeKwArgs(fetch_params));
     const { messages } = res;
     delete res.messages;
     return {
@@ -832,9 +825,9 @@ async function discuss_starred_messages(request) {
     /** @type {import("mock_models").MailMessage} */
     const MailMessage = this.env["mail.message"];
 
-    const { after, before, limit = 30, search_term } = await parseRequestParams(request);
+    const { fetch_params = {} } = await parseRequestParams(request);
     const domain = [["starred_partner_ids", "in", [this.env.user.partner_id]]];
-    const res = MailMessage._message_fetch(domain, search_term, before, after, false, limit);
+    const res = MailMessage._message_fetch(domain, makeKwArgs(fetch_params));
     const { messages } = res;
     delete res.messages;
     return {
@@ -872,14 +865,13 @@ async function mail_thread_messages(request) {
     /** @type {import("mock_models").MailMessage} */
     const MailMessage = this.env["mail.message"];
 
-    const { after, around, before, limit, search_term, thread_id, thread_model } =
-        await parseRequestParams(request);
+    const { fetch_params = {}, thread_id, thread_model } = await parseRequestParams(request);
     const domain = [
         ["res_id", "=", thread_id],
         ["model", "=", thread_model],
         ["message_type", "!=", "user_notification"],
     ];
-    const res = MailMessage._message_fetch(domain, search_term, before, after, around, limit);
+    const res = MailMessage._message_fetch(domain, makeKwArgs(fetch_params));
     const { messages } = res;
     delete res.messages;
     MailMessage.set_message_done(messages.map((message) => message.id));

--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -57,9 +57,7 @@ class PortalChatter(http.Controller):
         return store.get_result()
 
     @http.route('/mail/chatter_fetch', type='jsonrpc', auth='public', website=True)
-    def portal_message_fetch(
-            self, thread_model, thread_id, limit=10, after=None, before=None, **kw
-    ):
+    def portal_message_fetch(self, thread_model, thread_id, fetch_params=None, **kw):
         # Only search into website_message_ids, so apply the same domain to perform only one search
         # extract domain from the 'website_message_ids' field
         model = request.env[thread_model]
@@ -83,7 +81,7 @@ class PortalChatter(http.Controller):
             if not request.env.user._is_internal():
                 domain = expression.AND([Message._get_search_domain_share(), domain])
             Message = request.env["mail.message"].sudo()
-        res = Message._message_fetch(domain, None, before, after, None, limit)
+        res = Message._message_fetch(domain, **(fetch_params or {}))
         messages = res.pop("messages")
         return {
             **res,


### PR DESCRIPTION
This commit moves `search_term`, `before`, `after`, `limit` and `around` fetch params to a single parameter as `fetch_params` to simplify the code. This change applies to all available fetch messages routes.

Suggested [here](https://github.com/odoo/odoo/pull/182334/files#r1811034899)
