### PR TITLE
[FIX] project_account: display project updates using custom analytic plan

### DIFF
--- a/addons/project_account/models/project_project.py
+++ b/addons/project_account/models/project_project.py
@@ -139,7 +139,7 @@ class Project(models.Model):
     def _get_domain_aal_with_no_move_line(self):
         """ this method is used in order to overwrite the domain in sale_timesheet module. Since the field 'project_id' is added to the "analytic line" model
         in the hr_timesheet module, we can't add the condition ('project_id', '=', False) here. """
-        return [('account_id', '=', self.analytic_account_id.id), ('move_line_id', '=', False), ('category', '!=', 'manufacturing_order')]
+        return [('auto_account_id', '=', self.analytic_account_id.id), ('move_line_id', '=', False), ('category', '!=', 'manufacturing_order')]
 
     def _get_items_from_aal(self, with_action=True):
         domain = self._get_domain_aal_with_no_move_line()

--- a/addons/project_account/tests/test_project_profitability.py
+++ b/addons/project_account/tests/test_project_profitability.py
@@ -85,3 +85,29 @@ class TestProjectAccountProfitability(TestProjectProfitabilityCommon):
             },
             'The profitability data of the project should return the total amount for the revenues and costs from tha AAL of the account of the project.'
         )
+
+    def test_project_profitability_with_custom_analytic_account_plan(self):
+        plan = self.env['account.analytic.plan'].create({'name': 'Custom Plan'})
+        project = self.env['project.project'].create({'name': 'Project'})
+        project._create_analytic_account()
+        project.analytic_account_id.update({'plan_id': plan.id})
+
+        self.env['account.analytic.line'].create({
+            'name': 'Cost',
+            plan._column_name(): project.analytic_account_id.id,
+            'amount': -100,
+        })
+
+        self.assertDictEqual(
+            project._get_profitability_items(False)['costs'],
+            {
+                'data': [{
+                    'id': 'other_costs_aal',
+                    'sequence': project._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
+                    'billed': -100.0,
+                    'to_bill': 0.0,
+                }],
+                'total': {'billed': -100.0, 'to_bill': 0.0},
+            },
+            'Lines from different analytic plans should count towards project profitability'
+        )


### PR DESCRIPTION
Steps to reproduce:
- Install Accounting > Settings > Enable 'Analytic Accounting'
- Project App > New > Project Settings > Edit Analytic plan
- Change Plan from 'Projects' to any other (except Internal)
- Manufacturing > Operations > Manufacturing Orders > New
- Product: 'Table Top'
- Miscellaneous tab > Analytic distribution: <Project account>
- Confirm > Produce All > Set quantities & Validate
- Project > ':' Menu > Project Updates (Dashboard in 18.0+)
- The cost of materials ($160) is not deducted in Project costs

Analytic distributions include different categories for each plan, this is reflected in DB with a different column for each plan, account_id/x_plan2_id/x_plan3_id/... which contain the project's analytic account. In version 18.0 and above we allow each project to have several analytic accounts (for the project, department, ...) but prior to that we relied on plan_id to differentiate the project account category.

When checking for analytic lines to populate the project updates we check the `account_id`, meaning only lines with projects having analytic plan 'Projects' would pass that filter domain. We instead want to grab the account_id from any of the plan columns.

opw-4282092

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
