### PR TITLE
[IMP] l10n_it_edi: simplify Fattura settings

### DIFF
--- a/addons/l10n_it_edi/__init__.py
+++ b/addons/l10n_it_edi/__init__.py
@@ -2,3 +2,7 @@
 
 from . import models
 from . import tools
+
+
+def _l10n_it_edi_create_param(env):
+    env['ir.config_parameter'].set_param('l10n_it_edi.proxy_user_edi_mode', 'prod')

--- a/addons/l10n_it_edi/__manifest__.py
+++ b/addons/l10n_it_edi/__manifest__.py
@@ -28,4 +28,5 @@ E-invoice implementation
         'data/account_invoice_demo.xml',
     ],
     'license': 'LGPL-3',
+    'post_init_hook': '_l10n_it_edi_create_param',
 }

--- a/addons/l10n_it_edi/i18n/it.po
+++ b/addons/l10n_it_edi/i18n/it.po
@@ -4,13 +4,12 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.1alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-17 09:50+0000\n"
-"PO-Revision-Date: 2024-01-15 23:04+0000\n"
+"POT-Creation-Date: 2024-12-16 16:01+0000\n"
+"PO-Revision-Date: 2024-12-16 16:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -19,12 +18,12 @@ msgstr ""
 #. module: l10n_it_edi
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.report_invoice_document
 msgid "<b>CIG: </b>"
-msgstr "<b>CIG: </b>"
+msgstr ""
 
 #. module: l10n_it_edi
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.report_invoice_document
 msgid "<b>CUP: </b>"
-msgstr "<b>CUP: </b>"
+msgstr ""
 
 #. module: l10n_it_edi
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.report_invoice_document
@@ -56,28 +55,10 @@ msgstr ""
 #. module: l10n_it_edi
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
 msgid ""
-"<span class=\"o_form_label\">\n"
-"                                Fattura Elettronica mode\n"
-"                            </span>\n"
-"                            <span class=\"fa fa-lg fa-building-o\" "
-"title=\"Values set here are company-specific.\"/>"
+"<span class=\"text-muted\">\n"
+"                                    By checking this box, I authorize Odoo to send and receive my invoices using the Sistema di Interscambio (SDI).\n"
+"                                </span>"
 msgstr ""
-"<span class=\"o_form_label\">\n"
-"                                Modalità fattura elettronica\n"
-"                            </span>\n"
-"                            <span class=\"fa fa-lg fa-building-o\" title=\"I "
-"valori indicati di seguito sono specifici per l'azienda.\"/>"
-
-#. module: l10n_it_edi
-#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
-msgid "<span class=\"o_form_label\">Allow Odoo to process invoices</span>"
-msgstr ""
-"<span class=\"o_form_label\">Consenti a Odoo di inviare le fatture</span>"
-
-#. module: l10n_it_edi
-#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
-msgid "A Demo service is in use."
-msgstr "È in uso un servizio demo"
 
 #. module: l10n_it_edi
 #: model:ir.model,name:l10n_it_edi.model_account_edi_proxy_client_user
@@ -104,19 +85,14 @@ msgstr ""
 "essere completati."
 
 #. module: l10n_it_edi
-#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
-msgid "An Official or Test service has been registered."
-msgstr "È già stato registrato un servizio ufficiale o di prova."
-
-#. module: l10n_it_edi
 #. odoo-python
 #: code:addons/l10n_it_edi/models/account_move.py:0
 msgid ""
 "An error occurred while downloading updates from the Proxy Server: "
 "(%(code)s) %(message)s"
 msgstr ""
-"Si è verificato un errore duranto il download degli aggiornamenti dal server "
-"proxy:"
+"Si è verificato un errore duranto il download degli aggiornamenti dal server"
+" proxy:"
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -147,15 +123,10 @@ msgid "Being Sent To SdI"
 msgstr "Invio all'SdI in corso"
 
 #. module: l10n_it_edi
-#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
-msgid "By checking this box, I accept that Odoo may process my invoices."
-msgstr "Selezionando questa casella, accetto che Odoo invii le mie fatture."
-
-#. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_cig
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_cig
 msgid "CIG"
-msgstr "CIG"
+msgstr ""
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -164,14 +135,14 @@ msgid ""
 "CIG/CUP fields of partner(s) are present, please fill out Origin Document "
 "Type field in the Electronic Invoicing tab."
 msgstr ""
-"Sono presenti i campi CIG/CUP dei partner, compilare il campo Tipo Documento "
-"Origine nella scheda Fatturazione elettronica."
+"Sono presenti i campi CIG/CUP dei partner, compilare il campo Tipo Documento"
+" Origine nella scheda Fatturazione elettronica."
 
 #. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_cup
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_cup
 msgid "CUP"
-msgstr "CUP"
+msgstr ""
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -179,8 +150,8 @@ msgstr "CUP"
 msgid ""
 "Cannot apply Reverse Charge to bills which contains both services and goods."
 msgstr ""
-"Impossibile applicare l'inversione contabile ad una fattura che contiene sia "
-"beni che servizi."
+"Impossibile applicare l'inversione contabile ad una fattura che contiene sia"
+" beni che servizi."
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -298,8 +269,8 @@ msgid "Dati Bollo"
 msgstr ""
 
 #. module: l10n_it_edi
