### PR TITLE
[FIX] l10n_fr_facturx_chorus_pro: BIC's company must be set

### DIFF
--- a/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
+++ b/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
@@ -52,4 +52,6 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 constraints['chorus_customer'] = _("The siret is mandatory for the customer when invoicing to Chorus Pro.")
             if supplier.country_code == 'FR' and ('siret' not in supplier._fields or not supplier.siret):
                 constraints['chorus_supplier'] = _("The siret is mandatory for french suppliers when invoicing to Chorus Pro.")
+            if not invoice.partner_bank_id.bank_id.bic:
+                constraints['chorus_financial_institution_branch'] = _("The BIC of the payee's bank is mandatory when invoicing to Chorus Pro.")
         return constraints


### PR DESCRIPTION
After discussion with Pagero support, the BIC of the Payee must be set, therefore we add a constraint to enforce it when invoicing to Chorus Pro.

opw-4139689
