### PR TITLE
[FIX] base, l10n_ma: Custom Tax fields labels and MA improvements

### DIFF
--- a/addons/l10n_au/models/__init__.py
+++ b/addons/l10n_au/models/__init__.py
@@ -4,3 +4,4 @@ from . import template_au
 from . import account_move
 from . import res_partner_bank
 from . import account_payment
+from . import res_partner

--- a/addons/l10n_au/models/res_partner.py
+++ b/addons/l10n_au/models/res_partner.py
@@ -1,0 +1,10 @@
+from odoo import models, _
+
+
+class ResPartner(models.Model):
+    _inherit = ['res.partner']
+
+    def _get_company_registry_labels(self):
+        labels = super()._get_company_registry_labels()
+        labels['AU'] = _("ACN")
+        return labels

--- a/addons/l10n_ma/i18n/fr.po
+++ b/addons/l10n_ma/i18n/fr.po
@@ -647,3 +647,15 @@ msgstr "Avec droit à déduction"
 #: model:account.report.line,name:l10n_ma.tax_report_part_b_14_nd
 msgid "Without right to deduct"
 msgstr "Sans droit à déduction"
+
+#. module: l10n_ma
+#. odoo-python
+#: code:addons/l10n_ma/models/res_partner.py:0
+msgid "ICE number should have exactly 15 digits."
+msgstr "Le numéro ICE doit comporter exactement 15 chiffres."
+
+#. module: l10n_ma
+#. odoo-python
+#: code:addons/l10n_ma/models/res_partner.py:0
+msgid "ICE"
+msgstr "ICE"

--- a/addons/l10n_ma/i18n/l10n_ma.pot
+++ b/addons/l10n_ma/i18n/l10n_ma.pot
@@ -689,3 +689,15 @@ msgstr ""
 #: model:account.report.line,name:l10n_ma.tax_report_part_b_14_nd
 msgid "Without right to deduct"
 msgstr ""
+
+#. module: l10n_ma
+#. odoo-python
+#: code:addons/l10n_ma/models/res_partner.py:0
+msgid "ICE number should have exactly 15 digits."
+msgstr ""
+
+#. module: l10n_ma
+#. odoo-python
+#: code:addons/l10n_ma/models/res_partner.py:0
+msgid "ICE"
+msgstr ""

--- a/addons/l10n_ma/models/__init__.py
+++ b/addons/l10n_ma/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import base_document_layout
 from . import template_ma
+from . import res_partner

--- a/addons/l10n_ma/models/res_partner.py
+++ b/addons/l10n_ma/models/res_partner.py
@@ -1,0 +1,17 @@
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
+
+
+class ResPartner(models.Model):
+    _inherit = ['res.partner']
+
+    @api.constrains('company_registry')
+    def _check_company_registry_ma(self):
+        for record in self:
+            if record.country_code == 'MA' and record.company_registry and (len(record.company_registry) != 15 or not record.company_registry.isdigit()):
+                raise ValidationError(_("ICE number should have exactly 15 digits."))
+
+    def _get_company_registry_labels(self):
+        labels = super()._get_company_registry_labels()
+        labels['MA'] = _("ICE")
+        return labels

--- a/addons/l10n_ma/views/res_partner_views.xml
+++ b/addons/l10n_ma/views/res_partner_views.xml
@@ -5,13 +5,9 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='company_registry']" position="attributes">
-                <attribute name="nolabel">1</attribute>
+            <xpath expr="//field[@name='vat']" position="after">
+                <field name="company_registry" string="ICE" invisible="country_code != 'MA'"></field>
             </xpath>
-            <field name="company_registry" position="before">
-                <label for="company_registry" invisible="country_code == 'MA'" />
-                <label for="company_registry" string="ICE" invisible="country_code != 'MA'" />
-            </field>
         </field>
     </record>
 </odoo>

--- a/addons/l10n_nz/models/__init__.py
+++ b/addons/l10n_nz/models/__init__.py
@@ -3,3 +3,4 @@
 from . import account_move
 from . import template_nz
 from . import account_payment
+from . import res_partner

--- a/addons/l10n_nz/models/res_partner.py
+++ b/addons/l10n_nz/models/res_partner.py
@@ -1,0 +1,10 @@
+from odoo import models, _
+
+
+class ResPartner(models.Model):
+    _inherit = ['res.partner']
+
+    def _get_company_registry_labels(self):
+        labels = super()._get_company_registry_labels()
+        labels['NZ'] = _("NZBN")
+        return labels

--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -9229,16 +9229,12 @@ msgstr ""
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_partner_form
-msgid ""
-"A partner with the same <span><span class=\"o_vat_label\">Company "
-"Registry</span></span> already exists ("
+msgid "A partner with the same"
 msgstr ""
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_partner_form
-msgid ""
-"A partner with the same <span><span class=\"o_vat_label\">Tax "
-"ID</span></span> already exists ("
+msgid "already exists ("
 msgstr ""
 
 #. module: base
