### PR TITLE
[FIX] html_editor: traceback when pressing enter in unsplittable block

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -342,6 +342,7 @@ export class FontPlugin extends Plugin {
             // @todo @phoenix: if this condition can be anticipated before the split,
             // handle the splitBlock only in such case.
             if (
+                newElement &&
                 headingTags.includes(newElement.tagName) &&
                 !descendants(newElement).some(isVisibleTextNode)
             ) {

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -3,6 +3,9 @@ import { press } from "@odoo/hoot-dom";
 import { tick } from "@odoo/hoot-mock";
 import { testEditor } from "../_helpers/editor";
 import { insertText, splitBlock } from "../_helpers/user_actions";
+import { unformat } from "../_helpers/format";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { QWebPlugin } from "@html_editor/others/qweb_plugin";
 
 describe("Selection collapsed", () => {
     describe("Basic", () => {
@@ -87,6 +90,25 @@ describe("Selection collapsed", () => {
                 contentBefore: `<p>abc<a href="#" title="document" data-mimetype="application/pdf" class="o_image"></a>[]</p>`,
                 stepFunction: splitBlock,
                 contentAfter: `<p>abc<a href="#" title="document" data-mimetype="application/pdf" class="o_image"></a></p><p>[]<br></p>`,
+            });
+        });
+        test("should not split block with conditional template", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <h1 t-if="true">
+                        <t t-out="Hello"></t>
+                        []<t t-out="World"></t>
+                    </h1>
+                `),
+                stepFunction: splitBlock,
+                contentAfter: unformat(`
+                    <h1 t-if="true">
+                        <t t-out="Hello"></t>
+                        <br>
+                        []<t t-out="World"></t>
+                    </h1>
+                `),
+                config: { Plugins: [...MAIN_PLUGINS, QWebPlugin] },
             });
         });
     });


### PR DESCRIPTION
Steps to Reproduce:

1. Navigate to Project.
2. Open Studio and go to Reports -> Timesheets Report.
3. Place the cursor before the text "Expression" and press Enter.
4. Next, place the cursor before the text "Name" and press Enter.
5. A traceback occurs.

Description of the issue/feature this PR addresses:

When pressing Enter with the cursor inside an unsplittable block, instead of creating a new tag, the `insertLineBreakElement`is called which adds a `<br>` and returns `undefined`. Consequently, in `handleSplitBlockHeading`, `newElement` is `undefined`, leading to a traceback when attempting to access its `tagName`.

Desired behavior after PR is merged:

The traceback no longer occurs when pressing Enter in an unsplittable block.

task-4334925