### PR TITLE
[FIX] sale_pdf_quote_builder: fixed PdfReadError on upload/create Header/Footer

### DIFF
--- a/addons/sale_pdf_quote_builder/utils.py
+++ b/addons/sale_pdf_quote_builder/utils.py
@@ -24,6 +24,6 @@ def _get_form_fields_from_pdf(pdf_data):
     :return: set of form fields that are in the pdf.
     :rtype: set
     """
-    reader = pdf.PdfFileReader(io.BytesIO(base64.b64decode(pdf_data)))
+    reader = pdf.PdfFileReader(io.BytesIO(base64.b64decode(pdf_data)), strict=False)
 
     return set(reader.getFormTextFields() or {})


### PR DESCRIPTION
Currently a `PdfReadError` is arising when user try upload/create/edit the Headers/Footers from the menu.

To get this error:
- Go to "Headers/Footers" from the "Configuration" menu.
- Click "New" or "Upload" to upload the PDF file.
- For existing files, re-upload through "File Content(base64)".
- The error appears in the console log.

Sample File: 
[EA-20221231-13 (1).pdf](https://github.com/user-attachments/files/17813674/EA-20221231-13.1.pdf)

Error:  `PdfReadError: PDF starts with 'PK␃␄␔', but '%PDF-' expected`

To fix this issue, set the parameter "strict" to "False" to be lenient in checking the file type while uploading/creating.

sentry-6064981257
