### PR TITLE
[FIX] hr_expense: Fix bad commercial_partner_id

### DIFF
--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -9,6 +9,18 @@ class AccountMove(models.Model):
 
     expense_sheet_id = fields.One2many('hr.expense.sheet', 'account_move_id')
 
+    @api.depends('partner_id', 'expense_sheet_id', 'company_id')
+    def _compute_commercial_partner_id(self):
+        own_expense_moves = self.filtered(lambda move: move.sudo().expense_sheet_id.payment_mode == 'own_account')
+        for move in own_expense_moves:
+            if move.expense_sheet_id.payment_mode == 'own_account':
+                move.commercial_partner_id = (
+                    move.partner_id.commercial_partner_id
+                    if move.partner_id.commercial_partner_id != move.company_id.partner_id
+                    else move.partner_id
+                )
+        super(AccountMove, self - own_expense_moves)._compute_commercial_partner_id()
+
     def action_open_expense_report(self):
         self.ensure_one()
         return {

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1339,7 +1339,8 @@ class HrExpenseSheet(models.Model):
             # to set it to '' which cause no number to be given to the account.move when posted.
             'journal_id': self.journal_id.id,
             'move_type': 'in_invoice',
-            'partner_id': self.employee_id.sudo().address_home_id.commercial_partner_id.id,
+            'partner_id': self.employee_id.sudo().address_home_id.id,
+            'commercial_partner_id': self.employee_id.user_partner_id.id,
             'currency_id': self.currency_id.id,
             'line_ids':[Command.create(expense._prepare_move_line_vals()) for expense in self.expense_line_ids],
         }

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -1424,6 +1424,36 @@ class TestExpenses(TestExpenseCommon):
         expense_sheet.expense_line_ids.analytic_distribution = {self.analytic_account_1.id: 100.00}
         expense_sheet.with_context(validate_analytic=True).approve_expense_sheets()
 
+    def test_expense_no_stealing_from_employees(self):
+        """
+        Test to check that the company doesn't steal their employee when the commercial_partner_id of the employee partner
+        is the company
+        """
+        self.expense_employee.user_partner_id.parent_id = self.env.company.partner_id
+        self.assertEqual(self.env.company.partner_id, self.expense_employee.user_partner_id.commercial_partner_id)
+
+        expense_sheet = self.env['hr.expense.sheet'].create({
+            'name': 'Company Cash Basis Expense Report',
+            'employee_id': self.expense_employee.id,
+            'payment_mode': 'own_account',
+            'state': 'approve',
+            'expense_line_ids': [Command.create({
+                'name': 'Company Cash Basis Expense',
+                'product_id': self.product_c.id,
+                'payment_mode': 'own_account',
+                'total_amount': 20.0,
+                'employee_id': self.expense_employee.id,
+            })]
+        })
+        expense_sheet.action_submit_sheet()
+        expense_sheet.approve_expense_sheets()
+        expense_sheet.action_sheet_move_create()
+        move = expense_sheet.account_move_id
+
+        self.assertNotEqual(move.commercial_partner_id, self.env.company.partner_id)
+        self.assertEqual(move.partner_id, self.expense_employee.user_partner_id)
+        self.assertEqual(move.commercial_partner_id, self.expense_employee.user_partner_id)
+
     def test_expense_by_company_with_caba_tax(self):
         """When using cash basis tax in an expense paid by the company, the transition account should not be used."""
 


### PR DESCRIPTION
This fixes the simple, yet very common case where:
- You are creating an expense for one of your employee
- The partner of said employee has its field `parent_id` set to be your own company
- The expense move commercial_partner_id would then always be yourself
- You never pay your employees, only yourself
- ???
- Jail

task-id: 4345465

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
