### PR TITLE
[FIX] mail: correct push notif title in group chat with guests

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1347,19 +1347,20 @@ class Channel(models.Model):
         payload = super()._notify_by_web_push_prepare_payload(message, msg_vals=msg_vals)
         payload['options']['data']['action'] = 'mail.action_discuss'
         record_name = msg_vals.get('record_name') if msg_vals and 'record_name' in msg_vals else message.record_name
-        author_id = [msg_vals.get('author_id')] if 'author_id' in msg_vals else message.author_id.ids
+        author_id = [msg_vals["author_id"]] if msg_vals.get("author_id") else message.author_id.ids
+        author = self.env["res.partner"].browse(author_id) or self.env["mail.guest"].browse(
+            msg_vals.get("author_guest_id", message.author_guest_id.id)
+        )
         if self.channel_type == 'chat':
-            payload['title'] = self.env['res.partner'].browse(author_id).name
+            payload['title'] = author.name
             payload['options']['icon'] = '/discuss/channel/%d/partner/%d/avatar_128' % (message.res_id, author_id[0])
         elif self.channel_type == 'channel':
-            author_name = self.env['res.partner'].browse(author_id).name
-            payload['title'] = "#%s - %s" % (record_name, author_name)
+            payload['title'] = "#%s - %s" % (record_name, author.name)
         elif self.channel_type == 'group':
             if not record_name:
-                member_names = self.channel_member_ids.mapped("partner_id.name")
+                member_names = self.channel_member_ids.mapped(lambda m: m.partner_id.name if m.partner_id else m.guest_id.name)
                 record_name = f"{', '.join(member_names[:-1])} and {member_names[-1]}" if len(member_names) > 1 else member_names[0] if member_names else ""
-            author_name = self.env['res.partner'].browse(author_id).name
-            payload['title'] = "%s - %s" % (record_name, author_name)
+            payload['title'] = "%s - %s" % (record_name, author.name)
         else:
             payload['title'] = "#%s" % (record_name)
         return payload

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1301,6 +1301,7 @@ class MailCommon(common.TransactionCase, MailCase):
             signature='--\nErnest'
         )
         cls.partner_employee = cls.user_employee.partner_id
+        cls.guest = cls.env['mail.guest'].create({'name': 'Guest Mario'})
 
     @classmethod
     def _create_portal_user(cls):


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/186756

PR above improves push notification title in group chat without a name.

The fix assumed that all members are partners, which is not necessarily the case. As a result, title contains `False` in conversation name and author when new message comes from a guest.

This commit takes guests into account in push notification from new messages in channels as author. Group chat default name also uses guest names for the conversation name.
