### PR TITLE
[FIX] calendar: display recurrent meeting reminder notifications

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -41,7 +41,7 @@ class AlarmManager(models.AbstractModel):
                         END as last_alarm,
                         cal.start as first_event_date,
                         CASE
-                            WHEN cal.recurrency THEN rrule.until
+                            WHEN cal.recurrency AND end_type = 'end_date' THEN rrule.until
                             ELSE cal.stop
                         END as last_event_date,
                         calcul_delta.min_delta,

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -424,3 +424,40 @@ class TestEventNotifications(TransactionCase, MailCase, CronMixinCase):
         with freeze_time('2023-11-15 16:00:00'):
             self.assertEqual(len(search_event()), 3)
         events.unlink()
+
+    def test_recurring_meeting_reminder_notification(self):
+        alarm = self.env['calendar.alarm'].create({
+            'name': 'Alarm',
+            'alarm_type': 'notification',
+            'interval': 'minutes',
+            'duration': 30,
+        })
+
+        self.event._apply_recurrence_values({
+            'interval': 2,
+            'rrule_type': 'weekly',
+            'tue': True,
+            'count': 2,
+        })
+
+        now = fields.Datetime.now()
+        with patch.object(fields.Datetime, 'now', lambda: now):
+            with self.assertBus([(self.env.cr.dbname, 'res.partner', self.partner.id)], [
+                {
+                    "type": "calendar.alarm",
+                    "payload": [{
+                        "alarm_id": alarm.id,
+                        "event_id": self.event.id,
+                        "title": "Doom's day",
+                        "message": self.event.display_time,
+                        "timer": 20 * 60,
+                        "notify_at": fields.Datetime.to_string(now + relativedelta(minutes=20)),
+                    }],
+                },
+            ]):
+                self.event.with_context(no_mail_to_attendees=True).write({
+                    'start': now + relativedelta(minutes=50),
+                    'stop': now + relativedelta(minutes=55),
+                    'partner_ids': [(4, self.partner.id)],
+                    'alarm_ids': [(4, alarm.id)]
+                })


### PR DESCRIPTION
Steps to reproduce:
- Calendar > New > Tick 'Recurrent'
- 'Until' => 'Number of repetitions' or 'Forever'
- Set meeting start time in 5 mins
- Add reminder => Notification - 15 Minutes > Save

The notification is not sent, this is due to the use of 'until' to fetch the last event date of recurrent meetings despite that field only being set if the recrrence type is 'End date'. We want to check that date to avoid sending notifications for past meetings, but 'Number of Repetitions' recursions use a count instead of a date, and 'Forever' obviously doesn't need a date. Using the meeting end date instead should do the trick since it will always be in the future at the moment we want to send the reminder and it should never go over the last event date since no meeting record will be created after the recurrence ends anyway.

opw-4247282

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
