### PR TITLE
[FIX] mail_mobile: empty tracking value

### DIFF
--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -72,15 +72,15 @@ class MailTracking(models.Model):
             })
         elif col_info['type'] == 'selection':
             values.update({
-                'old_value_char': initial_value and dict(col_info['selection']).get(initial_value, initial_value) or '',
-                'new_value_char': new_value and dict(col_info['selection'])[new_value] or ''
+                'old_value_char': initial_value and dict(col_info['selection']).get(initial_value, initial_value) or 'None',
+                'new_value_char': new_value and dict(col_info['selection'])[new_value] or 'None'
             })
         elif col_info['type'] == 'many2one':
             values.update({
                 'old_value_integer': initial_value and initial_value.id or 0,
                 'new_value_integer': new_value and new_value.id or 0,
-                'old_value_char': initial_value and initial_value.sudo().name_get()[0][1] or '',
-                'new_value_char': new_value and new_value.sudo().name_get()[0][1] or ''
+                'old_value_char': initial_value and initial_value.sudo().name_get()[0][1] or 'None',
+                'new_value_char': new_value and new_value.sudo().name_get()[0][1] or 'None'
             })
         else:
             tracked = False

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1142,8 +1142,8 @@ class MailCase(MockEmail):
             elif value_type == 'many2one':
                 self.assertEqual(tracking.old_value_integer, old_value and old_value.id or False)
                 self.assertEqual(tracking.new_value_integer, new_value and new_value.id or False)
-                self.assertEqual(tracking.old_value_char, old_value and old_value.display_name or '')
-                self.assertEqual(tracking.new_value_char, new_value and new_value.display_name or '')
+                self.assertEqual(tracking.old_value_char, old_value and old_value.display_name or 'None')
+                self.assertEqual(tracking.new_value_char, new_value and new_value.display_name or 'None')
             elif value_type == 'monetary':
                 self.assertEqual(tracking.old_value_monetary, old_value)
                 self.assertEqual(tracking.new_value_monetary, new_value)


### PR DESCRIPTION
Previously, in the mail message body, setting any tracking value to 'none' would result in an empty value instead of showing 'none'. This commit addresses the issue, ensuring 'none' is displayed as expected.

Task-4282534