### PR TITLE
[IMP] point_of_sale, pos_*: use x_commands from frontend.

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -27,8 +27,6 @@ export class PosOrderline extends Base {
         this.uiState = {
             hasChange: true,
         };
-
-        // this.set_unit_price(this.price_unit);
     }
 
     set_full_product_name() {
@@ -171,12 +169,14 @@ export class PosOrderline extends Base {
         if (!this.product_id.to_weight && setQuantity) {
             this.set_quantity_by_lot();
         }
+        this.setDirty();
     }
 
     // FIXME related models update stuff
     set_product_lot(product) {
         this.has_product_lot = product.tracking !== "none";
         this.pack_lot_ids = this.has_product_lot && [];
+        this.setDirty();
     }
 
     set_discount(discount) {
@@ -189,6 +189,7 @@ export class PosOrderline extends Base {
 
         const disc = Math.min(Math.max(parsed_discount || 0, 0), 100);
         this.discount = disc;
+        this.setDirty();
     }
 
     // sets the qty of the product. The qty will be rounded according to the
@@ -252,6 +253,8 @@ export class PosOrderline extends Base {
                 )
             );
         }
+
+        this.setDirty();
         return true;
     }
 
@@ -350,6 +353,7 @@ export class PosOrderline extends Base {
             parsed_price || 0,
             this.models["decimal.precision"].find((dp) => dp.name === "Product Price").digits
         );
