### PR TITLE
[IMP] purchase_stock: create vendor from replenish wizard

### DIFF
--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -153,3 +153,14 @@ class ProductSupplierinfo(models.Model):
                 'target': 'new',
                 'view_mode': 'form',
             }
+
+    @api.model
+    def name_search(self, name='', args=None, operator='ilike', limit=100):
+        res = super().name_search(name, args, operator, limit)
+        res = [(r[0], r[1], {'is_vendor': True}) for r in res]
+
+        partner_args = [['display_name', '!=', r[1]] for r in res]
+        partners = self.env['res.partner'].name_search(name, partner_args, operator, limit - len(res))
+
+        res += [(False, p[1], {'is_vendor': False, 'partner_id': p[0]}) for p in partners]
+        return res

--- a/addons/purchase_stock/static/src/widgets/replenish_autocomplete.scss
+++ b/addons/purchase_stock/static/src/widgets/replenish_autocomplete.scss
@@ -1,0 +1,13 @@
+
+.o-autocomplete {
+    .ui-menu-item {
+        &.o_replenish_autocomplete_partner_link {
+            > a {
+                color: $link-color;
+                &.ui-state-active:not(.o_m2o_start_typing) {
+                    color: $link-hover-color;
+                }
+            }
+        }
+    }
+}

--- a/addons/purchase_stock/static/src/widgets/replenish_relational_utils.js
+++ b/addons/purchase_stock/static/src/widgets/replenish_relational_utils.js
@@ -1,0 +1,73 @@
+import { registry } from "@web/core/registry";
+import { AutoComplete } from "@web/core/autocomplete/autocomplete";
+import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
+import { Many2OneField, many2OneField } from "@web/views/fields/many2one/many2one_field";
+
+class ReplenishAutoComplete extends AutoComplete {
+    // static template = "purchase_stock.ReplenishAutoComplete";
+    onOptionClick(option) {
+        super.onOptionClick(option);
+    }
+}
+
+class ReplenishMany2XAutoComplete extends Many2XAutocomplete {
+    static template = "purchase_stock.ReplenishMany2XAutocomplete";
+    static components = { ReplenishAutoComplete };
+
+    setup() {
+        super.setup();
+    }
+
+    mapRecordToOption(result) {
+        const res = super.mapRecordToOption(result);
+        if (!result[2].is_vendor) {
+            res.classList += ' o_replenish_autocomplete_partner_link';
+            res.openEditForm = true;
+            res.partner_id = result[2].partner_id;
+        } else {
+            res.openEditForm = false;
+        }
+        return res;
+    }
+
+    onSelect(option, params = {}) {
+        if (option.openEditForm == false) {
+            return super.onSelect(option, params);
+        }
+
+        const record = {
+            id: option.value,
+            // bit hacky: passing partner_id for name_create
+            display_name: option.partner_id,
+        };
+        this.props.update([record], params);
+        option.action(params);
+    }
+
+    async loadOptionsSource(request) {
+        const res = await super.loadOptionsSource(request);
+        const options = res.map(r => {
+            if (r.openEditForm) {
+                r.action = () => this.openMany2X({
+                    context: this.getCreationContext(request),
+                    nextRecordsContext: this.props.context,
+                })
+            }
+
+            return r;
+        })
+        return options;
+    }
+}
+
+class ReplenishMany2OneField extends Many2OneField {
+    static components = {
+        ...Many2OneField.components,
+        Many2XAutocomplete: ReplenishMany2XAutoComplete,
+    };
+}
+
+registry.category("fields").add("replenish_many2one", {
+    ...many2OneField,
+    component: ReplenishMany2OneField,
+});

--- a/addons/purchase_stock/static/src/widgets/replenish_relational_utils.xml
+++ b/addons/purchase_stock/static/src/widgets/replenish_relational_utils.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates xml:space="preserve">
+
+<t t-name="purchase_stock.ReplenishAutoComplete" t-inherit="web.AutoComplete">
+    <xpath expr="">
+    </xpath>
+</t>
+
+<t t-name="purchase_stock.ReplenishMany2XAutocomplete" t-inherit="web.Many2XAutocomplete">
+    <xpath expr="//AutoComplete" position="replace">
+        <ReplenishAutoComplete t-else=""
+            value="props.value"
+            id="props.id"
+            placeholder="props.placeholder"
+            autocomplete="'off'"
+            sources="sources"
+            autoSelect="props.autoSelect"
+            onSelect.bind="onSelect"
+            onInput.bind="onInput"
+            onChange.bind="onChange"
+            dropdown="props.dropdown"
+            autofocus="props.autofocus"
+            resetOnSelect="props.value === ''"
+            onCancel.bind="onCancel"
+        />
+    </xpath>
+</t>
+
+</templates>

--- a/addons/purchase_stock/wizard/product_replenish_views.xml
+++ b/addons/purchase_stock/wizard/product_replenish_views.xml
@@ -9,7 +9,8 @@
                 <label for="supplier_id" invisible="not show_vendor"/>
                 <div class="o_row">
                     <field name="show_vendor" invisible="1"/>
-                    <field name="supplier_id" invisible="not show_vendor" required="show_vendor" domain="[('product_tmpl_id', '=', product_tmpl_id)]" options="{'no_open': 1, 'no_create': 1}"/>
+                    <field name="supplier_id" invisible="not show_vendor" required="show_vendor" domain="[('product_tmpl_id', '=', product_tmpl_id)]"
+                        widget="replenish_many2one" options="{'no_quick_create': True}" />
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
Before this commit, when attempting to replenish a missing product, the supplier field in the wizard was disabled, preventing the creating of a new supplier. This was frustrating when no supplier was previously set on the product. With this commit, it is now possible to create and edit supplier information directly from the wizard

task: 4314668

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
