### PR TITLE
[IMP] sale: improve performance of _compute_expected_date for large SOs

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -194,6 +194,9 @@ class SaleOrderLine(models.Model):
         self.filtered('is_delivery').order_id.filtered('carrier_id').carrier_id = False
         return super(SaleOrderLine, self).unlink()
 
+    def _get_expected_date_sol_domain(self):
+        return super()._get_expected_date_sol_domain() + [('is_delivery', '=', False)]
+
     def _is_delivery(self):
         self.ensure_one()
         return self.is_delivery


### PR DESCRIPTION

`expected_date` is a field that is added in standard in the list view of Sale Orders. If multiple SOs in the list view have multiple lines, this would read thousands of SOL (hitting the PREFETCH_MAX limit multiple tiems). In extreme cases this could also kill the process, as too many Lines would be fetched at once


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
