### PR TITLE
[FIX] mail: make discuss look less harsh visually

### DIFF
--- a/addons/mail/static/src/chatter/web/scheduled_message.xml
+++ b/addons/mail/static/src/chatter/web/scheduled_message.xml
@@ -25,8 +25,8 @@
                             <div class="position-relative overflow-x-auto d-inline-block">
                                 <div class="o-mail-Message-bubble rounded-end-3 rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100"
                                     t-att-class="{
-                                        'bg-success-light border border-success opacity-25': !props.scheduledMessage.is_note and props.scheduledMessage.isSelfAuthored,
-                                        'bg-info-light border border-info opacity-25': !props.scheduledMessage.is_note and !props.scheduledMessage.isSelfAuthored 
+                                        'bg-success-light opacity-25': !props.scheduledMessage.is_note and props.scheduledMessage.isSelfAuthored,
+                                        'bg-info-light opacity-25': !props.scheduledMessage.is_note and !props.scheduledMessage.isSelfAuthored 
                                     }"/>
                                 <div t-on-click="onClick"
                                     t-attf-class="position-relative text-break o-mail-Message-body #{props.scheduledMessage.is_note ? 'p-1' : 'mb-0 py-2 px-3 align-self-start'}">

--- a/addons/mail/static/src/core/common/chat_window.dark.scss
+++ b/addons/mail/static/src/core/common/chat_window.dark.scss
@@ -1,7 +1,3 @@
-.o-mail-ChatWindow {
-    --mail-ChatWindow-desktopBorderOpacity: 0.3;
-}
-
 .o-mail-ChatWindow-command {
     --mail-ChatWindow-commandHoverBg: #{mix($gray-200, $gray-300)};
 }

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -12,7 +12,7 @@
         z-index: 1001; // above messaging menu (chat window takes whole screen)
     }
     &:not(.o-mobile) {
-        --border-opacity: var(--mail-ChatWindow-desktopBorderOpacity, .15);
+        --border-opacity: .15;
     }
     outline: none;
 }

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -64,6 +64,7 @@
 
 .o-mail-Composer-bg {
     background-color: var(--mail-Composer-bg, $o-view-background-color);
+    --border-opacity: .5;
 }
 
 .o-mail-Composer-inputStyle {
@@ -127,7 +128,6 @@
 }
 
 .o-mail-Composer-compactContainer {
-    --border-opacity: 0.75;
 
     &.o-iosPwa:not(:focus-within) {
         margin-bottom: map-get($spacers, 5) !important;

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -32,9 +32,9 @@
                 <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => props.messageToReplyTo.cancel()"/>
             </div>
             <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : extended }">
-                <div class="d-flex o-mail-Composer-bg flex-grow-1 border"
+                <div class="d-flex o-mail-Composer-bg flex-grow-1 border border-secondary"
                     t-att-class="{
-                        'o-mail-Composer-compactContainer m-1 shadow-sm border-secondary': compact and !props.composer.message,
+                        'o-mail-Composer-compactContainer m-1 shadow-sm': compact and !props.composer.message,
                         'o-iosPwa': isIosPwa,
                         'rounded-3' : normal or isMobileOS or extended,
                         'align-self-stretch' : extended,

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -32,7 +32,7 @@ $o-discuss-talkingColor: lighten($success, 5%);
 }
 
 .o-discuss-separator {
-    opacity: $hr-opacity / 2;
+    opacity: $hr-opacity / 3;
 }
 
 .o-discuss-badge, .o-discuss-badgeShape {

--- a/addons/mail/static/src/core/common/date_section.dark.scss
+++ b/addons/mail/static/src/core/common/date_section.dark.scss
@@ -1,3 +1,0 @@
-.o-mail-DateSection span {
-    opacity: 50%;
-}

--- a/addons/mail/static/src/core/common/date_section.scss
+++ b/addons/mail/static/src/core/common/date_section.scss
@@ -1,3 +1,0 @@
-.o-mail-DateSection span {
-    opacity: 75%;
-}

--- a/addons/mail/static/src/core/common/date_section.xml
+++ b/addons/mail/static/src/core/common/date_section.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.DateSection">
     <div class="o-mail-DateSection d-flex align-items-center w-100 fw-bold z-1" t-attf-class="{{ props.className }}">
         <hr class="o-discuss-separator flex-grow-1"/>
-        <span class="px-2 smaller text-muted" t-att-class="{ 'user-select-none': isMobileOS }"><t t-esc="props.date"/></span>
+        <span class="px-2 smaller text-muted opacity-50" t-att-class="{ 'user-select-none': isMobileOS }"><t t-esc="props.date"/></span>
         <hr class="o-discuss-separator flex-grow-1"/>
     </div>
 </t>

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -11,9 +11,7 @@
 }
 
 .o-mail-Message-bubble {
-    .o-mail-Message:not(.o-card) & {
-        --border-opacity: 0.1;
-    }
+    --border-opacity: 0;
 
     &.o-blue {
         background-color: mix($gray-100, $info, 87.5%) !important;

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -2,7 +2,7 @@
     transition: background-color .2s ease-out, opacity .5s ease-out, box-shadow .5s ease-out, transform .2s ease-out;
 
     &.o-card {
-        outline: $border-width solid $border-color;
+        outline: $border-width solid rgba($border-color, .35);
         outline-offset: -$border-width;
         background-color: $o-view-background-color;
     }
@@ -97,7 +97,7 @@
 }
 
 .o-mail-Message-bubble {
-    --border-opacity: 0.15;
+    --border-opacity: .075;
 
     &.o-blue {
         background-color: mix($o-view-background-color, $info, 87.5%) !important;
@@ -106,7 +106,6 @@
         background-color: mix($o-view-background-color, $success, 87.5%) !important;
     }
     &.o-orange {
-        --border-opacity: 0.3;
         background-color: mix($o-view-background-color, $warning, 75%) !important;
     }
 }

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -70,10 +70,9 @@
                                         <t t-else="">
                                             <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
                                                 <div class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100" t-att-class="{
-                                                    'border': state.isEditing and !message.is_note,
-                                                    'o-blue border border-info': message.bubbleColor === 'blue',
-                                                    'o-green border border-success': message.bubbleColor === 'green',
-                                                    'o-orange border border-warning': message.bubbleColor === 'orange',
+                                                    'o-blue': message.bubbleColor === 'blue',
+                                                    'o-green': message.bubbleColor === 'green',
+                                                    'o-orange': message.bubbleColor === 'orange',
                                                     }" t-attf-class="{{ isAlignedRight ? 'rounded-start-3' : 'rounded-end-3' }}"/>
                                                 <MessageInReply t-if="message.parentMessage" message="message" onClick="props.onParentMessageClick"/>
                                                 <div class="position-relative text-break o-mail-Message-body" t-att-class="{

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -3,9 +3,9 @@
     <t t-name="mail.MessageInReply">
         <div class="o-mail-MessageInReply mx-2 mt-1 p-1 pb-0">
             <small class="o-mail-MessageInReply-core position-relative d-flex px-2 py-1" t-att-class="{
-                'o-otherMessageBlue border border-info': props.message.parentMessage.bubbleColor === 'blue',
-                'o-otherMessageGreen border border-success': props.message.parentMessage.bubbleColor === 'green',
-                'o-otherMessageOrange border border-warning': props.message.parentMessage.bubbleColor === 'orange',
+                'o-otherMessageBlue': props.message.parentMessage.bubbleColor === 'blue',
+                'o-otherMessageGreen': props.message.parentMessage.bubbleColor === 'green',
+                'o-otherMessageOrange': props.message.parentMessage.bubbleColor === 'orange',
             }">
                 <span t-if="!props.message.parentMessage.isEmpty" class="d-inline-flex align-items-center text-muted" t-att-class="{ 'cursor-pointer': props.onClick }" t-on-click="() => this.props.onClick?.()">
                     <img class="o-mail-MessageInReply-avatar me-2 rounded o_object_fit_cover" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>

