### PR TITLE
[FIX] web: fix wrong pager button `border-radius` in RTL

### DIFF
--- a/addons/web/static/src/core/pager/pager.xml
+++ b/addons/web/static/src/core/pager/pager.xml
@@ -20,8 +20,12 @@
             </span>
             <span class="btn-group d-print-none" aria-atomic="true">
                 <!-- accesskeys not wanted in X2Many widgets -->
-                <button type="button" class="oi oi-chevron-left btn btn-secondary o_pager_previous px-2 rounded-start" aria-label="Previous" data-tooltip="Previous" tabindex="-1" t-att-data-hotkey="props.withAccessKey ? 'p' : false" t-att-disabled="state.isDisabled or isSinglePage" t-on-click.stop="() => this.navigate(-1)" />
-                <button type="button" class="oi oi-chevron-right btn btn-secondary o_pager_next px-2 rounded-end" aria-label="Next" data-tooltip="Next" tabindex="-1" t-att-data-hotkey="props.withAccessKey ? 'n' : false" t-att-disabled="state.isDisabled or isSinglePage" t-on-click.stop="() => this.navigate(1)" />
+                <button type="button" class="btn btn-secondary o_pager_previous px-2 rounded-start" aria-label="Previous" data-tooltip="Previous" tabindex="-1" t-att-data-hotkey="props.withAccessKey ? 'p' : false" t-att-disabled="state.isDisabled or isSinglePage" t-on-click.stop="() => this.navigate(-1)">
+                    <i class="oi oi-chevron-left"/>
+                </button>
+                <button type="button" class="btn btn-secondary o_pager_next px-2 rounded-end" aria-label="Next" data-tooltip="Next" tabindex="-1" t-att-data-hotkey="props.withAccessKey ? 'n' : false" t-att-disabled="state.isDisabled or isSinglePage" t-on-click.stop="() => this.navigate(1)">
+                    <i class="oi oi-chevron-right"/>
+                </button>
             </span>
         </nav>
     </t>


### PR DESCRIPTION
This PR fixes an issue about the pager buttons having a wrong `border-radius` in RTL languages.

Prior to this PR, the icons were defined at the button level. On top of being unusual, this had a side-effect. In RTL languages, we use a CSS `transform: rotate(180deg);` on our directional icons,in order to flip their direction and match the RTL or LTR.

While this works totally fine, having the icon sets on the button directly means the whole button will be flipped, meaning the border-radius will be inverted.

To prevent this behaviour, we simply need to use a `<i/>` tag for both icons, which will allow them to be flipped without affecting the button design.

| 17.0 | This PR |
|--------|--------|
| <img width="159" alt="image" src="https://github.com/user-attachments/assets/2afc13b3-0b4b-4baf-a306-2196a3c83867"> | <img width="159" alt="image" src="https://github.com/user-attachments/assets/a405e167-6a0f-4a49-a15d-4e36735d95f5"> | 

task-4345233

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
