### PR TITLE
[FIX] mrp: expected duration with different BoM UoM

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -86,7 +86,8 @@ class MrpRoutingWorkcenter(models.Model):
             for item in data:
                 total_duration += item['duration']
                 capacity = item['workcenter_id']._get_capacity(item.product_id)
-                cycle_number += tools.float_round((item['qty_produced'] / capacity or 1.0), precision_digits=0, rounding_method='UP')
+                qty_produced = item.product_uom_id._compute_quantity(item['qty_produced'], item.product_id.uom_id)
+                cycle_number += tools.float_round((qty_produced / capacity or 1.0), precision_digits=0, rounding_method='UP')
             if cycle_number:
                 operation.time_cycle = total_duration / cycle_number
             else:

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4059,3 +4059,28 @@ class TestMrpOrder(TestMrpCommon):
         ])
         bo_2.button_mark_done()
         self.assertRecordValues(bo_2, [{'qty_produced': 4.0, 'state': 'done'}])
+
+    def test_compute_tracked_time_3(self):
+        """
+        Checks that the expected duration calculation is correct when the BoM has a different UoM than the product.
+        """
+        # Change the BoM UoM to be Dozens instead of Units
+        self.bom_4.product_uom_id = self.uom_dozen
+
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
+        production_form = Form(self.env['mrp.production'])
+        production_form.bom_id = self.bom_4
+        production = production_form.save()
+        production.action_confirm()
+        production.button_plan()
+        production_form = Form(production)
+        production_form.qty_producing = 1
+        with production_form.workorder_ids.edit(0) as wo:
+            wo.duration = 15  # Complete the work order in 15 minutes
+        production = production_form.save()
+        production.button_mark_done()
+
+        production_form = Form(self.env['mrp.production'])
+        production_form.bom_id = self.bom_4
+        production = production_form.save()
+        self.assertEqual(production.workorder_ids[0].duration_expected, 15)


### PR DESCRIPTION
Problem: When a BoM has a different UoM than the product, it will calculate the number of cycles needed for the work order using the product’s UoM. However, during the cycle time calculation, it uses the BoM’s UoM to calculate the number of cycles used in the previous work orders. It then uses this cycle number calculation to calculate the duration of each cycle. This can cause the expected duration for a work order to be calculated incorrectly.

Purpose: Changing the cycle time’s calculation to use the product’s UoM will make it consistent with the number of cycles calculation on the work order. 

Steps to Reproduce on Runbot:

1. Create a new storable product.
2. Create a BoM for this product, but set the UoM to Dozens.
3. Navigate to the Operations tab and add an operation.
4. Set the Duration Computation to Compute based on tracked time.
5. Create a manufacturing order and confirm it.
6. Navigate to the Work Orders tab, set the Real Duration to 20:00, and mark it as done.
7. Create a new manufacturing order.
8. Navigate to the Work Orders tab and observe the Expected Duration is 240:00.

opw-4239248

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
