### PR TITLE
[FIX] account: journal dashboard informations

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -699,7 +699,7 @@ class account_journal(models.Model):
                 *self.env['account.move.line']._check_company_domain(self.env.companies),
                 ('journal_id', 'in', self.ids),
                 ('payment_state', 'in', ('not_paid', 'partial')),
-                ('move_type', '=', 'out_invoice' if journal_type == 'sale' else 'in_invoice'),
+                ('move_type', 'in', ('out_invoice', 'out_refund') if journal_type == 'sale' else ('in_invoice', 'in_refund')),
                 ('state', '=', 'posted'),
             ])),
             ('account_type', '=', 'asset_receivable' if journal_type == 'sale' else 'liability_payable'),

--- a/addons/account/tests/test_account_journal_dashboard.py
+++ b/addons/account/tests/test_account_journal_dashboard.py
@@ -87,8 +87,8 @@ class TestAccountJournalDashboard(TestAccountJournalDashboardCommon):
         self.assertEqual(dashboard_data['number_draft'], 0)
         self.assertIn('0.00', dashboard_data['sum_draft'])
 
-        self.assertEqual(dashboard_data['number_waiting'], 1)
-        self.assertIn('68.42', dashboard_data['sum_waiting'])
+        self.assertEqual(dashboard_data['number_waiting'], 2)
+        self.assertIn('55.12', dashboard_data['sum_waiting'])
 
         # Check partial on refund
         payment = self.env['account.payment'].create({
@@ -107,12 +107,12 @@ class TestAccountJournalDashboard(TestAccountJournalDashboardCommon):
         self.assertEqual(dashboard_data['number_draft'], 0)
         self.assertIn('0.00', dashboard_data['sum_draft'])
 
-        self.assertEqual(dashboard_data['number_waiting'], 1)
-        self.assertIn('68.42', dashboard_data['sum_waiting'])
+        self.assertEqual(dashboard_data['number_waiting'], 2)
+        self.assertIn('65.12', dashboard_data['sum_waiting'])
 
         dashboard_data = journal._get_journal_dashboard_data_batched()[journal.id]
-        self.assertEqual(dashboard_data['number_late'], 1)
-        self.assertIn('68.42', dashboard_data['sum_late'])
+        self.assertEqual(dashboard_data['number_late'], 2)
+        self.assertIn('65.12', dashboard_data['sum_late'])
 
     def test_sale_purchase_journal_for_purchase(self):
         """

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -347,12 +347,12 @@
                             <div class="row" t-if="dashboard.number_waiting">
                                 <div class="col overflow-hidden text-start">
                                     <span t-if="journal_type == 'sale'">
-                                        <a type="object" name="open_action" context="{'action_name': 'action_amounts_to_settle', 'search_default_invoices': '1', 'journal_type': type}">
+                                        <a type="object" name="open_action" context="{'action_name': 'action_amounts_to_settle', 'journal_type': type}">
                                             <t t-out="dashboard.number_waiting"/> Unpaid
                                         </a>
                                     </span>
                                     <span t-if="journal_type == 'purchase'">
-                                        <a type="object" name="open_action" context="{'action_name': 'action_amounts_to_settle', 'search_default_bills': '1', 'journal_type': type}">
+                                        <a type="object" name="open_action" context="{'action_name': 'action_amounts_to_settle', 'journal_type': type}">
                                             <t t-out="dashboard.number_waiting"/> To Pay
                                         </a>
                                     </span>
@@ -364,12 +364,12 @@
                             <div class="row" t-if="dashboard.number_late">
                                 <div class="col overflow-hidden text-start">
                                     <span t-if="journal_type == 'sale'">
-                                        <a type="object" name="open_action" context="{'action_name': 'action_amounts_to_settle', 'search_default_invoices': '1', 'search_default_late': '1', 'journal_type': type}">
+                                        <a type="object" name="open_action" context="{'action_name': 'action_amounts_to_settle', 'search_default_late': '1', 'journal_type': type}">
                                             <t t-out="dashboard.number_late"/> Late
                                         </a>
                                     </span>
                                     <span t-if="journal_type == 'purchase'">
-                                        <a type="object" name="open_action" context="{'action_name': 'action_amounts_to_settle', 'search_default_bills': '1', 'search_default_late': '1', 'journal_type': type}">
+                                        <a type="object" name="open_action" context="{'action_name': 'action_amounts_to_settle', 'search_default_late': '1', 'journal_type': type}">
                                             <t t-out="dashboard.number_late"/> Late
                                         </a>
                                     </span>


### PR DESCRIPTION
The informations displayed on journal dashboard on
sale/purchase journals should include both invoices/bills
and credit notes/refunds, as well as the moves shown in the list view
when coming from the journal card hyperlinks.

opw-4328137