### PR TITLE
[FIX] stock: compute dirty move lines in get_move_line_quant_match

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -290,14 +290,15 @@ class StockMoveLine(models.Model):
             addtional_qty[ml.location_dest_id.id] = addtional_qty.get(ml.location_dest_id.id, 0) - qty
         return addtional_qty
 
-    def get_move_line_quant_match(self, move_id, quant_ids):
+    def get_move_line_quant_match(self, move_id, dirty_move_line_ids, dirty_quant_ids):
         # Since the quant_id field is neither stored nor computed, this method is used to compute the match if it exists
         move = self.env['stock.move'].browse(move_id)
-        deleted_move_line_ids = move.move_line_ids - self
+        deleted_move_lines = move.move_line_ids - self
+        dirty_move_lines = self.env['stock.move.line'].browse(dirty_move_line_ids)
         quants_data = []
         move_lines_data = []
-        domain = [("id", "in", quant_ids)]
-        for move_line in self | deleted_move_line_ids:
+        domain = [("id", "in", dirty_quant_ids)]
+        for move_line in dirty_move_lines | deleted_move_lines:
             move_line_domain = [
                 ("product_id", "=", move_line.product_id.id),
                 ("lot_id", "=", move_line.lot_id.id),
@@ -309,20 +310,20 @@ class StockMoveLine(models.Model):
         if domain:
             quants = self.env['stock.quant'].search(domain)
             for quant in quants:
-                move_lines = self.filtered(lambda ml: ml.product_id == quant.product_id
+                dirty_lines = dirty_move_lines.filtered(lambda ml: ml.product_id == quant.product_id
                     and ml.lot_id == quant.lot_id
                     and ml.location_id == quant.location_id
                     and ml.package_id == quant.package_id
                     and ml.owner_id == quant.owner_id
                 )
-                deleted_move_lines = deleted_move_line_ids.filtered(lambda ml: ml.product_id == quant.product_id
+                deleted_lines = deleted_move_lines.filtered(lambda ml: ml.product_id == quant.product_id
                     and ml.lot_id == quant.lot_id
                     and ml.location_id == quant.location_id
                     and ml.package_id == quant.package_id
                     and ml.owner_id == quant.owner_id
                 )
-                quants_data.append((quant.id, {"available_quantity": quant.available_quantity + sum(ml.quantity_product_uom for ml in deleted_move_lines), "move_line_ids": move_lines.ids}))
-                move_lines_data += [(ml.id, {"quantity": ml.quantity, "quant_id": quant.id}) for ml in move_lines]
+                quants_data.append((quant.id, {"available_quantity": quant.available_quantity + sum(ml.quantity_product_uom for ml in deleted_lines), "move_line_ids": dirty_lines.ids}))
+                move_lines_data += [(ml.id, {"quantity": ml.quantity, "quant_id": quant.id}) for ml in dirty_lines]
         return [quants_data, move_lines_data]
 
 

--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -92,8 +92,11 @@ export class SMLX2ManyField extends X2ManyField {
             "stock.move.line",
             "get_move_line_quant_match",
             [
-                dirtyMoveLines.map((rec) => rec.resId),
+                this.props.record.data.move_line_ids.records
+                    .filter((rec) => rec.resId)
+                    .map((rec) => rec.resId),
                 this.props.record.resId,
+                dirtyMoveLines.filter((rec) => rec.resId).map((rec) => rec.resId),
                 dirtyQuantMoveLines.map((ml) => ml.data.quant_id[0]),
             ],
             {}

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -185,9 +185,78 @@ registry.category("web_tour.tours").add("test_add_new_line_in_detailled_op", {
             isCheck: true,
         },
         {
+            trigger: ".o_field_x2many_list_row_add > a",
+            run: "click",
+        },
+        {
+            content: "Pick LOT001 to create a move line with a quantity of 0.00",
+            trigger: ".o_data_row .o_data_cell[name=lot_id]:contains(LOT001)",
+            run: "click",
+        },
+        {
+            content: "check that the move contains three lines",
+            trigger: ".modal-content:has(.modal-header .modal-title:contains(Open: Stock move)) .o_data_row:nth-child(3)",
+            isCheck: true,
+        },
+        {
+            trigger: ".modal-header .modal-title:contains(Open: Stock move)",
+            run: "click",
+        },
+        {
+            content: "Check that the first line is associated with LOT001 for a quantity of 0.00",
+            trigger:
+                ".modal-content .o_data_row:nth-child(1):has(.o_data_cell[name=quant_id]:contains(WH/Stock - LOT001)):has(.o_data_cell[name=quantity]:contains(0.00))",
+            isCheck: true,
+        },
+        {
+            trigger: ".o_field_x2many_list_row_add > a",
+            run: "click",
+        },
+        {
+            content: "LOT001 should not appear as it is not available",
+            trigger: ".modal-header .modal-title:contains(Add line: Product Lot)",
+            run: () => {
+                const lines = document.querySelectorAll(".o_data_row .o_data_cell[name=lot_id]");
+                if (lines.length !== 2) {
+                    throw new TourError(
+                        "Wrong number of available quants: " + lines.length + " instead of 2."
+                    );
+                }
+                const lineLOT001 = Array.from(lines).filter((line) =>
+                    line.textContent.includes("LOT001")
+                );
+                if (lineLOT001.length) {
+                    throw new TourError("LOT001 shoudld not be displayed as unavailable.");
+                }
+            },
+        },
+        {
+            content: "Cancel the move line creation",
+            trigger: ".modal-header:has(.modal-title:contains(Add line: Product Lot)) .btn-close",
+            run: "click",
+        },
+        {
+            content: "Remove the newly created line",
+            trigger:
+                ".modal-content .o_data_row:nth-child(1):has(.o_data_cell[name=quant_id]:contains(WH/Stock - LOT001)):has(.o_data_cell[name=quantity]:contains(0.00)) .o_list_record_remove",
+            run: "click",
+        },
+        {
+            content: "check that the move contains two lines",
+            trigger:
+                ".modal-content:has(.modal-header .modal-title:contains(Open: Stock move)):not(:has(.o_data_row:nth-child(3)))",
+            isCheck: true,
+        },
+        {
             content: "Check that the first line is associated with LOT001",
             trigger:
                 ".modal-content .o_data_row:nth-child(1) .o_data_cell[name=quant_id]:contains(WH/Stock - LOT001)",
+            isCheck: true,
+        },
+        {
+            content: "Check that the second line is associated with LOT002",
+            trigger:
+                ".modal-content .o_data_row:nth-child(2) .o_data_cell[name=quant_id]:contains(WH/Stock - LOT002)",
             isCheck: true,
         },
         {

--- a/addons/stock/tests/test_picking_tours.py
+++ b/addons/stock/tests/test_picking_tours.py
@@ -131,7 +131,7 @@ class TestStockPickingTour(HttpCase):
             {'lot_id': lot_2.id, 'quantity': 10.0},
         ])
         url = self._get_picking_url(delivery.id)
-        self.start_tour(url, 'test_add_new_line_in_detailled_op', login='admin', timeout=60)
+        self.start_tour(url, 'test_add_new_line_in_detailled_op', login='admin', timeout=100)
         self.assertRecordValues(delivery.move_line_ids.sorted("quantity"), [
             {'quantity': 2.0, 'lot_id': lot_1.id},
             {'quantity': 3.0, 'lot_id': lot_1.id},


### PR DESCRIPTION
### Issue:

The `get_move_line_quant_match` was introduced in cc64e99c047807b3691a1a80cdd09464b89aff64 to reconcile js and db data's during the edition of stock moves form. However, the assignment of deleted move lines is not correct: https://github.com/odoo/odoo/blob/0fc3752cacf25b6fd26b85302b1f23d5a35c8cd7/addons/stock/models/stock_move_line.py#L296 Its value should correspond to the move lines present in db but absent from the JS datas (removed from the form edition but with unsaved change). The problem here is that self is the set of records present in JS but flagged as dirty since either the quant or the quantity did change:
https://github.com/odoo/odoo/blob/0fc3752cacf25b6fd26b85302b1f23d5a35c8cd7/addons/stock/static/src/fields/stock_move_line_x2_many_field.js#L95 but it should be the complete set of move lines present still present in JS to work properly.

opw-4294650
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
