### PR TITLE
[FIX] mail: ensure proper emoji display

### DIFF
--- a/addons/mail/static/src/scss/composer.scss
+++ b/addons/mail/static/src/scss/composer.scss
@@ -20,6 +20,13 @@
     font-family: emojifont;
 }
 
+.o_field_widget:has(.o_field_input_buttons > .o_mail_emojis_buttons) {
+    position: relative;
+}
+.o_field_input_buttons:has(.o_mail_emojis_buttons):has([data-field-type="text"])  {
+    flex-direction: column;
+    justify-content: flex-end;
+}
 .o_modal_fullscreen {
     z-index: $o-mail-ChatWindow-zindex + 1;
 


### PR DESCRIPTION
The emoji button in the text field was misaligned. Appearing too far in the form view. This led to the emoji being overlapped by other components. The fix consists in :
 - Added a 'position-absolute' to the button for correct alignement
 - Updated the parent container to 'position:relative' in the css for correct positioning.

This fix addresses a user interface bug and ensures consistent emoji positioning/display.

opw-4332574

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
