### PR TITLE
[FIX] account_edi_ubl_cii: Fix wrong warning on Credit Note

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move_send.py
+++ b/addons/account_edi_ubl_cii/models/account_move_send.py
@@ -49,7 +49,7 @@ class AccountMoveSend(models.AbstractModel):
                 }
 
         ubl_formats = set(self.env['res.partner']._get_ubl_cii_formats())
-        if moves_without_bank := moves.filtered(lambda m: moves_data[m]['invoice_edi_format'] in ubl_formats and not m.partner_bank_id):
+        if moves_without_bank := moves.filtered(lambda m: m.move_type == 'out_invoice' and moves_data[m]['invoice_edi_format'] in ubl_formats and not m.partner_bank_id):
             alerts['account_edi_ubl_cii_configure_bank'] = {
                 'message': _("Please add a Recipient bank in the 'Other Info' tab to generate a complete file."),
                 'level': 'danger' if len(moves_without_bank) == 1 else 'warning',


### PR DESCRIPTION
The previous warning asking to add a Recipient Bank  was shown
incorrectly in previous versions in case of Credit Notes.
With the rework, we escalated this warning to a danger warning that
prevent from sending, as in case of Customer Invoices it is a
blocking error.

The combinations of those two is now preventing Credit Notes to be sent with
an UBL XML file.

See: https://github.com/odoo/odoo/commit/9e769e1b11f22890e5245859053bc8dd31e42634

task-no
