### PR TITLE
[FIX] rating : remove one click rating behavior

### DIFF
--- a/addons/rating/controllers/main.py
+++ b/addons/rating/controllers/main.py
@@ -24,15 +24,10 @@ class Rating(http.Controller):
         if rate not in (1, 3, 5):
             raise ValueError(_("Incorrect rating: should be 1, 3 or 5 (received %d)"), rate)
 
-        rating, record_sudo = self._get_rating_and_record(token)
-
-        record_sudo.rating_apply(
-            rate,
-            rating=rating,
-            feedback=_('Customer rated %r.', record_sudo.display_name),
-            subtype_xmlid=None,
-            notify_delay_send=True,
-        )
+        # This route used to allow sending a rating with a GET, the
+        # feature proved incompatible with various email provider URL crawlers and
+        # has been removed.
+        rating, _record_sudo = self._get_rating_and_record(token)
 
         lang = rating.partner_id.lang or get_lang(request.env).code
         return request.env['ir.ui.view'].with_context(lang=lang)._render_template('rating.rating_external_page_submit', {

--- a/addons/test_mail_full/tests/test_rating.py
+++ b/addons/test_mail_full/tests/test_rating.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import lxml
 from datetime import datetime
 
+from odoo import http
 from odoo.addons.test_mail_full.tests.common import TestMailFullCommon
 from odoo.addons.test_mail_sms.tests.common import TestSMSRecipients
 from odoo.tests import tagged
@@ -169,10 +171,67 @@ class TestRatingPerformance(TestRatingCommon):
 class TestRatingRoutes(HttpCase, TestRatingCommon):
 
     def test_open_rating_route(self):
+        """
+        16.0 + expected behavior
+        1) Clicking on the smiley image triggers the /rate/<string:token>/<int:rate>
+        route should not update the rating of the record but simply redirect
+        to the feedback form
+        2) Customer interacts with webpage and submits FORM. Triggers /rate/<string:token>/submit_feedback
+        route. Should update the rating of the record with the data in the POST request
+        """
+        self.authenticate(None, None)  # set up session for public user
         access_token = self.record_rating._rating_get_access_token()
-        self.url_open(f"/rate/{access_token}/5")
 
+        # First round of clicking the URL and then submitting FORM data
+        response_click_one = self.url_open(f"/rate/{access_token}/5")
+        response_click_one.raise_for_status()
+
+        # there should be a form to post to validate the feedback and avoid one-click anyway
+        forms = lxml.html.fromstring(response_click_one.content).xpath('//form')
+        self.assertEqual(forms[0].get('method'), 'post')
+        self.assertEqual(forms[0].get('action', ''), f'/rate/{access_token}/submit_feedback')
+
+        # rating should not change, i.e. default values
         rating = self.record_rating.rating_ids
-        self.assertTrue(rating.consumed)
-        self.assertEqual(rating.rating, 5)
+        self.assertFalse(rating.consumed)
+        self.assertEqual(rating.rating, 0)
+        self.assertFalse(rating.feedback)
+        self.assertEqual(self.record_rating.rating_last_value, 0)
+
+        response_submit_one = self.url_open(
+            f"/rate/{access_token}/submit_feedback",
+            data={
+                "rate": 5,
+                "csrf_token": http.Request.csrf_token(self),
+                "feedback": "good",
+            }
+        )
+        response_submit_one.raise_for_status()
+
+        rating_post_submit_one = self.record_rating.rating_ids
+        self.assertTrue(rating_post_submit_one.consumed)
+        self.assertEqual(rating_post_submit_one.rating, 5)
+        self.assertEqual(rating_post_submit_one.feedback, "good")
         self.assertEqual(self.record_rating.rating_last_value, 5)
+
+        # Second round of clicking the URL and then submitting FORM data
+        response_click_two = self.url_open(f"/rate/{access_token}/1")
+        response_click_two.raise_for_status()
+        self.assertEqual(self.record_rating.rating_last_value, 5)  # should not be updated to 1
+
+        # check returned form
+        forms = lxml.html.fromstring(response_click_two.content).xpath('//form')
+        self.assertEqual(forms[0].get('method'), 'post')
+        self.assertEqual(forms[0].get('action', ''), f'/rate/{access_token}/submit_feedback')
+
+        response_submit_two = self.url_open(f"/rate/{access_token}/submit_feedback",
+                                        data={"rate": 1,
+                                              "csrf_token": http.Request.csrf_token(self),
+                                              "feedback": "bad job"})
+        response_submit_two.raise_for_status()
+
+        rating_post_submit_second = self.record_rating.rating_ids
+        self.assertTrue(rating_post_submit_second.consumed)
+        self.assertEqual(rating_post_submit_second.rating, 1)
+        self.assertEqual(rating_post_submit_second.feedback, "bad job")
+        self.assertEqual(self.record_rating.rating_last_value, 1)


### PR DESCRIPTION
### Context:
In its current form, the HTTP route using `/rate/<string:token>/<int:rate>`, that is used in URL links generated by emails asking for customer feedback, will have a "one-click write" behavior that commits the rating encoded in `<int:rate>`. So the record is already updated with the new value. Only then renders the feedback submit Form, where the user can change their preselected rating and leave a commentary before submitting it via a POST request.

Over the last years email providers and third party services will preemptively crawl URL in emails to verify if they are "dangerous" (e.g. Microsoft's Safe link and Defender fatures).
By doing so, the rating for the records will be set to the last clicked URL using the above HTTP route, without any input from a human user.

It will be creating a number of false positive or negative ratings that do not represent the real satisfaction of the surveyed customer.

### Proposed solution:
We are removing the implicit "one-click write" behavior of the route and favoring the Form submission expecting human input. This will increase the likelihood a given rating was the result of the customer clicking on the link and taking the time to leave a feedback, versus random inputs from URL bots.

### Future outlook:
With the ever-changing landscape of URL crawler bots, trying to develop counter measures to identify and flag bot behavior is possible, but would add immense overhead and maintenance cost of the code for an arguably minor feature, i.e. the customer can rate the ticket by just clicking the picture in the email.
Other methods to make these routes more resilient to URL crawlers might be revisited in the future, but for the short-term this seems like a sufficient solution to the unwanted behavior.

OPW-3411799
OPW-4292166

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
