### PR TITLE
[FIX] website: fix issues with logout page

### DIFF
--- a/addons/test_website/models/website.py
+++ b/addons/test_website/models/website.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import fields, models
 
 
 class Website(models.Model):
     _inherit = "website"
+
+    some_translatable_field = fields.Char(string="A translatable field",
+                                          translate=True, default='something')
 
     def _search_get_details(self, search_type, order, options):
         result = super()._search_get_details(search_type, order, options)

--- a/addons/test_website/tests/test_session.py
+++ b/addons/test_website/tests/test_session.py
@@ -4,6 +4,7 @@ from lxml import html
 from unittest.mock import patch
 
 from odoo import http
+from odoo.addons.website.models.website import Website
 import odoo.tests
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
@@ -47,6 +48,22 @@ class TestWebsiteSession(HttpCaseWithUserDemo):
             res.raise_for_status()
         self.assertEqual(res.status_code, 303)
         self.assertTrue(res.next.path_url.startswith("/web/login/totp"))
+
+    def test_04_ensure_website_get_cached_values_can_be_called(self):
+        session = self.authenticate('portal', 'portal')
+
+        # Force a browser language that is not installed
+        session.context['lang'] = 'fr_MC'
+        http.root.session_store.save(session)
+
+        # Disable cache in order to make sure that values would be fetched at any time
+        get_cached_values_without_cache = Website._get_cached_values.__cache__.method
+        with patch.object(Website, '_get_cached_values',
+                          side_effect=get_cached_values_without_cache, autospec=True):
+
+            # ensure that permissions on logout are OK
+            res = self.url_open('/web/session/logout')
+            self.assertEqual(res.status_code, 200)
 
     def test_branding_cache(self):
         def has_branding(html_text):

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -30,6 +30,7 @@ from odoo.addons.http_routing.models.ir_http import slug, slugify, _guess_mimety
 from odoo.addons.portal.controllers.portal import pager as portal_pager
 from odoo.addons.portal.controllers.web import Home
 from odoo.addons.web.controllers.binary import Binary
+from odoo.addons.web.controllers.session import Session
 from odoo.addons.website.tools import get_base_domain
 
 logger = logging.getLogger(__name__)
@@ -949,6 +950,14 @@ class Website(Home):
                     return action_res
 
         return request.redirect('/')
+
+
+class WebsiteSession(Session):
+
+    # Force auth='public', required for logout
+    @http.route(auth="public")
+    def logout(self, *args, **kw):
+        return super().logout(*args, **kw)
 
 
 class WebsiteBinary(Binary):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1460,6 +1460,20 @@ class Website(models.Model):
     @tools.ormcache('self.id')
     def _get_cached_values(self):
         self.ensure_one()
+        # ir.http:_match is called by ir.http:_serve_db at a time when the
+        # environment hasn't been completely initialized (i.e. before the method
+        # ir.http:_authenticate is called by ir.http:_serve_ir_http), and its
+        # context language hasn't been checked against activated languages yet.
+
+        # Inside ir.http:_match, the http_routing module is trying to retrieve
+        # the default language via _get_default_lang, which is overridden by the
+        # website module and calls website._get_cached('default_lang_id'), which
+        # eventually calls this method.
+
+        # Here, we manually prefetch the needed fields only to avoid prefetching
+        # any translatable field, such as contact_us_button_url by website_sale,
+        # as translating to an invalid language would result in an error.
+        self.fetch(['user_id', 'company_id', 'default_lang_id', 'homepage_url'])
         return {
             'user_id': self.user_id.id,
             'company_id': self.company_id.id,


### PR DESCRIPTION
The website module overrides `ir.http:_get_default_lang`, which is called by `http_routing`'s override of `ir.http:_match`.
In this override, it calls `website:_get_cached('default_lang_id')` which calls `website:_get_cached_values`.

However, `ir.http:_match` is called at a time when the environment hasn't been completely initialized (it will be properly initialized when `ir.http:_authenticate` is called), and its context language hasn't been checked against activated languages yet.

This means that `website:_get_cached_values` cannot rely on this language. The first of the two bugs fixed by this commit happens when website has translatable fields. When reading data from the website, the ORM does a prefetch and tries to load this other field, but fails because the language of the context is invalid. The fix is to prefetch manually the four fields that are not translatable and that we want to cache.

The second bug happens specifically on the logout page, which is set as `auth='none'` by the web module. The website module already overrides the `/web/login` route to set it as `auth='public'` in order to be able to read the website. We need to do the same with the /web/session/logout route, so that the page renders properly.

This commit targets saas-17.2 as the first branch because it is fixing two bugs that were introduced as follows, as determined by a git bisect.
- in a3a3650 from #112000 (saas-17.1), the call to /web/session/logout fails with a 500 status (IndexError) because rule.endpoint.routing has no 'no_db' key, in '_serve_ir_http'.
- in 584a172 from #112000 too (saas-17.1), that code is removed, and the error is now a 403 status because it is not possible to read website records without a user. This error is fixed by adding user='public' to the logout route.
- since d01302b from #151502 (saas-17.2), the test added in this commit could reproduce the error in _get_cached_values by accessing the logout route.

As the saas-17.1 is already EOL, we target saas-17.2 and forward-port it to master.

[OPW-3721341](https://www.odoo.com/odoo/project.task/3721341)
[OPW-3911437](https://www.odoo.com/odoo/project.task/3911437)