### PR TITLE
[FIX] mrp: no unexpected untracked products

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -891,8 +891,6 @@ class MrpProduction(models.Model):
                     finished_move_lines.write({'lot_id': vals.get('lot_producing_id')})
                 if 'qty_producing' in vals:
                     finished_move.quantity = vals.get('qty_producing')
-                    if production.product_tracking == 'lot':
-                        finished_move.move_line_ids.lot_id = production.lot_producing_id
             if self._has_workorders() and not production.workorder_ids.operation_id and vals.get('date_start') and not vals.get('date_finished'):
                 new_date_start = fields.Datetime.to_datetime(vals.get('date_start'))
                 if not production.date_finished or new_date_start >= production.date_finished:

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -597,6 +597,12 @@ class StockMove(models.Model):
             return True
         return False
 
+    def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
+        vals = super()._prepare_move_line_vals(quantity, reserved_quant)
+        if self.production_id.product_tracking == 'lot' and self.product_id == self.production_id.product_id:
+            vals['lot_id'] = self.production_id.lot_producing_id.id
+        return vals
+
     def _key_assign_picking(self):
         keys = super(StockMove, self)._key_assign_picking()
         return keys + (self.created_production_id,)

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4201,9 +4201,11 @@ class TestMrpOrder(TestMrpCommon):
     def test_update_qty_producing_done_MO_with_lot(self):
         """
         Test that increasing the qty producing of a done MO for a product tracked by lot
-        will create an additional sml for the final product with the same producing lot
+        will create an additional sml for the final product with the same producing lot.
+        And test that removing products from stock, then increasing the qty producing of the MO
+        results in the correct qty of tracked products in stock.
         """
-        tracked_product = self.env['product.template'].create({
+        tracked_product = self.env['product.product'].create({
             'name': 'Super Product',
             'tracking': 'lot',
             'type': 'product',
@@ -4213,8 +4215,8 @@ class TestMrpOrder(TestMrpCommon):
             })],
         })
         mo = self.env['mrp.production'].create({
-            'product_id': tracked_product.product_variant_ids.id,
-            'product_uom_qty': 2.0,
+            'product_id': tracked_product.id,
+            'product_uom_qty': 5.0,
         })
         mo.action_generate_serial()
         producing_lot = mo.lot_producing_id
@@ -4222,9 +4224,17 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(mo.state, 'done')
         self.assertEqual(mo.move_finished_ids.lot_ids, producing_lot)
         self.assertEqual(mo.move_finished_ids.move_line_ids.mapped('lot_id'), producing_lot)
-        mo.qty_producing = 3.0
+        mo.qty_producing = 10.0
         self.assertTrue(all(sml.lot_id == producing_lot for sml in mo.move_finished_ids.move_line_ids))
-        self.assertEqual(sum(sml.quantity for sml in mo.move_finished_ids.move_line_ids), 3.0)
+        self.assertEqual(sum(sml.quantity for sml in mo.move_finished_ids.move_line_ids), 10.0)
+
+        stock_location = self.env.ref('stock.stock_location_stock')
+        self.env['stock.quant']._update_available_quantity(tracked_product, stock_location, -3, lot_id=producing_lot)
+        mo.qty_producing = 15.0
+        quants = tracked_product.stock_quant_ids.filtered(lambda q: q.location_id == stock_location)
+        self.assertRecordValues(quants, [
+            {'quantity': 12.0, 'lot_id': producing_lot.id},
+        ])
 
     def test_mrp_link_new_operations(self):
         """


### PR DESCRIPTION
Steps to reproduce:

- Create a product tracked by lot with a BOM
- Create and confirm an MO for 5 units of that product
- Assign a producing lot via the [+] smart button, and produce all
- Create, confirm, and validate the shipping for a SO of 3 items of that product
- Go back to the MO, unlock it, and change the quantity producing to 10
- Go to the product page, click on "On Hand"
> See that there exists 12 products with a lot id, and -5 **without** a lot id

Expected behavior:
There should be 7 products with lot it, and **NO products without lot id**

Cause of the issue:
When increasing the quantity producing, the newly created stock move line
 (SML) is created without a lot  id: https://github.com/odoo/odoo/blob/d5a7a3d02e3e2b4e47977abc8b9fc0d5d6135937/addons/stock/models/stock_move.py#L1471-L1477
Then only later, we update this new created move line to give it a lot_id
https://github.com/odoo/odoo/blob/a4ca3a3d6eb368bebcbcad00d81e098ee86a8610/addons/mrp/models/mrp_production.py#L900-L901
This update will first cause an undo of some move lines, calling `_synchronize_quant` (first call)
https://github.com/odoo/odoo/blob/49d25c58db2329d097566dc222d97cd8988d640d/addons/stock/models/stock_move_line.py#L459-L461
then, the actual lot_id update is committed
https://github.com/odoo/odoo/blob/49d25c58db2329d097566dc222d97cd8988d640d/addons/stock/models/stock_move_line.py#L473
then after that, another call to `_synchronize_quant` is being made to apply the changes (second call) https://github.com/odoo/odoo/blob/49d25c58db2329d097566dc222d97cd8988d640d/addons/stock/models/stock_move_line.py#L476-L477
However, since `_synchronize_quant` depends on reading the untracked quantities to decide
if it can compensate for negative values
https://github.com/odoo/odoo/blob/49d25c58db2329d097566dc222d97cd8988d640d/addons/stock/models/stock_move_line.py#L645
it sees different value of `untracked_qty` in the first call than that in the second call,
 which makes things go out of sync.

Solution:
The newly created move line has the correct lot_id at the moment of the creation,
so we avoid the issue of updating it later, and risking the quantities to go out of sync.

Another solution might be to edit the `write` method of `StockMoveLine`, by committing
changes related to lot_id before undoing any move lines
```py
if updates['lot_id'] and ml.lot_id != updates['lot_id']:
    super(StockMoveLine, ml).write({ 'lot_id': updates['lot_id'] })
# then here proceed to undoing
```

opw-4043539