### PR TITLE
[FIX] mass_mailing: make the snippets sidebar stick to the statusBar

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -287,13 +287,33 @@ export class MassMailingHtmlField extends HtmlField {
             }
         } else {
             const scrollableY = closestScrollableY(sidebar);
+            let stickyHeight = 0;
+            let stickyZindex = 0;
+            if (scrollableY) {
+                const statusBar = scrollableY.querySelector(".o_form_statusbar");
+                if (statusBar) {
+                    const statusBarStyle = getComputedStyle(statusBar);
+                    if (statusBarStyle.position === "sticky") {
+                        stickyHeight += statusBar.getBoundingClientRect().height;
+                    }
+                    stickyZindex = parseInt(statusBarStyle.zIndex) || 0;
+                }
+            }
             const top = scrollableY
-                ? `${-1 * (parseInt(getComputedStyle(scrollableY).paddingTop) || 0)}px`
-                : "0";
+                ? `${
+                      -1 * (parseInt(getComputedStyle(scrollableY).paddingTop) || 0) + stickyHeight
+                  }px`
+                : `${stickyHeight}px`;
             const maxHeight = this.iframe.parentNode.getBoundingClientRect().height;
-            const offsetHeight = window.innerHeight - document.querySelector(".o_content").getBoundingClientRect().y;
+            const offsetHeight =
+                window.innerHeight -
+                stickyHeight -
+                document.querySelector(".o_content").getBoundingClientRect().y;
             sidebar.style.height = `${Math.min(maxHeight, offsetHeight)}px`;
             sidebar.style.top = top;
+            if (stickyZindex > 0) {
+                sidebar.style.zIndex = `${stickyZindex - 1}`;
+            }
         }
     }
 


### PR DESCRIPTION
The snippets sidebar does not stick to the statusBar in the Email Marketing
Form view
- concerns: mass_mailing

How to reproduce:
- create a new mailing in email marketing
- choose Event Promo as the Email Template
- scroll the view to the bottom
Issue:
- snippets sidebar overlaps with the statusBar and does not stick to it

Solution:
- compute the height of the statusBar if it exists and offset the snippets of
  that value so that it does not overlap.

task-4178640

Co-authored-by: Astik Singh <assi@odoo.com>
Co-authored-by: Damien Abeloos <abd@odoo.com>
Co-authored-by: Mahdi Cheikh Rouhou <macr@odoo.com>
Co-authored-by: Shubham Thanki <shut@odoo.com>