### PR TITLE
[FIX] pos_self_order: modify combo quantity

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -146,7 +146,7 @@ export class CartPage extends Component {
         }
         increase ? line.qty++ : line.qty--;
         for (const cline of this.selfOrder.currentOrder.lines) {
-            if (cline.combo_parent_uuid === line.uuid) {
+            if (cline.combo_parent_id?.uuid === line.uuid) {
                 this._changeQuantity(cline, increase);
             }
         }

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -763,7 +763,7 @@ export class SelfOrder extends Reactive {
     verifyCart() {
         let result = true;
         for (const line of this.currentOrder.unsentLines) {
-            if (line.combo_parent_uuid) {
+            if (line.combo_parent_id?.uuid) {
                 continue;
             }
 

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
@@ -26,6 +26,10 @@ registry.category("web_tour.tours").add("self_combo_selector", {
             },
         ]),
         Utils.clickBtn("Order"),
+        {
+            trigger: '.btn:contains("＋")',
+            run: "click",
+        },
         ...CartPage.checkCombo("Office Combo", [
             {
                 product: "Desk Organizer",

--- a/addons/pos_self_order/tests/test_self_order_combo.py
+++ b/addons/pos_self_order/tests/test_self_order_combo.py
@@ -35,3 +35,5 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
         parent_line_id = self.env['pos.order.line'].search([('product_id.name', '=', 'Office Combo'), ('order_id', '=', order.id)])
         combo_line_ids = self.env['pos.order.line'].search([('product_id.name', '!=', 'Office Combo'), ('order_id', '=', order.id)])
         self.assertEqual(parent_line_id.combo_line_ids, combo_line_ids, "The combo parent should have 3 combo lines")
+        self.assertEqual(parent_line_id.qty, 2, "There should be 2 combo products")
+        self.assertEqual(parent_line_id.qty, combo_line_ids[0].qty, "The quantities should match with the parent")


### PR DESCRIPTION
Currently if you try to modify the quantity of a combo product from the cart in the kiosk, the price will not update.

Steps to reproduce:
-------------------
* Open a kiosk
* Add a combo product to the order
* Go to review the order
* Click on the + button
> Observation: The price of the order does not change.

Why the fix:
------------
In the backend we can see that the parent quantity was changed accordingly but the child products quantity stayed at 1. We were not accessing the right field when checking the child products.

opw-4283481