### PR TITLE
[IMP] pos_*: removed invoiced state from PoS order

### DIFF
--- a/addons/l10n_es_edi_tbai_pos/models/pos_order.py
+++ b/addons/l10n_es_edi_tbai_pos/models/pos_order.py
@@ -73,9 +73,9 @@ class PosOrder(models.Model):
             raise UserError(self.env._("Please create an invoice for an amount over %s.", self.company_id.l10n_es_simplified_invoice_limit))
 
         if self.refunded_order_id:
-            if self.to_invoice and self.refunded_order_id.state != 'invoiced':
+            if self.to_invoice and not self.refunded_order_id.account_move:
                 raise UserError(self.env._("You cannot invoice a refund whose linked order hasn't been invoiced."))
-            if not self.to_invoice and self.refunded_order_id.state == 'invoiced':
+            if not self.to_invoice and self.refunded_order_id.account_move:
                 raise UserError(self.env._("Please invoice the refund as the linked order has been invoiced."))
 
         return super()._process_saved_order(draft)

--- a/addons/l10n_es_edi_tbai_pos/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/l10n_es_edi_tbai_pos/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -5,7 +5,7 @@ import { AddTbaiRefundReasonPopup } from "@l10n_es_edi_tbai_pos/app/components/p
 
 patch(TicketScreen.prototype, {
     async addAdditionalRefundInfo(order, destinationOrder) {
-        if (this.pos.company.l10n_es_tbai_is_enabled && order.state == "invoiced") {
+        if (this.pos.company.l10n_es_tbai_is_enabled && order.account_move) {
             const payload = await makeAwaitable(this.dialog, AddTbaiRefundReasonPopup, {
                 order: destinationOrder,
             });

--- a/addons/l10n_es_edi_tbai_pos/tests/test_tbai_pos.py
+++ b/addons/l10n_es_edi_tbai_pos/tests/test_tbai_pos.py
@@ -81,7 +81,7 @@ class TestPosEdi(TestEsEdiTbaiCommonGipuzkoa, TestPointOfSaleCommon):
         pos_order.to_invoice = True
         self.pay_pos_order(pos_order)
 
-        self.assertEqual(pos_order.state, 'invoiced')
+        self.assertTrue(pos_order.account_move)
         # The edi is handled by the invoice
         self.assertFalse(pos_order.l10n_es_tbai_state)
 
@@ -131,5 +131,5 @@ class TestPosEdi(TestEsEdiTbaiCommonGipuzkoa, TestPointOfSaleCommon):
         pos_refund.to_invoice = True
         self.pay_pos_order(pos_refund)
 
-        self.assertEqual(pos_refund.state, 'invoiced')
+        self.assertTrue(pos_refund.account_move)
         self.assertFalse(pos_refund.l10n_es_tbai_state)

--- a/addons/l10n_fr_pos_cert/models/account_closing.py
+++ b/addons/l10n_fr_pos_cert/models/account_closing.py
@@ -88,7 +88,7 @@ class AccountSaleClosing(models.Model):
             date_start = previous_closing.create_date
             cumulative_total += previous_closing.cumulative_total
 
-        domain = [('company_id', '=', company.id), ('state', 'in', ('paid', 'done', 'invoiced'))]
+        domain = [('company_id', '=', company.id), ('state', 'in', ('paid', 'done'))]
         if first_order.l10n_fr_secure_sequence_number is not False and first_order.l10n_fr_secure_sequence_number is not None:
             domain = AND([domain, [('l10n_fr_secure_sequence_number', '>', first_order.l10n_fr_secure_sequence_number)]])
         elif date_start:

--- a/addons/l10n_fr_pos_cert/models/res_company.py
+++ b/addons/l10n_fr_pos_cert/models/res_company.py
@@ -60,7 +60,7 @@ class ResCompany(models.Model):
         msg_alert = ''
         report_dict = {}
         if self._is_accounting_unalterable():
-            orders = self.env['pos.order'].search([('state', 'in', ['paid', 'done', 'invoiced']), ('company_id', '=', self.id),
+            orders = self.env['pos.order'].search([('state', 'in', ['paid', 'done']), ('company_id', '=', self.id),
                                     ('l10n_fr_secure_sequence_number', '!=', 0)], order="l10n_fr_secure_sequence_number ASC")
 
             if not orders:

--- a/addons/point_of_sale/models/digest.py
+++ b/addons/point_of_sale/models/digest.py
@@ -19,7 +19,7 @@ class DigestDigest(models.Model):
             'pos.order',
             'kpi_pos_total_value',
             date_field='date_order',
-            additional_domain=[('state', 'not in', ['draft', 'cancel', 'invoiced'])],
+            additional_domain=[('state', 'not in', ['draft', 'cancel']), ('account_move', '=', False)],
             sum_field='amount_total',
         )
 

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -279,7 +279,7 @@ class PosOrder(models.Model):
         help='The rate of the currency to the currency of rate applicable at the date of the order')
 
     state = fields.Selection(
-        [('draft', 'New'), ('cancel', 'Cancelled'), ('paid', 'Paid'), ('done', 'Posted'), ('invoiced', 'Invoiced')],
+        [('draft', 'New'), ('cancel', 'Cancelled'), ('paid', 'Paid'), ('done', 'Posted')],
         'Status', readonly=True, copy=False, default='draft', index=True)
 
     account_move = fields.Many2one('account.move', string='Invoice', readonly=True, copy=False, index="btree_not_null")
@@ -506,7 +506,7 @@ class PosOrder(models.Model):
             if vals.get('payment_ids'):
                 order._compute_prices()
                 totally_paid_or_more = float_compare(order.amount_paid, order.amount_total, precision_rounding=order.currency_id.rounding)
-                if totally_paid_or_more < 0 and order.state in ['paid', 'done', 'invoiced']:
+                if totally_paid_or_more < 0 and order.state in ['paid', 'done']:
                     raise UserError(_('The paid amount is different from the total amount of the order.'))
                 elif totally_paid_or_more > 0 and order.state == 'paid':
                     list_line.append(_("Warning, the paid amount is higher than the total amount. (Difference: %s)", formatLang(self.env, order.amount_paid - order.amount_total, currency_obj=order.currency_id)))
@@ -957,7 +957,7 @@ class PosOrder(models.Model):
             move_vals = order._prepare_invoice_vals()
             new_move = order._create_invoice(move_vals)
 
-            order.write({'account_move': new_move.id, 'state': 'invoiced'})
+            order.write({'account_move': new_move.id, 'state': 'done'})
             new_move.sudo().with_company(order.company_id).with_context(skip_invoice_sync=True)._post()
 
             moves += new_move

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -58,7 +58,7 @@ class PosPayment(models.Model):
     @api.constrains('amount')
     def _check_amount(self):
         for payment in self:
-            if payment.pos_order_id.state in ['invoiced', 'done']:
+            if payment.pos_order_id.state == 'done' or payment.pos_order_id.account_move:
                 raise ValidationError(_('You cannot edit a payment for a posted order.'))
             elif payment.pos_order_id.nb_print > 0:
                 raise ValidationError(_('You cannot edit a payment for a printed order.'))

--- a/addons/point_of_sale/models/pos_preset.py
+++ b/addons/point_of_sale/models/pos_preset.py
@@ -107,7 +107,7 @@ class PosPreset(models.Model):
             ('preset_id', '=', self.id),
             ('session_id.state', '=', 'opened'),
             ('preset_time', '!=', False),
-            ('state', 'in', ['draft', 'paid', 'invoiced']),
+            ('state', 'in', ['draft', 'paid']),
             ('create_date', '>=', fields.Datetime.now() - timedelta(days=1))
         ])
         for order in orders:

--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -35,7 +35,7 @@ class ReportPoint_Of_SaleReport_Saledetails(models.AbstractModel):
         return date_start, date_stop
 
     def _get_domain(self, date_start=False, date_stop=False, config_ids=False, session_ids=False):
-        domain = [('state', 'in', ['paid', 'invoiced', 'done'])]
+        domain = [('state', 'in', ['paid', 'done'])]
 
         if (session_ids):
             domain = AND([domain, [('session_id', 'in', session_ids)]])

--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -17,8 +17,7 @@ class ReportPosOrder(models.Model):
     product_id = fields.Many2one('product.product', string='Product', readonly=True)
     product_tmpl_id = fields.Many2one('product.template', string='Product Template', readonly=True)
     state = fields.Selection(
-        [('draft', 'New'), ('paid', 'Paid'), ('done', 'Posted'),
-         ('invoiced', 'Invoiced'), ('cancel', 'Cancelled')],
+        [('draft', 'New'), ('paid', 'Paid'), ('done', 'Posted'), ('cancel', 'Cancelled')],
         string='Status', readonly=True)
     user_id = fields.Many2one('res.users', string='User', readonly=True)
     price_total = fields.Float(string='Total Price', readonly=True)

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -657,7 +657,6 @@ export class PosOrder extends Base {
         return [];
     }
 
-    // sjai
     _reduceTotalDiscountCallback(sum, orderLine) {
         let discountUnitPrice =
             orderLine.getUnitDisplayPriceBeforeDiscount() * (orderLine.getDiscount() / 100);

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1285,7 +1285,6 @@ export class PosStore extends WithLazyGetterTrap {
                     if (order) {
                         delete order.uiState.lineToRefund[refundedOrderLine.uuid];
                     }
-                    refundedOrderLine.refunded_qty += Math.abs(line.qty);
                 }
             }
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -608,10 +608,10 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ChromeTour', login="pos_user")
-        n_invoiced = self.env['pos.order'].search_count([('state', '=', 'invoiced')])
+        n_invoiced = self.env['pos.order'].search_count([('account_move', '!=', False)])
         n_paid = self.env['pos.order'].search_count([('state', '=', 'paid')])
         self.assertEqual(n_invoiced, 1, 'There should be 1 invoiced order.')
-        self.assertEqual(n_paid, 2, 'There should be 2 paid order.')
+        self.assertEqual(n_paid, 2, 'There should be 3 paid order.')
         last_order = self.env['pos.order'].search([], limit=1, order="id desc")
         self.assertEqual(last_order.lines[0].price_subtotal, 30.0)
         self.assertEqual(last_order.lines[0].price_subtotal_incl, 30.0)

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -225,12 +225,12 @@ class TestPoSBasicConfig(TestPoSCommon):
             invoiced_order = self.pos_session.order_ids.filtered(lambda order: order.account_move)
             self.assertEqual(1, len(invoiced_order), 'Only one order is invoiced in this test.')
 
-            # check state of orders before validating the session.
-            self.assertEqual('invoiced', invoiced_order.state, msg="state should be 'invoiced' for invoiced orders.")
+            # check account_move of orders before validating the session.
+            self.assertTrue(invoiced_order.account_move, msg="Invoiced orders must have account_move.")
             uninvoiced_orders = self.pos_session.order_ids - invoiced_order
             self.assertTrue(
-                all([order.state == 'paid' for order in uninvoiced_orders]),
-                msg="state should be 'paid' for uninvoiced orders before validating the session."
+                all(not order.account_move for order in uninvoiced_orders),
+                msg="Uninvoiced orders do not have account_move."
             )
 
         def _after_closing_cb():

--- a/addons/point_of_sale/tests/test_pos_multiple_receivable_accounts.py
+++ b/addons/point_of_sale/tests/test_pos_multiple_receivable_accounts.py
@@ -90,7 +90,7 @@ class TestPoSMultipleReceivableAccounts(TestPoSCommon):
             self.assertAlmostEqual(orders_total, self.pos_session.total_payments_amount, msg='Total order amount should be equal to the total payment amount.')
 
             # check if there is one invoiced order
-            self.assertEqual(len(self.pos_session.order_ids.filtered(lambda order: order.state == 'invoiced')), 1, 'There should only be one invoiced order.')
+            self.assertEqual(len(self.pos_session.order_ids.filtered(lambda order: order.account_move)), 1, 'There should only be one invoiced order.')
 
         self._run_test({
             'payment_methods': self.cash_pm1 | self.bank_pm1,
@@ -192,7 +192,7 @@ class TestPoSMultipleReceivableAccounts(TestPoSCommon):
             self.assertAlmostEqual(orders_total, self.pos_session.total_payments_amount, msg='Total order amount should be equal to the total payment amount.')
 
             # check if there is one invoiced order
-            self.assertEqual(len(self.pos_session.order_ids.filtered(lambda order: order.state == 'invoiced')), 3, 'All orders should be invoiced.')
+            self.assertEqual(len(self.pos_session.order_ids.filtered(lambda order: order.account_move)), 3, 'All orders should be invoiced.')
 
         self._run_test({
             'payment_methods': self.cash_pm1 | self.bank_pm1,

--- a/addons/point_of_sale/views/pos_order_report_view.xml
+++ b/addons/point_of_sale/views/pos_order_report_view.xml
@@ -50,8 +50,8 @@
                 <search string="Point of Sale Analysis">
                     <field name="date"/>
                     <separator/>
-                    <filter string="Invoiced" name="invoiced" domain="[('state','=',('invoiced'))]"/>
-                    <filter string="Not Invoiced" name="not_invoiced" domain="[('state','in',['paid', 'done'])]"/>
+                    <filter string="Invoiced" name="invoiced" domain="[('invoiced','=',True)]"/>
+                    <filter string="Not Invoiced" name="not_invoiced" domain="[('invoiced','=',False)]"/>
                     <filter string="Not Cancelled" name="not_cancelled" domain="[('state','!=','cancel')]"/>
                     <separator/>
                     <filter name="filter_date" date="date"/>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -8,7 +8,7 @@
                 <header>
                     <button name="%(action_pos_payment)d" string="Payment" class="oe_highlight" type="action" invisible="state != 'draft'" />
                     <button name="action_pos_order_invoice" string="Invoice" type="object"
-                            invisible="state not in ['paid', 'done']"/>
+                            invisible="state not in ['paid', 'done'] or account_move"/>
                     <button name="refund" string="Return Products" type="object"
                         invisible="state == 'draft' or not has_refundable_lines"/>
                     <field name="state" widget="statusbar" invisible="state == 'cancel'" statusbar_visible="draft,paid,done"/>
@@ -31,7 +31,7 @@
                         type="object"
                         class="oe_stat_button"
                         icon="fa-pencil-square-o"
-                        invisible="state != 'invoiced'">
+                        invisible="not account_move">
                     </button>
                     <button name="action_view_refund_orders"
                         type="object"
@@ -52,10 +52,10 @@
                     <field name="name"/>
                     <field name="date_order"/>
                     <field name="session_id"  readonly="state != 'draft'"/>
-                    <field string="User" name="user_id" readonly="state in ['done', 'invoiced']"/>
+                    <field string="User" name="user_id" readonly="account_move or state == 'done'"/>
                     <field name="order_edit_tracking" invisible="1"/>
                     <field name="is_edited" readonly="1" invisible="not order_edit_tracking"/>
-                    <field name="partner_id" context="{'res_partner_search_mode': 'customer'}" readonly="state == 'invoiced'"/>
+                    <field name="partner_id" context="{'res_partner_search_mode': 'customer'}" readonly="account_move"/>
                     <field name="fiscal_position_id" options="{'no_create': True}" readonly="state != 'draft'"/>
                 </group>
                 <notebook colspan="4">
@@ -150,7 +150,7 @@
                         <div class="clearfix"/>
                     </page>
                     <page string="Payments" name="payments">
-                        <field name="payment_ids" colspan="4" nolabel="1" readonly="state in ['invoiced', 'done'] or nb_print > 0">
+                        <field name="payment_ids" colspan="4" nolabel="1" readonly="account_move or state == 'done' or nb_print > 0">
                             <list string="Payments" create="1" editable="bottom">
                                 <field name="currency_id" column_invisible="True" />
                                 <field name="payment_date"/>
@@ -173,7 +173,7 @@
                             <group
                                 string="Accounting"
                                 groups="account.group_account_manager"
-                                invisible="not session_move_id or state == 'invoiced'">
+                                invisible="not session_move_id or account_move">
                                 <field name="session_move_id" readonly="1" />
                             </group>
                             <group string="Other Information" name="other_information">
@@ -232,7 +232,7 @@
                         <footer class="flex-wrap">
                             <field name="date_order" class="text-muted text-nowrap"/>
                             <field name="state" widget="label_selection" options="{'classes': {'draft': 'default',
-                            'invoiced': 'success', 'cancel': 'danger'}}" class="ms-auto text-truncate"/>
+                            'done': 'success', 'cancel': 'danger'}}" class="ms-auto text-truncate"/>
                         </footer>
                     </t>
                 </templates>
@@ -272,7 +272,7 @@
         <field name="name">Orders</field>
         <field name="res_model">pos.order</field>
         <field name="view_mode">graph,list,form,kanban,pivot</field>
-        <field name="domain">[('state', 'not in', ['draft', 'cancel', 'invoiced'])]</field>
+        <field name="domain">[('state', 'not in', ['draft', 'cancel']), ('account_move', '!=', False)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No data yet!
@@ -295,7 +295,7 @@
                 <field name="pos_reference"/>
                 <field name="tracking_number" optional="hide"/>
                 <field name="partner_id"/>
-                <field name="user_id" widget="many2one_avatar_user" readonly="state in ['done', 'invoiced']"/>
+                <field name="user_id" widget="many2one_avatar_user" readonly="account_move or state == 'done'"/>
                 <field name="amount_total" sum="Amount total" widget="monetary" decoration-bf="1"/>
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-success="state not in ('draft','cancel')"/>
                 <field name="invoice_status" widget="badge" decoration-success="invoice_status == 'invoiced'" decoration-info="invoice_status == 'to_invoice'"/>
@@ -417,7 +417,7 @@
                 <field name="session_id"/>
                 <field name="config_id"/>
                 <field name="lines" string="Product" filter_domain="[('lines.product_id', 'ilike', self)]"/>
-                <filter string="Invoiced" name="invoiced" domain="[('state', '=', 'invoiced')]"/>
+                <filter string="Invoiced" name="invoiced" domain="[('account_move', '!=', False)]"/>
                 <filter string="Posted" name="posted" domain="[('state', '=', 'done')]"/>
                 <filter string="Cancelled" name="cancelled" domain="[('state', '=', 'cancel')]"/>
                 <separator/>

--- a/addons/point_of_sale/wizard/pos_payment.py
+++ b/addons/point_of_sale/wizard/pos_payment.py
@@ -68,7 +68,7 @@ class PosMakePayment(models.TransientModel):
 
         if order.state == 'draft' and order._is_pos_order_paid():
             order._process_saved_order(False)
-            if order.state in {'paid', 'done', 'invoiced'}:
+            if order.state in {'paid', 'done'}:
                 order._send_order()
             return {'type': 'ir.actions.act_window_close'}
 

--- a/addons/pos_event/models/pos_order.py
+++ b/addons/pos_event/models/pos_order.py
@@ -20,7 +20,7 @@ class PosOrder(models.Model):
     @api.model
     def sync_from_ui(self, orders):
         results = super().sync_from_ui(orders)
-        paid_orders = self.browse([order['id'] for order in results['pos.order'] if order['state'] in ['paid', 'done', 'invoiced']])
+        paid_orders = self.browse([order['id'] for order in results['pos.order'] if order['state'] in ['paid', 'done']])
 
         if not paid_orders:
             return results

--- a/addons/pos_hr/views/pos_order_view.xml
+++ b/addons/pos_hr/views/pos_order_view.xml
@@ -32,7 +32,7 @@
         <field name="inherit_id" ref="point_of_sale.view_pos_order_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='user_id']" position="replace">
-                <field name="employee_id" widget="many2one_avatar_employee" readonly="state in ['done', 'invoiced']"/>
+                <field name="employee_id" widget="many2one_avatar_employee" readonly="account_move or state == 'done'"/>
             </xpath>
         </field>
     </record>

--- a/addons/pos_online_payment/controllers/payment_portal.py
+++ b/addons/pos_online_payment/controllers/payment_portal.py
@@ -36,7 +36,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
 
     @staticmethod
     def _get_amount_to_pay(order_to_pay_sudo):
-        if order_to_pay_sudo.state in ('paid', 'done', 'invoiced'):
+        if order_to_pay_sudo.state in ('paid', 'done'):
             return 0.0
         amount = order_to_pay_sudo._get_checked_next_online_payment_amount()
         if amount and PaymentPortal._is_valid_amount(amount, order_to_pay_sudo.currency_id):

--- a/addons/pos_online_payment/models/pos_order.py
+++ b/addons/pos_online_payment/models/pos_order.py
@@ -36,7 +36,7 @@ class PosOrder(models.Model):
             database, because it was probably added for the online payment flow.
         """
         self.ensure_one()
-        is_paid = self.state in ('paid', 'done', 'invoiced')
+        is_paid = self.state in ('paid', 'done')
         if is_paid:
             return {
                 'id': self.id,

--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -183,7 +183,7 @@ class PosOrderLine(models.Model):
     @api.depends('order_id.state', 'order_id.picking_ids', 'order_id.picking_ids.state', 'order_id.picking_ids.move_ids.quantity')
     def _compute_qty_delivered(self):
         for order_line in self:
-            if order_line.order_id.state in ['paid', 'done', 'invoiced']:
+            if order_line.order_id.state in ['paid', 'done']:
                 outgoing_pickings = order_line.order_id.picking_ids.filtered(
                     lambda pick: pick.state == 'done' and pick.picking_type_code == 'outgoing'
                 )

--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -32,8 +32,8 @@ class SaleReport(models.Model):
             SUM(l.qty) AS product_uom_qty,
             SUM(l.qty_delivered) AS qty_delivered,
             SUM(l.qty - l.qty_delivered) AS qty_to_deliver,
-            CASE WHEN pos.state = 'invoiced' THEN SUM(l.qty) ELSE 0 END AS qty_invoiced,
-            CASE WHEN pos.state != 'invoiced' THEN SUM(l.qty) ELSE 0 END AS qty_to_invoice,
+            CASE WHEN pos.account_move IS NOT NULL THEN SUM(l.qty) ELSE 0 END AS qty_invoiced,
+            CASE WHEN pos.account_move IS NULL THEN SUM(l.qty) ELSE 0 END AS qty_to_invoice,
             AVG(l.price_unit)
                 / MIN({self._case_value_or_one('pos.currency_rate')})
                 * {self._case_value_or_one('account_currency_table.rate')}
@@ -46,11 +46,11 @@ class SaleReport(models.Model):
                 / MIN({self._case_value_or_one('pos.currency_rate')})
                 * {self._case_value_or_one('account_currency_table.rate')}
             AS price_subtotal,
-            (CASE WHEN pos.state != 'invoiced' THEN SUM(l.price_subtotal) ELSE 0 END)
+            (CASE WHEN pos.account_move IS NULL THEN SUM(l.price_subtotal) ELSE 0 END)
                 / MIN({self._case_value_or_one('pos.currency_rate')})
                 * {self._case_value_or_one('account_currency_table.rate')}
             AS amount_to_invoice,
-            (CASE WHEN pos.state = 'invoiced' THEN SUM(l.price_subtotal) ELSE 0 END)
+            (CASE WHEN pos.account_move IS NOT NULL THEN SUM(l.price_subtotal) ELSE 0 END)
                 / MIN({self._case_value_or_one('pos.currency_rate')})
                 * {self._case_value_or_one('account_currency_table.rate')}
             AS amount_invoiced,

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -322,7 +322,7 @@ class PosConfig(models.Model):
 
     def action_close_kiosk_session(self):
         if self.current_session_id and self.current_session_id.order_ids:
-            self.current_session_id.order_ids.filtered(lambda o: o.state not in ['paid', 'invoiced']).unlink()
+            self.current_session_id.order_ids.filtered(lambda o: o.state != 'paid').unlink()
 
         self._notify('STATUS', {'status': 'closed'})
         return self.current_session_id.action_pos_session_closing_control()

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -95,7 +95,7 @@ export class SelfOrder extends Reactive {
                     const order = this.models["pos.order"].find(
                         (o) => o.access_token === data["pos.order"][0].access_token
                     );
-                    if (["paid", "invoiced", "done"].includes(order?.state)) {
+                    if (["paid", "done"].includes(order?.state)) {
                         this.notification.add(_t("Your order has been paid"), {
                             type: "success",
                         });
@@ -159,7 +159,7 @@ export class SelfOrder extends Reactive {
             this.models.loadData(data);
             const oUpdated = data["pos.order"].find((o) => o.uuid === this.selectedOrderUuid);
 
-            if (["paid", "invoiced", "done"].includes(oUpdated?.state)) {
+            if (["paid", "done"].includes(oUpdated?.state)) {
                 message = _t("Your order has been paid");
             } else if (oUpdated?.state === "cancel") {
                 message = _t("Your order has been cancelled");
@@ -171,7 +171,7 @@ export class SelfOrder extends Reactive {
                 });
             }
 
-            if (["paid", "invoiced", "done"].includes(oUpdated?.state)) {
+            if (["paid", "done"].includes(oUpdated?.state)) {
                 this.selectedOrderUuid = null;
                 this.router.navigate("default");
             }


### PR DESCRIPTION
pos_*: point_of_sale, l10n_es_edi_tbai_pos, l10n_fr_pos_cert, pos_event, pos_hr, pos_online_payment, pos_sale, pos_self_order

In this commit:
=========
- We are removing the `Invoiced` state from the Point of Sale order and using the `account_move` field to check if the order has been invoiced.
- Removed problematic single-line code which caused an issue that refund quantity was updated twice during the refund process.

Related PR:
- Enterprise: https://github.com/odoo/enterprise/pull/73983
- Upgrade: https://github.com/odoo/upgrade/pull/6903

task-4184446