### PR TITLE
[FIX] website_sale_loyalty: Consider free shipping discount in Express Checkout

### DIFF
--- a/addons/payment_stripe/static/src/js/express_checkout_form.js
+++ b/addons/payment_stripe/static/src/js/express_checkout_form.js
@@ -200,7 +200,7 @@ paymentExpressCheckoutForm.include({
                     status: 'success',
                     ...this._getOrderDetails(
                         ev.shippingOption.amount,
-                        result.delivery_discount_minor_amount || 0,
+                        parseInt(result.delivery_discount_minor_amount) || 0,
                     ),
                 });
             });

--- a/addons/website_sale_loyalty/controllers/delivery.py
+++ b/addons/website_sale_loyalty/controllers/delivery.py
@@ -4,6 +4,7 @@ from functools import partial
 
 from odoo.http import request
 
+from odoo.addons.payment import utils as payment_utils
 from odoo.addons.website_sale.controllers.delivery import Delivery
 
 
@@ -19,6 +20,9 @@ class WebsiteSaleLoyaltyDelivery(Delivery):
         shipping_discount = sum(free_shipping_lines.mapped('price_subtotal'))
         if shipping_discount:
             res['amount_delivery_discounted'] = to_html(shipping_discount)
+            res['delivery_discount_minor_amount'] = payment_utils.to_minor_currency_units(
+                shipping_discount, order.currency_id
+            )
         res['discount_reward_amounts'] = [
             to_html(line.price_subtotal)
             for line in order.order_line

--- a/addons/website_sale_loyalty/tests/test_website_sale_loyalty_delivery.py
+++ b/addons/website_sale_loyalty/tests/test_website_sale_loyalty_delivery.py
@@ -3,9 +3,20 @@
 from odoo import Command
 from odoo.tests import HttpCase, tagged
 
+from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+from odoo.addons.website_sale_loyalty.controllers.delivery import (
+    WebsiteSaleLoyaltyDelivery,
+)
+
 
 @tagged('post_install', '-at_install')
-class TestWebsiteSaleDelivery(HttpCase):
+class TestWebsiteSaleDelivery(HttpCase, WebsiteSaleCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Controller = WebsiteSaleLoyaltyDelivery()
 
     def setUp(self):
         super().setUp()
@@ -142,3 +153,35 @@ class TestWebsiteSaleDelivery(HttpCase):
         })
         self.ewallet.partner_id = self.partner_admin
         self.start_tour("/", 'check_shipping_discount', login="admin")
+
+    def test_express_checkout_shipping_discount(self):
+        """
+        Check display of shipping discount promotion in express checkout form by ensuring is present
+        in the values returned to the form.
+        """
+        # Create a discount code
+        program = self.env['loyalty.program'].sudo().create({
+            'name': 'Free Shipping',
+            'program_type': 'promo_code',
+            'rule_ids': [
+                Command.create({
+                    'code': "FREE",
+                    'minimum_amount': 0,
+                })
+            ],
+            'reward_ids': [
+                Command.create({
+                    'reward_type': 'shipping',
+                    'discount_max_amount': 6.0,
+                })
+            ]
+            }
+        )
+
+        # Apply discount
+        self.cart._try_apply_code("FREE")
+        self.cart._apply_program_reward(program.reward_ids, program.coupon_ids)
+
+        with MockRequest(self.env, sale_order_id=self.cart.id, website=self.website):
+            result = self.Controller.shop_set_delivery_method(self.normal_delivery2.id)
+        self.assertEqual(result['delivery_discount_minor_amount'], -600)


### PR DESCRIPTION
Versions
--------
- 17.4+

Steps
-----
1. Create a discount code with a free shipping reward with a max amount;
3. Create one or more shipping methods with a price higher than the max amount previously set;
4. in eCommerce, add a product to the cart, and go to checkout;
5. apply coupon;
6. open the express checkout form using Stripe
7. switch between shipping methods.

Issue
-----
The free shipping discount is not considered in the Express Checkout form.

Cause
-----
Commit 8e2b6ce accidentally removed `delivery_discount_minor_amount` from `_order_summary_values` (previously called
`_update_website_sale_delivery_return`) introduced by commit c047cc8, preventing the express checkout to get the up to date value.

Solution
--------
Add `delivery_discount_minor_amount` back to `_order_summary_values`.

opw-4204901
