### PR TITLE
[FIX] website_event_exhibitor: Ensure sponsor visibility on mobile view

### DIFF
--- a/addons/website_event_exhibitor/views/event_templates_sponsor.xml
+++ b/addons/website_event_exhibitor/views/event_templates_sponsor.xml
@@ -3,7 +3,7 @@
 
 <template name="Sponsors" id="event_sponsor" inherit_id="website_event.layout">
     <xpath expr="//div[@id='wrap']" position="inside">
-        <section class="o_wevent_sponsor_wrapper d-none d-md-block d-print-none mt-auto">
+        <section class="o_wevent_sponsor_wrapper d-block d-md-block d-print-none mt-auto">
             <div class="container pt32 pb16" t-if="event.sponsor_ids">
                 <div t-attf-class="d-flex flex-wrap mb-5 #{'' if (len(event.sponsor_ids) > 10) else 'justify-content-md-center'}">
                     <t t-foreach="event.sponsor_ids.sorted(


### PR DESCRIPTION
**Issue:**
The sponsor's icon on the website is visible in desktop view but disappears in mobile view.

**Steps to reproduce:**
1- Go to the Events module.
2- Select an event with an existing sponsor (or create a sponsor by clicking "Sponsors" on the top bar if none exists).
3- Click on "Go To Website"

The sponsor's logo appears at the bottom of the event page but is hidden in mobile view (see screenshots attached)

<img src="https://github.com/user-attachments/assets/61fbca34-2362-4fa0-b1a0-f51ab2dd7edc" alt="bug_sponsors_1" width="300"/><img src="https://github.com/user-attachments/assets/ebecd845-c720-4088-9aae-bb6046edc71a" alt="bug_sponsors_2" width="100"/>



opw-4280239