### PR TITLE
[IMP] core: Model.partitionned

### DIFF
--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -604,6 +604,23 @@ class TestAPI(SavepointCaseWithUserDemo):
         )
 
     @mute_logger('odoo.models')
+    def test_80_partition(self):
+        """ Check partition on recordsets. """
+        ps = self.partners
+        customers = ps.browse([p.id for p in ps if p.employee])
+        others = ps - customers
+
+        # partition on a single field
+        self.assertEqual(ps.partitionned(lambda p: p.employee), (customers, others))
+        self.assertEqual(ps.partitionned('employee'), (customers, others))
+
+        # partition on a sequence of fields
+        self.assertEqual(
+            ps.partitionned(lambda p: p.parent_id.employee),
+            ps.partitionned('parent_id.employee')
+        )
+
+    @mute_logger('odoo.models')
     def test_80_map(self):
         """ Check map on recordsets. """
         ps = self.partners

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -6430,6 +6430,24 @@ class BaseModel(metaclass=MetaModel):
                 return self.browse(rec.id for rec in self if rec[func])
         return self.browse(rec.id for rec in self if func(rec))
 
+    def partitionned(self, func) -> tuple[Self, Self]:
+        """Return the records in ``self`` satisfying and not satisfying ``func``.
+
+        :param func: a function or a dot-separated sequence of field names
+        :type func: callable or str
+        :return: tuple of recordsets satisfying func and not satisfying func
+
+        .. code-block:: python3
+
+            # keep records whose company is the current user's and others
+            records.partitionned(lambda r: r.company_id == user.company_id)
+
+            # only keep records whose partner is a company
+            real_records, new_records = records.partitionned("id")
+        """
+        truthy = self.filtered(func)
+        return truthy, self - truthy
+
     def grouped(self, key):
         """Eagerly groups the records of ``self`` by the ``key``, returning a
         dict from the ``key``'s result to recordsets. All the resulting


### PR DESCRIPTION
Add a `partitionned` function similar to `filtered`, but returns both recordsets satisfying the condition and the ones not satisfying the conditions.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
