### PR TITLE
[IMP] point_of_sale: disable fast payments option

### DIFF
--- a/addons/point_of_sale/static/src/app/payment/payment_interface.js
+++ b/addons/point_of_sale/static/src/app/payment/payment_interface.js
@@ -38,6 +38,16 @@ export class PaymentInterface {
     }
 
     /**
+     * This getter determines if send_payment_request
+     * is called automatically upon selecting the payment method.
+     * Overriding this to false allows manual input of an amount
+     * before sending the request to the terminal.
+     */
+    get fast_payments() {
+        return true;
+    }
+
+    /**
      * Called when a user clicks the "Send" button in the
      * interface. This should initiate a payment request and return a
      * Promise that resolves when the final status of the payment line

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -139,7 +139,10 @@ export class PaymentScreen extends Component {
         }
         if (result) {
             this.numberBuffer.reset();
-            if (paymentMethod.use_payment_terminal) {
+            if (
+                paymentMethod.use_payment_terminal &&
+                (paymentMethod.payment_terminal?.fast_payments ?? true)
+            ) {
                 const newPaymentLine = this.paymentLines.at(-1);
                 this.sendPaymentRequest(newPaymentLine);
             }

--- a/addons/web/tooling/_eslintignore
+++ b/addons/web/tooling/_eslintignore
@@ -319,6 +319,8 @@ addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
 !pos_self_order_preparation_display/**/*
 !pos_settle_due
 !pos_settle_due/**/*
+!pos_tyro
+!pos_tyro/**/*
 
 # Whitelist misc enterprise modules
 !sign

--- a/addons/web/tooling/_jsconfig.json
+++ b/addons/web/tooling/_jsconfig.json
@@ -93,6 +93,7 @@
                 "pos_self_order_preparation_display/static/src/*"
             ],
             "@pos_settle_due/*": ["pos_settle_due/static/src/*"],
+            "@pos_tyro/*": ["pos_tyro/static/src/*"],
             "@whatsapp_pos/*": ["whatsapp_pos/static/src/*"],
 
             "@test_mail/*": ["addons/test_mail/static/src/*"]


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/79432

As part of adding the Tyro payment method, new
functionality was required in order to not
automatically send payments to the terminal upon
adding a payment line. This gives a chance to
input a different payment amount, for example
when splitting the payment between multiple cards.

By default the behaviour is the same as before,
but if a payment method overrides `fast_payments`
to false, then payments will not be sent
automatically (the same behaviour as pre v18).

task-4086116

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
