### PR TITLE
[FIX] base: don't check access rule on server action with group(s)

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -973,7 +973,7 @@ class IrActionsServer(models.Model):
             eval_context = self._get_eval_context(action)
             records = eval_context.get('record') or eval_context['model']
             records |= eval_context.get('records') or eval_context['model']
-            if records.ids:
+            if not action_groups and records.ids:
                 # check access rules on real records only; base automations of
                 # type 'onchange' can run server actions on new records
                 try:


### PR DESCRIPTION
If the action server has a group and the current user belongs to it, skip the write access check on the records. This allows the action server to explicitly modify records even when the user lacks the necessary access rights.

However, if the model has write access but no group, ensure the access rule check is performed on the record.

This is a regression introduced in version 18.0 by PR https://github.com/odoo/odoo/pull/179148 (commit: https://github.com/odoo-dev/odoo/commit/298c96045ecaff6cdd89cf192d5ed3a7eb931e98)