### PR TITLE
[FIX] html_editor: remove redundant button styles in link popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -32,13 +32,10 @@ export class LinkPopover extends Component {
         { size: "lg", label: _t("Large") },
     ];
     buttonStylesData = [
-        { style: "", label: _t("Default") },
-        { style: "rounded-circle", label: _t("Default + Rounded") },
-        { style: "outline", label: _t("Outline") },
-        { style: "outline,rounded-circle", label: _t("Outline + Rounded") },
         { style: "fill", label: _t("Fill") },
         { style: "fill,rounded-circle", label: _t("Fill + Rounded") },
-        { style: "flat", label: _t("Flat") },
+        { style: "outline", label: _t("Outline") },
+        { style: "outline,rounded-circle", label: _t("Outline + Rounded") },
     ];
     setup() {
         this.ui = useService("ui");
@@ -268,7 +265,7 @@ export class LinkPopover extends Component {
      */
     onChangeClasses() {
         const shapes = this.state.buttonStyle ? this.state.buttonStyle.split(",") : [];
-        const style = ["outline", "fill"].includes(shapes[0]) ? `${shapes[0]}-` : "";
+        const style = ["outline", "fill"].includes(shapes[0]) ? `${shapes[0]}-` : "fill-";
         const shapeClasses = shapes.slice(style ? 1 : 0).join(" ");
         this.state.classes =
             (this.state.type ? `btn btn-${style}${this.state.type}` : "") +

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -59,7 +59,7 @@
                     </div>
                 </div>
             </div>
-            <div t-else="" style="max-width: 260px; min-width: 200px;" data-prevent-closing-overlay="true">
+            <div t-else="" style="width: 260px;" data-prevent-closing-overlay="true">
                 <div class="d-flex flex-column p-2">
                     <div class="d-flex">
                         <span class="o_we_preview_favicon" style="width: 16px;">

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -508,16 +508,16 @@ describe.tags("desktop")("Link formatting in the popover", () => {
         ]);
         expect(queryOne('select[name="link_type"]').selectedIndex).toBe(2);
         expect(queryOne('select[name="link_style_size"]').selectedIndex).toBe(0);
-        expect(queryOne('select[name="link_style_shape"]').selectedIndex).toBe(5);
+        expect(queryOne('select[name="link_style_shape"]').selectedIndex).toBe(1);
 
         await click('select[name="link_type"');
         await select("primary");
         await click('select[name="link_style_size"');
         await select("lg");
         await click('select[name="link_style_shape"');
-        await select("rounded-circle");
+        await select("fill,rounded-circle");
         await animationFrame();
-        expect(linkPreviewEl).toHaveClass(["btn", "btn-primary", "rounded-circle", "btn-lg"]);
+        expect(linkPreviewEl).toHaveClass(["btn", "btn-fill-primary", "rounded-circle", "btn-lg"]);
     });
     test("after applying the link format, the link's format should be updated", async () => {
         const { el } = await setupEditor('<p><a href="http://test.com/">link2[]</a></p>');
@@ -530,15 +530,15 @@ describe.tags("desktop")("Link formatting in the popover", () => {
         await select("secondary");
         await animationFrame();
         await click('select[name="link_style_shape"');
-        await select("flat");
+        await select("outline,rounded-circle");
         await animationFrame();
 
         const linkPreviewEl = queryOne("#link-preview");
-        expect(linkPreviewEl).toHaveClass(["btn", "btn-secondary", "flat"]);
+        expect(linkPreviewEl).toHaveClass(["btn", "btn-outline-secondary", "rounded-circle"]);
 
         await click(".o_we_apply_link");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="http://test.com/" class="btn btn-secondary flat">link2[]</a></p>'
+            '<p><a href="http://test.com/" class="btn btn-outline-secondary rounded-circle">link2[]</a></p>'
         );
     });
     test("no preview of the link when the url is empty", async () => {


### PR DESCRIPTION
Before this commit, the link popover contained three button styles, default, fill, and flat, which were visually identical. Here’s a summary of each:

default: Based on the website module and influenced by the theme.
fill: Not affected by theme choice.
flat: Specific to the website module.

After this commit, the redundant default and flat styles have been removed, as they are only relevant within the website module. The code has been cleaned up to improve maintainability, and tests have been updated to reflect these changes.

task-4240795


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
