### PR TITLE
[FIX] mail: no crash on GIF duplicated category name

### DIFF
--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -42,7 +42,7 @@
                         </t>
                     </t>
                     <t t-else="">
-                        <t t-foreach="state.categories" t-as="category" t-key="category.name">
+                        <t t-foreach="state.categories" t-as="category" t-key="category_index">
                             <div class="col">
                                 <div class="position-relative ratio ratio-16x9 cursor-pointer rounded overflow-hidden" t-on-click="() => this.onClickCategory(category)" aria-label="list-item">
                                     <img class="o-discuss-GifPickerCategory-img img-fluid" t-att-src="category.image" loading="lazy" alt="GIF Category"/>

--- a/addons/mail/static/tests/gif_picker/gif_picker.test.js
+++ b/addons/mail/static/tests/gif_picker/gif_picker.test.js
@@ -126,6 +126,37 @@ test("Open a GIF category trigger the search for the category", async () => {
     await contains("input[placeholder='Search for a GIF']", { value: "cry" });
 });
 
+test("Can have GIF categories with same name", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "" });
+    onRpc("/discuss/gif/categories", () => {
+        return {
+            locale: "en",
+            tags: [
+                {
+                    searchterm: "duplicate",
+                    path: "/v2/search?q=duplicate&locale=en&component=categories&contentfilter=low",
+                    image: "https://media.tenor.com/BiseY2UXovAAAAAM/duplicate.gif",
+                    name: "#duplicate",
+                },
+                {
+                    searchterm: "duplicate",
+                    path: "/v2/search?q=duplicate&locale=en&component=categories&contentfilter=low",
+                    image: "https://media.tenor.com/BiseY2UXovAAAAAM/duplicate.gif",
+                    name: "#duplicate",
+                },
+            ],
+        };
+    });
+    onRpc("/discuss/gif/search", () => rpc.search);
+    await start();
+    await openDiscuss(channelId);
+    await click("button[aria-label='GIFs']");
+    await contains("img[data-src='https://media.tenor.com/BiseY2UXovAAAAAM/duplicate.gif']", {
+        count: 2,
+    });
+});
+
 test("Reopen GIF category list when going back", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "" });


### PR DESCRIPTION
Before this commit, opening of GIF picker in some languages like Portuguese could lead to following crash:

```
OwlError: Got duplicate key in t-foreach: #irritado
```

This happens because GIF picker categories come from Tenor data and there might be duplicated categories. However in code we use `category.name` for `t-key`, thus there was a crash when 2 categories had the same name.

This commit fixes the issue by using `category_index` instead, which is the index of category in the global list of categories, which is necessarily unique for each GIF category.

opw-4319241