### PR TITLE
[FIX] pos_self_order: currency not visible on product card in self order

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -32,7 +32,7 @@ export class ConfirmationPage extends Component {
                     try {
                         await this.printer.print(OrderReceipt, {
                             data: this.selfOrder.orderExportForPrinting(this.confirmedOrder),
-                            formatCurrency: this.selfOrder.formatMonetary,
+                            formatCurrency: this.selfOrder.formatMonetary.bind(this.selfOrder),
                         });
                         if (!this.selfOrder.has_paper) {
                             this.updateHasPaper(true);

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -757,7 +757,7 @@ export class SelfOrder extends Reactive {
     }
 
     formatMonetary(price) {
-        return webFormatCurrency(price, this.currency_id);
+        return webFormatCurrency(price, this.currency.id);
     }
 
     verifyCart() {
@@ -873,7 +873,7 @@ export class SelfOrder extends Reactive {
             OrderReceipt,
             {
                 data: this.orderExportForPrinting(order),
-                formatCurrency: this.formatMonetary,
+                formatCurrency: this.formatMonetary.bind(this),
             },
             {}
         );


### PR DESCRIPTION
Before this commit:
==========
- The currency symbol was not visible on the product card on the self-order product page.

After this commit:
==========
- The currency symbol is now visible on the product card on the self-order product page.

task-4342039
