### PR TITLE
[IMP] l10n_es_edi_tbai, account, sale: reverse from sale

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4949,6 +4949,19 @@ class AccountMove(models.Model):
         '''
         return False
 
+    def _refunds_origin_required(self):
+        return False
+
+    def _set_reversed_entry(self, credit_note):
+        """ Try to find the original invoice for a single credit_note. """
+        if len(credit_note) != 1 or credit_note.move_type != 'out_refund':
+            return
+
+        original_invoice = self.filtered(lambda inv: inv.move_type == 'out_invoice'
+                                         and credit_note.invoice_line_ids.sale_line_ids in inv.invoice_line_ids.sale_line_ids)
+        if len(original_invoice) == 1 and original_invoice._refunds_origin_required():
+            credit_note.reversed_entry_id = original_invoice.id
+
     @api.model
     def get_invoice_localisation_fields_required_to_invoice(self, country_id):
         """ Returns the list of fields that needs to be filled when creating an invoice for the selected country.

--- a/addons/l10n_es_edi_tbai/models/account_move.py
+++ b/addons/l10n_es_edi_tbai/models/account_move.py
@@ -258,3 +258,8 @@ class AccountMove(models.Model):
                                'rec': tax})
         return {'iva_values': iva_values,
                 'amount_total': amount_total}
+
+    def _refunds_origin_required(self):
+        if self.l10n_es_tbai_is_required:
+            return True
+        return super()._refunds_origin_required()

--- a/addons/l10n_es_edi_tbai/views/account_move_view.xml
+++ b/addons/l10n_es_edi_tbai/views/account_move_view.xml
@@ -9,10 +9,15 @@
                 <xpath expr="//group[@id='other_tab_group']/group[last()]" position='after'>
                     <group id="ticketbai_group" string="TicketBAI" invisible="not l10n_es_tbai_is_required">
                         <field name="l10n_es_tbai_is_required" invisible="1"/>
+                        <field name="move_type" invisible="1"/>
                         <field name="l10n_es_tbai_chain_index" groups="base.group_no_one"/>
                         <field name="l10n_es_tbai_refund_reason"
-                            invisible="not l10n_es_tbai_refund_reason"
+                            invisible="move_type not in ('out_refund', 'in_refund')"
                             readonly="state != 'draft'"/>
+                        <field name="l10n_es_tbai_post_xml" invisible="1"/>
+                        <field name="reversed_entry_id"
+                               invisible="move_type not in ('in_refund', 'out_refund') or not l10n_es_tbai_is_required"
+                               readonly="l10n_es_tbai_post_xml"/>
                     </group>
                 </xpath>
             </field>

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1390,7 +1390,10 @@ class SaleOrder(models.Model):
         # We do this after the moves have been created since we need taxes, etc. to know if the total
         # is actually negative or not
         if final:
-            moves.sudo().filtered(lambda m: m.amount_total < 0).action_switch_move_type()
+            if moves_to_switch := moves.sudo().filtered(lambda m: m.amount_total < 0):
+                moves_to_switch.action_switch_move_type()
+                self.invoice_ids._set_reversed_entry(moves_to_switch)
+
         for move in moves:
             if final:
                 # Downpayment might have been determined by a fixed amount set by the user.

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from unittest.mock import patch
+
 from odoo import fields
 from odoo.fields import Command
 from odoo.tests import Form, tagged
@@ -1117,3 +1119,74 @@ class TestSaleToInvoice(TestSaleCommon):
 
         self.assertEqual(sale_order_1.amount_to_invoice, -700.0)
         self.assertEqual(sale_order_2.amount_to_invoice, 0.0)
+
+    def test_credit_note_automatic_matching(self):
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.company_data['product_service_delivery'].id,
+                }),
+            ],
+        })
+        sale_order.action_confirm()
+
+        sale_order.order_line.qty_delivered = 1
+
+        invoice = sale_order._create_invoices()
+        invoice.action_post()
+
+        sale_order.order_line.qty_delivered = 0
+
+        with patch.object(self.env.registry['account.move'], '_refunds_origin_required', lambda move: True):
+            wizard_context = {
+                'active_model': 'sale.order',
+                'active_id': sale_order.id,
+            }
+            credit_note = self.env['sale.advance.payment.inv'].with_context(wizard_context).create({})._create_invoices(sale_order)
+        credit_note.action_post()
+
+        self.assertEqual(credit_note.reversed_entry_id.id, invoice.id)
+
+    def test_credit_note_no_automatic_matching(self):
+        product = self.company_data['product_service_delivery']
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+        })
+        sale_line1 = self.env['sale.order.line'].create({
+            'product_id': product.id,
+            'product_uom_qty': 1,
+            'price_unit': 200.0,
+            'order_id': sale_order.id,
+        })
+        sale_line2 = self.env['sale.order.line'].create({
+            'product_id': product.id,
+            'product_uom_qty': 1,
+            'price_unit': 100.0,
+            'order_id': sale_order.id,
+        })
+        sale_order.action_confirm()
+
+        sale_line1.qty_delivered = 1
+
+        invoice = sale_order._create_invoices()
+        invoice.action_post()
+
+        sale_line2.qty_delivered = 1
+        sale_line1.qty_delivered = 0
+
+        with patch.object(self.env.registry['account.move'], '_refunds_origin_required', lambda move: True):
+            wizard_context = {
+                'active_model': 'sale.order',
+                'active_id': sale_order.id,
+            }
+            credit_note = self.env['sale.advance.payment.inv'].with_context(wizard_context).create({})._create_invoices(sale_order)
+        credit_note.action_post()
+
+        # The invoice contains one invoice line
+        self.assertEqual(len(invoice.invoice_line_ids), 1)
+        # the credit note contains 2
+        self.assertEqual(len(credit_note.invoice_line_ids), 2)
+        # so the credit note cannot be considered a reversal of the invoice
+        self.assertFalse(credit_note.reversed_entry_id)


### PR DESCRIPTION
When we have products on delivery on a sale order:
- we update delivered qties
- create invoice
- we diminish delivered qties
- create invoice -> should be a refund

We want this last refund to be linked with the
first invoice.  As there is only one, there is
no doubt that the two should be linked.

However, we only do this for the localizations where the link is absolutely required, which is KE (enterprise) and ES Ticketbai for now.

We also make sure in Ticketbai that the field is
sufficiently editable.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