-#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_config_settings__l10n_it_edi_demo_mode__demo
-msgid "Demo"
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
+msgid "Default Purchase Journal"
 msgstr ""
 
 #. module: l10n_it_edi
@@ -314,7 +285,14 @@ msgid "Destination Code must have between 6 and 7 characters."
 msgstr "Il codice destinatario deve avere 6/7 caratteri"
 
 #. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_edi_proxy_client_user__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move_send__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_ir_attachment__display_name
 #: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__display_name
 msgid "Display Name"
 msgstr "Nome visualizzato"
 
@@ -354,6 +332,11 @@ msgstr ""
 "elettronica:"
 
 #. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
+msgid "Fattura Electronica (FatturaPA)"
+msgstr ""
+
+#. module: l10n_it_edi
 #: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_partner__invoice_edi_format__it_edi_xml
 msgid "FatturaPA"
 msgstr ""
@@ -376,7 +359,14 @@ msgid "Fiscal code of your company"
 msgstr "Codice fiscale dell'azienda"
 
 #. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_edi_proxy_client_user__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move_send__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_ir_attachment__id
 #: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__id
 msgid "ID"
 msgstr ""
 
@@ -398,26 +388,8 @@ msgid ""
 "If one of Share Capital or Sole Shareholder is present, then they must be "
 "both filled out."
 msgstr ""
-"Se uno fra Capitale Sociale e Socio Unico è compilato, allora devono esserlo "
-"entrambi."
-
-#. module: l10n_it_edi
-#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
-msgid ""
-"In demo mode Odoo will just simulate the sending of invoices to the "
-"government.<br/>\n"
-"                                In test mode (experimental) Odoo will send "
-"the invoices to a non-production service.\n"
-"                                Saving this change will direct all companies "
-"on this database to this use this configuration.\n"
-"                                Once registered for testing or official, the "
-"mode cannot be changed."
-msgstr ""
-"In modalità demo, Odoo simula l'invio delle fatture all'Agenzia delle "
-"Entrate. In modalità test (sperimentale) Odoo invia le fatture a un servizio "
-"non ufficiale. Una volta salvata l'impostazione, tutte le aziende nel "
-"database utilizzano questa configurazione. Una volta registrata, la modalità "
-"non può essere modificata."
+"Se uno fra Capitale Sociale e Socio Unico è compilato, allora devono esserlo"
+" entrambi."
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -444,12 +416,14 @@ msgstr "Fattura/e da controllare"
 #. odoo-python
 #: code:addons/l10n_it_edi/models/account_move.py:0
 msgid "Invoices must have exactly one VAT tax set per line."
-msgstr "Le fatture devono avere esattamente una tassa IVA impostata per linea."
+msgstr ""
+"Le fatture devono avere esattamente una tassa IVA impostata per linea."
 
 #. module: l10n_it_edi
-#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__is_edi_proxy_active
-msgid "Is Edi Proxy Active"
-msgstr "È attivo il proxy EDI"
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_edi_purchase_journal_id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__l10n_it_edi_purchase_journal_id
+msgid "Italian Default Purchase Journal"
+msgstr ""
 
 #. module: l10n_it_edi
 #: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_edi_proxy_client_user__proxy_type__l10n_it_edi
@@ -473,11 +447,6 @@ msgid "L10N It Edi Attachment File"
 msgstr "Allegato SdI"
 
 #. module: l10n_it_edi
-#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__l10n_it_edi_demo_mode
-msgid "L10N It Edi Demo Mode"
-msgstr "Modalità Demo SdI"
-
-#. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_edi_header
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_edi_header
 msgid "L10N It Edi Header"
@@ -490,19 +459,20 @@ msgid "L10N It Edi Is Self Invoice"
 msgstr "È autofattura"
 
 #. module: l10n_it_edi
-#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__l10n_it_edi_proxy_current_state
-msgid "L10N It Edi Proxy Current State"
-msgstr "Stato corrente del Proxy L10n It EDI"
-
-#. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_edi_proxy_user_id
 msgid "L10N It Edi Proxy User"
 msgstr "Utente Proxy SdI"
 
 #. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_edi_register
 #: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__l10n_it_edi_register
 msgid "L10N It Edi Register"
 msgstr "Registra SdI"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__l10n_it_edi_show_purchase_journal_id
+msgid "L10N It Edi Show Purchase Journal"
+msgstr ""
 
 #. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_has_eco_index
@@ -539,8 +509,8 @@ msgstr "Stato liquidazione"
 #: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_eco_index_share_capital
 msgid ""
 "Mandatory if the seller/provider is a company with share        capital "
-"(SpA, SApA, Srl), this field must contain the amount        of share capital "
-"actually paid up as resulting from the last        financial statement"
+"(SpA, SApA, Srl), this field must contain the amount        of share capital"
+" actually paid up as resulting from the last        financial statement"
 msgstr ""
 "Obbligatorio se il venditore/fornitore è un'azienda con capitale sociale "
 "(SpA, SApA, Srl), il campo deve contenere l'ammontare del capitale sociale "
@@ -574,11 +544,6 @@ msgstr "Numero nel registro delle imprese"
 #: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__name
 msgid "Numero DDT"
 msgstr ""
