### PR TITLE
[FIX] cloud_storage: bypass file size check

### DIFF
--- a/addons/cloud_storage/__manifest__.py
+++ b/addons/cloud_storage/__manifest__.py
@@ -10,12 +10,13 @@
         "views/settings.xml",
     ],
     'assets': {
-            'web.assets_backend': [
-                'cloud_storage/static/src/core/common/**/*',
-            ],
-            'mail.assets_public': [
-                'cloud_storage/static/src/core/common/**/*',
-            ],
+        'web.assets_backend': [
+            'cloud_storage/static/src/core/common/**/*',
+            'cloud_storage/static/src/**/web_portal/**/*',
+        ],
+        'mail.assets_public': [
+            'cloud_storage/static/src/core/common/**/*',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/cloud_storage/static/src/chatter/web_portal/chatter_patch.js
+++ b/addons/cloud_storage/static/src/chatter/web_portal/chatter_patch.js
@@ -1,0 +1,11 @@
+import { Chatter } from "@mail/chatter/web_portal/chatter";
+
+import { patch } from "@web/core/utils/patch";
+import { session } from "@web/session";
+
+patch(Chatter.prototype, {
+    setup() {
+        super.setup();
+        this.cloudStorageUsable = session.cloud_storage_min_file_size !== undefined;
+    },
+});

--- a/addons/cloud_storage/static/src/chatter/web_portal/chatter_patch.xml
+++ b/addons/cloud_storage/static/src/chatter/web_portal/chatter_patch.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.Chatter" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('o-mail-Chatter-topbar')]//FileUploader" position="attributes">
+            <attribute name="checkSize">!cloudStorageUsable</attribute>
+        </xpath>
+        
+        <xpath expr="//div[hasclass('o-mail-AttachmentBox')]//FileUploader" position="attributes">
+            <attribute name="checkSize">!cloudStorageUsable</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/cloud_storage/static/src/core/common/attachment_upload_service_patch.js
+++ b/addons/cloud_storage/static/src/core/common/attachment_upload_service_patch.js
@@ -8,6 +8,9 @@ patch(AttachmentUploadService.prototype, {
     setup(env, services) {
         super.setup(env, services);
         this.uploadingCloudFiles = new Map();
+        window.addEventListener('beforeunload', () => 
+            this.abortByAttachmentId.forEach(abort => abort())
+        );
     },
 
     _processLoaded(thread, composer, { data, upload_info }, tmpId, def) {
@@ -15,7 +18,7 @@ patch(AttachmentUploadService.prototype, {
             super._processLoaded(...arguments);
             return;
         }
-        function removeAttachment() {
+        const removeAttachment = () => {
             const { Attachment } = this.store.insert(data);
             const [attachment] = Attachment;
             attachment.remove();

--- a/addons/cloud_storage/static/src/core/common/composer_patch.js
+++ b/addons/cloud_storage/static/src/core/common/composer_patch.js
@@ -1,0 +1,11 @@
+import { Composer } from "@mail/core/common/composer";
+
+import { patch } from "@web/core/utils/patch";
+import { session } from "@web/session";
+
+patch(Composer.prototype, {
+    setup() {
+        super.setup();
+        this.cloudStorageUsable = session.cloud_storage_min_file_size !== undefined;
+    },
+});

--- a/addons/cloud_storage/static/src/core/common/composer_patch.xml
+++ b/addons/cloud_storage/static/src/core/common/composer_patch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.Composer" t-inherit-mode="extension">
+        <xpath expr="//FileUploader" position="attributes">
+            <attribute name="checkSize">!cloudStorageUsable</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/common/attachment_upload_service.js
+++ b/addons/mail/static/src/core/common/attachment_upload_service.js
@@ -105,7 +105,7 @@ export class AttachmentUploadService {
         this.deferredByAttachmentId.delete(tmpId);
         this.uploadingAttachmentIds.delete(tmpId);
         this.targetsByTmpId.delete(tmpId);
-        this.store.Attachment.get(tmpId).remove();
+        this.store.Attachment.get(tmpId)?.remove();
     }
 
     getUploadURL(thread) {

--- a/addons/web/static/src/views/fields/file_handler.js
+++ b/addons/web/static/src/views/fields/file_handler.js
@@ -12,6 +12,7 @@ export class FileUploader extends Component {
         onUploaded: Function,
         onUploadComplete: { type: Function, optional: true },
         multiUpload: { type: Boolean, optional: true },
+        checkSize: { type: Boolean, optional: true },
         inputName: { type: String, optional: true },
         fileUploadClass: { type: String, optional: true },
         acceptedFileExtensions: { type: String, optional: true },
@@ -19,6 +20,7 @@ export class FileUploader extends Component {
         showUploadingText: { type: Boolean, optional: true },
     };
     static defaultProps = {
+        checkSize: true,
         showUploadingText: true,
     };
 
@@ -39,7 +41,7 @@ export class FileUploader extends Component {
         }
         const { target } = ev;
         for (const file of ev.target.files) {
-            if (!checkFileSize(file.size, this.notification)) {
+            if (this.props.checkSize && !checkFileSize(file.size, this.notification)) {
                 return null;
             }
             this.state.isUploading = true;


### PR DESCRIPTION
when cloud_storage is enabled for some uploader, the file size check should be removed to allow larger files to be uploaded to the cloud storage

there are 4 places shouldn't check the file sizes
1. discuss
<img width="1495" alt="image" src="https://github.com/user-attachments/assets/4d7e3b86-4de7-440f-bc97-4084609e9efd">

2. form view attachemnt (when the attachment list was empty)
<img width="1450" alt="Screenshot 2024-11-15 at 14 50 13" src="https://github.com/user-attachments/assets/20e69645-31f3-44ed-9021-ac524a1cf90c">

3. form view attach files button (when the attachment list is not empty)
<img width="1475" alt="Screenshot 2024-11-15 at 14 51 45" src="https://github.com/user-attachments/assets/8370ff5c-71c2-414f-a89b-fa44b3732398">

4. log note/send messages
<img width="383" alt="image" src="https://github.com/user-attachments/assets/274027b7-ad6e-436b-9c6a-3f12515a6f7d">



Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
