### PR TITLE
[FIX] point_of_sale: ensure invoice is paid when invoicing

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -926,7 +926,13 @@ class PosOrder(models.Model):
         if receivable_account.reconcile:
             invoice_receivables = self.account_move.line_ids.filtered(lambda line: line.account_id == receivable_account and not line.reconciled)
             if invoice_receivables:
-                payment_receivables = payment_moves.mapped('line_ids').filtered(lambda line: line.account_id == receivable_account and line.partner_id)
+                credit_line_ids = payment_moves._context.get('credit_line_ids', None)
+                payment_receivables = payment_moves.mapped('line_ids').filtered(
+                    lambda line: (
+                        (credit_line_ids and line.id in credit_line_ids) or
+                        (not credit_line_ids and line.account_id == receivable_account and line.partner_id)
+                    )
+                )
                 (invoice_receivables | payment_receivables).sudo().with_company(self.company_id).reconcile()
         return payment_moves
 

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -65,6 +65,7 @@ class PosPayment(models.Model):
 
     def _create_payment_moves(self, is_reverse=False):
         result = self.env['account.move']
+        credit_line_ids = []
         for payment in self:
             order = payment.pos_order_id
             payment_method = payment.payment_method_id
@@ -99,6 +100,10 @@ class PosPayment(models.Model):
                 'move_id': payment_move.id,
                 'partner_id': accounting_partner.id if is_split_transaction and is_reverse else False,
             }, amounts['amount'], amounts['amount_converted'])
-            self.env['account.move.line'].create([credit_line_vals, debit_line_vals])
+            lines = self.env['account.move.line'].create([credit_line_vals, debit_line_vals])
+            if amounts['amount_converted'] < 0:
+                credit_line_ids += lines.filtered(lambda l: l.debit).ids
+            else:
+                credit_line_ids += lines.filtered(lambda l: l.credit).ids
             payment_move._post()
-        return result
+        return result.with_context(credit_line_ids=credit_line_ids)


### PR DESCRIPTION
Before this commit, if a payment method requiring customer identification was used for an order in Point of Sale but the order was not immediately invoiced, closing the session and later invoicing the order in a new session would result in the invoice being marked as unpaid.

opw-4292231

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
