### PR TITLE
[FIX] point_of_sale: fix IoT customer display SSL

### DIFF
--- a/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
@@ -2,10 +2,12 @@ import { reactive } from "@odoo/owl";
 import { deduceUrl, getOnNotified } from "@point_of_sale/utils";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
+import { _t } from "@web/core/l10n/translation";
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
 export const CustomerDisplayDataService = {
-    dependencies: ["bus_service"],
-    async start(env, { bus_service }) {
+    dependencies: ["bus_service", "dialog"],
+    async start(env, { bus_service, dialog }) {
         const data = reactive({});
         if (session.type === "local") {
             new BroadcastChannel("UPDATE_CUSTOMER_DISPLAY").onmessage = (event) => {
@@ -21,22 +23,34 @@ export const CustomerDisplayDataService = {
             );
         }
         if (session.type === "proxy") {
-            setInterval(async () => {
-                const response = await fetch(
-                    `${deduceUrl(session.proxy_ip)}/hw_proxy/customer_facing_display`,
-                    {
-                        method: "POST",
-                        headers: {
-                            Accept: "application/json",
-                            "Content-Type": "application/json",
-                        },
-                        body: JSON.stringify({
-                            action: "get",
-                        }),
-                    }
-                );
-                const payload = await response.json();
-                Object.assign(data, payload.result.data);
+            const intervalId = setInterval(async () => {
+                try {
+                    const response = await fetch(
+                        `${deduceUrl(session.proxy_ip)}/hw_proxy/customer_facing_display`,
+                        {
+                            method: "POST",
+                            headers: {
+                                Accept: "application/json",
+                                "Content-Type": "application/json",
+                            },
+                            body: JSON.stringify({
+                                action: "get",
+                            }),
+                        }
+                    );
+                    const payload = await response.json();
+                    Object.assign(data, payload.result.data);
+                } catch (error) {
+                    dialog.add(AlertDialog, {
+                        title: _t("IoT customer display error"),
+                        body: _t(
+                            "Error: %s.\nMake sure there is an IoT Box subscription associated with your Odoo database, then restart the IoT Box.",
+                            error
+                        ),
+                    });
+                    console.error("Error fetching data for the IoT customer display: %s", error);
+                    clearInterval(intervalId);
+                }
             }, 1000);
         }
         return data;


### PR DESCRIPTION
Currently, when the IoT Box doesn't have a valid SSL certificate yet when the user is trying to open the Point of Sale customer display it triggers a request error related to invalid SSL certificate in a loop. The screen gets darker and darker and the user needs to connect a mouse to the IoT Box and click on "see the details" to see a non comprehensive error message "ERR_CERT_AUTH_INVALID". This is usually linked to the absence of the IoT subscribtion for this particular database.
After this PR the user will see an error on screen once (and not in a 1s loop) suggesting to check the SSL certificate status which will help functional support to solve related tickets more easily.

ticket-4175902