### PR TITLE
[FIX] account_payment: fix payment link for provider with inline form

### DIFF
--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -226,8 +226,11 @@
                                             </t>
                                         </div>
                                     </div>
-                                    <!-- the 'amount' is set js-side depending the active tab -->
-                                    <t t-call="account_payment.form"/>
+                                    <!-- set default amount as the max. amount due, the 'amount'
+                                         will be updated/set js-side depending the active tab -->
+                                    <t t-call="account_payment.form">
+                                        <t t-set="amount" t-value="amount_due"/>
+                                    </t>
                                 </div>
                             </div>
                             <t t-else="">


### PR DESCRIPTION
  Stripe (inline payment form) expect to have a default `amount` value
because it need to initialize a payment "intent" when opening the payment form, so before the user will be able to choose between one of the different installment/epd payment options.

This commit set that default amount to the total due amount, so that Stripe can successfully create the initial payment intent, the amount being then updated JS side when user choose any of the available option.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
