### PR TITLE
[FIX] Typo in website_sale template

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1200,7 +1200,7 @@
                         <div class="css_non_editable_mode_hidden">
                             <div class="missing_option_warning alert alert-info rounded-0 fade show d-none d-print-none o_default_snippet_text">
                                 Your Dynamic Snippet will be displayed here...
-                                This message is displayed because youy did not provide both a filter and a template to use.
+                                This message is displayed because you did not provide both a filter and a template to use.
                             </div>
                         </div>
                         <div class="dynamic_snippet_template"></div>

--- a/doc/cla/individual/tva-subteno-it.md
+++ b/doc/cla/individual/tva-subteno-it.md
@@ -1,0 +1,11 @@
+France, 2024-11-14
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Timothée VANNIER, tva@subteno.com https://github.com/tva-subteno-it


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
There is a typo in the sentence on the word "you".

Current behavior before PR:
Displaying "This message is displayed because youy..."

Desired behavior after PR is merged:
Displaying "This message is displayed because you..."



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
