### PR TITLE
[FIX] web_editor: prevent traceback when adding video in media dialog

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -184,7 +184,10 @@ export class MediaDialog extends Component {
                         if (this.props.media.dataset.shapeColors) {
                             element.dataset.shapeColors = this.props.media.dataset.shapeColors;
                         }
-                    } else if ([TABS.VIDEOS.id, TABS.DOCUMENTS.id].includes(this.state.activeTab)) {
+                    } else if (
+                        [TABS.VIDEOS.id, TABS.DOCUMENTS.id].includes(this.state.activeTab) &&
+                        this.props.media.parentElement
+                    ) {
                         const parentEl = this.props.media.parentElement;
                         if (
                             parentEl.tagName === "A" &&


### PR DESCRIPTION
Since [1], the media dialog component checks whether an URL should be removed by verifying if a parent element is an anchor. However, in some cases, there is no parent element, leading to a traceback.

Steps to reproduce:

- Insert a parallax snippet.
- Add a background YouTube video.
- Click "Add."
- A traceback occurs.

This commit resolves the issue by ensuring the check accounts for the absence of a parent element.

[1]: https://github.com/odoo/odoo/commit/36594d04a8909dd40ab6384f387c372ddae62345

opw-4328530
