### PR TITLE
[FIX] web_editor: remove video tab from media dialog in report

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1683,6 +1683,7 @@ export class Wysiwyg extends Component {
             close: () => restoreSelection(),
             ...this.options.mediaModalParams,
             ...params,
+            noVideos: !this.options.allowCommandVideo,
         });
     }
     // todo: test me


### PR DESCRIPTION
**Behavior before PR:**

In web_studio video command is not allowed in report. However, user can still upload video from media dialog using video tab.

**Behavior after PR is merged:**

This commit aims to remove videos tab from media dialog if video command is disabled.

task-4285231




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
