### PR TITLE
[FIX] pos_loyalty: Ensure loyalty post-process occurs after order sync

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -296,12 +296,9 @@ export class PaymentScreen extends Component {
         }
 
         // 3. Post process.
-        if (
-            syncOrderResult &&
-            syncOrderResult.length > 0 &&
-            this.currentOrder.wait_for_push_order()
-        ) {
-            await this.postPushOrderResolve(syncOrderResult.map((res) => res.id));
+        const postPushOrders = syncOrderResult.filter((order) => order.wait_for_push_order());
+        if (postPushOrders.length > 0) {
+            await this.postPushOrderResolve(postPushOrders.map((order) => order.id));
         }
 
         await this.afterOrderValidation(!!syncOrderResult && syncOrderResult.length > 0);

--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -71,6 +71,12 @@ patch(PaymentScreen.prototype, {
      * @override
      */
     async _postPushOrderResolve(order, server_ids) {
+        for (const order_id of server_ids) {
+            await this._postProcessLoyalty(this.pos.models["pos.order"].get(order_id));
+        }
+        return super._postPushOrderResolve(order, server_ids);
+    },
+    async _postProcessLoyalty(order) {
         // Compile data for our function
         const ProgramModel = this.pos.models["loyalty.program"];
         const rewardLines = order._get_reward_lines();
@@ -184,6 +190,5 @@ patch(PaymentScreen.prototype, {
             }
             order.new_coupon_info = payload.new_coupon_info;
         }
-        return super._postPushOrderResolve(order, server_ids);
     },
 });


### PR DESCRIPTION
Before this commit, if you validated an order while offline and then synced the order when back online, the post-process loyalty actions would not occur, resulting in data not being updated on the server.

opw-4290171

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
