### PR TITLE
[FIX] mail: handle name_addr formats when fnding, creating partners

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -6,6 +6,7 @@ from werkzeug.exceptions import NotFound
 
 from odoo import http
 from odoo.http import request
+from odoo.tools import email_normalize
 from odoo.addons.mail.models.discuss.mail_guest import add_guest_to_context
 from odoo.addons.mail.tools.discuss import Store
 
@@ -109,8 +110,12 @@ class ThreadController(http.Controller):
             post_data["body"] = Markup(post_data["body"])  # contains HTML such as @mentions
         new_partners = []
         if "partner_emails" in kwargs:
+            additional_values = {
+                email_normalize(email, strict=False) or email: values
+                for email, values in kwargs.get("partner_additional_values", {}).items()
+            }
             new_partners = [record.id for record in request.env["res.partner"]._find_or_create_from_emails(
-                kwargs["partner_emails"], kwargs.get("partner_additional_values", {})
+                kwargs["partner_emails"], additional_values
             )]
         post_data["partner_ids"] = list(set((post_data.get("partner_ids", [])) + new_partners))
         if "everyone" in special_mentions:

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -383,8 +383,11 @@ class TestMessageController(HttpCaseWithUserDemo):
                         "post_data": {
                             "body": "test",
                         },
-                        "partner_emails": ["john2@test.be"],
-                        "partner_additional_values": {"john2@test.be": {'phone': '123456789'}},
+                        "partner_emails": ["john2@test.be", "john3@test.be"],  # Both emails in one request
+                        "partner_additional_values": {
+                            "john2@test.be": {'phone': '123456789'},  # Original partner
+                            "john3 <john3@test.be>": {'phone': '987654321'}  # Name-Addr formatted partner
+                        },
                     },
                 }
             ),
@@ -395,6 +398,11 @@ class TestMessageController(HttpCaseWithUserDemo):
             1,
             self.env["res.partner"].search_count([('email', '=', "john2@test.be"), ('phone', '=', "123456789")]),
             "authenticated users can create a partner from an email from message_post",
+        )
+        self.assertEqual(
+            1,
+            self.env["res.partner"].search_count([('email', '=', "john3@test.be"), ('phone', '=', "987654321")]),
+            "additional_values should be handled correctly when using keys in name_addr format",
         )
         # should not create another partner with same email
         res6 = self.url_open(


### PR DESCRIPTION
Reproduce
---
- install crm
- enable leads
- create lead with: email, phone, contact name
- send email (that creates contact)
- BUG: phone not filled in the contact

note: email is only needed to send email thus create partner
note2: bug doens't happen without contact name

opw-4225694