### PR TITLE
[FIX] payment(_paypal): improve RPC error handling during payment

### DIFF
--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -394,9 +394,8 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
             if (error instanceof RPCError) {
                 this._displayErrorDialog(_t("Payment processing failed"), error.data.message);
                 this._enableButton(); // The button has been disabled before initiating the flow.
-            } else {
-                return Promise.reject(error);
             }
+            return Promise.reject(error);
         });
     },
 

--- a/addons/payment_paypal/static/src/js/payment_form.js
+++ b/addons/payment_paypal/static/src/js/payment_form.js
@@ -2,7 +2,7 @@
 
 import { loadJS } from '@web/core/assets';
 import { _t } from '@web/core/l10n/translation';
-import { rpc } from '@web/core/network/rpc';
+import { rpc, RPCError } from '@web/core/network/rpc';
 
 import paymentForm from '@payment/js/payment_form';
 
@@ -127,17 +127,23 @@ paymentForm.include({
      * @param {object} data - The data returned by PayPal on approving the order.
      * @return {void}
      */
-    _paypalOnApprove(data) {
+    async _paypalOnApprove(data) {
         const orderID = data.orderID;
         const { provider_id } = this.inlineFormValues
 
-        rpc('/payment/paypal/complete_order', {
+        await rpc('/payment/paypal/complete_order', {
             'provider_id': provider_id,
             'order_id': orderID,
         }).then(() => {
             // Close the PayPal buttons that were rendered
             this.paypalData[this.selectedOptionId]['paypalButton'].close();
             window.location = '/payment/status';
+        }).catch(error => {
+            if (error instanceof RPCError) {
+                this._displayErrorDialog(_t("Payment processing failed"), error.data.message);
+                this._enableButton(); // The button has been disabled before initiating the flow.
+            }
+            return Promise.reject(error);
         })
     },
 

--- a/addons/payment_paypal/static/src/js/payment_form.js
+++ b/addons/payment_paypal/static/src/js/payment_form.js
@@ -167,8 +167,8 @@ paymentForm.include({
         this.call('ui', 'unblock');
         // Paypal throws an error if the popup is closed before it can load;
         // this case should be treated as an onCancel event.
-        if (message !== "Detected popup close") {
-            this._displayErrorDialog(_t("Payment processing failed"), error.message);
+        if (message !== "Detected popup close" && !(error instanceof RPCError)) {
+            this._displayErrorDialog(_t("Payment processing failed"), message);
         }
     },
 });


### PR DESCRIPTION
**[FIX] payment: return a rejected promise on RPC error during payment**

This commit addresses the issue of RPC errors not triggering a promise rejection when initiating or processing the payment. This caused issues with PayPal not being able to pass the error to its error handler when a problem occurred during payment processing. For example, the error message "order id was not provided" would be shown instead of the actual RPC error message.

---

**[FIX] payment_paypal: show message on RPC error during order completion**

This commit fixes RPC errors occurring during order completion not being caught and not triggering a promise rejection. A simple "ValidationError" toaster notification was shown.

---

**[FIX] payment_paypal: show RPC error messages only once**

RPC errors occurring during payment were shown in a modal by the generic error handler of `payment` and again by the error handler of PayPal. RPC errors are now filtered out by the handler of PayPal.