### PR TITLE
[FIX] website_blog: display the first post correctly on the blogs page

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -103,13 +103,7 @@ class WebsiteBlog(http.Controller):
         else:
             domain += [("post_date", "<=", fields.Datetime.now())]
 
-        use_cover = request.website.is_view_active('website_blog.opt_blog_cover_post')
-        fullwidth_cover = request.website.is_view_active('website_blog.opt_blog_cover_post_fullwidth_design')
-
-        # if blog, we show blog title, if use_cover and not fullwidth_cover we need pager + latest always
         offset = (page - 1) * self._blog_post_per_page
-        if not blog and use_cover and not fullwidth_cover and not tags and not date_begin and not date_end and not search:
-            offset += 1
 
         options = self._get_blog_post_search_options(
             blog=blog,


### PR DESCRIPTION
Prior to [1], when the "Name / Latest post" option was active and "Full-width" was disabled, the blogs page displayed the first blog post as a cover. However, [1] replaced this dynamic cover with a static one titled "Our latest posts," inadvertently omitting the first blog post from the page.

Steps to reproduce the issue:

- Navigate to the "Blog" menu.
- Enable "Edit" mode.
- In the "Customize" panel, disable the "Full-width" option.
- The latest blog post no longer appears in the list.

This commit resolves the issue by ensuring the first blog post is displayed correctly.

[1]: https://github.com/odoo/odoo/commit/05ef95d3f13ac42713bb8d8a3002f149345cc08b

opw-4289735
