### PR TITLE
[FIX] web: tests - handle properties fields

### DIFF
--- a/addons/spreadsheet/static/tests/lists/list_plugin.test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin.test.js
@@ -4,17 +4,17 @@ import { user } from "@web/core/user";
 
 import {
     addGlobalFilter,
+    redo,
     selectCell,
     setCellContent,
     undo,
-    redo,
 } from "@spreadsheet/../tests/helpers/commands";
 import {
     getCell,
     getCellContent,
     getCellFormula,
-    getCellValue,
     getCells,
+    getCellValue,
     getEvaluatedCell,
     getEvaluatedGrid,
 } from "@spreadsheet/../tests/helpers/getters";
@@ -29,14 +29,14 @@ import {
     defineSpreadsheetActions,
     defineSpreadsheetModels,
     generateListDefinition,
-    getBasicServerData,
+    Partner,
+    Product,
 } from "@spreadsheet/../tests/helpers/data";
 
 import { waitForDataLoaded } from "@spreadsheet/helpers/model";
 const { DEFAULT_LOCALE, PIVOT_TABLE_CONFIG } = spreadsheet.constants;
 const { toZone } = spreadsheet.helpers;
 const { cellMenuRegistry } = spreadsheet.registries;
-
 
 describe.current.tags("headless");
 defineSpreadsheetModels();
