### PR TITLE
[FIX] account,*: Declaration EDI are not triggered from subscription

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -164,7 +164,7 @@ class AccountMoveSend(models.TransientModel):
         }
 
     @api.model
-    def _get_wizard_vals_restrict_to(self, only_options):
+    def _get_wizard_vals_restrict_to(self, only_options, enforce_gov_edi=False):
         return {
             'checkbox_download': False,
             'checkbox_send_mail': False,

--- a/addons/account_edi_ubl_cii/wizard/account_move_send.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send.py
@@ -27,9 +27,9 @@ class AccountMoveSend(models.TransientModel):
         return values
 
     @api.model
-    def _get_wizard_vals_restrict_to(self, only_options):
+    def _get_wizard_vals_restrict_to(self, only_options, enforce_gov_edi=False):
         # EXTENDS 'account'
-        values = super()._get_wizard_vals_restrict_to(only_options)
+        values = super()._get_wizard_vals_restrict_to(only_options, enforce_gov_edi=enforce_gov_edi)
         return {
             'checkbox_ubl_cii_xml': False,
             **values,

--- a/addons/account_peppol/wizard/account_move_send.py
+++ b/addons/account_peppol/wizard/account_move_send.py
@@ -24,9 +24,9 @@ class AccountMoveSend(models.TransientModel):
         return values
 
     @api.model
-    def _get_wizard_vals_restrict_to(self, only_options):
+    def _get_wizard_vals_restrict_to(self, only_options, enforce_gov_edi=False):
         # EXTENDS 'account'
-        values = super()._get_wizard_vals_restrict_to(only_options)
+        values = super()._get_wizard_vals_restrict_to(only_options, enforce_gov_edi=enforce_gov_edi)
         return {
             'checkbox_send_peppol': False,
             **values,

--- a/addons/l10n_es_edi_facturae/wizard/account_move_send.py
+++ b/addons/l10n_es_edi_facturae/wizard/account_move_send.py
@@ -24,9 +24,9 @@ class AccountMoveSend(models.TransientModel):
         return values
 
     @api.model
-    def _get_wizard_vals_restrict_to(self, only_options):
+    def _get_wizard_vals_restrict_to(self, only_options, enforce_gov_edi=False):
         # EXTENDS 'account'
-        values = super()._get_wizard_vals_restrict_to(only_options)
+        values = super()._get_wizard_vals_restrict_to(only_options, enforce_gov_edi=enforce_gov_edi)
         return {
             'l10n_es_edi_facturae_checkbox_xml': False,
             **values,

--- a/addons/l10n_it_edi/wizard/account_move_send.py
+++ b/addons/l10n_it_edi/wizard/account_move_send.py
@@ -29,12 +29,12 @@ class AccountMoveSend(models.TransientModel):
         return values
 
     @api.model
-    def _get_wizard_vals_restrict_to(self, only_options):
+    def _get_wizard_vals_restrict_to(self, only_options, enforce_gov_edi=False):
         # EXTENDS 'account'
-        values = super()._get_wizard_vals_restrict_to(only_options)
+        values = super()._get_wizard_vals_restrict_to(only_options, enforce_gov_edi=enforce_gov_edi)
         return {
-            'l10n_it_edi_checkbox_xml_export': False,
-            'l10n_it_edi_checkbox_send': False,
+            'l10n_it_edi_checkbox_xml_export': enforce_gov_edi,
+            'l10n_it_edi_checkbox_send': enforce_gov_edi,
             **values,
         }
 

--- a/addons/snailmail_account/wizard/account_move_send.py
+++ b/addons/snailmail_account/wizard/account_move_send.py
@@ -23,9 +23,9 @@ class AccountMoveSend(models.TransientModel):
         return values
 
     @api.model
-    def _get_wizard_vals_restrict_to(self, only_options):
+    def _get_wizard_vals_restrict_to(self, only_options, enforce_gov_edi=False):
         # EXTENDS 'account'
-        values = super()._get_wizard_vals_restrict_to(only_options)
+        values = super()._get_wizard_vals_restrict_to(only_options, enforce_gov_edi=enforce_gov_edi)
         return {
             'checkbox_send_by_post': False,
             **values,


### PR DESCRIPTION
*: account_edi_ubl_cii,account_peppol,l10n_es_edi_facturae,l10n_it_edi,snailmail_account

Steps to reproduce:
- Install "l10n_mx" and switch to a Mexican company
- Assign a UNSPSC to a subscription product
- Create a new subscription with this product, select a monthly recurring plan
- Normally the next invoice date is today
- Now go in "Scheduled Actions" > "Sale Subscription: generate recurring invoices and payments" and run it manually
- When coming back to the subscription, click on the invoice The PDF is created but not the XML file

Cause:
Subscription uses the method `_get_wizard_vals_restrict_to(...)`. This methods sets all checkboxes of the wizard to false. This was originally made to avoid sending by default with Peppol.

Solution:
Add the possibility to enforce mandatory EDI that typically declare the invoice to the government.

opw-4230920
