### PR TITLE
[FIX] hr_expense: Fix reset to draft button

### DIFF
--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -571,9 +571,9 @@ class HrExpenseSheet(models.Model):
 
     def action_reset_expense_sheets(self):
         self.filtered(lambda sheet: sheet.state not in {'draft', 'submit'})._check_can_reset_approval()
-        self._do_reverse_moves()
+        self.sudo()._do_reverse_moves()
         self._do_reset_approval()
-        self.account_move_ids = [Command.clear()]
+        self.sudo().account_move_ids = [Command.clear()]
 
     def action_register_payment(self):
         ''' Open the account.payment.register wizard to pay the selected journal entries.

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -783,14 +783,14 @@
                     <button name="action_reset_expense_sheets"
                             string="Reset to Draft"
                             type="object"
-                            data-hotkey="c"
+                            data-hotkey="r"
                             invisible="not can_reset or state  == 'draft'"
                             groups="account.group_account_invoice"/>
                     <!-- v In the case where the user has no accounting rights, we don't show the button in the post & done states  -->
                     <button name="action_reset_expense_sheets"
                             string="Reset to Draft"
                             type="object"
-                            data-hotkey="c"
+                            data-hotkey="r"
                             invisible="not can_reset or state in ('draft', 'post', 'done')"
                             groups="!account.group_account_invoice"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,submit,approve,post,done"

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -785,7 +785,14 @@
                             type="object"
                             data-hotkey="c"
                             invisible="not can_reset or state  == 'draft'"
-                            groups="account.group_account_readonly,account.group_account_invoice"/>
+                            groups="account.group_account_invoice"/>
+                    <!-- v In the case where the user has no accounting rights, we don't show the button in the post & done states  -->
+                    <button name="action_reset_expense_sheets"
+                            string="Reset to Draft"
+                            type="object"
+                            data-hotkey="c"
+                            invisible="not can_reset or state in ('draft', 'post', 'done')"
+                            groups="!account.group_account_invoice"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,submit,approve,post,done"
                            force_save="1" invisible="state == 'cancel'"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,submit,cancel"

--- a/addons/sale_expense/models/hr_expense_sheet.py
+++ b/addons/sale_expense/models/hr_expense_sheet.py
@@ -79,8 +79,7 @@ class HrExpenseSheet(models.Model):
 
     def action_reset_expense_sheets(self):
         super().action_reset_expense_sheets()
-        self._sale_expense_reset_sol_quantities()
-        return True
+        self.sudo()._sale_expense_reset_sol_quantities()
 
     def action_open_sale_orders(self):
         self.ensure_one()


### PR DESCRIPTION
This re-adds the possibility for a user with approval rights, but no accounting rights to reset an expense to draft after it has been refused/approved.

opw-4328933

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
