### PR TITLE
[FIX] mail: no gif loading when gif feature is disabled

### DIFF
--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
@@ -146,6 +146,9 @@ export class GifPicker extends Component {
     }
 
     async loadCategories() {
+        if (!this.store.hasGifPickerFeature) {
+            return;
+        }
         try {
             let { language, region } = new Intl.Locale(user.lang);
             if (!region && language === "sr") {
@@ -270,6 +273,9 @@ export class GifPicker extends Component {
     }
 
     async loadFavorites() {
+        if (!this.store.hasGifPickerFeature) {
+            return;
+        }
         this.state.loadingGif = true;
         try {
             const [results] = await rpc(


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/186084

PR above improved composer actions and removed Picker component. When the gif picker feature was disabled, the Picker component was showing the admin screen to suggest enabling it, without attempting any loading.

With PR above, this template was moved to `GifPicker` component, but nothing was guarding attempts at loading categories or favorites. Opening the Gif Picker by admin resulted in the following silent crash:

```
400 Client Error: Bad Request for url: https://tenor.googleapis.com/v2/categories?key=False
```