### PR TITLE
[FIX] sale: prevent modification of discount on locked sale orders

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1239,7 +1239,7 @@ class SaleOrderLine(models.Model):
         """
         return [
             'product_id', 'name', 'price_unit', 'product_uom_id', 'product_uom_qty',
-            'tax_ids', 'analytic_distribution'
+            'tax_ids', 'analytic_distribution', 'discount'
         ]
 
     def _update_line_quantity(self, values):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When a sale order is opened in multiple tabs and confirmed in one (locking it), other tabs still allow modifications like changes to the `discount` field. This leads to data inconsistencies, as locked orders should prevent further edits.

Current behavior before PR:

The `discount` field can still be modified in other tabs after a sale order is locked, causing inconsistencies.

Desired behavior after PR is merged:

The `discount` field is now protected on locked sale orders, preventing any modifications and ensuring data consistency.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr