### PR TITLE
[FIX] mail: better loop detection in mailgateway

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -487,7 +487,7 @@ class MailMail(models.Model):
                     email_list.append(values)
 
                 # headers
-                headers = {}
+                headers = {'X-Odoo-Message-Id': mail.message_id}
                 ICP = self.env['ir.config_parameter'].sudo()
                 bounce_alias = ICP.get_param("mail.bounce.alias")
                 catchall_domain = ICP.get_param("mail.catchall.domain")

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1247,10 +1247,17 @@ class MailThread(models.AbstractModel):
         if strip_attachments:
             msg_dict.pop('attachments', None)
 
-        existing_msg_ids = self.env['mail.message'].search([('message_id', '=', msg_dict['message_id'])], limit=1)
+        message_ids = [msg_dict['message_id']]
+        if msg_dict.get('x_odoo_message_id'):
+            message_ids.append(msg_dict['x_odoo_message_id'])
+        existing_msg_ids = self.env['mail.message'].search([('message_id', 'in', message_ids)], limit=1)
         if existing_msg_ids:
-            _logger.info('Ignored mail from %s to %s with Message-Id %s: found duplicated Message-Id during processing',
-                         msg_dict.get('email_from'), msg_dict.get('to'), msg_dict.get('message_id'))
+            if msg_dict.get('x_odoo_message_id'):
+                _logger.info('Ignored mail from %s to %s with Message-Id %s / Context Message-Id %s: found duplicated Message-Id during processing',
+                             msg_dict.get('email_from'), msg_dict.get('to'), msg_dict.get('message_id'), msg_dict.get('x_odoo_message_id'))
+            else:
+                _logger.info('Ignored mail from %s to %s with Message-Id %s: found duplicated Message-Id during processing',
+                             msg_dict.get('email_from'), msg_dict.get('to'), msg_dict.get('message_id'))
             return False
 
         if self._detect_loop_headers(msg_dict):
@@ -1547,6 +1554,7 @@ class MailThread(models.AbstractModel):
             # Very unusual situation, be we should be fault-tolerant here
             message_id = "<%s@localhost>" % time.time()
             _logger.debug('Parsing Message without message-id, generating a random one: %s', message_id)
+        msg_dict['x_odoo_message_id'] = (message.get('X-Odoo-Message-Id') or '').strip()
         msg_dict['message_id'] = message_id.strip()
 
         if message.get('Subject'):

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -767,6 +767,10 @@ class MailThread(models.AbstractModel):
                     followers
                 'partners': check that author_id id set
 
+        Note that this method also updates 'author_id' of message_dict as route
+        links an incoming message to a record and linking email to partner is
+        better done in a record's context.
+
         :param message: an email.message instance
         :param message_dict: dictionary of values that will be given to
                              mail_message.create()
@@ -900,32 +904,55 @@ class MailThread(models.AbstractModel):
         LOOP_THRESHOLD = int(get_param('mail.gateway.loop.threshold', 20))
 
         create_date_limit = self.env.cr.now() - datetime.timedelta(minutes=LOOP_MINUTES)
+        author_id = message_dict.get('author_id')
 
         # Search only once per model
-        models = {
-            self.env[model]
-            for model, thread_id, *__ in routes or []
-            if not thread_id  # Reply to an existing thread
-        }
+        model_res_ids = dict()
+        for model, thread_id, *__ in routes or []:
+            model_res_ids.setdefault(model, list()).append(thread_id)
 
-        for model in models:
+        for model_name, thread_ids in model_res_ids.items():
+            model = self.env[model_name]
             if not hasattr(model, '_detect_loop_sender_domain'):
                 continue
 
-            domain = model._detect_loop_sender_domain(email_from_normalized)
-            if not domain:
-                continue
+            loop_new, loop_update = False, False
+            search_new = 0 in thread_ids  # route creating new records = thread_id = 0
+            doc_ids = list(filter(None, thread_ids))  # route updating records = thread_id set
 
-            mail_incoming_messages_count = model.sudo().search_count(
-                expression.AND([
-                    [('create_date', '>', create_date_limit)],
-                    domain,
-                ]),
-            )
+            # search records created by email -> alias creating new records
+            if search_new:
+                base_domain = model._detect_loop_sender_domain(email_from_normalized)
+                if base_domain:
+                    mail_new_count = model.sudo().search_count(
+                        expression.AND([
+                            [('create_date', '>=', create_date_limit)],
+                            base_domain,
+                        ]),
+                    )
+                    loop_new = mail_new_count >= LOOP_THRESHOLD
 
-            if mail_incoming_messages_count >= LOOP_THRESHOLD:
-                _logger.info('--> ignored mail from %s to %s with Message-Id %s: created too many <%s>',
-                             message_dict.get('email_from'), message_dict.get('to'), message_dict.get('message_id'), model)
+            # search messages linked to email -> alias updating records
+            if doc_ids and not loop_new:
+                base_msg_domain = [('model', '=', model._name), ('res_id', 'in', doc_ids), ('create_date', '>=', create_date_limit)]
+                if author_id:
+                    msg_domain = expression.AND([[('author_id', '=', author_id)], base_msg_domain])
+                else:
+                    msg_domain = expression.AND([[('email_from', 'in', [email_from, email_from_normalized])], base_msg_domain])
+                mail_update_groups = self.env['mail.message'].sudo()._read_group_raw(msg_domain, ['res_id'], ['res_id'])
+                if mail_update_groups:
+                    loop_update = any(
+                        group['res_id_count'] >= LOOP_THRESHOLD
+                        for group in mail_update_groups
+                    )
+
+            if loop_new or loop_update:
+                if loop_new:
+                    _logger.info('--> ignored mail from %s to %s with Message-Id %s: created too many <%s>',
+                                message_dict.get('email_from'), message_dict.get('to'), message_dict.get('message_id'), model)
+                if loop_update:
+                    _logger.info('--> ignored mail from %s to %s with Message-Id %s: too much replies on same <%s>',
+                                message_dict.get('email_from'), message_dict.get('to'), message_dict.get('message_id'), model)
                 body = self.env['ir.qweb']._render(
                     'mail.message_notification_limit_email',
                     {'email': message_dict.get('to')},
@@ -1266,7 +1293,8 @@ class MailThread(models.AbstractModel):
                              msg_dict.get('email_from'), msg_dict.get('to'), msg_dict.get('message_id'))
             return
 
