### PR TITLE
[IMP] website,*: revert set task partner from form email

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -4269,12 +4269,6 @@ msgid "E.g. https://www.mydomain.com"
 msgstr ""
 
 #. module: website
-#. odoo-python
-#: code:addons/website/controllers/form.py:0
-msgid "EXTERNAL SUBMISSION - Customer not verified"
-msgstr ""
-
-#. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_table_of_content
 msgid ""
 "Easily design your own Odoo templates thanks to clean HTML\n"
@@ -10907,14 +10901,6 @@ msgstr ""
 #. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_mega_menu_multi_menus
 msgid "Third Menu"
-msgstr ""
-
-#. module: website
-#. odoo-python
-#: code:addons/website/controllers/form.py:0
-msgid ""
-"This %(model_name)s was submitted by %(user_name)s (%(user_email)s) on "
-"behalf of %(form_email)s"
 msgstr ""
 
 #. module: website

--- a/addons/website_crm/tests/test_website_crm.py
+++ b/addons/website_crm/tests/test_website_crm.py
@@ -16,7 +16,7 @@ class TestWebsiteCrm(odoo.tests.HttpCase):
         self.start_tour("/?utm_source=Source&utm_medium=Medium&utm_campaign=New campaign", 'website_crm_tour')
 
         # check result
-        record = self.env['crm.lead'].search([('description', '=', '<p>EXTERNAL SUBMISSION - Customer not verified<br>\n<br>\n</p><p>### TOUR DATA ###</p>')])
+        record = self.env['crm.lead'].search([('description', '=', '### TOUR DATA ###')])
         self.assertEqual(len(record), 1)
         self.assertEqual(record.contact_name, 'John Smith')
         self.assertEqual(record.email_from, 'john@smith.com')

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -346,8 +346,3 @@ class WebsiteHrRecruitment(WebsiteForm):
                 ' You can continue if it\'s not a mistake.'
             )
         }
-
-    def _should_log_authenticate_message(self, record):
-        if record._name == "hr.applicant" and not request.session.uid:
-            return False
-        return super()._should_log_authenticate_message(record)

--- a/addons/website_project/controllers/main.py
+++ b/addons/website_project/controllers/main.py
@@ -1,38 +1,40 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.http import request
-
-from odoo.addons.base.models.ir_qweb_fields import nl2br_enclose
+from odoo import _
+from odoo.addons.base.models.ir_qweb_fields import nl2br, nl2br_enclose
 from odoo.addons.website.controllers import form
+from odoo.tools import html2plaintext
 
 
 class WebsiteForm(form.WebsiteForm):
     def insert_record(self, request, model, values, custom, meta=None):
         if model.model == 'project.task':
+            visitor_sudo = request.env['website.visitor']._get_visitor_from_request()
+            visitor_partner = visitor_sudo.partner_id
+            if visitor_partner:
+                values['partner_id'] = visitor_partner.id
             # When a task is created from the web editor, if the key 'user_ids' is not present, the user_ids is filled with the odoo bot. We set it to False to ensure it is not.
             values.setdefault('user_ids', False)
-            if custom:
-                custom.replace('email_from', 'Email')
 
         res = super().insert_record(request, model, values, custom, meta=meta)
         if model.model != 'project.task':
             return res
         task = request.env['project.task'].sudo().browse(res)
+        custom = custom.replace('email_from', 'Email')
+        custom_label = nl2br_enclose(_("Other Information"), 'h4')  # Title for custom fields
         default_field = model.website_form_default_field_id
-        if default_field.name and task[default_field.name]:
+        default_field_data = values.get(default_field.name, '')
+        default_field_content = nl2br_enclose(default_field.name.capitalize(), 'h4') + nl2br_enclose(html2plaintext(default_field_data), 'p')
+        custom_content = (default_field_content if default_field_data else '') \
+                        + (custom_label + custom if custom else '') \
+                        + (self._meta_label + meta if meta else '')
+
+        if default_field.name:
+            if default_field.ttype == 'html':
+                custom_content = nl2br(custom_content)
+            task[default_field.name] = custom_content
             task._message_log(
-                body=nl2br_enclose(task[default_field.name], 'p'),
+                body=custom_content,
                 message_type='comment',
             )
         return res
