### PR TITLE
[IMP] point_of_sale: disable excluded attributes in product configurator

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -129,7 +129,7 @@ class PosSession(models.Model):
     def _load_pos_data_models(self, config_id):
         return ['pos.config', 'pos.preset', 'resource.calendar.attendance', 'pos.order', 'pos.order.line', 'pos.pack.operation.lot', 'pos.payment', 'pos.payment.method', 'pos.printer',
             'pos.bill', 'res.company', 'account.tax', 'account.tax.group', 'product.template', 'product.product', 'pos.category', 'product.attribute', 'product.attribute.custom.value',
-            'product.template.attribute.line', 'product.template.attribute.value', 'product.combo', 'product.combo.item', 'res.users', 'res.partner', 'product.uom',
+            'product.template.attribute.line', 'product.template.attribute.value', 'product.template.attribute.exclusion', 'product.combo', 'product.combo.item', 'res.users', 'res.partner', 'product.uom',
             'decimal.precision', 'uom.uom', 'res.country', 'res.country.state', 'res.lang', 'product.pricelist', 'product.pricelist.item', 'product.category',
             'account.cash.rounding', 'account.fiscal.position', 'account.fiscal.position.tax', 'stock.picking.type', 'res.currency', 'pos.note', 'product.tag', 'ir.module.module']
 

--- a/addons/point_of_sale/models/product_attribute.py
+++ b/addons/point_of_sale/models/product_attribute.py
@@ -56,4 +56,17 @@ class ProductTemplateAttributeValue(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['attribute_id', 'attribute_line_id', 'product_attribute_value_id', 'price_extra', 'name', 'is_custom', 'html_color', 'image']
+        return ['attribute_id', 'attribute_line_id', 'product_attribute_value_id', 'price_extra', 'name', 'is_custom', 'html_color', 'image', 'exclude_for']
+
+class ProductTemplateAttributeExclusion(models.Model):
+    _name = 'product.template.attribute.exclusion'
+    _inherit = ['product.template.attribute.exclusion', 'pos.load.mixin']
+
+    @api.model
+    def _load_pos_data_domain(self, data):
+        loaded_product_tmpl_ids = list({p['id'] for p in data['product.template']})
+        return [('product_tmpl_id', 'in', loaded_product_tmpl_ids)]
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        return ['value_ids']

--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
@@ -4,21 +4,28 @@
     <t t-name="point_of_sale.RadioProductAttribute">
         <div class="configurator_radio" t-ref="root">
             <div class="d-flex flex-wrap gap-3">
-                <t t-foreach="values" t-as="value" t-key="value.id">
-                    <div class="attribute-name-cell form-check" t-att-class="{'ptav-not-available': value.excluded}">
-                        <input class="form-check-input radio-check" type="radio" t-model="state.attribute_value_ids" t-att-name="value.attribute_id.id"
-                                t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}" t-att-value="value.id"/>
-                        <label t-attf-for="{{ value.attribute_id.id }}_{{ value.id }}" class="form-check-label">
-                            <span t-esc="value.name"/>
+                <t t-foreach="props.attribute.values()" t-as="value" t-key="value.id">
+                    <div class="attribute-name-cell form-check">
+                        <input 
+                            type="radio"
+                            t-att-checked="value.id === props.selected.id"
+                            t-on-change="() => props.setSelected(value)"
+                            t-att-disabled="value.doHaveConflictWith(props.allSelectedValues)" 
+                            t-att-name="value.attribute_id.id"
+                            t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}"
+                            class="form-check-input radio-check"
+                        />
+                        <label t-attf-for="{{ value.attribute_id.id }}_{{ value.id }}">
+                            <span t-att-class="{ 'text-muted': value.doHaveConflictWith(props.allSelectedValues) }" t-esc="value.name"/>
+                            <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2">
+                                <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
+                                    <t t-esc="getFormatPriceExtra(value.price_extra)"/>
+                                </span>
+                            </div>
                         </label>
-                        <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2">
-                            <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
-                                <t t-esc="getFormatPriceExtra(value.price_extra)"/>
-                            </span>
-                        </div>
                     </div>
-                    <div t-if="value.id == state.attribute_value_ids and value.is_custom" class="custom-value-cell">
-                        <input class="custom_value form-control form-control-lg mt-2" type="text" t-model="state.custom_value"/>
+                    <div t-if="value.id == props.selected.id and value.is_custom" class="custom-value-cell">
+                        <input type="text" t-att-value="props.customValue" t-on-change="(e) => props.setCustomValue(e.target.value)" class="custom_value form-control form-control-lg mt-2" />
                     </div>
                 </t>
             </div>
@@ -28,15 +35,21 @@
     <t t-name="point_of_sale.PillsProductAttribute">
         <div class="configurator_radio" t-ref="root">
             <div class="d-flex flex-wrap gap-2">