-        # find possible routes for the message
+        # find possible routes for the message; note this also updates notably
+        # 'author_id' of msg_dict
         routes = self.message_route(message, msg_dict, model, thread_id, custom_values)
         if self._detect_loop_sender(message, msg_dict, routes):
             return

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -4,6 +4,7 @@
 import base64
 import email
 import email.policy
+import logging
 import time
 
 from collections import defaultdict
@@ -18,9 +19,11 @@ from odoo.addons.bus.models.bus import ImBus, json_dump
 from odoo.addons.mail.models.mail_mail import MailMail
 from odoo.addons.mail.models.mail_message import Message
 from odoo.addons.mail.models.mail_notification import MailNotification
-from odoo.tests import common, new_test_user
+from odoo.tests import common, RecordCapturer, new_test_user
 from odoo.tools import email_normalize, formataddr, mute_logger, pycompat
 from odoo.tools.translate import code_translations
+
+_logger = logging.getLogger(__name__)
 
 mail_new_test_user = partial(new_test_user, context={'mail_create_nolog': True,
                                                      'mail_create_nosubscribe': True,
@@ -138,6 +141,11 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         if not msg_id:
             msg_id = "<%.7f-test@iron.sky>" % (time.time())
 
+        if kwargs.pop('debug_log', False):
+            _logger.info(
+                '-- Simulate routing --\n-From: %s (Return-Path %s)\n-To: %s / CC: %s\n-Message-Id: %s / Extra: %s',
+                email_from, return_path, to, cc, msg_id, extra,
+            )
         mail = self.format(template, to=to, subject=subject, cc=cc,
                            return_path=return_path, extra=extra,
                            email_from=email_from, msg_id=msg_id,
@@ -148,6 +156,28 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
     def gateway_reply_wrecord(self, template, record, use_in_reply_to=True):
         """ Deprecated, remove in 14.4 """
         return self.gateway_mail_reply_wrecord(template, record, use_in_reply_to=use_in_reply_to)
+
+    def gateway_mail_reply_last_email(self, template, force_to=False, force_rp=False, extra=False,
+                                      debug_log=False):
+        """ Tool to automatically reply to last outgoing mail.
+
+        :param str force_to: simulate a forwarding (which forces the To);
+        :param str force_rp: force return-path;
+        """
+        self.assertEqual(len(self._mails), 1)
+        mail = self._mails[0]
+        extra = f'{extra}\n' if extra else ''
+        extra = f'{extra}References:\r\n\t{mail["message_id"]}'
+        with RecordCapturer(self.env['mail.message'], []) as capture_messages, \
+             self.mock_mail_gateway():
+            self.format_and_process(
+                template, mail['email_to'][0], force_to or mail['reply_to'],
+                extra=extra,
+                return_path=force_rp or mail['email_to'][0],
+                subject=f'Re: {mail["subject"]}',
+                debug_log=debug_log,
+            )
+        return capture_messages
 
     def gateway_mail_reply_wrecord(self, template, record, use_in_reply_to=True,
                                    target_model=None, target_field=None):

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -296,20 +296,20 @@ class TestMailAliasMixin(TestMailCommon):
 
 
 @tagged('mail_gateway')
-class TestMailgateway(TestMailCommon):
+class MailGatewayCommon(TestMailCommon):
 
     @classmethod
     def setUpClass(cls):
-        super(TestMailgateway, cls).setUpClass()
+        super().setUpClass()
         cls.test_model = cls.env['ir.model']._get('mail.test.gateway')
         cls.email_from = '"Sylvie Lelitre" <test.sylvie.lelitre@agrolait.com>'
 
-        cls.test_record = cls.env['mail.test.gateway'].with_context(cls._test_context).create({
+        cls.test_record = cls.env['mail.test.gateway'].with_context(mail_create_nolog=True).create({
             'name': 'Test',
             'email_from': 'ignasse@example.com',
-        }).with_context({})
+        })
 
-        cls.partner_1 = cls.env['res.partner'].with_context(cls._test_context).create({
+        cls.partner_1 = cls.env['res.partner'].create({
             'name': 'Valid Lelitre',
             'email': 'valid.lelitre@agrolait.com',
         })
@@ -317,7 +317,7 @@ class TestMailgateway(TestMailCommon):
         cls.alias = cls.env['mail.alias'].create({
             'alias_name': 'groups',
             'alias_user_id': False,
-            'alias_model_id': cls.test_model.id,
+            'alias_model_id': cls.env['ir.model']._get_id('mail.test.gateway'),
             'alias_contact': 'everyone'})
 
         # Set a first message on public group to test update and hierarchy
@@ -338,6 +338,14 @@ class TestMailgateway(TestMailCommon):
         }
         msg_values.update(**values)
         return cls.env['mail.message'].create(msg_values)
+
+
+@tagged('mail_gateway')
+class TestMailgateway(MailGatewayCommon):
+
+    def test_assert_initial_values(self):
+        """ Just some basics checks to ensure tests coherency """
+        self.assertEqual(len(self.test_record.message_ids), 1)
 
     # --------------------------------------------------
     # Base low-level tests
@@ -824,7 +832,7 @@ class TestMailgateway(TestMailCommon):
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models.unlink')
     def test_message_process_create_uid_email_follower(self):
         self.alias.write({
-            'alias_parent_model_id': self.test_model.id,
+            'alias_parent_model_id': self.env['ir.model']._get_id(self.test_record._name),
             'alias_parent_thread_id': self.test_record.id,
         })
         follower_user = mail_new_test_user(self.env, login='better', groups='base.group_user', name='Ernest Follower', email=self.user_employee.email)
@@ -1754,106 +1762,6 @@ class TestMailgateway(TestMailCommon):
         self.assertEqual(str(capture.records.message_ids.body), '<pre>ร่างกาย</pre>\n')
 
     # --------------------------------------------------
-    # Emails loop detection
-    # --------------------------------------------------
-
-    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.addons.mail.models.mail_mail')
-    @patch.object(Cursor, 'now', lambda *args, **kwargs: datetime(2022, 1, 1, 10, 0, 0))
-    def test_routing_loop_alias(self):
-        """Test the limit on the number of record we can create by alias."""
-        self.env['ir.config_parameter'].sudo().set_param('mail.gateway.loop.minutes', 30)
-        self.env['ir.config_parameter'].sudo().set_param('mail.gateway.loop.threshold', 5)
-
-        self.env['mail.gateway.allowed'].create([
-            {'email': 'Bob@EXAMPLE.com'},
-            {'email': '"Alice From Example" <alice@EXAMPLE.com>'},
-            {'email': '"Eve From Example" <eve@EXAMPLE.com>'},
-        ])
-
-        alias = self.env['mail.alias'].create({
-            'alias_name': 'test',
-            'alias_user_id': False,
-            'alias_model_id': self.env['ir.model']._get('mail.test.container').id,
-            'alias_contact': 'everyone',
-        })
-
-        # Send an email 2 hours ago, should not have an impact on more recent emails
-        with patch.object(Cursor, 'now', lambda *args, **kwargs: datetime(2022, 1, 1, 8, 0, 0)):
-            self.format_and_process(
-                MAIL_TEMPLATE,
-                self.email_from,
-                f'{self.alias.alias_name}@{self.alias_domain}',
-                subject='Test alias loop old',
-                target_model=alias.alias_model_id.model,
-            )
-
-        for i in range(5):
-            self.format_and_process(
-                MAIL_TEMPLATE,
-                self.email_from,
-                f'{self.alias.alias_name}@{self.alias_domain}',
-                subject=f'Test alias loop {i}',
-                target_model=alias.alias_model_id.model,
-            )
-
-        records = self.env['mail.test.gateway'].search([('name', 'ilike', 'Test alias loop %')])
-        self.assertEqual(len(records), 6, 'Should have created 6 <mail.test.gateway>')
-        self.assertEqual(set(records.mapped('email_from')), set([self.email_from]),
-            msg='Should have automatically filled the email field')
-
-        self.assertEqual(set(records.mapped('email_from')), {self.email_from})
-
-        for email_from, exp_to in [
-            (self.email_from, formataddr(("Sylvie Lelitre", "test.sylvie.lelitre@agrolait.com"))),
-            (self.email_from.upper(), formataddr(("SYLVIE LELITRE", "test.sylvie.lelitre@agrolait.com"))),
-        ]:
-            with self.mock_mail_gateway():
-                self.format_and_process(
-                    MAIL_TEMPLATE,
-                    email_from,
-                    f'{self.alias.alias_name}@{self.alias_domain}',
-                    subject='Test alias loop X',
-                    target_model=alias.alias_model_id.model,
-                    return_path=email_from,
-                )
-
-            new_record = self.env['mail.test.gateway'].search([('name', '=', 'Test alias loop X')])
-            self.assertFalse(
-                new_record,
-                msg='The loop should have been detected and the record should not have been created')
-
-            self.assertSentEmail('"MAILER-DAEMON" <bounce.test@test.com>', [exp_to])
-            self.assertIn('-loop-detection-bounce-email@', self._mails[0]['references'],
-                msg='The "bounce email" tag must be in the reference')
-
-        # The reply to the bounce email must be ignored
-        with self.mock_mail_gateway():
-            self.format_and_process(
-                MAIL_TEMPLATE,
-                self.email_from,
-                f'{self.alias.alias_name}@{self.alias_domain}',
-                subject='Test alias loop X',
-                target_model=alias.alias_model_id.model,
-                return_path=self.email_from,
-                extra='References: <test-1337-loop-detection-bounce-email@odoo.com>',
-            )
-
-        self.assertNotSentEmail()
-
-        # Email address in the whitelist should not have the restriction
-        for i in range(10):
-            self.format_and_process(
-                MAIL_TEMPLATE,
-                'alice@example.com',
-                f'{self.alias.alias_name}@{self.alias_domain}',
-                subject=f'Whitelist test alias loop {i}',
-                target_model=alias.alias_model_id.model,
-            )
-
-        records = self.env['mail.test.gateway'].search([('name', 'ilike', 'Whitelist test alias loop %')])
-        self.assertEqual(len(records), 10, msg='Email whitelisted should not have the restriction')
-
-    # --------------------------------------------------
     # Corner cases / Bugs during message process
     # --------------------------------------------------
 
@@ -1936,6 +1844,109 @@ class TestMailgateway(TestMailCommon):
         self.assertEqual(record._name, 'mail.test.gateway')
         self.assertEqual(record.message_ids.subject, message.message_id)
         self.assertFalse(record.message_ids.parent_id)
+
+
+@tagged('mail_gateway', 'mail_loop')
+class TestMailGatewayLoops(MailGatewayCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env['ir.config_parameter'].sudo().set_param('mail.gateway.loop.minutes', 30)
+        cls.env['ir.config_parameter'].sudo().set_param('mail.gateway.loop.threshold', 5)
+
+        cls.env['mail.gateway.allowed'].create([
+            {'email': 'Bob@EXAMPLE.com'},
+            {'email': '"Alice From Example" <alice@EXAMPLE.com>'},
+            {'email': '"Eve From Example" <eve@EXAMPLE.com>'},
+        ])
+
+    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.addons.mail.models.mail_mail')
+    @patch.object(Cursor, 'now', lambda *args, **kwargs: datetime(2022, 1, 1, 10, 0, 0))
+    def test_routing_loop_alias_create(self):
+        """Test the limit on the number of record we can create by alias."""
+        alias = self.env['mail.alias'].create({
+            'alias_name': 'test',
+            'alias_user_id': False,
+            'alias_model_id': self.env['ir.model']._get('mail.test.container').id,
+            'alias_contact': 'everyone',
+        })
+
+        # Send an email 2 hours ago, should not have an impact on more recent emails
+        with patch.object(Cursor, 'now', lambda *args, **kwargs: datetime(2022, 1, 1, 8, 0, 0)):
+            self.format_and_process(
+                MAIL_TEMPLATE,
+                self.email_from,
+                f'{self.alias.alias_name}@{self.alias_domain}',
+                subject='Test alias loop old',
+                target_model=alias.alias_model_id.model,
+            )
+
+        for i in range(5):
+            self.format_and_process(
+                MAIL_TEMPLATE,
+                self.email_from,
+                f'{self.alias.alias_name}@{self.alias_domain}',
+                subject=f'Test alias loop {i}',
+                target_model=alias.alias_model_id.model,
+            )
+
+        records = self.env['mail.test.gateway'].search([('name', 'ilike', 'Test alias loop %')])
+        self.assertEqual(len(records), 6, 'Should have created 6 <mail.test.gateway>')
+        self.assertEqual(set(records.mapped('email_from')), set([self.email_from]),
+            msg='Should have automatically filled the email field')
+
+        self.assertEqual(set(records.mapped('email_from')), {self.email_from})
+
+        for email_from, exp_to in [
+            (self.email_from, formataddr(("Sylvie Lelitre", "test.sylvie.lelitre@agrolait.com"))),
+            (self.email_from.upper(), formataddr(("SYLVIE LELITRE", "test.sylvie.lelitre@agrolait.com"))),
+        ]:
+            with self.mock_mail_gateway():
+                self.format_and_process(
+                    MAIL_TEMPLATE,
+                    email_from,
+                    f'{self.alias.alias_name}@{self.alias_domain}',
+                    subject='Test alias loop X',
+                    target_model=alias.alias_model_id.model,
+                    return_path=email_from,
+                )
+
+            new_record = self.env['mail.test.gateway'].search([('name', '=', 'Test alias loop X')])
+            self.assertFalse(
+                new_record,
+                msg='The loop should have been detected and the record should not have been created')
+
+            self.assertSentEmail('"MAILER-DAEMON" <bounce.test@test.com>', [exp_to])
+            self.assertIn('-loop-detection-bounce-email@', self._mails[0]['references'],
+                msg='The "bounce email" tag must be in the reference')
+
+        # The reply to the bounce email must be ignored
+        with self.mock_mail_gateway():
+            self.format_and_process(
+                MAIL_TEMPLATE,
+                self.email_from,
+                f'{self.alias.alias_name}@{self.alias_domain}',
+                subject='Test alias loop X',
+                target_model=alias.alias_model_id.model,
+                return_path=self.email_from,
+                extra='References: <test-1337-loop-detection-bounce-email@odoo.com>',
+            )
+
+        self.assertNotSentEmail()
+
+        # Email address in the whitelist should not have the restriction
+        for i in range(10):
+            self.format_and_process(
+                MAIL_TEMPLATE,
+                'alice@example.com',
+                f'{self.alias.alias_name}@{self.alias_domain}',
+                subject=f'Whitelist test alias loop {i}',
+                target_model=alias.alias_model_id.model,
+            )
+
+        records = self.env['mail.test.gateway'].search([('name', 'ilike', 'Whitelist test alias loop %')])
+        self.assertEqual(len(records), 10, msg='Email whitelisted should not have the restriction')
 
 
 @tagged('mail_gateway', 'mail_thread')

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -10,11 +10,12 @@ from unittest.mock import DEFAULT
 from unittest.mock import patch
 
 from odoo import exceptions
+from odoo.addons.mail.models.mail_message import Message
 from odoo.addons.mail.models.mail_thread import MailThread
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.test_mail.data import test_mail_data
 from odoo.addons.test_mail.data.test_mail_data import MAIL_TEMPLATE, THAI_EMAIL_WINDOWS_874
-from odoo.addons.test_mail.models.test_mail_models import MailTestGateway
+from odoo.addons.test_mail.models.test_mail_models import MailTestGateway, MailTestGatewayGroups, MailTestTicket
 from odoo.addons.test_mail.tests.common import TestMailCommon
 from odoo.sql_db import Cursor
 from odoo.tests import tagged, RecordCapturer
@@ -1905,7 +1906,7 @@ class TestMailGatewayLoops(MailGatewayCommon):
             }
         ])
 
-    # @mute_logger('odoo.addons.mail.models.mail_thread')
+    @mute_logger('odoo.addons.mail.models.mail_thread')
     @patch.object(Cursor, 'now', lambda *args, **kwargs: datetime(2022, 1, 1, 10, 0, 0))
     def test_routing_loop_alias_create(self):
         """Test the limit on the number of record we can create by alias."""
@@ -1993,6 +1994,116 @@ class TestMailGatewayLoops(MailGatewayCommon):
             )
         records = self.env['mail.test.ticket'].search([('name', 'ilike', 'Whitelist test alias loop %')])
         self.assertEqual(len(records), 10, msg='Email whitelisted should not have the restriction')
+
+    @mute_logger('odoo.addons.mail.models.mail_thread')
+    def test_routing_loop_alias_mix(self):
+        """ Test loop detection in case of multiples routes, just be sure all
+        routes are checked and models checked once. """
+        # create 2 update-records aliases and 1 new-record alias on same model
+        test_updates = self.env['mail.test.gateway.groups'].create([
+            {
+                'alias_name': 'test.update1',
+                'name': 'Update1',
+            }, {
+                'alias_name': 'test.update2',
+                'name': 'Update2',
+            },
+        ])
+        alias_gateway_group, alias_ticket_other = self.env['mail.alias'].create([
+            {
+                'alias_contact': 'everyone',
+                'alias_model_id': self.env['ir.model']._get_id('mail.test.gateway.groups'),
+                'alias_name': 'test.new',
+            }, {
+                'alias_contact': 'everyone',
+                'alias_model_id': self.env['ir.model']._get_id('mail.test.ticket'),
+                'alias_name': 'test.ticket.other',
+            }
+        ])
+
+        _original_ticket_sc = MailTestTicket.search_count
+        _original_groups_sc = MailTestGatewayGroups.search_count
+        _original_rgr = Message._read_group_raw
+        with self.mock_mail_gateway(), \
+             patch.object(MailTestTicket, 'search_count', autospec=True, side_effect=_original_ticket_sc) as mock_ticket_sc, \
+             patch.object(MailTestGatewayGroups, 'search_count', autospec=True, side_effect=_original_groups_sc) as mock_groups_sc, \
+             patch.object(Message, '_read_group_raw', autospec=True, side_effect=_original_rgr) as mock_msg_rgr:
+            self.format_and_process(
+                MAIL_TEMPLATE,
+                self.other_partner.email_formatted,
+                f'"Super Help" <{self.alias_ticket.alias_name}@{self.alias_ticket.alias_domain}>,'
+                f'{test_updates[0].alias_id.display_name}, {test_updates[1].alias_id.display_name}, '
+                f'{alias_gateway_group.display_name}, {alias_ticket_other.display_name}',
+                subject='Valid Inquiry',
+                return_path=self.other_partner.email_formatted,
+                target_model='mail.test.ticket',
+            )
+        self.assertEqual(mock_ticket_sc.call_count, 1, 'Two alias creating tickets but one check anyway')
+        self.assertEqual(mock_groups_sc.call_count, 1, 'One alias creating groups')
+        self.assertEqual(mock_msg_rgr.call_count, 1, 'Only one model updating records, one call even if two aliases')
+        self.assertEqual(
+            len(self.env['mail.test.ticket'].search([('name', '=', 'Valid Inquiry')])),
+            2, 'One by creating alias, as no loop was detected'
+        )
+
+        # create 'looping' history by pre-creating messages on a thread -> should block future incoming emails
+        self.env['mail.message'].create([
+            {
+                'author_id': self.other_partner.id,
+                'model': test_updates[0]._name,
+                'res_id': test_updates[0].id,
+            } for x in range(4)  # 4 + 1 posted before = 5 aka threshold
+        ])
+        with self.mock_mail_gateway():
+            self.format_and_process(
+                MAIL_TEMPLATE,
+                self.other_partner.email_formatted,
+                f'"Super Help" <{self.alias_ticket.alias_name}@{self.alias_ticket.alias_domain}>,'
+                f'{test_updates[0].alias_id.display_name}, {test_updates[1].alias_id.display_name}, '
+                f'{alias_gateway_group.display_name}, {alias_ticket_other.display_name}',
+                subject='Looping Inquiry',
+                return_path=self.other_partner.email_formatted,
+                target_model='mail.test.ticket',
+            )
+        self.assertFalse(
+            self.env['mail.test.ticket'].search([('name', '=', 'Looping Inquiry')]),
+            'Even if other routes are ok, one looping route is sufficient to block the incoming email'
+        )
+
+    @mute_logger('odoo.addons.mail.models.mail_thread')
+    def test_routing_loop_auto_notif(self):
+        """ Test Odoo servers talking to each other """
+        with self.mock_mail_gateway():
+            record = self.format_and_process(
+                MAIL_TEMPLATE,
+                self.other_partner.email_formatted,
+                f'"Super Help" <{self.alias_ticket.alias_name}@{self.alias_ticket.alias_domain}>',
+                subject='Inquiry',
+                return_path=self.other_partner.email_formatted,
+                target_model='mail.test.ticket',
+            )
+        self.assertTrue(record)
+        self.assertEqual(record.message_partner_ids, self.other_partner)
+
+        for incoming_count in range(6):  # threshold + 1
+            with self.mock_mail_gateway():
+                record.with_user(self.user_employee).message_post(
+                    body='Automatic answer',
+                    message_type='auto_comment',
+                    subtype_xmlid='mail.mt_comment',
+                )
+            capture_messages = self.gateway_mail_reply_last_email(MAIL_TEMPLATE)
+            msg = capture_messages.records
+            self.assertTrue(msg)
+            # first messages are accepted -> post a message on record
+            if incoming_count < 4:  # which makes 5 accepted messages
+                self.assertIn(msg, record.message_ids)
+            # other attempts triggers only a bounce
+            else:
+                self.assertFalse(msg.model)
+                self.assertFalse(msg.res_id)
+                self.assertIn('loop-detection-bounce-email', msg.mail_ids.references,
+                              'Should be a msg linked to a bounce email with right header')
 
     @mute_logger('odoo.addons.mail.models.mail_thread')
     def test_routing_loop_follower_alias(self):

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -1993,6 +1993,55 @@ class TestMailGatewayLoops(MailGatewayCommon):
         records = self.env['mail.test.ticket'].search([('name', 'ilike', 'Whitelist test alias loop %')])
         self.assertEqual(len(records), 10, msg='Email whitelisted should not have the restriction')
 
+    @mute_logger('odoo.addons.mail.models.mail_thread')
+    def test_routing_loop_follower_alias(self):
+        """ Use case: managing follower that are aliases. """
+        with self.mock_mail_gateway():
+            record = self.format_and_process(
+                MAIL_TEMPLATE,
+                f'"Annoying Customer" <{self.customer_email}>',
+                f'"Super Help" <{self.alias_ticket.alias_name}@{self.alias_ticket.alias_domain}>',
+                cc=f'{self.alias_partner.email_normalized}, {self.other_partner.email_normalized}',
+                subject='Inquiry',
+                return_path=self.customer_email,
+                target_model='mail.test.ticket',
+            )
+        self.assertEqual(record.name, 'Inquiry')
+        self.assertFalse(record.message_partner_ids, 'Inquiry')
+        self.assertNotSentEmail()
+        self.assertEqual(record.message_ids.partner_ids, self.other_partner,
+                         'MailGateway: recipients = alias should not be linked to message')
+
+        # for some stupid reason, people add an alias as follower
+        with self.mock_mail_gateway():
+            _message = record.with_user(self.user_employee).message_post(
+                body='Answer',
+                partner_ids=self.alias_partner.ids,
+            )
+        last_mail = self._mails  # save to reuse
+        self.assertSentEmail(self.user_employee.email_formatted, [self.alias_partner.email_formatted])
+
+        # simulate this email coming back to the same Odoo server -> msg_id is
+        # a duplicate, hence rejected
+        with RecordCapturer(self.env['mail.test.ticket'], []) as capture_ticket, \
+             RecordCapturer(self.env['mail.test.gateway'], []) as capture_gateway:
+            self._reinject()
+        self.assertFalse(capture_ticket.records)
+        self.assertFalse(capture_gateway.records)
+        self.assertNotSentEmail()
+        self.assertFalse(bool(self._new_msgs))
+
+        # simulate stupid email providers that rewrites msg_id -> thanks to
+        # a custom header, it is rejected as already managed by mailgateway
+        self._mails = last_mail
+        with RecordCapturer(self.env['mail.test.ticket'], []) as capture_ticket, \
+             RecordCapturer(self.env['mail.test.gateway'], []) as capture_gateway:
+            self._reinject(force_msg_id='123donotnamemailjet456')
+        self.assertFalse(capture_ticket.records)
+        self.assertFalse(capture_gateway.records)
+        self.assertFalse(bool(self._new_msgs))
+        self.assertNotSentEmail()
+
 
 @tagged('mail_gateway', 'mail_thread')
 class TestMailThreadCC(TestMailCommon):

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -323,6 +323,25 @@ class MailGatewayCommon(TestMailCommon):
         # Set a first message on public group to test update and hierarchy
         cls.fake_email = cls._create_gateway_message(cls.test_record, '123456')
 
+    def _reinject(self, force_msg_id=False, debug_log=False):
+        """ Tool to automatically 'inject' an outgoing mail into the gateway.
+        Content changes.
+
+        :param str force_msg_id: allow to change the msg_id to simulate stupid
+            email providers that change message IDs;
+        """
+        self.assertEqual(len(self._mails), 1)
+        mail = self._mails[0]
+        extra = f'References: {mail["references"]}'
+        if mail["headers"].get("X-Odoo-Message-Id"):
+            extra += f'\nX-Odoo-Message-Id: {mail["headers"]["X-Odoo-Message-Id"]}'
+        with self.mock_mail_gateway(), self.mock_mail_app():
+            self.format_and_process(
+                MAIL_TEMPLATE, mail['email_from'], ','.join(mail['email_to']),
+                msg_id=force_msg_id or mail['message_id'], extra=extra,
+                debug_log=debug_log,
+            )
+
     @classmethod
     def _create_gateway_message(cls, record, msg_id_prefix, **values):
         msg_values = {
@@ -1861,42 +1880,58 @@ class TestMailGatewayLoops(MailGatewayCommon):
             {'email': '"Eve From Example" <eve@EXAMPLE.com>'},
         ])
 
