### PR TITLE
[FIX] html_editor: don't use self closing `a` elements in editor

### DIFF
--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -2,7 +2,7 @@ import { MAIN_PLUGINS } from "./plugin_sets";
 import { removeClass } from "./utils/dom";
 import { isEmpty } from "./utils/dom_info";
 import { resourceSequenceSymbol, withSequence } from "./utils/resource";
-import { initElementForEdition } from "./utils/sanitize";
+import { fixInvalidHTML, initElementForEdition } from "./utils/sanitize";
 
 /**
  * @typedef { import("./plugin_sets").SharedMethods } SharedMethods
@@ -94,7 +94,8 @@ export class Editor {
         this.editable = editable;
         this.document = editable.ownerDocument;
         if (this.config.content) {
-            editable.innerHTML = this.config.content;
+            const content = fixInvalidHTML(this.config.content);
+            editable.innerHTML = content;
             if (isEmpty(editable)) {
                 editable.innerHTML = "<p><br></p>";
             }

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -581,7 +581,10 @@ export class LinkPlugin extends Plugin {
                 continue;
             }
             const classes = [...link.classList].filter((c) => !this.ignoredClasses.has(c));
-            if (!classes.length) {
+            const attributes = [...link.attributes].filter(
+                (a) => !["style", "href", "class"].includes(a.name)
+            );
+            if (!classes.length && !attributes.length) {
                 link.remove();
             }
         }

--- a/addons/html_editor/static/src/utils/sanitize.js
+++ b/addons/html_editor/static/src/utils/sanitize.js
@@ -57,3 +57,8 @@ export function initElementForEdition(element, options = {}) {
         element.replaceChildren(...newChildren);
     }
 }
+
+export function fixInvalidHTML(content) {
+    const regex = /<\s*(a|strong)[^<]*?\/\s*>/g;
+    return content.replace(regex, (match, g0) => match.replace(/\/\s*>/, `></${g0}>`));
+}

--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -6,6 +6,7 @@ import { mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { getContent, getSelection, setContent } from "./selection";
 import { animationFrame } from "@odoo/hoot-mock";
 import { dispatchCleanForSave } from "./dispatch";
+import { fixInvalidHTML } from "@html_editor/utils/sanitize";
 
 export const Direction = {
     BACKWARD: "BACKWARD",
@@ -23,7 +24,7 @@ class TestEditor extends Component {
 
     setup() {
         const props = this.props;
-        const content = props.content;
+        const content = fixInvalidHTML(props.content);
         this.wysiwygProps = Object.assign({}, this.props.wysiwygProps);
         const iframe = this.props.wysiwygProps.iframe;
         const oldOnLoad = this.wysiwygProps.onLoad;
@@ -33,14 +34,13 @@ class TestEditor extends Component {
                 // @todo @phoenix move it to setupMultiEditor
                 if (iframe) {
                     // el is here the body
-                    const content = props.content || "";
-                    var html = `<div>${content}</div><style>${props.styleContent}</style>`;
+                    var html = `<div>${content || ""}</div><style>${props.styleContent}</style>`;
                     el.innerHTML = html;
                     el = el.firstChild;
                 }
-                if (props.content) {
+                if (content) {
                     el.setAttribute("contenteditable", true); // so we can focus it if needed
-                    const configSelection = getSelection(el, props.content);
+                    const configSelection = getSelection(el, content);
                     if (configSelection) {
                         el.focus();
                     }

--- a/addons/html_editor/static/tests/editor.test.js
+++ b/addons/html_editor/static/tests/editor.test.js
@@ -96,3 +96,17 @@ test("clean_for_save_listeners is done last", async () => {
     const el = editor.getElContent();
     expect(getContent(el)).toBe(`<div><c-div>a</c-div><c-div>b</c-div></div>`);
 });
+
+test("Convert self closing a elements to opening/closing tags", async () => {
+    const { el, editor } = await setupEditor(`
+        <ul>
+            <li><a href="xyz" t-out="xyz"/></li>
+        </ul>
+    `);
+    expect(el.innerHTML.trim().replace(/\s+/g, " ")).toBe(
+        `<ul> <li> <a href="xyz" t-out="xyz"> </a> </li> </ul>`
+    );
+    expect(editor.getContent().trim().replace(/\s+/g, " ")).toBe(
+        '<ul> <li><a href="xyz" t-out="xyz"></a></li> </ul>'
+    );
+});


### PR DESCRIPTION
Issue:
======
Self-closing `a` and `strong` elements doesn't render properly.

Steps to reproduce the issue:
=============================
- Go to email templates
- Open "Send Quotation" template
- You will see the `a` element of the attachment is appearing a lot of
  times.

Origin of the issue:
====================
Since the content of the template is in xml, using self closing `a` element
is acceptable but it's not valid html so using the same content of xml
into html will produce incorrect ui.

Solution:
=========
Change the self closing `a` and `strong` elements into opening and
closing tags.

opw-4322575