### PR TITLE
[REF] web: ControlPanel buttons as dropdown on small screens

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -17,7 +17,15 @@ import { Transition } from "@web/core/transition";
 import { Breadcrumbs } from "../breadcrumbs/breadcrumbs";
 import { SearchBar } from "../search_bar/search_bar";
 
-import { Component, useState, onMounted, useExternalListener, useRef, useEffect } from "@odoo/owl";
+import {
+    Component,
+    useState,
+    onMounted,
+    useExternalListener,
+    useRef,
+    useEffect,
+    onWillUpdateProps,
+} from "@odoo/owl";
 
 const STICKY_CLASS = "o_mobile_sticky";
 
@@ -131,6 +139,7 @@ export class ControlPanel extends Component {
                     {},
                 currentEmbeddedAction: this.currentEmbeddedAction,
             },
+            disableDropdown: this.props.display?.disableDropdown,
         });
 
         this.onScrollThrottledBound = this.onScrollThrottled.bind(this);
@@ -204,27 +213,18 @@ export class ControlPanel extends Component {
 
         this.mainButtons = useRef("mainButtons");
 
+        onWillUpdateProps((newProps) => {
+            this.state.disableDropdown = newProps.display?.disableDropdown;
+        });
+
         useEffect(() => {
             // on small screen, clean-up the dropdown elements
             const dropdownButtons = this.mainButtons.el.querySelectorAll(
-                ".o_control_panel_collapsed_create.dropdown-menu button"
+                ".o_control_panel_collapsed_create > .dropdown-menu button"
             );
-            if (!dropdownButtons.length) {
-                this.mainButtons.el
-                    .querySelectorAll(
-                        ".o_control_panel_collapsed_create.dropdown-menu, .o_control_panel_collapsed_create.dropdown-toggle"
-                    )
-                    .forEach((el) => el.classList.add("d-none"));
-                this.mainButtons.el
-                    .querySelectorAll(".o_control_panel_collapsed_create.btn-group")
-                    .forEach((el) => el.classList.remove("btn-group"));
-                return;
-            }
+            this.state.disableDropdown = !dropdownButtons.length;
             for (const button of dropdownButtons) {
-                for (const cl of Array.from(button.classList)) {
-                    button.classList.toggle(cl, !cl.startsWith("btn-"));
-                }
-                button.classList.add("dropdown-item", "btn", "btn-link");
+                button.classList.add("dropdown-item", "o-dropdown-item-unstyled-button");
             }
         });
 

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -22,12 +22,12 @@
             <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-lg-3 flex-grow-1">
                 <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0 h-lg-100">
                     <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none" t-ref="mainButtons" t-on-keydown="onMainButtonsKeydown">
-                        <div t-if="env.isSmall" class="btn-group o_control_panel_collapsed_create">
+                        <div t-if="env.isSmall" t-att-class="{'btn-group': !state.disableDropdown}" class="o_control_panel_collapsed_create">
                             <t t-slot="control-panel-create-button"/>
-                            <button t-att-class="{invisible: display.disableDropdown}" type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split o_control_panel_collapsed_create" data-bs-toggle="dropdown" aria-expanded="false">
+                            <button t-att-class="{'d-none': state.disableDropdown}" type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
                                  <span class="visually-hidden">Toggle Dropdown</span>
                             </button>
-                            <ul class="dropdown-menu o_control_panel_collapsed_create">
+                            <ul t-att-class="{'d-none': state.disableDropdown}" class="dropdown-menu">
                                 <t t-slot="layout-buttons"/>
                                 <t t-slot="control-panel-always-buttons"/>
                             </ul>


### PR DESCRIPTION
On smaller screens, the ControlPanel's main buttons are grouped as a dropdown if there are more than one (to take less space).

This commit refactors the logic behind this behaviour to have less juggling with the DOM and the buttons' classes and use the `disableDropdown` state to hide them when needed; also it uses the `.o-dropdown-item-unstyled-button` to cleanup the buttons that are transformed into dropdown items.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
