### PR TITLE
[FIX] base: prevent trailing nul byte in datamatrix barcode

### DIFF
--- a/odoo/addons/base/tests/test_barcode.py
+++ b/odoo/addons/base/tests/test_barcode.py
@@ -3,6 +3,7 @@
 
 from odoo.tests.common import TransactionCase
 from odoo.tools import check_barcode_encoding, get_barcode_check_digit
+from odoo.tools.barcode import datamatrix_encode_ascii, ECC200DataMatrix
 
 
 class TestBarcode(TransactionCase):
@@ -25,3 +26,27 @@ class TestBarcode(TransactionCase):
         self.assertFalse(check_barcode_encoding('9745213796148', 'ean13'), 'incorrect check digit')
         self.assertFalse(check_barcode_encoding('2022!71416014', 'ean13'), 'should contains digits only')
         self.assertFalse(check_barcode_encoding('0022071416014', 'ean13'), 'when starting with one zero, it indicates that a 12-digit UPC-A code follows')
+
+    def test_datamatrix_ascii_encoding(self):
+        self.assertEqual(list(datamatrix_encode_ascii("2022071416014")), [150, 152, 137, 144, 146, 131, 53])
+        self.assertEqual(list(datamatrix_encode_ascii("9745213796142")), [227, 175, 151, 167, 226, 144, 51])
+        self.assertEqual(list(datamatrix_encode_ascii("abc123")), [98, 99, 100, 142, 52])
+
+    def test_datamatrix_c40_encoding(self):
+        def get_datamatrix(data):
+            codewords = ECC200DataMatrix()._encode_c40(data)
+            # Ignore the padding, which begins at the value 129 (after 254, the end of data)
+            return codewords[: codewords.index(129, codewords.index(254))]
+
+        # Values taken from `echo -n $CODE | dmtxwrite -s 44x44 -ec -c | grep '^d:'`
+        self.assertEqual(get_datamatrix("123a"), [230, 32, 56, 254, 98])
+        self.assertEqual(get_datamatrix("1234"), [230, 32, 56, 254, 53])
+        self.assertEqual(get_datamatrix("1234a"), [230, 32, 56, 50, 82, 254])
+        self.assertEqual(get_datamatrix("abc123"), [230, 12, 171, 12, 212, 32, 56, 254])
+
+        self.assertEqual(get_datamatrix("2022071416014"), [230, 38, 39, 38, 44, 32, 134, 63, 38, 254, 53])
+        self.assertEqual(get_datamatrix("9745213796142"), [230, 83, 1, 57, 54, 45, 134, 63, 81, 254, 51])
+        self.assertEqual(
+            get_datamatrix("011234567890510abcde"),
+            [230, 25, 206, 38, 161, 57, 220, 77, 13, 57, 13, 12, 171, 12, 212, 13, 35, 254, 102],
+        )


### PR DESCRIPTION
## Steps to reproduce:
1. Enable datamatrix when printing GS1 barcodes in the settings
2. Create a product:
    - with the barcode 12345678905
    - tracked by lot
3. Create a lot for the product: abcde
4. Print the Lot number into PDF
5. Scan the datamatrix

The scanned barcode ends with an additional NUL byte.

## Before this commit:
During the barcode encoding to C40, reportlab adds padding to ensure the message's length is always a multiple of 3, to simplify the encoding process.
However, when the last chunk has a single byte of data, the padding will be considered as data during the decoding, introducing a trailing NUL byte in the barcode.

## After this commit:
Encode the last chunk of data using ASCII mode, as indicated in the C40 encodation rules [1].

[1]: https://www.keepautomation.com/tips/data_matrix/c40_encodation_in_data_matrix.html

opw-4295946