### PR TITLE
[FIX] payment{,*}: wait for initiate payment flow completion

### DIFF
--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -374,7 +374,7 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
      */
     async _initiatePaymentFlow(providerCode, paymentOptionId, paymentMethodCode, flow) {
         // Create a transaction and retrieve its processing values.
-        this.rpc(
+        await this.rpc(
             this.paymentContext['transactionRoute'],
             this._prepareTransactionRouteParams(),
         ).then(processingValues => {

--- a/addons/payment_adyen/static/src/js/payment_form.js
+++ b/addons/payment_adyen/static/src/js/payment_form.js
@@ -142,9 +142,9 @@ paymentForm.include({
      * @param {string} flow - The online payment flow of the transaction.
      * @return {void}
      */
-    _initiatePaymentFlow(providerCode, paymentOptionId, paymentMethodCode, flow) {
+    async _initiatePaymentFlow(providerCode, paymentOptionId, paymentMethodCode, flow) {
         if (providerCode !== 'adyen' || flow === 'token') {
-            this._super(...arguments); // Tokens are handled by the generic flow
+            await this._super(...arguments); // Tokens are handled by the generic flow
             return;
         }
 

--- a/addons/payment_authorize/static/src/js/payment_form.js
+++ b/addons/payment_authorize/static/src/js/payment_form.js
@@ -26,7 +26,7 @@ paymentForm.include({
      */
     async _prepareInlineForm(providerId, providerCode, paymentOptionId, paymentMethodCode, flow) {
         if (providerCode !== 'authorize') {
-            this._super(...arguments);
+            await this._super(...arguments);
             return;
         }
 
@@ -36,7 +36,7 @@ paymentForm.include({
             return; // Don't show the form for tokens.
         } else if (this.authorizeData[paymentOptionId]) {
             this._setPaymentFlow('direct'); // Overwrite the flow even if no re-instantiation.
-            loadJS(this.authorizeData[paymentOptionId]['acceptJSUrl']); // Reload the SDK.
+            await loadJS(this.authorizeData[paymentOptionId]['acceptJSUrl']); // Reload the SDK.
             return; // Don't re-extract the data if already done for this payment method.
         }
 
@@ -58,7 +58,7 @@ paymentForm.include({
         this.authorizeData[paymentOptionId].acceptJSUrl = acceptJSUrl;
 
         // Load the SDK.
-        loadJS(acceptJSUrl);
+        await loadJS(acceptJSUrl);
     },
 
     // #=== PAYMENT FLOW ===#
@@ -76,7 +76,7 @@ paymentForm.include({
      */
     async _initiatePaymentFlow(providerCode, paymentOptionId, paymentMethodCode, flow) {
         if (providerCode !== 'authorize' || flow === 'token') {
-            this._super(...arguments); // Tokens are handled by the generic flow
+            await this._super(...arguments); // Tokens are handled by the generic flow
             return;
         }
 


### PR DESCRIPTION
We have to await for `_initiatePaymentFlow()` completion to ensure we correctly got the result of the transaction route.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
