### PR TITLE
[FIX] web_editor: copy paste within blockquote and pre testcases

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -453,7 +453,7 @@ describe('Paste', () => {
             });
             it('should paste text and understand \\n newlines within PRE element', async () => {
                 await testEditor(BasicEditor, {
-                    contentBefore: '<pre>[]<br></div>',
+                    contentBefore: '<pre>[]<br></pre>',
                     stepFunction: async editor => {
                         await pasteText(editor, 'a\nb\nc');
                     },
@@ -1139,66 +1139,6 @@ describe('Paste', () => {
                     contentAfter: '<h1><font style="background-color: rgb(255, 0, 0);">mnabc</font></h1><h1>def</h1><h1>ghi[]</h1>',
                 });
             });
-            it('should paste all nodes as blockquote when pasting in blockquote', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<blockquote>[]<br></blockquote>',
-                    stepFunction: async editor => {
-                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
-                    },
-                    contentAfter: '<blockquote><h1>abc</h1><h2>def</h2><h3>ghi[]</h3></blockquote>',
-                });
-                await testEditor(BasicEditor, {
-                    contentBefore: '<blockquote>x[]</blockquote>',
-                    stepFunction: async editor => {
-                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
-                    },
-                    contentAfter: '<blockquote>x<h1>abc</h1><h2>def</h2><h3>ghi[]</h3></blockquote>',
-                });
-                await testEditor(BasicEditor, {
-                    contentBefore: '<blockquote>[]x</blockquote>',
-                    stepFunction: async editor => {
-                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
-                    },
-                    contentAfter: '<blockquote><h1>abc</h1><h2>def</h2><h3>ghi[]</h3>x</blockquote>',
-                });
-                await testEditor(BasicEditor, {
-                    contentBefore: '<blockquote>x[]y</blockquote>',
-                    stepFunction: async editor => {
-                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
-                    },
-                    contentAfter: '<blockquote>x<h1>abc</h1><h2>def</h2><h3>ghi[]</h3>y</blockquote>',
-                });
-            });
-            it('should paste all nodes as pre when pasting in pre', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<pre>[]<br></pre>',
-                    stepFunction: async editor => {
-                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
-                    },
-                    contentAfter: '<pre><h1>abc</h1><h2>def</h2><h3>ghi[]</h3></pre>',
-                });
-                await testEditor(BasicEditor, {
-                    contentBefore: '<pre>x[]</pre>',
-                    stepFunction: async editor => {
-                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
-                    },
-                    contentAfter: '<pre>x<h1>abc</h1><h2>def</h2><h3>ghi[]</h3></pre>',
-                });
-                await testEditor(BasicEditor, {
-                    contentBefore: '<pre>[]x</pre>',
-                    stepFunction: async editor => {
-                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
-                    },
-                    contentAfter: '<pre><h1>abc</h1><h2>def</h2><h3>ghi[]</h3>x</pre>',
-                });
-                await testEditor(BasicEditor, {
-                    contentBefore: '<pre>x[]y</pre>',
-                    stepFunction: async editor => {
-                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
-                    },
-                    contentAfter: '<pre>x<h1>abc</h1><h2>def</h2><h3>ghi[]</h3>y</pre>',
-                });
-            });
             it('should not unwrap empty block nodes even when pasting on same node', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a[]</p>',
@@ -1209,7 +1149,71 @@ describe('Paste', () => {
                 });
             });
         });
-    })
+    });
+    describe('Pasting within Blockquote', () => {
+        it('should paste paragraph related elements within blockquote', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<blockquote>[]<br></blockquote>',
+                stepFunction: async editor => {
+                    await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                },
+                contentAfter: '<blockquote><h1>abc</h1><h2>def</h2><h3>ghi[]</h3></blockquote>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: '<blockquote>x[]</blockquote>',
+                stepFunction: async editor => {
+                    await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                },
+                contentAfter: '<blockquote>x<h1>abc</h1><h2>def</h2><h3>ghi[]</h3></blockquote>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: '<blockquote>[]x</blockquote>',
+                stepFunction: async editor => {
+                    await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                },
+                contentAfter: '<blockquote><h1>abc</h1><h2>def</h2><h3>ghi[]</h3>x</blockquote>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: '<blockquote>x[]y</blockquote>',
+                stepFunction: async editor => {
+                    await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                },
+                contentAfter: '<blockquote>x<h1>abc</h1><h2>def</h2><h3>ghi[]</h3>y</blockquote>',
+            });
+        });
+    });
+    describe('Pasting within Pre', () => {
+        it('should paste paragraph releted elements within pre', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<pre>[]<br></pre>',
+                stepFunction: async editor => {
+                    await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                },
+                contentAfter: '<pre><h1>abc</h1><h2>def</h2><h3>ghi[]</h3></pre>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: '<pre>x[]</pre>',
+                stepFunction: async editor => {
+                    await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                },
+                contentAfter: '<pre>x<h1>abc</h1><h2>def</h2><h3>ghi[]</h3></pre>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: '<pre>[]x</pre>',
+                stepFunction: async editor => {
+                    await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                },
+                contentAfter: '<pre><h1>abc</h1><h2>def</h2><h3>ghi[]</h3>x</pre>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: '<pre>x[]y</pre>',
+                stepFunction: async editor => {
+                    await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                },
+                contentAfter: '<pre>x<h1>abc</h1><h2>def</h2><h3>ghi[]</h3>y</pre>',
+            });
+        });
+    });
     describe('Complex html span', () => {
         const complexHtmlData = '<span style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;">1</span><b style="box-sizing: border-box; font-weight: bolder; font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">23</b><span style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;"><span> </span>4</span>';
         describe('range collapsed', async () => {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Commit [1] made sure that when pasting within blockquote and pre the pasted tag are not unwrapped. But the commit did not change the title as well as the describe of the test cases. This PR places the test cases at correct place.

[1]: https://github.com/odoo/odoo/commit/460d88a20a908182e7e9aaf607816c0419a1c6bc

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
