### PR TITLE
[FIX] event: avoid saving event with empty name

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -583,6 +583,8 @@ class EventEvent(models.Model):
         return events
 
     def write(self, vals):
+        if 'name' in vals and vals['name'] == '':
+            raise ValidationError("The event title cannot be empty.")
         if 'stage_id' in vals and 'kanban_state' not in vals:
             # reset kanban state when changing stage
             vals['kanban_state'] = 'normal'

--- a/addons/test_event_full/tests/test_event_event.py
+++ b/addons/test_event_full/tests/test_event_event.py
@@ -7,6 +7,7 @@ from freezegun import freeze_time
 from odoo import Command, exceptions
 from odoo.addons.test_event_full.tests.common import TestEventFullCommon
 from odoo.tests.common import users
+from odoo.exceptions import ValidationError
 
 
 class TestEventEvent(TestEventFullCommon):
@@ -74,6 +75,12 @@ class TestEventEvent(TestEventFullCommon):
             self.assertFalse(event.is_finished)
             self.assertTrue(event.is_ongoing)
             self.assertTrue(event.event_registrations_started)
+
+    def test_event_write_with_empty_name_raises_validation_error(self):
+        test_event = self.env['event.event'].browse(self.test_event.ids)
+
+        with self.assertRaises(ValidationError, msg="The event title cannot be empty."):
+            test_event.write({'name': ''})
 
     @freeze_time('2021-12-01 11:00:00')
     @users('event_user')


### PR DESCRIPTION
Steps to reproduce:

- Install event and website_event
- Go to any event on the website side and activate the website editor
- Edit the event name/tile leave it blank and save

As we can see no error is raised for avoiding this , if we go back to the event form we can see that
the changes have been actually saved in the db and we have an empty name.

Added a validation in the event 'write' to raise a ValidationError with a proper message to inform
the user that it shouldn't be posible to have an
empty name in the event.

After the fix we show the warning when trying to save as:
![image](https://github.com/user-attachments/assets/f52c55a0-32ba-4144-9f64-65f34220a4c4)

opw-4315680
