### PR TITLE
[FIX] html_editor: add implicit dependencies (position and input)

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -58,7 +58,7 @@ import { withSequence } from "@html_editor/utils/resource";
  */
 
 export class DeletePlugin extends Plugin {
-    static dependencies = ["selection", "history"];
+    static dependencies = ["selection", "history", "input"];
     static id = "delete";
     static shared = ["deleteRange", "deleteSelection", "delete"];
     resources = {

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -34,7 +34,7 @@ function isFormatted(formatPlugin, format) {
 
 export class FormatPlugin extends Plugin {
     static id = "format";
-    static dependencies = ["selection", "history", "split"];
+    static dependencies = ["selection", "history", "input", "split"];
     // TODO ABD: refactor to handle Knowledge comments inside this plugin without sharing mergeAdjacentInlines.
     static shared = [
         "isSelectionFormat",

--- a/addons/html_editor/static/src/core/line_break_plugin.js
+++ b/addons/html_editor/static/src/core/line_break_plugin.js
@@ -12,7 +12,7 @@ import { DIRECTIONS, leftPos, rightPos } from "../utils/position";
  */
 
 export class LineBreakPlugin extends Plugin {
-    static dependencies = ["selection", "history", "delete"];
+    static dependencies = ["selection", "history", "input", "delete"];
     static id = "lineBreak";
     static shared = ["insertLineBreak", "insertLineBreakNode", "insertLineBreakElement"];
     resources = {

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -19,7 +19,7 @@ import { isProtected, isProtecting } from "@html_editor/utils/dom_info";
  */
 
 export class SplitPlugin extends Plugin {
-    static dependencies = ["selection", "history", "delete", "lineBreak"];
+    static dependencies = ["selection", "history", "input", "delete", "lineBreak"];
     static id = "split";
     static shared = [
         "splitBlock",

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -99,7 +99,7 @@ const handledElemSelector = [...headingTags, "PRE", "BLOCKQUOTE"].join(", ");
 
 export class FontPlugin extends Plugin {
     static id = "font";
-    static dependencies = ["split", "selection", "dom", "format"];
+    static dependencies = ["input", "split", "selection", "dom", "format"];
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -5,7 +5,7 @@ import { DIRECTIONS } from "@html_editor/utils/position";
 
 export class InlineCodePlugin extends Plugin {
     static id = "inlineCode";
-    static dependencies = ["selection", "history"];
+    static dependencies = ["selection", "history", "input"];
     resources = {
         input_handlers: this.onInput.bind(this),
     };

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -109,7 +109,7 @@ async function fetchInternalMetaData(url) {
 
 export class LinkPlugin extends Plugin {
     static id = "link";
-    static dependencies = ["dom", "history", "selection", "split", "lineBreak", "overlay"];
+    static dependencies = ["dom", "history", "input", "selection", "split", "lineBreak", "overlay"];
     // @phoenix @todo: do we want to have createLink and insertLink methods in link plugin?
     static shared = ["createLink", "insertLink", "getPathAsUrlCommand"];
     resources = {

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -33,7 +33,7 @@ function isListActive(listMode) {
 
 export class ListPlugin extends Plugin {
     static id = "list";
-    static dependencies = ["tabulation", "history", "split", "selection", "delete", "dom"];
+    static dependencies = ["tabulation", "history", "input", "split", "selection", "delete", "dom"];
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -40,7 +40,7 @@ import { omit, pick } from "@web/core/utils/objects";
 
 export class PowerButtonsPlugin extends Plugin {
     static id = "powerButtons";
-    static dependencies = ["selection", "localOverlay", "powerbox", "userCommand"];
+    static dependencies = ["selection", "position", "localOverlay", "powerbox", "userCommand"];
     resources = {
         layout_geometry_change_handlers: this.updatePowerButtons.bind(this),
         selectionchange_handlers: this.updatePowerButtons.bind(this),

--- a/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
@@ -8,7 +8,7 @@ import { Plugin } from "../../plugin";
 
 export class SearchPowerboxPlugin extends Plugin {
     static id = "searchPowerbox";
-    static dependencies = ["powerbox", "selection", "history"];
+    static dependencies = ["powerbox", "selection", "history", "input"];
     resources = {
         beforeinput_handlers: this.onBeforeInput.bind(this),
         input_handlers: this.onInput.bind(this),

--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_plugin.js
@@ -12,7 +12,7 @@ import { _t } from "@web/core/l10n/translation";
 
 export class CollaborationSelectionPlugin extends Plugin {
     static id = "collaborationSelection";
-    static dependencies = ["history", "collaborationOdoo", "localOverlay"];
+    static dependencies = ["history", "collaborationOdoo", "position", "localOverlay"];
     resources = {
         /** Handlers */
         collaboration_notification_handlers: this.handleCollaborationNotification.bind(this),

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -465,7 +465,7 @@ export function allowsParagraphRelatedElements(node) {
 
 export const phrasingContent = new Set(["#text", ...phrasingTagNames]);
 const flowContent = new Set([...phrasingContent, ...paragraphRelatedElements, "DIV", "HR"]);
-const listItem = new Set(["LI"]);
+export const listItem = new Set(["LI"]);
 
 const allowedContent = {
     BLOCKQUOTE: phrasingContent, // HTML spec: flow content

--- a/addons/html_editor/static/tests/dependencies.test.js
+++ b/addons/html_editor/static/tests/dependencies.test.js
@@ -1,0 +1,43 @@
+import { DeletePlugin } from "@html_editor/core/delete_plugin";
+import { FormatPlugin } from "@html_editor/core/format_plugin";
+import { InputPlugin } from "@html_editor/core/input_plugin";
+import { LineBreakPlugin } from "@html_editor/core/line_break_plugin";
+import { SplitPlugin } from "@html_editor/core/split_plugin";
+import { InlineCodePlugin } from "@html_editor/main/inline_code";
+import { LinkPlugin } from "@html_editor/main/link/link_plugin";
+import { ListPlugin } from "@html_editor/main/list/list_plugin";
+import { PositionPlugin } from "@html_editor/main/position_plugin";
+import { PowerButtonsPlugin } from "@html_editor/main/power_buttons_plugin";
+import { SearchPowerboxPlugin } from "@html_editor/main/powerbox/search_powerbox_plugin";
+import { CollaborationSelectionPlugin } from "@html_editor/others/collaboration/collaboration_selection_plugin";
+import { describe, expect, test } from "@odoo/hoot";
+
+describe("Implicit plugin dependencies", () => {
+    test("input as an implicit dependency", async () => {
+        for (const P of [
+            DeletePlugin,
+            FormatPlugin,
+            InlineCodePlugin,
+            LineBreakPlugin,
+            LinkPlugin,
+            ListPlugin,
+            SearchPowerboxPlugin,
+            SplitPlugin,
+        ]) {
+            // input dependency through the "beforeinput_handlers" and
+            // "input_handlers" resources. This dependency was added because the
+            // plugin is heavily dependent on inputs handling and will appear
+            // broken without the appropriate handlers.
+            expect(P.dependencies).toInclude(InputPlugin.id);
+        }
+    });
+    test("position as an implicit dependency", async () => {
+        for (const P of [PowerButtonsPlugin, CollaborationSelectionPlugin]) {
+            // position dependency through the "layout_geometry_change_handlers"
+            // resource. This dependency was added because the plugin is
+            // heavily dependent on layout changes and will appear broken
+            // without the appropriate handler.
+            expect(P.dependencies).toInclude(PositionPlugin.id);
+        }
+    });
+});

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
@@ -6,7 +6,7 @@ import { url } from "@web/core/utils/urls";
 
 export class MentionPlugin extends Plugin {
     static id = "mention";
-    static dependencies = ["overlay", "dom", "history", "selection"];
+    static dependencies = ["overlay", "dom", "history", "input", "selection"];
 
     resources = {
         beforeinput_handlers: this.onBeforeInput.bind(this),

--- a/addons/mail/static/tests/html_editor/editor_plugin_dependencies.test.js
+++ b/addons/mail/static/tests/html_editor/editor_plugin_dependencies.test.js
@@ -1,0 +1,15 @@
+import { InputPlugin } from "@html_editor/core/input_plugin";
+import { MentionPlugin } from "@mail/views/web/fields/html_composer_message_field/mention_plugin";
+import { describe, expect, test } from "@odoo/hoot";
+
+describe("Implicit plugin dependencies", () => {
+    test("position as an implicit dependency", async () => {
+        for (const P of [MentionPlugin]) {
+            // input dependency through the "beforeinput_handlers" and
+            // "input_handlers" resources. This dependency was added because the
+            // plugin is heavily dependent on inputs handling and will appear
+            // broken without the appropriate handlers.
+            expect(P.dependencies).toInclude(InputPlugin.id);
+        }
+    });
+});


### PR DESCRIPTION
`position_plugin` and `input_plugin` don't share methods, but they offer
features through resources that are pretty much essential for other plugins. In
these cases, it makes sense to add them as a dependency.

Knowledge `comments_plugins` needs a set of all nodes where it should be allowed
to insert a new comment. `LI` element is part of it, and therefore `listItem` is
exported for external use.

task-4331264