### PR TITLE
[FIX] l10n_es_edi_tbai: shorten if invoice_origin is too long

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_invoice.xml
+++ b/addons/l10n_es_edi_tbai/data/template_invoice.xml
@@ -106,7 +106,7 @@
                 </t>
             </CabeceraFactura>
             <DatosFactura t-if="is_emission">
-                <DescripcionFactura t-out="invoice.invoice_origin or 'manual'"/>
+                <DescripcionFactura t-out="invoice.invoice_origin and invoice.invoice_origin[:250] or 'manual'"/>
                 <DetallesFactura>
                     <IDDetalleFactura t-foreach="invoice_lines" t-as="line_values">
                         <t t-set="line" t-value="line_values['line']"/>


### PR DESCRIPTION
When a lot of sale orders are making one big invoice, the invoice_origin field which is used in the DescripcionFactura in Ticketbai and contains the list of all the sale orders in text will be too long (should be max 250 chars length)

We simply shorten to 250 chars.

Reported by Rafael Blasco, Moduon (MT-8041)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
