### PR TITLE
[FIX] website_blog: prevent access error for blog post author

### DIFF
--- a/addons/website/models/website_snippet_filter.py
+++ b/addons/website/models/website_snippet_filter.py
@@ -105,7 +105,7 @@ class WebsiteSnippetFilter(models.Model):
                     order=','.join(literal_eval(filter_sudo.sort)) or None,
                     limit=limit
                 )
-                return self._filter_records_to_values(records)
+                return self._filter_records_to_values(records.sudo())
             except MissingError:
                 _logger.warning("The provided domain %s in 'ir.filters' generated a MissingError in '%s'", domain, self._name)
                 return []

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -119,7 +119,9 @@
 <template id="website_blog.s_dynamic_snippet_template_author" name="Blog Post Author">
     <div t-if="blog_posts_post_author_active" class="s_blog_posts_post_author d-inline-flex align-items-center">
         <img class="o_avatar me-2 rounded-pill" t-attf-src="data:image/png;base64,{{record.author_avatar}}"/>
-        <span t-field="record.author_id.name"/>
+        <!-- t-if to remove in MASTER -->
+        <span t-if="False" t-field="record.author_id.name"/>
+        <span t-field="record.author_name"/>
     </div>
 </template>
 


### PR DESCRIPTION
Since [1], the template attempted to display the author's name using `record.author_id.name`, which caused access errors for portal users due to insufficient permissions on the res.partner model. By switching to the related field `author_name`, the template no longer requires direct access to `res.partner`, ensuring smooth functionality for all users.

Steps to reproduce:
- Log in as an administrator
- Navigate to Website
- Enter Edit Mode
- Add a "Blog" snippet to the home page
- Save the changes
- Log out
- Log in as a portal user
- Observe that a traceback occurs

[1]: https://github.com/odoo/odoo/commit/dbb72d1f68cf7f462e1d6bdf8998f29627ccc2f0

opw-4330845
