### PR TITLE
[FIX] stock, purchase_stock, sale_stock: fix dark mode readability issues

### DIFF
--- a/addons/purchase_stock/static/src/purchase_stock_forecasted/forecasted_details.xml
+++ b/addons/purchase_stock/static/src/purchase_stock_forecasted/forecasted_details.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="purchase_stock.ForecastedDetails" owl="1" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
          <xpath expr="//tr[@name='draft_picking_in']" position="after">
-            <tr t-if="props.docs.draft_purchase_qty" name="draft_po_in" t-attf-class="#{props.docs.draft_purchase_orders_matched and 'o_grid_match'}">
+            <tr t-if="props.docs.draft_purchase_qty" name="draft_po_in" t-attf-class="#{props.docs.draft_purchase_orders_matched and 'o_grid_match table-info'}">
                 <td colspan="2">Requests for quotation</td>
                 <td t-out="_formatFloat(props.docs.draft_purchase_qty)" class="text-end"/>
                 <td>

--- a/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.xml
+++ b/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="sale_stock.ForecastedDetails" owl="1" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
         <xpath expr="//tr[@name='draft_picking_out']" position="after">
-            <tr t-if="props.docs.draft_sale_qty" name="draft_so_out" t-attf-class="#{props.docs.draft_sale_orders_matched and 'o_grid_match'}">
+            <tr t-if="props.docs.draft_sale_qty" name="draft_so_out" t-attf-class="#{props.docs.draft_sale_orders_matched and 'o_grid_match table-info'}">
                 <td colspan="2">Quotations</td>
                 <td t-out="_formatFloat(-props.docs.draft_sale_qty)" class="text-end"/>
                 <td>

--- a/addons/stock/static/src/scss/stock_forecasted.scss
+++ b/addons/stock/static/src/scss/stock_forecasted.scss
@@ -1,13 +1,4 @@
 .o_stock_forecasted_page {
-    .o_report_replenishment {
-        .o_grid_warning {
-            background-color: #f4cccc;
-        }
-        .o_grid_match {
-            background-color: #f0f0f0;
-        }
-    }
-
 
     .o_priority {
         display: inline-block;

--- a/addons/stock/static/src/stock_forecasted/forecasted_details.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.xml
@@ -23,8 +23,8 @@
                     <td/>
                     <td/>
                 </tr>
-                <tr t-foreach="props.docs.lines" t-as="line" t-key="line.index" t-attf-class="#{line.is_matched and 'o_grid_match'}">
-                    <td t-attf-class="#{line.is_late and 'o_grid_warning'}">
+                <tr t-foreach="props.docs.lines" t-as="line" t-key="line.index" t-attf-class="#{line.is_matched and 'o_grid_match table-info'}">
+                    <td t-attf-class="#{line.is_late and 'o_grid_warning table-danger'}">
                         <a t-if="line.document_in"
                             href="#" 
                             t-on-click.prevent="() => this.props.openView(line.document_in._name, 'form', line.document_in.id)"
@@ -54,10 +54,10 @@
                         <span t-else="" class="text-muted">Not Available</span>
                     </td>
                     <td t-out="line.receipt_date or ''"
-                        t-attf-class="#{line.is_late and 'o_grid_warning'}"/>
+                        t-attf-class="#{line.is_late and 'o_grid_warning table-danger'}"/>
                     <td t-if="props.docs.multiple_product" t-out="line.product.display_name"/>
                     <td class="text-end"><t t-if="! line.replenishment_filled">- </t><t t-out="_formatFloat(line.quantity)"/></td>
-                    <td t-attf-class="#{! line.replenishment_filled and 'o_grid_warning'}" name="usedby_cell">
+                    <td t-attf-class="#{! line.replenishment_filled and 'o_grid_warning table-danger'}" name="usedby_cell">
                         <button t-if="line.move_out and line.move_out.picking_id"
                             t-attf-class="o_priority o_priority_star o_report_replenish_change_priority fa fa-star#{line.move_out.picking_id.priority=='1' ? '' : '-o'}"
                             t-on-click="() => this._onClickChangePriority('stock.picking', line.move_out.picking_id)"
@@ -69,7 +69,7 @@
                             class="fw-bold"/>
                     </td>
                     <td t-out="line.delivery_date or ''"
-                        t-attf-class="#{! line.replenishment_filled and 'o_grid_warning'}"/>
+                        t-attf-class="#{! line.replenishment_filled and 'o_grid_warning table-danger'}"/>
                 </tr>
             </tbody>
             <thead>


### PR DESCRIPTION
This PR fixes readability issues within the forecast details table.

Prior to this PR, the table was using arbitrary color that were out of our color maps, meaning that they were not dark mode proof by default.

As no variation was defined for these color in dark mode, some readability issues would occur in some cases (e.g link color over that background in dark mode).

To handle this issue, we go back to basics and use Bootstrap default table utility classes, easing the maintenance and preventing. readability issues.

| 16.0 | This PR |
|--------|--------|
| <img width="459" alt="image" src="https://github.com/user-attachments/assets/571d9dea-2f42-479d-9fb1-85c9e1afbc76"> | <img width="451" alt="image" src="https://github.com/user-attachments/assets/121ec777-5a24-48da-912e-41f51e662e7a"> | 

task-4344045

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
