### PR TITLE
[FIX] registry: re-expose DummyRLock

### DIFF
--- a/odoo/modules/registry/__init__.py
+++ b/odoo/modules/registry/__init__.py
@@ -1,3 +1,3 @@
 # ruff: noqa: F401
 # Exposed here so that exist code is unaffected.
-from odoo.orm.registry import Registry, _REGISTRY_CACHES
+from odoo.orm.registry import DummyRLock, Registry, _REGISTRY_CACHES


### PR DESCRIPTION
Existing code was in fact affected: auth_ldap uses DummyRLock for its tests.