-
-#. module: l10n_it_edi
-#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_config_settings__l10n_it_edi_demo_mode__prod
-msgid "Official"
-msgstr "Ufficiale"
 
 #. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_origin_document_date
@@ -665,7 +630,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_it_edi/models/account_edi_proxy_user.py:0
 msgid ""
-"Please fill your codice fiscale to be able to receive invoices from FatturaPA"
+"Please fill your codice fiscale to be able to receive invoices from "
+"FatturaPA"
 msgstr ""
 "Per favore, inserisci il codice fiscale per poter ricevere le fatture da "
 "FatturaPA"
@@ -774,13 +740,10 @@ msgstr "Invia Agenzia Entrate"
 #: code:addons/l10n_it_edi/models/account_move.py:0
 msgid ""
 "Sending invoices to Public Administration partners is not supported.\n"
-"The IT EDI XML file is generated, please sign the document and upload it "
-"through the 'Fatture e Corrispettivi' portal of the Tax Agency."
+"The IT EDI XML file is generated, please sign the document and upload it through the 'Fatture e Corrispettivi' portal of the Tax Agency."
 msgstr ""
-"L'invio della Fatturazione Elettronica ai Partner della Pubblica "
-"Amministrazione non è supportato\n"
-"Il file XML è stato generato, va firmato e inviato tramite il portale "
-"'Fatture e Corrispettivi' dell'Agenzia delle Entrate."
+"L'invio della Fatturazione Elettronica ai Partner della Pubblica Amministrazione non è supportato\n"
+"Il file XML è stato generato, va firmato e inviato tramite il portale 'Fatture e Corrispettivi' dell'Agenzia delle Entrate."
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -847,25 +810,16 @@ msgid "Tender Unique Identifier"
 msgstr "Codice Identificativo Gara"
 
 #. module: l10n_it_edi
-#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_config_settings__l10n_it_edi_demo_mode__test
-msgid "Test (experimental)"
-msgstr "Test (sperimentale)"
+#. odoo-python
+#: code:addons/l10n_it_edi/models/res_company.py:0
+msgid "The Italian default purchase journal requires a default account."
+msgstr ""
 
 #. module: l10n_it_edi
 #. odoo-python
 #: code:addons/l10n_it_edi/models/account_move.py:0
 msgid "The Origin Document Date cannot be in the future."
 msgstr "La Data Documento Origine non può essere nel futuro."
-
-#. module: l10n_it_edi
-#. odoo-python
-#: code:addons/l10n_it_edi/models/res_config_settings.py:0
-msgid ""
-"The company has already registered with the service as 'Test' or 'Official', "
-"it cannot change."
-msgstr ""
-"L'azienda è già registrata al servizio con la modalità test o ufficiale, non "
-"può essere modificata."
 
 #. module: l10n_it_edi
 #: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_eco_index_liquidation_state__ls
@@ -881,15 +835,11 @@ msgstr "L'azienda non è in stato di liquidazione"
 #. odoo-python
 #: code:addons/l10n_it_edi/models/account_move.py:0
 msgid ""
-"The e-invoice file %(file)s can't be forward to %(partner)s (Public "
-"Administration) by the SdI at the moment.\n"
-"It will try again for 10 days, after which it will be considered accepted, "
-"but you will still have to send it by post or e-mail."
+"The e-invoice file %(file)s can't be forward to %(partner)s (Public Administration) by the SdI at the moment.\n"
+"It will try again for 10 days, after which it will be considered accepted, but you will still have to send it by post or e-mail."
 msgstr ""
-"La fattura elettronica %(file)s non può essere inviata a %(partner)s "
-"(Amministrazione pubblica) dall'SdI al momento.\n"
-"Verranno effettuati nuovi tentativi per 10 giorni, in seguito verrà "
-"considerata accettata, ma dovrai inviarla via posta o e-mail."
+"La fattura elettronica %(file)s non può essere inviata a %(partner)s (Amministrazione pubblica) dall'SdI al momento.\n"
+"Verranno effettuati nuovi tentativi per 10 giorni, in seguito verrà considerata accettata, ma dovrai inviarla via posta o e-mail."
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -898,8 +848,7 @@ msgid ""
 "The e-invoice file %(file)s couldn't be forwarded to %(partner)s.\n"
 "Please remember to send it via post or e-mail."
 msgstr ""
-"Non è stato possibile inviare la fattura elettronica %(file)s a "
-"%(partner)s.\n"
+"Non è stato possibile inviare la fattura elettronica %(file)s a %(partner)s.\n"
 "Ricordati di inviarla via posta o e-mail."
 
 #. module: l10n_it_edi
@@ -918,28 +867,21 @@ msgstr ""
 msgid ""
 "The e-invoice file %(file)s has been accepted by the SdI.\n"
 "The SdI is trying to forward it to %(partner)s.\n"
-"It will try for up to 2 days, after which you'll eventually need to send it "
-"the invoice to the partner by post or e-mail."
+"It will try for up to 2 days, after which you'll eventually need to send it the invoice to the partner by post or e-mail."
 msgstr ""
 "La fattura elettronica %(file)s è stata accettata dall'SdI.\n"
 "L'SdI sta cercando di inviarla a %(partner)s.\n"
