### PR TITLE
[FIX] mail: fix email loop detection

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -398,6 +398,10 @@ class MailMail(models.Model):
                 )
         headers.setdefault('Return-Path', self.record_alias_domain_id.bounce_email or self.env.company.bounce_email)
 
+        # some mail providers overwrite the Message-Id, so we add a custom header
+        # to be able to track the email
+        headers.setdefault('X-Odoo-Message-Id', self.message_id)
+
         # prepare recipients: use email_to if defined then check recipient_ids
         # that receive a specific email, notably due to link shortening / redirect
         # that is recipients-dependent. Keep original email/partner as this is

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1690,6 +1690,10 @@ class MailThread(models.AbstractModel):
         msg_dict = {'message_type': 'email'}
 
         message_id = message.get('Message-Id')
+        original_message_id = message.get('X-Odoo-Message-Id')
+        if original_message_id:
+            # If we have message id set by Odoo, we should use it as the message_id
+            message_id = original_message_id
         if not message_id:
             # Very unusual situation, be we should be fault-tolerant here
             message_id = "<%s@localhost>" % time.time()


### PR DESCRIPTION
To reproduce:
=============
- use Mailjet as outgoing mail server
- on CRM or Helpdesk have a team with alias
- create a ticket and add a follower with email that forwards to the team alias
- send message -> email loop

Problem:
========
To detect if the alias received an email from the team, we check the Message-ID of the incoming email. But Mailjet changes the Message-ID.

Solution:
=========
- introduced a custom header to store the original Message-ID `X-Odoo-Message-Id`
- use this header to detect if the alias received an email from the team

opw-4295745
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
