### PR TITLE
[FIX] stock: parse warehouse context key on use

### DIFF
--- a/addons/purchase_stock/report/stock_forecasted.py
+++ b/addons/purchase_stock/report/stock_forecasted.py
@@ -16,7 +16,7 @@ class ReplenishmentReport(models.AbstractModel):
         res = super()._compute_draft_quantity_count(product_template_ids, product_variant_ids, wh_location_ids)
         domain = [('state', 'in', ['draft', 'sent', 'to approve'])]
         domain += self._product_purchase_domain(product_template_ids, product_variant_ids)
-        warehouse_id = self.env.context.get('warehouse', False)
+        warehouse_id = self.env['stock.warehouse']._get_warehouse_id_from_context()
         if warehouse_id:
             domain += [('order_id.picking_type_id.warehouse_id', '=', warehouse_id)]
         po_lines = self.env['purchase.order.line'].search(domain)

--- a/addons/sale_stock/report/stock_forecasted.py
+++ b/addons/sale_stock/report/stock_forecasted.py
@@ -49,7 +49,7 @@ class ReplenishmentReport(models.AbstractModel):
             domain += [('product_template_id', 'in', product_template_ids)]
         elif product_variant_ids:
             domain += [('product_id', 'in', product_variant_ids)]
-        warehouse_id = self.env.context.get('warehouse', False)
+        warehouse_id = self.env['stock.warehouse']._get_warehouse_id_from_context()
         if warehouse_id:
             domain += [('warehouse_id', '=', warehouse_id)]
         return domain

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -654,6 +654,26 @@ class Warehouse(models.Model):
         }
         return sub_locations
 
