### PR TITLE
[IMP] (test_)mail: add partner_manager group by default

### DIFF
--- a/addons/base_automation/tests/test_mail_composer.py
+++ b/addons/base_automation/tests/test_mail_composer.py
@@ -16,9 +16,6 @@ class TestMailFullComposer(MailCommon, HttpCase):
             'name': 'Test template',
             'partner_to': '{{ object.id }}',
         })
-        self.user_employee.write({
-            'groups_id': [(4, self.env.ref('base.group_partner_manager').id)],
-        })
 
         automation = self.env['base.automation'].create({
             'name': 'Test',

--- a/addons/calendar/tests/test_mail_activity_mixin.py
+++ b/addons/calendar/tests/test_mail_activity_mixin.py
@@ -6,7 +6,6 @@ from dateutil.relativedelta import relativedelta
 
 import pytz
 
-from odoo import Command
 from odoo import tests
 from odoo.addons.mail.tests.common import MailCommon
 
@@ -48,10 +47,8 @@ class TestMailActivityMixin(MailCommon):
             meeting.calendar_event_id = calendar_event
             return meeting
 
-        group_partner_manager = self.env['ir.model.data']._xmlid_to_res_id('base.group_partner_manager')
         self.user_employee.write({
             'tz': self.user_admin.tz,
-            'groups_id': [Command.link(group_partner_manager)]
         })
         with self.with_user('employee'):
             test_record = self.env['res.partner'].browse(self.test_record.id)

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1350,7 +1350,7 @@ class MailCommon(common.TransactionCase, MailCase):
             cls.env,
             company_id=cls.company_admin.id,
             country_id=cls.env.ref('base.be').id,
-            groups='base.group_user,mail.group_mail_template_editor',
+            groups='base.group_user,mail.group_mail_template_editor,base.group_partner_manager',
             login='employee',
             name='Ernest Employee',
             notification_type='inbox',
@@ -1425,7 +1425,7 @@ class MailCommon(common.TransactionCase, MailCase):
         # employee specific to second company
         cls.user_employee_c2 = mail_new_test_user(
             cls.env, login='employee_c2',
-            groups='base.group_user',
+            groups='base.group_user,base.group_partner_manager',
             company_id=cls.company_2.id,
             company_ids=[(4, cls.company_2.id)],
             email='enguerrand@example.com',
@@ -1438,6 +1438,7 @@ class MailCommon(common.TransactionCase, MailCase):
             company_id=cls.company_3.id,
             company_ids=[(4, cls.company_3.id)],
             email='freudenbergerg@example.com',
+            groups='base.group_user,base.group_partner_manager',
             name='Freudenbergerg Employee C3',
             notification_type='inbox'
         )

--- a/addons/mail/tests/common_controllers.py
+++ b/addons/mail/tests/common_controllers.py
@@ -5,7 +5,7 @@ from requests.exceptions import HTTPError
 
 from odoo import fields
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
-from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.http import Request
 from odoo.tests import JsonRpcException
 from odoo.tools import file_open, mute_logger
@@ -49,6 +49,17 @@ class MailControllerCommon(HttpCaseWithUserDemo, MailCommon):
         cls.guest = cls.env["mail.guest"].create({"name": "Guest"})
         last_message = cls.env["mail.message"].search([], order="id desc", limit=1)
         cls.fake_message = cls.env["mail.message"].browse(last_message.id + 1000000)
+        cls.user_employee_nopartner = mail_new_test_user(
+            cls.env,
+            company_id=cls.company_admin.id,
+            country_id=cls.env.ref('base.be').id,
+            groups='base.group_user,mail.group_mail_template_editor',
+            login='employee_nopartner',
+            name='Elodie EmployeeNoPartner',
+            notification_type='inbox',
+        )
+        # whatever default creation values, we need a "no partner manager" user
+        cls.user_employee_nopartner.write({'groups_id': [(3, cls.env.ref('base.group_partner_manager').id)]})
 
     def _authenticate_pseudo_user(self, pseudo_user):
         user = pseudo_user if pseudo_user._name == "res.users" else self.user_public

--- a/addons/mail/tests/common_controllers.py
+++ b/addons/mail/tests/common_controllers.py
@@ -4,7 +4,7 @@ from markupsafe import Markup
 from requests.exceptions import HTTPError
 
 from odoo import fields
-from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.addons.base.tests.common import HttpCase
 from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.http import Request
 from odoo.tests import JsonRpcException
@@ -35,7 +35,7 @@ class MessagePostSubTestData:
         self.exp_emails = exp_emails
 
 
-class MailControllerCommon(HttpCaseWithUserDemo, MailCommon):
+class MailControllerCommon(HttpCase, MailCommon):
     # Note that '_get_with_access' is going to call '_get_thread_with_access'
     # which relies on classic portal parameter given as kwargs on most routes
     # (aka hash, token, pid)
@@ -135,14 +135,6 @@ class MailControllerBinaryCommon(MailControllerCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.user_test = cls.env["res.users"].create(
-            {
-                "email": "testuser@testuser.com",
-                "name": "Test User",
-                "login": "test_user",
-                "password": "test_user",
-            }
-        )
         cls.guest_2 = cls.env["mail.guest"].create({"name": "Guest 2"})
 
     def _execute_subtests(self, record, subtests):

--- a/addons/mail/tests/discuss/test_discuss_attachment_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_attachment_controller.py
@@ -18,7 +18,6 @@ class TestDiscussAttachmentController(MailControllerAttachmentCommon):
             (
                 (self.guest, False),
                 (self.user_admin, True),
-                (self.user_demo, True),
                 (self.user_employee, True),
                 (self.user_portal, False),
                 (self.user_public, False),
@@ -38,7 +37,6 @@ class TestDiscussAttachmentController(MailControllerAttachmentCommon):
             (
                 (self.guest, True),
                 (self.user_admin, True),
-                (self.user_demo, True),
                 (self.user_employee, True),
                 (self.user_portal, True),
                 (self.user_public, True),

--- a/addons/mail/tests/discuss/test_discuss_binary_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_binary_controller.py
@@ -15,7 +15,7 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
             name="Public Channel", group_id=None
         )
         cls.partner_ids = (
-            cls.user_public + cls.user_portal + cls.user_employee + cls.user_demo + cls.user_admin
+            cls.user_public + cls.user_portal + cls.user_employee + cls.user_admin
         ).partner_id.ids
 
     def test_open_guest_avatar(self):
@@ -28,7 +28,6 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
                 (self.guest, False),
                 (self.user_portal, False),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -48,7 +47,6 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
                 (self.guest, True),
                 (self.user_portal, True),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -61,16 +59,15 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
         - other users join the channel: True
         - target sends a message: False"""
         self.private_channel.add_members(
-            self.partner_ids + [self.user_test.partner_id.id], self.guest.id
+            self.partner_ids + [self.user_employee_nopartner.partner_id.id], self.guest.id
         )
         self._execute_subtests(
-            self.user_test.partner_id,
+            self.user_employee_nopartner.partner_id,
             (
                 (self.user_public, False),
                 (self.guest, True),
                 (self.user_portal, True),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -91,7 +88,6 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
                 (self.guest, True),
                 (self.user_portal, True),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -104,17 +100,16 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
         - other users join the channel: True
         - target sends a message: True"""
         self.private_channel.add_members(
-            self.partner_ids + [self.user_test.partner_id.id], self.guest.id
+            self.partner_ids + [self.user_employee_nopartner.partner_id.id], self.guest.id
         )
-        self._post_message(self.private_channel, self.user_test)
+        self._post_message(self.private_channel, self.user_employee_nopartner)
         self._execute_subtests(
-            self.user_test.partner_id,
+            self.user_employee_nopartner.partner_id,
             (
                 (self.user_public, False),
                 (self.guest, True),
                 (self.user_portal, True),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -138,7 +133,6 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
                 (self.guest, False),
                 (self.user_portal, False),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -152,22 +146,21 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
         - target sends a message: False
         - target leaves the channel: True"""
         self.private_channel.add_members(
-            self.partner_ids + [self.user_test.partner_id.id], self.guest.id
+            self.partner_ids + [self.user_employee_nopartner.partner_id.id], self.guest.id
         )
         self.env["discuss.channel.member"].search(
             [
-                ("partner_id", "=", self.user_test.partner_id.id),
+                ("partner_id", "=", self.user_employee_nopartner.partner_id.id),
                 ("channel_id", "=", self.private_channel.id),
             ]
         ).unlink()
         self._execute_subtests(
-            self.user_test.partner_id,
+            self.user_employee_nopartner.partner_id,
             (
                 (self.user_public, False),
                 (self.guest, False),
                 (self.user_portal, False),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -192,7 +185,6 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
                 (self.guest, True),
                 (self.user_portal, True),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -206,23 +198,22 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
         - target sends a message: True
         - target leaves the channel: True"""
         self.private_channel.add_members(
-            self.partner_ids + [self.user_test.partner_id.id], self.guest.id
+            self.partner_ids + [self.user_employee_nopartner.partner_id.id], self.guest.id
         )
-        self._post_message(self.private_channel, self.user_test)
+        self._post_message(self.private_channel, self.user_employee_nopartner)
         self.env["discuss.channel.member"].search(
             [
-                ("partner_id", "=", self.user_test.partner_id.id),
+                ("partner_id", "=", self.user_employee_nopartner.partner_id.id),
                 ("channel_id", "=", self.private_channel.id),
             ]
         ).unlink()
         self._execute_subtests(
-            self.user_test.partner_id,
+            self.user_employee_nopartner.partner_id,
             (
                 (self.user_public, False),
                 (self.guest, True),
                 (self.user_portal, True),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -244,7 +235,6 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
                 (self.guest, False),
                 (self.user_portal, False),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -260,16 +250,15 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
             body="Test",
             subtype_xmlid="mail.mt_comment",
             message_type="comment",
-            author_id=self.user_test.partner_id.id,
+            author_id=self.user_employee_nopartner.partner_id.id,
         )
         self._execute_subtests(
-            self.user_test.partner_id,
+            self.user_employee_nopartner.partner_id,
             (
                 (self.user_public, False),
                 (self.guest, False),
                 (self.user_portal, False),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -291,7 +280,6 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
                 (self.guest, True),
                 (self.user_portal, True),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -303,15 +291,14 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
         - target joins the channel: False
         - other users join the channel: False
         - target sends a message: True"""
-        self._post_message(self.public_channel, self.user_test)
+        self._post_message(self.public_channel, self.user_employee_nopartner)
         self._execute_subtests(
-            self.user_test.partner_id,
+            self.user_employee_nopartner.partner_id,
             (
                 (self.user_public, True),
                 (self.guest, True),
                 (self.user_portal, True),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -333,7 +320,6 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
                 (self.guest, False),
                 (self.user_portal, False),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -346,16 +332,15 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
         - other users join the channel: False
         - target sends a message: False
         - target leaves the channel: True"""
-        target_member = self.public_channel.add_members(self.user_test.partner_id.id)
+        target_member = self.public_channel.add_members(self.user_employee_nopartner.partner_id.id)
         target_member.unlink()
         self._execute_subtests(
-            self.user_test.partner_id,
+            self.user_employee_nopartner.partner_id,
             (
                 (self.user_public, False),
                 (self.guest, False),
                 (self.user_portal, False),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -378,7 +363,6 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
                 (self.guest, True),
                 (self.user_portal, True),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -391,17 +375,16 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
         - other users join the channel: False
         - target sends a message: True
         - target leaves the channel: True"""
-        target_member = self.public_channel.add_members(self.user_test.partner_id.id)
-        self._post_message(self.public_channel, self.user_test)
+        target_member = self.public_channel.add_members(self.user_employee_nopartner.partner_id.id)
+        self._post_message(self.public_channel, self.user_employee_nopartner)
         target_member.unlink()
         self._execute_subtests(
-            self.user_test.partner_id,
+            self.user_employee_nopartner.partner_id,
             (
                 (self.user_public, True),
                 (self.guest, True),
                 (self.user_portal, True),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )

--- a/addons/mail/tests/discuss/test_discuss_message_update_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_message_update_controller.py
@@ -21,7 +21,6 @@ class TestDiscussMessageUpdateController(MailControllerUpdateCommon):
             (
                 (self.guest, True),
                 (self.user_admin, True),
-                (self.user_demo, False),
                 (self.user_employee, False),
                 (self.user_portal, False),
                 (self.user_public, False),
@@ -42,7 +41,6 @@ class TestDiscussMessageUpdateController(MailControllerUpdateCommon):
             (
                 (self.guest, False),
                 (self.user_admin, True),
-                (self.user_demo, False),
                 (self.user_employee, False),
                 (self.user_portal, False),
                 (self.user_public, False),

--- a/addons/mail/tests/discuss/test_discuss_reaction_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_reaction_controller.py
@@ -18,7 +18,6 @@ class TestMessageReactionController(MailControllerReactionCommon):
                 (self.guest, True),
                 (self.user_portal, True),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -27,7 +26,7 @@ class TestMessageReactionController(MailControllerReactionCommon):
         """Test access of message reaction for a channel as member."""
         channel = self.env["discuss.channel"].browse(
             self.env["discuss.channel"].create_group(
-                partners_to=(self.user_portal + self.user_employee + self.user_demo).partner_id.ids
+                partners_to=(self.user_portal + self.user_employee).partner_id.ids
             )["id"]
         )
         channel.add_members(guest_ids=self.guest.ids)
@@ -39,7 +38,6 @@ class TestMessageReactionController(MailControllerReactionCommon):
                 (self.guest, True),
                 (self.user_portal, True),
                 (self.user_employee, True),
-                (self.user_demo, True),
                 (self.user_admin, True),
             ),
         )
@@ -57,7 +55,6 @@ class TestMessageReactionController(MailControllerReactionCommon):
                 (self.guest, False),
                 (self.user_portal, False),
                 (self.user_employee, False),
-                (self.user_demo, False),
                 (self.user_admin, True),
             ),
         )

--- a/addons/mail/tests/discuss/test_discuss_thread_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_thread_controller.py
@@ -69,7 +69,7 @@ class TestDiscussThreadController(MailControllerThreadCommon):
                 test_partners(self.guest, True, members),
                 test_partners(self.user_portal, True, members),
                 test_partners(self.user_employee, True, partners),
-                test_partners(self.user_demo, True, partners),
+                test_partners(self.user_employee_nopartner, True, partners),
                 test_partners(self.user_admin, True, partners),
             ),
         )
@@ -81,7 +81,7 @@ class TestDiscussThreadController(MailControllerThreadCommon):
             {"name": "Public Channel", "group_public_id": None}
         )
         no_emails = []
-        partner_emails = [self.user_demo.email, "test@example.com"]
+        partner_emails = [self.user_employee.email, "test@example.com"]
 
         def test_emails(user, allowed, exp_emails, exp_author=None):
             return MessagePostSubTestData(
@@ -99,8 +99,8 @@ class TestDiscussThreadController(MailControllerThreadCommon):
                 test_emails(self.guest, True, no_emails),
                 test_emails(self.user_portal, True, no_emails),
                 # restricted because not base.group_partner_manager
-                test_emails(self.user_employee, True, no_emails),
-                test_emails(self.user_demo, True, partner_emails),
+                test_emails(self.user_employee_nopartner, True, no_emails),
+                test_emails(self.user_employee, True, partner_emails),
                 test_emails(self.user_admin, True, partner_emails),
             ),
         )

--- a/addons/mail/tests/discuss/test_discuss_thread_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_thread_controller.py
@@ -19,7 +19,6 @@ class TestDiscussThreadController(MailControllerThreadCommon):
                 test_access(self.guest, False),
                 test_access(self.user_portal, False),
                 test_access(self.user_employee, True),
-                test_access(self.user_demo, True),
                 test_access(self.user_admin, True),
             ),
         )
@@ -40,7 +39,6 @@ class TestDiscussThreadController(MailControllerThreadCommon):
                 test_access(self.guest, True),
                 test_access(self.user_portal, True),
                 test_access(self.user_employee, True),
-                test_access(self.user_demo, True),
                 test_access(self.user_admin, True),
             ),
         )
@@ -51,11 +49,11 @@ class TestDiscussThreadController(MailControllerThreadCommon):
         channel = self.env["discuss.channel"].create(
             {"name": "Public Channel", "group_public_id": None}
         )
-        channel.add_members(partner_ids=self.user_demo.partner_id.ids)
+        channel.add_members(partner_ids=self.user_employee_nopartner.partner_id.ids)
         partners = (
-            self.user_portal + self.user_employee + self.user_demo + self.user_admin
+            self.user_portal + self.user_employee + self.user_employee_nopartner + self.user_admin
         ).partner_id
-        members = self.user_demo.partner_id
+        members = self.user_employee_nopartner.partner_id
 
         def test_partners(user, allowed, exp_partners, exp_author=None):
             return MessagePostSubTestData(

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -48,7 +48,6 @@ class TestMailComposerForm(TestMailComposer):
         super(TestMailComposerForm, cls).setUpClass()
         cls.other_company = cls.env['res.company'].create({'name': 'Other Company'})
         cls.user_employee.write({
-            'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
             'company_ids': [(4, cls.other_company.id)]
         })
         cls.partner_private, cls.partner_private_2, cls.partner_classic = cls.env['res.partner'].create([
@@ -271,9 +270,6 @@ class TestMailComposerUI(MailCommon, HttpCase):
             'model_id': self.env['ir.model']._get_id('res.partner'),
             'name': 'Test template',
             'partner_to': '{{ object.id }}',
-        })
-        self.user_employee.write({
-            'groups_id': [(4, self.env.ref('base.group_partner_manager').id)],
         })
         partner = self.env["res.partner"].create({"name": "Jane", "email": "jane@example.com"})
         user = self.env["res.users"].create({"name": "Not A Demo User", "login": "nadu"})

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -241,10 +241,6 @@ class TestPartner(MailCommon):
     def test_find_or_create_from_emails(self):
         """ Test for '_find_or_create_from_emails' allowing to find or create
         partner based on emails in a batch-enabled and optimized fashion. """
-        self.user_employee_c2.write({
-            'groups_id': [(4, self.env.ref('base.group_partner_manager').id)],
-        })
-
         with self.mockPartnerCalls():
             partners = self.env['res.partner'].with_context(lang='en_US')._find_or_create_from_emails(
                 [item[0] for item in self.samples],
@@ -311,10 +307,6 @@ class TestPartner(MailCommon):
     def test_res_partner_find_or_create_from_emails_dupes_email_field(self):
         """ Specific test for duplicates management: based on email to avoid
         creating similar partners. """
-        self.user_employee_c2.write({
-            'groups_id': [(4, self.env.ref('base.group_partner_manager').id)],
-        })
-
         # all same partner, same email 'test.customer@test.dupe.example.com'
         email_dupes_samples = [
             '"Formatted Customer" <test.customer@TEST.DUPE.EXAMPLE.COM>',

--- a/addons/portal/tests/test_portal_wizard.py
+++ b/addons/portal/tests/test_portal_wizard.py
@@ -10,6 +10,8 @@ class TestPortalWizard(MailCommon):
     def setUp(self):
         super(TestPortalWizard, self).setUp()
 
+        # for those tests, consider user_employee cannot manager partners for acl testse
+        self.user_employee.write({'groups_id': [(3, self.env.ref('base.group_partner_manager').id)]})
         self.partner = self.env['res.partner'].create({
             'name': 'Testing Partner',
             'email': 'testing_partner@example.com',

--- a/addons/project/tests/test_project_thread_controller.py
+++ b/addons/project/tests/test_project_thread_controller.py
@@ -15,11 +15,11 @@ class TestProjectThreadController(MailControllerThreadCommon):
         )
         token, bad_token, sign, bad_sign, partner = self._get_sign_token_params(task)
         all_partners = (
-            self.user_portal + self.user_employee + self.user_demo + self.user_admin
+            self.user_portal + self.user_employee + self.user_employee_nopartner + self.user_admin
         ).partner_id
         project.message_subscribe(partner_ids=self.user_employee.partner_id.ids)
-        task.message_subscribe(partner_ids=self.user_demo.partner_id.ids)
-        followers = (self.user_employee + self.user_demo).partner_id
+        task.message_subscribe(partner_ids=self.user_employee_nopartner.partner_id.ids)
+        followers = (self.user_employee + self.user_employee_nopartner).partner_id
 
         def test_partners(user, allowed, exp_partners, route_kw=None, exp_author=None):
             return MessagePostSubTestData(
@@ -54,11 +54,11 @@ class TestProjectThreadController(MailControllerThreadCommon):
                 test_partners(self.user_employee, True, all_partners, route_kw=bad_sign),
                 test_partners(self.user_employee, True, all_partners, route_kw=token),
                 test_partners(self.user_employee, True, all_partners, route_kw=sign),
-                test_partners(self.user_demo, True, all_partners),
-                test_partners(self.user_demo, True, all_partners, route_kw=bad_token),
-                test_partners(self.user_demo, True, all_partners, route_kw=bad_sign),
-                test_partners(self.user_demo, True, all_partners, route_kw=token),
-                test_partners(self.user_demo, True, all_partners, route_kw=sign),
+                test_partners(self.user_employee_nopartner, True, all_partners),
+                test_partners(self.user_employee_nopartner, True, all_partners, route_kw=bad_token),
+                test_partners(self.user_employee_nopartner, True, all_partners, route_kw=bad_sign),
+                test_partners(self.user_employee_nopartner, True, all_partners, route_kw=token),
+                test_partners(self.user_employee_nopartner, True, all_partners, route_kw=sign),
                 test_partners(self.user_admin, True, all_partners),
                 test_partners(self.user_admin, True, all_partners, route_kw=bad_token),
                 test_partners(self.user_admin, True, all_partners, route_kw=bad_sign),

--- a/addons/test_mail/models/mail_test_access.py
+++ b/addons/test_mail/models/mail_test_access.py
@@ -1,6 +1,38 @@
 from odoo import fields, models
 
 
+class MailTestAccess(models.Model):
+    """ Test access on mail models without depending on real models like channel
+    or partner which have their own set of ACLs. Public, portal and internal
+    have access to this model depending on 'access' field, allowing to check
+    ir.rule usage. """
+    _description = 'Access Test'
+    _name = 'mail.test.access'
+    _inherit = ['mail.thread.blacklist']
+    _mail_post_access = 'write'  # default value but ease mock
+    _order = 'id DESC'
+    _primary_email = 'email_from'
+
+    name = fields.Char()
+    email_from = fields.Char()
+    phone = fields.Char()
+    customer_id = fields.Many2one('res.partner', 'Customer')
+    access = fields.Selection(
+        [
+            ('public', 'public'),
+            ('logged', 'Logged'),
+            ('logged_ro', 'Logged readonly for portal'),
+            ('followers', 'Followers'),
+            ('internal', 'Internal'),
+            ('internal_ro', 'Internal readonly'),
+            ('admin', 'Admin'),
+        ],
+        name='Access', default='public')
+
+    def _mail_get_partner_fields(self):
+        return ['customer_id']
+
+
 class MailTestAccessPublic(models.Model):
     """A model inheriting from mail.thread with public read and write access
     to test some public and guest interactions."""

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -1,6 +1,9 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_mail_performance_thread,access_mail_performance_thread,model_mail_performance_thread,base.group_user,1,1,1,1
 access_mail_performance_tracking_user,mail.performance.tracking,model_mail_performance_tracking,base.group_user,1,1,1,1
+access_mail_test_access_portal,mail.access.portal.portal,model_mail_test_access,base.group_portal,1,1,0,0
+access_mail_test_access_public,mail.access.portal.public,model_mail_test_access,base.group_public,1,0,0,0
+access_mail_test_access_user,mail.access.portal.user,model_mail_test_access,base.group_user,1,1,1,1
 access_mail_test_access_public_public,mail.test.access.public.public,model_mail_test_access_public,base.group_public,1,1,0,0
 access_mail_test_access_public_portal,mail.test.access.public.portal,model_mail_test_access_public,base.group_portal,1,1,0,0
 access_mail_test_access_public_user,mail.test.access.public.user,model_mail_test_access_public,base.group_user,1,1,1,1

--- a/addons/test_mail/security/test_mail_security.xml
+++ b/addons/test_mail/security/test_mail_security.xml
@@ -1,13 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
 
+    <!-- MAIL.TEST.ACCESS -->
+    <record id="ir_rule_mail_test_access_public" model="ir.rule">
+        <field name="name">Public: public only</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access"/>
+        <field name="domain_force">[('access', '=', 'public')]</field>
+        <field name="groups" eval="[(4, ref('base.group_public'))]"/>
+    </record>
+    <record id="ir_rule_mail_test_access_portal" model="ir.rule">
+        <field name="name">Portal: public/logged/logged readonly only</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access"/>
+        <field name="domain_force">[
+            '|', ('access', 'in', ('public', 'logged', 'logged_ro')),
+            '&amp;', ('access', '=', 'followers'), ('message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+    <record id="ir_rule_mail_test_access_portal_update" model="ir.rule">
+        <field name="name">Portal: update logged only</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access"/>
+        <field name="domain_force">[
+            '|', ('access', '=', 'logged'),
+            '&amp;', ('access', '=', 'followers'), ('message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="perm_write" eval="True"/>
+    </record>
+    <record id="ir_rule_mail_test_access_internal" model="ir.rule">
+        <field name="name">Internal: read not admin</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access"/>
+        <field name="domain_force">[('access', '!=', 'admin')]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+    <record id="ir_rule_mail_test_access_internal_update" model="ir.rule">
+        <field name="name">Internal: update not admin and not readonly</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access"/>
+        <field name="domain_force">[('access', 'not in', ('internal_ro', 'admin'))]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+    <record id="ir_rule_mail_test_access_admin" model="ir.rule">
+        <field name="name">Admin: all</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('base.group_system'))]"/>
+    </record>
+
+    <!-- MAIL.TEST.MULTI.COMPANY(.*) -->
     <record id="mail_test_multi_company_rule" model="ir.rule">
         <field name="name">Mail Test Multi Company</field>
         <field name="model_id" ref="test_mail.model_mail_test_multi_company"/>
         <field eval="True" name="global"/>
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
-
     <record id="mail_test_multi_company_read_rule" model="ir.rule">
         <field name="name">MC Readonly Rule</field>
         <field name="model_id" ref="test_mail.model_mail_test_multi_company_read"/>
@@ -15,7 +70,6 @@
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         <field name="global" eval="True"/>
     </record>
-
     <record id="mail_test_multi_company_with_activity_rule" model="ir.rule">
         <field name="name">Mail Test Multi Company With Activity</field>
         <field name="model_id" ref="test_mail.model_mail_test_multi_company_with_activity"/>
@@ -23,15 +77,13 @@
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
-    <!-- TICKET-LIKE -->
+    <!-- MAIL.TEST.TICKET(.*) (TICKET-LIKE) -->
     <record id="mail_test_ticket_rule_portal" model="ir.rule">
         <field name="name">Portal Mail Test Ticket</field>
         <field name="model_id" ref="test_mail.model_mail_test_ticket"/>
         <field name="domain_force">[('message_partner_ids', 'in', [user.partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
-
-    <!-- MULTI COMPANY TICKET LIKE -->
     <record id="mail_test_ticket_mc_rule" model="ir.rule">
         <field name="name">Mail Test Ticket Multi Company</field>
         <field name="model_id" ref="test_mail.model_mail_test_ticket_mc"/>
@@ -45,15 +97,13 @@
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 
-    <!-- PROJECT-LIKE -->
+    <!-- MAIL.TEST.CONTAINER(.*) (PROJECT-LIKE) -->
     <record id="mail_test_container_rule_portal" model="ir.rule">
         <field name="name">Portal Mail Test Container</field>
         <field name="model_id" ref="test_mail.model_mail_test_container"/>
         <field name="domain_force">[('message_partner_ids', 'in', [user.partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
-
-    <!-- MULTI COMPANY PROJECT LIKE -->
     <record id="mail_test_container_mc_rule" model="ir.rule">
         <field name="name">Mail Test Container Multi Company</field>
         <field name="model_id" ref="test_mail.model_mail_test_container_mc"/>

--- a/addons/test_mail/tests/test_controller_binary.py
+++ b/addons/test_mail/tests/test_controller_binary.py
@@ -8,7 +8,7 @@ class TestPublicBinaryController(MailControllerBinaryCommon):
     def test_avatar_no_public(self):
         """Test access to open a guest / partner avatar who hasn't sent a message on a
         public record."""
-        for source in (self.guest_2, self.user_test.partner_id):
+        for source in (self.guest_2, self.user_employee_nopartner.partner_id):
             self._execute_subtests(
                 source, (
                     (self.user_public, False),
@@ -21,9 +21,9 @@ class TestPublicBinaryController(MailControllerBinaryCommon):
     def test_avatar_private(self):
         """Test access to open a partner avatar who has sent a message on a private record."""
         document = self.env["mail.test.simple.unfollow"].create({"name": "Test"})
-        self._post_message(document, self.user_test)
+        self._post_message(document, self.user_employee_nopartner)
         self._execute_subtests(
-            self.user_test.partner_id, (
+            self.user_employee_nopartner.partner_id, (
                 (self.user_public, False),
                 (self.guest, False),
                 (self.user_portal, False),
@@ -34,7 +34,7 @@ class TestPublicBinaryController(MailControllerBinaryCommon):
     def test_avatar_public(self):
         """Test access to open a guest avatar who has sent a message on a public record."""
         document = self.env["mail.test.access.public"].create({"name": "Test"})
-        for author, source in ((self.guest_2, self.guest_2), (self.user_test, self.user_test.partner_id)):
+        for author, source in ((self.guest_2, self.guest_2), (self.user_employee_nopartner, self.user_employee_nopartner.partner_id)):
             self._post_message(document, author)
             self._execute_subtests(
                 source,

--- a/addons/test_mail/tests/test_controller_thread.py
+++ b/addons/test_mail/tests/test_controller_thread.py
@@ -13,8 +13,6 @@ class TestMessageController(MailControllerThreadCommon):
     def setUpClass(cls):
         super().setUpClass()
 
-        # be sure to be able to create partner records
-        cls.user_employee.write({'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)]})
         cls.test_public_record = cls.env["mail.test.access.public"].create({"name": "Public Channel"})
 
     @mute_logger("odoo.http")

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -32,11 +32,6 @@ class TestMailComposer(MailCommon, TestRecipients):
         # force 'now' to ease test about schedulers
         cls.reference_now = FieldDatetime.from_string('2022-12-24 12:00:00')
 
-        # ensure employee can create partners, necessary for templates
-        cls.user_employee.write({
-            'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
-        })
-
         cls.user_employee_2 = mail_new_test_user(
             cls.env, login='employee2', groups='base.group_user',
             notification_type='email', email='eglantine@example.com',
@@ -2297,11 +2292,6 @@ class TestComposerResultsCommentStatus(TestMailComposer):
         """
         super(TestComposerResultsCommentStatus, cls).setUpClass()
 
-        # ensure employee can create partners, necessary for templates
-        cls.user_employee.write({
-            'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
-        })
-
         # add 2 new records with customers
         cls.test_records, cls.test_partners = cls._create_records_for_batch(
             'mail.test.ticket.el', 4,
@@ -2384,10 +2374,6 @@ class TestComposerResultsMass(TestMailComposer):
     @classmethod
     def setUpClass(cls):
         super(TestComposerResultsMass, cls).setUpClass()
-        # ensure employee can create partners, necessary for templates
-        cls.user_employee.write({
-            'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
-        })
         cls.template.write({
             "scheduled_date": False,
         })
@@ -3404,11 +3390,6 @@ class TestComposerResultsMassStatus(TestMailComposer):
         Record5 and Record6 have same email (notlinked to any customer)
         """
         super(TestComposerResultsMassStatus, cls).setUpClass()
-
-        # ensure employee can create partners, necessary for templates
-        cls.user_employee.write({
-            'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
-        })
 
         # add 2 new records with customers
         cls.test_records, cls.test_partners = cls._create_records_for_batch(

--- a/addons/test_mail/tests/test_mail_composer_mixin.py
+++ b/addons/test_mail/tests/test_mail_composer_mixin.py
@@ -15,11 +15,6 @@ class TestMailComposerMixin(MailCommon, TestRecipients):
     def setUpClass(cls):
         super(TestMailComposerMixin, cls).setUpClass()
 
-        # ensure employee can create partners, necessary for templates
-        cls.user_employee.write({
-            'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
-        })
-
         cls.mail_template = cls.env['mail.template'].create({
             'body_html': '<p>EnglishBody for <t t-out="object.name"/></p>',
             'model_id': cls.env['ir.model']._get('mail.test.composer.source').id,

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -25,9 +25,6 @@ class BaseFollowersTest(MailCommon):
         cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
         cls._create_portal_user()
 
-        # allow employee to update partners
-        cls.user_employee.write({'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)]})
-
         Subtype = cls.env['mail.message.subtype']
         # global
         cls.mt_al_def = Subtype.create({'name': 'mt_al_def', 'default': True, 'res_model': False})

--- a/addons/test_mail/tests/test_mail_scheduled_message.py
+++ b/addons/test_mail/tests/test_mail_scheduled_message.py
@@ -25,11 +25,15 @@ class TestScheduledMessage(MailCommon, TestRecipients):
                 'customer_id': cls.partner_1.id,
                 'user_id': cls.user_employee.id,
             }])
+            cls.private_record = cls.env['mail.test.access'].create({
+                'access': 'admin',
+                'name': 'Private Record',
+            })
             cls.hidden_scheduled_message, cls.visible_scheduled_message = cls.env['mail.scheduled.message'].create([
                 {
                     'author_id': cls.partner_admin.id,
-                    'model': cls.partner_employee._name,
-                    'res_id': cls.partner_employee.id,
+                    'model': cls.private_record._name,
+                    'res_id': cls.private_record.id,
                     'body': 'Hidden Scheduled Message',
                     'scheduled_date': '2022-12-24 15:00:00',
                 },
@@ -60,7 +64,7 @@ class TestScheduledMessageAccess(TestScheduledMessage):
     def test_scheduled_message_model_without_post_right(self):
         # creation on a record that the user cannot post to
         with self.assertRaises(AccessError):
-            self.schedule_message(self.partner_employee)
+            self.schedule_message(self.private_record)
         # read a message scheduled on a record the user can't post to
         with self.assertRaises(AccessError):
             self.hidden_scheduled_message.read()

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -23,10 +23,6 @@ class TestMailTemplateCommon(MailCommon, TestRecipients):
             'name': 'Test',
         })
 
-        cls.user_employee.write({
-            'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
-        })
-
         cls._attachments = [{
             'name': 'first.txt',
             'datas': base64.b64encode(b'My first attachment'),

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -572,11 +572,6 @@ class TestMessageLog(TestMessagePostCommon):
     @classmethod
     def setUpClass(cls):
         super(TestMessageLog, cls).setUpClass()
-        # ensure employee can create partners, necessary for templates
-        cls.user_employee.write({
-            'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
-        })
-
         cls.test_records, cls.test_partners = cls._create_records_for_batch(
             'mail.test.ticket',
             10,
@@ -1448,15 +1443,6 @@ class TestMessagePostHelpers(TestMessagePostCommon):
     @classmethod
     def setUpClass(cls):
         super(TestMessagePostHelpers, cls).setUpClass()
-        # ensure employee can create partners, necessary for templates
-        cls.user_employee.write({
-            'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
-        })
-
-        cls.user_employee.write({
-            'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
-        })
-
         cls.test_records, cls.test_partners = cls._create_records_for_batch(
             'mail.test.ticket',
             10,
@@ -1799,9 +1785,6 @@ class TestMessagePostLang(MailCommon, TestRecipients):
             'partner_to': '{{ object.customer_id.id if object.customer_id else "" }}',
             'subject': 'EnglishSubject for {{ object.name }}',
             'use_default_to': False,
-        })
-        cls.user_employee.write({  # add group to create contacts, necessary for templates
-            'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
         })
 
         cls._activate_multi_lang(test_record=cls.test_records[0], test_template=cls.test_template)

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -18,8 +18,6 @@ class BaseMailPerformance(MailCommon, TransactionCaseWithUserDemo):
     def setUpClass(cls):
         super(BaseMailPerformance, cls).setUpClass()
 
-        # creating partners is required notably with template usage
-        cls.user_employee.write({'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)]})
         res_users = cls.env["res.users"].with_context(cls._test_context)
         cls.user_test = cls.user_test_inbox = res_users.create(
             {

--- a/addons/test_mail_full/tests/test_controller_thread.py
+++ b/addons/test_mail_full/tests/test_controller_thread.py
@@ -83,10 +83,10 @@ class TestPortalThreadController(MailControllerThreadCommon):
         record = self.env["mail.test.portal.no.partner"].create({"name": "Test"})
         token, bad_token, sign, bad_sign, partner = self._get_sign_token_params(record)
         all_partners = (
-            self.user_portal + self.user_employee + self.user_demo + self.user_admin
+            self.user_portal + self.user_employee + self.user_admin
         ).partner_id
-        record.message_subscribe(partner_ids=self.user_demo.partner_id.ids)
-        followers = self.user_demo.partner_id
+        record.message_subscribe(partner_ids=self.user_employee.partner_id.ids)
+        followers = self.user_employee.partner_id
 
         def test_partners(user, allowed, exp_partners, route_kw=None, exp_author=None):
             return MessagePostSubTestData(


### PR DESCRIPTION
Add 'base.group_patner_manager' by default on test internal user as anyway
it is mostly always used for internal users.

With this commit we need to update 'TestScheduledMessageAccess' as it
was based on employee that cannot update its own partner, which is not
the case with default behavior. To get rid of partner dependency we
introduce a new model that eases modeling restricted accesses. It is
going to be used in a new test suit sonner or later.

In controller tests lot of tests are simply duplicated due to using both
demo user and test-specific internal user. This pattern has been
reproduced a lot in all controller tests introduced a few months ago
and already cleaned during https://github.com/odoo/odoo/pull/186937.

In this commit we remove usage of demo user, just replacing it when
strictly necessary by another test user we control.

Task-4332801 [test_mail] Cleanup controller tests
Prepares Task-4332797 : [mail] Partner from emails 3.0
Prepares Task-4273479 : [mail] Email-like recipients