### PR TITLE
[REM] html_editor: lingering handleCommand method

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -218,17 +218,6 @@ export class LinkPlugin extends Plugin {
         this.removeLinkShortcut();
     }
 
-    handleCommand(command, payload) {
-        switch (command) {
-            case "NORMALIZE":
-                this.normalizeLink();
-                break;
-            case "CLEAN_FOR_SAVE":
-                this.removeEmptyLinks(payload.root);
-                break;
-        }
-    }
-
     // -------------------------------------------------------------------------
     // Commands
     // -------------------------------------------------------------------------


### PR DESCRIPTION
The handleCommand method was removed from Plugin in a recent API refactor [1] but, due to an oversight, this one was forgotten.

[1]: https://github.com/odoo/odoo/commit/9aebe936fea2f260d85581062d84860dfcea6c3c
