### PR TITLE
[ADD] l10n_din5008_expense: add bridge module for din5008 expense reports

### DIFF
--- a/addons/l10n_din5008_expense/__init__.py
+++ b/addons/l10n_din5008_expense/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/l10n_din5008_expense/__manifest__.py
+++ b/addons/l10n_din5008_expense/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    'name': 'DIN 5008 - Expenses',
+    'category': 'Accounting/Localizations',
+    'version': '1.0',
+    'depends': [
+        'l10n_din5008',
+        'hr_expense',
+    ],
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_din5008_expense/i18n/de.po
+++ b/addons/l10n_din5008_expense/i18n/de.po
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_din5008_expense
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-03 09:12+0000\n"
+"PO-Revision-Date: 2025-06-03 09:12+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_din5008_expense
+#: model:ir.model,name:l10n_din5008_expense.model_hr_expense_sheet
+msgid "Expense Report"
+msgstr "Spesenabrechnung"
+
+#. module: l10n_din5008_expense
+#. odoo-python
+#: code:addons/l10n_din5008_expense/models/hr_expense_sheet.py:0
+#, python-format
+msgid "Expenses Report"
+msgstr "Spesenabrechnung"
+
+#. module: l10n_din5008_expense
+#: model:ir.model.fields,field_description:l10n_din5008_expense.field_hr_expense_sheet__l10n_din5008_document_title
+msgid "L10N Din5008 Document Title"
+msgstr "L10N Din5008 Dokumenttitel"

--- a/addons/l10n_din5008_expense/i18n/fr.po
+++ b/addons/l10n_din5008_expense/i18n/fr.po
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_din5008_expense
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-03 09:16+0000\n"
+"PO-Revision-Date: 2025-06-03 09:16+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_din5008_expense
+#: model:ir.model,name:l10n_din5008_expense.model_hr_expense_sheet
+msgid "Expense Report"
+msgstr "Dépense"
+
+#. module: l10n_din5008_expense
+#. odoo-python
+#: code:addons/l10n_din5008_expense/models/hr_expense_sheet.py:0
+#, python-format
+msgid "Expenses Report"
+msgstr "Rapport de dépenses"
+
+#. module: l10n_din5008_expense
+#: model:ir.model.fields,field_description:l10n_din5008_expense.field_hr_expense_sheet__l10n_din5008_document_title
+msgid "L10N Din5008 Document Title"
+msgstr "Titre du document L10N Din5008"

--- a/addons/l10n_din5008_expense/i18n/it.po
+++ b/addons/l10n_din5008_expense/i18n/it.po
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_din5008_expense
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-03 09:16+0000\n"
+"PO-Revision-Date: 2025-06-03 09:16+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_din5008_expense
+#: model:ir.model,name:l10n_din5008_expense.model_hr_expense_sheet
+msgid "Expense Report"
+msgstr "Nota spese"
+
+#. module: l10n_din5008_expense
+#. odoo-python
+#: code:addons/l10n_din5008_expense/models/hr_expense_sheet.py:0
+#, python-format
+msgid "Expenses Report"
+msgstr "Nota spese"
+
+#. module: l10n_din5008_expense
+#: model:ir.model.fields,field_description:l10n_din5008_expense.field_hr_expense_sheet__l10n_din5008_document_title
+msgid "L10N Din5008 Document Title"
+msgstr "Titolo del documento L10N Din5008"

--- a/addons/l10n_din5008_expense/i18n/l10n_din5008_expense.pot
+++ b/addons/l10n_din5008_expense/i18n/l10n_din5008_expense.pot
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_din5008_expense
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-03 09:03+0000\n"
+"PO-Revision-Date: 2025-06-03 09:03+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_din5008_expense
+#: model:ir.model,name:l10n_din5008_expense.model_hr_expense_sheet
+msgid "Expense Report"
+msgstr ""
+
+#. module: l10n_din5008_expense
+#. odoo-python
+#: code:addons/l10n_din5008_expense/models/hr_expense_sheet.py:0
+#, python-format
+msgid "Expenses Report"
+msgstr ""
+
+#. module: l10n_din5008_expense
+#: model:ir.model.fields,field_description:l10n_din5008_expense.field_hr_expense_sheet__l10n_din5008_document_title
+msgid "L10N Din5008 Document Title"
+msgstr ""

--- a/addons/l10n_din5008_expense/models/__init__.py
+++ b/addons/l10n_din5008_expense/models/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_expense_sheet

--- a/addons/l10n_din5008_expense/models/hr_expense_sheet.py
+++ b/addons/l10n_din5008_expense/models/hr_expense_sheet.py
@@ -1,0 +1,11 @@
+from odoo import _, fields, models
+
+
+class HrExpenseSheet(models.Model):
+    _inherit = 'hr.expense.sheet'
+
+    l10n_din5008_document_title = fields.Char(compute='_compute_l10n_din5008_document_title')
+
+    def _compute_l10n_din5008_document_title(self):
+        for sheet in self:
+            sheet.l10n_din5008_document_title = _("Expenses Report")


### PR DESCRIPTION
Issue:
Expense title is duplicated when printing an expense report for localizations using the DIN5008 standard.

Steps to reproduce:
- Install German localization
- Create a new expense report
- Print the expense report PDF
-> Title is duplicated

Cause:
DIN5008 reports tries to load a specific field `l10n_din5008_document_title` in their header
and fallbacks to report's name

With this commit, we add a bridge module to add the field
`l10n_din5008_document_title` to `hr.expense.sheet` and set it to
'Expenses Report`, therefore the header will have 'Expenses Report' as
title, like in the standard expense report.

opw-4314414