+        this.setDirty();
     }
 
     get_unit_price() {
@@ -549,6 +553,7 @@ export class PosOrderline extends Base {
 
     set_customer_note(note) {
         this.customer_note = note || "";
+        this.setDirty();
     }
 
     get_customer_note() {
@@ -673,6 +678,7 @@ export class PosOrderline extends Base {
         return this.note || "";
     }
     setNote(note) {
+        this.setDirty();
         this.note = note;
     }
     setHasChange(isChange) {

--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -163,6 +163,12 @@ export class Base {
         }
     }
 
+    setDirty() {
+        if (typeof this.id === "number") {
+            this.models.commands[this.model.modelName].update.add(this.id);
+        }
+    }
+
     setupState(vals) {
         this.uiState = vals;
     }
@@ -174,8 +180,8 @@ export class Base {
     update(vals) {
         this.model.update(this, vals);
     }
-    delete() {
-        return this.model.delete(this);
+    delete(opts = {}) {
+        return this.model.delete(this, opts);
     }
     /**
      * @param {object} options
@@ -183,6 +189,7 @@ export class Base {
      */
     serialize(options = {}) {
         const orm = options.orm ?? false;
+        const clear = options.clear ?? false;
 
         const serializedData = this.model.serialize(this, { orm });
 
@@ -200,41 +207,66 @@ export class Base {
                 }
 
                 if (X2MANY_TYPES.has(params.type)) {
-                    serializedDataOrm[name] = serializedData[name].map((id) => {
-                        let serData = {};
-                        let data = {};
+                    serializedDataOrm[name] = serializedData[name]
+                        .map((id) => {
+                            let serData = false;
+                            let data = {};
 
-                        if (
-                            !SERIALIZABLE_MODELS.includes(params.relation) &&
-                            typeof id === "number"
-                        ) {
-                            return [4, id];
-                        } else if (!SERIALIZABLE_MODELS.includes(params.relation)) {
-                            throw new Error(
-                                "Trying to create a non serializable record" + params.relation
-                            );
-                        }
-
-                        if (params.relation !== params.model) {
-                            data = this.records[params.relation][id].serialize(options);
-                            data.id = typeof id === "number" ? id : parseInt(id.split("_")[1]);
-                        } else {
-                            return typeof id === "number" ? id : parseInt(id.split("_")[1]);
-                        }
-
-                        serData = typeof id === "number" ? [1, id, data] : [0, 0, data];
-
-                        for (const [key, value] of Object.entries(serData[2])) {
                             if (
-                                this.models[params.relation].modelFields[key]?.relation &&
-                                typeof value === "string"
+                                !SERIALIZABLE_MODELS.includes(params.relation) &&
+                                typeof id === "number"
                             ) {
-                                serData[2][key] = parseInt(value.split("_")[1]);
+                                return [4, id];
+                            } else if (!SERIALIZABLE_MODELS.includes(params.relation)) {
+                                throw new Error(
+                                    "Trying to create a non serializable record" + params.relation
+                                );
                             }
-                        }
 
-                        return serData;
-                    });
+                            if (params.relation !== params.model) {
+                                data = this.records[params.relation][id].serialize(options);
+                                data.id = typeof id === "number" ? id : parseInt(id.split("_")[1]);
+                            } else {
+                                return typeof id === "number" ? id : parseInt(id.split("_")[1]);
+                            }
+
+                            if (
+                                typeof id === "number" &&
+                                this.models.commands[params.relation].update.has(id)
+                            ) {
+                                serData = [1, id, data];
+
+                                if (clear) {
+                                    this.models.commands[params.relation].update.delete(id);
+                                }
+                            } else if (typeof id !== "number") {
+                                serData = [0, 0, data];
+                            }
+
+                            if (serData) {
+                                for (const [key, value] of Object.entries(serData[2])) {
+                                    if (
+                                        this.models[params.relation].modelFields[key]?.relation &&
+                                        typeof value === "string"
+                                    ) {
+                                        serData[2][key] = parseInt(value.split("_")[1]);
+                                    }
+                                }
+                            }
+
+                            return serData;
+                        })
+                        .filter((s) => s);
+
+                    if (this.models.commands[params.model].delete.has(name)) {
+                        const ids = this.models.commands[params.model].delete.get(name);
+                        for (const id of ids) {
+                            serializedDataOrm[name].push([3, id]);
+                        }
+                        if (clear) {
+                            this.models.commands[params.model].delete.delete(name);
+                        }
+                    }
                 } else {
                     let value = serializedData[name];
                     if (name === "id" && typeof value === "string") {
@@ -263,32 +295,34 @@ export class Base {
 
 export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) {
     const [inverseMap, processedModelDefs] = processModelDefs(modelDefs);
-    const records = reactive(mapObj(processedModelDefs, () => reactive({})));
-    const orderedRecords = reactive(mapObj(processedModelDefs, () => reactive([])));
+    const records = mapObj(processedModelDefs, () => reactive({}));
+    const orderedRecords = mapObj(processedModelDefs, () => reactive([]));
     const callbacks = mapObj(processedModelDefs, () => []);
+    const commands = mapObj(processedModelDefs, () => ({
+        delete: new Map(),
+        update: new Set(),
+    }));
     const baseData = {};
     const missingFields = {};
 
     // object: model -> key -> keyval -> record
-    const indexedRecords = reactive(
-        mapObj(processedModelDefs, (model) => {
-            const container = reactive({});
+    const indexedRecords = mapObj(processedModelDefs, (model) => {
+        const container = reactive({});
 
-            // We always want an index by id
-            if (!indexes[model]) {
-                indexes[model] = ["id"];
-            } else {
-                indexes[model].push("id");
-            }
+        // We always want an index by id
+        if (!indexes[model]) {
+            indexes[model] = ["id"];
+        } else {
+            indexes[model].push("id");
+        }
 
-            for (const key of indexes[model] || []) {
-                container[key] = reactive({});
-            }
+        for (const key of indexes[model] || []) {
+            container[key] = reactive({});
+        }
 
-            baseData[model] = {};
-            return container;
-        })
-    );
+        baseData[model] = {};
+        return container;
+    });
 
     function getFields(model) {
         return processedModelDefs[model];
@@ -389,6 +423,11 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
         const record = reactive(new Model({ models, records, model: models[model] }));
         const id = vals["id"];
         record.id = id;
+
+        if (!baseData[model][id]) {
+            baseData[model][id] = vals;
+        }
+
         record._raw = baseData[model][id];
         records[model][id] = record;
 
@@ -491,6 +530,8 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
 
     function update(model, record, vals) {
         const fields = getFields(model);
+        Object.assign(baseData[model][record.id], vals);
+
         for (const name in vals) {
             if (!(name in fields)) {
                 continue;
@@ -544,18 +585,33 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
                 record[name] = vals[name];
             }
         }
+
+        if (typeof record.id === "number") {
+            commands[model].update.add(record.id);
+        }
     }
 
-    function delete_(model, record) {
+    function delete_(model, record, opts = {}) {
         const id = record.id;
         const fields = getFields(model);
+        const handleDelete = (inverse, field, record) => {
+            if (inverse && !inverse.dummy && !opts.silent && typeof id === "number") {
+                const oldVal = commands[field.relation].delete.get(inverse.name);
+                commands[field.relation].delete.set(inverse.name, [...(oldVal || []), record.id]);
+            }
+        };
+
         for (const name in fields) {
             const field = fields[name];
+            const inverse = inverseMap.get(field);
+
             if (X2MANY_TYPES.has(field.type)) {
                 for (const record2 of [...record[name]]) {
+                    handleDelete(inverse, field, record);
                     disconnect(field, record, record2);
                 }
             } else if (field.type === "many2one" && typeof record[name] === "object") {
+                handleDelete(inverse, field, record);
                 disconnect(field, record, record[name]);
             }
         }
@@ -573,7 +629,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
                 delete indexedRecords[model][key][keyVal];
             }
         }
-        models[model].triggerEvents("delete", id);
+
         return id;
     }
 
@@ -618,8 +674,8 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
             update(record, vals) {
                 return update(model, record, vals);
             },
-            delete(record) {
-                return delete_(model, record);
+            delete(record, opts = {}) {
+                return delete_(model, record, opts);
             },
             deleteMany(records) {
                 const result = [];
@@ -762,17 +818,13 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
 
                 callbacks[model][event].push(callback);
             },
-            triggerEvents(event, values) {
-                if (
-                    !(event in callbacks[model]) ||
-                    callbacks[model][event].length === 0 ||
-                    values.length === 0
-                ) {
+            triggerEvents(event, data) {
+                if (!(event in callbacks[model]) || callbacks[model][event].length === 0 || !data) {
                     return;
                 }
 
                 for (const callback of callbacks[model][event]) {
-                    callback(values);
+                    callback(data);
                 }
             },
         };
@@ -803,7 +855,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
                     if (data.uiState) {
                         uiState[data[key]] = { ...data.uiState };
                     }
-                    data.delete();
+                    data.delete({ silent: true });
                 }
             }
 
@@ -1018,11 +1070,15 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
             }
 
             const event = valuesToAdd.length > 0 ? "create" : "update";
-            models[model].triggerEvents(event, values);
+            models[model].triggerEvents(event, {
+                ids: values.map((v) => v.id),
+                model: model,
+            });
         }
     }
 
     models.loadData = loadData;
+    models.commands = commands;
     models.replaceDataByKey = replaceDataByKey;
 
     return { models, records, indexedRecords, orderedRecords };

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -296,6 +296,9 @@ export class PosStore extends Reactive {
         return true;
     }
     computeProductPricelistCache(data) {
+        if (data) {
+            data = this.models[data.model].readMany(data.ids);
+        }
         // This function is called via the addEventListener callback initiated in the
         // processServerData function when new products or pricelists are loaded into the PoS.
         // It caches the heavy pricelist calculation when there are many products and pricelists.
@@ -1002,6 +1005,9 @@ export class PosStore extends Reactive {
             await this.preSyncAllOrders(orders);
             const context = this.getSyncAllOrdersContext(orders, options);
 
+            if (this.pendingOrder.delete.size) {
+                await this.deleteOrders([], Array.from(this.pendingOrder.delete));
+            }
             // Allow us to force the sync of the orders In the case of
             // pos_restaurant is usefull to get unsynced orders
             // for a specific table
@@ -1017,7 +1023,9 @@ export class PosStore extends Reactive {
                 order.recomputeOrderData();
             }
 
-            const serializedOrder = orders.map((order) => order.serialize({ orm: true }));
+            const serializedOrder = orders.map((order) =>
+                order.serialize({ orm: true, clear: true })
+            );
             const data = await this.data.call("pos.order", "sync_from_ui", [serializedOrder], {
                 context,
             });

--- a/addons/point_of_sale/static/tests/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/tours/chrome_tour.js
@@ -87,7 +87,6 @@ registry.category("web_tour.tours").add("ChromeTour", {
             ProductScreen.orderIsEmpty(),
             Chrome.clickMenuOption("Orders"),
             TicketScreen.deleteOrder("-0004"),
-            TicketScreen.deleteOrder("-0001"),
 
             // After deleting order 1 above, order 2 became
             // the 2nd-row order and it has payment status

--- a/addons/pos_event/models/pos_order.py
+++ b/addons/pos_event/models/pos_order.py
@@ -44,7 +44,7 @@ class PosOrder(models.Model):
     @api.model
     def _process_order(self, order, existing_order):
         res = super()._process_order(order, existing_order)
-        refunded_line_ids = [line[2].get('refunded_orderline_id') for line in order.get('lines') if line[2].get('refunded_orderline_id')]
+        refunded_line_ids = [line[2].get('refunded_orderline_id') for line in order.get('lines') if line[0] in [0, 1] and line[2].get('refunded_orderline_id')]
         refunded_orderlines = self.env['pos.order.line'].browse(refunded_line_ids)
         event_to_cancel = []
 

--- a/addons/pos_loyalty/static/src/overrides/components/partner_line/partner_line.js
+++ b/addons/pos_loyalty/static/src/overrides/components/partner_line/partner_line.js
@@ -9,6 +9,9 @@ patch(PartnerLine.prototype, {
         super.setup(...arguments);
         this.pos = usePos();
     },
+    get loyaltyCard() {
+        return this.props.partner["<-loyalty.card.partner_id"];
+    },
     _getLoyaltyPointsRepr(loyaltyCard) {
         const program = loyaltyCard.program_id;
         if (program.program_type === "ewallet") {

--- a/addons/pos_loyalty/static/src/overrides/components/partner_line/partner_line.xml
+++ b/addons/pos_loyalty/static/src/overrides/components/partner_line/partner_line.xml
@@ -3,7 +3,7 @@
 
      <t t-name="pos_loyalty.PartnerLine" t-inherit="point_of_sale.PartnerLine" t-inherit-mode="extension">
         <xpath expr="//td[hasclass('partner-line-balance')]" position="inside">
-            <t t-set="_loyaltyCards" t-value="pos.getLoyaltyCards(props.partner)" />
+            <t t-set="_loyaltyCards" t-value="this.loyaltyCard" />
             <t t-foreach="_loyaltyCards" t-as="_loyaltyCard" t-key="_loyaltyCard.id">
                 <div class="pos-right-align">
                     <t t-esc="_getLoyaltyPointsRepr(_loyaltyCard)"/>

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -540,8 +540,8 @@ patch(PosStore.prototype, {
     },
 
     //@override
-    async processServerData(loadedData) {
-        await super.processServerData(loadedData);
+    async processServerData() {
+        await super.processServerData();
 
         this.partnerId2CouponIds = {};
 
@@ -562,13 +562,14 @@ patch(PosStore.prototype, {
             rule.validProductIds = new Set(rule.raw.valid_product_ids);
         }
 
-        this.models["loyalty.card"].addEventListener("create", (records) => {
-            this.computePartnerCouponIds(records);
+        this.models["loyalty.card"].addEventListener("create", (data) => {
+            this.computePartnerCouponIds(data);
         });
         this.computePartnerCouponIds();
     },
 
-    computePartnerCouponIds(loyaltyCards = null) {
+    computePartnerCouponIds(data) {
+        const loyaltyCards = this.models["loyalty.card"].readMany(data?.ids || []);
         const cards = loyaltyCards || this.models["loyalty.card"].getAll();
         for (const card of cards) {
             if (!card.partner_id || card.id < 0) {

--- a/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.js
@@ -2,17 +2,6 @@ import { patch } from "@web/core/utils/patch";
 import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_summary/order_summary";
 
 patch(OrderSummary.prototype, {
-    releaseTable() {
-        const orderOnTable = this.pos.models["pos.order"].filter(
-            (o) => o.table_id?.id === this.pos.selectedTable.id && o.finalized === false
-        );
-
-        for (const order of orderOnTable) {
-            this.pos.removeOrder(order);
-        }
-
-        this.pos.showScreen("FloorScreen");
-    },
     bookTable() {
         this.pos.get_order().setBooked(true);
         this.pos.showScreen("FloorScreen");
@@ -32,7 +21,7 @@ patch(OrderSummary.prototype, {
         );
     },
     unbookTable() {
-        this.pos.removeOrder(this.pos.get_order());
+        this.pos.removeOrder(this.pos.get_order(), true);
         this.pos.showScreen("FloorScreen");
     },
     showUnbookButton() {

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -140,6 +140,7 @@ patch(PosStore.prototype, {
             const product_unit = line.product_id.uom_id;
             if (product_unit && !product_unit.is_pos_groupable) {
                 let remaining_quantity = newLine.qty;
+                newLine.delete();
                 while (!this.env.utils.floatIsZero(remaining_quantity)) {
                     const splitted_line = this.models["pos.order.line"].create({
                         ...newLineValues,
@@ -147,7 +148,6 @@ patch(PosStore.prototype, {
                     splitted_line.set_quantity(Math.min(remaining_quantity, 1.0), true);
                     remaining_quantity -= splitted_line.qty;
                 }
-                newLine.delete();
             }
         }
     },

--- a/addons/pos_self_order/static/src/overrides/models/pos_store.js
+++ b/addons/pos_self_order/static/src/overrides/models/pos_store.js
@@ -3,10 +3,6 @@ import { patch } from "@web/core/utils/patch";
 import { PosOrder } from "@point_of_sale/app/models/pos_order";
 
 patch(PosStore.prototype, {
-    // @Override
-    async processServerData(loadedData) {
-        await super.processServerData(...arguments);
-    },
     async getServerOrders() {
         if (this.session._self_ordering) {
             await this.loadServerOrders([


### PR DESCRIPTION
*: pos_sale, pos_loyalty, pos_restaurant, pos_event

Before all lines was sent to the backend to be processed, if the backend had a line that wasn't sent by the frontend, it was removed from the order.

Now the frontend sends only modified lines to the backend, if a line is deleted from the frontend, it will be deleted from the backend too. But the backend doesn't remove lines that weren't sent by the frontend.

This change was made to avoid losing information when the backend delete a line that wasn't sent by the frontend.

Cherry-picked from bdd57e0576ad2c061494676325a26644a8427c5e