-                <t t-foreach="values" t-as="value" t-key="value.id">
+                <t t-foreach="props.attribute.values()" t-as="value" t-key="value.id">
                     <div class="attribute-name-cell" t-att-class="{'ptav-not-available': value.excluded}">
-                        <input class="form-check-input d-none" type="radio" t-model="state.attribute_value_ids" t-att-name="value.attribute_id.id"
-                            t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}" t-att-value="value.id"/>
+                        <input 
+                            type="radio"
+                            t-att-checked="value.id === props.selected.id"
+                            t-on-change="() => props.setSelected(value)" 
+                            t-att-name="value.attribute_id.id" 
+                            t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}" 
+                            class="form-check-input d-none"
+                        />
                         <label
-                            t-attf-class="btn btn-secondary btn-lg lh-lg d-flex {{ value.id == state.attribute_value_ids ? 'active' : '' }}"
+                            t-attf-class="btn btn-secondary btn-lg lh-lg d-flex {{ value.id == props.selected.id ? 'active' : '' }}"
                             t-att-name="value.name"
                             t-attf-for="{{ value.attribute_id.id }}_{{ value.id }}">
-                            <span t-esc="value.name"/>
+                            <span t-att-class="{ 'text-muted': value.doHaveConflictWith(props.allSelectedValues) }" t-esc="value.name"/>
                             <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2">
                                 <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
                                     <t t-esc="getFormatPriceExtra(value.price_extra)"/>
@@ -44,8 +57,8 @@
                             </div>
                         </label>
                     </div>
-                    <div t-if="value.id == state.attribute_value_ids and value.is_custom" class="custom-value-cell">
-                        <input class="custom_value form-control form-control-lg mt-2" type="text" t-model="state.custom_value"/>
+                    <div t-if="value.id == props.selected.id and value.is_custom" class="custom-value-cell">
+                        <input type="text" t-att-value="props.customValue" t-on-change="(e) => props.setCustomValue(e.target.value)" class="custom_value form-control form-control-lg mt-2" />
                     </div>
                 </t>
             </div>
@@ -56,17 +69,19 @@
         <div>
             <t t-set="is_custom" t-value="false"/>
 
-            <select class="configurator_select form-select form-select-md" t-model="state.attribute_value_ids">
-                <option t-foreach="values" t-as="value" t-key="value.id" t-att-value="value.id" t-att-class="{'ptav-not-available': value.excluded}">
-                    <t t-set="is_custom" t-value="is_custom || (value.is_custom and value.id == state.attribute_value_ids)"/>
-                    <t t-esc="value.name"/>
-                    <t t-if="value.price_extra">
-                        <t t-esc="getFormatPriceExtra(value.price_extra)"/>
-                    </t>
-                </option>
+            <select class="configurator_select form-select form-select-md" t-on-change="(e) => this.onChange(e)">
+                <t t-foreach="props.attribute.values()" t-as="value" t-key="value.id">
+                    <option t-att-value="value.id" t-att-disabled="value.doHaveConflictWith(props.allSelectedValues)"  t-att-class="{'ptav-not-available': value.excluded}">
+                        <t t-set="is_custom" t-value="is_custom || (value.is_custom and value.id == props.selected.id)"/>
+                        <t t-esc="value.name"/>
+                        <t t-if="value.price_extra">
+                            <t t-esc="getFormatPriceExtra(value.price_extra)"/>
+                        </t>
+                    </option>
+                </t>
             </select>
 
-            <input class="custom_value form-control form-control-lg mt-2" t-if="is_custom" type="text" t-model="state.custom_value"/>
+            <input class="custom_value form-control form-control-lg mt-2" t-if="is_custom" type="text" t-att-value="props.customValue" t-on-change="(e) => props.setCustomValue(e.target.value)"/>
         </div>
     </t>
 
@@ -75,15 +90,23 @@
             <t t-set="is_custom" t-value="false"/>
 
             <ul class="color_attribute_list d-flex gap-3">
-                <li t-foreach="values" t-as="value" t-key="value.id" class="color_attribute_list_item">
-                    <t t-set="is_custom" t-value="is_custom || (value.is_custom and value.id == state.attribute_value_ids)"/>
+                <li t-foreach="props.attribute.values()" t-as="value" t-key="value.id" class="color_attribute_list_item">
+                    <t t-set="is_custom" t-value="is_custom || (value.is_custom and value.id == props.selected.id)"/>
                     <t t-set="img_style" t-value="value.image ? 'background:url(/web/image/product.template.attribute.value/' + value.id + '/image); background-size:cover;' : ''"/>
                     <t t-set="color_style" t-value="value.is_custom ? '' : 'background-color: ' + value.html_color" />
                     <span class="d-flex flex-row justify-content-center align-items-center">
