### PR TITLE
[IMP] l10n_es_edi_tbai: shorten if invoice_origin is too long

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_invoice.xml
+++ b/addons/l10n_es_edi_tbai/data/template_invoice.xml
@@ -107,7 +107,7 @@
             </CabeceraFactura>
             <DatosFactura t-if="is_emission">
                 <FechaOperacion t-if="invoice.delivery_date and format_date(invoice.invoice_date) != format_date(invoice.delivery_date)" t-out="format_date(invoice.delivery_date)"/>
-                <DescripcionFactura t-out="invoice.invoice_origin or 'manual'"/>
+                <DescripcionFactura t-out="invoice.invoice_origin and invoice.invoice_origin[:250] or 'manual'"/>
                 <DetallesFactura>
                     <IDDetalleFactura t-foreach="invoice_lines" t-as="line_values">
                         <t t-set="line" t-value="line_values['line']"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---17.0-esoriginlength-jco
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
