### PR TITLE
[FIX] l10n_id_efaktur: visible code transaction field on invoice

### DIFF
--- a/addons/l10n_id_efaktur/views/account_move_views.xml
+++ b/addons/l10n_id_efaktur/views/account_move_views.xml
@@ -6,7 +6,7 @@
             <field name="model">account.move</field>
             <field name="inherit_id" ref="account.view_move_form"/>
             <field name="arch" type="xml">
-                <field name="partner_id" position="after">
+                <field name="partner_shipping_id" position="before">
                     <field name="l10n_id_need_kode_transaksi" invisible="1"/>
                     <field name="l10n_id_attachment_id" invisible="1"/>
                     <field name="l10n_id_kode_transaksi" invisible="country_code != 'ID' or not l10n_id_need_kode_transaksi" readonly="state in ['cancel', 'posted']" required="l10n_id_need_kode_transaksi"/>


### PR DESCRIPTION
Previously, the l10n_id_kode_transaksi field was invisible on the invoice form view.
This is because the xpath was incorrectly done. This solution is inspired to what is already done in 18.0.

Steps to reproduce:
 - Install l10n_id_efaktur
 - Select ID company
 - Create an Indonesian customer with a VAT number, and select boolean field PKP
 - Create an invoice, select this customer, and add a line with a tax

 -> the field below Customer has no display name, but the value is visible

opw-4315901


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
