### PR TITLE
[IMP] * : standardize masonry layout & update s_image_gallery options

### DIFF
--- a/addons/web_editor/static/src/js/common/masonry_layout_utils.js
+++ b/addons/web_editor/static/src/js/common/masonry_layout_utils.js
@@ -1,0 +1,369 @@
+import { debounce } from "@web/core/utils/timing";
+
+// Constants for class names and data attributes
+export const MASONRY = {
+    CLASSES: {
+        MODE: "o_masonry",
+        CONTAINER_CLASSES: ["o_container_small", "container", "container-fluid"],
+        ROW: "o_masonry_mode",
+        FIXED_COLUMNS: "s_nb_column_fixed",
+        COLUMN: "o_masonry_col",
+        ITEM: "w-100",
+        NOT_SELECTABLE: "o_snippet_not_selectable",
+    },
+    DATA_ATTRS: {
+        DESKTOP_COLUMNS: "data-columns",
+        MOBILE_COLUMNS: "data-mobile-columns",
+        ITEM_INDEX: "data-index",
+    },
+    DEFAULTS: {
+        DESKTOP_COLUMNS: 3,
+        MOBILE_COLUMNS: 1,
+    },
+};
+
+/**
+ * Gets the number of columns for desktop and mobile based on container's
+ * column attribute (between 1 and 12).
+ *
+ * @private
+ * @param {Element} containerEl - The container element
+ * @returns {Object} Object containing desktop and mobile column counts
+ */
+function _getColumnConfiguration(containerEl) {
+    const desktopColumnCount =
+        parseInt(containerEl.getAttribute(MASONRY.DATA_ATTRS.DESKTOP_COLUMNS)) ||
+        parseInt(containerEl.parentElement.getAttribute(MASONRY.DATA_ATTRS.DESKTOP_COLUMNS)) ||
+        MASONRY.DEFAULTS.DESKTOP_COLUMNS;
+    const mobileColumnCount =
+        parseInt(containerEl.getAttribute(MASONRY.DATA_ATTRS.MOBILE_COLUMNS)) ||
+        parseInt(containerEl.parentElement.getAttribute(MASONRY.DATA_ATTRS.MOBILE_COLUMNS)) ||
+        MASONRY.DEFAULTS.MOBILE_COLUMNS;
+
+    return {
+        desktop: Math.min(Math.max(desktopColumnCount, 1), 12),
+        mobile: Math.min(Math.max(mobileColumnCount, 1), 12),
+    };
+}
+
+/**
+ * Creates masonry column elements based on the configuration.
+ *
+ * @private
+ * @param {number} desktopColumnCount - Number of columns for desktop
+ * @param {number} mobileColumnCount - Number of columns for mobile
+ * @returns {Element[]} Array of column elements
+ */
+function _createColumnElements(desktopColumnCount, mobileColumnCount) {
+    const desktopColSpan = Math.floor(12 / desktopColumnCount);
+    const mobileColSpan = Math.floor(12 / mobileColumnCount);
+
+    const columnEls = Array.from(
+        { length: Math.max(desktopColumnCount, mobileColumnCount) },
+        () => {
+            const columnEl = document.createElement("div");
+            columnEl.classList.add(
+                MASONRY.CLASSES.COLUMN,
+                MASONRY.CLASSES.NOT_SELECTABLE,
+                `col-${mobileColSpan}`,
+                `col-lg-${desktopColSpan}`
+            );
+            return columnEl;
+        }
+    );
+
+    return columnEls;
+}
+
+/**
+ * Finds the shortest column in the masonry layout.
+ *
+ * @private
+ * @param {Element[]} columnEls - Array of column elements
+ * @returns {Element} The shortest column element
+ */
+function _getShortestColumn(columnEls) {
+    return columnEls.reduce((shortestEl, currentEl) => {
+        const currentHeight = currentEl.lastElementChild
+            ? currentEl.lastElementChild.getBoundingClientRect().bottom
+            : currentEl.getBoundingClientRect().top;
+        const shortestHeight = shortestEl.lastElementChild
+            ? shortestEl.lastElementChild.getBoundingClientRect().bottom
+            : shortestEl.getBoundingClientRect().top;
+
+        return currentHeight < shortestHeight ? currentEl : shortestEl;
+    }, columnEls[0]);
+}
+
+/**
+ * Retrieves the index of an element based on a defined data attribute.
+ * If the element is wrapped in a container (e.g., an anchor tag), it checks the
+ * first child element for the index.
+ *
+ * @private
+ * @param {Element} el - The element or wrapper to retrieve the index from.
+ * @returns {number} The numeric value of the index, or Infinity if no index
+ *                   is found.
+ */
+function _getElementIndex(el) {
+    if (el.hasAttribute(MASONRY.DATA_ATTRS.ITEM_INDEX)) {
+        return Number(el.getAttribute(MASONRY.DATA_ATTRS.ITEM_INDEX));
+    }
+
+    // Handle case where the element is wrapped in a container (e.g. anchor tag)
+    const firstChildEl = el.firstElementChild;
+    if (firstChildEl && firstChildEl.hasAttribute(MASONRY.DATA_ATTRS.ITEM_INDEX)) {
+        return Number(firstChildEl.getAttribute(MASONRY.DATA_ATTRS.ITEM_INDEX));
+    }
+
+    return Infinity; // Ensure elements without an index appear last
+}
+
+/**
+ * Retrieves and sorts the original elements from the row based on the defined
+ * data index attribute.
+ * It also considers the possibility of elements being wrapped in a
+ * link (anchor) tag.
+ *
+ * @param {Element} rowEl - The row element containing child elements with data
+ *                          index attributes.
+ * @returns {Element[]} An array of child elements or their wrappers sorted by
+ *                      the specified data index attribute.
+ */
+export function _getOriginalElements(rowEl) {
+    if (!rowEl || !rowEl.children) {
+        return [];
+    }
+
+    // Check if the row contains only masonry columns (masonry mode applied)
+    // If true, get elements from inside the columns; otherwise, use row's
+    // direct children
+    const isMasonryMode = Array.from(rowEl.children).every((child) =>
+        child.classList.contains(MASONRY.CLASSES.COLUMN)
+    );
+    const originalEls = isMasonryMode
+        ? Array.from(rowEl.children).flatMap((columnEl) => Array.from(columnEl.children))
+        : Array.from(rowEl.children);
+
+    return originalEls.sort(
+        (firstEl, secondEl) => _getElementIndex(firstEl) - _getElementIndex(secondEl)
+    );
+}
+
+/**
+ * Creates the masonry layout by organizing elements one by one in the
+ * shortest column.
+ *
+ * @param {Element} rowEl - The row element containing the items to organize
+ * @param {number} desktopColumnCount - Number of columns for desktop view
+ * @param {number} mobileColumnCount - Number of columns for mobile view
+ */
+async function _createMasonryLayout(rowEl, desktopColumnCount, mobileColumnCount) {
+    if (!rowEl) {
+        return Promise.resolve();
+    }
+
+    const originalEls = _getOriginalElements(rowEl);
+    if (!originalEls.length) {
+        return Promise.resolve();
+    }
+
+    // Clear row and create masonry columns
+    rowEl.innerHTML = "";
+    const columnEls = _createColumnElements(desktopColumnCount, mobileColumnCount);
+    columnEls.forEach((colEl) => rowEl.appendChild(colEl));
+    rowEl.classList.add(MASONRY.CLASSES.ROW, MASONRY.CLASSES.FIXED_COLUMNS);
+
+    // Distribute items across the columns
+    for (const el of originalEls) {
+        el.classList.add(MASONRY.CLASSES.ITEM);
+
+        // Get the shortest column and append the element to it
+        const shortestColumnEl = _getShortestColumn(columnEls);
+        shortestColumnEl.appendChild(el);
+
+        // Wait for all images in the shortest column to load before continuing
+        // to ensure next shortest column is correctly calculated
+        // TODO: move onceAllImagesLoaded in web_editor and to use it here
+        const imageEls = shortestColumnEl.querySelectorAll("img");
+        await Promise.all(
+            Array.from(imageEls).map(
+                (imgEl) =>
+                    new Promise((resolve) => {
+                        if (imgEl.complete) {
+                            resolve();
+                        } else {
+                            imgEl.onload = resolve;
+                        }
+                    })
+            )
+        );
+    }
+}
+
+/**
+ * Toggles the masonry layout mode for the given container element.
+ * Ensures the container has a `.row` element, which acts as the parent for
+ * masonry columns.
+ *
+ * @public
+ * @param {Element} containerEl - Container element with the class in
+ *                                MASONRY.CLASSES.CONTAINER_CLASSES, consisting
+ *                                of a child with the class "row" that holds all
+ *                                the masonry items.
+ * @returns {Promise} Resolves when all images are loaded and placed
+ */
+export async function toggleMasonryMode(containerEl) {
+    if (!containerEl) {
+        return Promise.resolve();
+    }
+
+    let rowEl = containerEl.querySelector(":scope > .row");
+    const outOfRowEls = [...containerEl.children].filter((el) => !el.classList.contains("row"));
+
+    // Create row if needed
+    if (!rowEl) {
+        rowEl = document.createElement("div");
+        rowEl.classList.add("row");
+        [...containerEl.children].forEach((childEl) => rowEl.appendChild(childEl));
+        containerEl.appendChild(rowEl);
+    }
+
+    // Add out-of-row elements to row
+    outOfRowEls.forEach((el) => rowEl.appendChild(el));
+
+    const { desktop: desktopColumnCount, mobile: mobileColumnCount } =
+        _getColumnConfiguration(containerEl);
+    await _createMasonryLayout(rowEl, desktopColumnCount, mobileColumnCount);
+}
+
+/**
+ * Checks if the given section element follows a valid masonry layout structure.
+ *
+ * @param {HTMLElement} sectionEl - The root section element to validate.
+ * @returns {boolean} True if the masonry layout structure is valid,
+ *                    otherwise false.
+ */
+export function isValidMasonryLayout(sectionEl) {
+    if (!sectionEl || !sectionEl.classList.contains(MASONRY.CLASSES.MODE)) {
+        return false;
+    }
+
+    const containerEl = sectionEl.firstElementChild;
+    if (!containerEl) {
+        return false;
+    }
+
+    const isContainerClass = MASONRY.CLASSES.CONTAINER_CLASSES.some((containerClass) =>
+        containerEl.classList.contains(containerClass)
+    );
+    if (!isContainerClass) {
+        return false;
+    }
+
+    const rowEl = containerEl.firstElementChild;
+    if (!rowEl || !rowEl.classList.contains(MASONRY.CLASSES.ROW)) {
+        return false;
+    }
+
+    const columnEls = rowEl.children;
+    const allColumnsValid = Array.from(columnEls).every((columnEl) =>
+        columnEl.classList.contains(MASONRY.CLASSES.COLUMN)
+    );
+    if (!allColumnsValid) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Clears the masonry layout
+ *
+ * @public
+ * @param {Element} sectionEl - Root element containing the masonry layout
+ */
+export function clearMasonryLayout(sectionEl) {
+    if (!sectionEl) {
+        return;
+    }
+
+    if (!isValidMasonryLayout(sectionEl)) {
+        return;
+    }
+
+    sectionEl.classList.remove(MASONRY.CLASSES.MODE);
+
+    const containerEl = sectionEl.firstElementChild;
+    const rowEl = containerEl.firstElementChild;
+    rowEl.classList.remove(MASONRY.CLASSES.ROW, MASONRY.CLASSES.FIXED_COLUMNS);
+
+    const originalEls = Array.from(rowEl.children)
+        .flatMap((columnEl) => Array.from(columnEl.children))
+        .sort((firstEl, secondEl) => _getElementIndex(firstEl) - _getElementIndex(secondEl));
+
+    originalEls.forEach((el) => rowEl.appendChild(el));
+}
+
+/**
+ * Updates the column configuration for a container
+ *
+ * @public
+ * @param {Element} containerEl - The container element
+ * @param {Object} config - Configuration object
+ * @param {number} [config.desktopColumnCount] - Number of columns for desktop view
+ * @param {number} [config.mobileColumnCount] - Number of columns for mobile view
+ */
+export function updateMasonryConfig(containerEl, { desktopColumnCount, mobileColumnCount } = {}) {
+    if (desktopColumnCount !== undefined) {
+        containerEl.setAttribute(MASONRY.DATA_ATTRS.DESKTOP_COLUMNS, desktopColumnCount);
+    }
+    if (mobileColumnCount !== undefined) {
+        containerEl.setAttribute(MASONRY.DATA_ATTRS.MOBILE_COLUMNS, mobileColumnCount);
+    }
+
+    // Reapply masonry layout if it's already active
+    const rowEl = containerEl.querySelector(":scope > .row");
+    if (rowEl && rowEl.classList.contains(MASONRY.CLASSES.ROW)) {
+        toggleMasonryMode(containerEl);
+    }
+}
+
+/**
+ * Creates a resize observer for automatically updating masonry layout when the
+ * screen size changes.
+ *
+ * @public
+ * @param {Element} sectionEl - The section element to observe.
+ * @param {number} debounceTime - Debounce time in milliseconds.
+ * @returns {ResizeObserver|null} The resize observer instance,
+ *                                or null if masonry element is not found.
+ * @default debounceTime 100
+ */
+export function observeMasonryLayoutWidthChange(sectionEl, debounceTime = 100) {
+    if (!sectionEl) {
+        return null;
+    }
+
+    if (!isValidMasonryLayout(sectionEl)) {
+        return null;
+    }
+
+    const masonryContainerEl = sectionEl.firstElementChild;
+    const masonryRowEl = masonryContainerEl.firstElementChild;
+
+    let lastWidth = masonryRowEl.offsetWidth;
+    const resizeObserver = new ResizeObserver(
+        debounce(() => {
+            const newWidth = masonryRowEl.offsetWidth;
+            // Only trigger when width has changed
+            if (newWidth !== lastWidth) {
+                lastWidth = newWidth;
+                toggleMasonryMode.call(this, masonryContainerEl);
+            }
+        }, debounceTime)
+    );
+    resizeObserver.observe(masonryRowEl);
+
+    return resizeObserver;
+}

--- a/addons/web_editor/static/src/js/common/masonry_layout_utils.js
+++ b/addons/web_editor/static/src/js/common/masonry_layout_utils.js
@@ -175,8 +175,16 @@ async function _createMasonryLayout(rowEl, desktopColumnCount, mobileColumnCount
     rowEl.classList.add(MASONRY.CLASSES.ROW, MASONRY.CLASSES.FIXED_COLUMNS);
 
     // Distribute items across the columns
+    const originallyHiddenEls = [];
     for (const el of originalEls) {
         el.classList.add(MASONRY.CLASSES.ITEM);
+
+        // Make hidden elements available for layout calculation.
+        if (el.classList.contains("d-none")) {
+            el.classList.remove("d-none");
+            el.classList.add("opacity-0");
+            originallyHiddenEls.push(el);
+        }
 
         // Get the shortest column and append the element to it
         const shortestColumnEl = _getShortestColumn(columnEls);
@@ -198,6 +206,12 @@ async function _createMasonryLayout(rowEl, desktopColumnCount, mobileColumnCount
                     })
             )
         );