-                        <label t-attf-class="configurator_color rounded-circle border position-relative {{ value.id == state.attribute_value_ids ? 'active border-3' : 'border-3 border-secondary' }}"
+                        <label t-attf-class="configurator_color rounded-circle border position-relative {{ value.id == props.selected.id ? 'active border-3' : 'border-3 border-secondary' }}"
                             t-att-class="{'ptav-not-available' : value.excluded}"
                             t-attf-style="{{ img_style or color_style }}" t-att-data-color="value.name">
-                            <input class="m-2 opacity-0" type="radio" t-model="state.attribute_value_ids" t-att-value="value.id" t-att-name="value.attribute_id.id"/>
+                            <input 
+                                type="radio"
+                                t-att-checked="value.id === props.selected.id"
+                                t-on-change="() => props.setSelected(value)"
+                                t-att-name="value.attribute_id.id"
+                                t-att-disabled="value.doHaveConflictWith(props.allSelectedValues)" 
+                                t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}"
+                                class="m-2 opacity-0" 
+                            />
                         </label>
                         <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2" t-att-class="{'ptav-not-available' : value.excluded}">
                             <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
@@ -94,24 +117,25 @@
                 </li>
             </ul>
 
-            <input class="custom_value form-control form-control-lg mt-2" t-if="is_custom" type="text" t-model="state.custom_value"/>
+            <input class="custom_value form-control form-control-lg mt-2" t-if="is_custom" type="text" t-att-value="props.customValue" t-on-change="(e) => props.setCustomValue(e.target.value)"/>
         </div>
     </t>
 
     <t t-name="point_of_sale.MultiProductAttribute">
         <div class="d-flex gap-2 flex-wrap">
-            <div t-foreach="values" t-as="value" t-key="value.id">
+            <div t-foreach="props.attribute.values()" t-as="value" t-key="value.id">
                 <input
                     class="form-check-input d-none"
                     type="checkbox"
                     t-attf-id="multi-{{value.id}}"
                     t-attf-name="multi-{{value.id}}"
-                    t-model="state.attribute_value_ids[value.id]"/>
+                    t-on-change="() => this.onChange(value)"
+                    />
                 <label
-                    t-attf-class="form-check-label btn btn-secondary btn-lg lh-lg d-flex {{ state.attribute_value_ids[value.id] === true ? 'active' : '' }}"
+                    t-attf-class="form-check-label btn btn-secondary btn-lg lh-lg d-flex {{ this.state.is_value_selected[value.id] === true ? 'active' : '' }}"
                     t-attf-name="multi-{{value.id}}"
                     t-attf-for="multi-{{value.id}}">
-                    <span t-esc="value.name"/>
+                    <span t-att-class="{ 'text-muted': value.doHaveConflictWith(props.allSelectedValues) }" t-esc="value.name"/>
                     <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2">
                         <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
                             <t t-esc="getFormatPriceExtra(value.price_extra)"/>
@@ -124,18 +148,33 @@
 
     <t t-name="point_of_sale.ProductConfiguratorPopup">
         <Dialog title.translate="Attribute selection">
-            <ProductInfoBanner productTemplate="this.state.productTemplate" product="this.state.product" />
+            <ProductInfoBanner productTemplate="props.productTemplate" product="this.product" />
             <div t-ref="input-area">
                 <div t-if="isArchivedCombination()" class="alert alert-warning mt-3">
-                    <span>This combination does not exist.</span>
+                    <span>This option or combination of options is not available</span>
                 </div>
