### PR TITLE
[IMP] core: ensure constraint for required boolean fields

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3239,8 +3239,9 @@ class BaseModel(metaclass=MetaModel):
         else:
             value = None
         # Write value if non-NULL, except for booleans for which False means
-        # the same as NULL - this saves us an expensive query on large tables.
-        necessary = (value is not None) if field.type != 'boolean' else value
+        # the same as NULL - this saves us an expensive query on large tables,
+        # if the boolean is required we still write False to allow NOT NULL constraints.
+        necessary = (value is not None) if field.type != 'boolean' or field.required else value
         if necessary:
             _logger.debug("Table '%s': setting default value of new column %s to %r",
                           self._table, column_name, value)


### PR DESCRIPTION
When we add a required boolean field with default `False` the ORM deoesn't fill existing rows and thus outputs an error to the logs.

Example model to reproduce the issue in a custom Module `mymodule`:
```
class A(models.Model):
    _inherit = "res.users"
    foo = field.Boolean(required=True, default=False)
```

If we install `mymodule`
```
2024-11-19 13:05:31,076 277801 INFO test_m_x odoo.registry: module mymodule: creating or updating database tables
2024-11-19 13:05:31,092 277801 ERROR test_m_x odoo.schema: Table 'res_users': unable to set NOT NULL on column 'foo'
```
The ORM fails to add the `NOT NULL` and moves on (no crash).

In this patch we ensure that the ORM adds the `NOT NULL` constraint.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