-    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.addons.mail.models.mail_mail')
+        cls.alias_ticket = cls.env['mail.alias'].create({
+            'alias_contact': 'everyone',
+            'alias_model_id': cls.env['ir.model']._get_id('mail.test.ticket'),
+            'alias_name': 'test.ticket',
+            'alias_user_id': False,
+        })
+        cls.alias_other = cls.env['mail.alias'].create({
+            'alias_contact': 'everyone',
+            'alias_model_id': cls.env['ir.model']._get_id('mail.test.gateway'),
+            'alias_user_id': False,
+            'alias_name': 'test.gateway',
+        })
+
+        # recipients
+        cls.customer_email = "customer@test.example.com"
+        cls.alias_partner, cls.other_partner = cls.env['res.partner'].create([
+            {
+                'email': f'"Stupid Idea" <{cls.alias_other.alias_name}@{cls.alias_other.alias_domain}>',
+                'name': 'Stupid Idea',
+            }, {
+                'email': '"Other Customer" <other.customer@test.example.com>',
+                'name': 'Other Customer',
+            }
+        ])
+
+    @mute_logger('odoo.addons.mail.models.mail_thread')
     @patch.object(Cursor, 'now', lambda *args, **kwargs: datetime(2022, 1, 1, 10, 0, 0))
     def test_routing_loop_alias_create(self):
         """Test the limit on the number of record we can create by alias."""
