### PR TITLE
[IMP] stock: Add more context to label for related locations

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -86,8 +86,8 @@ class StockMoveLine(models.Model):
     description_picking = fields.Text(string="Description picking")
     quant_id = fields.Many2one('stock.quant', "Pick From", store=False)  # Dummy field for the detailed operation view
     product_packaging_qty = fields.Float(string="Reserved Packaging Quantity", compute='_compute_product_packaging_qty')
-    picking_location_id = fields.Many2one(related='picking_id.location_id')
-    picking_location_dest_id = fields.Many2one(related='picking_id.location_dest_id')
+    picking_location_id = fields.Many2one(related='picking_id.location_id', string="Picking Location From")
+    picking_location_dest_id = fields.Many2one(related='picking_id.location_dest_id', string="Picking Location To")
 
     @api.depends('product_uom_id.category_id', 'product_id.uom_id.category_id', 'move_id.product_uom', 'product_id.uom_id')
     def _compute_product_uom_id(self):


### PR DESCRIPTION
It happens that in studio or domain, the user wants to add location dest and source from `stock.move.line` but the related to picking can be confusing. So we rename the labels.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
