### PR TITLE
[IMP] *: clean up unnecessary SCSS from the Kanban view

### DIFF
--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
@@ -4,11 +4,11 @@
 
 table.o_section_and_note_list_view tr.o_data_row.o_is_line_note,
 table.o_section_and_note_list_view tr.o_data_row.o_is_line_note textarea[name="name"],
-div.oe_kanban_card.o_is_line_note {
+div.o_is_line_note {
     font-style: italic;
 }
 table.o_section_and_note_list_view tr.o_data_row.o_is_line_section,
-div.oe_kanban_card.o_is_line_section {
+div.o_is_line_section {
     font-weight: bold;
     background-color: #DDDDDD;
 }

--- a/addons/base_automation/static/src/base_automation.scss
+++ b/addons/base_automation/static/src/base_automation.scss
@@ -32,7 +32,7 @@
         }
     }
 
-    .o_kanban_ungrouped .o_kanban_record .oe_kanban_global_click {
+    .o_kanban_ungrouped .o_kanban_record {
         border-top: 0;
         display: flex;
         align-items: center;

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -55,14 +55,14 @@
                                     <div class="d-flex align-items-baseline">
                                         <field name="company_currency" invisible="1"/>
                                         <field name="expected_revenue" class="o_input_13ch" widget='monetary' options="{'currency_field': 'company_currency'}"/>
-                                        <span class="oe_grey p-2" groups="crm.group_use_recurring_revenues"> + </span>
-                                        <span class="oe_grey p-2" groups="!crm.group_use_recurring_revenues"> at </span>
+                                        <span class="opacity-50 p-2" groups="crm.group_use_recurring_revenues"> + </span>
+                                        <span class="opacity-50 p-2" groups="!crm.group_use_recurring_revenues"> at </span>
                                         <div class="d-flex align-items-baseline gap-3" groups="crm.group_use_recurring_revenues">
                                             <field name="recurring_revenue" class="o_input_10ch" widget="monetary" options="{'currency_field': 'company_currency'}"/>
                                             <div class="d-flex align-items-baseline">
                                                 <field name="recurring_plan" class="oe_inline o_input_13ch" placeholder='e.g. "Monthly"'
                                                     required="recurring_revenue != 0" options="{'no_create': True, 'no_open': True}"/>
-                                                <span class="oe_grey p-2 text-nowrap"> at </span>
+                                                <span class="opacity-50 p-2 text-nowrap"> at </span>
                                             </div>
                                         </div>
                                     </div>
@@ -73,13 +73,13 @@
                                             invisible="is_automated_probability">
                                         <i class="fa fa-gear" role="img" title="Switch to automatic probability" aria-label="Switch to automatic probability"></i>
                                     </button>
-                                    <small class="d-inline-block oe_grey h6 mb-0" invisible="is_automated_probability">
+                                    <small class="d-inline-block opacity-50 h6 mb-0" invisible="is_automated_probability">
                                         <field class="mb-0" name="automated_probability" force_save="1"/> %
                                     </small>
                                     <div id="probability" class="d-flex align-items-baseline">
                                         <field name="is_automated_probability" invisible="1"/>
                                         <field name="probability" widget="float" class="oe_inline o_input_6ch"/>
-                                        <span class="oe_grey p-2"> %</span>
+                                        <span class="opacity-50 p-2"> %</span>
                                     </div>
                                 </div>
                             </h2>

--- a/addons/event/static/src/scss/event.scss
+++ b/addons/event/static/src/scss/event.scss
@@ -5,9 +5,6 @@
 }
 
 .o_kanban_view.o_event_attendee_kanban_view .o_kanban_renderer {
-    .o_kanban_record_title {
-        margin-right: 35px;
-    }
     .o_kanban_event_registration_event_name{
         margin-right: 35px;
     }

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -247,7 +247,7 @@
                         </aside>
                         <main class="col pt-3 pb-2 px-3 justify-content-between">
                             <div>
-                                <div class="fw-bold fs-5 o_text_overflow" t-att-title="record.name.value">
+                                <div class="fw-bold fs-5 text-truncate" t-att-title="record.name.value">
                                     <field name="name"/>
                                 </div>
                                 <div class="d-flex ps-1">

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -131,7 +131,7 @@
                 <templates>
                     <t t-name="card" class="row g-0">
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
-                        <div class="col-8 col-md-9">
+                        <div class="col-8">
                             <field class="d-block fw-bold fs-5" name="name"/>
                             <field name="state" widget="badge" decoration-success="state == 'done'" class="position-absolute top-0 end-0 o_event_registration_kanban_badge"/>
                             <div class="o_kanban_event_registration_event_name">

--- a/addons/gamification/views/gamification_badge_views.xml
+++ b/addons/gamification/views/gamification_badge_views.xml
@@ -66,7 +66,7 @@
                         <field name="description" nolabel="1" placeholder="Badge Description" colspan="2"/>
                     </group>
                     <group string="Granting">
-                        <div class="oe_grey" colspan="2">
+                        <div class="opacity-50" colspan="2">
                             Security rules to define who is allowed to manually grant badges. Not enforced for administrator.
                         </div>
                         <group>
@@ -79,10 +79,10 @@
                             <label for="stat_my_monthly_sending"/>
                             <div>
                                 <field name="stat_my_monthly_sending" invisible="rule_auth == 'nobody'" />
-                                <div invisible="remaining_sending == -1" class="oe_grey">
+                                <div invisible="remaining_sending == -1" class="opacity-50">
                                     You can still grant <field name="remaining_sending" class="oe_inline"/> badges this month
                                 </div>
-                                <div invisible="remaining_sending != -1" class="oe_grey">
+                                <div invisible="remaining_sending != -1" class="opacity-50">
                                     No monthly sending limit
                                 </div>
                             </div>

--- a/addons/gamification/views/gamification_challenge_views.xml
+++ b/addons/gamification/views/gamification_challenge_views.xml
@@ -86,7 +86,7 @@
                                 <field name="reward_failure" invisible="not reward_first_id" />
                                 <field name="reward_realtime" />
                             </group>
-                            <div class="oe_grey">
+                            <div class="opacity-50">
                                 <p>Badges are granted when a challenge is finished. This is either at the end of a running period (eg: end of the month for a monthly challenge), at the end date of a challenge (if no periodicity is set) or when the challenge is manually closed.</p>
                             </div>
                         </page>
@@ -95,7 +95,7 @@
                                 <field name="invited_user_ids" widget="many2many_tags" />
                             </group>
                             <group string="Notification Messages">
-                                <div class="oe_grey" colspan="4">
+                                <div class="opacity-50" colspan="4">
                                     <p>Depending on the Display mode, reports will be individual or shared.</p>
                                 </div>
                                 <group colspan="4">

--- a/addons/gamification/views/gamification_goal_views.xml
+++ b/addons/gamification/views/gamification_goal_views.xml
@@ -92,7 +92,7 @@
                             <div>
                                 <field name="current" class="oe_inline"/>
                                 <button string="refresh" type="object" name="update_goal" class="oe_link" invisible="computation_mode == 'manually' or state == 'draft'" />
-                                <div class="oe_grey" invisible="not definition_id">
+                                <div class="opacity-50" invisible="not definition_id">
                                     Reached when current value is <strong><field name="definition_condition" class="oe_inline"/></strong> than the target.
                                 </div>
                             </div>

--- a/addons/hr/static/src/scss/hr.scss
+++ b/addons/hr/static/src/scss/hr.scss
@@ -56,12 +56,6 @@
     .o_employee_availability {
         margin: unset !important;
     }
-    .o_kanban_record_bottom {
-        margin: 0 var(--KanbanRecord-padding-h);
-        .fa.fa-comments {
-            margin-bottom: 5px;
-        }
-    }
 }
 
 .hr_tags {

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -146,7 +146,7 @@
                                     </div>
                                 </div>
                                 <field t-if="record.job_title.raw_value" name="job_title"/>
-                                <div t-if="record.work_email.raw_value" class="o_text_overflow">
+                                <div t-if="record.work_email.raw_value" class="text-truncate">
                                     <i class="fa fa-fw me-2 fa-envelope text-primary" title="Email"/>
                                     <field name="work_email"/>
                                 </div>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -343,7 +343,7 @@
                                     </div>
                                 </div>
                                 <field t-if="record.job_title.raw_value" name="job_title"/>
-                                <div t-if="record.work_email.raw_value" class="o_text_overflow">
+                                <div t-if="record.work_email.raw_value" class="text-truncate">
                                     <i class="fa fa-fw me-2 fa-envelope text-primary" title="Email"/>
                                     <field name="work_email" />
                                 </div>

--- a/addons/hr_expense/static/src/js/tours/hr_expense.js
+++ b/addons/hr_expense/static/src/js/tours/hr_expense.js
@@ -109,7 +109,7 @@ registry.category("web_tour.tours").add('hr_expense_tour' , {
     run: "click",
 }, {
     isActive: ["mobile"],
-    trigger: '.o_kanban_renderer .oe_kanban_card',
+    trigger: '.o_kanban_renderer .o_kanban_record',
     content: _t('Managers can inspect all expenses from here.'),
     tooltipPosition: 'bottom',
     run: "click",

--- a/addons/hr_gamification/views/hr_employee_views.xml
+++ b/addons/hr_gamification/views/hr_employee_views.xml
@@ -14,7 +14,7 @@
                     <div class="o_field_nocontent mt-2" invisible="has_badges">
                         <p>
                             Grant this employee his first badge
-                        </p><p class="oe_grey">
+                        </p><p class="opacity-50">
                             Badges are rewards of good work. Give them to people you believe deserve it.
                         </p>
                     </div>
@@ -40,7 +40,7 @@
                     <div class="o_field_nocontent" invisible="has_badges">
                         <p>
                             Grant this employee his first badge
-                        </p><p class="oe_grey">
+                        </p><p class="opacity-50">
                             Badges are rewards of good work. Give them to people you believe deserve it.
                         </p>
                     </div>

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -156,7 +156,7 @@
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                         </group>
                     </group>
-                    <span class="oe_grey" invisible="1">
+                    <span class="opacity-50" invisible="1">
                     </span>
                     <div class="o_hr_holidays_hierarchy">
                         <div class="o_hr_holidays_title">Rules</div>

--- a/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
+++ b/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
@@ -78,7 +78,7 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     trigger: ".o_kanban_applicant",
 },
 {
-    trigger: ".oe_kanban_card",
+    trigger: ".o_kanban_record",
     content: markup(_t("<b>Drag this card</b>, to qualify him for a first interview.")),
     tooltipPosition: "bottom",
     run: "drag_and_drop(.o_kanban_group:eq(1))",
@@ -88,7 +88,7 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     trigger: ".o_kanban_applicant",
 },
 {
-    trigger: ".oe_kanban_card",
+    trigger: ".o_kanban_record",
     content: markup(_t("<b>Click to view</b> the application.")),
     tooltipPosition: "bottom",
     run: "click",

--- a/addons/im_livechat/static/src/views/livechat_channel_kanban/livechat_channel_kanban.scss
+++ b/addons/im_livechat/static/src/views/livechat_channel_kanban/livechat_channel_kanban.scss
@@ -1,10 +1,3 @@
-.o_kanban_record:has(.o-livechat-ChannelKanban-highlighted) {
-    & .oe_kanban_global_click {
-        background-color: $o-component-active-bg !important;
-        color: $o-component-active-color;
-    }
-}
-
 .o-livechat-ChannelKanban-highlighted {
     background-color: $o-component-active-bg !important;
     color: $o-component-active-color;

--- a/addons/lunch/views/lunch_supplier_views.xml
+++ b/addons/lunch/views/lunch_supplier_views.xml
@@ -125,7 +125,7 @@
                             <div t-if="record.city.raw_value and record.country_id.raw_value">
                                 <field name="city"/>, <field name="country_id"/>
                             </div>
-                            <field t-if="record.email.raw_value" class="o_text_overflow" name="email"/>
+                            <field t-if="record.email.raw_value" class="text-truncate" name="email"/>
                         </main>
                     </t>
                 </templates>

--- a/addons/mail/static/src/scss/kanban_view.scss
+++ b/addons/mail/static/src/scss/kanban_view.scss
@@ -22,11 +22,9 @@ $o-kanban-attachement-image-size: 80px;
             }
         }
 
-        .o_kanban_details {
-            .o_kanban_details_wrapper {
-                min-height: $o-kanban-attachement-image-size;
-                padding: $o-kanban-inside-vgutter $o-kanban-inside-hgutter;
-            }
+        .o_kanban_details_wrapper {
+            min-height: $o-kanban-attachement-image-size;
+            padding: $o-kanban-inside-vgutter $o-kanban-inside-hgutter;
         }
     }
 }

--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -153,7 +153,7 @@
                                     <div t-else="!webimage" class="o_image o_image_thumbnail" t-att-data-mimetype="record.mimetype.value"/>
                                 </div>
                             </aside>
-                            <main class="o_kanban_details ms-1">
+                            <main class="ms-1">
                                 <div class="o_kanban_details_wrapper d-flex flex-column">
                                     <field name="name" class="text-truncate fw-bold fs-5"/>
                                     <div class="d-flex flex-grow-1 align-items-center">

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -208,7 +208,7 @@
             </xpath>
             <xpath expr="//field[@name='name']" position="after">
                 <!-- simulate the placeholder on the readonly field -->
-                <span class="oe_grey" invisible="name">e.g. "John Smith"</span>
+                <span class="opacity-50" invisible="name">e.g. "John Smith"</span>
             </xpath>
             <xpath expr="//group/label[@for='email']" position="before">
                 <field name="first_name" placeholder="e.g. &quot;John&quot;"/>

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -70,7 +70,7 @@
                         <group>
                             <field name="code"/>
                             <field name="type" widget="radio" invisible="context.get('parent_production_id')"/>
-                            <p colspan="2" class="oe_grey oe_edit_only" invisible="type != 'phantom'">
+                            <p colspan="2" class="opacity-50 oe_edit_only" invisible="type != 'phantom'">
                             <ul>
                                 A BoM of type Kit is not produced with a manufacturing order.<br/>
                                 Instead, it is used to decompose a BoM into its components when:

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -78,7 +78,7 @@
                                 groups="product.group_product_variant"/>
                         </list>
                     </field>
-                        <p class="oe_grey oe_edit_only">
+                        <p class="opacity-50 oe_edit_only">
                         <strong>Warning</strong>: adding or deleting attributes
                         will delete and recreate existing variants and lead
                         to the loss of their possible customizations.

--- a/addons/project/static/src/views/project_update_kanban/project_update_kanban.scss
+++ b/addons/project/static/src/views/project_update_kanban/project_update_kanban.scss
@@ -24,17 +24,11 @@
                     top: 0px;
                     position: absolute;
                 }
-                .o_pupdate_name {
-                    overflow-wrap: break-word;
-                }
                 .o_pupdate_kanban_actions_ungrouped {
                     button {
                         float: right;
                         margin: 4px;
                     }
-                }
-                .o_country_flag {
-                    margin-right: 8px;
                 }
 
                 .o_field_status_with_color {
@@ -50,30 +44,5 @@
                 }
             }
         }
