### PR TITLE
[FIX] website: support uppercase letters in domain names

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -345,7 +345,7 @@ class Website(models.Model):
         :param url: the url to check
         :return: True if the url has to be indexed, False otherwise
         """
-        return get_base_domain(url, True) == get_base_domain(self.domain, True)
+        return get_base_domain(url.lower(), True) == get_base_domain(self.domain.lower(), True)
 
     # ----------------------------------------------------------
     # Configurator


### PR DESCRIPTION
Since [1], the _is_indexable_url() method was introduced to determine whether a website should be indexed. However, if a domain name contains uppercase letters, the method incorrectly returns a falsy value. This happens because browsers automatically convert URLs to lowercase, causing a mismatch.

Steps to reproduce the issue:

- Navigate to Website > Configuration > Website.
- Set a domain name with uppercase letters (e.g., http://TEST.localhost:8069).
- Go to settings and modify the robots.txt file.
- Visit http://TEST.localhost:8069/robots.txt and notice that the changes are not reflected.

This commit resolves the issue by handling uppercase letters in domain names correctly.

[1]: https://github.com/odoo/odoo/commit/49c226a243864a935b7f8e13c79247a1d9405afa

opw-4306840