### PR TITLE
[FIX] account: prevent tax application on discount

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -897,7 +897,7 @@ class AccountMoveLine(models.Model):
             if line.display_type in ('line_section', 'line_note', 'payment_term'):
                 continue
             # /!\ Don't remove existing taxes if there is no explicit taxes set on the account.
-            if line.product_id or line.account_id.tax_ids or not line.tax_ids:
+            if line.product_id or (line.display_type != 'discount' and (line.account_id.tax_ids or not line.tax_ids)):
                 line.tax_ids = line._get_computed_taxes()
 
     def _get_computed_taxes(self):

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -2733,3 +2733,35 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         move_form.save()
         self.invoice.action_post()
         self.assertEqual(payment_term_line.name, 'XYZ', 'Manual name of payment term line should be kept')
+
+    def test_duplicate_invoice_with_separate_discount_acccount(self):
+        """When a separate discount account, make sure that discount lines don't have a tax_id set
+        So, when creating a credit note from the invoice, data are coherent (=same amount)"""
+        sale_tax = self.company_data['default_tax_sale']
+        self.env.company.account_discount_expense_allocation_id = self.company_data['default_account_expense'].id
+        great_account = self.company_data['default_account_revenue'].copy()
+        great_account.tax_ids = [Command.set(sale_tax.ids)]
+        invoice = self.env['account.move'].create({
+            'partner_id': self.partner_a.id,
+            'move_type': 'out_invoice',
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'quantity': 1,
+                'price_unit': 100.00,
+                'tax_ids': sale_tax.ids,
+                'discount': 10,
+                'account_id': great_account.id,
+            })]
+        })
+        invoice.action_post()
+        self.assertFalse(invoice.line_ids.filtered(lambda l: l.display_type == 'discount').tax_ids)
+
+        credit_note_wizard = self.env['account.move.reversal'] \
+            .with_context({'active_ids': [invoice.id], 'active_id': invoice.id, 'active_model': 'account.move'}) \
+            .create({
+                'reason': 'reason test create',
+                'journal_id': invoice.journal_id.id,
+        })
+        action = credit_note_wizard.reverse_moves()
+        credit_note = self.env['account.move'].browse(action['res_id'])
+        self.assertEqual(credit_note.amount_total, invoice.amount_total)


### PR DESCRIPTION
Minimal Configuration:
- Create an account (49999 Great Account) that has a default tax (15%)
- Settings > Accounting: define "Separate discount accounts on invoices" > Customer invoices with an account (e.g. 443000 Cash Discount Loss)

Steps to reproduce:
- Create an invoice with an invoice line that has "Great Account", a discount (10%) and a price (100) and a tax (15%)
- Confirm -> amount = 108.9
- Duplicate the invoice (in the ticket: Create a Credit Note)

Issue:
=> The credit note is not of the same amount = 106.80. That is, MINUS discount * tax_amount <-> 108.90 MINUS 10% * 21= 106.80

Cause:
When there is a "Separate discount accounts on invoices" that is set, discount line appear on the journal items of the document; moves between the default account for such transaction to the chosen move in the settings.
When iterating through those discount lines, the condition was not strict enough to filter them out and would put a tax on them (as my dear colleague Andrea said: the bomb has been planted)

Therefore, when creating a credit/duplicating,  we copy the data  wrongly (but in a correct a way for a standard flow) which gives incoherent results

opw-4166601