### PR TITLE
[FIX] web_editor, *: resolve visibility issue at initial stage

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1616,6 +1616,14 @@ var SnippetEditor = Widget.extend({
             return;
         }
         ev.data.show = this._toggleVisibilityStatus(ev.data.show);
+        // Toggle the value of ev.data.show so that when trigger_up is called,
+        // it passes the value `true` to its parent. Additionally, in this
+        // block, we are calling `trigger_up` with `activate_snippet` to false,
+        // which disables options for that specific block.
+        if (this.$target[0] === ev.target.$target[0] && !ev.data.show) {
+            this.trigger_up("activate_snippet", { $snippet: false });
+            ev.data.show = true;
+        }
     },
     /**
      * @private

--- a/addons/website/static/tests/tours/popup_visibility_option.js
+++ b/addons/website/static/tests/tours/popup_visibility_option.js
@@ -1,0 +1,26 @@
+/** @odoo-module */
+
+import wTourUtils from "website.tour_utils";
+
+wTourUtils.registerWebsitePreviewTour("website_popup_visibility_option", {
+    test: true,
+    edition: true,
+    url: "/",
+}, [
+    wTourUtils.dragNDrop({
+        id: "s_popup",
+        name: "Popup",
+    }),
+    {
+        content: "Click on the column within the popup snippet.",
+        trigger: "iframe #wrap .s_popup .o_cc1",
+    },
+    {
+        content: "Click the 'No Desktop' visibility option.",
+        trigger: ".snippet-option-DeviceVisibility we-button[data-toggle-device-visibility='no_desktop']",
+    },
+    {
+        content: "Verify that the popup is visible and the column is invisible.",
+        trigger: ".o_we_invisible_root_parent i.fa-eye, ul .o_we_invisible_entry i.fa-eye-slash",
+    },
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -571,3 +571,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_snippet_background_video(self):
         self.start_tour("/", "website_snippet_background_video", login="admin")
+
+    def test_popup_visibility_option(self):
+        self.start_tour("/", "website_popup_visibility_option", login="admin")


### PR DESCRIPTION
Steps to reproduce:
1. Drag and drop a popup snippet.
2. Add a banner inside the popup snippet.
3. Set the banner to be invisible on desktop by selecting `no_desktop` visibility on the `Block` element.

Issue:
The popup remains open, but the element is incorrectly marked as hidden in the invisibility elements list.

Solution:
This PR ensures that the element's visibility is toggled correctly and triggers the snippet activation to false.

task-4337481