+    }
+
+    // Restore element's original visibility
+    for (const el of originallyHiddenEls) {
+        el.classList.remove("opacity-0");
+        el.classList.add("d-none");
     }
 }
 

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -4780,6 +4780,21 @@ class SnippetsMenu extends Component {
                 gridUtils._reloadLazyImages(gridItemEl);
             }
 
+            // For s_image_gallery:
+            // Triggers an event to handle relayout when the mobile preview is
+            // toggled. This ensures images are relaid out correctly as the
+            // column count changes between mobile and desktop views.
+            const galleryDataJsIdentifier = "gallery";
+            const gallerySnippetEditors = this.snippetEditors.filter((snippetEditor) =>
+                snippetEditor.$target[0]?.classList.contains("s_image_gallery")
+            );
+            gallerySnippetEditors.forEach((gallerySnippet) => {
+                gallerySnippet.trigger_up("option_update", {
+                    optionName: galleryDataJsIdentifier,
+                    name: "change_container_width",
+                })
+            });
+
             const isMobilePreview = weUtils.isMobileView(this.$body[0]);
             for (const invisibleOverrideEl of this.getEditableArea().find('.o_snippet_mobile_invisible, .o_snippet_desktop_invisible')) {
                 const isMobileHidden = invisibleOverrideEl.classList.contains("o_snippet_mobile_invisible");

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -9225,6 +9225,10 @@ registry.ContainerWidth = SnippetOptionWidget.extend({
             optionName: 'StepsConnector',
             name: 'change_container_width',
         });
+        this.trigger_up("option_update", {
+            optionName: "gallery",
+            name: "change_container_width",
+        });
     },
 });
 