-"Verranno effettuati tentativi per 2 giorni a seguito dei quali sarà "
-"necessario inviare la fattura al partner via posta o e-mail."
+"Verranno effettuati tentativi per 2 giorni a seguito dei quali sarà necessario inviare la fattura al partner via posta o e-mail."
 
 #. module: l10n_it_edi
 #. odoo-python
 #: code:addons/l10n_it_edi/models/account_move.py:0
 msgid ""
-"The e-invoice file %(file)s has been refused by %(partner)s (Public "
-"Administration).\n"
-"You have 5 days from now to issue a full refund for this invoice, then "
-"contact the PA partner to create a new one according to their requests and "
-"submit it."
+"The e-invoice file %(file)s has been refused by %(partner)s (Public Administration).\n"
+"You have 5 days from now to issue a full refund for this invoice, then contact the PA partner to create a new one according to their requests and submit it."
 msgstr ""
-"La fattura elettronica %(file)s è stata rifiutata da %(partner)s "
-"(Amministrazione pubblica).\n"
-"Hai 5 giorni da ora per effettuare il rimborso della fattura e contattare il "
-"partner PA per crearne e inviarne una nuova secondo le richieste."
+"La fattura elettronica %(file)s è stata rifiutata da %(partner)s (Amministrazione pubblica).\n"
+"Hai 5 giorni da ora per effettuare il rimborso della fattura e contattare il partner PA per crearne e inviarne una nuova secondo le richieste."
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -955,17 +897,11 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_it_edi/models/account_move.py:0
 msgid ""
-"The e-invoice file %(file)s is succesfully sent to the SdI. The invoice is "
-"now considered fiscally relevant.\n"
-"The %(partner)s (Public Administration) had 15 days to either accept or "
-"refused this document,but since they did not reply, it's now considered "
-"accepted."
+"The e-invoice file %(file)s is succesfully sent to the SdI. The invoice is now considered fiscally relevant.\n"
+"The %(partner)s (Public Administration) had 15 days to either accept or refused this document,but since they did not reply, it's now considered accepted."
 msgstr ""
-"La fattura elettronica %(file)s è stata inviata con successo all'SdI. La "
-"fattura ora viene considerata rilevante a livello fiscale.\n"
-"%(partner)s (Amministrazione pubblica) ha avuto 15 giorni per accettare o "
-"rifiutare il documento. La mancata risposta corrisponde all'accettazione del "
-"documento."
+"La fattura elettronica %(file)s è stata inviata con successo all'SdI. La fattura ora viene considerata rilevante a livello fiscale.\n"
+"%(partner)s (Amministrazione pubblica) ha avuto 15 giorni per accettare o rifiutare il documento. La mancata risposta corrisponde all'accettazione del documento."
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -1013,15 +949,13 @@ msgid ""
 "It is not yet considered accepted, please wait further notifications."
 msgstr ""
 "La fattura elettronca %s è stata inviata all'SdI per esser validata.\n"
-"Non è stata ancora considerata accettata, per favore attendere ulteriori "
-"notifiche."
+"Non è stata ancora considerata accettata, per favore attendere ulteriori notifiche."
 
 #. module: l10n_it_edi
 #. odoo-python
 #: code:addons/l10n_it_edi/models/account_move.py:0
 msgid ""
-"The e-invoice filename %(file)s is duplicated. Please check the FatturaPA "
-"Filename sequence.\n"
+"The e-invoice filename %(file)s is duplicated. Please check the FatturaPA Filename sequence.\n"
 "Original message from the SdI: %(message)s"
 msgstr ""
 "Il nome della fattura elettronica %(file)s è stato duplicato. Verifica la "
@@ -1037,8 +971,7 @@ msgstr "La fattura elettronica è stata rifiutata dall'SdI."
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
 msgid ""
 "The seller/provider is a company listed on the register of companies and as\n"
-"                            such must also indicate the registration data on "
-"all documents (art. 2250, Italian\n"
+"                            such must also indicate the registration data on all documents (art. 2250, Italian\n"
 "                            Civil Code)"
 msgstr ""
 "Il venditore/fornitore è un'azienda presente nel registro delle imprese\n"
@@ -1048,20 +981,19 @@ msgstr ""
 #. module: l10n_it_edi
 #: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_has_eco_index
 msgid ""
-"The seller/provider is a company listed on the register of companies and "
-"as        such must also indicate the registration data on all documents "
-"(art. 2250, Italian        Civil Code)"
+"The seller/provider is a company listed on the register of companies and as"
+"        such must also indicate the registration data on all documents (art."
+" 2250, Italian        Civil Code)"
 msgstr ""
-"Il venditore/fornitore è un'azienda presente nel registro delle Imprese e "
-"come tale deve indicare i dati di registrazione in tutti i documenti\n"
+"Il venditore/fornitore è un'azienda presente nel registro delle Imprese e come tale deve indicare i dati di registrazione in tutti i documenti\n"
 "(art. 2250 del Codice Civile)."
 
 #. module: l10n_it_edi
 #: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_has_tax_representative
 msgid ""
 "The seller/provider is a non-resident subject which        carries out "
