### PR TITLE
Show an error when a user tries to take a time off without having an employee in the selected company

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -777,6 +777,8 @@ Attempting to double-book your time off won't magically make your vacation 2x be
                 if mapped_validation_type[leave_type_id] == 'both':
                     self._check_double_validation_rules(employee_id, values.get('state', False))
 
+        if any(not vals.get('employee_id') for vals in vals_list):
+            raise UserError(_("There is no employee set on the time off. Please make sure you're logged in the correct company."))
         holidays = super(HolidaysRequest, self.with_context(mail_create_nosubscribe=True)).create(vals_list)
         holidays._check_validity()
 


### PR DESCRIPTION
Steps to reproduce:
  1. Login as `Mitchell Admin`.
  2. Select Indian Company (without selecting any other company).
  1. Open `Time Off` app.
  3. Click on any day on the calendar.
  4. Confirm the time off.
  5. An error will occur.

In order take a time off from the dashboard, the logged in user must have an employee in the selected company. `Mitchell Admin` doesn't have an employee in the `Indian Company` which causes the bug. This problem is general and happens when any user tries to take a time off from the dashboard without having an employee in the selected company.

To solve the issue, an error message will appear to the user if they try to take a time off without having an employee in the selected company.

task-4034228