--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -55,6 +55,41 @@
     }
 }
 
+// MASONRY LAYOUT
+.o_masonry {
+    &.o_spc-none div.o_masonry_col {
+        padding: 0;
+
+        > img, > a > img, > .media_iframe_video {
+            margin: 0 !important;
+        }
+    }
+
+    &.o_spc-small div.o_masonry_col {
+        padding: 0 ($spacer * .5);
+
+        > img, > a > img, > .media_iframe_video {
+            margin-bottom: $spacer !important;
+        }
+    }
+
+    &.o_spc-medium div.o_masonry_col {
+        padding: 0 $spacer;
+
+        > img, > a > img, > .media_iframe_video {
+            margin-bottom: $spacer * 2 !important;
+        }
+    }
+
+    &.o_spc-big div.o_masonry_col {
+        padding: 0 ($spacer * 1.5);
+
+        > img, > a > img, > .media_iframe_video {
+            margin-bottom: $spacer * 3 !important;
+        }
+    }
+}
+
 @include media-breakpoint-up(lg) {
     .o_grid_mode {
         display: grid !important;

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -495,6 +495,63 @@ export function checkAndNotifySEO(seo_data, OptimizeSEODialog, services) {
     }
 }
 
+/**
+ * Retrieves a sorted list of gallery items based on a specified `data-index`
+ * attribute.
+ *
+ * @param {HTMLElement} rootEl - The parent element containing gallery items.
+ * @param {string[]} containerSelectors - Array of CSS selectors for container
+ *                                        elements that may wrap the actual
+ *                                        gallery items.
+ * @param {string} indexAttribute - The attribute used to determine the order of
+ *                                  gallery items (default: 'data-index').
+ * @returns {HTMLElement[]} A sorted array of gallery item elements.
+ */
+export function getSortedGalleryItems(
+    rootEl,
+    containerSelectors = [],
+    indexAttribute = "data-index"
+) {
+    /**
+     * Helper function to retrieve the index of a gallery item.
+     *
+     * @param {HTMLElement} element - Either the gallery item itself or its
+     *                                container.
+     * @returns {number} The numeric index of the gallery item. Items without an
+     *                   index will be assigned `Infinity` to ensure they appear
+     *                   last.
+     */
+    const getItemIndex = (element) => {
+        // If the element itself has the index attribute
+        if (element.hasAttribute(indexAttribute)) {
+            return parseInt(element.getAttribute(indexAttribute), 10);
+        }
+
+        // If the gallery item is wrapped in a container, look for a child
+        // element with the index
+        const itemWithIndexEl = element.querySelector(`[${indexAttribute}]`);
+        if (itemWithIndexEl && itemWithIndexEl.hasAttribute(indexAttribute)) {
+            return parseInt(itemWithIndexEl.getAttribute(indexAttribute), 10);
+        }
+
+        return Infinity; // Items without a valid index appear last
+    };
+
+    // Retrieve all elements with the index attribute (direct gallery items).
+    const indexedElements = Array.from(rootEl.querySelectorAll(`[${indexAttribute}]`));
+
+    // Map each element to its container (if it exists), or the element itself.
+    const galleryItems = indexedElements.map((element) => {
+        const wrappingContainer = element.closest(containerSelectors.join(",")) || element; // Fallback to self
+        return wrappingContainer;
+    });
+
+    // Sort the gallery items based on their index.
+    return galleryItems.sort(
+        (firstItemEl, secondItemEl) => getItemIndex(firstItemEl) - getItemIndex(secondItemEl)
+    );
+}
+
 export default {
     loadAnchors: loadAnchors,
     autocompleteWithPages: autocompleteWithPages,
@@ -511,4 +568,5 @@ export default {
     getParsedDataFor: getParsedDataFor,
     cloneContentEls: cloneContentEls,
     checkAndNotifySEO: checkAndNotifySEO,
+    getSortedGalleryItems: getSortedGalleryItems,
 };

--- a/addons/website/static/src/snippets/s_image_gallery/002.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/002.scss
@@ -9,26 +9,8 @@
         }
     }
 
