### PR TITLE
[IMP] point_of_sale: Upgrade IoT to 2024-10-22 RPi OS

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/logrotate.conf
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/logrotate.conf
@@ -14,19 +14,4 @@ create
 # packages drop log rotation information into this directory
 include /etc/logrotate.d
 
-# no packages own wtmp, or btmp -- we'll rotate them here
-/var/log/wtmp {
-    missingok
-    monthly
-    create 0664 root utmp
-    rotate 1
-}
-
-/var/log/btmp {
-    missingok
-    monthly
-    create 0660 root utmp
-    rotate 1
-}
-
 # system-specific logs may be configured here

--- a/addons/point_of_sale/tools/posbox/posbox_create_image.sh
+++ b/addons/point_of_sale/tools/posbox/posbox_create_image.sh
@@ -45,7 +45,7 @@ REPO="https://github.com/${REPO:-$current_repo}/odoo.git"
 echo "Using repo: ${REPO}"
 
 if ! file_exists *raspios*.img ; then
-    wget "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2024-07-04/2024-07-04-raspios-bookworm-armhf-lite.img.xz" -O raspios.img.xz
+    wget "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2024-10-28/2024-10-22-raspios-bookworm-armhf-lite.img.xz" -O raspios.img.xz
     unxz --verbose raspios.img.xz
 fi
 


### PR DESCRIPTION
For the next IoT box image, we will upgrade to the latest version of RPi OS Lite. This fixes an issue on bootup where the display is not initalised (hangs waiting on `dev-dri-card0/start`). It also fixes printers not being detected when no display is plugged in (see https://github.com/odoo/odoo/issues/186436).

We also remove the `wtmp` and `btmp` paths from `logrotate.conf`. These paths were duplicated from existing logrotate config files, causing the service to fail to start.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
