### PR TITLE
[IMP] stock_landed_cost: use an expense account instead of an inventory

### DIFF
--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -30,7 +30,7 @@ class AccountMove(models.Model):
             'cost_lines': [(0, 0, {
                 'product_id': l.product_id.id,
                 'name': l.product_id.name,
-                'account_id': l.product_id.product_tmpl_id.get_product_accounts()['stock_input'].id,
+                'account_id': l.product_id.product_tmpl_id.get_product_accounts()['expense'].id,
                 'price_unit': l.currency_id._convert(l.price_subtotal, l.company_currency_id, l.company_id, self.invoice_date or fields.Date.context_today(l)),
                 'split_method': l.product_id.split_method_landed_cost or 'equal',
             }) for l in landed_costs_lines],

--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -341,8 +341,7 @@ class StockLandedCostLine(models.Model):
         self.split_method = self.product_id.product_tmpl_id.split_method_landed_cost or self.split_method or 'equal'
         self.price_unit = self.product_id.standard_price or 0.0
         accounts_data = self.product_id.product_tmpl_id.get_product_accounts()
-        self.account_id = accounts_data['stock_input']
-
+        self.account_id = accounts_data['expense']
 
 class AdjustmentLines(models.Model):
     _name = 'stock.valuation.adjustment.lines'


### PR DESCRIPTION

Product landed cost is type service, user setup Inventory Valuation is real_time Match default account when recording bill

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
