### PR TITLE
[FIX] portal: prevent Sign duplication in edit mode

### DIFF
--- a/addons/portal/static/src/signature_form/signature_form.js
+++ b/addons/portal/static/src/signature_form/signature_form.js
@@ -45,8 +45,13 @@ class SignatureForm extends Component {
         onMounted(() => {
             this.rootRef.el.closest('.modal').addEventListener('shown.bs.modal', () => {
                 this.signature.resetSignature();
+                this.toggleSignatureFormVisibility();
             });
         });
+    }
+
+    toggleSignatureFormVisibility() {
+        this.rootRef.el.classList.toggle('d-none', document.querySelector('.editor_enable'));
     }
 
     get sendLabel() {


### PR DESCRIPTION
**Problem:**
When editing the "Sign & Pay" modal in customer preview for a sale
order, changes are not saved due to multiple issues:
1. Saving the signature component directly results in only the
   signature UI being saved, missing the logic and props of the
   original component.
2. If the signature component is saved with other fields, it gets
   duplicated upon saving due to `<owl-component />` behavior. This
   re-renders every saved component and mounts those passed as props,
   causing duplication and breaking functionality.
   - Reference: public_component_service.js

**Solution:**
1. Hide the signature component during editing to prevent saving its
   UI-only state, preserving its logic and props.

**Steps to Reproduce:**
1. Create a sale order.
2. Click on "Customer Preview."
3. Enable edit mode.
4. Open the "Sign & Pay" modal, modify the content, and save.
   - The signature UI duplicates

**opw-4216372**
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
