### PR TITLE
[FIX] point_of_sale: fix lot/SN

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -145,7 +145,7 @@ export class PosOrderline extends Base {
         const lotLinesToRemove = [];
 
         for (const lotLine of this.pack_lot_ids) {
-            const modifiedLotName = modifiedPackLotLines[lotLine.uuid];
+            const modifiedLotName = modifiedPackLotLines[lotLine.id];
             if (modifiedLotName) {
                 lotLine.lot_name = modifiedLotName;
             } else {
@@ -352,6 +352,9 @@ export class PosOrderline extends Base {
     merge(orderline) {
         this.order_id.assert_editable();
         this.set_quantity(this.get_quantity() + orderline.get_quantity());
+        this.update({
+            pack_lot_ids: [["link", ...orderline.pack_lot_ids]],
+        });
     }
 
     set_unit_price(price) {

--- a/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
@@ -237,3 +237,37 @@ registry.category("web_tour.tours").add("RefundFewQuantities", {
             Order.hasLine("Sugar", "-0.02", "-0.06"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("LotTour", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            ProductScreen.enterLotNumber("1"),
+            ProductScreen.selectedOrderlineHas("Product A", "1.00"),
+            inLeftSide(
+                [
+                    ProductScreen.clickLotIcon(),
+                    ProductScreen.enterLotNumber("2"),
+                    Order.hasLine({
+                        productName: "Product A",
+                        quantity: 1.0,
+                    }),
+                    ProductScreen.clickLotIcon(),
+                    ProductScreen.enterLastLotNumber("1"),
+                    Order.hasLine({
+                        productName: "Product A",
+                        quantity: 2.0,
+                    }),
+                ].flat()
+            ),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            ProductScreen.enterLastLotNumber("3"),
+            ProductScreen.selectedOrderlineHas("Product A", "3.00"),
+            inLeftSide({
+                trigger: ".info-list:contains('SN 3')",
+            }),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -366,6 +366,17 @@ export function enterLotNumber(number) {
     ];
 }
 
+export function enterLastLotNumber(number) {
+    return [
+        {
+            content: "enter lot number",
+            trigger: ".edit-list-inputs .input-group:last-child input",
+            run: "edit " + number,
+        },
+        Dialog.confirm(),
+    ];
+}
+
 export function isShown() {
     return [
         {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1549,6 +1549,17 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, "AutofillCashCount", login="pos_user")
 
+    def test_lot(self):
+        self.product1 = self.env['product.product'].create({
+            'name': 'Product A',
+            'is_storable': True,
+            'tracking': 'serial',
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'available_in_pos': True,
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'LotTour', login="pos_user")
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
When adding/modifying SN on an orderline in the PoS the changes where not always correctly reflected and sometimes it was just not displayed.

Steps to reproduce:
-------------------
* Create a product tracked by SN
* Open PoS
* Add this product to the cart and put SN 1
* Add the same product by clicking on it, and put SN 2
> Observation: The item in the cart won't be updated correctly, only one
SN will be shown
* Click on the lot icon
* Add a new SN 3
> Observation: Again the new SN won't be shown

opw-4323167