### PR TITLE
[IMP] base: streamlining command argparser, description, epilog

### DIFF
--- a/odoo/addons/base/tests/test_cli.py
+++ b/odoo/addons/base/tests/test_cli.py
@@ -45,6 +45,10 @@ class TestCommand(BaseCase):
             self.assertFalse('\n' in cmd.__doc__ or len(cmd.__doc__) > 120,
                 msg=f"Command {name}'s docstring format is invalid for 'odoo-bin help'")
 
+    def test_unknown_command(self):
+        command_output = self.run_command('bonbon', check=False).stderr.strip()
+        self.assertEqual(command_output, "Unknown command 'bonbon'")
+
     def test_help(self):
         expected = {
             'cloc',

--- a/odoo/cli/__init__.py
+++ b/odoo/cli/__init__.py
@@ -1,3 +1,2 @@
 # Import just the command, the rest will get imported as needed
 from .command import Command, main  # noqa: F401
-from .help import Help  # noqa: F401

--- a/odoo/cli/cloc.py
+++ b/odoo/cli/cloc.py
@@ -1,39 +1,35 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-import argparse
 import sys
-from pathlib import Path
 
 from odoo.tools import cloc, config
 from . import Command
 
+
 class Cloc(Command):
     """ Count lines of code per modules """
+
+    description = """
+        Odoo cloc is a tool to count the number of relevant lines written
+        in Python, Javascript or XML. This can be used as rough metric for
+        pricing maintenance of customizations.
+
+        It has two modes of operation, either by providing a path:
+
+            odoo-bin cloc -p module_path
+
+        Or by providing the name of a database:
+
+            odoo-bin --addons-path=dirs cloc -d database
+
+        In the latter mode, only the custom code is accounted for.
+    """
+
     def run(self, args):
-        parser = argparse.ArgumentParser(
-            prog=f'{Path(sys.argv[0]).name} {self.name}',
-            description="""\
-Odoo cloc is a tool to count the number of relevant lines written in
-Python, Javascript or XML. This can be used as rough metric for pricing
-maintenance of customizations.
-
-It has two modes of operation, either by providing a path:
-
-    odoo-bin cloc -p module_path
-
-Or by providing the name of a database:
-
-    odoo-bin cloc --addons-path=dirs -d database
-
-In the latter mode, only the custom code is accounted for.
-""",
-            formatter_class=argparse.RawDescriptionHelpFormatter
-        )
-        parser.add_argument('--database', '-d', dest="database", help="Database name")
-        parser.add_argument('--path', '-p', action='append', help="File or directory path")
-        parser.add_argument('--verbose', '-v', action='count', default=0)
-        opt, unknown = parser.parse_known_args(args)
+        self.parser.add_argument('--database', '-d', dest="database", help="Database name")
+        self.parser.add_argument('--path', '-p', action='append', help="File or directory path")
+        self.parser.add_argument('--verbose', '-v', action='count', default=0)
+        opt, unknown = self.parser.parse_known_args(args)
         if not opt.database and not opt.path:
-            parser.print_help()
+            self.parser.print_help()
             sys.exit()
         if ',' in opt.database:
             sys.exit("-d/--database has multiple database, please provide a single one")

--- a/odoo/cli/command.py
+++ b/odoo/cli/command.py
@@ -1,23 +1,43 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import argparse
 import contextlib
 import logging
 import sys
+from inspect import cleandoc
 from pathlib import Path
 
-import odoo.cli
+import odoo
 from odoo.modules import get_module_path, get_modules, initialize_sys_path
 
 commands = {}
 """All loaded commands"""
 
+PROG_NAME = Path(sys.argv[0]).name
+
 
 class Command:
     name = None
-    prog_name = Path(sys.argv[0]).name
+    description = None
+    epilog = None
+    _parser = None
 
     def __init_subclass__(cls):
         cls.name = cls.name or cls.__name__.lower()
         commands[cls.name] = cls
+
+    @property
+    def prog(self):
+        return f"{PROG_NAME} [--addons-path=PATH,...] {self.name}"
+
+    @property
+    def parser(self):
+        if not self._parser:
+            self._parser = argparse.ArgumentParser(
+                formatter_class=argparse.RawDescriptionHelpFormatter,
+                prog=self.prog,
+                description=cleandoc(self.description or self.__doc__ or ""),
+                epilog=cleandoc(self.epilog or ""),
+            )
+        return self._parser
 
 
 def load_internal_commands():
@@ -85,4 +105,4 @@ def main():
         o = command()
         o.run(args)
     else:
-        sys.exit('Unknown command %r' % (command,))
+        sys.exit(f"Unknown command {command_name!r}")

--- a/odoo/cli/db.py
+++ b/odoo/cli/db.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-import argparse
 import io
 import urllib.parse
 import sys
@@ -16,20 +14,19 @@ from ..tools import config
 
 eprint = partial(print, file=sys.stderr, flush=True)
 
+
 class Db(Command):
     """ Create, drop, dump, load databases """
     name = 'db'
-
-    def run(self, cmdargs):
-        """Command-line version of the database manager.
+    description = """
+        Command-line version of the database manager.
 
         Doesn't provide a `create` command as that's not useful. Commands are
         all filestore-aware.
-        """
-        parser = argparse.ArgumentParser(
-            prog=f'{Path(sys.argv[0]).name} {self.name}',
-            description=self.__doc__.strip()
-        )
+    """
+
+    def run(self, cmdargs):
+        parser = self.parser
         parser.add_argument('-c', '--config')
         parser.add_argument('-D', '--data-dir')
         parser.add_argument('--addons-path')

--- a/odoo/cli/deploy.py
+++ b/odoo/cli/deploy.py
@@ -1,18 +1,17 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-import argparse
 import os
 import requests
 import sys
 import tempfile
 import zipfile
-from pathlib import Path
 
 from . import Command
 
+
 class Deploy(Command):
     """Deploy a module on an Odoo instance"""
+
     def __init__(self):
-        super(Deploy, self).__init__()
+        super().__init__()
         self.session = requests.session()
 
     def deploy_module(self, module_path, url, login, password, db='', force=False):
@@ -61,10 +60,7 @@ class Deploy(Command):
             raise
 
     def run(self, cmdargs):
-        parser = argparse.ArgumentParser(
-            prog=f'{Path(sys.argv[0]).name} {self.name}',
-            description=self.__doc__
-        )
+        parser = self.parser
         parser.add_argument('path', help="Path of the module to deploy")
         parser.add_argument('url', nargs='?', help='Url of the server (default=http://localhost:8069)', default="http://localhost:8069")
         parser.add_argument('--db', dest='db', help='Database to use if server does not use db-filter.')

--- a/odoo/cli/genproxytoken.py
+++ b/odoo/cli/genproxytoken.py
@@ -1,10 +1,6 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-import argparse
-import os
 import secrets
 import sys
 import textwrap
-from pathlib import Path
 
 from passlib.hash import pbkdf2_sha512
 
@@ -21,13 +17,9 @@ class GenProxyToken(Command):
         return '-'.join(textwrap.wrap(token, split_size))
 
     def run(self, cmdargs):
-        parser = argparse.ArgumentParser(
-            prog=f'{Path(sys.argv[0]).name} {self.name}',
-            description=self.__doc__.strip()
-        )
-        parser.add_argument('-c', '--config', type=str, help="Specify an alternate config file")
-        parser.add_argument('--token-length', type=int, help="Token Length", default=16)
-        args, _ = parser.parse_known_args()
+        self.parser.add_argument('-c', '--config', type=str, help="Specify an alternate config file")
+        self.parser.add_argument('--token-length', type=int, help="Token Length", default=16)
+        args, _ = self.parser.parse_known_args()
         if args.config:
             config.rcfile = args.config
         token = self.generate_token(length=args.token_length)

--- a/odoo/cli/help.py
+++ b/odoo/cli/help.py
@@ -1,22 +1,23 @@
-from .command import Command, commands, load_addons_commands, load_internal_commands
+import textwrap
 
+from .command import PROG_NAME, Command, commands, load_addons_commands, load_internal_commands
 import odoo.release
 
 
 class Help(Command):
     """ Display the list of available commands """
 
-    template = """\
-usage: {prog_name} [--addons-path=PATH,...] <command> [...]
+    template = textwrap.dedent("""\
+        usage: {prog_name} [--addons-path=PATH,...] <command> [...]
 
-Odoo {version}
-Available commands:
+        Odoo {version}
+        Available commands:
 
-{command_list}
+        {command_list}
 
-Use '{prog_name} server --help' for regular server options.
-Use '{prog_name} <command> --help' for other individual commands options.
-"""
+        Use '{prog_name} server --help' for regular server options.
+        Use '{prog_name} <command> --help' for other individual commands options.
+    """)
 
     def run(self, args):
         load_internal_commands()
