### PR TITLE
[FIX] l10n_my_edi: Remove Sale Order info

### DIFF
--- a/addons/l10n_my_edi/data/my_ubl_templates.xml
+++ b/addons/l10n_my_edi/data/my_ubl_templates.xml
@@ -29,6 +29,8 @@
                 <cbc:UUID t-out="billing_reference_vals.get('uuid')"/>
             </t>
         </xpath>
+        <!-- MyInvois does not support order references, having one will cause issues -->
+        <xpath expr="//*[local-name()='OrderReference']" position="replace"/>
     </template>
 
     <!-- They are not using the same template at all, so we make a new one. They basically want the same data as supplier/customer party -->

--- a/addons/l10n_my_edi/tests/test_file_generation.py
+++ b/addons/l10n_my_edi/tests/test_file_generation.py
@@ -5,6 +5,7 @@ from freezegun import freeze_time
 from lxml import etree
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tools import cleanup_xml_node
 from odoo.tests import tagged
 
 NS_MAP = {
@@ -260,6 +261,26 @@ class L10nMyEDITestSubmission(AccountTestInvoicingCommon):
             'cac:BillingReference/cac:InvoiceDocumentReference/cbc:UUID',
             basic_invoice.l10n_my_edi_external_uuid,
         )
+
+    def test_05_invoice_with_so(self):
+        """
+        Ensure that an invoice linked to an SO will not contain this information in the xml.
+        """
+        basic_invoice = self.init_invoice(
+            'out_invoice', amounts=[100], currency=self.currency_data['currency']
+        )
+        basic_invoice.l10n_my_edi_external_uuid = '12345678912345678912345678'
+        basic_invoice.action_post()
+
+        vals = self.env['account.edi.xml.ubl_myinvois_my']._export_invoice_vals(basic_invoice.with_context(lang=basic_invoice.partner_id.lang))
+        # As we don't rely on the sale module, we'll provide the sale_order_id manually in the vals.
+        vals['vals']['sales_order_id'] = 'TEST/123'
+        xml_content = self.env['ir.qweb']._render(vals['main_template'], vals)
+        file = etree.tostring(cleanup_xml_node(xml_content), xml_declaration=True, encoding='UTF-8')
+        root = etree.fromstring(file)
+        # Check the invoice type to endure that it is marked as credit note.
+        node = root.xpath('cac:OrderReference', namespaces=NS_MAP)
+        self.assertEqual(node, [])
 
     def _assert_node_values(self, root, node_path, text, attributes=None):
         node = root.xpath(node_path, namespaces=NS_MAP)


### PR DESCRIPTION
The UBL file could contain SO or PO information if the invoice is linked to one.
The MyInvois platform does not support this information and return a validation error if it is provided.

This fix will update the template in order to
remove this information from the file.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
