### PR TITLE
[FIX] sale_pdf_quote_builder: make texts read-only

### DIFF
--- a/addons/sale_pdf_quote_builder/models/ir_actions_report.py
+++ b/addons/sale_pdf_quote_builder/models/ir_actions_report.py
@@ -213,10 +213,10 @@ class IrActionsReport(models.Model):
                         new_key = prefix + form_key
 
                         # Modifying the form flags to force some characteristics
-                        # 1. text fields that are already filled get marked as readonly
+                        # 1. make all text fields read-only
                         # 2. make all text fields support multiline
                         form_flags = reader_annot.get('/Ff', 0)
-                        readonly_flag = 1 if field_names[form_key] else 0  # 1st bit sets readonly
+                        readonly_flag = 1  # 1st bit sets readonly
                         multiline_flag = 1 << 12  # 13th bit sets multiline text
                         new_flags = form_flags | readonly_flag | multiline_flag
 


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Print a PDF quote with forms.

Issue
-----
Form fields can be modified.

Cause
-----
Commit be2f31a4ad03 changed some logic in a forward port, making field read-only, only if they have values. This logic was moved between 17.4 & 18.0 to before the values are known, so in 18.0, no fields are marked as read-only.

Solution
--------
Make all fields read-only.

opw-4290594