### PR TITLE
[FIX] stock_account: disable valuation by Lot/SN when Changing Tracking

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -17,8 +17,15 @@ class ProductTemplate(models.Model):
     valuation = fields.Selection(related="categ_id.property_valuation", readonly=True)
     lot_valuated = fields.Boolean(
         "Valuation by Lot/Serial number",
+        compute='_compute_lot_valuated', store=True, readonly=False,
         help="If checked, the valuation will be specific by Lot/Serial number.",
     )
+
+    @api.depends('tracking')
+    def _compute_lot_valuated(self):
+        for product in self:
+            if product.tracking == 'none':
+                product.lot_valuated = False
 
     @api.onchange('standard_price')
     def _onchange_standard_price(self):

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -566,3 +566,19 @@ class TestLotValuation(TestStockValuationCommon):
         quant.action_apply_inventory()
         self.assertEqual(lot.standard_price, 9)
         self.assertEqual(lot.value_svl, 27)
+
+    def test_lot_valuation_after_tracking_update(self):
+        """
+        Test that 'lot_valuated' is set to False when the tracking is changed to 'none'.
+        """
+        # update the tracking from product.product
+        self.assertEqual(self.product1.tracking, 'lot')
+        self.product1.lot_valuated = True
+        self.assertTrue(self.product1.lot_valuated)
+        self.product1.tracking = 'none'
+        self.assertFalse(self.product1.lot_valuated)
+        # update the tracking from product.template
+        self.product1.tracking = 'lot'
+        self.product1.lot_valuated = True
+        self.product1.product_tmpl_id.tracking = 'none'
+        self.assertFalse(self.product1.product_tmpl_id.lot_valuated)


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product “P1”:
    - Set it to be tracked by Serial Number (SN).
    - Enable Valuation by Lot/SN.
- Save.
- Disable inventory tracking.

**Problem:**
The Valuation by Lot/SN option becomes invisible but is not actually disabled. For example, when processing a receipt, a user error occurs, requiring a serial number to be set.

opw-4330877