-                <div t-foreach="this.props.productTemplate.attribute_line_ids" t-as="attributeLine" t-key="attributeLine.id" class="attribute mb-3">
-                    <div class="attribute_name mb-2 fw-bolder" t-esc="attributeLine.attribute_id.name"/>
-                    <RadioProductAttribute t-if="attributeLine.attribute_id.display_type === 'radio'" attributeLine="attributeLine"/>
-                    <PillsProductAttribute t-elif="attributeLine.attribute_id.display_type === 'pills'" attributeLine="attributeLine"/>
-                    <SelectProductAttribute t-elif="attributeLine.attribute_id.display_type === 'select'" attributeLine="attributeLine"/>
-                    <ColorProductAttribute t-elif="attributeLine.attribute_id.display_type === 'color'" attributeLine="attributeLine"/>
-                    <MultiProductAttribute t-elif="attributeLine.attribute_id.display_type === 'multi'" attributeLine="attributeLine"/>
+                <div t-foreach="this.attributes" t-as="attribute" t-key="attribute.id" class="attribute mb-3">
+                    <div class="attribute_name mb-2 fw-bolder" t-esc="attribute.attribute_id.name"/>
+                    <RadioProductAttribute t-if="attribute.attribute_id.display_type === 'radio'" attribute="attribute" 
+                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)" 
+                        customValue="this.state.attributes[attribute.attribute_id.id].custom_value" setCustomValue="setCustomValue(attribute)"
+                        allSelectedValues="this.selectedValues"/>
+                    <PillsProductAttribute t-elif="attribute.attribute_id.display_type === 'pills'" attribute="attribute" 
+                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)" 
+                        customValue="this.state.attributes[attribute.attribute_id.id].custom_value" setCustomValue="setCustomValue(attribute)"
+                        allSelectedValues="this.selectedValues"/>
+                    <SelectProductAttribute t-elif="attribute.attribute_id.display_type === 'select'" attribute="attribute" 
+                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)" 
+                        customValue="this.state.attributes[attribute.attribute_id.id].custom_value" setCustomValue="setCustomValue(attribute)"
+                        allSelectedValues="this.selectedValues"/>
+                    <ColorProductAttribute t-elif="attribute.attribute_id.display_type === 'color'" attribute="attribute" 
+                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)" 
+                        customValue="this.state.attributes[attribute.attribute_id.id].custom_value" setCustomValue="setCustomValue(attribute)"
+                        allSelectedValues="this.selectedValues"/>
+                    <MultiProductAttribute t-elif="attribute.attribute_id.display_type === 'multi'" attribute="attribute" 
+                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)" 
+                        customValue="this.state.attributes[attribute.attribute_id.id].custom_value" setCustomValue="setCustomValue(attribute)"
+                        allSelectedValues="this.selectedValues"/>
                 </div>
             </div>
             <t t-set-slot="footer">

--- a/addons/point_of_sale/static/src/app/models/product_template_attribute_line.js
+++ b/addons/point_of_sale/static/src/app/models/product_template_attribute_line.js
@@ -1,0 +1,14 @@
+import { registry } from "@web/core/registry";
+import { Base } from "./related_models";
+
+export class ProductTemplateAttributeLine extends Base {
+    static pythonModel = "product.template.attribute.line";
+
+    values() {
+        return this.product_template_value_ids;
+    }
+}
+
+registry
+    .category("pos_available_models")
+    .add(ProductTemplateAttributeLine.pythonModel, ProductTemplateAttributeLine);

--- a/addons/point_of_sale/static/src/app/models/product_template_attribute_value.js
+++ b/addons/point_of_sale/static/src/app/models/product_template_attribute_value.js
@@ -1,0 +1,27 @@
+import { registry } from "@web/core/registry";
+import { Base } from "./related_models";
+
+export class ProductTemplateAttributeValue extends Base {
+    static pythonModel = "product.template.attribute.value";
+
+    setup() {
+        super.setup(...arguments);
+    }
+
+    get exclusions() {
+        const values = this.models["product.template.attribute.value"].filter((value) =>
+            value.exclude_for.some(({ value_ids }) => value_ids.some(({ id }) => id === this.id))
+        );
+
+        return [...this.exclude_for.flatMap(({ value_ids }) => value_ids), ...values];
+    }
+
+    doHaveConflictWith(values) {
+        const excludedIds = values.map(({ id }) => id);
+        return this.exclusions.some(({ id }) => excludedIds.includes(id));
+    }
+}
+
+registry
+    .category("pos_available_models")
+    .add(ProductTemplateAttributeValue.pythonModel, ProductTemplateAttributeValue);

--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -40,7 +40,7 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
                 "Configurable Chair",
                 "1",
                 "11.0",
-                "Fabrics: Other: Custom Fabric, Metal, Red"
+                "Red, Metal, Fabrics: Other: Custom Fabric"
             ),
 
             // Orderlines with the same attributes should be merged
@@ -54,7 +54,7 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
                 "Configurable Chair",
                 "2",
                 "22.0",
-                "Fabrics: Other: Custom Fabric, Metal, Red"
+                "Red, Metal, Fabrics: Other: Custom Fabric"
             ),
 
             // Orderlines with different attributes shouldn't be merged
@@ -67,7 +67,7 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
                 "Configurable Chair",
                 "1",
                 "10.0",
-                "Leather, Metal, Blue"
+                "Blue, Metal, Leather"
             ),
 
             // Inactive variant attributes should not be displayed

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -117,7 +117,7 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
                 content: "validate the variant dialog (with default values)",
             },
             ProductScreen.selectedOrderlineHas("Desk Organizer"),
-            checkOrderChanges([{ name: "Desk Organizer (Leather, S)", quantity: 1 }]),
+            checkOrderChanges([{ name: "Desk Organizer (S, Leather)", quantity: 1 }]),
             ProductScreen.clickOrderButton(),
             {
                 ...Dialog.confirm(),


### PR DESCRIPTION
When configuring a product in POS, ensure that the chosen combination adheres to the attributes' exclusion rules.
