### PR TITLE
[FIX] portal, point_of_sale: return new instance of fields list

### DIFF
--- a/addons/l10n_mx/__init__.py
+++ b/addons/l10n_mx/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+from . import controllers

--- a/addons/l10n_mx/controllers/__init__.py
+++ b/addons/l10n_mx/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import portal

--- a/addons/l10n_mx/controllers/portal.py
+++ b/addons/l10n_mx/controllers/portal.py
@@ -1,0 +1,28 @@
+from odoo.addons.portal.controllers import portal
+from odoo.http import request
+
+class CustomerPortal(portal.CustomerPortal):
+
+    def _get_mandatory_fields(self):
+        # EXTENDS 'portal'
+        try:
+            country_id = int(request.env.context.get('portal_form_country_id', ''))
+        except ValueError:
+            country_id = None
+
+        mandatory_fields = super()._get_mandatory_fields()
+        if country_id and request.env['res.country'].sudo().browse(country_id).code == 'MX':
+            mandatory_fields += ['zipcode', 'vat']
+        return mandatory_fields
+
+    def _get_optional_fields(self):
+        # EXTENDS 'portal'
+        try:
+            country_id = int(request.env.context.get('portal_form_country_id', ''))
+        except ValueError:
+            country_id = None
+
+        optional_fields = super()._get_optional_fields()
+        if country_id and request.env['res.country'].sudo().browse(country_id).code == 'MX':
+            optional_fields = [field for field in optional_fields if field not in ['zipcode', 'vat']]
+        return optional_fields

--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -182,7 +182,7 @@ class PosController(PortalAccount):
                 # Check that the billing information of the user are filled.
                 error, error_message = {}, []
                 partner = request.env.user.partner_id
-                for field in self.MANDATORY_BILLING_FIELDS:
+                for field in self._get_mandatory_fields():
                     if not partner[field]:
                         error[field] = 'error'
                         error_message.append(_('The %s must be filled in your details.', request.env['ir.model.fields']._get('res.partner', field).field_description))
@@ -235,8 +235,8 @@ class PosController(PortalAccount):
         # If the user is not connected, then we will simply create a new partner with the form values.
         # Matching with existing partner was tried, but we then can't update the values, and it would force the user to use the ones from the first invoicing.
         if request.env.user._is_public() and not pos_order.partner_id.id:
-            partner_values.update({key: kwargs[key] for key in self.MANDATORY_BILLING_FIELDS})
-            partner_values.update({key: kwargs[key] for key in self.OPTIONAL_BILLING_FIELDS if key in kwargs})
+            partner_values.update({key: kwargs[key] for key in self._get_mandatory_fields()})
+            partner_values.update({key: kwargs[key] for key in self._get_optional_fields() if key in kwargs})
             for field in {'country_id', 'state_id'} & set(partner_values.keys()):
                 try:
                     partner_values[field] = int(partner_values[field])

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -376,10 +376,13 @@ class CustomerPortal(Controller):
         error = dict()
         error_message = []
 
+        request.update_context(portal_form_country_id=data['country_id'])
         # Validation
         for field_name in self._get_mandatory_fields():
             if not data.get(field_name):
                 error[field_name] = 'missing'
+                if field_name == 'zipcode':
+                    error['zip'] = 'missing'
 
         # email validation
         if data.get('email') and not tools.single_email_re.match(data.get('email')):
@@ -420,11 +423,11 @@ class CustomerPortal(Controller):
 
     def _get_mandatory_fields(self):
         """ This method is there so that we can override the mandatory fields """
-        return self.MANDATORY_BILLING_FIELDS
+        return list(self.MANDATORY_BILLING_FIELDS)
 
     def _get_optional_fields(self):
         """ This method is there so that we can override the optional fields """
-        return self.OPTIONAL_BILLING_FIELDS
+        return list(self.OPTIONAL_BILLING_FIELDS)
 
     def _document_check_access(self, model_name, document_id, access_token=None):
         """Check if current user is allowed to access the specified record.


### PR DESCRIPTION
[FIX] portal, point_of_sale: return new instance of fields list
This commit contains a backport of https://github.com/odoo/odoo/commit/1e39d5c2e5f4d4c77b0190ea1eb4781e2143657f to fix the following issue:

In the l10n_mx localization, the field RFC(VAT) and zipcode should be required to prevent the field from being defaulted to "public en general".

How to reproduce:

-Install l10n_mx
-Go to POS and sell an article to generate the ticket
-Go to the POS portal to request an invoice
-Fill all the fields except for RFC
-Odoo does not request this field and allows the client to submit the information
-The invoice will be generated to "public en general" and not to the client requesting the invoice (Expected when there is no RFC)


opw-4332357

enterprise pr: https://github.com/odoo/enterprise/pull/74072

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
