### PR TITLE
[FIX] hr_holidays: accrual plans access rights

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -598,7 +598,7 @@ class HolidaysType(models.Model):
         for allocation in allocations:
             expiration_date = allocation.date_to
 
-            accrual_plan_level = allocation._get_current_accrual_plan_level_id(target_date)[0]
+            accrual_plan_level = allocation.sudo()._get_current_accrual_plan_level_id(target_date)[0]
             carryover_policy = accrual_plan_level.action_with_unused_accruals if accrual_plan_level else False
             carryover_date = False
             if carryover_policy in ['maximum', 'lost']:
@@ -625,7 +625,7 @@ class HolidaysType(models.Model):
                 if expiration_date and expiration_date == closest_expiration_date:
                     expiring_leaves_count += remaining_leaves[allocation]['virtual_remaining_leaves']
                 elif carryover_date and carryover_date == closest_expiration_date:
-                    accrual_plan_level = allocation._get_current_accrual_plan_level_id(target_date)[0]
+                    accrual_plan_level = allocation.sudo()._get_current_accrual_plan_level_id(target_date)[0]
                     expiring_leaves_count += max(0, remaining_leaves[allocation]['virtual_remaining_leaves'] - accrual_plan_level.postpone_max_days)
             if expiring_leaves_count != 0:
                 return closest_expiration_date, expiring_leaves_count


### PR DESCRIPTION
Accrual plans are not readable for regular users, so once a user has an accrual plan set on one of his allocation, he cannot open anymore his time off dashboard when it tries to get his allocation data (the time off he has).

To ensure the correct computation of available time off, we add a sudo.

This has been introduced in https://github.com/odoo/odoo/pull/172892/


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
