### PR TITLE
[FIX] account_audit_trail: normalize subject by removing whitespace

### DIFF
--- a/addons/account_audit_trail/models/mail_message.py
+++ b/addons/account_audit_trail/models/mail_message.py
@@ -195,9 +195,11 @@ class Message(models.Model):
                 raise UserError(_("You cannot remove parts of the audit trail. Archive the record instead."))
 
     def write(self, vals):
+        # We allow any whitespace modifications in the subject
+        normalized_subject = ' '.join(vals['subject'].split()) if vals.get('subject') else None
         if (
             vals.keys() & {'res_id', 'res_model', 'message_type', 'subtype_id'}
-            or ('subject' in vals and any(self.mapped('subject')))
+            or ('subject' in vals and any(' '.join(s.subject.split()) != normalized_subject for s in self if s.subject))
             or ('body' in vals and any(self.mapped('body')))
         ):
             self._except_audit_log()


### PR DESCRIPTION
An error can occur when the email subject contains line breaks when the audit trail is enabled.

For example, steps to reproduce using follow-up reports:
1. Add or modify the "Payment Reminder" mail template to add a line break in the subject, like {{ '\n' }
2. Install the 'account_audit_trail' module.
3. Enable audit trail in the settings
4. Attempt to send a follow-up report email to the partner
5. An error will occur: "You cannot remove parts of the audit trail.
    Archive the record instead."

The issue arises because the subject is considered different from the original message, prompting Odoo to attempt an update.

New behavior:
We allow any subject whitespace modifications to be ignored whenchecking for changes in the audit trail.

opw-4317844