### PR TITLE
[18.0][FIX] fix _compute_is_mto() since warehouse_id is now computed …

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -151,7 +151,7 @@ class SaleOrderLine(models.Model):
         remaining.free_qty_today = False
         remaining.qty_available_today = False
 
-    @api.depends('product_id', 'route_id', 'order_id.warehouse_id', 'product_id.route_ids')
+    @api.depends('product_id', 'route_id', 'warehouse_id', 'product_id.route_ids')
     def _compute_is_mto(self):
         """ Verify the route of the product based on the warehouse
             set 'is_available' at True if the product availability in stock does
@@ -165,7 +165,7 @@ class SaleOrderLine(models.Model):
             product_routes = line.route_id or (product.route_ids + product.categ_id.total_route_ids)
 
             # Check MTO
-            mto_route = line.order_id.warehouse_id.mto_pull_id.route_id
+            mto_route = line.warehouse_id.mto_pull_id.route_id
             if not mto_route:
                 try:
                     mto_route = self.env['stock.warehouse']._find_or_create_global_route('stock.route_warehouse0_mto', _('Replenish on Order (MTO)'), create=False)

--- a/doc/cla/corporate/akretion.md
+++ b/doc/cla/corporate/akretion.md
@@ -46,3 +46,4 @@ Sylvain Legal sylvain.legal@akretion.com https://github.com/legalsylvain
 Thiago Moreira de Souza Arrais thiago.moreira@akretion.com.br https://github.com/thiagomds
 Valentin Chemiere valentin.chemiere@akretion.com https://github.com/viggor
 Vianney da Costa vianney.dacosta@akretion.com.br https://launchpad.net/~vianneydc
+Kevin Roche kevin.roche@akretion.com https://github.com/Kev-Roche


### PR DESCRIPTION
…on sale.order.line

Description of the issue/feature this PR addresses:
Since v18.0, the warehouse_id field on sale.order.line is now computed.
Before v18.0, the field was related to the warehouse of the order (order_id.warehouse_id).

Current behavior before PR:
The method _compute_is_mto() is still referencing the warehouse of the order instead of the warehouse of the line. As a result, in cases where the warehouse of the line differs from that of the order, the is_mto value may be incorrect.

Desired behavior after PR is merged:
The is_mto value should be computed based on the warehouse of the line, not the order.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
