### PR TITLE
[FIX] mail: no crash on message post with `@`mention in some chatters

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3206,7 +3206,7 @@ class MailThread(models.AbstractModel):
                         user.partner_id,
                         "mail.message/inbox",
                         Store(
-                            message.with_user(user).with_context(allowed_company_ids=None),
+                            message.with_user(user).with_context(allowed_company_ids=[]),
                             msg_vals=msg_vals,
                             for_current_user=True,
                             add_followers=True,


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/185583

PR above fixed an issue that results in a traceback when posting a message with `@`mention in multi-company. This happens because a message post with `@`mention notifies the recipients of new message in their inbox, but the computing of this notification was made in the context of the recipient but with `allowed_company_ids` of the person that sends the message. If the recipient does not have access to the `allowed_company_ids` of the sender then this leads to the crash that PR above fixes.

The PR fixed it by removing the `allowed_company_ids` from the context, with `allowed_company_ids=None`. However, some code inspect presence of `ctx.allowed_company_ids` with the following code:

```py
len(self.env.context.get('allowed_company_ids', [])) <= 1
```

Due to `allowed_company_ids` being present as `None`, code attempts to `len(None)` which is invalid thus it crashes.

This commit fixes the issue by passing `[]` as allowed_company_ids. This is semantically the same as passing no `allowed_company_ids` but it prevents crash from the pattern above.

opw-4231529