### PR TITLE
[IMP][BACKPORT] point_of_sale: Upgrade IoT to 2024-10-22 RPi OS

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/logrotate.conf
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/logrotate.conf
@@ -14,19 +14,4 @@ create
 # packages drop log rotation information into this directory
 include /etc/logrotate.d
 
-# no packages own wtmp, or btmp -- we'll rotate them here
-/var/log/wtmp {
-    missingok
-    monthly
-    create 0664 root utmp
-    rotate 1
-}
-
-/var/log/btmp {
-    missingok
-    monthly
-    create 0660 root utmp
-    rotate 1
-}
-
 # system-specific logs may be configured here

--- a/addons/point_of_sale/tools/posbox/posbox_create_image.sh
+++ b/addons/point_of_sale/tools/posbox/posbox_create_image.sh
@@ -29,7 +29,7 @@ MOUNT_POINT="${__dir}/root_mount"
 OVERWRITE_FILES_BEFORE_INIT_DIR="${__dir}/overwrite_before_init"
 OVERWRITE_FILES_AFTER_INIT_DIR="${__dir}/overwrite_after_init"
 VERSION=17.0
-VERSION_IOTBOX=24.10
+VERSION_IOTBOX=24.11
 
 
 # ask user for the branch/version
@@ -45,7 +45,7 @@ REPO="https://github.com/${REPO:-$current_repo}/odoo.git"
 echo "Using repo: ${REPO}"
 
 if ! file_exists *raspios*.img ; then
-    wget "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2024-07-04/2024-07-04-raspios-bookworm-armhf-lite.img.xz" -O raspios.img.xz
+    wget "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2024-10-28/2024-10-22-raspios-bookworm-armhf-lite.img.xz" -O raspios.img.xz
     unxz --verbose raspios.img.xz
 fi
 


### PR DESCRIPTION
Backport of #187206.

For the next IoT box image, we will upgrade to the latest version of RPi OS Lite. This fixes an issue on bootup where the display is not initalised (hangs waiting on `dev-dri-card0/start`).

Also removes the `wtmp` and `btmp` paths from `logrotate.conf`. These paths were duplicated from existing logrotate config files, causing the service to fail to start.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