+    @api.model
+    def _get_warehouse_id_from_context(self):
+        """
+        Helper method used to extract a single id from the context.
+
+        The `warehouse_id` dummy field of the `product.template` model is meant to
+        to be used in the `product_template_search_form_view_stock` search view in
+        order to add a `warehouse` context key. That key can therefore be any of
+        the following types: Int, String, List(Int?, String?).
+        """
+        context_warehouse = self.env.context.get('warehouse', False)
+        if context_warehouse:
+            if isinstance(context_warehouse, int):
+                return context_warehouse
+            elif isinstance(context_warehouse, list):
+                relevant_context = list(filter(lambda key: isinstance(key, int), context_warehouse))
+                if relevant_context:
+                    return relevant_context[0]
+        return False
+
     def _valid_barcode(self, barcode, company_id):
         location = self.env['stock.location'].with_context(active_test=False).search([
             ('barcode', '=', barcode),

--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -132,11 +132,7 @@ class ReplenishmentReport(models.AbstractModel):
         assert product_template_ids or product_variant_ids
         res = {}
 
-        if self.env.context.get('warehouse') and isinstance(self.env.context['warehouse'], int):
-            warehouse = self.env['stock.warehouse'].browse(self.env.context.get('warehouse'))
-        else:
-            warehouse = self.env['stock.warehouse'].browse(self.get_warehouses()[0]['id'])
-
+        warehouse = self.env['stock.warehouse'].browse(self.env['stock.warehouse']._get_warehouse_id_from_context() or self.get_warehouses()[0]['id'])
         wh_location_ids = [loc['id'] for loc in self.env['stock.location'].search_read(
             [('id', 'child_of', warehouse.view_location_id.id)],
             ['id'],

--- a/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.js
@@ -22,10 +22,14 @@ export class ForecastedWarehouseFilter extends Component {
     }
 
     get activeWarehouse(){
-        if (this.context.warehouse)
-            return this.warehouses.find(w => w.id == this.context.warehouse);
-        else
-            return this.warehouses[0];
+        let warehouseId = null;
+        if (Array.isArray(this.context.warehouse)) {
+            const validWarehouseIds = this.context.warehouse.filter(Number.isInteger);
+            warehouseId = validWarehouseIds.length ? validWarehouseIds[0] : null;
+        } else if (Number.isInteger(this.context.warehouse)) {
+            warehouseId = this.context.warehouse;
+        }
+        return warehouseId ? this.warehouses.find((w) => w.id == warehouseId) : this.warehouses[0];
     }
 }
 

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -97,9 +97,16 @@ class StockForecasted extends Component{
     }
 
     get graphDomain() {
+        let warehouseId = null;
+        if (Array.isArray(this.context.warehouse)) {
+            const validWarehouseIds = this.context.warehouse.filter(Number.isInteger);
+            warehouseId = validWarehouseIds.length ? validWarehouseIds[0] : null;
+        } else if (Number.isInteger(this.context.warehouse)) {
+            warehouseId = this.context.warehouse;
+        }
         const domain = [
             ['state', '=', 'forecast'],
-            ['warehouse_id', '=', this.context.warehouse],
+            ['warehouse_id', '=', warehouseId],
         ];
         if (this.resModel === undefined || this.resModel === 'product.template') {
             domain.push(['product_tmpl_id', '=', this.productId]);

--- a/addons/stock/static/tests/tours/stock_report_tests.js
+++ b/addons/stock/static/tests/tours/stock_report_tests.js
@@ -20,4 +20,63 @@ odoo.define('stock.reports.setup.tour', function (require) {
         trigger: 'iframe .o_report_stock_rule',
     },
     ]);
+
+    tour.register("test_context_from_warehouse_filter", { test: true }, [
+        // Add "foo" to the warehouse context key
+        {
+            trigger: ".o_searchview_input",
+            run: "click",
+        },
+        {
+            trigger: ".o_searchview_input",
+            run: "text foo",
+        },
+        {
+            trigger: ".o_menu_item.dropdown-item:contains(Warehouse):contains(foo)",
+            run: "click",
+        },
+        // Add warehouse A's id to the warehouse context key
+        {
+            trigger: ".o_searchview_input",
+            run: "click",
+        },
+        {
+            trigger: ".o_searchview_input",
+            run: "text warehouse",
+        },
+        {
+            trigger: ".o_menu_item.dropdown-item:contains(Warehouse) a.o_expand > i",
+            run: "click",
+        },
+        {
+            trigger: ".o_menu_item.dropdown-item.o_indent:contains(Warehouse A) a",
+            run: "click",
+        },
+        // Add warehouse B's id to the warehouse context key
+        {
+            trigger: ".o_searchview_input",
+            run: "text warehouse",
+        },
+        {
+            trigger: ".o_menu_item.dropdown-item:contains(Warehouse) a.o_expand > i",
+            run: "click",
+        },
+        {
+            trigger: ".o_menu_item.dropdown-item.o_indent:contains(Warehouse B) a",
+            run: "click",
+        },
+        {
+            content: "Go to product page",
+            trigger: ".oe_kanban_card:has(.o_kanban_record_title span:contains(Lovely Product))",
+            run: "click",
+        },
+        {
+            trigger: "button[name=action_product_tmpl_forecast_report]",
+            run: "click",
+        },
+        {
+            trigger: ".o_graph_view",
+            isCheck: true,
+        },
+    ]);
 });

--- a/addons/stock/tests/test_report_tours.py
+++ b/addons/stock/tests/test_report_tours.py
@@ -14,3 +14,25 @@ class TestStockReportTour(HttpCase):
         url = self._get_report_url()
 
         self.start_tour(url, 'test_stock_route_diagram_report', login='admin', timeout=180)
+
+    def test_context_from_warehouse_filter(self):
+        """
+        Check that the warehouse context key added from the product search warehouse filter
+        is correctly parsed when used. 
+        """
+        self.env['product.product'].create({
+            'name': 'Lovely Product',
+            'type': 'product'
+        })
+        self.env['stock.warehouse'].create({
+            'name': 'Warehouse A',
+            'code': 'WH-A',
+            'company_id': self.env.user.company_id.id,
+        })
+        self.env['stock.warehouse'].create({
+            'name': 'Warehouse B',
+            'code': 'WH-B',
+            'company_id': self.env.user.company_id.id,
+        })
+
+        self.start_tour(self._get_report_url(), 'test_context_from_warehouse_filter', login='admin', timeout=180)


### PR DESCRIPTION
### Steps to reproduce:

- Inventory > Configuration > Warehouse Management > Warehouses
- Create a second warehouse
- Go to Inventory > Products > Products
- In the search bar type `foo` string > Search Warehouse for `foo`
- Click on any product Kandan record
- Click on the Forecast smart button of the product
#### > Traceback

### Cause of the issue:

Thanks to the dummy `warehouse_id` field of the `product.template` model a `warehouse` context key can be set in the context from the search bar: https://github.com/odoo/odoo/blob/a72763acfc4d83ae2aadad2e807547c5b1819002/addons/stock/models/product.py#L685 https://github.com/odoo/odoo/blob/a72763acfc4d83ae2aadad2e807547c5b1819002/addons/stock/views/product_views.xml#L78 This trick is notably used in order to take the warehouse into account in the computation of the various quantity fields associated to products by generating custom location domains:
https://github.com/odoo/odoo/blob/a72763acfc4d83ae2aadad2e807547c5b1819002/addons/stock/models/product.py#L136-L137 https://github.com/odoo/odoo/blob/a72763acfc4d83ae2aadad2e807547c5b1819002/addons/stock/models/product.py#L250-L255 However, since that context key was added via the search bar, it type might be: a string, an integerId or a list of either/both other types. (E.g. to create a list of a string and integer type and select a string and then type a string allowing you to find a real warehouse id that you can select after clicking on the dropdown arrow). Therefore, in order to be properly used, this context key needs to be parsed to be used properly as done in the `_get_domain_locations` for instance. However, the `warehouse` context key is used at many other places in the code, each time expecting a single integer id, and since the warehouse context key is not cleaned from one action to an other you are technically able to provide a string where the code is expecting a an integer.

### Fix:

The proper fix of this use case would be to change the context key name used by the search view to only match flows expecting such a context. However, this change is not stable as it requires to modify a view and hence can't be applied before master (18.1). As such, in prior versions, we add a context parser for to extract a single integer id from the `warehouse` context key where it is used but unexpected to match something else.

### Note:

This patch will improve other fixes and hopefully prevent yet unoticed error raised by this issue:
903d8beeea5d332e556ef81e231a3b8b4c51cd45 and afa7c6bf25c9de5fc0c878faa29e1cc35bc11805

opw-4290818
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
