### PR TITLE
[IMP] web: display `None` instead of False for groupby in list and kanban view

### DIFF
--- a/addons/web/static/src/views/graph/graph_model.js
+++ b/addons/web/static/src/views/graph/graph_model.js
@@ -414,6 +414,8 @@ export class GraphModel extends Model {
                     const { type } = fields[fieldName];
                     if (type === "boolean") {
                         label = `${val}`; // toUpperCase?
+                    } else if (type === "integer") {
+                        label = val === false ? "0" : `${val}`;
                     } else if (val === false) {
                         label = this._getDefaultFilterLabel(gb);
                     } else if (["many2many", "many2one"].includes(type)) {

--- a/addons/web/static/src/views/kanban/kanban_header.js
+++ b/addons/web/static/src/views/kanban/kanban_header.js
@@ -8,7 +8,6 @@ import { memoize } from "@web/core/utils/functions";
 import { useService } from "@web/core/utils/hooks";
 import { useDebounced } from "@web/core/utils/timing";
 import { isRelational } from "@web/model/relational_model/utils";
-import { isNull } from "@web/views/utils";
 import { ColumnProgress } from "@web/views/view_components/column_progress";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 import { registry } from "@web/core/registry";
@@ -101,20 +100,13 @@ export class KanbanHeader extends Component {
 
     get groupName() {
         const { groupByField, displayName } = this.group;
-        let name = displayName;
         if (groupByField.type === "boolean") {
-            name = name ? _t("Yes") : _t("No");
-        } else if (!name) {
-            if (
-                isRelational(groupByField) ||
-                groupByField.type === "date" ||
-                groupByField.type === "datetime" ||
-                isNull(name)
-            ) {
-                name = this._getEmptyGroupLabel(groupByField.name);
-            }
+            return displayName ? _t("Yes") : _t("No");
+        } else if (groupByField.type === "integer") {
+            return displayName || "0";
+        } else {
+            return displayName || this._getEmptyGroupLabel(groupByField.name);
         }
-        return name;
     }
 
     get groupAggregate() {

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -848,11 +848,11 @@ export class ListRenderer extends Component {
 
     getGroupDisplayName(group) {
         if (group.groupByField.type === "boolean") {
-            return group.value === undefined ? _t("None") : group.value ? _t("Yes") : _t("No");
+            return group.value ? _t("Yes") : _t("No");
+        } else if (group.groupByField.type === "integer") {
+            return group.displayName || "0";
         } else {
-            return group.value === undefined || group.value === false
-                ? _t("None")
-                : group.displayName;
+            return group.displayName || _t("None");
         }
     }
 

--- a/addons/web/static/src/views/pivot/pivot_model.js
+++ b/addons/web/static/src/views/pivot/pivot_model.js
@@ -1576,12 +1576,12 @@ export class PivotModel extends Model {
     _sanitizeLabel(value, groupBy, config) {
         const { metaData } = config;
         const fieldName = groupBy.split(":")[0];
-        if (
-            fieldName &&
-            metaData.fields[fieldName] &&
-            metaData.fields[fieldName].type === "boolean"
-        ) {
-            return value === undefined ? _t("None") : value ? _t("Yes") : _t("No");
+        if (fieldName && metaData.fields[fieldName]) {
+            if (metaData.fields[fieldName].type === "boolean") {
+                return value === undefined ? _t("None") : value ? _t("Yes") : _t("No");
+            } else if (metaData.fields[fieldName].type === "integer") {
+                return value || "0";
+            }
         }
         if (value === false) {
             return this._getEmptyGroupLabel(fieldName);

--- a/addons/web/static/tests/views/graph/graph_view.test.js
+++ b/addons/web/static/tests/views/graph/graph_view.test.js
@@ -2837,3 +2837,16 @@ test("missing deleted property field definition is created", async function () {
         ]
     );
 });
+
+test("display '0' for empty int field values in grouped graph view", async () => {
+    Foo._records[0].foo = false;
+
+    const view = await mountView({
+        type: "graph",
+        resModel: "foo",
+        groupBy: ["foo"],
+        arch: /* xml */ `<graph type="pie" />`,
+    });
+
+    checkLabels(view, ["2", "4", "24", "42", "48", "53", "63", "0"]);
+});

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -13494,3 +13494,43 @@ test("kanban records are middle clickable by default", async () => {
         'set current_action-{"id":1,"res_model":"partner","type":"ir.actions.act_window","views":[[false,"kanban"],[false,"form"]]}',
     ]);
 });
+
+test("display 'None' for empty char field values in grouped Kanban view", async () => {
+    Partner._records[0].foo = false;
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="card">
+                        <field name="foo"/>
+                    </t>
+                </templates>
+            </kanban>`,
+        groupBy: ["foo"],
+    });
+
+    expect(".o_kanban_group:first-child .o_column_title").toHaveText("None\n(1)");
+});
+
+test("display '0' for empty int field values in grouped Kanban view", async () => {
+    Partner._records[0].int_field = 0;
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="card">
+                        <field name="int_field"/>
+                    </t>
+                </templates>
+            </kanban>`,
+        groupBy: ["int_field"],
+    });
+
+    expect(".o_kanban_group:first-child .o_column_title").toHaveText("0\n(1)");
+});

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -17593,3 +17593,36 @@ test("add custom field button not shown to non-system users (wo opt. col.)", asy
 
     expect("table .o_optional_columns_dropdown_toggle").toHaveCount(0);
 });
+
+test(`display 'None' for empty char field values in grouped list view`, async () => {
+    Foo._records[0].foo = false;
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list open_form_view="True">
+                <field name="foo"/>
+            </list>
+        `,
+        groupBy: ["foo"],
+    });
+
+    expect(`tbody tr:nth-child(3)`).toHaveText("None (1)");
+});
+
+test(`display '0' for empty int field values in grouped list view`, async () => {
+    Foo._records[0].int_field = 0;
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list expand="1">
+                <field name="foo"/>
+            </list>`,
+        groupBy: ["int_field"],
+    });
+
+    expect(`tbody tr:nth-child(3)`).toHaveText("0 (1)");
+});

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -3767,3 +3767,19 @@ test("middle clicking on a cell triggers a doAction", async () => {
     expect("table").toHaveClass("o_enable_linking");
     await contains(".o_pivot_cell_value:eq(1)").click({ ctrlKey: true }); // should trigger a do_action
 });
+
+test("display '0' for empty int field values in grouped pivot view", async () => {
+    Partner._records[0].foo = false;
+
+    await mountView({
+        type: "pivot",
+        resModel: "partner",
+        arch: `
+            <pivot o_enable_linking="1">
+                <field name="foo" type="row"/>
+            </pivot>`,
+        groupBy: ["foo"],
+    });
+
+    expect(queryAllTexts("tbody th")).toEqual(["Total", "1", "2", "17", "0"]);
+});


### PR DESCRIPTION
SPECIFICATION:

When grouping by a field, ensure the following behavior:
 - If a field's value is empty or undefined, display the string "None" instead
    of "False" in both the list and Kanban views.
 - For integer fields, display 0 in all views when a field value is empty

Related Enterprise PR-https://github.com/odoo/enterprise/pull/75414
Task-4327850
