### PR TITLE
[IMP] Remove sync from UI when going back to floorplan

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -2041,14 +2041,7 @@ export class PosStore extends Reactive {
             if (this._shouldLoadOrders()) {
                 try {
                     this.setLoadingOrderState(true);
-                    const orders = await this.getServerOrders();
-                    if (orders && orders.length > 0) {
-                        const message = _t(
-                            "%s orders have been loaded from the server. ",
-                            orders.length
-                        );
-                        this.notification.add(message);
-                    }
+                    await this.getServerOrders();
                 } finally {
                     this.setLoadingOrderState(false);
                     this.showScreen("TicketScreen");

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -8,15 +8,7 @@ import { NumberPopup } from "@point_of_sale/app/utils/input_popups/number_popup"
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { useService } from "@web/core/utils/hooks";
-import {
-    Component,
-    onMounted,
-    useRef,
-    useState,
-    onWillStart,
-    useEffect,
-    useExternalListener,
-} from "@odoo/owl";
+import { Component, onMounted, useRef, useState, useEffect, useExternalListener } from "@odoo/owl";
 import { ask } from "@point_of_sale/app/store/make_awaitable_dialog";
 import { loadImage } from "@point_of_sale/utils";
 import { getDataURLFromFile } from "@web/core/utils/urls";
@@ -241,8 +233,9 @@ export class FloorScreen extends Component {
         this.useResizeHook();
         onMounted(() => {
             this.pos.openOpeningControl();
+            this.pos.searchProductWord = "";
+            this.pos.unsetTable();
         });
-        onWillStart(this.onWillStart);
         useEffect(
             () => {
                 this.computeFloorSize();
@@ -359,10 +352,6 @@ export class FloorScreen extends Component {
             this.state.floorHeight = `${positionV}px`;
             this.state.floorWidth = `${positionH}px`;
         }
-    }
-    async onWillStart() {
-        this.pos.searchProductWord = "";
-        await this.pos.unsetTable();
     }
     get floorBackround() {
         return this.activeFloor.floor_background_image


### PR DESCRIPTION
- We don't wait anymore the server's response (from the call to `sync_from_ui`) when going to the floorplan.
- Remove useless toaster notification when going to the ticket screen.

task_id: 4329314




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
