### PR TITLE
[FIX] website: blog tags do not get removed on refresh or search

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -209,8 +209,14 @@ class WebsiteBlog(http.Controller):
 
         date_begin, date_end, state = opt.get('date_begin'), opt.get('date_end'), opt.get('state')
 
-        if tag and request.httprequest.method == 'GET':
-            # redirect get tag-1,tag-2 -> get tag-1
+        # Checking request.env.user._is_internal() to see if the GET request is from
+        # the user opening the editor, in which case the extra tags should not be removed
+        if tag and request.httprequest.method == 'GET' and not search and not request.env.user._is_internal():
+            # Redirect `tag-1,tag-2` to `tag-1` to disallow multi tags
+            # in GET request for proper bot indexation;
+            # if the search term is available, do not remove any existing
+            # tags because it is user who provided search term with GET
+            # request and so clearly it's not SEO bot.
             tags = tag.split(',')
             if len(tags) > 1:
                 url = QueryURL('' if blog else '/blog', ['blog', 'tag'], blog=blog, tag=tags[0], date_begin=date_begin, date_end=date_end, search=search)()

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -364,7 +364,9 @@ class WebsiteSlides(WebsiteProfile):
 
     @http.route(['/slides/all', '/slides/all/tag/<string:slug_tags>'], type='http', auth="public", website=True, sitemap=True)
     def slides_channel_all(self, slide_category=None, slug_tags=None, my=False, **post):
-        if slug_tags and request.httprequest.method == 'GET':
+        # Checking request.env.user._is_internal() to see if the GET request is from
+        # the user opening the editor, in which case the extra tags should not be removed
+        if slug_tags and request.httprequest.method == 'GET' and  not request.env.user._is_internal():
             # Redirect `tag-1,tag-2` to `tag-1` to disallow multi tags
             # in GET request for proper bot indexation;
             # if the search term is available, do not remove any existing


### PR DESCRIPTION
Before the change in the blog page of a website every tag but one
disappears when opening the editor or when the search bar is used.

Steps to reproduce:

Log in Odoo with a user that can access the website editor
Open the Website
Install the blog app if it is not already present
Open the blog app
Click on two or more tags to add them to the filter
Open the Website editor or use the search bar
Every tag but one will be removed

After the change all the tags will be kept when opening the editor
or using the searchbar.

task-4216129
Fixes https://github.com/odoo/odoo/pull/164577

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
