### PR TITLE
[FIX] mail: empty tracking value

### DIFF
--- a/addons/mail/data/mail_templates_email_layouts.xml
+++ b/addons/mail/data/mail_templates_email_layouts.xml
@@ -63,7 +63,7 @@
 <div t-out="message.body" style="font-size: 13px;"/>
 <ul t-if="tracking_values">
     <t t-foreach="tracking_values" t-as="tracking">
-        <li><t t-out="tracking[0]"/>: <t t-out="tracking[1]"/> &#8594; <t t-out="tracking[2]"/></li>
+        <li><t t-out="tracking[0]"/>: <t t-if="tracking[1]" t-out="tracking[1]"/><em t-else="">None</em> &#8594; <t t-if="tracking[2]" t-out="tracking[2]"/><em t-else="">None</em></li>
     </t>
 </ul>
 <t class="o_signature">


### PR DESCRIPTION
Previously, in the mail message body, setting any tracking value to 'none' would result in an empty value instead of showing 'none'. This commit addresses the issue, ensuring 'none' is displayed as expected.

Task-4282534