### PR TITLE
[IMP] mail: make attachment message noticiable in messageMenu

### DIFF
--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -3,6 +3,7 @@ import { assignDefined } from "@mail/utils/common/misc";
 import { rpc } from "@web/core/network/rpc";
 
 import { FileModelMixin } from "@web/core/file_viewer/file_model";
+import { _t } from "@web/core/l10n/translation";
 
 export class Attachment extends FileModelMixin(Record) {
     static _name = "ir.attachment";
@@ -67,6 +68,10 @@ export class Attachment extends FileModelMixin(Record) {
             await rpc("/mail/attachment/delete", rpcParams);
         }
         this.delete();
+    }
+
+    get previewName() {
+        return this.voice ? _t("Voice Message") : this.name || "";
     }
 }
 

--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -16,12 +16,12 @@ class ChatBubblePreview extends Component {
         return this.props.chatWindow.thread;
     }
 
-    get previewContent() {
+    get previewText() {
         const lastMessage = this.thread?.newestPersistentOfAllMessage;
         if (!lastMessage) {
             return false;
         }
-        return lastMessage.inlineBody;
+        return lastMessage.previewText;
     }
 }
 

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -16,11 +16,16 @@
     <t t-name="mail.ChatBubblePreview">
         <div class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border border-secondary bg-100 rounded">
             <div class="text-truncate base-fs fw-bolder mb-0 mx-2" t-esc="props.chatWindow.displayName"/>
-            <div t-if="previewContent" class="text-truncate small mx-2 text-muted">
+            <t t-set="message" t-value="thread?.newestPersistentOfAllMessage" />
+            <div t-if="previewText" class="text-truncate small mx-2 text-muted">
                 <t t-call="mail.message_preview_prefix">
-                    <t t-set="message" t-value="thread?.newestPersistentOfAllMessage"/>
+                    <t t-set="message" t-value="message"/>
                 </t>
-                <t t-esc="previewContent"/>
+                <t t-if="message.hasOnlyAttachments">
+                    <i class="fa me-1" t-att-class="message.previewIcon"/>
+                    <t t-out="message.previewText" />
+                </t>
+                <t t-else="" t-out="previewText" />
             </div>
         </div>
     </t>

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -358,6 +358,53 @@ export class Message extends Record {
         );
     }
 
+    get hasOnlyAttachments() {
+        return this.isBodyEmpty && this.attachment_ids.length > 0;
+    }
+
+    get previewText() {
+        if (!this.hasOnlyAttachments) {
+            return this.inlineBody || this.subtype_description;
+        }
+        const { attachment_ids: attachments } = this;
+        if (!attachments || attachments.length === 0) {
+            return "";
+        }
+        switch (attachments.length) {
+            case 1:
+                return attachments[0].previewName;
+            case 2:
+                return _t("%(file1)s and %(file2)s", {
+                    file1: attachments[0].previewName,
+                    file2: attachments[1].previewName,
+                    count: attachments.length - 1,
+                });
+            default:
+                return _t("%(file1)s and %(count)s other attachments", {
+                    file1: attachments[0].previewName,
+                    count: attachments.length - 1,
+                });
+        }
+    }
+
+    get previewIcon() {
+        const { attachment_ids: attachments } = this;
+        if (!attachments || attachments.length === 0) {
+            return "";
+        }
+        const firstAttachment = attachments[0];
+        switch (true) {
+            case firstAttachment.isImage:
+                return "fa-picture-o";
+            case firstAttachment.mimetype === "audio/mpeg":
+                return firstAttachment.voice ? "fa-microphone" : "fa-headphones";
+            case firstAttachment.isVideo:
+                return "fa-video-camera";
+            default:
+                return "fa-file";
+        }
+    }
+
     /** @param {import("models").Thread} thread the thread where the message is shown */
     canAddReaction(thread) {
         return Boolean(!this.is_transient && this.thread && !this.thread.isTransient);

--- a/addons/mail/static/src/core/common/out_of_focus_service.js
+++ b/addons/mail/static/src/core/common/out_of_focus_service.js
@@ -1,5 +1,3 @@
-import { htmlToTextContentInline } from "@mail/utils/common/format";
-
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
@@ -53,10 +51,7 @@ export class OutOfFocusService {
                 notificationTitle = author.name;
             }
         }
