### PR TITLE
[IMP] payment_xendit: improve error message

### DIFF
--- a/addons/payment_xendit/static/src/js/payment_form.js
+++ b/addons/payment_xendit/static/src/js/payment_form.js
@@ -138,7 +138,11 @@ paymentForm.include({
      */
     _xenditHandleResponse(err, token, processingValues) {
         if (err) {
-            this._displayErrorDialog(_t("Payment processing failed"), err.message);
+            let errMessage = err.message;
+            if (err.errors) {
+                errMessage += _t(" Details:") + `\n${err.errors.map(el => el.message).join('\n')}`;
+            }
+            this._displayErrorDialog(_t("Payment processing failed"), errMessage);
             this._enableButton();
             return;
         }


### PR DESCRIPTION
When there was an error of bad formatted data on submitting card form, it was not clear for the user what was wrong.
After this commit the details of the error message from Xendit (if any) will be displayed.

