### PR TITLE
[FIX] account: autoinstall matching coa

### DIFF
--- a/addons/account/models/ir_module.py
+++ b/addons/account/models/ir_module.py
@@ -65,13 +65,13 @@ class IrModule(models.Model):
         is_installed = len(self) == 1 and self.state == 'installed'
         if (
             not was_installed and is_installed
+            and self.env.company.country_id.id
             and not self.env.company.chart_template
             and self.account_templates
             and (guessed := next((
                 tname
                 for tname, tvals in self.account_templates.items()
-                if tvals['country_id'] == self.env.company.country_id.id
-                or not tvals['country_id']
+                if tvals['country_id'] == self.env.company.country_id.id or tname == 'generic_coa'
             ), None))
         ):
             def try_loading(env):


### PR DESCRIPTION
When new modules with coas are being installed, the matching coa based on country is autoinstalled if possible, but if multiple charts match then we overwrite the autoinstall and use the one from the last module.
Here we make sure we do not overwrite the chart if it is not associated with the company's country.

Using a chart not associated with any country (except generic_coa) during module installation will result in failure.
Problem is reproduced on:
1- CI when any syscohada module is installed
2- start a new db and do not set a country on your company, then try installing any syscohada module




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
