### PR TITLE
[IMP] mrp: improved mass produce wizard

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4152,7 +4152,7 @@ class TestMrpOrder(TestMrpCommon):
             {'name': "00003"},
             {'name': "00004"},
         ])
-        self.assertEqual(productions.mapped('state'), ['to_close'] * 4)
+        self.assertEqual(productions.mapped('state'), ['confirmed'] * 4)
 
     def test_batch_production_02(self):
         """ Test the wizard mrp.batch.produce with a single tracked serial.
@@ -4227,7 +4227,7 @@ class TestMrpOrder(TestMrpCommon):
             00001,LOT01;2|LOT02;3,P01|P02
             00002,LOT01;4,P03
             00003,LOT01,P04|P05
-            00004
+            00004,LOT03,P06
         """
         batch_produce = batch_produce.save()
         self.assertEqual(batch_produce.production_text_help.split('\n')[1],
@@ -4280,8 +4280,10 @@ class TestMrpOrder(TestMrpCommon):
 
         move_1 = production_4.move_raw_ids.filtered(lambda m: m.product_id == self.product_1)
         move_2 = production_4.move_raw_ids.filtered(lambda m: m.product_id == self.product_2)
-        self.assertRecordValues(move_2.move_line_ids, [{'quantity': 0.5, 'lot_id': False}])
-        self.assertRecordValues(move_1.move_line_ids, [{'quantity': 1, 'lot_id': False}])
+        self.assertRecordValues(move_2.move_line_ids, [{'quantity': 0.5}])
+        self.assertRecordValues(move_2.move_line_ids.lot_id, [{'name': 'LOT03'}])
+        self.assertRecordValues(move_1.move_line_ids, [{'quantity': 1}])
+        self.assertRecordValues(move_1.move_line_ids.lot_id, [{'name': 'P06'}])
 
     def test_batch_production_04(self):
         """ Test that splitting a MO correctly computes the duration of the workorders. """

--- a/addons/mrp/tests/test_smp.py
+++ b/addons/mrp/tests/test_smp.py
@@ -40,9 +40,9 @@ class TestMrpSerialMassProduce(TestMrpCommon):
         wizard = wizard_form.save()
         wizard.action_generate_production_text()
         wizard.action_prepare()
-        # Initial MO should have a backorder-sequenced name and be in to_close state
+        # Initial MO should have a backorder-sequenced name and be in confirmed state
         self.assertTrue("-001" in mo.name)
-        self.assertEqual(mo.state, "to_close")
+        self.assertEqual(mo.state, "confirmed")
         # Each generated serial number should have its own mo
         self.assertEqual(len(mo.procurement_group_id.mrp_production_ids), count)
         # Check generated serial numbers
@@ -227,9 +227,9 @@ class TestMrpSerialMassProduce(TestMrpCommon):
         wizard.action_generate_production_text()
         # Reload the wizard to apply generated serial numbers
         wizard.action_prepare()
-        # Initial MO should have a backorder-sequenced name and be in to_close state
+        # Initial MO should have a backorder-sequenced name and be in confirmed state
         self.assertTrue("-001" in mo.name)
-        self.assertEqual(mo.state, "to_close")
+        self.assertEqual(mo.state, "confirmed")
         # Each generated serial number should have its own mo
         self.assertEqual(len(mo.procurement_group_id.mrp_production_ids), 2)
         # Check generated serial numbers
@@ -273,10 +273,10 @@ class TestMrpSerialMassProduce(TestMrpCommon):
         self.assertRecordValues(mo.procurement_group_id.mrp_production_ids.move_raw_ids, [
             {'quantity': 1.0, 'picked': True},
             {'quantity': 1.0, 'picked': True},
-            {'quantity': 1.0, 'picked': True},
-            {'quantity': 1.0, 'picked': True},
-            {'quantity': 1.0, 'picked': True},
-            {'quantity': 1.0, 'picked': True},
+            {'quantity': 1.0, 'picked': False},
+            {'quantity': 0.0, 'picked': False},
+            {'quantity': 1.0, 'picked': False},
+            {'quantity': 0.0, 'picked': False},
         ])
         mo.procurement_group_id.mrp_production_ids.button_mark_done()
         self.assertEqual(mo.procurement_group_id.mrp_production_ids.mapped('state'), ['done', 'done', 'done'])
@@ -326,9 +326,9 @@ class TestMrpSerialMassProduce(TestMrpCommon):
         wizard.action_generate_production_text()
         wizard.action_prepare()
 
-        # Initial MO should have a backorder-sequenced name and be in to_close state
+        # Initial MO should have a backorder-sequenced name and be in confirmed state
         self.assertTrue("-001" in mo.name)
-        self.assertEqual(mo.state, "to_close")
+        self.assertEqual(mo.state, "confirmed")
         # Each generated serial number should have its own mo
         self.assertEqual(len(mo.procurement_group_id.mrp_production_ids), 12)
 

--- a/addons/mrp/wizard/mrp_batch_produce.py
+++ b/addons/mrp/wizard/mrp_batch_produce.py
@@ -113,10 +113,11 @@ class MrpBatchProduct(models.TransientModel):
             productions_to_set.add(production.id)
 
         productions = self.env['mrp.production'].browse(productions_to_set)
-        for production in reversed(productions):
-            production.qty_producing = production.product_uom_qty
-            production.set_qty_producing()
-            production.move_raw_ids.picked = True
+        if not productions.product_id.tracking == 'serial':
+            for production in reversed(productions):
+                production.qty_producing = production.product_uom_qty
+                production.set_qty_producing()
+                production.move_raw_ids.picked = True
 
         if mark_done:
             return productions.with_context(from_wizard=True).button_mark_done()
@@ -159,7 +160,6 @@ class MrpBatchProduct(models.TransientModel):
             })
             lots[(lot_name, move.product_id)] = lot
         ml_vals['lot_id'] = lots[(lot_name, move.product_id)].id
-        ml_vals['picked'] = True
         return ml_vals
 
     def _get_lot_and_qty(self, move, text):


### PR DESCRIPTION
In this commit:
====================
- The changes ensure better traceability by generating back-orders in a
  'confirmed" state with serial numbers assigned, preventing unintended
  consumption of components. This approach enhances clarity and aligns with
  user expectations for managing partial production.

task-4280758