### PR TITLE
[FIX] web: Prevent traceback when users use shift click on several page

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1859,7 +1859,8 @@ export class ListRenderer extends Component {
         if (!this.canSelectRecord) {
             return;
         }
-        if (this.shiftKeyMode && this.lastCheckedRecord) {
+        const isRecordPresent = this.props.list.records.includes(this.lastCheckedRecord);
+        if (this.shiftKeyMode && isRecordPresent) {
             this.toggleRecordShiftSelection(record);
         } else {
             record.toggleSelection();

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -20772,4 +20772,44 @@ QUnit.module("Views", (hooks) => {
         await toggleMenuItem(target, "My filter");
         assert.containsOnce(target, ".o_list_renderer th[data-name='properties.property_char']");
     });
+
+    QUnit.test("select records range with shift click on several page", async (assert) => {
+        assert.expect(5);
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `<tree limit="3">
+                    <field name="foo"/>
+                    <field name="int_field"/>
+                </tree>`,
+        });
+
+        await click(target.querySelectorAll(".o_data_row .o_list_record_selector input")[0]);
+        assert.containsOnce(
+            target.querySelector(".o_control_panel_actions"),
+            ".o_list_selection_box"
+        );
+        assert.containsNone(target.querySelector(".o_list_selection_box"), ".o_list_select_domain");
+        assert.strictEqual(
+            target.querySelector(".o_list_selection_box").textContent.trim(),
+            "1 selected"
+        );
+        assert.strictEqual(
+            document.querySelectorAll(".o_data_row .o_list_record_selector input:checked").length,
+            1
+        );
+        // click the pager next button
+        await click(target.querySelector(".o_pager_next"));
+        // shift click the first record of the second page
+        await triggerEvents(
+            target.querySelectorAll(".o_data_row .o_list_record_selector input")[0],
+            null,
+            [["keydown", { key: "Shift", shiftKey: true }], "click"]
+        );
+        assert.strictEqual(
+            target.querySelector(".o_list_selection_box").textContent.trim(),
+            "1 selected  Select all 4"
+        );
+    });
 });


### PR DESCRIPTION
Steps:
    - Open any list view with more than 1 page
    - apply a limit if you don't have enough records
    - Toggle first record checkbox
    - Click on `o_pager_next`
    - Shift click on another record
    - Traceback

The problem arises when you change page after using range-selection with the shift key.

Indeed, range-selection uses `this.lastCheckedRecord`, which is the last record clicked on to start the selection, except that if you change page (and if you use a filter), this element may no longer be in the current page.

Currently, the code just checks that this element exists before attempting to create a selection by range.

The fix consists in checking that this element exists in the list of records before attempting anything.

opw-4284708