### PR TITLE
[FIX] mail: channel from native notification in existing tab

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
@@ -41,6 +41,18 @@ export class DiscussCorePublicWeb {
                 );
             }
         });
+        browser.navigator.serviceWorker?.addEventListener(
+            "message",
+            async ({ data: { action, data } }) => {
+                if (action === "OPEN_CHANNEL") {
+                    const channel = await this.store.Thread.getOrFetch({
+                        model: "discuss.channel",
+                        id: data.id,
+                    });
+                    channel?.open();
+                }
+            }
+        );
     }
 
     /**

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -22,7 +22,14 @@ import {
 import { describe, expect, test } from "@odoo/hoot";
 import { queryFirst } from "@odoo/hoot-dom";
 import { mockDate, tick } from "@odoo/hoot-mock";
-import { Command, getService, serverState, withUser } from "@web/../tests/web_test_helpers";
+import { EventBus } from "@odoo/owl";
+import {
+    Command,
+    getService,
+    patchWithCleanup,
+    serverState,
+    withUser,
+} from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
 
 import { rpc } from "@web/core/network/rpc";
@@ -1075,4 +1082,29 @@ test("Bigger chat windows is locally persistent (saved in local storage)", async
     await click("button:contains(Large windows)");
     await contains(".o-mail-ChatWindow.o-large");
     expect(browser.localStorage.getItem("mail.user_setting.chat_window_big")).toBe(null);
+});
+
+test("open channel in chat window from push notification", async () => {
+    patchWithCleanup(window.navigator, {
+        serviceWorker: Object.assign(new EventBus(), { register: () => Promise.resolve() }),
+    });
+    const pyEnv = await startServer();
+    const [channelId] = pyEnv["discuss.channel"].create([
+        { name: "General" },
+        {
+            name: "Sales",
+            channel_member_ids: [
+                Command.create({ partner_id: serverState.partnerId, fold_state: "open" }),
+            ],
+        },
+    ]);
+    await start();
+    await contains(".o-mail-ChatWindow", { text: "Sales" });
+    await contains(".o-mail-ChatWindow", { text: "General", count: 0 });
+    browser.navigator.serviceWorker.dispatchEvent(
+        new MessageEvent("message", {
+            data: { action: "OPEN_CHANNEL", data: { id: channelId } },
+        })
+    );
+    await contains(".o-mail-ChatWindow", { text: "General" });
 });


### PR DESCRIPTION
When enabled, message notifications are sent as a native notification. However, the notification opens a new tab each time a notification is clicked.

This behavior is not natural and leads to many opened tabs which is cumbersome. This PR fixes this behavior:
- If a tab is opened on discuss, open the channel in this tab.
- If a tab is opened in Odoo, open in a chat window.
- Only open a new tab if no Odoo tab is available.

task-4295517