### PR TITLE
[IMP] website, web_editor: move common utility functions to web_editor

### DIFF
--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -540,6 +540,31 @@ async function _isSrcCorsProtected(src) {
     return _isImageCorsProtected(dummyImg);
 }
 
+/**
+ * @param {jQuery} $element
+ * @param {jQuery} [$excluded]
+ * @param {boolean} [resolveOnError=false]
+ */
+function onceAllImagesLoaded($element, $excluded, resolveOnError = false) {
+    const defs = Array.from($element.find("img").addBack("img")).map((img) => {
+        if (img.complete || ($excluded && ($excluded.is(img) || $excluded.has(img).length))) {
+            return; // Already loaded
+        }
+        const def = new Promise(function (resolve, reject) {
+            $(img).one("load", function () {
+                resolve();
+            });
+            if (resolveOnError) {
+                $(img).one("error", function () {
+                    resolve();
+                });
+            }
+        });
+        return def;
+    });
+    return Promise.all(defs);
+}
+
 export default {
     COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES: COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES,
     CSS_SHORTHANDS: CSS_SHORTHANDS,
@@ -571,4 +596,5 @@ export default {
     forwardToThumbnail: _forwardToThumbnail,
     isImageCorsProtected: _isImageCorsProtected,
     isSrcCorsProtected: _isSrcCorsProtected,
+    onceAllImagesLoaded: onceAllImagesLoaded,
 };

--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -10,6 +10,7 @@ import {
     onMounted,
 } from "@odoo/owl";
 import { localization } from "@web/core/l10n/localization";
+import weUtils from "@web_editor/js/common/utils";
 
 export class RenameCustomSnippetDialog extends Component {
     static template = "web_editor.RenameCustomSnippetDialog";
@@ -254,20 +255,10 @@ export class AddSnippetDialog extends Component {
 
             // Await images.
             const imageEls = snippetPreviewWrapEl.querySelectorAll("img");
-            // TODO: move onceAllImagesLoaded in web_editor and to use it here
-            await Promise.all(Array.from(imageEls).map(imgEl => {
-                imgEl.setAttribute("loading", "eager");
-                return new Promise(resolve => {
-                    if (imgEl.complete) {
-                        resolve();
-                    } else {
-                        imgEl.onload = () => resolve();
-                        // If the image could not be loaded, we still want the
-                        // "d-none" class to be removed.
-                        imgEl.onerror = () => resolve();
-                    }
-                });
-            }));
+            imageEls.forEach((imgEl) => imgEl.setAttribute("loading", "eager"));
+            // If the image could not be loaded, we still want the
+            // "d-none" class to be removed.
+            await weUtils.onceAllImagesLoaded($(snippetPreviewWrapEl), null, true);
 
             snippetPreviewWrapEl.classList.remove("d-none");
         }

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -9,7 +9,7 @@ import { WebsiteDialog } from '@website/components/dialog/dialog';
 import { Switch } from '@website/components/switch/switch';
 import { applyTextHighlight } from "@website/js/text_processing";
 import { useRef, useState, useSubEnv, Component, onWillStart, onMounted } from "@odoo/owl";
-import wUtils from '@website/js/utils';
+import weUtils from "@web_editor/js/common/utils";
 
 const NO_OP = () => {};
 
@@ -181,7 +181,7 @@ export class AddPageTemplatePreview extends Component {
             }
             mainEl.appendChild(wrapEl);
             await ensureJQuery();
-            await wUtils.onceAllImagesLoaded($(wrapEl));
+            await weUtils.onceAllImagesLoaded($(wrapEl));
             // Restore image lazy loading.
             for (const imgEl of lazyLoadedImgEls) {
                 imgEl.setAttribute("loading", "lazy");

--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -9,7 +9,7 @@ import { escape } from "@web/core/utils/strings";
 import { debounce, throttleForAnimation } from "@web/core/utils/timing";
 import Class from "@web/legacy/js/core/class";
 import publicWidget from "@web/legacy/js/public/public_widget";
-import wUtils from "@website/js/utils";
+import weUtils from "@web_editor/js/common/utils";
 import { renderToElement } from "@web/core/utils/render";
 import { hasTouch } from "@web/core/browser/feature_detection";
 import { SIZES, utils as uiUtils } from "@web/core/ui/ui_service";
@@ -1711,7 +1711,7 @@ registry.ImagesLazyLoading = publicWidget.Widget.extend({
         const imgEls = this.el.querySelectorAll('img[loading="lazy"]');
         for (const imgEl of imgEls) {
             this._updateImgMinHeight(imgEl);
-            wUtils.onceAllImagesLoaded($(imgEl)).then(() => {
+            weUtils.onceAllImagesLoaded($(imgEl)).then(() => {
                 if (this.isDestroyed()) {
                     return;
                 }

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -72,25 +72,6 @@ function autocompleteWithPages(input, options= {}) {
 }
 
 /**
- * @param {jQuery} $element
- * @param {jQuery} [$excluded]
- */
-function onceAllImagesLoaded($element, $excluded) {
-    var defs = Array.from($element.find("img").addBack("img")).map((img) => {
-        if (img.complete || $excluded && ($excluded.is(img) || $excluded.has(img).length)) {
-            return; // Already loaded
-        }
-        var def = new Promise(function (resolve, reject) {
-            $(img).one('load', function () {
-                resolve();
-            });
-        });
-        return def;
-    });
-    return Promise.all(defs);
-}
-
-/**
  * @deprecated
  * @todo create Dialog.prompt instead of this
  */
@@ -497,7 +478,6 @@ export function checkAndNotifySEO(seo_data, OptimizeSEODialog, services) {
 export default {
     loadAnchors: loadAnchors,
     autocompleteWithPages: autocompleteWithPages,
-    onceAllImagesLoaded: onceAllImagesLoaded,
     prompt: prompt,
     sendRequest: sendRequest,
     websiteDomain: websiteDomain,

--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -1,6 +1,6 @@
 import { MediaDialog } from "@web_editor/components/media_dialog/media_dialog";
 import options from "@web_editor/js/editor/snippets.options";
-import wUtils from '@website/js/utils';
+import weUtils from "@web_editor/js/common/utils";
 import { _t } from "@web/core/l10n/translation";
 import { renderToElement } from "@web/core/utils/render";
 import {
@@ -103,7 +103,7 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
                 // and not correctly loaded from cache, we use a clone of the
                 // image to force the loading.
                 smallestColEl.append(imgEl.cloneNode(true));
-                await wUtils.onceAllImagesLoaded(this.$target);
+                await weUtils.onceAllImagesLoaded(this.$target);
             }
             resolve();
         });

--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -7,6 +7,7 @@ import { isVisible } from "@web/core/utils/ui";
 import { utils as uiUtils, MEDIAS_BREAKPOINTS, SIZES } from "@web/core/ui/ui_service";
 import {setUtmsHtmlDataset} from '@website/js/content/inject_dom';
 import wUtils from "@website/js/utils";
+import weUtils from "@web_editor/js/common/utils";
 import { ObservingCookieWidgetMixin } from "@website/snippets/observing_cookie_mixin";
 
 // TODO In master, export this class too or merge it with PopupWidget
@@ -426,7 +427,7 @@ publicWidget.registry.cookies_bar = PopupWidget.extend({
             this.toggleEl.style.removeProperty("--cookies-bar-toggle-inset-block-end");
         } else {
             // Lazy-loaded images don't have a height yet. We need to await them
-            wUtils.onceAllImagesLoaded($(popupEl)).then(() => {
+            weUtils.onceAllImagesLoaded($(popupEl)).then(() => {
                 const popupHeight = popupEl.querySelector(".modal-content").offsetHeight;
                 const toggleMargin = 8;
                 // Avoid having the toggleEl over another button, but if the


### PR DESCRIPTION
1) onceAllImagesLoaded
- Moved from website to web_editor utility file to avoid duplication when required in web_editor module.
- Added an option to continue execution even when images fail to load.
- Maintained backward compatibility for existing usage.

This change improves code re usability across both modules while providing more flexibility in handling image loading. All references in website module have been updated to use the new centralized utility.