### PR TITLE
[FIX] web: list column widths: support width on button nodes

### DIFF
--- a/addons/web/static/src/views/list/column_width_hook.js
+++ b/addons/web/static/src/views/list/column_width_hook.js
@@ -212,7 +212,7 @@ function getWidthSpecs(columns) {
     return columns.map((column) => {
         let minWidth;
         let maxWidth;
-        if (column.options && column.attrs.width) {
+        if (column.attrs && column.attrs.width) {
             minWidth = maxWidth = parseInt(column.attrs.width.split("px")[0]);
         } else {
             let width;

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -78,7 +78,8 @@ export class ListArchParser {
                     type: "button",
                     id: buttonId++,
                 };
-                if (buttonGroup) {
+                const width = button.attrs.width;
+                if (buttonGroup && !width) {
                     buttonGroup.buttons.push(button);
                     buttonGroup.column_invisible = combineModifiers(
                         buttonGroup.column_invisible,
@@ -94,6 +95,10 @@ export class ListArchParser {
                         column_invisible: node.getAttribute("column_invisible"),
                     };
                     columns.push(buttonGroup);
+                    if (width) {
+                        buttonGroup.attrs = { width };
+                        buttonGroup = undefined;
+                    }
                 }
             } else if (node.tagName === "field") {
                 const fieldInfo = this.parseFieldNode(node, models, modelName);

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -221,7 +221,7 @@ export function processButton(node) {
     for (const { name, value } of node.attributes) {
         if (BUTTON_CLICK_PARAMS.includes(name)) {
             clickParams[name] = withDefault[name] ? withDefault[name](value) : value;
-        } else if (name === "data-hotkey") {
+        } else {
             attrs[name] = value;
         }
     }

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -719,6 +719,27 @@ test(`width computation: button columns don't have a max width`, async () => {
     expect(columnWidths[1]).toBeGreaterThan(330);
 });
 
+test(`width computation: button with width in arch`, async () => {
+    Foo._records = [];
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list>
+                <field name="foo"/>
+                <button string="choucroute"/>
+                <button icon="fa-heart" width="25px"/>
+                <button icon="fa-cog" width="59px"/>
+                <button icon="fa-list"/>
+                <button icon="fa-play"/>
+            </list>
+        `,
+    });
+
+    expect(getColumnWidths()).toEqual([40, 216, 216, 34, 68, 227]);
+});
+
 // freeze column widths
 test(`freeze widths: add first record`, async () => {
     Foo._records = []; // in this scenario, we start with no records

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -772,6 +772,29 @@ test(`list view with adjacent buttons with invisible modifier`, async () => {
     expect(`td button i.fa-exclamation`).toHaveCount(3);
 });
 
+test(`list view with adjacent buttons with width attribute`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list>
+                <field name="foo"/>
+                <button icon="fa-play"/>
+                <button icon="fa-heart" width="25px"/>
+                <button icon="fa-cog"/>
+                <button icon="fa-list"/>
+            </list>
+        `,
+    });
+    expect(`th:not(.o_list_record_selector)`).toHaveCount(4, {
+        message: "adjacent buttons with no width in the arch must be grouped in a single column",
+    });
+    expect(".o_data_row td:not(.o_list_record_selector):nth-child(3) .fa-play").toHaveCount(4);
+    expect(".o_data_row td:not(.o_list_record_selector):nth-child(4) .fa-heart").toHaveCount(4);
+    expect(".o_data_row td:not(.o_list_record_selector):nth-child(5) .fa-cog").toHaveCount(4);
+    expect(".o_data_row td:not(.o_list_record_selector):nth-child(5) .fa-list").toHaveCount(4);
+});
+
 test(`list view with icon buttons`, async () => {
     Foo._records.splice(1);
 

--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -339,6 +339,7 @@
             <rng:optional><rng:attribute name="aria-pressed"/></rng:optional>
             <rng:optional><rng:attribute name="display"/></rng:optional>
             <rng:optional><rng:attribute name="data-hotkey"/></rng:optional>
+            <rng:optional><rng:attribute name="width"/></rng:optional>
             <rng:zeroOrMore>
                 <rng:choice>
                     <rng:ref name="field" />


### PR DESCRIPTION
Before this commit, it was not possible to set the width attribute in a list view arch on `<button>` nodes. This commit allows it.

One difficulty was that there's already some magic around button columns. Indeed, adjacent buttons in the arch are gathered in a single column. This doesn't map well with the width logic, as we want to be able to define a width on a button, which will thus define the width of its column. This can only work if the button is alone in its column. For that reason, when a button has a width, we do not group it with its potential adjacent buttons.

Task~4307553

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