-"transactions in Italy with relevance for VAT        purposes and which takes "
-"avail of a tax representative in        Italy"
+"transactions in Italy with relevance for VAT        purposes and which takes"
+" avail of a tax representative in        Italy"
 msgstr ""
 "Il venditore/fornitore è un soggetto non-residente che svolge le sue "
 "transazioni in Italia con rilevanza fiscale e che fa riferimento  a un "
@@ -1070,10 +1002,8 @@ msgstr ""
 #. module: l10n_it_edi
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
 msgid ""
-"The seller/provider is a non-resident subject which carries out transactions "
-"in Italy\n"
-"                            with relevance for VAT purposes and which takes "
-"avail of a tax representative in Italy"
+"The seller/provider is a non-resident subject which carries out transactions in Italy\n"
+"                            with relevance for VAT purposes and which takes avail of a tax representative in Italy"
 msgstr ""
 "Il venditore/fornitore è un soggetto non-residente che svolge le sue "
 "transazioni in Italia con rilevanza fiscale e che fa riferimento  a un "
@@ -1082,11 +1012,11 @@ msgstr ""
 #. module: l10n_it_edi
 #: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_eco_index_number
 msgid ""
-"This field must contain the number under which the        seller/provider is "
-"listed on the register of companies."
+"This field must contain the number under which the        seller/provider is"
+" listed on the register of companies."
 msgstr ""
-"Questo campo deve contenere il numero sotto il quale è presente nel registro "
-"delle imprese."
+"Questo campo deve contenere il numero sotto il quale è presente nel registro"
+" delle imprese."
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -1146,8 +1076,8 @@ msgstr "Errore sconosciuto"
 msgid ""
 "User description of the current state, with hints to make the flow progress"
 msgstr ""
-"Descrizione utente dello stato corrente, con suggerimenti per far progredire "
-"il flusso"
+"Descrizione utente dello stato corrente, con suggerimenti per far progredire"
+" il flusso"
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -1232,7 +1162,8 @@ msgstr ""
 #. module: l10n_it_edi
 #: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf04
 msgid ""
-"[RF04] Agricoltura e attività connesse e pesca (artt.34 e 34-bis, DPR 633/72)"
+"[RF04] Agricoltura e attività connesse e pesca (artt.34 e 34-bis, DPR "
+"633/72)"
 msgstr ""
 
 #. module: l10n_it_edi
@@ -1265,8 +1196,8 @@ msgstr ""
 #. module: l10n_it_edi
 #: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf10
 msgid ""
-"[RF10] Intrattenimenti, giochi e altre attività di cui alla tariffa allegata "
-"al DPR 640/72 (art.74, c.6, DPR 633/72)"
+"[RF10] Intrattenimenti, giochi e altre attività di cui alla tariffa allegata"
+" al DPR 640/72 (art.74, c.6, DPR 633/72)"
 msgstr ""
 
 #. module: l10n_it_edi

--- a/addons/l10n_it_edi/i18n/l10n_it_edi.pot
+++ b/addons/l10n_it_edi/i18n/l10n_it_edi.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0\n"
+"Project-Id-Version: Odoo Server 18.1alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-17 09:50+0000\n"
-"PO-Revision-Date: 2024-10-17 09:50+0000\n"
+"POT-Creation-Date: 2024-12-16 16:01+0000\n"
+"PO-Revision-Date: 2024-12-16 16:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -55,20 +55,9 @@ msgstr ""
 #. module: l10n_it_edi
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
 msgid ""
-"<span class=\"o_form_label\">\n"
-"                                Fattura Elettronica mode\n"
-"                            </span>\n"
-"                            <span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-specific.\"/>"
-msgstr ""
-
-#. module: l10n_it_edi
-#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
-msgid "<span class=\"o_form_label\">Allow Odoo to process invoices</span>"
-msgstr ""
-
-#. module: l10n_it_edi
-#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
-msgid "A Demo service is in use."
+"<span class=\"text-muted\">\n"
+"                                    By checking this box, I authorize Odoo to send and receive my invoices using the Sistema di Interscambio (SDI).\n"
+"                                </span>"
 msgstr ""
 
 #. module: l10n_it_edi
@@ -91,11 +80,6 @@ msgstr ""
 #: code:addons/l10n_it_edi/models/res_company.py:0
 msgid ""
 "All fields about the Economic and Administrative Index must be completed."
-msgstr ""
-
-#. module: l10n_it_edi
-#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
-msgid "An Official or Test service has been registered."
 msgstr ""
 
 #. module: l10n_it_edi
@@ -132,11 +116,6 @@ msgstr ""
 #. module: l10n_it_edi
 #: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_edi_state__being_sent
 msgid "Being Sent To SdI"
-msgstr ""
-
-#. module: l10n_it_edi
-#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
-msgid "By checking this box, I accept that Odoo may process my invoices."
 msgstr ""
 
 #. module: l10n_it_edi
@@ -280,8 +259,8 @@ msgid "Dati Bollo"
 msgstr ""
 
 #. module: l10n_it_edi
-#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_config_settings__l10n_it_edi_demo_mode__demo
-msgid "Demo"
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
+msgid "Default Purchase Journal"
 msgstr ""
 
 #. module: l10n_it_edi