@@ -15290,6 +15286,8 @@ msgid "Company Details"
 msgstr ""
 
 #. module: base
+#. odoo-python
+#: code:addons/base/models/res_partner.py:0
 #: model:ir.model.fields,field_description:base.field_res_company__company_registry
 #: model:ir.model.fields,field_description:base.field_res_partner__company_registry
 #: model:ir.model.fields,field_description:base.field_res_users__company_registry
@@ -33731,6 +33729,8 @@ msgid "Task Logs"
 msgstr ""
 
 #. module: base
+#. odoo-python
+#: code:addons/base/models/res_partner.py:0
 #: model:ir.model.fields,field_description:base.field_res_company__vat
 #: model:ir.model.fields,field_description:base.field_res_partner__vat
 #: model:ir.model.fields,field_description:base.field_res_users__vat

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -242,10 +242,12 @@ class Partner(models.Model):
         readonly=False, store=True,
         help='The internal user in charge of this contact.')
     vat = fields.Char(string='Tax ID', index=True, help="The Tax Identification Number. Values here will be validated based on the country format. You can use '/' to indicate that the partner is not subject to tax.")
+    vat_label = fields.Char(string='Tax ID Label', compute='_compute_vat_label')
     same_vat_partner_id: Partner = fields.Many2one('res.partner', string='Partner with same Tax ID', compute='_compute_same_vat_partner_id', store=False)
     same_company_registry_partner_id: Partner = fields.Many2one('res.partner', string='Partner with same Company Registry', compute='_compute_same_vat_partner_id', store=False)
     company_registry = fields.Char(string="Company ID", compute='_compute_company_registry', store=True, readonly=False,
        help="The registry number of the company. Use it if it is different from the Tax ID. It must be unique across all partners of a same country")
+    company_registry_label = fields.Char(string='Company ID Label', compute='_compute_company_registry_label')
     bank_ids: ResPartnerBank = fields.One2many('res.partner.bank', 'partner_id', string='Banks')
     website = fields.Char('Website Link')
     comment = fields.Html(string='Notes')
@@ -427,6 +429,10 @@ class Partner(models.Model):
                 domain += [('id', '!=', partner_id), '!', ('id', 'child_of', partner_id)]
             partner.same_company_registry_partner_id = bool(partner.company_registry) and not partner.parent_id and Partner.search(domain, limit=1)
 
+    @api.depends_context('company')
+    def _compute_vat_label(self):
+        self.vat_label = self.env.company.country_id.vat_label or _("Tax ID")
+
     @api.depends(lambda self: self._display_address_depends())
     def _compute_contact_address(self):
         for partner in self:
@@ -454,6 +460,16 @@ class Partner(models.Model):
         # exists to allow overrides
         for company in self:
             company.company_registry = company.company_registry
+
+    @api.depends('country_id')
+    def _compute_company_registry_label(self):
+        label_by_country = self._get_company_registry_labels()
+        for company in self:
+            country_code = company.country_id.code
+            company.company_registry_label = label_by_country.get(country_code, _("Company ID"))
+
+    def _get_company_registry_labels(self):
+        return {}
 
     @api.constrains('parent_id')
     def _check_parent_id(self):

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -145,10 +145,10 @@
             <field name="arch" type="xml">
                 <form string="Partners">
                 <div class="alert alert-warning oe_edit_only" role="alert" name="warning_tax" invisible="not same_vat_partner_id">
-                  A partner with the same <span><span class="o_vat_label">Tax ID</span></span> already exists (<field name="same_vat_partner_id" context="{'show_address': False, 'show_vat': False}"/>), are you sure you want to create a new one?
+                  A partner with the same <span><field name="vat_label" /></span> already exists (<field name="same_vat_partner_id" context="{'show_address': False, 'show_vat': False}"/>), are you sure you want to create a new one?
                 </div>
                 <div class="alert alert-warning oe_edit_only" role="alert" name="warning_company" invisible="not same_company_registry_partner_id">
-                  A partner with the same <span><span class="o_vat_label">Company Registry</span></span> already exists (<field name="same_company_registry_partner_id" context="{'show_address': False, 'show_vat': False}"/>), are you sure you want to create a new one?
+                  A partner with the same <span><field name="company_registry_label" /></span> already exists (<field name="same_company_registry_partner_id" context="{'show_address': False, 'show_vat': False}"/>), are you sure you want to create a new one?
                 </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box"/>


### PR DESCRIPTION
* Add custom tax ID and company registry labels for warning messages to partners with the same tax ID/company registry.
* Add custom company registry label for AU and NZ
* Make sure the ICE number has 15 digits otherwise show an error message.
* Move ICE to be below the Tax ID field.

task-4226448

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
