### PR TITLE
[FIX] l10n_id: Display tax percentage instead of code on purchase order

### DIFF
--- a/addons/l10n_id/data/account_tax_template_data.xml
+++ b/addons/l10n_id/data/account_tax_template_data.xml
@@ -6,7 +6,7 @@
         <field name="country_id" ref="base.id"/>
     </record>
     <record id="tax_ST1" model="account.tax.template">
-        <field name="description">ST1</field>
+        <field name="description">11%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">sale</field>
         <field name="name">11%</field>
@@ -34,7 +34,7 @@
         ]"/>
     </record>
     <record id="tax_PT1" model="account.tax.template">
-        <field name="description">PT1</field>
+        <field name="description">11%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">11%</field>
@@ -62,7 +62,7 @@
         ]"/>
     </record>
     <record id="tax_ST0" model="account.tax.template">
-        <field name="description">ST0</field>
+        <field name="description">0%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">sale</field>
         <field name="name">0%</field>
@@ -84,7 +84,7 @@
         ]"/>
     </record>
     <record id="tax_ST2" model="account.tax.template">
-        <field name="description">ST2</field>
+        <field name="description">0%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Exempt</field>
@@ -106,7 +106,7 @@
         ]"/>
     </record>
     <record id="tax_PT2" model="account.tax.template">
-        <field name="description">PT2</field>
+        <field name="description">0%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Exempt</field>
@@ -128,7 +128,7 @@
         ]"/>
     </record>
     <record id="tax_PT0" model="account.tax.template">
-        <field name="description">PT0</field>
+        <field name="description">0%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">0%</field>
@@ -150,7 +150,7 @@
         ]"/>
     </record>
     <record id="tax_ST3" model="account.tax.template">
-        <field name="description">ST3</field>
+        <field name="description">12%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">sale</field>
         <field name="name">12%</field>
@@ -178,7 +178,7 @@
         ]"/>
     </record>
     <record id="tax_PT3" model="account.tax.template">
-        <field name="description">PT3</field>
+        <field name="description">12%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">12%</field>

--- a/addons/l10n_id/i18n_extra/id.po
+++ b/addons/l10n_id/i18n_extra/id.po
@@ -19,7 +19,7 @@ msgstr ""
 #. module: l10n_id
 #: model:account.tax.template,name:l10n_id.tax_PT1
 #: model:account.tax.template,name:l10n_id.tax_ST1
-msgid "10%"
+msgid "11%"
 msgstr ""
 
 #. module: l10n_id
@@ -313,7 +313,7 @@ msgid "Event"
 msgstr "Event"
 
 #. module: l10n_id
-#: model:account.tax.template,name:l10n_id.tax_PT0
+#: model:account.tax.template,name:l10n_id.tax_PT2
 #: model:account.tax.template,name:l10n_id.tax_ST2
 msgid "Exempt"
 msgstr ""
@@ -553,17 +553,17 @@ msgstr "Piutang Owner"
 
 #. module: l10n_id
 #: model:account.tax.template,description:l10n_id.tax_PT0
-msgid "PT0"
+msgid "0%"
 msgstr ""
 
 #. module: l10n_id
 #: model:account.tax.template,description:l10n_id.tax_PT1
-msgid "PT1"
+msgid "11%"
 msgstr ""
 
 #. module: l10n_id
 #: model:account.tax.template,description:l10n_id.tax_PT2
-msgid "PT2"
+msgid "0%"
 msgstr ""
 
 #. module: l10n_id
@@ -653,7 +653,7 @@ msgstr "Research & Development"
 
 #. module: l10n_id
 #: model:account.tax.template,description:l10n_id.tax_ST0
-msgid "ST0"
+msgid "0%"
 msgstr ""
 
 #. module: l10n_id
@@ -663,7 +663,7 @@ msgstr ""
 
 #. module: l10n_id
 #: model:account.tax.template,description:l10n_id.tax_ST2
-msgid "ST2"
+msgid "0%"
 msgstr ""
 
 #. module: l10n_id

--- a/addons/l10n_id/i18n_extra/l10n_id.pot
+++ b/addons/l10n_id/i18n_extra/l10n_id.pot
@@ -18,7 +18,7 @@ msgstr ""
 #. module: l10n_id
 #: model:account.tax.template,name:l10n_id.tax_PT1
 #: model:account.tax.template,name:l10n_id.tax_ST1
-msgid "10%"
+msgid "11%"
 msgstr ""
 
 #. module: l10n_id
@@ -312,7 +312,7 @@ msgid "Event"
 msgstr ""
 
 #. module: l10n_id
-#: model:account.tax.template,name:l10n_id.tax_PT0
+#: model:account.tax.template,name:l10n_id.tax_PT2
 #: model:account.tax.template,name:l10n_id.tax_ST2
 msgid "Exempt"
 msgstr ""
@@ -552,17 +552,17 @@ msgstr ""
 
 #. module: l10n_id
 #: model:account.tax.template,description:l10n_id.tax_PT0
-msgid "PT0"
+msgid "0%"
 msgstr ""
 
 #. module: l10n_id
 #: model:account.tax.template,description:l10n_id.tax_PT1
-msgid "PT1"
+msgid "11%"
 msgstr ""
 
 #. module: l10n_id
 #: model:account.tax.template,description:l10n_id.tax_PT2
-msgid "PT2"
+msgid "0%"
 msgstr ""
 
 #. module: l10n_id
@@ -652,17 +652,17 @@ msgstr ""
 
 #. module: l10n_id
 #: model:account.tax.template,description:l10n_id.tax_ST0
-msgid "ST0"
+msgid "0%"
 msgstr ""
 
 #. module: l10n_id
 #: model:account.tax.template,description:l10n_id.tax_ST1
-msgid "ST1"
+msgid "11%"
 msgstr ""
 
 #. module: l10n_id
 #: model:account.tax.template,description:l10n_id.tax_ST2
-msgid "ST2"
+msgid "0%"
 msgstr ""
 
 #. module: l10n_id


### PR DESCRIPTION
**Issue:**

When printing a Purchase Order or Quotation in a company using the Indonesian tax chart, a tax code (Indonesian tax description) appears instead of the tax percentage.

**Steps to Reproduce:**

1- Ensure the company uses the Indonesian chart of accounts.
	- Install the l10n_id module.
	- Go to Settings > Taxes and set the Fiscal Country to Indonesia. 2- Navigate to Purchase and create a Purchase Order. 3- Add a product line and select an Indonesian tax (ex: 11%). 4- Print the Purchase Order.

The printed Purchase Order displays the tax code (description) instead of the tax percentage. The same behavior occurs in the Sales module regarding quotation printing (see screenshots attached)

<img src ="https://github.com/user-attachments/assets/08dd6940-e07e-4e44-9f03-85f8ae2e8914" width=300 />
<img src ="https://github.com/user-attachments/assets/a8d16f6c-c6a0-441f-8c3f-3546387fb4e6" width=300 />

opw-4333143
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
