### PR TITLE
[FIX] pos_restaurant: test_03_preparation_display_skip_change tour

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -58,6 +58,14 @@ export function clickDisplayedProduct(
 ) {
     const step = [
         {
+            isActive: ["body:has(.modal:contains(printing failed))"],
+            trigger: ".modal button:contains(ok)",
+            run: "click",
+        },
+        {
+            trigger: "body:not(:has(.modal))",
+        },
+        {
             content: `click product '${name}'`,
             trigger: `article.product .product-content .product-name:contains("${name}")`,
             run: "click",

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -4,6 +4,14 @@ import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_scre
 export function clickOrderButton() {
     return [
         {
+            isActive: ["body:has(.modal:contains(printing failed))"],
+            trigger: ".modal button:contains(ok)",
+            run: "click",
+        },
+        {
+            trigger: "body:not(:has(.modal))",
+        },
+        {
             content: "click order button",
             trigger: ".actionpad .submit-order",
             run: "click",


### PR DESCRIPTION
In this commit, we ensure to close modal (failed printing) before continue the tour or it can cause failures in tour.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
