### PR TITLE
[FIX] sale: Fix price unit on downpayment line on the sale order when change currency on the invoice

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -79,6 +79,8 @@ class AccountMove(models.Model):
             try:
                 dpl.price_unit = dpl._get_downpayment_line_price_unit(real_invoices)
                 dpl.tax_id = dpl.invoice_lines.tax_ids
+                if self.currency_id != dpl.currency_id:
+                    dpl.price_unit = self.currency_id._convert(dpl.price_unit, dpl.currency_id, self.company_id, self.invoice_date or fields.Date.today())
             except UserError:
                 # a UserError here means the SO was locked, which prevents changing the taxes
                 # just ignore the error - this is a nice to have feature and should not be blocking


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When generating a downpayment invoice from a sales order and changing the currency on the invoice, the unit price of the downpayment line was incorrectly adjusted to match the invoice currency's unit price. This caused inconsistencies because the unit price should respect the original sales order's currency and apply the appropriate exchange rate.

**Current behavior before PR:**
The unit price on the downpayment line is recalculated directly in the invoice currency without considering the sales order currency. This results in incorrect amounts because the value is not converted using the applicable exchange rate, leading to discrepancies between the sales order and the invoice.

**Desired behavior after PR is merged:**
The unit price on the downpayment line will be correctly adjusted based on the applicable currency exchange rate when the invoice currency is changed.

**Steps to reproduce the issue:**
1- Create a Sales Order:
  Set the currency of the Sales Order to USD.
  Add a product with a unit price of 50 USD.
2- Generate an Advance Payment Invoice:
  Create a downpayment invoice for 10% of the Sales Order.
  The invoice will reflect an amount of 5 USD as the downpayment.
3- Change the Currency of the Invoice:
  Modify the currency of the invoice to EUR.
  Assume an exchange rate of 1 EUR = 1.52 USD.
  The downpayment amount in the invoice will now display 5 EUR, which corresponds to 7.64 USD.
4- Review the Sales Order price unit
  Go back to the Sales Order and check the price unit.

**Video** 
https://drive.google.com/file/d/1-EEkaSByrnQcEzmL9TRPcDuV3tLTr61C/view



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