@@ -79,17 +79,25 @@ test("Boolean fields are correctly formatted", async () => {
 });
 
 test("properties field displays property display names", async () => {
-    const serverData = getBasicServerData();
-    serverData.models.partner.records = [
+    Product._records = [
         {
-            partner_properties: [
-                { name: "dbfc66e0afaa6a8d", type: "date", string: "prop 1", default: false },
-                { name: "f80b6fb58d0d4c72", type: "integer", string: "prop 2", default: 0 },
+            id: 1,
+            properties_definitions: [
+                { name: "dbfc66e0afaa6a8d", type: "date", string: "prop 1" },
+                { name: "f80b6fb58d0d4c72", type: "integer", string: "prop 2" },
             ],
         },
     ];
+    Partner._records = [
+        {
+            product_id: 1,
+            partner_properties: {
+                dbfc66e0afaa6a8d: false,
+                f80b6fb58d0d4c72: 0,
+            },
+        },
+    ];
     const { model } = await createSpreadsheetWithList({
-        serverData,
         columns: ["partner_properties"],
     });
     expect(getCellValue(model, "A2")).toBe("prop 1, prop 2");
@@ -635,7 +643,7 @@ test("Can see record on vectorized list index", async function () {
     model.dispatch("CREATE_SHEET", { sheetId: "42" });
     model.dispatch("ACTIVATE_SHEET", {
         sheetIdFrom: model.getters.getActiveSheetId(),
-        sheetIdTo: "42"
+        sheetIdTo: "42",
     });
     setCellContent(model, "C1", "1");
     setCellContent(model, "C2", "2");

--- a/addons/test_mail/static/tests/properties_field.test.js
+++ b/addons/test_mail/static/tests/properties_field.test.js
@@ -38,15 +38,23 @@ async function testPropertyFieldAvatarOpenChat(propertyType) {
     await start();
     const partnerId = pyEnv["res.partner"].create({ name: "Partner Test" });
     const userId = pyEnv["res.users"].create({ name: "User Test", partner_id: partnerId });
-    const parentId = pyEnv["mail.test.properties"].create({ name: "Parent" });
+    const propertyDefinition = {
+        type: propertyType,
+        comodel: "res.users",
+        name: "user",
+        string: "user",
+    };
+    const parentId = pyEnv["mail.test.properties"].create({
+        name: "Parent",
+        definition_properties: [propertyDefinition],
+    });
     const value = propertyType === "many2one" ? [userId, "User Test"] : [[userId, "User Test"]];
     const childId = pyEnv["mail.test.properties"].create({
         name: "Test",
         parent_id: parentId,
-        properties: [
-            { type: propertyType, comodel: "res.users", name: "user", string: "user", value },
-        ],
+        properties: [{ ...propertyDefinition, value }],
     });
+
     await openFormView("mail.test.properties", childId);
     await assertSteps([]);
     await click(

--- a/addons/web/static/tests/_framework/mock_server/mock_fields.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_fields.js
@@ -218,7 +218,9 @@ export const One2many = makeFieldGenerator("one2many", {
     requiredKeys: ["relation"],
 });
 
-export const Properties = makeFieldGenerator("properties");
+export const Properties = makeFieldGenerator("properties", {
+    requiredKeys: ["definition_record", "definition_record_field"],
+});
 
 export const PropertiesDefinition = makeFieldGenerator("properties_definition");
 

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -4630,12 +4630,18 @@ test(`calendar render properties in popover`, async () => {
         definition_record_field: "definitions",
     });
     Event._records[0].type_id = 1;
-    Event._records[0].properties = [
+    Event._records[0].properties = {
+        property_1: "hello",
+        property_2: "b",
+        property_3: "hidden",
+    };
+
+    EventType._fields.definitions = fields.PropertiesDefinition();
+    EventType._records[0].definitions = [
         {
             name: "property_1",
             string: "My Char",
             type: "char",
-            value: "hello",
             view_in_cards: true,
         },
         {
@@ -4647,7 +4653,6 @@ test(`calendar render properties in popover`, async () => {
                 ["b", "B"],
                 ["c", "C"],
             ],
-            value: "b",
             default: "c",
             view_in_cards: true,
         },
@@ -4655,15 +4660,8 @@ test(`calendar render properties in popover`, async () => {
             name: "property_3",
             string: "Hidden Char",
             type: "char",
-            value: "hidden",
             view_in_cards: false,
         },
-    ];
-
-    EventType._fields.definitions = fields.PropertiesDefinition();
-    EventType._records[0].definitions = [
-        { name: "event_prop_1", string: "My Char", type: "char" },
-        { name: "event_prop_2", string: "My Selection", type: "selection" },
     ];
 
     await mountView({
@@ -4689,7 +4687,6 @@ test(`calendar create record with default properties`, async () => {
     Event._fields.properties = fields.Properties({
         definition_record: "type_id",
         definition_record_field: "definitions",
-        default: [{ name: "event_prop", string: "Hello", type: "char" }],
     });
     Event._views = {
         form: `
@@ -4714,6 +4711,9 @@ test(`calendar create record with default properties`, async () => {
                 <field name="properties"/>
             </calendar>
         `,
+        context: {
+            default_properties: [{ name: "event_prop", string: "Hello", type: "char" }],
+        },
     });
     await selectTimeRange("2016-12-15 06:00:00", "2016-12-15 08:00:00");
     expect(`.modal`).toHaveCount(1);

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -69,7 +69,10 @@ async function changeType(propertyType) {
 // Separators tests utils
 // -----------------------------------------
 
-async function makePropertiesGroupView(properties) {
+/**
+ * @param {boolean[]} propertySpecs
+ */
+async function makePropertiesGroupView(propertySpecs) {
     // mock random function to have predictable auto generated properties names
     let counter = 1;
     patchWithCleanup(PropertiesField.prototype, {
@@ -81,19 +84,24 @@ async function makePropertiesGroupView(properties) {
 
     onRpc("has_access", () => true);
 
-    Partner._records[1].properties = properties.map((isSeparator, index) => {
-        return {
-            name: `property_${index + 1}`,
-            string: isSeparator ? `Separator ${index + 1}` : `Property ${index + 1}`,
+    const { properties } = Partner._records[1];
+    const definitions = propertySpecs.map((isSeparator, i) => {
+        const property = {
+            name: `property_${i + 1}`,
+            string: isSeparator ? `Separator ${i + 1}` : `Property ${i + 1}`,
             type: isSeparator ? "separator" : "char",
         };
+        properties[property.name] = false;
+        return property;
     });
+
+    ResCompany._records[0].definitions = definitions;
 
     // unfold all separators
     window.localStorage.setItem(
         "properties.fold,res.company,37",
         JSON.stringify(
-            Partner._records[1].properties
+            definitions
                 .filter((property) => property.type === "separator")
                 .map((property) => property.name)
         )
@@ -165,84 +173,37 @@ class Partner extends models.Model {
         {
             id: 1,
             display_name: "first partner",
-            properties: [
-                {
-                    name: "property_1",
-                    string: "My Char",
-                    type: "char",
-                    value: "char value",
-                    view_in_cards: true,
-                },
-                {
-                    name: "property_2",
-                    string: "My Selection",
-                    type: "selection",
-                    selection: [
-                        ["a", "A"],
-                        ["b", "B"],
-                        ["c", "C"],
-                    ],
-                    value: "b",
-                    default: "c",
-                    view_in_cards: true,
-                },
-            ],
+            properties: {
+                property_1: "char value",
+                property_2: "b",
+            },
             company_id: 37,
         },
         {
             id: 2,
             display_name: "second partner",
-            properties: [
-                {
-                    name: "property_1",
-                    string: "My Char",
-                    type: "char",
-                    value: "char value",
-                    view_in_cards: true,
-                },
-                {
-                    name: "property_2",
-                    string: "My Selection",
-                    type: "selection",
-                    selection: [
-                        ["a", "A"],
-                        ["b", "B"],
-                        ["c", "C"],
-                    ],
-                    value: "c",
-                    default: "c",
-                    view_in_cards: true,
-                },
-                {
-                    name: "property_3",
-                    string: "My Char 3",
-                    type: "char",
-                    value: "char value 3",
-                },
-                {
-                    name: "property_4",
-                    string: "My Char 4",
-                    type: "char",
-                    value: "char value 4",
-                    view_in_cards: true,
-                },
-            ],
+            properties: {
+                property_1: "char value",
+                property_2: "c",
+                property_3: "char value 3",
+                property_4: "char value 4",
+            },
             company_id: 37,
         },
         {
             id: 3,
             display_name: "third partner",
-            properties: [
-                { name: "property_1", type: "char" },
-                { name: "property_3", type: "char", definition_changed: true },
-                { name: "property_4", type: "char" },
-            ],
+            properties: {
+                property_1: false,
+                property_3: false,
+                property_4: false,
+            },
             company_id: 37,
         },
         {
             id: 4,
             display_name: "fourth partner",
-            properties: [],
+            properties: {},
             company_id: 37,
         },
     ];
@@ -311,6 +272,7 @@ class User extends models.Model {
         },
     ];
 }
+
 defineModels([Partner, ResCompany, User]);
 
 /**
@@ -356,7 +318,7 @@ test("properties: no access to parent", async () => {
     expect(".o_field_properties:first-child .o_field_property_open_popover").toHaveCount(0, {
         message: "The edit definition button must not be in the view",
     });
-    expect(".o_field_properties:first-child .o_property_field_value input").toHaveValue(
+    expect(".o_field_properties:first-child .o_property_field_value input:first").toHaveValue(
         "char value"
     );
 });
@@ -396,7 +358,7 @@ test("properties: access to parent", async () => {
         message: "The edit definition button must be in the view",
     });
 
-    expect(".o_field_properties:first-child .o_property_field_value input").toHaveValue(
+    expect(".o_field_properties:first-child .o_property_field_value input:first").toHaveValue(
         "char value"
     );
 
@@ -449,7 +411,7 @@ test("properties: access to parent", async () => {
     // Discard the form view and check that the properties take its old values
     await clickCancel();
     await animationFrame();
-    expect(".o_property_field:first-child .o_property_field_value input").toHaveValue(
+    expect(".o_property_field:first-child .o_property_field_value input:first").toHaveValue(
         "char value",
         { message: "Discarding the form view should reset the old values" }
     );
@@ -459,6 +421,9 @@ test("properties: access to parent", async () => {
  * Test the creation of a new property.
  */
 test("properties: add a new property", async () => {
+    ResCompany._records[0].definitions.pop();
+    ResCompany._records[0].definitions.pop();
+
     onRpc("has_access", () => true);
 
     await mountView({
@@ -512,10 +477,8 @@ test("properties: add a new property", async () => {
     expect(newProperty).toHaveText("Property 3");
 });
 
-/**
- * Test the selection property.
- */
-test.tags("desktop")("properties: selection", async () => {
+test.tags("desktop", "focus required");
+test("properties: selection", async () => {
     onRpc("has_access", () => true);
 
     await mountView({
@@ -1103,14 +1066,17 @@ test.tags("desktop")("properties: many2one 'Search more...'", async () => {
             id: 1,
             company_id: 37,
             display_name: "Pierre",
-            properties: [
-                {
-                    name: "many_2_one",
-                    type: "many2one",
-                    string: "My Many-2-one",
-                    comodel: "partner",
-                },
-            ],
+            properties: {
+                many_2_one: false,
+            },
+        },
+    ];
+    ResCompany._records[0].definitions = [
+        {
+            name: "many_2_one",
+            type: "many2one",
+            string: "My Many-2-one",
+            comodel: "partner",
         },
     ];
     Partner._views[["list", false]] = /* xml */ `
@@ -1194,22 +1160,24 @@ test("properties: date(time) property manipulations", async () => {
     Partner._records.push({
         id: 5000,
         display_name: "third partner",
-        properties: [
-            {
-                name: "property_1",
-                string: "My Date",
-                type: "date",
-                value: "2019-01-01",
-            },
-            {
-                name: "property_2",
-                string: "My DateTime",
-                type: "datetime",
-                value: "2019-01-01 10:00:00",
-            },
-        ],
+        properties: {
+            property_1: "2019-01-01",
+            property_2: "2019-01-01 10:00:00",
+        },
         company_id: 37,
     });
+    ResCompany._records[0].definitions = [
+        {
+            name: "property_1",
+            string: "My Date",
+            type: "date",
+        },
+        {
+            name: "property_2",
+            string: "My DateTime",
+            type: "datetime",
+        },
+    ];
     onRpc(({ method, args }) => {
         expect.step(method);
         if (method === "has_access") {
@@ -1403,24 +1371,28 @@ test("properties: kanban view with date and datetime property fields", async () 
     Partner._records.push({
         id: 40,
         display_name: "fifth partner",
-        properties: [
-            {
-                name: "property_1",
-                string: "My Date",
-                type: "date",
-                value: "2019-01-01",
-                view_in_cards: true,
-            },
-            {
-                name: "property_2",
-                string: "My DateTime",
-                type: "datetime",
-                value: "2019-01-01 10:00:00",
-                view_in_cards: true,
-            },
-        ],
+        properties: {
+            property_1: "2019-01-01",
+            property_2: "2019-01-01 10:00:00",
+        },
         company_id: 37,
     });
+    ResCompany._records[0].definitions = [
+        {
+            name: "property_1",
+            string: "My Date",
+            type: "date",
+            value: "2019-01-01",
+            view_in_cards: true,
+        },
+        {
+            name: "property_2",
+            string: "My DateTime",
+            type: "datetime",
+            value: "2019-01-01 10:00:00",
+            view_in_cards: true,
+        },
+    ];
 
     await mountView({
         type: "kanban",
@@ -1447,26 +1419,24 @@ test("properties: kanban view with date and datetime property fields", async () 
 });
 
 test("properties: kanban view with multiple sources of properties definitions", async () => {
-    const definition = {
-        name: "property_integer",
-        string: "My Integer",
-        type: "integer",
-        view_in_cards: true,
-    };
     ResCompany._records.push({
         id: 38,
         name: "Company 2",
-        definitions: [definition],
+        definitions: [
+            {
+                name: "property_integer",
+                string: "My Integer",
+                type: "integer",
+                view_in_cards: true,
+            },
+        ],
     });
     Partner._records.push({
         id: 10,
         display_name: "other partner",
-        properties: [
-            {
-                ...definition,
-                value: 1,
-            },
-        ],
+        properties: {
+            property_integer: 1,
+        },
         company_id: 38,
     });
 
@@ -1503,45 +1473,47 @@ test("properties: kanban view with label and border", async () => {
     Partner._records.push({
         id: 12,
         display_name: "fifth partner",
-        properties: [
-            {
-                name: "property_integer",
-                string: "My Integer",
-                type: "integer",
-                value: 12,
-                view_in_cards: true,
-            },
-            {
-                name: "property_float",
-                string: "My Float",
-                type: "float",
-                value: 12.2,
-                view_in_cards: true,
-            },
-            {
-                name: "property_date",
-                string: "My Date",
-                type: "date",
-                value: "2023-06-05",
-                view_in_cards: true,
-            },
-            {
-                name: "property_datetime",
-                string: "My Datetime",
-                type: "datetime",
-                value: "2023-06-05 11:05:00",
-                view_in_cards: true,
-            },
-            {
-                name: "property_checkbox",
-                string: "My Checkbox",
-                type: "boolean",
-                value: true,
-                view_in_cards: true,
-            },
-        ],
+        properties: {
+            property_integer: 12,
+            property_float: 12.2,
+            property_date: "2023-06-05",
+            property_datetime: "2023-06-05 11:05:00",
+            property_checkbox: true,
+        },
         company_id: 37,
     });
+    ResCompany._records[0].definitions.push(
+        {
+            name: "property_integer",
+            string: "My Integer",
+            type: "integer",
+            view_in_cards: true,
+        },
+        {
+            name: "property_float",
+            string: "My Float",
+            type: "float",
+            view_in_cards: true,
+        },
+        {
+            name: "property_date",
+            string: "My Date",
+            type: "date",
+            view_in_cards: true,
+        },
+        {
+            name: "property_datetime",
+            string: "My Datetime",
+            type: "datetime",
+            view_in_cards: true,
+        },
+        {
+            name: "property_checkbox",
+            string: "My Checkbox",
+            type: "boolean",
+            view_in_cards: true,
+        }
+    );
 
     await mountView({
         type: "kanban",
@@ -1717,8 +1689,7 @@ test("properties: default value", async () => {
     await animationFrame();
     await closePopover();
 
-    const newProperty = queryFirst(".o_field_properties .o_property_field:nth-child(3)");
-    expect(queryFirst(".o_property_field_value input", { root: newProperty })).toHaveValue(
+    expect(".o_field_properties .o_property_field:last .o_property_field_value input").toHaveValue(
         "First Default Value"
     );
 
@@ -1743,7 +1714,7 @@ test("properties: default value", async () => {
 
         expect(queryFirst(".o_property_field_value input", { root: property })).toHaveValue("");
     };
-    await checkProperty(newProperty);
+    await checkProperty(".o_field_properties .o_property_field:last");
     const existingProperty = queryFirst(".o_field_properties .o_property_field:nth-child(1)");
     await checkProperty(existingProperty);
 });
@@ -1835,6 +1806,8 @@ test("properties: close property popover once clicked on delete icon", async () 
  * In that case, some properties start without the flag "definition_deleted".
  */
 test("properties: form view and falsy domain, properties are not empty", async () => {
+    ResCompany._records[0].definitions.splice(1, 1);
+
     onRpc("has_access", () => true);
     await mountView({
         type: "form",
@@ -1890,6 +1863,8 @@ test("properties: form view and falsy domain, properties are not empty", async (
  * In that case, all properties start with the flag "definition_deleted".
  */
 test("properties: form view and falsy domain, properties are empty", async () => {
+    ResCompany._records[0].definitions = [];
+
     onRpc("has_access", () => true);
     await mountView({
         type: "form",
@@ -2478,28 +2453,12 @@ test.tags("desktop")("properties: onChange return new properties", async () => {
 });
 
 test("new property, change record, change property type", async () => {
-    const records = Partner._records;
-    records[0].properties = [];
-    records[1].properties = [];
+    for (const record of Partner._records) {
+        record.properties = {};
+    }
+    ResCompany._records[0].definitions = [];
+
     onRpc("has_access", () => true);
-    onRpc("web_save", ({ args }) => {
-        if (args[0][0] === 1) {
-            // On property creation in first record, add a copy with empty value in
-            // second record
-            records[1].properties.push({
-                ...args[1].properties[0],
-            });
-            records[1].properties[0].value = "";
-        } else {
-            // When changing type of second record's properties, also apply it to
-            // first record and the property's value should be reset on name change
-            records[0].properties[0].type = args[1].properties[0].type;
-            if (records[0].properties[0].name !== args[1].properties[0].name) {
-                records[0].properties[0].value = null;
-            }
-            records[0].properties[0].name = args[1].properties[0].name;
-        }
-    });
 
     await mountView({
         type: "form",

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -123,7 +123,7 @@ class Foo extends models.Model {
             amount: 1200,
             currency_id: 2,
             reference: "bar,1",
-            properties: [],
+            properties: {},
         },
         {
             id: 2,
@@ -135,7 +135,7 @@ class Foo extends models.Model {
             m2m: [1, 2, 3],
             amount: 500,
             reference: "res.currency,1",
-            properties: [],
+            properties: {},
         },
         {
             id: 3,
@@ -147,7 +147,7 @@ class Foo extends models.Model {
             m2m: [],
             amount: 300,
             reference: "res.currency,2",
-            properties: [],
+            properties: {},
         },
         {
             id: 4,
@@ -158,7 +158,7 @@ class Foo extends models.Model {
             m2o: 1,
             m2m: [1],
             amount: 0,
-            properties: [],
+            properties: {},
         },
     ];
 }
@@ -14959,7 +14959,7 @@ test(`Properties: char`, async () => {
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: "CHAR" }];
+            record.properties = { [definition.name]: "CHAR" };
         }
     }
 
@@ -15006,7 +15006,7 @@ test(`Properties: boolean`, async () => {
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: true }];
+            record.properties = { [definition.name]: true };
         }
     }
 
@@ -15049,7 +15049,7 @@ test(`Properties: integer`, async () => {
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: 123 }];
+            record.properties = { [definition.name]: 123 };
         }
     }
 
@@ -15096,7 +15096,7 @@ test(`Properties: float`, async () => {
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: record.id === 4 ? false : 123.45 }];
+            record.properties = { [definition.name]: record.id === 4 ? false : 123.45 };
         }
     }
 
@@ -15143,7 +15143,7 @@ test(`Properties: date`, async () => {
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: "2022-12-12" }];
+            record.properties = { [definition.name]: "2022-12-12" };
         }
     }
 
@@ -15187,7 +15187,7 @@ test(`Properties: datetime`, async () => {
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: "2022-12-12 12:12:00" }];
+            record.properties = { [definition.name]: "2022-12-12 12:12:00" };
         }
     }
 
@@ -15239,7 +15239,7 @@ test(`Properties: selection`, async () => {
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: "b" }];
+            record.properties = { [definition.name]: "b" };
         }
     }
 
@@ -15287,7 +15287,7 @@ test(`Properties: tags`, async () => {
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: ["a", "c"] }];
+            record.properties = { [definition.name]: ["a", "c"] };
         }
     }
 
@@ -15339,7 +15339,7 @@ test(`Properties: many2one`, async () => {
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: [1, "USD"] }];
+            record.properties = { [definition.name]: [1, "USD"] };
         }
     }
 
@@ -15384,7 +15384,7 @@ test(`Properties: many2many`, async () => {
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: [[1, "USD"]] }];
+            record.properties = { [definition.name]: [[1, "USD"]] };
         }
     }
 
@@ -15422,9 +15422,9 @@ test(`multiple sources of properties definitions`, async () => {
     Bar._records[1].definitions = [definition1];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition0, value: "0" }];
+            record.properties = { [definition0.name]: "0" };
         } else if (record.m2o === 2) {
-            record.properties = [{ ...definition1, value: true }];
+            record.properties = { [definition1.name]: true };
         }
     }
 
@@ -15467,9 +15467,12 @@ test(`toggle properties`, async () => {
     Bar._records[1].definitions = [definition1, definition2];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition0, value: "0" }];
+            record.properties = { [definition0.name]: "0" };
         } else if (record.m2o === 2) {
-            record.properties = [definition1, { ...definition2, value: true }];
+            record.properties = {
+                [definition1.name]: false,
+                [definition2.name]: true,
+            };
         }
     }
 
@@ -15512,7 +15515,7 @@ test(`properties: optional show/hide (no config in local storage)`, async () => 
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: "0" }];
+            record.properties = { [definition.name]: "0" };
         }
     }
 
@@ -15541,7 +15544,7 @@ test(`properties: optional show/hide (config from local storage)`, async () => {
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: "0" }];
+            record.properties = { [definition.name]: "0" };
         }
     }
 
@@ -15576,7 +15579,7 @@ test(`properties: optional show/hide (at reload, config from local storage)`, as
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: "0" }];
+            record.properties = { [definition.name]: "0" };
         }
     }
 
@@ -15622,7 +15625,7 @@ test(`reload properties definitions when domain change`, async () => {
     Bar._records[0].definitions = [definition0];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition0, value: "AA" }];
+            record.properties = { [definition0.name]: "AA" };
         }
     }
 
@@ -15669,7 +15672,7 @@ test(`do not reload properties definitions when page change`, async () => {
     Bar._records[0].definitions = [definition0];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition0, value: "0" }];
+            record.properties = { [definition0.name]: "0" };
         }
     }
 
@@ -15705,7 +15708,7 @@ test(`load properties definitions only once when grouped`, async () => {
     Bar._records[0].definitions = [definition0];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition0, value: "0" }];
+            record.properties = { [definition0.name]: "0" };
         }
     }
 
@@ -15742,7 +15745,7 @@ test(`Invisible Properties`, async () => {
     Bar._records[0].definitions = [definition];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition, value: 123 }];
+            record.properties = { [definition.name]: 123 };
         }
     }
 
@@ -16215,7 +16218,7 @@ test(`properties do not disappear after domain change`, async () => {
     Bar._records[0].definitions = [definition0];
     for (const record of Foo._records) {
         if (record.m2o === 1) {
-            record.properties = [{ ...definition0, value: "AA" }];
+            record.properties = { [definition0.name]: "AA" };
         }
     }
 

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -150,14 +150,9 @@ class Partner extends models.Model {
             company_type: "individual",
             ref: "product,41",
             parent_id: 1,
-            properties: [
-                {
-                    name: "my_char",
-                    string: "My Char",
-                    type: "char",
-                    value: "aaa",
-                },
-            ],
+            properties: {
+                my_char: "aaa",
+            },
         },
         {
             id: 3,
@@ -170,14 +165,9 @@ class Partner extends models.Model {
             company_type: "company",
             ref: "customer,1",
             parent_id: 1,
-            properties: [
-                {
-                    name: "my_char",
-                    string: "My Char",
-                    type: "char",
-                    value: "bbb",
-                },
-            ],
+            properties: {
+                my_char: "bbb",
+            },
         },
         {
             id: 4,


### PR DESCRIPTION
This commit allows the mock server to properly handle 'property' and
'property_definition' fields in tests.

Enterprise: https://github.com/odoo/enterprise/pull/73851
Task: [4058174](https://www.odoo.com/odoo/project.task/4058174)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
