### PR TITLE
[IMP] mail, {test_}mass_mailing{_sms}, sms: Option to bypass blacklist

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -191,7 +191,9 @@ class MailComposeMessage(models.TransientModel):
         help="In comment mode: if set, postpone notifications sending. "
              "In mass mail mode: if sent, send emails after that date. "
              "This date is considered as being in UTC timezone.")
-    use_exclusion_list = fields.Boolean('Check Exclusion List', default=True)
+    use_exclusion_list = fields.Boolean(
+        'Use Exclusion List', default=True, copy=False,
+        help='Prevent sending messages to blacklisted contacts. Disable only when absolutely necessary.')
     # template generation
     template_name = fields.Char('Template Name')
 

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -53,7 +53,7 @@
                                 context="{'force_email': True, 'show_email': True, 'form_view_ref': 'base.view_partner_simple_form', 'forward_mode': True}"/>
                         </div>
                         <field name="subject" placeholder="e.g. Welcome to MyCompany!" required="True"/>
-                        <field name="reply_to" placeholder='Recipient Followers'
+                        <field name="reply_to" placeholder="e.g. info@company.com"
                             invisible="reply_to_mode == 'update'"
                             required="reply_to_mode != 'update'"/>
                     </group>
@@ -77,6 +77,7 @@
                             <!-- mass mailing -->
                             <field name="reply_to_force_new" invisible="1"/>
                             <field name="reply_to_mode" invisible="composition_mode != 'mass_mail'" widget="radio"/>
+                            <field name="use_exclusion_list" invisible="1"/>
                         </page>
                     </notebook>
                     <footer>

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1077,7 +1077,8 @@ class MailingMailing(models.Model):
         return self._action_send_mail(res_ids)
 
     def _action_send_mail(self, res_ids=None):
-        author_id = self.env.user.partner_id.id
+        odoobot = self.env.ref('base.partner_root')
+        user_partner = self.env.user.partner_id
 
         for mailing in self:
             context_user = mailing.user_id or mailing.write_uid or self.env.user
@@ -1092,7 +1093,8 @@ class MailingMailing(models.Model):
                 'auto_delete': not mailing.keep_archives,
                 # email-mode: keep original message for routing
                 'auto_delete_keep_log': mailing.reply_to_mode == 'update',
-                'author_id': author_id,
+                # If current user is odoobot, use mailing responsible (no impact on email_from)
+                'author_id': mailing.user_id.partner_id.id if user_partner == odoobot else user_partner.id,
                 'attachment_ids': [(4, attachment.id) for attachment in mailing.attachment_ids],
                 'body': mailing._prepend_preview(mailing.body_html or '', mailing.preview),
                 'composition_mode': 'mass_mail',

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -175,6 +175,9 @@ class MailingMailing(models.Model):
         default=_get_default_mail_server_id,
         help="Use a specific mail server in priority. Otherwise Odoo relies on the first outgoing mail server available (based on their sequencing) as it does for normal mails.")
     contact_list_ids = fields.Many2many('mailing.list', 'mail_mass_mailing_list_rel', string='Mailing Lists')
+    use_exclusion_list = fields.Boolean(
+        'Use Exclusion List', default=True, copy=False,
+        help='Prevent sending messages to blacklisted contacts. Disable only when absolutely necessary.')
     # Mailing Filter
     mailing_filter_id = fields.Many2one(
         'mailing.filter', string='Favorite Filter',
@@ -1106,6 +1109,7 @@ class MailingMailing(models.Model):
                 'reply_to_force_new': mailing.reply_to_mode == 'new',
                 'subject': mailing.subject,
                 'template_id': False,
+                'use_exclusion_list': mailing.use_exclusion_list,
             }
             if mailing.reply_to_mode == 'new':
                 composer_values['reply_to'] = mailing.reply_to

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1466,10 +1466,6 @@ class MailingMailing(models.Model):
         mailing_domain = Domain.TRUE
         if hasattr(self.env[self.mailing_model_name], '_mailing_get_default_domain'):
             mailing_domain = Domain(self.env[self.mailing_model_name]._mailing_get_default_domain(self))
