### PR TITLE
[FIX] web_editor, website: fix traceback when clicking on insert media

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.js
@@ -71,7 +71,7 @@ export class ImageSelector extends FileSelector {
         this.MIN_ROW_HEIGHT = 128;
 
         this.fileMimetypes = IMAGE_MIMETYPES.join(',');
-        this.isImageField = !!this.props.media?.closest("[data-oe-type=image]") || !!this.env.addFieldImage;
+        this.isImageField = !!(this.props.media && this.props.media.closest("[data-oe-type=image]")) || !!this.env.addFieldImage;
     }
 
     get canLoadMore() {

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -150,3 +150,36 @@ wTourUtils.registerWebsitePreviewTour("website_media_dialog_image_shape", {
         run: () => {}, //it's a check
     },
 ]);
+
+wTourUtils.registerWebsitePreviewTour("website_media_dialog_insert_media", {
+    test: true,
+    url: "/",
+    edition: true,
+}, () => [
+    wTourUtils.dragNDrop({
+        id: "s_text_block",
+        name: "Text",
+    }),
+    {
+        content: "Click on the first paragraph",
+        trigger: "iframe .s_text_block p",
+    },
+    {
+        content: "Click on the toolbar's 'insert media' button",
+        trigger: ".oe-toolbar #media-insert",
+    },
+    {
+        content: "Search for an illustration/image",
+        trigger: ".o_select_media_dialog .o_we_search",
+        run: "text a",
+    },
+    {
+        content: "Click on the first illustration/image",
+        trigger: ".o_select_media_dialog img.o_we_attachment_highlight",
+    },
+    {
+        content: "Verify that the illustration/image was inserted",
+        trigger: "iframe .s_text_block p > img",
+        run: () => {}, //it's a check
+    },
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -500,6 +500,9 @@ class TestUi(odoo.tests.HttpCase):
     def test_website_media_dialog_image_shape(self):
         self.start_tour("/", 'website_media_dialog_image_shape', login='admin')
 
+    def test_website_media_dialog_insert_media(self):
+        self.start_tour("/", "website_media_dialog_insert_media", login="admin")
+
     def test_website_text_font_size(self):
         self.start_tour('/@/', 'website_text_font_size', login='admin', timeout=300)
 


### PR DESCRIPTION
Steps to reproduce:

- In Website edit mode.
- Drag and drop a "Text" block into the page.
- Click on the first paragaph of the "Text" block.
- click the "Insert media" button of the text toolbar.
- A traceback occurs.

The bug was introduced in commit [1], where we checked that "this.props.media" was not undefined before calling the "closest" function on it. However, this was incorrect because, in cases where "this.props.media" was false, the "closest" function was still called, causing the traceback.

With this fix, the "closest" function is not called if "this.props.media" is false.

[1]: https://github.com/odoo/odoo/commit/625c1aa71e17882848dd827f3be6162e49cbc8ca

opw-4335833
opw-4328280
opw-4334279
opw-4328490
opw-4334012
opw-4332500
opw-4332028
opw-4332684
opw-4329687
opw-4331635
opw-4331371
opw-4331287
opw-4332437
opw-4331144
opw-4329646
opw-4328364
opw-4323197
opw-4325959
opw-4322945