### PR TITLE
[IMP] account: Fix dynamic PDF reports generation on send & print

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -394,6 +394,62 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
         # invoice update
         self.assertTrue(test_move.is_move_sent)
 
+    def test_move_composer_with_dynamic_reports(self):
+        """
+        It makes sure that when an invoice is sent using a template that
+        has additional dynamic reports, those extra reports are also
+        generated and sent by mail along side the invoice PDF and the
+        other attachments that were manually added.
+        """
+        test_move = self.test_account_moves[0].with_env(self.env)
+        test_customer = self.test_customers[0].with_env(self.env)
+        move_template = self.move_template.with_env(self.env)
+
+        extra_dynamic_report = self.env.ref('account.action_account_original_vendor_bill')
+        move_template.report_template_ids += extra_dynamic_report
+
+        composer = self.env['account.move.send']\
+            .with_context(active_model='account.move', active_ids=test_move.ids)\
+            .create({'mail_template_id': move_template.id})
+
+        with self.mock_mail_gateway(mail_unlink_sent=False), \
+             self.mock_mail_app():
+            composer.action_send_and_print()
+            self.env.cr.flush()  # force tracking message
+
+        self.assertMailMail(
+            test_customer,
+            'sent',
+            author=self.user_account_other.partner_id,  # author: synchronized with email_from of template
+            content=f'TemplateBody for {test_move.name}',
+            email_values={
+                'attachments_info': [
+                    {'name': 'AttFileName_00.txt', 'raw': b'AttContent_00', 'type': 'text/plain'},
+                    {'name': 'AttFileName_01.txt', 'raw': b'AttContent_01', 'type': 'text/plain'},
+                    {'name': f'{test_move.name}.pdf', 'type': 'application/pdf'},
+                    {'name': f'{extra_dynamic_report.name.lower()}_{test_move.name}.pdf', 'type': 'application/pdf'},
+                ],
+                'body_content': f'TemplateBody for {test_move.name}',
+                'email_from': self.user_account_other.email_formatted,
+                'subject': f'{self.env.user.company_id.name} Invoice (Ref {test_move.name})',
+                'reply_to': formataddr((
+                    f'{test_move.company_id.name} {test_move.display_name}',
+                    f'{self.alias_catchall}@{self.alias_domain}'
+                )),
+            },
+            fields_values={
+                'auto_delete': True,
+                'email_from': self.user_account_other.email_formatted,
+                'is_notification': True,  # should keep logs by default
+                'mail_server_id': self.mail_server_default,
+                'subject': f'{self.env.user.company_id.name} Invoice (Ref {test_move.name})',
+                'reply_to': formataddr((
+                    f'{test_move.company_id.name} {test_move.display_name}',
+                    f'{self.alias_catchall}@{self.alias_domain}'
+                )),
+            },
+        )
+
     def test_invoice_sent_to_additional_partner(self):
         """
         Make sure that when an invoice is sent to a partner who is not

--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -137,6 +137,7 @@ class AccountMoveSend(models.TransientModel):
 
     def _get_default_mail_attachments_widget(self, move, mail_template):
         return self._get_placeholder_mail_attachments_data(move) \
+            + self._get_placeholder_mail_template_dynamic_attachments_data(move, mail_template) \
             + self._get_invoice_extra_attachments_data(move) \
             + self._get_mail_template_attachments_data(mail_template)
 
@@ -191,6 +192,21 @@ class AccountMoveSend(models.TransientModel):
             'mimetype': 'application/pdf',
             'placeholder': True,
         }]
+
+    @api.model
+    def _get_placeholder_mail_template_dynamic_attachments_data(self, move, mail_template):
+        invoice_template = self.env.ref('account.account_invoices')
+        extra_mail_templates = mail_template.report_template_ids - invoice_template
+        filename = move._get_invoice_report_filename()
+        return [
+            {
+                'id': f'placeholder_{extra_mail_template.name.lower()}_{filename}',
+                'name': f'{extra_mail_template.name.lower()}_{filename}',
+                'mimetype': 'application/pdf',
+                'placeholder': True,
+                'dynamic_report': extra_mail_template.report_name,
+            } for extra_mail_template in extra_mail_templates
+        ]
 
     @api.model
     def _get_invoice_extra_attachments(self, move):
@@ -519,8 +535,46 @@ class AccountMoveSend(models.TransientModel):
         }
 
     @api.model
+    def _generate_dynamic_reports(self, moves_data):
+        for move, move_data in moves_data.items():
+            mail_attachments_widget = move_data.get('mail_attachments_widget', [])
+
+            dynamic_reports = [
+                attachment_widget
+                for attachment_widget in mail_attachments_widget
+                if attachment_widget.get('dynamic_report')
+                and not attachment_widget.get('skip')
+            ]
+
+            attachments_to_create = []
+            for dynamic_report in dynamic_reports:
+                content, _report_format = self.env['ir.actions.report']\
+                .with_company(move.company_id)\
+                .with_context(from_account_move_send=True)\
+                ._render(dynamic_report['dynamic_report'], move.ids)
+
+                attachments_to_create.append({
+                    'raw': content,
+                    'name': dynamic_report['name'],
+                    'mimetype': 'application/pdf',
+                    'res_model': move._name,
+                    'res_id': move.id,
+                })
+
+            attachments = self.env['ir.attachment'].create(attachments_to_create)
+            mail_attachments_widget += [{
+                'id': attachment.id,
+                'name': attachment.name,
+                'mimetype': 'application/pdf',
+                'placeholder': False,
+                'protect_from_deletion': True,
+            } for attachment in attachments]
+
+    @api.model
     def _send_mails(self, moves_data):
         subtype = self.env.ref('mail.mt_comment')
+
+        self._generate_dynamic_reports(moves_data)
 
         for move, move_data in [(move, move_data) for move, move_data in moves_data.items() if move.partner_id.email]:
             mail_template = move_data['mail_template_id']


### PR DESCRIPTION
Problem
---------
Additional attachments linked to an Email Template used in the Send & Print are completely ignored. They should not, and it's especially useful for Timesheets.

Steps
---------
1. Install Accouting, Timesheet and Sales
2. In debug, access mail templates
3. Go to the 'Invoice: Sending' record > Setting tab
4. In Dynamic Reports, add 'Timesheet'
5. Go to sale
6. Create an SO with 'Junior Architect' product for 10 units
7. Confirm the SO
8. Click the Timesheet widget on the SO form view
9. Register some hours for today (for example 3 hours)
10. On the SO Form view, click 'Create Invoice'
11. Select the option to invoice timesheeted hours and select from today to today as the date range
12. Create the Invoice and post
13. Send & Print -> The timesheet report appears in the send and print widget, when you click send, the timesheet report is actually not sent.

Solution
---------
1. Add a placeholder in the send&print widget, the placeholders are stored in the `mail_attachments_widget` used for such purposes. The dynamic reports are defined with an new key: `dynamic_report` to differenciate them from the `manual` attachments and the invoice PDF. This new key eases the complexity to retreive and create the attachments fom the placeholders list.
2. Add a method when sending the mails to generate the dynamic reports only if the reports have not been removed in the S&P widget (`skip != False`). Since the attachments placed in the mails are a collection of elements from `mail_attachments_widget` that possess a valid attachment ID. We add the relevant attachment data in the mail_attachments_widget of the invoice.

task-4283972

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
