### PR TITLE
[FIX] website_sale: ensure extra images show for no-variant products

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -497,7 +497,7 @@ class WebsiteSale(http.Controller):
             if not product_product:
                 product_product = request.env['product.product'].browse(
                     product_template.create_product_variant(combination_ids))
-        if product_template.has_configurable_attributes and product_product:
+        if product_template.has_configurable_attributes and product_product and not all(pa.create_variant == 'no_variant' for pa in product_template.attribute_line_ids.attribute_id):
             product_product.write({
                 'product_variant_image_ids': image_create_data
             })


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps (16.0+)
-------------
1. Create a no-variant attribute with multiple values;
2. Create a product and assign it  those attributes;
3. Add an extra product media from the sales tab;
4. Go to the website and add an extra image through the web editor;
5. Go back and check the extra product media field. The only image displayed is the one you uploaded in step 3.

Issue
-----
Both images should be shown as this product only has no-variant attributes so they don't create product variants.

Cause
-----
In Step 4, the uploaded image is saved to the product variant based on the evaluation of the `has_configurable_attributes` field on the product template and the presence of the variant.

Solution
--------
Check if the attributes are all `no_variant`. In that case, no product variant is created, so the images should be saved on the product template.

opw-4174331