-
-        if self.mailing_type == 'mail' and 'is_blacklisted' in self.env[self.mailing_model_name]._fields:
-            mailing_domain = Domain('is_blacklisted', '=', False) & mailing_domain
-
         return mailing_domain
 
     def _get_image_by_url(self, url, session):

--- a/addons/mass_mailing/tests/common.py
+++ b/addons/mass_mailing/tests/common.py
@@ -425,13 +425,13 @@ class MassMailCommon(MailCommon, MassMailCase):
     def setUpClass(cls):
         super(MassMailCommon, cls).setUpClass()
 
-        cls.user_marketing = mail_new_test_user(
+        cls.user_marketing, cls.user_marketing_1 = [mail_new_test_user(
             cls.env,
             groups='base.group_user,base.group_partner_manager,mass_mailing.group_mass_mailing_user',
-            login='user_marketing',
-            name='Martial Marketing',
-            signature='--\nMartial',
-        )
+            login=f'user_marketing{suffix}',
+            name=f'Martial Marketing{suffix}',
+            signature=f'--\nMartial{suffix}',
+        ) for suffix in ('', '_1')]
 
         cls.email_reply_to = 'MyCompany SomehowAlias <test.alias@test.mycompany.com>'
 

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -739,12 +739,13 @@ class TestMassMailFeatures(MassMailCommon, CronMixinCase):
             'mailing_domain': [('id', 'in', (partner_a | partner_b).ids)],
             'body_html': 'This is mass mail marketing demo'
         })
+        self.assertEqual(mailing.user_id, self.user_marketing)
         mailing.action_put_in_queue()
         self.assertEqual(mailing.email_from, self.env.user.email_formatted)
         with self.mock_mail_gateway(mail_unlink_sent=False), self.enter_registry_test_mode():
             self.env.ref('mass_mailing.ir_cron_mass_mailing_queue').sudo().method_direct_trigger()
 
