### PR TITLE
[FIX] account: prevent error when resetting expense report to draft

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1800,7 +1800,7 @@ class AccountMoveLine(models.Model):
         other_aml = (other_aml_values or {}).get('aml')
         remaining_amount_curr = aml_values['amount_residual_currency']
         remaining_amount = aml_values['amount_residual']
-        company_currency = aml.company_currency_id
+        company_currency = aml.company_currency_id or self.env.company.currency_id
         currency = aml._get_reconciliation_aml_field_value('currency_id', shadowed_aml_values)
         account = aml._get_reconciliation_aml_field_value('account_id', shadowed_aml_values)
         has_zero_residual = company_currency.is_zero(remaining_amount)
@@ -2495,6 +2495,8 @@ class AccountMoveLine(models.Model):
                 amounts_list = []
                 exchange_max_date = date.min
                 for aml in involved_amls:
+                    if not aml.company_currency_id:
+                        continue
                     if not aml.company_currency_id.is_zero(aml.amount_residual):
                         exchange_lines_to_fix += aml
                         amounts_list.append({'amount_residual': aml.amount_residual})


### PR DESCRIPTION
When the user tries to reset the expense report to draft,
A traceback will appear.

Steps to reproduce the error:
- Go to Expenses > Configuration > Settings > Select Employee Expense Oustanding Account
- Create a new expense > Paid by: Company > Create Report > Submit to Manager >
  Approve > Post Journal Entries > Reset to Draft

Error:
```
File "/home/odoo/odoo/community/addons/account/models/account_move_line.py", line 1807, in _prepare_move_line_residual_amounts
    has_zero_residual = company_currency.is_zero(remaining_amount)
  File "/home/odoo/odoo/community/odoo/addons/base/models/res_currency.py", line 257, in is_zero
    self.ensure_one()
  File "/home/odoo/odoo/community/odoo/models.py", line 6196, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: res.currency()
```

https://github.com/odoo/odoo/blob/7ad6205ca901ed97a9728d5eec746b7b68e40c48/addons/account/models/account_move_line.py#L1803-L1806
Here, When ``company_currency`` is empty,
It will lead to the above traceback.

sentry-5988408651

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
