### PR TITLE
Update res_currency_data.xml

### DIFF
--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -409,6 +409,7 @@
             <field name="iso_numeric">608</field>
             <field name="full_name">Philippine peso</field>
             <field name="symbol">₱</field>
+            <field name="position">before</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Peso</field>


### PR DESCRIPTION
Set PHP currency symbol  position to 'before'

Description of the issue/feature this PR addresses:
This will set to accurate PHP currency symbol position as observed and practiced in the Philippines.

Current behavior before PR:
PHP currency symbol is position 'after'.

Desired behavior after PR is merged:
PHP currency symbol is position 'before'.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
