### PR TITLE
[FIX] l10n_din5008_purchase: add missing informations to rfq template

### DIFF
--- a/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
+++ b/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
@@ -57,4 +57,62 @@
             </t>
         </xpath>
     </template>
+
+    <template id="report_purchasequotation_document" inherit_id="purchase.report_purchasequotation_document">
+        <xpath expr="//t[@t-set='address']" position="after">
+            <t t-set="din5008_document_information">
+                <div class="information_block" t-if="o and o._name=='purchase.order'">
+                    <table>
+                        <tr t-if="o.name">
+                            <td t-if="o.state == 'draft'">Request for Quotation No.:</td>
+                            <td t-elif="o.state in {'sent', 'to approve', 'purchase', 'done'}">Purchase Order No.:</td>
+                            <td t-elif="o.state == 'cancel'">Cancelled Purchase Order No.:</td>
+                            <td><t t-out="o.name"/></td>
+                        </tr>
+                        <tr t-if="o.user_id">
+                            <td>Purchase Representative:</td>
+                            <td><t t-out="o.user_id.name"/></td>
+                        </tr>
+                        <tr t-if="o.partner_ref">
+                            <td>Order Reference:</td>
+                            <td><t t-out="o.partner_ref"/></td>
+                        </tr>
+                        <tr t-if="o.date_approve">
+                            <td>Order Date:</td>
+                            <td><t t-out="o.date_approve" t-options="{'widget': 'date'}"/></td>
+                        </tr>
+                        <tr t-if="o.date_order">
+                            <td>Order Deadline:</td>
+                            <td><t t-out="o.date_order" t-options="{'widget': 'date'}"/></td>
+                        </tr>
+                        <tr t-if="o.incoterm_id">
+                            <td>Incoterm:</td>
+                            <td><t t-out="o.incoterm_id"/></td>
+                        </tr>
+                    </table>
+                </div>
+            </t>
+
+            <t t-set="din5008_address_block">
+                <tr t-if="o and o._name=='purchase.order'">
+                    <td class="shipping_address" t-if="o.dest_address_id">
+                        <span class="fw-bold">Shipping Address:</span>
+                        <address t-esc="o.dest_address_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                    </td>
+                    <td class="shipping_address" t-elif="'picking_type_id' in o._fields and o.picking_type_id.warehouse_id">
+                        <span class="fw-bold">Shipping Address:</span>
+                        <address t-esc="o.picking_type_id.warehouse_id.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                    </td>
+                </tr>
+            </t>
+
+            <t t-set="din5008_document_title">
+                <span t-if="o and o._name == 'purchase.order'">
+                    <t t-if="o.state in {'draft', 'sent', 'to approve'}">Request for Quotation</t>
+                    <t t-elif="o.state in {'purchase', 'done'}">Purchase Order</t>
+                    <t t-elif="o.state == 'cancel'">Cancelled Purchase Order</t>
+                </span>
+            </t>
+        </xpath>
+    </template>
 </odoo>


### PR DESCRIPTION
### Steps to reproduce the issue:

1. In the Document Layout, choose DIN 5008 as Layout
2. Create a Request for Quotation
3. In the extra menu (cog wheel), select Print > Purchase Order
4. In the extra menu (cog wheel), select Print > Request for Quotation
5. When comparing both templates, some informations are missing in the Request for Quotation PDF

### Explanation:

An override adding those informations is implemented for `report_purchaseorder_document` but not for `report_purchasequotation_document`.

### Fix reasoning:

Adding a similar override for the latter will fix the issue.

opw-4337273
