### PR TITLE
[IMP] website_sale_collect: stop creating useless sales orders

### DIFF
--- a/addons/website_sale_collect/controllers/delivery.py
+++ b/addons/website_sale_collect/controllers/delivery.py
@@ -10,26 +10,33 @@ class InStoreDelivery(Delivery):
     @route()
     def website_sale_get_pickup_locations(self, zip_code=None, **kwargs):
         """ Override of `website_sale` to set the pickup in store delivery method on the order in
-        order to retrieve pickup locations when called from the the product page.
+        order to retrieve pickup locations when called from the product page. If there is no order
+        create a temporary one to display pickup locations.
         """
         if kwargs.get('product_id'):  # Called from the product page.
-            order_sudo = request.cart or request.website._create_cart()
+            order_sudo = request.cart
             in_store_dm = request.website.sudo().in_store_dm_id
-            if order_sudo.carrier_id.delivery_type != 'in_store':
+            if not order_sudo:  # Pickup location requested without a cart creation.
+                # Create a temporary order to fetch pickup locations.
+                temp_order = request.env['sale.order'].new({'carrier_id': in_store_dm.id})
+                return temp_order.sudo()._get_pickup_locations(zip_code, **kwargs)  # Skip super
+            elif order_sudo.carrier_id.delivery_type != 'in_store':
                 order_sudo.set_delivery_line(in_store_dm, in_store_dm.product_id.list_price)
         return super().website_sale_get_pickup_locations(zip_code, **kwargs)
 
     @route('/shop/set_click_and_collect_location', type='jsonrpc', auth='public', website=True)
     def shop_set_click_and_collect_location(self, pickup_location_data):
-        """ Set the pickup location and the in-store delivery method on the current order.
+        """ Set the pickup location and the in-store delivery method on the current order or created
+        one.
 
-        This route is distinct from /website_sale/get_pickup_locations as the latter is only called
-        from the checkout page after the delivery method is selected.
+        This route is called from location selector on /product and is distinct from
+        /website_sale/set_pickup_location as the latter is only called from the checkout page after
+        the delivery method is selected.
 
         :param str pickup_location_data: The JSON-formatted pickup location data.
         :return: None
         """
-        order_sudo = request.cart
+        order_sudo = request.cart or request.website._create_cart()
         if order_sudo.carrier_id.delivery_type != 'in_store':
             in_store_dm = request.website.sudo().in_store_dm_id
             order_sudo.set_delivery_line(in_store_dm, in_store_dm.product_id.list_price)

--- a/addons/website_sale_collect/tests/__init__.py
+++ b/addons/website_sale_collect/tests/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_delivery_carrier
+from . import test_in_store_delivery
 from . import test_payment_provider
 from . import test_payment_transaction
 from . import test_sale_order

--- a/addons/website_sale_collect/tests/test_in_store_delivery.py
+++ b/addons/website_sale_collect/tests/test_in_store_delivery.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from unittest.mock import patch
+from odoo.tests import tagged
+
+from odoo.addons.payment.tests.http_common import PaymentHttpCommon
+from odoo.addons.website_sale_collect.controllers.delivery import InStoreDelivery
+from odoo.addons.website_sale_collect.tests.common import ClickAndCollectCommon
+
+
+@tagged('post_install', '-at_install')
+class TestInStoreDeliveryController(PaymentHttpCommon, ClickAndCollectCommon):
+    def setUp(self):
+        super().setUp()
+        self.InStoreController = InStoreDelivery()
+
+    def test_order_not_created_on_fetching_pickup_location_with_empty_cart(self):
+        count_so_before = self.env['sale.order'].search_count([])
+        url = self._build_url('/website_sale/get_pickup_locations')
+        with patch(
+            'odoo.addons.website_sale_collect.models.sale_order.SaleOrder._get_pickup_locations',
+            return_value={}
+        ):
+            self.make_jsonrpc_request(url, {'product_id': 1})
+        count_so_after = self.env['sale.order'].search_count([])
+        self.assertEqual(count_so_after, count_so_before)


### PR DESCRIPTION
When click and collect is enabled, users can see pickup locations from a location selector on /product page. Before this commit a sales order was created on opening location selector that could result in a lot of abandoned carts. After this commit temporary orders are created instead on opening location selector and a cart is created only after selecting a pickup location.