-
-    def extract_data(self, model, values):
-        data = super().extract_data(model, values)
-        if model.model == 'project.task' and values.get('email_from'):
-            partners_list = request.env['mail.thread'].sudo()._mail_find_partner_from_emails([values['email_from']])
-            partner_id = partners_list[0].id if partners_list else False
-            data['record']['partner_id'] = partner_id
-            data['record']['email_from'] = values['email_from']
-            if not partner_id:
-                data['record']['email_cc'] = values['email_from']
-        return data

--- a/addons/website_project/i18n/website_project.pot
+++ b/addons/website_project/i18n/website_project.pot
@@ -52,5 +52,11 @@ msgstr ""
 #. module: website_project
 #. odoo-python
 #: code:addons/website_project/controllers/main.py:0
-msgid "Other Information"
+msgid "⚠️ EXTERNAL SUBMISSION - Customer not verified"
+msgstr ""
+
+#. module: website_project
+#. odoo-python
+#: code:addons/website_project/controllers/main.py:0
+msgid "This task was submitted by %(user_name)s (%(user_email)s) on behalf of %(form_email)s"
 msgstr ""

--- a/addons/website_project/i18n/website_project.pot
+++ b/addons/website_project/i18n/website_project.pot
@@ -48,3 +48,9 @@ msgstr ""
 #: code:addons/website_project/static/src/js/website_project_editor.js:0
 msgid "Your Email"
 msgstr ""
+
+#. module: website_project
+#. odoo-python
+#: code:addons/website_project/controllers/main.py:0
+msgid "Other Information"
+msgstr ""

--- a/addons/website_project/tests/test_website_project.py
+++ b/addons/website_project/tests/test_website_project.py
@@ -32,9 +32,8 @@ class TestWebsiteProject(HttpCase):
         self.assertTrue(task.exists())
         self.assertFalse(task.partner_id, "Partner id should be False")
         self.assertEqual(task.email_cc, 'test@test.com', "email_cc should be same as added on website")
-        self.assertIn('EXTERNAL SUBMISSION - Customer not verified', html2plaintext(task.description), "Warning message should be displayed in description of task")
 
-        mail_message = task.message_ids.filtered(lambda m: m.body == '<div class="alert alert-info">/!\\ EXTERNAL SUBMISSION - Customer not verified</div>')
+        mail_message = task.message_ids.filtered(lambda m: m.body == '<div class="alert alert-info">⚠️ EXTERNAL SUBMISSION - Customer not verified</div>')
         self.assertEqual(len(mail_message), 1, "Alert message should be displayed in the chatter of the task created.")
         self.assertEqual(mail_message.author_id, self.env.ref('base.partner_root'), 'The author of the warning message should be OdooBot.')
 
@@ -55,7 +54,6 @@ class TestWebsiteProject(HttpCase):
         self.assertFalse(task.email_cc, "email_cc field should be empty")
         admin_user = self.env.ref('base.user_admin')
         asserttext = '%s (%s)' % (admin_user.name, admin_user.email)
-        self.assertIn('This Task was submitted by %s on behalf of test@partner.com' % asserttext, html2plaintext(task.description), "Warning message should be displayed in description of task")
 
         mail_message = task.message_ids.filtered(lambda m: m.body == '<div class="alert alert-info">This Task was submitted by %s on behalf of test@partner.com</div>' % asserttext)
         self.assertEqual(len(mail_message), 1, "Alert message should be displayed in the chatter of the task created.")


### PR DESCRIPTION
*_ = website_crm, website_project, website_hr_recruitment

Reimplement Partner Assignment and Messaging for Website Form Tasks

- Automatically assigns a partner to tasks if the form email matches an existing partner; otherwise, leaves the partner unset.
- Adds a chatter message for external submissions and warns if the email doesn't match the customer's verified email.

task-4295363


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