@@ -30,7 +31,7 @@ Use '{prog_name} <command> --help' for other individual commands options.
         command_list = "\n".join(f"    {name:<{padding}}{desc}" for name, desc in name_desc)
 
         print(Help.template.format(  # noqa: T201
-            prog_name=self.prog_name,
+            prog_name=PROG_NAME,
             version=odoo.release.version,
             command_list=command_list,
         ))

--- a/odoo/cli/neutralize.py
+++ b/odoo/cli/neutralize.py
@@ -1,8 +1,6 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
 import optparse
 import sys
-from pathlib import Path
 
 import odoo.modules.neutralize
 import odoo.sql_db
@@ -18,7 +16,7 @@ class Neutralize(Command):
 
     def run(self, args):
         parser = odoo.tools.config.parser
-        parser.prog = f'{Path(sys.argv[0]).name} {self.name}'
+        parser.prog = self.prog
         group = optparse.OptionGroup(parser, "Neutralize", "Neutralize the database specified by the `-d` argument.")
         group.add_option("--stdout", action="store_true", dest="to_stdout",
                          help="Output the neutralization SQL instead of applying it")

--- a/odoo/cli/obfuscate.py
+++ b/odoo/cli/obfuscate.py
@@ -1,4 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 import odoo
 import sys
 import optparse
