### PR TITLE
[FIX] sale: handle empty so_reference_type in payment transaction

### DIFF
--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -18,10 +18,12 @@ class PaymentTransaction(models.Model):
         self.ensure_one()
         if self.provider_id.so_reference_type == 'so_name':
             order_reference = order.name
-        else:
-            # self.provider_id.so_reference_type == 'partner'
+        elif self.provider_id.so_reference_type == 'partner':
             identification_number = order.partner_id.id
             order_reference = '%s/%s' % ('CUST', str(identification_number % 97).rjust(2, '0'))
+        else:
+            # self.provider_id.so_reference_type is empty
+            order_reference = False
 
         invoice_journal = self.env['account.journal'].search([('type', '=', 'sale'), ('company_id', '=', self.env.company.id)], limit=1)
         if invoice_journal:


### PR DESCRIPTION
As so_reference_type can be left empty on the payment.provider, we need to handle the case in the back end and effectively allow an empty payment reference.

With no payment reference defined on the sale.order (field reference), we have the possibility to let the invoice define the payment reference itself (field payment_reference) which allows an easier reconciliation of payments and invoices.

opw-4282903
