### PR TITLE
[IMP] html_editor: add tooltip for movenode button

### DIFF
--- a/addons/html_editor/static/src/main/movenode_plugin.js
+++ b/addons/html_editor/static/src/main/movenode_plugin.js
@@ -1,7 +1,9 @@
 import { useNativeDraggable } from "@html_editor/utils/drag_and_drop";
 import { endPos } from "@html_editor/utils/position";
+import { xml } from "@odoo/owl";
 import { Plugin } from "../plugin";
 import { ancestors, closestElement } from "../utils/dom_traversal";
+import { _t } from "@web/core/l10n/translation";
 
 const WIDGET_CONTAINER_WIDTH = 25;
 const WIDGET_MOVE_SIZE = 20;
@@ -242,6 +244,14 @@ export class MoveNodePlugin extends Plugin {
         this.moveWidget.style.top = `${anchorY - containerRect.y - moveWidgetOffsetTop}px`;
         this.moveWidget.style.left = `${anchorX - containerRect.x - WIDGET_CONTAINER_WIDTH}px`;
 
+        this.services.tooltip.add(this.moveWidget, {
+            template: xml`
+                <div class="o-tooltip tooltip-inner text-start px-3">
+                    ${_t("Drag to move")}
+                </div>`,
+            arrow: true,
+        });
+
         if (this.scrollableElement) {
             this.smoothScrollOnDrag && this.smoothScrollOnDrag.destroy();
             // TODO: This should be made more generic, one hook for the entire
@@ -449,6 +459,7 @@ const simpleDraggableHook = {
         ctx.current.element.style.position = "fixed";
         // makeDraggableHook disables pointer events, we want them in this case
         document.body.classList.remove("pe-none");
+        document.body.style.cursor = "grabbing";
         return ctx.current;
     },
     onDrag({ ctx }) {
@@ -457,6 +468,9 @@ const simpleDraggableHook = {
     },
     onDragEnd({ ctx }) {
         ctx.current.element.remove();
+        if (document.body.style.cursor === "grabbing") {
+            document.body.style.cursor = "";
+        }
         return ctx.current;
     },
 };


### PR DESCRIPTION
This adds a tooltip on click or hover the movenode button, to inform the user of its effect.

task-3775598

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
