### PR TITLE
[FIX] website_blog: allow editing of the blog page title

### DIFF
--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -111,7 +111,9 @@ list of filtered posts (by date or tag).
                     </div>
                 </t>
                 <t t-else="">
-                    <div class="h1 o_not_editable" style="text-align:center;">Our Latest Posts</div>
+                    <!-- Remove this t-if from master -->
+                    <div t-if="False" class="h1 o_not_editable" style="text-align:center;">Our Latest Posts</div>
+                    <div class="h1" style="text-align:center;">Our Latest Posts</div>
                 </t>
                 <div class="col-12 mt-3"> <hr/> </div>
             </div>
@@ -137,7 +139,9 @@ list of filtered posts (by date or tag).
             </div>
         </t>
         <t t-else="">
-            <div class="h1 my-4 o_not_editable" style="text-align:center;">Our Latest Posts</div>
+            <!-- Remove this t-if from master -->
+            <div t-if="False" class="h1 my-4 o_not_editable" style="text-align:center;">Our Latest Posts</div>
+            <div class="h1 my-4" style="text-align:center;">Our Latest Posts</div>
         </t>
     </xpath>
 </template>


### PR DESCRIPTION
Following [1], the blog page reverted to using the first blog post as the cover. However, the title of the page ("Our Latest Posts") was made non-editable and, consequently, non-translatable, which is not ideal.

This commit addresses the issue by making the title editable, ensuring it can also be translated.

[1]: https://github.com/odoo/odoo/commit/05ef95d3f13ac42713bb8d8a3002f149345cc08b

opw-4289735