### PR TITLE
[IMP] l10n_in_website_event_sale: add place of supply for events

### DIFF
--- a/addons/l10n_in_website_event_sale/__init__.py
+++ b/addons/l10n_in_website_event_sale/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/l10n_in_website_event_sale/__manifest__.py
+++ b/addons/l10n_in_website_event_sale/__manifest__.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Indian - Online Event Ticketing',
+    'countries': ['in'],
+    'description': """ Sell online tickets for Indian Events """,
+    'category': 'Marketing/Events',
+    'depends': [
+        'website_event_sale',
+        'l10n_in_sale',
+    ],
+    'auto_install': True,
+    'data': [
+        'views/event_event_views.xml',
+    ],
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_in_website_event_sale/models/__init__.py
+++ b/addons/l10n_in_website_event_sale/models/__init__.py
@@ -1,0 +1,2 @@
+from . import event_event
+from . import sale_order

--- a/addons/l10n_in_website_event_sale/models/event_event.py
+++ b/addons/l10n_in_website_event_sale/models/event_event.py
@@ -1,0 +1,19 @@
+from odoo import api, fields, models
+
+class EventEvent(models.Model):
+    """Event"""
+    _inherit = ['event.event']
+
+    country_code = fields.Char(related='company_id.country_code')
+    l10n_in_state_id = fields.Many2one('res.country.state', string="Place of supply",
+        compute="_compute_l10n_in_event_state_id", store=True, copy=True, readonly=False)
+    l10n_in_pos_treatment = fields.Selection([('always', 'Always'),
+                                              ('for_unregistered', 'For Unregistered'),
+                                             ], default='always', required=True)
+
+    @api.depends('address_id', 'country_code')
+    def _compute_l10n_in_event_state_id(self):
+        for event in self:
+            event.l10n_in_state_id = False
+            if event.country_code == 'IN':
+                event.l10n_in_state_id = event.address_id.state_id if event.address_id.country_code == 'IN' else self.env.ref('l10n_in.state_in_oc', raise_if_not_found=False)

--- a/addons/l10n_in_website_event_sale/models/sale_order.py
+++ b/addons/l10n_in_website_event_sale/models/sale_order.py
@@ -1,0 +1,18 @@
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def _prepare_invoice(self):
+        values = super(SaleOrder, self)._prepare_invoice()
+        if not self.website_id:
+            return values
+
+        for line in self.order_line:
+            if line.event_id.l10n_in_state_id and\
+                (line.event_id.l10n_in_pos_treatment == 'always' or\
+                (line.event_id.l10n_in_pos_treatment == 'for_unregistered'\
+                and self.l10n_in_gst_treatment in ['consumer', 'unregistered'])):
+                values['l10n_in_state_id'] = line.event_id.l10n_in_state_id.id
+        return values

--- a/addons/l10n_in_website_event_sale/views/event_event_views.xml
+++ b/addons/l10n_in_website_event_sale/views/event_event_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_event_form" model="ir.ui.view">
+        <field name="name">event.event.form.inherit</field>
+        <field name="model">event.event</field>
+        <field name="inherit_id" ref="event.view_event_form"/>
+        <field name="arch" type="xml">
+           <field name="address_id" position="after">
+                <label for="l10n_in_state_id" invisible="country_code != 'IN'" />
+                <div class="o_field_highlight" invisible="country_code != 'IN'">
+                    <field name="l10n_in_state_id" class="w-50" domain="[('country_id.code', '=', 'IN')]"
+                                    options="{'no_create': True, 'no_open': True}"
+                                    required="country_code == 'IN'"/>
+                    <field name="l10n_in_pos_treatment" class="w-50" />
+                </div>
+           </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Before this **PR**:
By default, the customer's place of supply was selected when a ticket was booked for an event through the website, regardless of the event's venue. This caused issues because GST is handled differently depending on the place of supply and the customer's GST treatment.

After this **PR**:
A new module, l10n_in_website_event_sale, has been created to add a 'Place of Supply' field to events. This allows event managers to specify the place of supply that should be selected for generating invoices, depending on the type of customer.

Two options have been provided for treatment of place of supply:
1) Always: This option sets the specified place of supply for every ticket booked for the event.
2) For Unregistered: This option applies the specified place of supply only for unregistered customers and consumers.

**task**-4014357
