### PR TITLE
[FIX] sale_stock: Force to put our product to 'invoice on order'

### DIFF
--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -117,6 +117,16 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         and whatever other model there is in stock with "invoice on order" products
         """
         # let's cheat and put all our products to "invoice on order"
+        product_list = (
+                    self.company_data['product_order_no'],
+                    self.company_data['product_service_delivery'],
+                    self.company_data['product_service_order'],
+                    self.company_data['product_delivery_no'],
+                )
+
+        for product in product_list:
+            product.invoice_policy = 'order'
+
         self.so = self.env['sale.order'].create({
             'partner_id': self.partner_a.id,
             'partner_invoice_id': self.partner_a.id,
@@ -127,17 +137,10 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
                 'product_uom_qty': 2,
                 'product_uom': p.uom_id.id,
                 'price_unit': p.list_price,
-                }) for p in (
-                    self.company_data['product_order_no'],
-                    self.company_data['product_service_delivery'],
-                    self.company_data['product_service_order'],
-                    self.company_data['product_delivery_no'],
-                )],
+                }) for p in product_list],
             'pricelist_id': self.company_data['default_pricelist'].id,
             'picking_policy': 'direct',
         })
-        for sol in self.so.order_line:
-            sol.product_id.invoice_policy = 'order'
         # confirm our standard so, check the picking
         self.so.order_line._compute_product_updatable()
         self.assertTrue(self.so.order_line.sorted()[0].product_updatable)


### PR DESCRIPTION
The issue:
Before this commit, the product was intended to be set as 'invoice on order', but this wasn't applied. The status was overridden due to the '_compute_invoice_policy' function override in the 'l10n_ke_edi_oscu_stock' module, which caused the test to fail on runbot when this module is installed.

The fix:
Put the product to 'invoice on order' before creating the sale order

runbot-70731