### PR TITLE
[FIX] sale: legacy invoices not taken into account for amount to invoice

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -850,7 +850,7 @@ class SaleOrderLine(models.Model):
         for line in self:
             amount_invoiced = 0.0
             for invoice_line in line._get_invoice_lines():
-                if invoice_line.move_id.state == 'posted':
+                if invoice_line.move_id.state == 'posted' or invoice_line.move_id.payment_state == 'invoicing_legacy':
                     invoice_date = invoice_line.move_id.invoice_date or fields.Date.today()
                     if invoice_line.move_id.move_type == 'out_invoice':
                         amount_invoiced += invoice_line.currency_id._convert(invoice_line.price_subtotal, line.currency_id, line.company_id, invoice_date)

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -900,6 +900,7 @@ class TestSaleToInvoice(TestSaleCommon):
                 Command.create({
                     'product_id': self.company_data['product_delivery_no'].id,
                     'product_uom_qty': 20,
+                    'price_unit': 30,
                 }),
             ],
         })
@@ -923,6 +924,7 @@ class TestSaleToInvoice(TestSaleCommon):
         self.assertEqual(line.qty_invoiced, 10)
         line.qty_delivered = 15
         self.assertEqual(line.qty_invoiced, 10)
+        self.assertEqual(line.untaxed_amount_invoiced, 300)
 
     def test_salesperson_in_invoice_followers(self):
         """


### PR DESCRIPTION
When a SO is partially invoiced, and we change the 'Invoicing Switch Threshold' such
that the partial invoices are before the new threshold, the SO will not take
invoices into account for computation of amount to invoice / invoiced.

Steps to reproduce (needs account_accountant installed):
- Create a SO with a line having prod invoiced on delivery and qty 3
- Set delivered quantity to 1
- Click Create Invoice > create the draft invoice, set a date (date1) in the past
- set a date2 Settings > Accounting > Invoicing Switch Threshold later
  than date1
- Back to the SO, set delivered quantity to 2
- Click Create Invoice > create a new invoice and confirm it

Issue: Sale order amount invoiced will take into account only the latest
invoice, while it should account also for the legacy invoices

opw-4295531