### PR TITLE
[FIX] sale_project: analytic assigned to payment term line

### DIFF
--- a/addons/sale_project/models/account_move.py
+++ b/addons/sale_project/models/account_move.py
@@ -14,5 +14,5 @@ class AccountMoveLine(models.Model):
         project_id = self.env.context.get('project_id')
         if project_id:
             analytic_account = self.env['project.project'].browse(project_id).analytic_account_id
-            for line in self:
+            for line in project_amls:
                 line.analytic_distribution = line.analytic_distribution or {analytic_account.id: 100}


### PR DESCRIPTION
When confirming a BILL via Project's Updates, the generated payment
terms line will have the analytic account of the project assigned
Version: 17.0+

Steps to reproduce:
- Have a project (i.e. Renovations)
- Create a Purchase Order
- Add on the line the analytic account of the project
- Go to Projects Kanban view
- Open Project 3 dots menu > Reporting > Project Updates
- Open the created PO, Create Bill

Issue: Analytic account will be assigned to the payment term line

opw-4193509