### PR TITLE
[FIX] hr_attendance: restrict update `check_out`/`check_in` when no permissions

### DIFF
--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -18,3 +18,4 @@ Miquel Raich miquel.raich@forgeflow.com https://github.com/MiquelRForgeFlow
 Jordi Ballester jordi.ballester@forgeflow.com https://github.com/JordiBForgeFlow
 Jordi Masvidal jordi.masvidal@forgeflow.com https://github.com/JordiMForgeFlow
 Hector Villarreal hector.villarreal@forgeflow.com https://github.com/HviorForgeFlow
+Guillem Casassas guillem.casassas@forgeflow.com https://github.com/GuillemCForgeFlow


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
If the user does not have the `hr_attendance.group_hr_attendance_user` group, which is the one that allows to modify attendances even after they have been finished, raise a `ValidationError` to not allow transitioning the `check_in` / `check_out` values to the database.

Current behavior before PR:
If the user accesses his/her old attendances, by editing the frontend, he/she'll be able to update the previous `check_in` / `check_out` date.

Desired behavior after PR is merged:
For users which do not have the rights to overwrite the dates even after the attendance has finished, it should never be possible to update the `check_in` /  `check_out` date.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
cc @ForgeFlow