### PR TITLE
[REF] web: remove unused menu_data from webclient rendering context

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -68,7 +68,6 @@ class IrHttp(models.AbstractModel):
 
     def webclient_rendering_context(self):
         return {
-            'menu_data': request.env['ir.ui.menu'].load_menus(request.session.debug),
             'session_info': self.session_info(),
         }
 


### PR DESCRIPTION
`menu_data` isn't used in rendering context since [1]. This commit
removes it. This shouldn't have any impact as the method is cached,
so that unnecessary call probably allowed a systematic cache hit
for the actual (necessary) call done by session_info.

[1] https://github.com/odoo/odoo/commit/19eacf7d23c9413de4430a3422b5ed74b37ef242
