### PR TITLE
[FIX] account: prevent deletion of email tamplate

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -220,6 +220,7 @@ class AccountMoveSend(models.TransientModel):
                 'mimetype': attachment.mimetype,
                 'placeholder': False,
                 'mail_template_id': mail_template.id,
+                'protect_from_deletion': True,
             }
             for attachment in mail_template.attachment_ids
         ]


### PR DESCRIPTION
Steps to reproduce:
- Modify the invoice mail template by adding a default attachment
- Create and confirm an invoice
- Send and Print: delete the attachment from the wizard

Issue:
Back to the mail template, you will see that the attachment has been deleted

Cause:
The attachment is not protected from deletion and is added to list of attahcments to be deleted https://github.com/odoo/odoo/blob/ef424a9dc22a5abbe7b0a6eff61cf113826f04c0/addons/account/static/src/components/mail_attachments/mail_attachments.js#L59-L63 and is deleted
https://github.com/odoo/odoo/blob/ef424a9dc22a5abbe7b0a6eff61cf113826f04c0/addons/account/static/src/components/mail_attachments/mail_attachments.js#L81-L82

Solution:
Make sure that attachements from template are protected

opw-4295826