-        alias = self.env['mail.alias'].create({
-            'alias_name': 'test',
-            'alias_user_id': False,
-            'alias_model_id': self.env['ir.model']._get('mail.test.container').id,
-            'alias_contact': 'everyone',
-        })
-
         # Send an email 2 hours ago, should not have an impact on more recent emails
         with patch.object(Cursor, 'now', lambda *args, **kwargs: datetime(2022, 1, 1, 8, 0, 0)):
             self.format_and_process(
                 MAIL_TEMPLATE,
                 self.email_from,
-                f'{self.alias.alias_name}@{self.alias_domain}',
+                f'{self.alias_ticket.alias_name}@{self.alias_domain}',
                 subject='Test alias loop old',
-                target_model=alias.alias_model_id.model,
+                target_model=self.alias_ticket.alias_model_id.model,
             )
 
         for i in range(5):
             self.format_and_process(
                 MAIL_TEMPLATE,
                 self.email_from,
-                f'{self.alias.alias_name}@{self.alias_domain}',
+                f'{self.alias_ticket.alias_name}@{self.alias_domain}',
                 subject=f'Test alias loop {i}',
-                target_model=alias.alias_model_id.model,
+                target_model=self.alias_ticket.alias_model_id.model,
             )
 
-        records = self.env['mail.test.gateway'].search([('name', 'ilike', 'Test alias loop %')])
+        records = self.env['mail.test.ticket'].search([('name', 'ilike', 'Test alias loop %')])
         self.assertEqual(len(records), 6, 'Should have created 6 <mail.test.gateway>')
