### PR TITLE
18.0 remove format table cells deso

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -297,16 +297,10 @@ export class FormatPlugin extends Plugin {
                     if (!formatSpec.isFormatted(tag, formatProps)) {
                         tag.after(node);
                         tag.remove();
-                        formatSpec.addStyle(
-                            getOrCreateSpan(node, inlineAncestors),
-                            formatProps
-                        );
+                        formatSpec.addStyle(getOrCreateSpan(node, inlineAncestors), formatProps);
                     }
                 } else if (formatName !== "fontSize" || formatProps.size !== undefined) {
-                    formatSpec.addStyle(
-                        getOrCreateSpan(node, inlineAncestors),
-                        formatProps
-                    );
+                    formatSpec.addStyle(getOrCreateSpan(node, inlineAncestors), formatProps);
                 }
             }
         }
@@ -335,7 +329,11 @@ export class FormatPlugin extends Plugin {
             }
         }
 
-        if (selectedNodes[0] && selectedNodes[0].textContent === "\u200B") {
+        if (
+            selectedNodes.length === 1 &&
+            selectedNodes[0] &&
+            selectedNodes[0].textContent === "\u200B"
+        ) {
             this.dependencies.selection.setCursorStart(selectedNodes[0]);
         } else if (selectedNodes.length) {
             const firstNode = selectedNodes[0];

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -207,7 +207,7 @@ export class ColorPlugin extends Plugin {
         }
 
         const selectedNodes =
-            mode === "backgroundColor"
+            mode === "backgroundColor" && color
                 ? selectionNodes.filter((node) => !closestElement(node, "table.o_selected_table"))
                 : selectionNodes;
 

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -149,7 +149,7 @@ export class ColorPlugin extends Plugin {
                 const hasAnySelectedNodeColor = (mode) => {
                     const nodes = this.dependencies.selection
                         .getTraversedNodes()
-                        .filter(isTextNode);
+                        .filter((n) => isTextNode(n) || n.classList.contains("o_selected_td"));
                     return hasAnyNodesColor(nodes, mode);
                 };
                 while (hasAnySelectedNodeColor(mode) && max > 0) {

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -735,4 +735,14 @@ describe("Toolbar", () => {
         expect(".btn[name='remove_format']").toHaveCount(1);
         expect(".btn[name='remove_format'].disabled").toHaveCount(0);
     });
+
+    test("Should remove background color of text within a fully selected table", async () => {
+        const { el } = await setupEditor(
+            `<table class="table table-bordered o_table o_selected_table"><tbody><tr><td class="o_selected_td"><p><font style="background-color: rgb(255, 0, 0);">[abc</font></p></td><td class="o_selected_td"><p><br></p></td></tr></tbody></table><p>]<br></p>`
+        );
+        await removeFormatClick();
+        expect(getContent(el)).toBe(
+            `<table class="table table-bordered o_table o_selected_table"><tbody><tr><td class="o_selected_td"><p>[abc</p></td><td class="o_selected_td"><p>\u200b</p></td></tr></tbody></table><p>]\u200b</p>`
+        );
+    });
 });

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -745,4 +745,14 @@ describe("Toolbar", () => {
             `<table class="table table-bordered o_table o_selected_table"><tbody><tr><td class="o_selected_td"><p>[abc</p></td><td class="o_selected_td"><p>\u200b</p></td></tr></tbody></table><p>]\u200b</p>`
         );
     });
+
+    test("Should remove background color of a table cell", async () => {
+        const { el } = await setupEditor(
+            `<table class="table table-bordered o_table o_selected_table"><tbody><tr><td style="background-color: rgb(255, 0, 0);" class="o_selected_td"><p>[<br></p></td><td style="background-color: rgb(255, 0, 0);" class="o_selected_td"><p>]<br></p></td></tr></tbody></table>`
+        );
+        await removeFormatClick();
+        expect(getContent(el)).toBe(
+            `<table class="table table-bordered o_table o_selected_table"><tbody><tr><td style="" class="o_selected_td"><p>[\u200b</p></td><td style="" class="o_selected_td"><p>]\u200b</p></td></tr></tbody></table>`
+        );
+    });
 });


### PR DESCRIPTION
Description of the issue this PR addresses:

I. Removing formatting on text with a background color inside a fully selected table triggers an infinite loop in `removeAllColor`. This happened because applying background color to selected table cells filtered out child nodes in each `<td>` to apply background color directly to the cell. However, this filtering should be skipped when there is no color to apply, such as when removing background color.

II. This PR fixes an issue where the background color of a table cell could not be removed when clearing formatting.

task-4333327

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
