### PR TITLE
[FIX] project: select default stage relative to project's company

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import ast
@@ -462,13 +461,22 @@ class Project(models.Model):
             for vals in vals_list:
                 if 'label_tasks' in vals and not vals['label_tasks']:
                     vals['label_tasks'] = task_label
-        if len(self.env.companies) > 1 and self.env.user.has_group('project.group_project_stages'):
-            # Select the stage whether the default_stage_id field is set in context (quick create) or if it is not (normal create)
-            stage = self.env['project.project.stage'].browse(self._context['default_stage_id']) if 'default_stage_id' in self._context else self._default_stage_id()
-            # The project's company_id must be the same as the stage's company_id
-            if stage.company_id:
+        if self.env.user.has_group('project.group_project_stages'):
+            if 'default_stage_id' in self._context:
+                stage = self.env['project.project.stage'].browse(self._context['default_stage_id'])
+                # The project's company_id must be the same as the stage's company_id
+                if stage.company_id:
+                    for vals in vals_list:
+                        vals['company_id'] = stage.company_id.id
+            else:
+                companies_ids = [vals.get('company_id', False) for vals in vals_list] + [False]
+                stages = self.env['project.project.stage'].search([('company_id', 'in', companies_ids)])
                 for vals in vals_list:
-                    vals['company_id'] = stage.company_id.id
+                    # Pick the stage with the lowest sequence with no company or project's company
+                    stage_domain = [False] if 'company_id' not in vals else [False, vals.get('company_id')]
+                    stage = stages.filtered(lambda s: s.company_id.id in stage_domain)[:1]
+                    vals['stage_id'] = stage.id
+
         projects = super().create(vals_list)
         return projects
 

--- a/addons/project/tests/test_project_stage_multicompany.py
+++ b/addons/project/tests/test_project_stage_multicompany.py
@@ -77,3 +77,52 @@ class TestProjectStagesMulticompany(TestMultiCompanyProject):
 
         # Check that project was moved to stage_company_b
         self.assertFalse(self.project_company_a.stage_id.company_id, "Project Company A should now be in a stage without company")
+
+    def test_project_creation_default_stage(self):
+        """
+         Check that when creating a project with a company set, the default stage
+         for this project has the same company as the project or no company.
+         If no company is set on the project, the first stage without a company
+         should be chosen.
+        """
+        # Stage order: company A, company B, no company
+        self.stage_company_a.sequence = 1
+        self.stage_company_b.sequence = 3
+
+        project_company_b = self.env['project.project'].with_user(self.user_manager_companies).create({
+            'name': 'Project company B',
+            'company_id': self.company_b.id,
+        })
+        self.assertEqual(project_company_b.company_id, self.company_b)
+        self.assertEqual(project_company_b.stage_id, self.stage_company_b)
+
+        # Stage order: company A, no company, company B
+        self.stage_company_none.sequence = 2
+
+        project_company_b = self.env['project.project'].with_user(self.user_manager_companies).create({
+            'name': 'Project company B',
+            'company_id': self.company_b.id,
+        })
+        self.assertEqual(project_company_b.company_id, self.company_b)
+        self.assertEqual(project_company_b.stage_id, self.stage_company_none)
+
+        project_no_company = self.env['project.project'].with_user(self.user_manager_companies).create({
+            'name': 'Project no company',
+        })
+        self.assertFalse(project_no_company.company_id)
+        self.assertEqual(project_no_company.stage_id, self.stage_company_none)
+
+        self.env['project.project.stage'].search([]).active = False
+        project_no_company = self.env['project.project'].with_user(self.user_manager_companies).create({
+            'name': 'Project no company',
+        })
+        self.assertFalse(project_no_company.stage_id)
+
+    def test_project_creation_default_stage_in_context(self):
+        """
+        Project's company should be the same as the default stage's company in the context.
+        """
+        project = self.env['project.project'].with_user(self.user_manager_companies).with_context(default_stage_id=self.stage_company_b.id).create({
+            'name': 'Project company B',
+        })
+        self.assertEqual(project.company_id, self.company_b)


### PR DESCRIPTION
Steps
-----
- Have two companies A and B.
- Activate Project Stages, and in the list of stages set the first one of the list as belonging to company A.
- Create a project (from 'new' button in list view to be able to set a company at creation) belonging to company B (company B needs to be in the list of selected companies).
- Save it: the project's company has changed to company A.

Cause
-----
If no stage is set on the project at creation, we default to the default stage provided by `_default_stage_id`, which is the first stage in sequence, regardless of its company.
We then change the company of the project to match the stage's company, which overrides the stage set at creation.

Change
-----
If the project has a company set a creation, use the first stage without a company or with the same company as the project.
This is done even if the user doesn't have multiple companies selected, since the `search` on `project.project.stage` can return a stage from another company than the one selected.

opw-4290711