-        self.assertEqual(set(records.mapped('email_from')), set([self.email_from]),
+        self.assertEqual(set(records.mapped('email_from')), {self.email_from},
             msg='Should have automatically filled the email field')
-
-        self.assertEqual(set(records.mapped('email_from')), {self.email_from})
 
         for email_from, exp_to in [
             (self.email_from, formataddr(("Sylvie Lelitre", "test.sylvie.lelitre@agrolait.com"))),
@@ -1906,33 +1941,44 @@ class TestMailGatewayLoops(MailGatewayCommon):
                 self.format_and_process(
                     MAIL_TEMPLATE,
                     email_from,
-                    f'{self.alias.alias_name}@{self.alias_domain}',
+                    f'{self.alias_ticket.alias_name}@{self.alias_domain}',
                     subject='Test alias loop X',
-                    target_model=alias.alias_model_id.model,
+                    target_model=self.alias_ticket.alias_model_id.model,
                     return_path=email_from,
                 )
 
-            new_record = self.env['mail.test.gateway'].search([('name', '=', 'Test alias loop X')])
+            new_record = self.env['mail.test.ticket'].search([('name', '=', 'Test alias loop X')])
             self.assertFalse(
                 new_record,
                 msg='The loop should have been detected and the record should not have been created')
 
             self.assertSentEmail('"MAILER-DAEMON" <bounce.test@test.com>', [exp_to])
-            self.assertIn('-loop-detection-bounce-email@', self._mails[0]['references'],
+            bounce_references = self._mails[0]['references']
+            self.assertIn('-loop-detection-bounce-email@', bounce_references,
                 msg='The "bounce email" tag must be in the reference')
 
         # The reply to the bounce email must be ignored
         with self.mock_mail_gateway():
             self.format_and_process(
                 MAIL_TEMPLATE,
-                self.email_from,
-                f'{self.alias.alias_name}@{self.alias_domain}',
+                'alice@example.com',  # whitelisted from, should be taken into account
+                f'{self.alias_ticket.alias_name}@{self.alias_domain}',
                 subject='Test alias loop X',
-                target_model=alias.alias_model_id.model,
+                target_model=self.alias_ticket.alias_model_id.model,
                 return_path=self.email_from,
-                extra='References: <test-1337-loop-detection-bounce-email@odoo.com>',
+                extra=f'References: {bounce_references}',
             )
-
+        self.assertNotSentEmail()
+        with self.mock_mail_gateway():
+            self.format_and_process(
+                MAIL_TEMPLATE,
+                'alice@example.com',  # whitelisted from, should be taken into account
+                f'{self.alias_ticket.alias_name}@{self.alias_domain}',
+                subject='Test alias loop X',
+                target_model=self.alias_ticket.alias_model_id.model,
+                return_path=self.email_from,
+                extra=f'In-Reply-To: {bounce_references}',
+            )
         self.assertNotSentEmail()
 
         # Email address in the whitelist should not have the restriction
@@ -1940,12 +1986,11 @@ class TestMailGatewayLoops(MailGatewayCommon):
             self.format_and_process(
                 MAIL_TEMPLATE,
                 'alice@example.com',
-                f'{self.alias.alias_name}@{self.alias_domain}',
+                f'{self.alias_ticket.alias_name}@{self.alias_domain}',
                 subject=f'Whitelist test alias loop {i}',
-                target_model=alias.alias_model_id.model,
+                target_model=self.alias_ticket.alias_model_id.model,
             )
-
-        records = self.env['mail.test.gateway'].search([('name', 'ilike', 'Whitelist test alias loop %')])
+        records = self.env['mail.test.ticket'].search([('name', 'ilike', 'Whitelist test alias loop %')])
         self.assertEqual(len(records), 10, msg='Email whitelisted should not have the restriction')
 
 

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -1905,7 +1905,7 @@ class TestMailGatewayLoops(MailGatewayCommon):
             }
         ])
 