@@ -134,6 +133,7 @@ class Obfuscate(Command):
 
     def run(self, cmdargs):
         parser = odoo.tools.config.parser
+        parser.prog = self.prog
         group = optparse.OptionGroup(parser, "Populate Configuration")
         group.add_option('--pwd', dest="pwd", default=False, help="Cypher password")
         group.add_option('--fields', dest="fields", default=False, help="List of table.columns to obfuscate/unobfuscate: table1.column1,table2.column1,table2.column2")

--- a/odoo/cli/populate.py
+++ b/odoo/cli/populate.py
@@ -1,9 +1,7 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
 import optparse
 import sys
 import time
-from pathlib import Path
 
 from . import Command
 import odoo
@@ -23,7 +21,7 @@ class Populate(Command):
 
     def run(self, cmdargs):
         parser = odoo.tools.config.parser
-        parser.prog = f'{Path(sys.argv[0]).name} {self.name}'
+        parser.prog = self.prog
         group = optparse.OptionGroup(parser, "Populate Configuration")
         group.add_option("--factors", dest="factors",
                          help="Comma separated list of factors for each model, or just a single factor."

--- a/odoo/cli/scaffold.py
+++ b/odoo/cli/scaffold.py
@@ -1,24 +1,25 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-import argparse
 import os
 import re
 import sys
-from pathlib import Path
 
 import jinja2
 
 from . import Command
 
+
 class Scaffold(Command):
     """ Generates an Odoo module skeleton. """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.epilog = "Built-in templates available are: %s" % ', '.join(
+            d for d in os.listdir(builtins())
+            if d != 'base'
+        )
+
     def run(self, cmdargs):
         # TODO: bash completion file
-        parser = argparse.ArgumentParser(
-            prog=f'{Path(sys.argv[0]).name} {self.name}',
-            description=self.__doc__,
-            epilog=self.epilog(),
-        )
+        parser = self.parser
         parser.add_argument(
             '-t', '--template', type=template, default=template('default'),
             help="Use a custom module template, can be a template name or the"
@@ -47,11 +48,6 @@ class Scaffold(Command):
             params=params,
         )
 
-    def epilog(self):
-        return "Built-in templates available are: %s" % ', '.join(
-            d for d in os.listdir(builtins())
-            if d != 'base'
-        )
 
 builtins = lambda *args: os.path.join(
     os.path.abspath(os.path.dirname(__file__)),

--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -16,7 +16,6 @@ import logging
 import os
 import re
 import sys
-from pathlib import Path
 
 from psycopg2.errors import InsufficientPrivilege
 
@@ -172,8 +171,10 @@ def main(args):
     rc = odoo.service.server.start(preload=config['db_name'], stop=stop)
     sys.exit(rc)
 
+
 class Server(Command):
     """Start the odoo server (default command)"""
+
     def run(self, args):
-        odoo.tools.config.parser.prog = f'{Path(sys.argv[0]).name} {self.name}'
+        odoo.tools.config.parser.prog = self.prog
         main(args)

--- a/odoo/cli/shell.py
+++ b/odoo/cli/shell.py
@@ -4,7 +4,6 @@ import optparse
 import os
 import signal
 import sys
-from pathlib import Path
 
 import odoo
 from odoo.modules.registry import Registry
@@ -56,11 +55,11 @@ class Shell(Command):
     supported_shells = ['ipython', 'ptpython', 'bpython', 'python']
 
     def init(self, args):
-        config.parser.prog = f'{Path(sys.argv[0]).name} {self.name}'
+        config.parser.prog = self.prog
 
         group = optparse.OptionGroup(config.parser, "Shell options")
         group.add_option(
-            '--shell-file', dest='shell_file', type='string', default='', my_default='',
+            '--shell-file', dest='shell_file', type='string', my_default='',
             help="Specify a python script to be run after the start of the shell. "
                  "Overrides the env variable PYTHONSTARTUP."
         )

--- a/odoo/cli/start.py
+++ b/odoo/cli/start.py
@@ -1,10 +1,7 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-import argparse
 import glob
 import itertools
 import os
 import sys
-from pathlib import Path
 
 import odoo
 from . import Command
@@ -24,18 +21,13 @@ class Start(Command):
         return [mod.split(os.path.sep)[-2] for mod in mods]
 
     def run(self, cmdargs):
-        odoo.tools.config.parser.prog = f'{Path(sys.argv[0]).name} {self.name}'
-        parser = argparse.ArgumentParser(
-            prog=f'{Path(sys.argv[0]).name} {self.name}',
-            description=self.__doc__.strip(),
-        )
-        parser.add_argument('--path', default=".",
+        odoo.tools.config.parser.prog = self.prog
+        self.parser.add_argument('--path', default=".",
             help="Directory where your project's modules are stored (will autodetect from current dir)")
-        parser.add_argument("-d", "--database", dest="db_name", default=None,
-                         help="Specify the database name (default to project's directory name")
+        self.parser.add_argument("-d", "--database", dest="db_name", default=None,
+            help="Specify the database name (default to project's directory name")
 
-
-        args, unknown = parser.parse_known_args(args=cmdargs)
+        args, _unknown = self.parser.parse_known_args(args=cmdargs)
 
         # When in a virtualenv, by default use it's path rather than the cwd
         if args.path == '.' and os.environ.get('VIRTUAL_ENV'):

--- a/odoo/cli/tsconfig.py
+++ b/odoo/cli/tsconfig.py
@@ -1,11 +1,7 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-import argparse
 import glob
 import json
 import os
 import re
-import sys
-from pathlib import Path
 
 from . import Command
 from odoo.modules.module import MANIFEST_NAMES
@@ -33,12 +29,8 @@ class TSConfig(Command):
                 modules.remove((name, path))
 
     def run(self, cmdargs):
-        parser = argparse.ArgumentParser(
-            prog=f'{Path(sys.argv[0]).name} {self.name}',
-            description=self.__doc__.strip()
-        )
-        parser.add_argument('--addons-path', type=str, nargs=1, dest="paths")
-        args = parser.parse_args(args=cmdargs)
+        self.parser.add_argument('--addons-path', type=str, nargs=1, dest="paths")
+        args = self.parser.parse_args(args=cmdargs)
 
         paths = list(map(self.clean_path, args.paths[0].split(',')))
         modules = {}

--- a/odoo/cli/upgrade_code.py
+++ b/odoo/cli/upgrade_code.py
@@ -39,6 +39,9 @@ from types import ModuleType
 from typing import Iterator
 
 ROOT = Path(__file__).parent.parent
+UPGRADE = ROOT / 'upgrade_code'
+AVAILABLE_EXT = ('.py', '.js', '.css', '.scss', '.xml', '.csv')
+
 
 try:
     import odoo.addons
@@ -55,13 +58,16 @@ except ImportError:
     import release
     from parse_version import parse_version
     class Command:
-        pass
+        """ Simplified version of the one in command.py, for standalone execution """
+        @property
+        def parser(self):
+            return argparse.ArgumentParser(
+                prog=Path(sys.argv[0]).name,
+                description=__doc__.replace('/odoo/upgrade_code', str(UPGRADE)),
+                formatter_class=argparse.RawDescriptionHelpFormatter,
+            )
     config = None
     initialize_sys_path = None
-
-
-UPGRADE = ROOT / 'upgrade_code'
-AVAILABLE_EXT = ('.py', '.js', '.css', '.scss', '.xml', '.csv')
 
 
 class FileAccessor:
@@ -169,18 +175,8 @@ def migrate(
 class UpgradeCode(Command):
     """ Rewrite the entire source code using the scripts found at /odoo/upgrade_code """
     name = 'upgrade_code'
-    prog_name = Path(sys.argv[0]).name
 
     def __init__(self):
-        self.parser = argparse.ArgumentParser(
-            prog=(
-                f"{self.prog_name} [--addons-path=PATH,...] {self.name}"
-                if config else
-                self.prog_name
-            ),
-            description=__doc__.replace('/odoo/upgrade_code', str(UPGRADE)),
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-        )
         group = self.parser.add_mutually_exclusive_group(required=True)
         group.add_argument(
             '--script',


### PR DESCRIPTION
Refactored all Commands to have a `self.parser` without having to manually instantiate one.

Command descriptions shown on their single command's help improved:
- refactored to Command class
- used `inspect.cleandoc` to have a better output.

Commands' parsers are now all given `Command.epilog` which defaults to None but can be overridden by subclasses.

Reviewed some useless imports and license messages that got in the way.

Task [link](https://www.odoo.com/odoo/project/1364/tasks/4350863)
task-4350863