### PR TITLE
[FIX] account: properly use fiscal year fields when computing fiscal year dates

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -6,6 +6,7 @@ import calendar
 
 from odoo import fields, models, api, _, Command
 from odoo.exceptions import ValidationError, UserError, RedirectWarning
+from odoo.tools import date_utils
 from odoo.tools.mail import is_html_empty
 from odoo.tools.misc import format_date
 from odoo.tools.float_utils import float_round, float_is_zero
@@ -839,16 +840,14 @@ class ResCompany(models.Model):
 
     def compute_fiscalyear_dates(self, current_date):
         """
-        The role of this method is to provide a fallback when account_accounting is not installed.
-        As the fiscal year is irrelevant when account_accounting is not installed, this method returns the calendar year.
-        :param current_date: A datetime.date/datetime.datetime object.
+        Returns the dates of the fiscal year containing the provided date for this company.
         :return: A dictionary containing:
             * date_from
             * date_to
         """
-
-        return {'date_from': datetime(year=current_date.year, month=1, day=1).date(),
-                'date_to': datetime(year=current_date.year, month=12, day=31).date()}
+        self.ensure_one()
+        date_from, date_to = date_utils.get_fiscal_year(current_date, day=self.fiscalyear_last_day, month=self.fiscalyear_last_month)
+        return {'date_from': date_from, 'date_to': date_to}
 
     @api.depends('country_code')
     def _compute_early_pay_discount_computation(self):


### PR DESCRIPTION
fiscalyear_last_day and fiscalyear_last_month can be defined in order to use fiscal years not aligned on the civil calendar. In enterprise, it works fine (it's overridden there to add functionalities), however, community forgot to make use of these fields, even though they are declared in it.
