### PR TITLE
[FIX] mail: flush user_tz in mail activity search

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -162,7 +162,7 @@ class MailActivityMixin(models.AbstractModel):
 
         search_states_int = {integer_state_value.get(s or False) for s in search_states}
 
-        self.env['mail.activity'].flush_model(['active', 'date_deadline', 'res_model', 'user_id'])
+        self.env['mail.activity'].flush_model(['active', 'date_deadline', 'res_model', 'user_id', 'user_tz'])
         query = SQL(
             """(
             SELECT res_id


### PR DESCRIPTION
The user timezone is not flushed and used in the SQL to search by `activity_state` in the activity mixin.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
