### PR TITLE
[FIX] pos_sale: prevent duplicate lines when applying down payment

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -210,9 +210,10 @@ patch(PosStore.prototype, {
     },
     async _createDownpaymentLines(sale_order, total_down_payment) {
         //This function will create all the downpaymentlines. We will create on downpayment line per unique tax combination
-        const grouped = Object.groupBy(sale_order.order_line, (ol) => {
-            return ol.tax_id.map((tax_id) => tax_id.id).sort((a, b) => a - b);
-        });
+        const grouped = Object.groupBy(
+            sale_order.order_line.filter((ol) => ol.product_id),
+            (ol) => ol.tax_id.map((tax_id) => tax_id.id).sort((a, b) => a - b)
+        );
         Object.keys(grouped).forEach(async (key) => {
             const group = grouped[key];
 
@@ -237,7 +238,7 @@ patch(PosStore.prototype, {
                 price_unit: new_price,
                 sale_order_origin_id: sale_order,
                 tax_ids: [["link", ...taxes_to_apply]],
-                down_payment_details: sale_order.order_line
+                down_payment_details: group
                     .filter(
                         (line) =>
                             line.product_id &&


### PR DESCRIPTION
Before this commit, if a sale order had some note lines and the rest of the lines had tax on them, there would be two lines created when applying a down payment.

opw-4281589

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
