### PR TITLE
[FIX] base: check also related stored fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -263,6 +263,14 @@ class IrModel(models.Model):
             stored_fields = set(
                 model.field_id.filtered('store').mapped('name') + models.MAGIC_COLUMNS
             )
+            if model.model in self.env:
+                # add fields inherited from models specified via code if they are already loaded
+                stored_fields.update(
+                    fname
+                    for fname, fval in self.env[model.model]._fields.items()
+                    if fval.inherited and fval.base_field.store
+                )
+
             order_fields = RE_ORDER_FIELDS.findall(model.order)
             for field in order_fields:
                 if field not in stored_fields:

--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -277,6 +277,10 @@ class TestIrModel(TransactionCase):
                 'field_id': fields_value,
             })
 
+        # ensure we can order by a stored field via inherits
+        user_model = self.env['ir.model'].search([('model', '=', 'res.users')])
+        user_model._check_order()  # must not raise
+
     def test_model_order_search(self):
         """Check that custom orders are applied when querying a model."""
         ORDERS = {


### PR DESCRIPTION
Since odoo/odoo@4d2aa271 we cannot add any manual field to `res.users`. We are always faced with the error:
```
... fields used for ordering must be present on the model and stored.
```
The reason is that the `res.users.name` field is a related stored field, via inherits.

Similarly if we install base_automation we cannot add any field to `base.automation` model, because they are ordered by `sequence`, another stored related field.

In this patch we propose to extend the check for field used in `_order` to related fields.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
