### PR TITLE
[FIX] base_import_module: check dependencies

### DIFF
--- a/addons/base_import_module/i18n/base_import_module.pot
+++ b/addons/base_import_module/i18n/base_import_module.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-13 10:27+0000\n"
-"PO-Revision-Date: 2024-08-13 10:27+0000\n"
+"POT-Creation-Date: 2024-11-18 09:37+0000\n"
+"PO-Revision-Date: 2024-11-18 09:37+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -204,6 +204,11 @@ msgid "Module Type"
 msgstr ""
 
 #. module: base_import_module
+#: model:ir.model,name:base_import_module.model_base_module_uninstall
+msgid "Module Uninstall"
+msgstr ""
+
+#. module: base_import_module
 #: model_terms:ir.ui.view,arch_db:base_import_module.view_base_module_import
 msgid "Module file (.zip)"
 msgstr ""
@@ -260,13 +265,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/base_import_module/models/ir_module.py:0
 #, python-format
-msgid "Studio customizations require Studio"
-msgstr ""
-
-#. module: base_import_module
-#. odoo-python
-#: code:addons/base_import_module/models/ir_module.py:0
-#, python-format
 msgid "Studio customizations require the Odoo Studio app."
 msgstr ""
 
@@ -292,6 +290,13 @@ msgstr ""
 #: code:addons/base_import_module/models/ir_module.py:0
 #, python-format
 msgid "The module %s cannot be downloaded"
+msgstr ""
+
+#. module: base_import_module
+#. odoo-python
+#: code:addons/base_import_module/models/ir_module.py:0
+#, python-format
+msgid "Unknown module dependencies:"
 msgstr ""
 
 #. module: base_import_module

--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -94,12 +94,12 @@ class IrModule(models.Model):
         unmet_dependencies = set(terp.get('depends', [])).difference(installed_mods)
 
         if unmet_dependencies:
-            if (unmet_dependencies == set(['web_studio']) and
-                    _is_studio_custom(path)):
-                err = _("Studio customizations require Studio")
-            else:
-                to_install = known_mods.filtered(lambda mod: mod.name in unmet_dependencies)
-                to_install.button_immediate_install()
+            wrong_dependencies = unmet_dependencies.difference(known_mods.mapped("name"))
+            if wrong_dependencies:
+                err = _("Unknown module dependencies:") + "\n - " + "\n - ".join(wrong_dependencies)
+                raise UserError(err)
+            to_install = known_mods.filtered(lambda mod: mod.name in unmet_dependencies)
+            to_install.button_immediate_install()
         elif 'web_studio' not in installed_mods and _is_studio_custom(path):
             raise UserError(_("Studio customizations require the Odoo Studio app."))
 


### PR DESCRIPTION
Issue: when we import a data only module with unknown dependencies we
allow it to be installed, and in the process we add wrong data to the
dependencies table.

Example manifest:
```
{'data': ['foo.xml'], 'depends': ['base', 'bar', 'baz']}
```
Will end up with:
```
test_17=> select id,name,latest_version,state from ir_module_module where name in ('base','foo', 'bar', 'baz')
+------+------+----------------+-----------+
| id   | name | latest_version | state     |
|------+------+----------------+-----------|
| 84   | base | 17.0.1.3       | installed |
| 1148 | foo  | <null>         | installed |
+------+------+----------------+-----------+
test_17=>  select * from ir_module_module_dependency where module_id=1148
+------+------+-----------+-----------------------+
| id   | name | module_id | auto_install_required |
|------+------+-----------+-----------------------|
| 2468 | bar  | 1148      | False                 |
| 2469 | baz  | 1148      | False                 |
| 2470 | base | 1148      | False                 |
+------+------+-----------+-----------------------+
```

This later causes issues during the upgrade of the DB.

In this patch we reinstate the check for missing dependencies taking
into account only those that cannot be installed --i.e those that are
truly unknown to the ORM. The installation of such data modules with
wrong dependencies will now be blocked with a UserError.

See: odoo/odoo@234590f3

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
