### PR TITLE
[FIX] base_iban: ensure Oman iban mapping

### DIFF
--- a/addons/base_iban/models/res_partner_bank.py
+++ b/addons/base_iban/models/res_partner_bank.py
@@ -158,6 +158,7 @@ _map_iban_template = {
     'mu': 'MUkk BBBB BBSS CCCC CCCC CCCC CCCC CC',  # Mauritius
     'nl': 'NLkk BBBB CCCC CCCC CC',  # Netherlands
     'no': 'NOkk BBBB CCCC CCK',  # Norway
+    'om': 'OMkk BBBC CCCC CCCC CCCC CCC', # Oman
     'pk': 'PKkk BBBB CCCC CCCC CCCC CCCC',  # Pakistan
     'pl': 'PLkk BBBS SSSK CCCC CCCC CCCC CCCC',  # Poland
     'ps': 'PSkk BBBB XXXX XXXX XCCC CCCC CCCC C',  # Palestinian


### PR DESCRIPTION
Steps to reproduce:

 - Create an employe with an oman bank account number
 - Create a payslip for this employe
 - Create a payment report

Issue:

when trying to create a payment report in the payroll app for an employee with an oman bank account number, when creating the payment report an error :"Invalid IBAN for the following employees: .." will raise.

Fix:

This issue can be fixed by adding the 'om' in the variable _map_iban_template. This ensure that the mapping will be done correctly and the error will not be raised anymore.

opw-4312502

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
