### PR TITLE
[FIX] website_sale: fix layout shift in cart

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1530,13 +1530,29 @@
                  t-attf-class="o_cart_product d-flex align-items-stretch gap-3 #{line.linked_line_id and 'optional_product info'} #{not line_last and 'border-bottom pb-4'} #{line_index &gt; 0 and 'pt-4'}"
                  t-attf-data-product-id="#{line.product_id and line.product_id.id}">
                 <t t-if="line.product_id">
-                    <img t-if="line._is_not_sellable_line() and line.product_id.image_128"
-                         t-att-src="image_data_uri(line.product_id.image_128)"
-                         class="o_image_64_max  img rounded"
-                         t-att-alt="line.name_short"/>
-                    <div t-else=""
-                         t-field="line.product_id.image_128"
-                         t-options="{'widget': 'image', 'qweb_img_responsive': False, 'class': 'o_image_64_max rounded'}"/>
+                    <div style="width: 64px">
+                        <!--
+                            Unsellable lines can have unpublished products, but portal users have no
+                            access to unpublished product images. To ensure product images are
+                            always shown for unsellable lines, we use the raw image data as src
+                            (which doesn't require access, unlike the image URL).
+                        -->
+                        <img
+                            t-if="line._is_not_sellable_line() and line.product_id.image_128"
+                            t-att-src="image_data_uri(line.product_id.image_128)"
+                            class="o_image_64_max img rounded"
+                            t-att-alt="line.name_short"
+                        />
+                        <div
+                            t-else=""
+                            t-field="line.product_id.image_128"
+                            t-options="{
+                                'widget': 'image',
+                                'qweb_img_responsive': False,
+                                'class': 'o_image_64_max rounded',
+                            }"
+                        />
+                    </div>
                     <div class="flex-grow-1">
                         <t t-call="website_sale.cart_line_product_link">
                             <h6 t-field="line.name_short" class="d-inline align-top h6 fw-bold"/>
@@ -1688,7 +1704,7 @@
                      t-as="product"
                      t-attf-class="d-flex gap-3 #{not product_last and 'border-bottom pb-4'} #{product_index &gt; 0 and 'pt-4'}"
                      t-att-data-publish="product.website_published and 'on' or 'off'">
-                    <div>
+                    <div style="width: 64px">
                         <a t-att-href="product.website_url">
                             <span t-field="product.image_128" t-options="{'widget': 'image', 'qweb_img_responsive': False, 'class': 'o_image_64_max rounded'}"/>
                         </a>


### PR DESCRIPTION
Product images are lazy-loaded on the cart page, causing them to be displayed later than the rest of the page. As a result, some parts of the page were shifted once the image was loaded (since the image had no size before loading).

This change wraps the image in a fixed-size container to avoid the layout shift.

Incidentally, this change also fixes some alignment issues when the cart contains images with various aspect ratios.

opw-4029017