@@ -296,7 +275,14 @@ msgid "Destination Code must have between 6 and 7 characters."
 msgstr ""
 
 #. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_edi_proxy_client_user__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move_send__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_ir_attachment__display_name
 #: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__display_name
 msgid "Display Name"
 msgstr ""
 
@@ -332,6 +318,11 @@ msgid "Errors occurred while creating the e-invoice file:"
 msgstr ""
 
 #. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
+msgid "Fattura Electronica (FatturaPA)"
+msgstr ""
+
+#. module: l10n_it_edi
 #: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_partner__invoice_edi_format__it_edi_xml
 msgid "FatturaPA"
 msgstr ""
@@ -354,7 +345,14 @@ msgid "Fiscal code of your company"
 msgstr ""
 
 #. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_edi_proxy_client_user__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move_send__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_ir_attachment__id
 #: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__id
 msgid "ID"
 msgstr ""
 
@@ -375,15 +373,6 @@ msgstr ""
 msgid ""
 "If one of Share Capital or Sole Shareholder is present, then they must be "
 "both filled out."
-msgstr ""
-
-#. module: l10n_it_edi
-#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
-msgid ""
-"In demo mode Odoo will just simulate the sending of invoices to the government.<br/>\n"
-"                                In test mode (experimental) Odoo will send the invoices to a non-production service.\n"
-"                                Saving this change will direct all companies on this database to this use this configuration.\n"
-"                                Once registered for testing or official, the mode cannot be changed."
 msgstr ""
 
 #. module: l10n_it_edi
@@ -412,8 +401,9 @@ msgid "Invoices must have exactly one VAT tax set per line."
 msgstr ""
 
 #. module: l10n_it_edi
-#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__is_edi_proxy_active
-msgid "Is Edi Proxy Active"
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_edi_purchase_journal_id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__l10n_it_edi_purchase_journal_id
+msgid "Italian Default Purchase Journal"
 msgstr ""
 
 #. module: l10n_it_edi
@@ -438,11 +428,6 @@ msgid "L10N It Edi Attachment File"
 msgstr ""
 
 #. module: l10n_it_edi
-#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__l10n_it_edi_demo_mode
-msgid "L10N It Edi Demo Mode"
-msgstr ""
-
-#. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_edi_header
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_edi_header
 msgid "L10N It Edi Header"
@@ -455,18 +440,19 @@ msgid "L10N It Edi Is Self Invoice"
 msgstr ""
 
 #. module: l10n_it_edi
-#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__l10n_it_edi_proxy_current_state
-msgid "L10N It Edi Proxy Current State"
-msgstr ""
-
-#. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_edi_proxy_user_id
 msgid "L10N It Edi Proxy User"
 msgstr ""
 
 #. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_edi_register
 #: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__l10n_it_edi_register
 msgid "L10N It Edi Register"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__l10n_it_edi_show_purchase_journal_id
+msgid "L10N It Edi Show Purchase Journal"
 msgstr ""
 
 #. module: l10n_it_edi
@@ -531,11 +517,6 @@ msgstr ""
 #. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__name
 msgid "Numero DDT"
-msgstr ""
-
-#. module: l10n_it_edi
-#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_config_settings__l10n_it_edi_demo_mode__prod
-msgid "Official"
 msgstr ""
 
 #. module: l10n_it_edi
@@ -793,22 +774,15 @@ msgid "Tender Unique Identifier"
 msgstr ""
 
 #. module: l10n_it_edi
-#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_config_settings__l10n_it_edi_demo_mode__test
-msgid "Test (experimental)"
+#. odoo-python
+#: code:addons/l10n_it_edi/models/res_company.py:0
+msgid "The Italian default purchase journal requires a default account."
 msgstr ""
 
 #. module: l10n_it_edi
 #. odoo-python
 #: code:addons/l10n_it_edi/models/account_move.py:0
 msgid "The Origin Document Date cannot be in the future."
-msgstr ""
-
-#. module: l10n_it_edi
-#. odoo-python
-#: code:addons/l10n_it_edi/models/res_config_settings.py:0
-msgid ""
-"The company has already registered with the service as 'Test' or 'Official',"
-" it cannot change."
 msgstr ""
 
 #. module: l10n_it_edi

--- a/addons/l10n_it_edi/models/account_edi_proxy_user.py
+++ b/addons/l10n_it_edi/models/account_edi_proxy_user.py
@@ -28,3 +28,18 @@ class Account_Edi_Proxy_ClientUser(models.Model):
                 raise UserError(_('Please fill your codice fiscale to be able to receive invoices from FatturaPA'))
             return company.partner_id._l10n_it_edi_normalized_codice_fiscale()
         return super()._get_proxy_identification(company, proxy_type)
+
+    def _toggle_proxy_user_active(self):
+        """
+        Toggle the value of the ``active`` boolean field of the proxy_user,
+        and handle sending the reactivate/deactivate requests to the IAP side.
+        """
+        self.ensure_one()
+        server_url = self._get_proxy_urls()['l10n_it_edi'][self.edi_mode]
+
+        if self.active:
+            self._make_request(f"{server_url}/api/l10n_it_edi/1/deactivate_user")
+        else:
+            self._make_request(f"{server_url}/api/l10n_it_edi/1/reactivate_user")
+
+        self.active = not self.active

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -1019,6 +1019,10 @@ class AccountMove(models.Model):
 
             self.move_type = move_type
 
