### PR TITLE
[FIX] account: add syscebnl to uninstallable coas

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -13492,7 +13492,7 @@ msgstr ""
 #: code:addons/account/models/chart_template.py:0
 #, python-format
 msgid ""
-"The Syscohada chart template shouldn't be selected directly. Instead, you "
+"The %s chart template shouldn't be selected directly. Instead, you "
 "should directly select the chart template related to your country."
 msgstr ""
 

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -149,8 +149,8 @@ class AccountChartTemplate(models.AbstractModel):
 
         template_code = template_code or company and self._guess_chart_template(company.country_id)
 
-        if template_code == 'syscohada' and template_code != company.chart_template:
-            raise UserError(_("The Syscohada chart template shouldn't be selected directly. Instead, you should directly select the chart template related to your country."))
+        if template_code in {'syscohada', 'syscebnl'} and template_code != company.chart_template:
+            raise UserError(_("The %s chart template shouldn't be selected directly. Instead, you should directly select the chart template related to your country.", template_code))
 
         return self._load(template_code, company, install_demo)
 


### PR DESCRIPTION
Raise an error when the user tries to load syscebnl template the same way we block syscohada, as those templates should not be used directly.

chart added in https://github.com/odoo/odoo/pull/166211

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
