### PR TITLE
[FIX] web: missing properties field definitions

### DIFF
--- a/addons/web/static/src/model/model.js
+++ b/addons/web/static/src/model/model.js
@@ -192,3 +192,39 @@ export function useModelWithSampleData(ModelClass, params, options = {}) {
 
     return model;
 }
+
+export function _makeFieldFromPropertyDefinition(name, definition, relatedPropertyField) {
+    return {
+        ...definition,
+        name,
+        propertyName: definition.name,
+        relation: definition.comodel,
+        relatedPropertyField,
+    };
+}
+
+export async function addPropertyFieldDefs(orm, resModel, context, fields, groupBy) {
+    const proms = [];
+    for (const gb of groupBy) {
+        if (gb in fields) {
+            continue;
+        }
+        const [fieldName] = gb.split(".");
+        const field = fields[fieldName];
+        if (field?.type === "properties") {
+            proms.push(
+                orm
+                    .call(resModel, "get_property_definition", [gb], {
+                        context,
+                    })
+                    .then((definition) => {
+                        fields[gb] = _makeFieldFromPropertyDefinition(gb, definition, field);
+                    })
+                    .catch(() => {
+                        fields[gb] = _makeFieldFromPropertyDefinition(gb, {}, field);
+                    })
+            );
+        }
+    }
+    return Promise.all(proms);
+}

--- a/addons/web/static/src/search/utils/group_by.js
+++ b/addons/web/static/src/search/utils/group_by.js
@@ -23,10 +23,10 @@ export function getGroupBy(descr, fields) {
         throw Error();
     }
     if (fields) {
-        if (!fields[fieldName]) {
+        if (!fields[fieldName] && !fieldName.includes(".")) {
             throw Error(errorMsg(descr));
         }
-        const fieldType = fields[fieldName].type;
+        const fieldType = fields[fieldName]?.type;
         if (["date", "datetime"].includes(fieldType)) {
             if (!interval) {
                 interval = DEFAULT_INTERVAL;

--- a/addons/web/static/src/views/pivot/pivot_model.js
+++ b/addons/web/static/src/views/pivot/pivot_model.js
@@ -5,7 +5,7 @@ import { Domain } from "@web/core/domain";
 import { cartesian, sections, sortBy, symmetricalDifference } from "@web/core/utils/arrays";
 import { KeepLast, Race } from "@web/core/utils/concurrency";
 import { DEFAULT_INTERVAL } from "@web/search/utils/dates";
-import { Model } from "@web/model/model";
+import { addPropertyFieldDefs, Model } from "@web/model/model";
 import { computeReportMeasures, processMeasure } from "@web/views/utils";
 
 /**
@@ -734,6 +734,13 @@ export class PivotModel extends Model {
             ...allActivesMeasures,
         ]);
         const config = { metaData, data: this.data };
+        await addPropertyFieldDefs(
+            this.orm,
+            metaData.resModel,
+            searchParams.context,
+            metaData.fields,
+            new Set([...metaData.rowGroupBys, ...metaData.colGroupBys])
+        );
         return this._loadData(config);
     }
     /**

--- a/addons/web/static/tests/views/pivot_view_tests.js
+++ b/addons/web/static/tests/views/pivot_view_tests.js
@@ -3678,7 +3678,7 @@ QUnit.module("Views", (hooks) => {
             '["Foo","Foo","Foo"]',
             // origin headers
             '["November 2016","December 2016","Variation","November 2016","December 2016"' +
-            ',"Variation","November 2016","December 2016","Variation"]',
+                ',"Variation","November 2016","December 2016","Variation"]',
             // number of 'measures'
             "1",
             // number of 'origins'
@@ -5773,5 +5773,94 @@ QUnit.module("Views", (hooks) => {
             },
         });
         assert.verifySteps([`[]`, `["date:month"]`, `["date:month"]`, `["date:month"]`]);
+    });
+
+    QUnit.test("missing property field definition is fetched", async function (assert) {
+        await makeView({
+            type: "pivot",
+            resModel: "partner",
+            serverData,
+            arch: `<pivot/>`,
+            irFilters: [
+                {
+                    user_id: [2, "Mitchell Admin"],
+                    name: "My Filter",
+                    id: 5,
+                    context: `{"group_by": ['properties.my_char']}`,
+                    sort: "[]",
+                    domain: "[]",
+                    is_default: true,
+                    model_id: "partner",
+                    action_id: false,
+                },
+            ],
+            mockRPC(_, { method, kwargs }) {
+                if (method === "read_group" && kwargs.groupby?.includes("properties.my_char")) {
+                    assert.step(JSON.stringify(kwargs.groupby));
+                    return [
+                        {
+                            "properties.my_char": false,
+                            __domain: [["properties.my_char", "=", false]],
+                            __count: 2,
+                        },
+                        {
+                            "properties.my_char": "aaa",
+                            __domain: [["properties.my_char", "=", "aaa"]],
+                            __count: 1,
+                        },
+                    ];
+                } else if (method === "get_property_definition") {
+                    return {
+                        name: "my_char",
+                        type: "char",
+                    };
+                }
+            },
+        });
+        assert.verifySteps([`["properties.my_char"]`]);
+        assert.strictEqual(getCurrentValues(target), "4,2,1");
+    });
+
+    QUnit.test("missing deleted property field definition is created", async function (assert) {
+        await makeView({
+            type: "pivot",
+            resModel: "partner",
+            serverData,
+            arch: `<pivot/>`,
+            irFilters: [
+                {
+                    user_id: [2, "Mitchell Admin"],
+                    name: "My Filter",
+                    id: 5,
+                    context: `{"group_by": ['properties.my_char']}`,
+                    sort: "[]",
+                    domain: "[]",
+                    is_default: true,
+                    model_id: "partner",
+                    action_id: false,
+                },
+            ],
+            mockRPC(_, { method, kwargs }) {
+                if (method === "read_group" && kwargs.groupby?.includes("properties.my_char")) {
+                    assert.step(JSON.stringify(kwargs.groupby));
+                    return [
+                        {
+                            "properties.my_char": false,
+                            __domain: [["properties.my_char", "=", false]],
+                            __count: 2,
+                        },
+                        {
+                            "properties.my_char": "aaa",
+                            __domain: [["properties.my_char", "=", "aaa"]],
+                            __count: 1,
+                        },
+                    ];
+                } else if (method === "get_property_definition") {
+                    return {};
+                }
+            },
+        });
+        assert.verifySteps([`["properties.my_char"]`]);
+        assert.strictEqual(getCurrentValues(target), "4,2,1");
     });
 });


### PR DESCRIPTION
We fix a problem occuring in pivot and graph views. Have a property like properties.441515 used somewhere as groupby. If that property has not been added via the search bar menu, the corresponding (fake) field definition is not known (fillSearchViewItemsProperty has not been called). Thus in that case, a crash occurs because one tries to read info in the undefined field definition for instance.

This can happen in several ways:

- save a favorite with a property used somewhere (context.group_by or context.pivot_row_groupby for example), reload, apply the favorite -> crash.
- add the pivot or graph view to dashboard or to spreadsheet, (re)Load the dashboard or the spreadsheet -> crash.

We fix the problem by adding on the fly a fake field definition when the groupbys used by the views are known (i.e. when the view models are about to fetch the data).

Task ID: 4141824