-    @mute_logger('odoo.addons.mail.models.mail_thread')
+    # @mute_logger('odoo.addons.mail.models.mail_thread')
     @patch.object(Cursor, 'now', lambda *args, **kwargs: datetime(2022, 1, 1, 10, 0, 0))
     def test_routing_loop_alias_create(self):
         """Test the limit on the number of record we can create by alias."""
@@ -1969,6 +1969,7 @@ class TestMailGatewayLoops(MailGatewayCommon):
                 extra=f'References: {bounce_references}',
             )
         self.assertNotSentEmail()
+
         with self.mock_mail_gateway():
             self.format_and_process(
                 MAIL_TEMPLATE,
@@ -2041,6 +2042,42 @@ class TestMailGatewayLoops(MailGatewayCommon):
         self.assertFalse(capture_gateway.records)
         self.assertFalse(bool(self._new_msgs))
         self.assertNotSentEmail()
+
+    @mute_logger('odoo.addons.mail.models.mail_thread')
+    def test_routing_loop_forward_catchall(self):
+        """ Use case: broad email forward to catchall. Example: customer sends an
+        email to catchall. It bounces: to=customer, return-path=bounce. Autoreply
+        replies to bounce: to=bounce. It is forwarded to catchall. It bounces,
+        and hop we have a loop. """
+        customer_email = "customer@test.example.com"
+
+        with self.mock_mail_gateway():
+            self.format_and_process(
+                MAIL_TEMPLATE,
+                f'"Annoying Customer" <{customer_email}>',
+                f'"No Reply" <{self.alias_catchall}@{self.alias_domain}>, Unroutable <unroutable@{self.alias_domain}>',
+                subject='Should Bounce (initial)',
+                return_path=customer_email,
+            )
+        self.assertSentEmail(
+            f'"MAILER-DAEMON" <{self.alias_bounce}@{self.alias_domain}>',
+            [customer_email],
+            subject='Re: Should Bounce (initial)')
+        original_mail = self._mails
+
+        # auto-reply: write to bounce = no more bounce
+        self.gateway_mail_reply_last_email(MAIL_TEMPLATE, force_to=f'{self.alias_bounce}@{self.alias_domain}')
+        self.assertNotSentEmail()
+
+        # auto-reply but forwarded to catchall -> should not bounce again
+        self._mails = original_mail  # just to revert state prior to auto reply
+        self.gateway_mail_reply_last_email(MAIL_TEMPLATE, force_to=f'{self.alias_catchall}@{self.alias_domain}')
+        # TDE FIXME: this should not bounce again
+        # self.assertNotSentEmail()
+        self.assertSentEmail(
+            f'"MAILER-DAEMON" <{self.alias_bounce}@{self.alias_domain}>',
+            [customer_email],
+            subject=f'Re: Re: Re: Should Bounce (initial)')
 
 
 @tagged('mail_gateway', 'mail_thread')

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -790,6 +790,25 @@ class TestMailMail(TestMailCommon):
             [['test.cc.1@test.example.com', 'test.cc.2@test.example.com']] * 3,
         )
 
