### PR TITLE
[FIX] website_sale: cart entries will not overflow in mobile eCommerce page

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -992,3 +992,9 @@ a.no-decoration {
 .o_categories_recursive_button:after {
     display: none;
 }
+
+.text-overflow-ellipsis {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1923,7 +1923,7 @@
                             }"
                         />
                     </div>
-                    <div class="flex-grow-1">
+                    <div class="flex-grow-1 text-overflow-ellipsis">
                         <t t-call="website_sale.cart_line_product_link">
                             <h6 t-field="line.name_short" class="d-inline align-top h6 fw-bold"/>
                         </t>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
There is an issue where product names that are too long or too big cause certain elements to be pushed offscreen in the mobile version of the cart in the eCommerce.

Current behavior before PR:
Before the change, in the mobile version of the eCommerce cart, if a product had a name that was too long or the font size was too big it would push the elements to its right offscreen.

Desired behavior after PR is merged:
 After the change, the overflow of a product name that is too long or too big gets replaced with ellipsis, keeping the elements to its right from beign pushed offscreen.

task-4260720
opw-4253880

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
