### PR TITLE
[FIX] website_blog: use author_name field on author snippet

### DIFF
--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -119,7 +119,7 @@
 <template id="website_blog.s_dynamic_snippet_template_author" name="Blog Post Author">
     <div t-if="blog_posts_post_author_active" class="s_blog_posts_post_author d-inline-flex align-items-center">
         <img class="o_avatar me-2 rounded-pill" t-attf-src="data:image/png;base64,{{record.author_avatar}}"/>
-        <span t-field="record.author_id.name"/>
+        <span t-field="record.author_name"/>
     </div>
 </template>
 


### PR DESCRIPTION
Author snippet previously used the author_id field on the blog post record which would run in to permission issues as public user. Used the already existing author_name field on the blog record which also seemed to be used in older versions of Odoo to bypass this permission issue.

opw-4330319
