### PR TITLE
[FIX] stock_picking_batch: detach non-picked picking only if batch done

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -117,6 +117,10 @@ class StockPicking(models.Model):
     def button_validate(self):
         res = super().button_validate()
         to_assign_ids = set()
+        # Having non-done pickings after the `super()` call means it stopped early,
+        # so we shouldn’t remove the pickings from batches yet.
+        if not any(picking.state == 'done' for picking in self):
+            return res
         if self and self.env.context.get('pickings_to_detach'):
             pickings_to_detach = self.env['stock.picking'].browse(self.env.context['pickings_to_detach'])
             pickings_to_detach.batch_id = False

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -829,8 +829,11 @@ class TestBatchPicking02(TransactionCase):
         })
         batch.action_confirm()
         action = batch.action_done()
+        # Picking_1 should be detached from the batch after the wizard and picking_2 are validated.
+        self.assertEqual(batch.picking_ids, picking_1 | picking_2)
         Form(self.env[action['res_model']].with_context(action['context'])).save().process_cancel_backorder()
         self.assertEqual(batch.state, 'done')
+        self.assertEqual(batch.picking_ids, picking_2)
 
     def test_backorder_batching(self):
         """


### PR DESCRIPTION
Steps to reproduce the bug:
- Create storable products “P1,” “P2,” and “P3,” and update their quantities in stock.
- Create a picking for one unit of P1 and P2.
- Create a second picking for one unit of “P3.”
- Mark both pickings as "To Do."
- Set the move of P1 as "Picked."
- Add both pickings to a new batch.
- Try to validate the batch.
- A wizard to create a backorder is triggered.
-  Discard the wizard

Problem:
The picking for P3 is detached from the batch.

When validating the batch, empty or non-picked pickings are checked for detachment. Since the picking for P3 is not picked, it is marked to be detached:

https://github.com/odoo/odoo/blob/7dda6bb92715ea25b2818a62fec5e646f3678b81/addons/stock_picking_batch/models/stock_picking_batch.py#L213-L214

https://github.com/odoo/odoo/blob/7dda6bb92715ea25b2818a62fec5e646f3678b81/addons/stock_picking_batch/models/stock_picking_batch.py#L201-L202

Afterward, we check if the other pickings can be validated. Since one move (P1) is picked and the other (P2) is not, the wizard to create a backorder is triggered, but the result is not checked, and detachment continues regardless:

https://github.com/odoo/odoo/blob/7dda6bb92715ea25b2818a62fec5e646f3678b81/addons/stock_picking_batch/models/stock_picking.py#L125-L126

opw-4320352