-    }
-}
-
-.oe_kanban_color_20 {
-    border-left-color: $o-success;
-    &:after {
-        background-color: $o-success;
-    }
-}
-.oe_kanban_color_21 {
-    border-left-color: $o-info;
-    &:after {
-        background-color: $o-info;
-    }
-}
-.oe_kanban_color_22 {
-    border-left-color: $o-warning;
-    &:after {
-        background-color: $o-warning;
-    }
-}
-.oe_kanban_color_23 {
-    border-left-color: $o-danger;
-    &:after {
-        background-color: $o-danger;
     }
 }

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -206,7 +206,7 @@
                         </group>
                     </group>
                     <group string="Applicable On" name="route_selector">
-                        <p colspan="2" class="oe_grey">Select the places where this route can be selected</p>
+                        <p colspan="2" class="opacity-50">Select the places where this route can be selected</p>
                         <group>
                             <field name="product_categ_selectable" string="Product Categories"/>
                             <field name="product_selectable" string="Products"/>

--- a/addons/uom/views/uom_uom_views.xml
+++ b/addons/uom/views/uom_uom_views.xml
@@ -29,7 +29,7 @@
                                 <field name="factor"
                                     digits="[42,5]"
                                     readonly="uom_type == 'bigger'"/>
-                                <span class="oe_grey oe_inline">
+                                <span class="opacity-50 oe_inline">
                                     e.g: 1*(reference unit)=ratio*(this unit)
                                 </span>
                             </div>
