### PR TITLE
[FIX] web: notify user when a required field is left empty

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -539,7 +539,9 @@ export class Record extends DataPoint {
         this._savePoint = undefined;
         this._setEvalContext();
         this._invalidFields.clear();
-        this._closeInvalidFieldsNotification();
+        if (this._closeInvalidFieldsNotification) {
+            this._closeInvalidFieldsNotification();
+        }
         this._closeInvalidFieldsNotification = () => {};
         this._restoreActiveFields();
     }
@@ -1128,9 +1130,15 @@ export class Record extends DataPoint {
             return;
         }
         if (this.selected && this.model.multiEdit && !this._invalidFields.has(fieldName)) {
+            this._invalidFields.add(fieldName);
+
             await this.model.dialog.add(AlertDialog, {
                 body: _t("No valid record to save"),
                 confirm: async () => {
+                    await this.discard();
+                    this.switchMode("readonly");
+                },
+                dismiss: async () => {
                     await this.discard();
                     this.switchMode("readonly");
                 },

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -581,6 +581,9 @@ export class ListController extends Component {
             this.nextActionAfterMouseup = () => this.model.root.multiSave(editedRecord);
             return false;
         }
+        if (!editedRecord._checkValidity({ displayNotification: true })) {
+            return false;
+        }
         if (validSelectedRecords.length > 1) {
             const { isDomainSelected, selection } = this.model.root;
             return new Promise((resolve) => {


### PR DESCRIPTION
**Before this commit:**
In the list view, if a user clears a required many2many field and attempts to save the record, 
the record is saved without notifying the user about the invalid field.

**After this commit:**
Now, if a user clears a required field and tries to save the record, then the record does not get saved, 
and the user receives a notification indicating the field is invalid.

Task-3981155

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
