### PR TITLE
[FIX] web: Fix the issue of Navbar flickering

### DIFF
--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -8,6 +8,7 @@ import { registry } from "@web/core/registry";
 import { useBus, useService } from "@web/core/utils/hooks";
 import { ActionContainer } from "./actions/action_container";
 import { NavBar } from "./navbar/navbar";
+import { browser } from "@web/core/browser/browser";
 
 import { Component, onMounted, useExternalListener, useState } from "@odoo/owl";
 
@@ -30,8 +31,10 @@ export class WebClient extends Component {
             );
         }
         this.localization = localization;
+        const storedAction = browser.sessionStorage.getItem("current_action");
+        const lastAction = JSON.parse(storedAction || "{}");
         this.state = useState({
-            fullscreen: false,
+            fullscreen: (lastAction && lastAction.target) || false,
         });
         this.title.setParts({ zopenerp: "Odoo" }); // zopenerp is easy to grep
         useBus(this.env.bus, "ROUTE_CHANGE", this.loadRouterState);


### PR DESCRIPTION
Users were facing an issue of flickering when trying to configure a newly created website. The reason behind this was that the target was decided after the web client was mounted. When the action target is evaluated (i.e., new, current, or fullscreen), the navbar was hidden based on the target and state of the webclient was getting updated using ACTION_MANAGER:UI-UPDATED event.

What if we already have current_action in browser.sessionStorage, in that case we should consider current_action.target first.

In this commit, the state of the web client is now set based on the current_action, if it is not available then we set fullscreen - false.

task-3050040




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
