### PR TITLE
[FIX] hr_holidays: ignore past leaves after carryover resets allocation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -571,7 +571,7 @@ class HolidaysAllocation(models.Model):
             return 0
 
         fake_allocation = self.env['hr.leave.allocation'].with_context(default_date_from=accrual_date).new(origin=self)
-        fake_allocation.sudo()._process_accrual_plans(accrual_date, log=False)
+        fake_allocation.sudo().with_context(default_date_from=accrual_date)._process_accrual_plans(accrual_date, log=False)
         if self.type_request_unit in ['hour']:
             return float_round(fake_allocation.number_of_hours_display - self.number_of_hours_display, precision_digits=2)
         res = round((fake_allocation.number_of_days - self.number_of_days), 2)


### PR DESCRIPTION
Steps to reproduce:
- Employee > New
- Time Off > Configuration > Accrual Plans > New
- Accrued Gain Time: 'Start of the accrual period'
- New Milestone > 20 days; Yearly; Carry over: None
- Time Off > Management > Allocations > New
- Accrual allocation; Start at the 1st Jan this year
- Asign it to your new employee
- Employees > Your employee > Time Off
- Take 10 days off this year
- Check balance at the beginning of next year

Only 10 days are available when we should get 20 after the carryover date. While the allocation is computed correctly, leaves taken prior to the carryover are still deducted from the available days. This should not happen for days reset on carryover as the allocated days should have already been taken from the previous year's days we no longer have access to.

This happens because sudo drops the context when creating a new environment, meaning we lose the target date which simply defaults back to today, making the accrual computation wrong. Note that this fix only addresses the case where leaves are validated.

opw-4326914

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