+            # Set the move journal to the preferred/default purchase journal set from the italian EDI settings
+            if self.move_type in self.get_purchase_types(include_receipts=True) and self.company_id.l10n_it_edi_purchase_journal_id:
+                self.journal_id = self.company_id.l10n_it_edi_purchase_journal_id
+
             if self.name and self.name != '/':
                 # the journal might've changed, so we need to recompute the name in case it was set (first entry in journal)
                 self.name = False

--- a/addons/l10n_it_edi/models/res_config_settings.py
+++ b/addons/l10n_it_edi/models/res_config_settings.py
@@ -1,93 +1,53 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models, fields, _
-from odoo.exceptions import UserError
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    is_edi_proxy_active = fields.Boolean(compute='_compute_is_edi_proxy_active')
-    l10n_it_edi_proxy_current_state = fields.Char(compute='_compute_l10n_it_edi_proxy_current_state')
-    l10n_it_edi_register = fields.Boolean(compute='_compute_l10n_it_edi_register', inverse='_set_l10n_it_edi_register_demo_mode')
-    l10n_it_edi_demo_mode = fields.Selection(
-        [('demo', 'Demo'),
-         ('test', 'Test (experimental)'),
-         ('prod', 'Official')],
-        compute='_compute_l10n_it_edi_demo_mode',
-        inverse='_set_l10n_it_edi_register_demo_mode',
-        readonly=False)
+    l10n_it_edi_register = fields.Boolean(
+        compute='_compute_l10n_it_edi_register',
+        inverse='_set_l10n_it_edi_register',
+        readonly=False,
+    )
+    l10n_it_edi_purchase_journal_id = fields.Many2one(
+        related='company_id.l10n_it_edi_purchase_journal_id',
+        readonly=False,
+    )
+    l10n_it_edi_show_purchase_journal_id = fields.Boolean(compute='_compute_l10n_it_edi_show_purchase_journal_id')
 
     def _create_proxy_user(self, company_id, edi_mode):
-        self.env['account_edi_proxy_client.user']._register_proxy_user(company_id, 'l10n_it_edi', edi_mode)
+        return self.env['account_edi_proxy_client.user']._register_proxy_user(company_id, 'l10n_it_edi', edi_mode)
 
-    def button_create_proxy_user(self):
-        self._create_proxy_user(self.company_id, self.l10n_it_edi_demo_mode)
-
-    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
-    def _compute_l10n_it_edi_demo_mode(self):
+    @api.depends('company_id')
+    def _compute_l10n_it_edi_show_purchase_journal_id(self):
         for config in self:
-            edi_user = self.env['account_edi_proxy_client.user'].search([
-                ('company_id', '=', config.company_id.id),
-                ('proxy_type', '=', 'l10n_it_edi'),
-            ], limit=1)
-            config.l10n_it_edi_demo_mode = edi_user.edi_mode or 'demo'
-
-    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
-    def _compute_is_edi_proxy_active(self):
-        for config in self:
-            config.is_edi_proxy_active = config.company_id.account_edi_proxy_client_ids
-
-    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
-    def _compute_l10n_it_edi_proxy_current_state(self):
-        for config in self:
-            proxy_user = config.company_id.account_edi_proxy_client_ids.search([
-                ('company_id', '=', config.company_id.id),
-                ('proxy_type', '=', 'l10n_it_edi'),
-            ], limit=1)
-
-            config.l10n_it_edi_proxy_current_state = 'inactive' if not proxy_user else 'demo' if proxy_user.id_client[:4] == 'demo' else 'active'
+            # Only show the setting when there exists more than 1 purchase journal.
+            purchase_journal_count = self.env['account.journal'].search_count([
+                *self.env['account.journal']._check_company_domain(config.company_id),
+                ('type', '=', 'purchase'),
+            ])
+            config.l10n_it_edi_show_purchase_journal_id = purchase_journal_count >= 2
 
     @api.depends('company_id')
     def _compute_l10n_it_edi_register(self):
-        """Needed because it expects a compute"""
-        self.l10n_it_edi_register = False
-
-    def _set_l10n_it_edi_register_demo_mode(self):
         for config in self:
+            config.l10n_it_edi_register = config.company_id.l10n_it_edi_register
 
+    def _set_l10n_it_edi_register(self):
+        for config in self:
+            config.company_id.l10n_it_edi_register = config.l10n_it_edi_register
             proxy_user = self.env['account_edi_proxy_client.user'].search([
                 ('company_id', '=', config.company_id.id),
                 ('proxy_type', '=', 'l10n_it_edi'),
+                ('edi_mode', '!=', 'demo'),  # make sure it's a "real" proxy_user (edi_mode is 'test' or 'prod')
             ], limit=1)
 
