### PR TITLE
[FIX] stock, sale, website_sale: install the new ups from settings

### DIFF
--- a/addons/sale/wizard/res_config_settings.py
+++ b/addons/sale/wizard/res_config_settings.py
@@ -66,7 +66,7 @@ class ResConfigSettings(models.TransientModel):
     module_delivery_fedex = fields.Boolean("FedEx Connector")
     module_delivery_sendcloud = fields.Boolean("Sendcloud Connector")
     module_delivery_shiprocket = fields.Boolean("Shiprocket Connector")
-    module_delivery_ups = fields.Boolean("UPS Connector")
+    module_delivery_ups_rest = fields.Boolean("UPS Connector")
     module_delivery_usps = fields.Boolean("USPS Connector")
     module_delivery_starshipit = fields.Boolean("Starshipit Connector")
 

--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -109,7 +109,7 @@
                         </setting>
                         <setting id="ups" help="Compute shipping costs and ship with UPS"
                                  documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                            <field name="module_delivery_ups" widget="upgrade_boolean"/>
+                            <field name="module_delivery_ups_rest" widget="upgrade_boolean"/>
                         </setting>
                         <setting id="shipping_costs_dhl" help="Compute shipping costs and ship with DHL"
                                  documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -33,7 +33,7 @@ class ResConfigSettings(models.TransientModel):
     module_delivery = fields.Boolean("Delivery Methods")
     module_delivery_dhl = fields.Boolean("DHL Express Connector")
     module_delivery_fedex = fields.Boolean("FedEx Connector")
-    module_delivery_ups = fields.Boolean("UPS Connector")
+    module_delivery_ups_rest = fields.Boolean("UPS Connector")
     module_delivery_usps = fields.Boolean("USPS Connector")
     module_delivery_bpost = fields.Boolean("bpost Connector")
     module_delivery_easypost = fields.Boolean("Easypost Connector")

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -73,7 +73,7 @@
                         </block>
                         <block title="Shipping Connectors" name="shipping_connectors_setting_container">
                             <setting id="compute_shipping_costs_ups" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" help="Compute shipping costs and ship with UPS">
-                                <field name="module_delivery_ups" widget="upgrade_boolean"/>
+                                <field name="module_delivery_ups_rest" widget="upgrade_boolean"/>
                             </setting>
                             <setting id="compute_shipping_costs_dhl" help=" Compute shipping costs and ship with DHL" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
                                 <field name="module_delivery_dhl" widget="upgrade_boolean"/>

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -157,7 +157,7 @@
                     </setting>
                     <setting id="ups_provider_setting" string="UPS" help="Compute shipping costs and ship with UPS"
                              documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                        <field name="module_delivery_ups" widget="upgrade_boolean"/>
+                        <field name="module_delivery_ups_rest" widget="upgrade_boolean"/>
                     </setting>
                     <setting id="shipping_provider_dhl_setting" string="DHL Express Connector" help="Compute shipping costs and ship with DHL"
                              documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to the inventory settings:
    - Enable the UPS delivery

Problem:
The Legacy UPS is installed instead of the new one

opw-4341776
