### PR TITLE
[FIX] mrp: change BLOCK button to lower case

### DIFF
--- a/addons/mrp/wizard/mrp_workcenter_block_view.xml
+++ b/addons/mrp/wizard/mrp_workcenter_block_view.xml
@@ -13,7 +13,7 @@
                     <field name="company_id" invisible="1"/>
                 </group>
                 <footer>
-                    <button name="button_block" string="Block" type="object" class="btn-danger text-uppercase" data-hotkey="q"/>
+                    <button name="button_block" string="Block" type="object" class="btn-danger" data-hotkey="q"/>
                     <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
                 </footer>
             </form>


### PR DESCRIPTION
`BLOCK` button in the workcenter blocking wizard should be in lowercase

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