-    &.o_grid {
-        &.o_spc-none div.row {
-            margin-bottom: 0px;
-        }
-
-        &.o_spc-small div.row > div {
-            margin-bottom: $spacer;
-        }
-
-        &.o_spc-medium div.row > div {
-            margin-bottom: $spacer * 2;
-        }
-
-        &.o_spc-big div.row > div {
-            margin-bottom: $spacer * 3;
-        }
-    }
-
-    &.o_masonry {
-        &.o_spc-none div.o_masonry_col {
+    &.o_col {
+        &.o_spc-none div.o_col_col {
             padding: 0;
 
             > img, > a > img, > .media_iframe_video {
@@ -36,7 +18,7 @@
             }
         }
 
-        &.o_spc-small div.o_masonry_col {
+        &.o_spc-small div.o_col_col {
             padding: 0 ($spacer * .5);
 
             > img, > a > img, > .media_iframe_video {
@@ -44,7 +26,7 @@
             }
         }
 
-        &.o_spc-medium div.o_masonry_col {
+        &.o_spc-medium div.o_col_col {
             padding: 0 $spacer;
 
             > img, > a > img, > .media_iframe_video {
@@ -52,34 +34,12 @@
             }
         }
 
-        &.o_spc-big div.o_masonry_col {
+        &.o_spc-big div.o_col_col {
             padding: 0 ($spacer * 1.5);
 
             > img, > a > img, > .media_iframe_video {
                 margin-bottom: $spacer * 3 !important;
             }
-        }
-    }
-
-    &.o_nomode {
-        &.o_spc-none .row > div {
-            padding-top: 0;
-            padding-bottom: 0;
-        }
-
-        &.o_spc-small .row > div {
-            padding-top: $spacer * .5;
-            padding-bottom: $spacer * .5;
-        }
-
-        &.o_spc-medium .row > div {
-            padding-top: $spacer;
-            padding-bottom: $spacer;
-        }
-
-        &.o_spc-big .row > div {
-            padding-top: $spacer * 1.5;
-            padding-bottom: $spacer * 1.5;
         }
     }
 

--- a/addons/website/static/src/snippets/s_image_gallery/002.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/002.scss
@@ -363,6 +363,22 @@
             }
         }
     }
+
+    & #btn-expand-gallery {
+        position: relative;
+
+        &::before {
+            content: "";
+            position: absolute;
+            width: 100vw;
+            height: 5rem;
+            background-image: linear-gradient(to top, var(--white), transparent);
+            bottom: calc(100% +  var(--border-width));
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: calc(var(--gallery-items-count) + 1);
+        }
+    }
 }
 
 .s_gallery_lightbox {

--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -7,6 +7,8 @@ import {
     loadImageInfo,
     applyModifications,
 } from "@web_editor/js/editor/image_processing";
+import * as gridUtils from "@web_editor/js/common/grid_layout_utils";
+import * as masonryUtils from "@web_editor/js/common/masonry_layout_utils";
 
 /**
  * This class provides layout methods for interacting with the ImageGallery
@@ -15,16 +17,34 @@ import {
  * layout mode and changing the number of columns.
  */
 options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    async notify(name) {
+        if (name === "change_container_width") {
+            const mode = this._getMode();
+            const relayoutRequiredModes = ["grid", "masonry"];
+            if (relayoutRequiredModes.includes(mode)) {
+                await this._relayout();
+            }
+        } else {
+            this._super(...arguments);
+        }
+    },
 
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
 
     /**
-     * Get the image target's layout mode (slideshow, masonry, grid or nomode).
+     * Get the image target's layout mode (slideshow, masonry, grid or col).
      *
      * @private
-     * @returns {String('slideshow'|'masonry'|'grid'|'nomode')}
+     * @returns {String('slideshow'|'masonry'|'grid'|'col')}
      */
     _getMode() {
         var mode = 'slideshow';
@@ -34,8 +54,8 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
         if (this.$target.hasClass('o_grid')) {
             mode = 'grid';
         }
-        if (this.$target.hasClass('o_nomode')) {
-            mode = 'nomode';
+        if (this.$target[0].classList.contains("o_col")) {
+            mode = "col";
         }
         return mode;
     },
@@ -44,22 +64,26 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
      *
      * @private
      */
-    _grid() {
+    async _grid() {
         const imgs = this._getImgHolderEls();
-        var $row = $('<div/>', {class: 'row s_nb_column_fixed'});
-        var columns = this._getColumns();
-        var colClass = 'col-lg-' + (12 / columns);
-        var $container = this._replaceContent($row);
-
-        imgs.forEach((img, index) => {
-            const $img = $(img.cloneNode(true));
-            var $col = $('<div/>', {class: colClass});
-            $col.append($img).appendTo($row);
-            if ((index + 1) % columns === 0) {
-                $row = $('<div/>', {class: 'row s_nb_column_fixed'});
-                $row.appendTo($container);
-            }
+        const columnCount = this._getColumns();
+        const mobileColumnCount = this._getMobileColumns();
+        const rowEl = document.createElement("div");
+        rowEl.classList.add("row", "s_nb_column_fixed");
+        const $container = this._replaceContent($(rowEl));
+        imgs.forEach((imgEl) => {
+            const imgContainerEl = document.createElement("div");
+            imgContainerEl.classList.add(
+                `col-${12 / mobileColumnCount}`,
+                `col-lg-${12 / columnCount}`
+            );
+            rowEl.appendChild(imgContainerEl);
+            const clonedImgEl = imgEl.cloneNode(true);
+            imgContainerEl.appendChild(clonedImgEl);
         });
+        // Wait for images to load to ensure grid areas are properly calculated.
+        await wUtils.onceAllImagesLoaded($container);
+        gridUtils._toggleGridMode($container[0]);
         this.$target.css('height', '');
     },
     /**
@@ -70,46 +94,51 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
      */
     _masonry() {
         const imgs = this._getImgHolderEls();
-        var columns = this._getColumns();
-        var colClass = 'col-lg-' + (12 / columns);
-        var cols = [];
 
-        var $row = $('<div/>', {class: 'row s_nb_column_fixed'});
-        this._replaceContent($row);
+        // Create initial row structure
+        const rowEl = document.createElement("div");
+        rowEl.classList.add("row", "s_nb_column_fixed");
+        const $container = this._replaceContent($(rowEl));
 
-        // Create columns
-        for (var c = 0; c < columns; c++) {
-            var $col = $('<div/>', {class: 'o_masonry_col o_snippet_not_selectable ' + colClass});
-            $row.append($col);
-            cols.push($col[0]);
-        }
+        // Add images to container
+        imgs.forEach((imgEl) => {
+            const clonedImgEl = imgEl.cloneNode(true);
+            rowEl.appendChild(clonedImgEl);
+        });
 
-        // Dispatch images in columns by always putting the next one in the
-        // smallest-height column
-        return new Promise(async resolve => {
-            for (const imgEl of imgs) {
-                let min = Infinity;
-                let smallestColEl;
-                for (const colEl of cols) {
-                    const imgEls = colEl.querySelectorAll("img");
-                    const lastImgRect = imgEls.length && imgEls[imgEls.length - 1].getBoundingClientRect();
-                    const height = lastImgRect ? Math.round(lastImgRect.top + lastImgRect.height) : 0;
-                    if (height < min) {
-                        min = height;
-                        smallestColEl = colEl;
-                    }
-                }
-                // Only on Chrome: appended images are sometimes invisible
-                // and not correctly loaded from cache, we use a clone of the
-                // image to force the loading.
-                smallestColEl.append(imgEl.cloneNode(true));
-                await wUtils.onceAllImagesLoaded(this.$target);
-            }
-            resolve();
+        return masonryUtils.toggleMasonryMode($container[0]);
+    },
+    /**
+     * Displays the images with the "column" layout.
+     *
+     * @private
+     * @returns {Promise}
+     */
+    _col() {
+        const imgEls = this._getImgHolderEls();
+        const columnCount = this._getColumns();
+        const mobileColumnCount = this._getMobileColumns();
+
+        // Create initial row structure
+        const rowEl = document.createElement("div");
+        rowEl.classList.add("row", "s_nb_column_fixed", "o_col_mode");
+        this._replaceContent($(rowEl));
+
+        // Add images to container
+        imgEls.forEach((imgEl) => {
+            const imgContainerEl = document.createElement("div");
+            imgContainerEl.classList.add(
+                "o_col_col",
+                `col-${12 / mobileColumnCount}`,
+                `col-lg-${12 / columnCount}`
+            );
+            rowEl.appendChild(imgContainerEl);
+            const clonedImgEl = imgEl.cloneNode(true);
+            imgContainerEl.appendChild(clonedImgEl);
         });
     },
     /**
-     * Allows to change the images layout. @see grid, masonry, nomode, slideshow
+     * Allows to change the images layout. @see grid, masonry, col, slideshow
      *
      * @private
      * @param {string} modeName
@@ -118,9 +147,8 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
     async _setMode(modeName) {
         modeName = modeName || 'slideshow'; // FIXME should not be needed
         this.$target.css('height', '');
-        this.$target
-            .removeClass('o_nomode o_masonry o_grid o_slideshow')
-            .addClass('o_' + modeName);
+        this.$target[0].classList.remove("o_masonry", "o_grid", "o_col", "o_slideshow");
+        this.$target[0].classList.add("o_" + modeName);
         // Used to prevent the editor's "unbreakable protection mechanism" from
         // restoring Image Wall adaptations (images removed > new images added
         // to the container & layout updates) when adding new images to the
@@ -131,27 +159,6 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
         await this[`_${modeName}`]();
         this.trigger_up('cover_update');
         await this._refreshPublicWidgets();
-    },
-    /**
-     * Displays the images with the standard layout: floating images.
-     *
-     * @private
-     */
-    _nomode() {
-        var $row = $('<div/>', {class: 'row s_nb_column_fixed'});
-        const imgs = this._getItemsGallery();
-        const imgHolderEls = this._getImgHolderEls();
-
-        this._replaceContent($row);
-
-        imgs.forEach((img, index) => {
-            var wrapClass = 'col-lg-3';
-            if (img.width >= img.height * 2 || img.width > 600) {
-                wrapClass = 'col-lg-6';
-            }
-            var $wrap = $('<div/>', {class: wrapClass}).append(imgHolderEls[index]);
-            $row.append($wrap);
-        });
     },
     /**
      * Displays the images with a "slideshow" layout.
@@ -230,6 +237,15 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
      */
     _getColumns: function () {
         return parseInt(this.$target.attr('data-columns')) || 3;
+    },
+    /**
+     * Returns the currently selected mobile column option.
+     *
+     * @private
+     * @returns {integer}
+     */
+    _getMobileColumns: function () {
+        return parseInt(this.$target[0].dataset.mobileColumns) || 1;
     },
     /**
      * @override
@@ -365,12 +381,28 @@ options.registry.gallery = options.registry.GalleryLayout.extend({
         return this._relayout();
     },
     /**
-     * Allows to change the images layout. @see grid, masonry, nomode, slideshow
+     * Allows to change the number of columns on mobile when displaying
+     * images in different layout.
+     *
+     * @see this.selectClass for parameters
+     */
+    mobileColumns(previewMode, widgetValue, params) {
+        const nbColumns = parseInt(widgetValue || "1");
+        this.$target[0].setAttribute("data-mobile-columns", nbColumns);
+
+        return this._relayout();
+    },
+    /**
+     * Allows to change the images layout. @see grid, masonry, col, slideshow
      *
      * @see this.selectClass for parameters
      */
     mode(previewMode, widgetValue, params) {
-        return this._setMode(widgetValue);
+        // Set the mode during preview only if it differs from the current mode
+        // to avoid redundant calls.
+        if (previewMode && widgetValue !== this._getMode()) {
+            return this._setMode(widgetValue);
+        }
     },
 
     //--------------------------------------------------------------------------
@@ -395,6 +427,9 @@ options.registry.gallery = options.registry.GalleryLayout.extend({
             }
             case 'columns': {
                 return `${this._getColumns()}`;
+            }
+            case "mobileColumns": {
+                return `${this._getMobileColumns()}`;
             }
         }
         return this._super(...arguments);

--- a/addons/website/static/tests/tours/snippet_images_wall.js
+++ b/addons/website/static/tests/tours/snippet_images_wall.js
@@ -1,4 +1,10 @@
-import {clickOnSnippet, insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import {
+    clickOnSnippet,
+    insertSnippet,
+    registerWebsitePreviewTour,
+    clickOnSave,
+    clickOnEditAndWaitEditMode,
+} from "@website/js/tours/tour_utils";
 
 const wallRaceConditionClass = "image_wall_race_condition";
 const preventRaceConditionSteps = [{
@@ -117,4 +123,68 @@ registerWebsitePreviewTour("snippet_images_wall", {
 }, {
     content: "Check layout",
     trigger: ":iframe .s_image_gallery .o_masonry_col:nth-child(3):has(img[data-index='5'][data-original-src*='library_image_14'])",
-}]);
+},
+        {
+            content: "Click on move to previous",
+            trigger: ".snippet-option-GalleryElement we-button[data-position='prev']",
+            run: "click",
+        },
+        {
+            content: "Check if sign is in first column",
+            trigger:
+                ":iframe .s_image_gallery .o_masonry_col:nth-child(1):has(img[data-index='4'][data-original-src*='library_image_14'])",
+        },
+        {
+            content: "Enable the Expandable option",
+            trigger: "we-button[data-attribute-name=expandable] we-checkbox",
+            run: "click",
+        },
+        {
+            content: "Set the max visible item count to 5",
+            trigger: "we-input[data-attribute-name=expandableCount] input",
+            run: "edit 5",
+        },
+        ...clickOnSave(),
+        {
+            content: "Check if the last(6th) image is hidden",
+            trigger:
+                ":iframe .s_image_gallery .o_masonry_col:nth-child(3):has(:nth-child(2).d-none)",
+        },
+        {
+            content: "Click on show more (expand) button",
+            trigger: ":iframe .s_image_gallery #btn-expand-gallery",
+            run: "click",
+        },
+        {
+            content: "Check if the last(6th) image is visible",
+            trigger:
+                ":iframe .s_image_gallery .o_masonry_col:nth-child(3) :nth-child(2):not(.d-none)",
+        },
+        {
+            content: "Click on hide extra button",
+            trigger: ":iframe .s_image_gallery #btn-collapse-gallery",
+            run: "click",
+        },
+        {
+            content: "Check if the last(6th) image is hidden",
+            trigger:
+                ":iframe .s_image_gallery .o_masonry_col:nth-child(3):has(:nth-child(2).d-none)",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        ...clickOnSnippet({
+            id: "s_image_gallery",
+            name: "Images Wall",
+        }),
+        {
+            content: "Disable the Expandable option",
+            trigger: "we-button[data-attribute-name=expandable] we-checkbox",
+            run: "click",
+        },
+        ...clickOnSave(),
+        {
+            content: "Check if the last(6th) image is visible",
+            trigger:
+                ":iframe .s_image_gallery .o_masonry_col:nth-child(3) :nth-child(2):not(.d-none)",
+        },
+    ]
+);

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -37,7 +37,7 @@
 </template>
 
 <template id="s_images_wall" name="Images Wall">
-    <section class="s_image_gallery o_spc-small o_masonry pt24 pb24" data-vcss="002" data-columns="3" data-mobile-columns="1" style="overflow: hidden;">
+    <section class="s_image_gallery o_spc-small o_masonry pt24 pb24" data-vcss="002" data-columns="3" data-mobile-columns="1" data-expandable="false" data-expandable-count="6" style="overflow: hidden;">
         <div class="container">
             <div class="row s_nb_column_fixed">
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
@@ -53,6 +53,11 @@
                     <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_16" data-index="5" data-name="Image" alt=""/>
                 </div>
             </div>
+        </div>
+        <div id="expandable_controls" class="d-flex justify-content-center">
+            <!-- Expandable control buttons -->
+            <button class="btn btn-primary rounded-circle d-none" id="btn-expand-gallery"><span class="fa fa-2x fa-angle-down"/></button>
+            <button class="btn btn-primary rounded-circle d-none" id="btn-collapse-gallery"><span class="fa fa-2x fa-angle-up"/></button>
         </div>
     </section>
 </template>
@@ -129,6 +134,17 @@
                 <t t-set="apply_to" t-valuef="img"/>
                 <t t-set="so_rounded_no_dependencies" t-value="true"/>
             </t>
+            <we-checkbox string="Expandable"
+                data-dependencies="!slideshow_mode_opt"
+                data-select-data-attribute="true"
+                data-attribute-name="expandable"
+                data-name="expandable_opt"/>
+            <we-input string="Default Limit"
+                data-step="1"
+                data-select-data-attribute="true"
+                data-dependencies="expandable_opt"
+                class="o_we_sublevel_1"
+                data-attribute-name="expandableCount"/>
         </div>
         <div data-js="gallery_img" data-selector=".s_image_gallery img"></div>
     </xpath>

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -37,16 +37,16 @@
 </template>
 
 <template id="s_images_wall" name="Images Wall">
-    <section class="s_image_gallery o_spc-small o_masonry pt24 pb24" data-vcss="002" data-columns="3" style="overflow: hidden;">
+    <section class="s_image_gallery o_spc-small o_masonry pt24 pb24" data-vcss="002" data-columns="3" data-mobile-columns="1" style="overflow: hidden;">
         <div class="container">
             <div class="row s_nb_column_fixed">
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
                     <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_03" data-index="0" data-name="Image" alt=""/>
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_10" data-index="3" data-name="Image" alt=""/>
+                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_10" data-index="4" data-name="Image" alt=""/>
                 </div>
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
                     <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_13" data-index="1" data-name="Image" alt=""/>
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_05" data-index="4" data-name="Image" alt=""/>
+                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_05" data-index="3" data-name="Image" alt=""/>
                 </div>
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
                     <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_14" data-index="2" data-name="Image" alt=""/>
@@ -68,29 +68,40 @@
     </xpath>
     <xpath expr="." position="inside">
         <div data-js="gallery" data-selector=".s_image_gallery">
-            <we-select string="Mode" data-dependencies="!slideshow_mode_opt">
-                <we-button data-mode="grid" data-name="grid_mode_opt">Grid</we-button>
-                <we-button data-mode="masonry" data-name="masonry_mode_opt">Masonry</we-button>
-                <we-button data-mode="nomode">Float</we-button>
+            <we-row>
+                <we-select string="Layout" data-dependencies="!slideshow_mode_opt">
+                    <we-button data-mode="grid" data-name="grid_mode_opt">Grid</we-button>
+                    <we-button data-mode="masonry" data-name="masonry_mode_opt">Masonry</we-button>
+                    <we-button data-mode="col" data-name="col_mode_opt">Column</we-button>
 
-                <!-- Hidden option -->
-                <we-button data-mode="slideshow" data-name="slideshow_mode_opt">Slideshow</we-button>
-            </we-select>
+                    <!-- Hidden option -->
+                    <we-button data-mode="slideshow" data-name="slideshow_mode_opt">Slideshow</we-button>
+                </we-select>
+                <we-select class="o_grid" data-dependencies="!slideshow_mode_opt">
+                    <we-button data-columns="1">1</we-button>
+                    <we-button data-columns="2">2</we-button>
+                    <we-button data-columns="3">3</we-button>
+                    <we-button data-columns="4">4</we-button>
+                    <we-button data-columns="6">6</we-button>
+                    <we-button data-columns="12">12</we-button>
+                </we-select>
+                <we-select class="o_grid" data-dependencies="!slideshow_mode_opt">
+                    <we-button data-mobile-columns="1">1</we-button>
+                    <we-button data-mobile-columns="2">2</we-button>
+                    <we-button data-mobile-columns="3">3</we-button>
+                    <we-button data-mobile-columns="4">4</we-button>
+                    <we-button data-mobile-columns="6">6</we-button>
+                    <we-button data-mobile-columns="12">12</we-button>
+                </we-select>
+            </we-row>
+            <t t-call="website.grid_layout_spacing" />
             <we-input string="Speed"
                 data-dependencies="slideshow_mode_opt"
                 data-apply-to=".carousel:first"
                 data-select-data-attribute="0s" data-attribute-name="bsInterval"
                 data-unit="s" data-save-unit="ms" data-step="0.1"/>
-            <we-select string="Columns" data-dependencies="masonry_mode_opt, grid_mode_opt">
-                <we-button data-columns="1">1</we-button>
-                <we-button data-columns="2">2</we-button>
-                <we-button data-columns="3">3</we-button>
-                <we-button data-columns="4">4</we-button>
-                <we-button data-columns="6">6</we-button>
-                <we-button data-columns="12">12</we-button>
-            </we-select>
             <we-range string="Images Spacing"
-                data-dependencies="!slideshow_mode_opt"
+                data-dependencies="masonry_mode_opt, col_mode_opt"
                 data-select-class="o_spc-none|o_spc-small|o_spc-medium|o_spc-big"/>
             <we-select string="Style" data-dependencies="slideshow_mode_opt">
                 <we-button data-select-class="">Classic</we-button>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -683,17 +683,24 @@
 </template>
 
 <!-- Grid layout options -->
-<template id="grid_layout_options">
+<template id="grid_layout_add_elements">
     <we-button-group t-att-class="indent and 'o_we_sublevel_1'" string="Add Elements" data-no-preview="true" data-dependencies="grid_mode">
         <we-button class="o_we_bg_brand_primary o_grid" data-add-element="image" title="Image" data-name="image">Image</we-button>
         <we-button class="o_we_bg_brand_primary o_grid" data-add-element="text" title="Text" data-name="text">Text</we-button>
         <we-button class="o_we_bg_brand_primary o_grid" data-add-element="button" title="Button" data-name="button">Button</we-button>
     </we-button-group>
+</template>
+<template id="grid_layout_spacing">
     <we-row t-att-class="indent and 'o_we_sublevel_1'" string="Spacing (Y, X)">
         <we-input data-dependencies="grid_mode" data-select-style="" data-css-property="row-gap" data-unit="px" data-prevent-important="true" data-apply-to=".row.o_grid_mode"/>
         <we-input data-dependencies="grid_mode" data-select-style="" data-css-property="column-gap" data-unit="px" data-max="60" data-prevent-important="true" data-apply-to=".row.o_grid_mode"/>
     </we-row>
 </template>
+<template id="grid_layout_options">
+    <t t-call="website.grid_layout_add_elements"/>
+    <t t-call="website.grid_layout_spacing"/>
+</template>
+
 
 <template id="vertical_alignment_option">
     <we-button-group t-att-class="indent and 'o_we_sublevel_1'" string="Vert. Alignment" title="Vertical Alignment" data-dependencies="normal_mode">


### PR DESCRIPTION
\* = web_editor, website

Standardized the masonry layout and updated options for the s_image_gallery snippet.
 <br>

#### Key Changes in s_image_gallery:

- Reorganized **Layout** (previously "Mode") and **Column** options for improved UX.

- Removed the **Float** layout option.

- Added a **Column** layout option.

- Updated **Grid** layout to use real CSS grids instead of flexbox with the help of existing standard grid option.

- In **Grid** layout, image spacing now uses **Spacing (Y, X)** for better control.

- **Masonry** layout now uses a newly created standard masonry option.

- **Column** option now allow different values for desktop and mobile.

- Added a new **Expandable** option, allowing users to set the number of items visible by default in the gallery. Hidden items are toggled with a "Show more" button.