-        author = self.env.ref('base.user_root').partner_id
+        author = self.user_marketing.partner_id
         email_values = {'email_from': mailing.email_from}
         self.assertMailTraces(
             [{'partner': partner_a, 'email_values': email_values},
@@ -781,7 +782,7 @@ Email: <a id="url5" href="mailto:test@odoo.com">test@odoo.com</a></div>""",
         with self.mock_mail_gateway(mail_unlink_sent=False), self.enter_registry_test_mode():
             self.env.ref('mass_mailing.ir_cron_mass_mailing_queue').sudo().method_direct_trigger()
 
-        author = self.env.ref('base.user_root').partner_id
+        author = self.user_marketing.partner_id
         email_values = {'email_from': mailing.email_from}
         self.assertMailTraces(
             [{'email': 'fleurus@example.com', 'email_values': email_values},

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -211,8 +211,7 @@ class TestMassMailValues(MassMailCommon):
         self.assertEqual(mailing.mailing_model_real, 'res.partner')
         self.assertEqual(mailing.reply_to_mode, 'new')
         self.assertEqual(mailing.reply_to, self.user_marketing.email_formatted)
-        # default for partner: remove blacklisted
-        self.assertEqual(literal_eval(mailing.mailing_domain), [('is_blacklisted', '=', False)])
+        self.assertEqual(literal_eval(mailing.mailing_domain), [])
         # update domain
         mailing.write({
             'mailing_domain': [('email', 'ilike', 'test.example.com')]
@@ -255,8 +254,7 @@ class TestMassMailValues(MassMailCommon):
             'body_html': '<p>Hello <t t-out="object.name"/></p>',
             'mailing_model_id': self.env['ir.model']._get('res.partner').id,
         })
-        # default for partner: remove blacklisted
-        self.assertEqual(literal_eval(mailing.mailing_domain), [('is_blacklisted', '=', False)])
+        self.assertEqual(literal_eval(mailing.mailing_domain), [])
 
         # prepare initial data
         filter_1, filter_2, filter_3 = self.env['mailing.filter'].create([

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -384,6 +384,8 @@
                                         <field name="name" string="Name" required="False" readonly="state in ('sending', 'done')"/>
                                         <field name="mail_server_id" invisible="not mail_server_available" readonly="state in ('sending', 'done')"/>
                                         <field name="keep_archives" readonly="state in ('sending', 'done')"/>
+                                        <!-- Not using a dedicated server and being set means generic sending, won't allow disabling it. -->
+                                        <field name="use_exclusion_list" invisible="not mail_server_id and use_exclusion_list" readonly="state != 'draft'"/>
                                     </group>
                                 </group>
                             </page>

--- a/addons/mass_mailing/wizard/mail_compose_message.py
+++ b/addons/mass_mailing/wizard/mail_compose_message.py
@@ -130,6 +130,7 @@ class MailComposeMessage(models.TransientModel):
             'sent_date': now,
             'state': 'done',
             'subject': self.subject,
+            'use_exclusion_list': self.use_exclusion_list,
         }
 
     def _manage_mail_values(self, mail_values_all):

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -236,6 +236,7 @@ class MailingMailing(models.Model):
             'mass_keep_log': self.keep_archives,
             'mass_force_send': self.sms_force_send,
             'mass_sms_allow_unsubscribe': self.sms_allow_unsubscribe,
+            'use_exclusion_list': self.use_exclusion_list,
         }
 
     def _action_send_mail(self, res_ids=None):

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -302,13 +302,6 @@ class MailingMailing(models.Model):
     # TOOLS
     # --------------------------------------------------
 
-    def _get_default_mailing_domain(self):
-        mailing_domain = super()._get_default_mailing_domain()
-        if self.mailing_type == 'sms' and 'phone_sanitized_blacklisted' in self.env[self.mailing_model_name]._fields:
-            mailing_domain &= Domain('phone_sanitized_blacklisted', '=', False)
-
-        return mailing_domain
-
     def convert_links(self):
         sms_mailings = self.filtered(lambda m: m.mailing_type == 'sms')
         res = {}

--- a/addons/mass_mailing_sms/tests/test_mailing_internals.py
+++ b/addons/mass_mailing_sms/tests/test_mailing_internals.py
@@ -35,8 +35,7 @@ class TestMassMailValues(MassSMSCommon):
         self.assertEqual(mailing.medium_id, self.env.ref('mass_mailing_sms.utm_medium_sms'))
         self.assertEqual(mailing.mailing_model_name, 'res.partner')
         self.assertEqual(mailing.mailing_model_real, 'res.partner')
-        # default for partner: remove blacklisted
-        self.assertEqual(literal_eval(mailing.mailing_domain), [('phone_sanitized_blacklisted', '=', False)])
+        self.assertEqual(literal_eval(mailing.mailing_domain), [])
         # update template -> update body
         mailing.write({'sms_template_id': self.sms_template_partner.id})
         self.assertEqual(mailing.body_plaintext, self.sms_template_partner.body)

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -47,7 +47,7 @@ class SmsComposer(models.TransientModel):
     # options for comment and mass mode
     mass_keep_log = fields.Boolean('Keep a note on document', default=True)
     mass_force_send = fields.Boolean('Send directly', default=False)
-    mass_use_blacklist = fields.Boolean('Use blacklist', default=True)
+    use_exclusion_list = fields.Boolean('Use blacklist', default=True)
     # recipients
     recipient_valid_count = fields.Integer('# Valid recipients', compute='_compute_recipients', compute_sudo=False)
     recipient_invalid_count = fields.Integer('# Invalid recipients', compute='_compute_recipients', compute_sudo=False)
@@ -276,7 +276,7 @@ class SmsComposer(models.TransientModel):
     def _get_blacklist_record_ids(self, records, recipients_info):
         """ Get a list of blacklisted records. Those will be directly canceled
         with the right error code. """
-        if self.mass_use_blacklist:
+        if self.use_exclusion_list:
             bl_numbers = self.env['phone.blacklist'].sudo().search([]).mapped('number')
             return [r.id for r in records if recipients_info[r.id]['sanitized'] in bl_numbers]
         return []

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -47,7 +47,9 @@ class SmsComposer(models.TransientModel):
     # options for comment and mass mode
     mass_keep_log = fields.Boolean('Keep a note on document', default=True)
     mass_force_send = fields.Boolean('Send directly', default=False)
-    use_exclusion_list = fields.Boolean('Use blacklist', default=True)
+    use_exclusion_list = fields.Boolean(
+        'Use Exclusion List', default=True, copy=False,
+        help='Prevent sending messages to blacklisted contacts. Disable only when absolutely necessary.')
     # recipients
     recipient_valid_count = fields.Integer('# Valid recipients', compute='_compute_recipients', compute_sudo=False)
     recipient_invalid_count = fields.Integer('# Invalid recipients', compute='_compute_recipients', compute_sudo=False)

--- a/addons/sms/wizard/sms_composer_views.xml
+++ b/addons/sms/wizard/sms_composer_views.xml
@@ -56,6 +56,7 @@
                         <field name="body" widget="sms_widget" invisible="not comment_single_recipient"
                         placeholder="Write a message..."/>
                         <field name="mass_keep_log" invisible="1"/>
+                        <field name="use_exclusion_list" invisible="1"/>
                 </sheet>
                 <footer>
                     <!-- attrs doesn't work for 'disabled'-->

--- a/addons/test_mail_sms/tests/test_sms_composer.py
+++ b/addons/test_mail_sms/tests/test_sms_composer.py
@@ -389,7 +389,7 @@ class TestSMSComposerMass(SMSCommon):
             ).create({
                 'body': self._test_body,
                 'mass_keep_log': False,
-                'mass_use_blacklist': True,
+                'use_exclusion_list': True,
             })
 
             with self.mockSMSGateway():
@@ -421,7 +421,7 @@ class TestSMSComposerMass(SMSCommon):
             ).create({
                 'body': self._test_body,
                 'mass_keep_log': False,
-                'mass_use_blacklist': False,
+                'use_exclusion_list': False,
             })
 
             with self.mockSMSGateway():
@@ -452,7 +452,7 @@ class TestSMSComposerMass(SMSCommon):
             ).create({
                 'body': self._test_body,
                 'mass_keep_log': False,
-                'mass_use_blacklist': True,
+                'use_exclusion_list': True,
             })
 
             with self.mockSMSGateway():

--- a/addons/test_mass_mailing/tests/__init__.py
+++ b/addons/test_mass_mailing/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_blacklist_behavior
 from . import test_blacklist_mixin
 from . import test_link_tracker
 from . import test_link_tracker_sms
+from . import test_mail_composer
 from . import test_mailing
 from . import test_mailing_server
 from . import test_mailing_sms

--- a/addons/test_mass_mailing/tests/test_mail_composer.py
+++ b/addons/test_mass_mailing/tests/test_mail_composer.py
@@ -1,0 +1,38 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields
+from odoo.tests import freeze_time, tagged, users
+from odoo.tools import mute_logger
+
+from odoo.addons.test_mail.tests.test_mail_composer import TestMailComposer
+from odoo.addons.test_mass_mailing.tests import common
+
+
+@tagged('mail_composer')
+class TestMailComposerMassMailing(TestMailComposer, common.TestMassMailCommon):
+
+    @users('user_marketing')
+    @mute_logger('odoo.addons.mass_mailing.models.mailing')
+    @freeze_time('2025-08-06 15:02:00')
+    def test_mail_composer_mailing_creation(self):
+        """Check mailing configuration created through the mail composer."""
+        for use_exclusion_list in (True, False):
+            mass_mailing_name = f'Test Create Mass Mailing From Composer (use_exclusion_list: {use_exclusion_list})'
+            composer = self.env['mail.compose.message'].with_context(
+                self._get_web_context(self.test_records)
+            ).create({
+                'body': '<p>Body</p>',
+                'mass_mailing_name': mass_mailing_name,
+                'subject': 'Test',
+                'use_exclusion_list': use_exclusion_list,
+            })
+            composer._action_send_mail()
+            mailing = self.env['mailing.mailing'].search([('name', '=', mass_mailing_name)])
+            self.assertTrue(mailing)
+            self.assertEqual(mailing.body_html, '<p>Body</p>')
+            self.assertEqual(mailing.mailing_domain, f"[('id', 'in', {self.test_records.ids})]")
+            self.assertEqual(mailing.mailing_model_name, self.test_record._name)
+            self.assertEqual(mailing.sent_date, fields.Datetime.now())
+            self.assertEqual(mailing.state, 'done')
+            self.assertEqual(mailing.subject, 'Test')
+            self.assertEqual(mailing.use_exclusion_list, use_exclusion_list)

--- a/addons/test_mass_mailing/tests/test_mailing_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_sms.py
@@ -30,7 +30,7 @@ class TestMassSMSInternals(TestMassSMSCommon):
             'mailing_model_id': self.env['ir.model']._get('mail.test.sms.bl').id,
             'mailing_type': 'sms',
         })
-        self.assertEqual(literal_eval(mailing.mailing_domain), [('phone_sanitized_blacklisted', '=', False)])
+        self.assertEqual(literal_eval(mailing.mailing_domain), [])
 
     @users('user_marketing')
     def test_mass_sms_internals(self):

--- a/addons/test_mass_mailing/tests/test_mailing_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_sms.py
@@ -157,6 +157,22 @@ class TestMassSMSInternals(TestMassSMSCommon):
              for record in falsy_record_1 + falsy_record_2],
             mailing, falsy_record_1 + falsy_record_2,
         )
+        self.assertEqual(mailing.canceled, 5)
+
+        # Same test using use_exclusion_list = False
+        mailing_no_blacklist = mailing.copy()
+        mailing_no_blacklist.use_exclusion_list = False
+        with self.with_user('user_marketing'):
+            with self.mockSMSGateway():
+                mailing_no_blacklist.action_send_sms()
+
+        self.assertSMSTraces(
+            [{'partner': bl_record_1.customer_id,
+              'number': phone_validation.phone_format(bl_record_1.phone_nbr, 'BE', '32', force_format='E164'),
+              'content': 'Dear %s this is a mass SMS' % bl_record_1.display_name}],
+            mailing_no_blacklist, bl_record_1,
+        )
+        self.assertEqual(mailing_no_blacklist.canceled, 4)
 
     @users('user_marketing')
     def test_mass_sms_internals_done_ids(self):

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -49,7 +49,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         # runbot needs +101 compared to local
         with (
             self.mock_mail_gateway(mail_unlink_sent=True),
-            self.assertQueryCount(__system__=1377, marketing=1379),  # 1326, 1328
+            self.assertQueryCount(__system__=1378, marketing=1380),  # 1227, 1229
         ):
             mailing.action_send_mail()
 
@@ -93,7 +93,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +52 compared to local
-        with self.assertQueryCount(__system__=1408, marketing=1410):  # 1356, 1358
+        with self.assertQueryCount(__system__=1409, marketing=1411):  # 1257, 1259
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)


### PR DESCRIPTION
Add an option to bypass the black list for example for transactional or incident emails/sms. This option is only displayed for erp manager and when debug mode is enabled.

[IMP] mass_mailing: set mailing responsible as author when sent by odoobot

Having odoobot as author of a mailing is not helpful especially if we want to determine why blacklisted contacts have been included. This solves the problem by setting the mailing responsible as author instead of odoobot when the mailing is sent by odoobot (cron task). Indeed, it is a good choice because the mailing responsible has created the mailing and probably configured it entirely.

[IMP] {mass_mailing,test_mail}_sms, sms : uniformize blacklist option name

We uniformize the name of the option that activate the use of the exclusion list when sending sms or emails. Concretely, we rename the sms composer field "mass_use_blacklist" to "use_exclusion_list" to match the name used in the mail composer for the same feature.

Task-3575361