### PR TITLE
[IMP] website_event{_track,_track_live}: small UI/UX changes

### DIFF
--- a/addons/website_event/data/event_question_demo.xml
+++ b/addons/website_event/data/event_question_demo.xml
@@ -76,7 +76,7 @@
     <record id="event_1_question_0" model="event.question">
         <field name="title">How did you learn about this event?</field>
         <field name="question_type">simple_choice</field>
-        <field name="once_per_order" eval="False"/>
+        <field name="once_per_order" eval="True"/>
         <field name="event_id" ref="event.event_1"/>
     </record>
     <record id="event_1_question_0_answer_0" model="event.question.answer">
@@ -99,7 +99,7 @@
     <record id="event_5_question_0" model="event.question">
         <field name="title">How did you learn about this event?</field>
         <field name="question_type">simple_choice</field>
-        <field name="once_per_order" eval="False"/>
+        <field name="once_per_order" eval="True"/>
         <field name="event_id" ref="event.event_5"/>
     </record>
     <record id="event_5_question_0_answer_0" model="event.question.answer">

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -251,9 +251,10 @@
                     <t t-if="availability_check" t-foreach="tickets" t-as="ticket">
                         <t t-foreach="range(1, ticket['quantity'] + 1)" t-as="att_counter" name="attendee_loop">
                             <t t-set="counter" t-value="counter + 1"/>
-                            <div class="modal-body">
+                            <input class="d-none" type="text" t-attf-name="#{counter}-event_ticket_id" t-attf-value="#{ticket['id']}"/>
+                            <div t-if="event.specific_question_ids" class="modal-body">
                                 <h5 t-attf-class="mt-1 pb-2 #{'border-bottom' if event.question_ids else ''}">Ticket #<span t-out="counter"/> <small class="text-muted">- <span t-out="ticket['name']"/></small></h5>
-                                <div t-if="event.specific_question_ids" class="row">
+                                <div class="row">
                                     <t t-foreach="event.specific_question_ids" t-as="question">
                                         <div class="col-lg-6 mt-2">
                                             <t t-call="website_event.registration_event_question">
@@ -262,7 +263,6 @@
                                         </div>
                                     </t>
                                 </div>
-                                <input class="d-none" type="text" t-attf-name="#{counter}-event_ticket_id" t-attf-value="#{ticket['id']}"/>
                             </div>
                         </t>
                     </t>

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -234,16 +234,17 @@
             <list string="Event Track" multi_edit="1">
                 <field name="name"/>
                 <field name="active" column_invisible="True"/>
-                <field name="partner_name"/>
+                <field name="partner_name" string="Speaker Name"/>
                 <field name="partner_id" optional="hide"/>
-                <field name="partner_email"/>
-                <field name="partner_phone"/>
+                <field name="partner_email" optional="hide"/>
+                <field name="partner_phone" optional="hide"/>
                 <field name="event_id" column_invisible="context.get('default_event_id')"/>
                 <field name="wishlisted_by_default" optional="hide"/>
                 <field name="wishlist_visitor_count" optional="hide"/>
                 <field name="stage_id"/>
-                <field name="color" widget="color_picker" optional="hide"/>
+                <field name="color" string="Color" widget="color_picker"/>
                 <field name="activity_exception_decoration" widget="activity_exception"/>
+                <field name="location_id"/>
             </list>
         </field>
     </record>

--- a/addons/website_event_track_live/views/event_track_views.xml
+++ b/addons/website_event_track_live/views/event_track_views.xml
@@ -14,4 +14,15 @@
         </field>
     </record>
 
+    <record id="event_track_view_list" model="ir.ui.view">
+        <field name="name">event.track.view.list.inherit.live</field>
+        <field name="model">event.track</field>
+        <field name="inherit_id" ref="website_event_track.view_event_track_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//list" position="inside">
+                <field name="youtube_video_url" widget="CopyClipboardURL" optional="hide"/>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
### Specifications:

1. On the demo data, mark the question 'How did you learn about this event?' as 'once per order' for the following events:
- Great Reno Ballon Race
- Hockey Tournament

2. If there are only 'Once per Order' question(s), we should not show Attendees Details Section on Registration

3. Minor changes in Event Track List View

Task-4255135
