### PR TITLE
[IMP] web: TreeEditor: domain in autocompletes

### DIFF
--- a/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
@@ -17,6 +17,7 @@ import { unique } from "@web/core/utils/arrays";
 import { Input, Select, List, Range } from "@web/core/tree_editor/tree_editor_components";
 import { formatValue } from "@web/core/tree_editor/condition_tree";
 import { getResModel, disambiguate, isId } from "@web/core/tree_editor/utils";
+import { Domain } from "@web/core/domain";
 
 const { DateTime } = luxon;
 
@@ -79,6 +80,17 @@ function makeSelectEditor(options, params = {}) {
     };
 }
 
+function getDomain(fieldDef) {
+    if (fieldDef.type === "many2one") {
+        return [];
+    }
+    try {
+        return new Domain(fieldDef.domain || []).toList();
+    } catch {
+        return [];
+    }
+}
+
 function makeAutoCompleteEditor(fieldDef) {
     return {
         component: DomainSelectorAutocomplete,
@@ -86,6 +98,7 @@ function makeAutoCompleteEditor(fieldDef) {
             return {
                 resModel: getResModel(fieldDef),
                 fieldString: fieldDef.string,
+                domain: getDomain(fieldDef),
                 update: (value) => update(unique(value)),
                 resIds: unique(value),
             };


### PR DESCRIPTION
In the domain selector (and expression editor), using autocompletion to build conditions for X2many fields will use their domains. Note that it cannot be done for a field many2one since values can be created outside of the field domain in that case.