### PR TITLE
[FIX] website: allow proper patch website_switcher

### DIFF
--- a/addons/website/static/src/systray_items/website_switcher.js
+++ b/addons/website/static/src/systray_items/website_switcher.js
@@ -21,6 +21,12 @@ export class WebsiteSwitcherSystray extends Component {
             name: website.name,
             id: website.id,
             domain: website.domain,
+            dataset: Object.assign({
+                websiteId: website.id,
+            }, website.domain ? {} : {
+                tooltipValue: this.env._t('This website does not have a domain configured'),
+                tooltipPosition: 'left',
+            }),
             callback: () => {
                 if (website.domain && !wUtils.isHTTPSorNakedDomainRedirection(website.domain, window.location.origin)) {
                     const { location: { pathname, search, hash } } = this.websiteService.contentWindow;

--- a/addons/website/static/src/systray_items/website_switcher.xml
+++ b/addons/website/static/src/systray_items/website_switcher.xml
@@ -11,12 +11,11 @@
                 <i class="fa fa-globe"/>
             </div>
         </t>
-        <t t-set="tooltipValue">This website does not have a domain configured.</t>
         <t t-foreach="getElements()" t-as="element" t-key="element_index">
             <DropdownItem
                 onSelected="element.callback"
                 class="element.class"
-                dataset="!element.domain ? {'tooltip': tooltipValue, 'tooltipPosition': 'left', websiteId: element.id} : {websiteId: element.id}">
+                dataset="element.dataset">
                 <t t-if="!element.domain">
                     <span class="fa fa-warning me-2 text-warning"/>
                 </t>


### PR DESCRIPTION
Defines dataset directly on website elements such that it can be overridden by other modules if necessary.
This was done due to the override in the `test_themes` module completely overriding all attributes of the website_switcher's dropdown items.

Runbot Error 106501

