### PR TITLE
[FIX] hr: fix the department organization chart

### DIFF
--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -162,6 +162,7 @@ class Department(models.Model):
             'type': 'ir.actions.act_window',
             'res_model': res_model,
             'view_mode': 'list,kanban,form',
+            'views': [(False, 'list'), (False, 'kanban'), (False, 'form')],
             'search_view_id': [search_view_id, 'search'],
             'context': {
                 'searchpanel_default_department_id': self.id,

--- a/addons/hr/static/src/components/department_chart/department_chart.js
+++ b/addons/hr/static/src/components/department_chart/department_chart.js
@@ -34,11 +34,13 @@ export class DepartmentChart extends Component {
     }
 
     async openDepartmentEmployees(departmentId) {
-        this.action.doAction("hr.action_employee_from_department" , {
-            additionalContext: {
-                active_id: departmentId,
-            },
-        });
+        const dialogAction = await this.orm.call(
+            this.props.record.resModel,
+            "action_employee_from_department",
+            [departmentId],
+            {}
+        );
+        this.action.doAction(dialogAction);
     }
 }
 

--- a/addons/hr/static/src/components/department_chart/department_chart.xml
+++ b/addons/hr/static/src/components/department_chart/department_chart.xml
@@ -35,7 +35,7 @@
                     <span class="department_name ms-2">
                         <t t-esc="dept.name"/>
                     </span>
-                    <a class="badge rounded-pill bg-300 border px-2" role="button"
+                    <a class="badge rounded-pill bg-300 border px-2 cursor-pointer" role="button"
                         title="Show employees"
                         t-on-click.prevent="() => this.openDepartmentEmployees(dept.id)">
                         <t t-esc="dept.employees"/>


### PR DESCRIPTION
Step to reproduce:

1) Install the hr Application and open the form view of department
2) Clicking the gray button that shows the employee number in the department organization chart will result in an error

Cause:
The argument in the doAction function is incorrect; it should be an action record, not a Python function

Solution:
First, we retrieve the action using the ORM and then pass it to the doAction function as an argument.

Task-4337876