@@ -39,7 +39,7 @@
                                 <field name="factor_inv"
                                     digits="[42,5]"
                                     readonly="uom_type != 'bigger'"/>
-                                <span class="oe_grey oe_inline">
+                                <span class="opacity-50 oe_inline">
                                     e.g: 1*(this unit)=ratio*(reference unit)
                                 </span>
                             </div>

--- a/addons/web/static/src/core/file_upload/file_upload_progress_record.scss
+++ b/addons/web/static/src/core/file_upload/file_upload_progress_record.scss
@@ -2,9 +2,6 @@
     .o_kanban_progress_card {
         min-height: 80px;
 
-        .o_kanban_record_bottom {
-            color: $gray-900;
-        }
         .o_kanban_image_wrapper {
             opacity: 0.7;
         }

--- a/addons/web/static/src/core/file_upload/file_upload_progress_record.xml
+++ b/addons/web/static/src/core/file_upload/file_upload_progress_record.xml
@@ -4,26 +4,16 @@
         <t t-set="progressTexts" t-value="getProgressTexts()"/>
         <div class="o_kanban_record d-flex flex-grow-1 flex-md-shrink-1 flex-shrink-0">
             <div class="o_kanban_progress_card o_kanban_attachment position-relative p-0 cursor-pointer">
-                <div class="o_kanban_image">
-                    <div class="o_kanban_image_wrapper">
-                        <div class="o_image o_image_thumbnail" t-att-data-mimetype="props.fileUpload.type"/>
-                    </div>
+                <div class="o_kanban_image_wrapper">
+                    <div class="o_image o_image_thumbnail" t-att-data-mimetype="props.fileUpload.type"/>
                 </div>
-                <div class="o_kanban_details">
-                    <div class="o_kanban_details_wrapper">
-                        <div t-att-title="props.fileUpload.title" t-att-aria-label="props.fileUpload.title" class="o_kanban_record_title">
-                            <span t-esc="props.fileUpload.title"/>
-                        </div>
-                        <div class="o_kanban_record_body"/>
-                        <div class="o_kanban_record_bottom">
-                            <div class="oe_kanban_bottom_left">
-                                <div class="o_file_upload_progress_text_left" t-esc="progressTexts.left"/>
-                            </div>
-                            <div class="oe_kanban_bottom_right">
-                                <span class="o_file_upload_progress_text_right" t-esc="progressTexts.right"/>
-                            </div>
-                        </div>
-                    </div>
+                <div t-att-title="props.fileUpload.title" t-att-aria-label="props.fileUpload.title" class="fw-bold fs-5 mb-2 p-2">
+                    <span t-esc="props.fileUpload.title"/>
+                </div>
+                <div class="o_kanban_record_body"/>
+                <div class="d-flex p-2 text-dark">
+                    <div class="o_file_upload_progress_text_left" t-esc="progressTexts.left"/>
+                    <span class="o_file_upload_progress_text_right ms-auto" t-esc="progressTexts.right"/>
                 </div>
                 <FileUploadProgressBar fileUpload="props.fileUpload"/>
             </div>

--- a/addons/web/static/src/scss/utils.scss
+++ b/addons/web/static/src/scss/utils.scss
@@ -252,7 +252,7 @@
 @mixin o-kanban-record-color {
     @for $size from 2 through length($o-colors) {
         // Note: the first color is not defined as it is the 'no color' for kanban
-        .oe_kanban_color_#{$size - 1} {
+        .o_kanban_color_#{$size - 1} {
             border-left-color: nth($o-colors, $size);
             &:after {
                 background-color: nth($o-colors, $size);

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -78,9 +78,6 @@
     .oe_text_center {
         text-align: center;
     }
-    .oe_grey {
-        opacity: 0.5;
-    }
     .oe_inline, .o_field_widget.oe_inline > * {
         width: auto!important;
     }

--- a/addons/website_crm_partner_assign/views/crm_lead_views.xml
+++ b/addons/website_crm_partner_assign/views/crm_lead_views.xml
@@ -11,14 +11,14 @@
                             <group col="2">
                                 <label for="partner_latitude" string="Geolocation"/>
                                 <div>
-                                    <span class="oe_grey">( </span>
+                                    <span class="opacity-50">( </span>
                                     <field name="partner_latitude" class="oe_inline o_input_12ch px-1"/>
-                                    <span class="oe_grey" invisible="partner_latitude &lt;= 0">N </span>
-                                    <span class="oe_grey" invisible="partner_latitude &gt;= 0">S </span>
+                                    <span class="opacity-50" invisible="partner_latitude &lt;= 0">N </span>
+                                    <span class="opacity-50" invisible="partner_latitude &gt;= 0">S </span>
                                     <field name="partner_longitude" class="oe_inline o_input_12ch ps-2 pe-1"/>
-                                    <span class="oe_grey" invisible="partner_longitude &lt;= 0">E </span>
-                                    <span class="oe_grey" invisible="partner_longitude &gt;= 0">W </span>
-                                    <span class="oe_grey ps-1">) </span>
+                                    <span class="opacity-50" invisible="partner_longitude &lt;= 0">E </span>
+                                    <span class="opacity-50" invisible="partner_longitude &gt;= 0">W </span>
+                                    <span class="opacity-50 ps-1">) </span>
                                 </div>
                                 <field name="partner_assigned_id" domain="[('grade_id','!=',False)]" context="{'partner_set_default_grade_activation': 1}"/>
                             </group>

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -397,7 +397,7 @@
                                 </group>
                         </group>
                         <field name="child_ids" domain="[('model_id', '=', model_id)]" invisible="state != 'multi'"/>
-                        <p class="oe_grey" invisible="state != 'multi'">
+                        <p class="opacity-50" invisible="state != 'multi'">
                             If several child actions return an action, only the last one will be executed.
                             This may happen when having server actions executing code that returns an action, or server actions returning a client action.
                         </p>

--- a/odoo/addons/base/wizard/base_partner_merge_views.xml
+++ b/odoo/addons/base/wizard/base_partner_merge_views.xml
@@ -18,7 +18,7 @@
                             <h2 colspan="2">There are no more contacts to merge for this request</h2>
                             <button name="%(action_partner_deduplicate)d" string="Deduplicate the other Contacts" class="oe_highlight" type="action" colspan="2"/>
                         </group>
-                        <p class="oe_grey" invisible="state != 'option'">
+                        <p class="opacity-50" invisible="state != 'option'">
                             Select the list of fields used to search for
                             duplicated records. If you select several fields,
                             Odoo will propose you to merge only those having
@@ -47,7 +47,7 @@
                         <separator string="Merge the following contacts"
                             invisible="state in ('option', 'finished')"/>
                         <group invisible="state in ('option', 'finished')" col="1">
-                            <p class="oe_grey">
+                            <p class="opacity-50">
                                 Selected contacts will be merged together.
                                 All documents linked to one of these contacts
                                 will be redirected to the destination contact.


### PR DESCRIPTION
- In an effort to simplify the Kanban architecture, we previously removed several SCSS and CSS elements from the Kanban view. As a result, many of the associated classes have become redundant and are no longer functional.
- oe_grey class has been removed from the form view and replaced with the opacity-50 class.

This commit aims to remove all such trivial and ineffective classes, improving overall code clarity and maintainability.

Task-4202915

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