--- a/addons/mail/static/src/core/public_web/discuss.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss.dark.scss
@@ -1,3 +1,7 @@
+.o-mail-Discuss {
+    --mail-Discuss-coreBgColor: #{mix($body-bg, $gray-200, 75%)};
+}
+
 .o-mail-Discuss-header {
     background-color: mix($o-gray-100, $o-gray-200, 15%);
 }

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -5,7 +5,7 @@
 }
 
 .o-mail-Discuss-core {
-    background-color: $body-bg;
+    background-color: var(--mail-Discuss-coreBgColor, $body-bg);
 }
 
 .o-mail-Discuss-selfAvatar {
@@ -19,6 +19,7 @@
 .o-mail-Discuss-header {
     background-color: $white;
     box-shadow: 0px 1px 6px -3px rgba(50, 50, 50, 0.15);
+    --border-opacity: .25;
 }
 
 .o-mail-Discuss-headerActions button {

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -6,7 +6,7 @@
     <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center bg-view': ui.isSmall }" t-ref="root">
         <DiscussSidebar t-if="!ui.isSmall and props.hasSidebar"/>
         <div t-if="!(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
-            <div class="o-mail-Discuss-header px-3 d-flex flex-shrink-0 align-items-center border-bottom z-1 flex-grow-0" t-ref="header">
+            <div class="o-mail-Discuss-header px-3 d-flex flex-shrink-0 align-items-center border-bottom border-secondary z-1 flex-grow-0" t-ref="header">
                 <t t-if="thread">
                     <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
                         <img class="rounded o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.scss
@@ -1,6 +1,7 @@
 .o-mail-DiscussSidebar {
     box-shadow: 1px 0px 6px -3px rgba(50, 50, 50, 0.15);
     width: 60px;
+    --border-opacity: .5;
 
     &:not(.o-compact) {
         width: $o-mail-Discuss-inspector;
@@ -25,9 +26,11 @@
 
 .o-mail-DiscussSidebar-item {
     outline: 1px solid transparent !important;
+    padding-top: map-get($spacers, 1) / 2;
+    padding-bottom: map-get($spacers, 1) / 2;
 
     &.o-active, &:hover {
         background-color: var(--mail-DiscussSidebar-itemActiveBgColor, mix($o-view-background-color, $o-action, 90%)) !important;
-        outline-color: var(--mail-DiscussSidebar-itemActiveOutlineColor, rgba($o-action, .25)) !important;
+        outline-color: var(--mail-DiscussSidebar-itemActiveOutlineColor, rgba($o-action, .15)) !important;
     }
 }

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebar">
-        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 border-end z-1 o-mail-discussSidebarBgColor gap-1" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
+        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 border-end border-secondary z-1 o-mail-discussSidebarBgColor gap-1" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
             <div class="o-mail-DiscussSidebar-top position-sticky justify-content-center top-0 z-2 o-mail-discussSidebarBgColor" t-att-class="{ 'pt-2 pb-1': !store.inPublicPage, 'pt-1': store.inPublicPage }">
                 <div class="d-flex align-items-center justify-content-center" t-att-class="{ 'flex-column gap-2': store.discuss.isSidebarCompact }">
                     <t name="options-btn">

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
@@ -1,4 +1,4 @@
 .o-mail-DiscussSidebar-item {
-    --mail-DiscussSidebar-itemActiveBgColor: #{mix($gray-100, $o-action, 87.5%)};
-    --mail-DiscussSidebar-itemActiveOutlineColor: #{rgba($o-action, .5)};
+    --mail-DiscussSidebar-itemActiveBgColor: #{$gray-300};
+    --mail-DiscussSidebar-itemActiveOutlineColor: #{rgba($gray-400, .35)};
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
@@ -1,3 +1,7 @@
+.o-mail-DiscussSidebar-item {
+    --mail-DiscussSidebarChannel-commandsHover: #{rgba($gray-400, .5)};
+}
+
 .o-mail-DiscussSidebarChannel-container {
     --mail-DiscussSidebarChannel-borderOpacity: .2;
     ---mail-DiscussSidebarChannel-borderedBgColor: #{$gray-100};

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -89,7 +89,7 @@ export class DiscussSidebarChannel extends Component {
             "opacity-50": this.thread.isMuted,
             "position-relative justify-content-center o-compact mt-0 p-1":
                 this.store.discuss.isSidebarCompact,
-            "p-0": !this.store.discuss.isSidebarCompact,
+            "px-0": !this.store.discuss.isSidebarCompact,
         };
     }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -35,7 +35,7 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
         display: flex !important;
         .btn-group .btn {
             &:hover {
-                border-color: rgba($o-action, .25);
+                border-color: var(--mail-DiscussSidebarChannel-commandsHover, rgba($o-action, .15));
                 background-color: $o-view-background-color !important;
             }
             &:not(:hover) {

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -94,14 +94,14 @@ test("Message post in chat window of chatter should log a note", async () => {
     await contains(".o-mail-ChatWindow");
     await contains(".o-mail-Message", {
         text: "A needaction message to have it in messaging menu",
-        contains: [".o-mail-Message-bubble.border"], // bordered bubble = "Send message" mode
+        contains: [".o-mail-Message-bubble.o-blue"], // colored bubble = "Send message" mode
     });
     await contains(".o-mail-Composer [placeholder='Log an internal note…']");
     await insertText(".o-mail-ChatWindow .o-mail-Composer-input", "Test");
     triggerHotkey("control+Enter");
     await contains(".o-mail-Message", {
         text: "Test",
-        contains: [".o-mail-Message-bubble:not(.border)"], // non-bordered bubble = "Log note" mode
+        contains: [".o-mail-Message-bubble:not(.o-blue)"], // non-colored bubble = "Log note" mode
     });
 });
 

--- a/addons/portal_rating/static/src/chatter/frontend/message_patch.xml
+++ b/addons/portal_rating/static/src/chatter/frontend/message_patch.xml
@@ -52,7 +52,7 @@
                             </div>
                             <div class="position-relative d-flex">
                                 <div class="o-min-width-0 position-relative d-flex overflow-x-auto d-inline-block">
-                                    <div class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 bg-info-light border border-info opacity-25 rounded-end-3"/>
+                                    <div class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 bg-info-light opacity-25 rounded-end-3"/>
                                     <div class="position-relative text-break o-mail-Message-body mb-0 py-2 px-3 align-self-start rounded-end-3 rounded-bottom-3">
                                         <p><t t-out="message.rating.publisher_comment"/></p>
                                     </div>


### PR DESCRIPTION
Especially in dark theme, UI had too much contrast, which makes using Discuss more exhausting than it should.

PR makes the following improvements to make Discuss look more pleasing:

- Dark theme: selected item is greyish rather than greenish
- Discuss app borders and composer have half reduced opacity
- Dark theme: background of conversation is slightly less dark
- Message bubbles no longer have borders
- White theme: date separator is slightly less visible
- Discuss sidebar channel items have more vertical spacing

Before (white)
![before-white](https://github.com/user-attachments/assets/b873898b-0489-4e97-ba5e-dd0388738500)
After (white)
![Screenshot 2024-11-19 at 14 38 43](https://github.com/user-attachments/assets/ee433321-ec5b-48b4-9051-a289fc4ff67c)

Before (dark)
![before-dark](https://github.com/user-attachments/assets/8038b49e-603e-410a-a56b-ac998169b6f0)
After (dark)
![Screenshot 2024-11-19 at 14 38 31](https://github.com/user-attachments/assets/9cbecadf-88c6-4f28-a250-9e84e6c34760)
