### PR TITLE
[FIX] mail: don't add query strings on non-binary attachment

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -69,6 +69,9 @@ export class AttachmentList extends Component {
      * @param {import("models").Attachment} attachment
      */
     getImageUrl(attachment) {
+        if (attachment.type === "url") {
+            return attachment.url;
+        }
         if (attachment.uploading && attachment.tmpUrl) {
             return attachment.tmpUrl;
         }

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -33,7 +33,7 @@ export class Attachment extends FileModelMixin(Record) {
     message = Record.one("Message");
     /** @type {string} */
     create_date;
-    /** @type {string} */
+    /** @type {'binary'|'url'} */
     type;
     /** @type {string} */
     url;


### PR DESCRIPTION
Before this PR, query strings were added to the attachment of URL types. This is incorrect since those URLs can already have query strings, and the added query strings don't make sense for non-binary attachments.