+    def test_mail_mail_values_headers(self):
+        """ Test headers content, notably X-Odoo-Message-Id added to keep context
+        when going through exotic mail providers that change our message IDs. """
+        mail = self.env['mail.mail'].create({
+            'body_html': '<p>Test</p>',
+            'email_to': 'test.😊@example.com',
+        })
+        message_id = mail.message_id
+        with self.mock_mail_gateway():
+            mail.send()
+        self.assertEqual(len(self._mails), 1)
+        self.assertDictEqual(
+            self._mails[0]['headers'],
+            {
+                'Return-Path': f'{self.alias_bounce}@{self.alias_domain}',
+                'X-Odoo-Message-Id': message_id,
+            }
+        )
+
     @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_mail_mail_values_email_unicode(self):
         """ Unicode should be fine. """

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -785,7 +785,6 @@ def formataddr(pair, charset='utf-8'):
             return f'"{name}" <{local}@{domain}>'
     return f"{local}@{domain}"
 
-
 def encapsulate_email(old_email, new_email):
     """Change the FROM of the message and use the old one as name.
 
@@ -812,3 +811,14 @@ def encapsulate_email(old_email, new_email):
         name_part,
         new_email_split[0][1],
     ))
+
+def unfold_references(msg_references):
+    """ As it declared in [RFC2822] long header bodies can be "folded" using
+    CRLF+WSP. Some mail clients split References header body which contains
+    Message Ids by "\n ".
+
+    RFC2882: https://tools.ietf.org/html/rfc2822#section-2.2.3 """
+    return [
+        re.sub(r'[\r\n\t ]+', r'', ref)  # "Unfold" buggy references
+        for ref in mail_header_msgid_re.findall(msg_references)
+    ]


### PR DESCRIPTION
Improve loop detection and break. Indeed heavy usage of mailgateway on
Odoo servers lead us to face email loops. Those lead to email being disabled
on our servers due to email limit, and to other issues (spam, never ending
notifications, ...) on hosted servers.

Three scenarios are fixed with this PR. See individual commits for more
details. Those are
 * having followers using alias email, and using a mail provider that rewrites
   msg-id: we cannot detect message duplication and this may generate loops.
   Several mail providers rewrite message IDs and that is a pain for us. We
   therefore add a custom header allowing to keep message ID in envelope;
 * replying to bounce may create bounce in loops: this is fixed using the
   loop detection custom reference;
 * detect loops on record update in addition to record creation: do not limit
   loops detection on aliases creating records, also check updated records;

Task-3895869
OPW-4051539
OPW-4295745
OPW-4302257
