### PR TITLE
[FIX] account_payment: prevent error while post-processing payment transaction

### DIFF
--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -151,7 +151,7 @@ class PaymentTransaction(models.Model):
                     )
 
         payment_method_line = self.provider_id.journal_id.inbound_payment_method_line_ids\
-            .filtered(lambda l: l.payment_provider_id == self.provider_id)
+            .filtered(lambda l: l.payment_provider_id == self.provider_id)[0]
         payment_values = {
             'amount': abs(self.amount),  # A tx may have a negative amount, but a payment must >= 0
             'payment_type': 'inbound' if self.amount > 0 else 'outbound',


### PR DESCRIPTION
Currently, an exception is generated at the time of the post-processing payment transaction.

error:
```
ValueError: Expected singleton: account.payment.method.line(11, 12)
  File "addons/payment/models/payment_transaction.py", line 852, in _cron_post_process
    tx._post_process()
  File "addons/pos_online_payment/models/payment_transaction.py", line 29, in _post_process
    super()._post_process()
  File "addons/website_payment/models/payment_transaction.py", line 14, in _post_process
    super()._post_process()
  File "addons/sale/models/payment_transaction.py", line 91, in _post_process
    super(PaymentTransaction, done_tx)._post_process()  # Post the invoices.
  File "addons/account_payment/models/payment_transaction.py", line 122, in _post_process
    tx.with_company(tx.company_id)._create_payment()
  File "addons/account_payment/models/payment_transaction.py", line 163, in _create_payment
    'payment_method_line_id': payment_method_line.id,
  File "odoo/fields.py", line 5287, in __get__
    raise ValueError("Expected singleton: %s" % record)
```
The above exception was generated because we got multiple payment method lines in a single journal.

This commit fixes the above issue by accessing the first payment method line.

sentry-6007333118





