### PR TITLE
[FIX] purchase: ensure correct uom_po_id

### DIFF
--- a/addons/purchase/tests/test_access_rights.py
+++ b/addons/purchase/tests/test_access_rights.py
@@ -125,3 +125,13 @@ class TestPurchaseInvoice(AccountTestInvoicingCommon):
         self.purchase_user.groups_id += group_purchase_manager
         order.with_user(self.purchase_user).button_approve()
         self.assertEqual(order.state, 'purchase')
+
+    def test_create_product_purchase_user(self):
+        uom = self.env.ref('uom.product_uom_gram')
+        self.purchase_user.groups_id += self.env.ref('product.group_product_manager')
+        product = self.env['product.template'].with_user(self.purchase_user).create({
+            'name': 'Test Product UOM Default',
+            'type': 'consu',
+            'uom_id': uom.id,
+        })
+        self.assertTrue(product, "The default purchase UOM should be in the same category as the sale UOM.")


### PR DESCRIPTION
Steps to reproduce:

 - User permission on purchase
 - Create a product with a specific uom_id
 - The uom_po_id is set to the default "Units" since the user has no
   access to the uom_po_id due to visibility restriction.

Issue:

The error occurs when users without admin rights on Purchase do not have
visibility into uom_po_id. this leads to uom_po_id defaulting to "Units"
during product creation. Consequently, there is a mismatch between
uom_id and uom_po_id.

Fix:

The fix has been [implemented](https://github.com/odoo/odoo/commit/c6fd91d61b2f62cab4) .This commits aims
to add a test to ensure alignement between the different uom (purchase
and sales).

opw-4286165

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