-        const notificationContent = htmlToTextContentInline(message.body).substring(
-            0,
-            PREVIEW_MSG_MAX_SIZE
-        );
+        const notificationContent = message.previewText.substring(0, PREVIEW_MSG_MAX_SIZE);
         this.sendNotification({
             message: notificationContent,
             sound: message.thread?.model === "discuss.channel",

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -32,7 +32,11 @@
                         <t t-else="" t-esc="thread.displayName"/>
                     </t>
                     <t t-set-slot="body">
-                        <t t-esc="message?.inlineBody or message?.subtype_description" t-att-class="{ 'opacity-75': message?.isEmpty }"/>
+                        <t t-if="message?.hasOnlyAttachments">
+                            <i class="fa me-1" t-att-class="message.previewIcon"/>
+                            <t t-out="message.previewText" />
+                        </t>
+                        <span t-else="" t-esc="message?.previewText" t-att-class="{ 'opacity-75': message?.isEmpty }"/>
                     </t>
                     <t t-set-slot="icon">
                         <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" member="thread.correspondent" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -921,6 +921,135 @@ test("preview should display last needaction message preview even if there is a 
     });
 });
 
+test("Attachment-only message preview shows file type icon", async () => {
+    const pyEnv = await startServer();
+    const partners = pyEnv["res.partner"].create([
+        { name: "Partner1" },
+        { name: "Partner2" },
+        { name: "Partner3" },
+        { name: "Partner4" },
+        { name: "Partner5" },
+    ]);
+    const channelIds = pyEnv["discuss.channel"].create([
+        { name: "Channel1" },
+        { name: "Channel2" },
+        { name: "Channel3" },
+        { name: "Channel4" },
+        { name: "Channel5" },
+    ]);
+    const attachments = [
+        {
+            mimetype: "audio/mpeg",
+            name: "voicemessage",
+            icon: "fa-microphone",
+            text: "Voice Message",
+            voice_ids: [Command.create({ display_name: "voicemessage" })],
+        },
+        { mimetype: "video/mp4", name: "Video.mp4", icon: "fa-video-camera", text: "Video.mp4" },
+        { mimetype: "application/pdf", name: "File.pdf", icon: "fa-file", text: "File.pdf" },
+        { mimetype: "image/jpeg", name: "Image.jpeg", icon: "fa-picture-o", text: "Image.jpeg" },
+        { mimetype: "audio/mpeg", name: "Audio.mp3", icon: "fa-headphones", text: "Audio.mp3" },
+    ];
+
+    pyEnv["mail.message"].create(
+        attachments.map((attachment, i) => ({
+            attachment_ids: [
+                Command.create({
+                    mimetype: attachment.mimetype,
+                    name: attachment.name,
+                    res_id: channelIds[i],
+                    res_model: "discuss.channel",
+                    voice_ids: attachment.voice_ids || [],
+                }),
+            ],
+            author_id: partners[i],
+            body: "",
+            model: "discuss.channel",
+            res_id: channelIds[i],
+        }))
+    );
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await contains(".o-mail-NotificationItem:eq(0) i.fa-microphone");
+    await contains(".o-mail-NotificationItem:eq(0)", { text: "Partner1: Voice Message" });
+    await contains(".o-mail-NotificationItem:eq(1) i.fa-video-camera");
+    await contains(".o-mail-NotificationItem:eq(1)", { text: "Partner2: Video.mp4" });
+    await contains(".o-mail-NotificationItem:eq(2) i.fa-file");
+    await contains(".o-mail-NotificationItem:eq(2)", { text: "Partner3: File.pdf" });
+    await contains(".o-mail-NotificationItem:eq(3) i.fa-picture-o");
+    await contains(".o-mail-NotificationItem:eq(3)", { text: "Partner4: Image.jpeg" });
+    await contains(".o-mail-NotificationItem:eq(4) i.fa-headphones");
+    await contains(".o-mail-NotificationItem:eq(4)", { text: "Partner5: Audio.mp3" });
+});
+
+test("Attachment-only message preview shows file names (2 files)", async () => {
+    const pyEnv = await startServer();
+    const partner1 = pyEnv["res.partner"].create({ name: "Partner" });
+    const channel1 = pyEnv["discuss.channel"].create({ name: "test" });
+    pyEnv["mail.message"].create({
+        attachment_ids: [
+            Command.create({
+                mimetype: "application/pdf",
+                name: "File.pdf",
+                res_id: channel1,
+                res_model: "discuss.channel",
+            }),
+            Command.create({
+                mimetype: "image/jpeg",
+                name: "Image.jpeg",
+                res_id: channel1,
+                res_model: "discuss.channel",
+            }),
+        ],
+        author_id: partner1,
+        body: "",
+        model: "discuss.channel",
+        res_id: channel1,
+    });
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await contains(".o-mail-NotificationItem-text", {
+        text: "Partner: File.pdf and Image.jpeg",
+    });
+});
+
+test("Attachment-only message preview shows file names (3 files)", async () => {
+    const pyEnv = await startServer();
+    const partner1 = pyEnv["res.partner"].create({ name: "Partner" });
+    const channel1 = pyEnv["discuss.channel"].create({ name: "test" });
+    pyEnv["mail.message"].create({
+        attachment_ids: [
+            Command.create({
+                mimetype: "application/pdf",
+                name: "File.pdf",
+                res_id: channel1,
+                res_model: "discuss.channel",
+            }),
+            Command.create({
+                mimetype: "image/jpeg",
+                name: "Image.jpeg",
+                res_id: channel1,
+                res_model: "discuss.channel",
+            }),
+            Command.create({
+                mimetype: "video/mp4",
+                name: "Video.mp4",
+                res_id: channel1,
+                res_model: "discuss.channel",
+            }),
+        ],
+        author_id: partner1,
+        body: "",
+        model: "discuss.channel",
+        res_id: channel1,
+    });
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await contains(".o-mail-NotificationItem-text", {
+        text: "Partner: File.pdf and 2 other attachments",
+    });
+});
+
 test("single preview for channel if it has unread and needaction messages", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Partner1" });


### PR DESCRIPTION
This commit addresses the issue where the messagingMenu and chat bubble's preview content appears empty for threads with attachments or voice messages. It now displays relevant content for these cases, enhancing the visual appeal and overall user experience.

Before [messaging_menu]:
![image](https://github.com/user-attachments/assets/f8c9b138-259b-48b6-8e50-26501e73692d)
Before [chat_bubble: ]
![image](https://github.com/user-attachments/assets/161728f1-d48d-4ce8-b225-b28c427e676e)

After [messaging_menu]:
For Audio attachment
![image](https://github.com/user-attachments/assets/7cf75b7d-e4aa-43cd-93f7-27f92bce99c7)
For Voice Message
![image](https://github.com/user-attachments/assets/f8456454-d7bd-4241-aea2-5e957df81ec2)
For Image
![image](https://github.com/user-attachments/assets/322a7e59-769f-4b2a-83b0-d7ab82efdb85)
For Files
![image](https://github.com/user-attachments/assets/dcc8e467-ba80-406f-9420-f55b5f6e8a75)
For Video
![image](https://github.com/user-attachments/assets/3ebf73e4-3718-41a0-88e2-882758fe7415)
For multiple attachments
![image](https://github.com/user-attachments/assets/b7c890a1-b758-4871-8939-8304f3659ff2)

After [chat_bubble]:
![image](https://github.com/user-attachments/assets/7d2fd696-fb49-4808-967f-436f8f40a89a)
[For all the other cases, the result would be similar as that for messaging menu]

task-4373355