-            real_proxy_users = self.env['account_edi_proxy_client.user'].sudo().search([
-                ('company_id', '=', config.company_id.id),
-                ('proxy_type', '=', 'l10n_it_edi'),
-                ('id_client', 'not like', 'demo'),
-            ])
-
-            # Update the config as per the selected radio button
-            previous_demo_state = proxy_user.edi_mode
-            edi_mode = config.l10n_it_edi_demo_mode
-
-            # If the user is trying to change from a state in which they have a registered official or testing proxy client
-            # to another state, we should stop them
-            if real_proxy_users and previous_demo_state != edi_mode:
-                raise UserError(_("The company has already registered with the service as 'Test' or 'Official', it cannot change."))
-
-            if config.l10n_it_edi_register:
-                # There should only be one user at a time, if there are no users, register one
-                if not proxy_user:
-                    self._create_proxy_user(config.company_id, edi_mode)
-                    return
-
-                # If there is a demo user, and we are transitioning from demo to test or production, we should
-                # delete all demo users and then create the new user.
-                elif proxy_user.id_client[:4] == 'demo' and edi_mode != 'demo':
-                    self.env['account_edi_proxy_client.user'].search([
-                        ('company_id', '=', config.company_id.id),
-                        ('proxy_type', '=', 'l10n_it_edi'),
-                        ('id_client', '=like', 'demo%'),
-                    ]).sudo().unlink()
-                    self._create_proxy_user(config.company_id, edi_mode)
+            if proxy_user and proxy_user.active != config.l10n_it_edi_register:
+                # Deactivate / Reactive the current proxy user based on the config's l10n_it_edi_register value
+                proxy_user._toggle_proxy_user_active()
+            elif config.l10n_it_edi_register and not proxy_user:
+                # Create a new proxy user
+                edi_mode = self.env['ir.config_parameter'].sudo().get_param('l10n_it_edi.proxy_user_edi_mode') or 'prod'
+                self._create_proxy_user(config.company_id, edi_mode)

--- a/addons/l10n_it_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi/views/res_config_settings_views.xml
@@ -7,39 +7,24 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//block[@id='account_vendor_bills']" position="after">
-                <block title="Italian Electronic Invoicing" invisible="country_code != 'IT'" id='account_edi'>
-                    <setting id="italian_edi">
-                        <div class="group-content">
-                            <field name="l10n_it_edi_proxy_current_state" invisible="1"/>
-                            <span class="o_form_label">
-                                Fattura Elettronica mode
-                            </span>
-                            <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
-                            <div class="text-muted">
-                                In demo mode Odoo will just simulate the sending of invoices to the government.<br/>
-                                In test mode (experimental) Odoo will send the invoices to a non-production service.
-                                Saving this change will direct all companies on this database to this use this configuration.
-                                Once registered for testing or official, the mode cannot be changed.
-                            </div>
-                            <field name="l10n_it_edi_demo_mode"
-                                    widget="radio"
-                                    options="{'horizontal': true}"/>
-                        </div>
-                        <div class="mt8 content-group" invisible="l10n_it_edi_proxy_current_state == 'active' or l10n_it_edi_proxy_current_state == 'demo' and l10n_it_edi_demo_mode == 'demo'">
-                            <span class="o_form_label">Allow Odoo to process invoices</span>
-                            <div class="text-muted">
-                                By checking this box, I accept that Odoo may process my invoices.
-                            </div>
-                            <div class="content-group">
-                                <field name="l10n_it_edi_register"/>
-                            </div>
+                <block title="Italian Electronic Invoicing" invisible="country_code != 'IT'" id='l10n_it_edi'>
+                    <setting id="l10n_it_edi_setting" string="Fattura Electronica (FatturaPA)">
+                        <field name="l10n_it_edi_show_purchase_journal_id" invisible="1"/>
 
+                        <div class="mt8 content-group">
+                            <div class="content-group d-flex align-items-center gap-2">
+                                <field name="l10n_it_edi_register" class="oe_inline"/>
+                                <span class="text-muted">
+                                    By checking this box, I authorize Odoo to send and receive my invoices through the Sistema di Interscambio (SDI).
+                                </span>
+                            </div>
                         </div>
-                        <div class="text-success mt8" invisible="l10n_it_edi_proxy_current_state in ['inactive', 'demo']">
-                            An Official or Test service has been registered.
-                        </div>
-                        <div class="text-success mt8" invisible="l10n_it_edi_proxy_current_state != 'demo' or l10n_it_edi_demo_mode != 'demo'">
-                            A Demo service is in use.
+
+                        <div class="mt8 content-group" invisible="not l10n_it_edi_show_purchase_journal_id">
+                            <div class="row mt16">
+                                <label for="l10n_it_edi_purchase_journal_id" string="Default Purchase Journal" class="col-6 o_light_label"/>
+                                <field name="l10n_it_edi_purchase_journal_id"/>
+                            </div>
                         </div>
                     </setting>
                 </block>


### PR DESCRIPTION
This commit simplifies and improves on the italian EDI settings called Fattura Electronica (FatturaPA), by removing the demo/test/prod checkbox for new proxy user and also added a way to save the user's preferred purchase journal to use when importing invoices from the Sistema di Interscambio (SDI).

In addition, the way we handle proxy user creation is now also simplified. We always use the official (prod) by default, even when running it on a runbot/test server.

Because of this, it's now important that we also handle cancelling a registered proxy user, to make sure the government doesn't keep sending invoices/bills to an abandoned user from a test/runbot database.

Related IAP PR: https://github.com/odoo/iap-apps/pull/929
Related Upgrade PR: https://github.com/odoo/upgrade/pull/6947
task-id: 4290446