### PR TITLE
[FIX] mail: open emoji picker animation

### DIFF
--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -31,7 +31,8 @@ export class QuickReactionMenu extends Component {
             position: "bottom-end",
             popoverClass: "o-mail-QuickReactionMenu-pickerPopover shadow-none",
             animation: false,
-            arrow: true,
+            onPositioned: (el, { direction, variant }) =>
+                el.classList.add(`o-popover--${direction[0]}${variant[0]}`),
         });
         this.dropdown = useState(useDropdownState());
         this.frequentEmojiService = useState(useService("web.frequent.emoji"));

--- a/addons/mail/static/src/core/common/quick_reaction_menu.scss
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.scss
@@ -102,10 +102,6 @@ $quick-reaction-menu-picker-grow-duration: 0.3s;
     background-color: unset;
     border: none;
 
-    & .popover-arrow {
-        display: none, ;
-    }
-
     & .o-EmojiPicker {
         transform: scale(0);
     }


### PR DESCRIPTION
The quick reaction menu relied on the popover position classes to determine the anchor for its animation. However, these classes were removed in [1], causing the picker not to appear. This PR restores those classes for this specific popover, resolving the issue.

[1]: https://github.com/odoo/odoo/pull/178376