### PR TITLE
[FIX] mail: request iOS push permission when actually promptable

### DIFF
--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -6,7 +6,6 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { MessagingMenuQuickSearch } from "@mail/core/web/messaging_menu_quick_search";
-import { isDisplayStandalone, isIOS, isIosApp } from "@web/core/browser/feature_detection";
 
 Object.assign(MessagingMenu.components, { MessagingMenuQuickSearch });
 
@@ -175,10 +174,6 @@ patch(MessagingMenu.prototype, {
         return value;
     },
     get shouldAskPushPermission() {
-        if (isIOS() && !isDisplayStandalone() && !isIosApp()) {
-            // iOS browser apps do not have push notifications: Only PWA and apps have them.
-            return false;
-        }
         return this.notification.permission === "prompt";
     },
 });


### PR DESCRIPTION
Follow-up of [1] and [2]

iOS push notifications do not work on Safari: they only work in apps. The notifications are managed by the apps, whether with native mobile app or PWA.

With PWA, it should normally rely on `Notification.permission`, but somehow it doesn't work and always has value "default". Its showing has been limited to the PWA, but it keeps showing a persistent notification. Clicking on it the 1st time displays a prompt to either accept or deny the permissions. Afterwards, further clicks on the "odoobot has a request" automatically display "granted" or "denied" based on user initial choice.

iOS push permissions seem to necessarily rely on
`serviceWorker.getRegistration().pushManager`, which works only on HTTPS, hence why iOS push notifications do not work on HTTP. Also actual push permission state are correct there whereas on Notification.permission they are wrong.

This commit fixes the issue by computing the push notification permisssion state correctly on iOS, using
`serviceWorker.getRegistration().pushManager`.

[1]: https://github.com/odoo/odoo/pull/178057
[2]: https://github.com/odoo/odoo/pull/187038
