### PR TITLE
[FIX] mail: unfollow icon in message actions

### DIFF
--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -113,7 +113,7 @@ messageActionsRegistry
     })
     .add("unfollow", {
         condition: (component) => component.props.message.canUnfollow(component.props.thread),
-        icon: "fa-user-times",
+        icon: "fa fa-user-times",
         title: _t("Unfollow"),
         onClick: (component) => component.props.message.unfollow(),
         sequence: 60,


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/184552

Commit above fixed an issue with `.oi` icon not showing correctly.
To fix the issue, it puts the appropriate prefix `.fa` and `.oi` in the icon of the message action.

The "Unfollow" message action was not properly adapted, which results in buggy icon due to missing `.fa`.
This commit adds `.fa` in its icon definition similarly to how all message actions that use a font awesome icon should do.