### PR TITLE
[FIX] account_edi_ubl_cii: _get_customization_ids not inherited

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_21.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_21.py
@@ -40,7 +40,6 @@ class AccountEdiXmlUBL21(models.AbstractModel):
 
         return vals
 
-    @api.model
     def _get_customization_ids(self):
         return {
             'ubl_bis3': 'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0',


### PR DESCRIPTION
The method has an api.model while it is inherited (and designed as such) in other modules.
It causes issues if you create a company with an existing participant in the country of these other modules and with the default eas.

Example: create a company with the module l10n_jp_ubl_pint installed, 
Japan as country and put as Tax number the endpoint of an existing participant 
When saving, it will traceback, as the key is not in the dict



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
