### PR TITLE
[IMP] *: use models.Index instead of init() when possible

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -245,6 +245,8 @@ class CrmLead(models.Model):
         'check(probability >= 0 and probability <= 100)',
         'The probability of closing the deal should be between 0% and 100%!',
     )
+    _user_id_team_id_type_index = models.Index("(user_id, team_id, type)")
+    _create_date_team_id_idx = models.Index("(create_date, team_id)")
 
     @api.depends('company_id')
     def _compute_user_company_ids(self):
@@ -721,13 +723,6 @@ class CrmLead(models.Model):
     # ------------------------------------------------------------
     # ORM
     # ------------------------------------------------------------
-
-    def _auto_init(self):
-        super()._auto_init()
-        tools.create_index(self._cr, 'crm_lead_user_id_team_id_type_index',
-                           self._table, ['user_id', 'team_id', 'type'])
-        tools.create_index(self._cr, 'crm_lead_create_date_team_id_idx',
-                           self._table, ['create_date', 'team_id'])
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -10,7 +10,7 @@ from pytz import timezone, UTC
 
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
-from odoo import api, Command, fields, models, tools
+from odoo import api, Command, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.addons.resource.models.utils import float_to_time, HOURS_PER_DAY
 from odoo.exceptions import AccessError, UserError, ValidationError
@@ -231,12 +231,7 @@ class HrLeave(models.Model):
         'CHECK ( number_of_days >= 0 )',
         "If you want to change the number of days you should use the 'period' mode",
     )
-
-    def _auto_init(self):
-        res = super()._auto_init()
-        tools.create_index(self._cr, 'hr_leave_date_to_date_from_index',
-                           self._table, ['date_to', 'date_from'])
-        return res
+    _date_to_date_from_index = models.Index("(date_to, date_from)")
 
     @api.onchange('request_hour_from', 'request_hour_to')
     def _onchange_hours(self):

--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -8,7 +8,7 @@ import itertools
 from psycopg2 import OperationalError
 from odoo.exceptions import UserError
 
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, _
 from odoo.osv import expression
 
 
@@ -67,9 +67,7 @@ class HrWorkEntry(models.Model):
         """,
         'Validated work entries cannot overlap',
     )
-
-    def init(self):
-        tools.create_index(self._cr, "hr_work_entry_date_start_date_stop_index", self._table, ["date_start", "date_stop"])
+    _date_start_date_stop_index = models.Index("(date_start, date_stop)")
 
     @api.depends('work_entry_type_id', 'employee_id')
     def _compute_name(self):

--- a/addons/project/models/mail_message.py
+++ b/addons/project/models/mail_message.py
@@ -1,18 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
-from odoo.tools.sql import create_index
 
 
 class MailMessage(models.Model):
     _inherit = 'mail.message'
 
-    def init(self):
-        super().init()
-        create_index(
-            self._cr,
-            'mail_message_date_res_id_id_for_burndown_chart',
-            self._table,
-            ['date', 'res_id', 'id'],
-            where="model='project.task' AND message_type='notification'"
-        )
+    _date_res_id_id_for_burndown_chart = models.Index("(date, res_id, id) WHERE model = 'project.task' AND message_type = 'notification'")

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -13,7 +13,6 @@ from odoo.http import request
 from odoo.osv import expression
 from odoo.tools import (
     SQL,
-    create_index,
     float_is_zero,
     format_amount,
     format_date,
@@ -312,8 +311,7 @@ class SaleOrder(models.Model):
     show_update_pricelist = fields.Boolean(
         string="Has Pricelist Changed", store=False)  # True if the pricelist was changed
 
-    def init(self):
-        create_index(self._cr, 'sale_order_date_order_id_idx', 'sale_order', ["date_order desc", "id desc"])
+    _date_order_id_idx = models.Index("(date_order desc, id desc)")
 
     #=== COMPUTE METHODS ===#
 

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, fields, models, tools
+from odoo import _, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import float_compare, float_is_zero
 
@@ -38,11 +38,7 @@ class StockValuationLayer(models.Model):
     warehouse_id = fields.Many2one('stock.warehouse', string="Receipt WH", compute='_compute_warehouse_id', search='_search_warehouse_id')
     lot_id = fields.Many2one('stock.lot', 'Lot/Serial Number', check_company=True, index=True)
 
-    def init(self):
-        tools.create_index(
-            self._cr, 'stock_valuation_layer_index',
-            self._table, ['product_id', 'remaining_qty', 'stock_move_id', 'company_id', 'create_date']
-        )
+    _index = models.Index("(product_id, remaining_qty, stock_move_id, company_id, create_date)")
 
     def _compute_warehouse_id(self):
         for svl in self:

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -14,7 +14,7 @@ import werkzeug
 
 from collections import defaultdict
 
-from odoo import api, fields, models, SUPERUSER_ID, tools, _
+from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.exceptions import AccessError, ValidationError, UserError
 from odoo.http import Stream, root, request
 from odoo.tools import config, human_size, image, str2bool, consteq
@@ -421,11 +421,7 @@ class IrAttachment(models.Model):
     mimetype = fields.Char('Mime Type', readonly=True)
     index_content = fields.Text('Indexed Content', readonly=True, prefetch=False)
 
-    def _auto_init(self):
-        res = super(IrAttachment, self)._auto_init()
-        tools.create_index(self._cr, 'ir_attachment_res_idx',
-                           self._table, ['res_model', 'res_id'])
-        return res
+    _res_idx = models.Index("(res_model, res_id)")
 
     @api.model
     def check(self, mode, values=None):


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
Use the newer API to create some multi-column indexes that are managed by the ORM.

Current behavior before PR:
Indexes are created during init.

Desired behavior after PR is merged:
Let the ORM manage the indexes.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
