### PR TITLE
[FIX] base: Allow proper access to res.currency.rate objects from company branches

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -330,6 +330,7 @@ class CurrencyRate(models.Model):
     _description = "Currency Rate"
     _rec_names_search = ['name', 'rate']
     _order = "name desc"
+    _check_company_domain = models.check_company_domain_parent_of
 
     name = fields.Date(string='Date', required=True, index=True,
                            default=fields.Date.context_today)

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -62,7 +62,7 @@
         <record id="res_currency_rate_rule" model="ir.rule">
             <field name="name">multi-company currency rate rule</field>
             <field name="model_id" ref="model_res_currency_rate"/>
-            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+            <field name="domain_force">['|', ('company_id', 'parent_of', company_ids), ('company_id', '=', False)]</field>
         </record>
 
         <record id="change_password_rule" model="ir.rule">


### PR DESCRIPTION
To reproduce the issue:

1) Create a company A, with a branch B
2) Define a currency rate for A, for currency C
3) Open currency C's form view with only B as active company ==> The rate created in 2) is not shown

