### PR TITLE
[FIX] base: fix jsonb null cast error

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2961,8 +2961,6 @@ class BaseModel(metaclass=MetaModel):
                     fallback=fallback,
                     column_type=SQL(field._column_type[1]),
                 )
-            if field.type in ('boolean', 'integer', 'float', 'monetary'):
-                return SQL('(%s)::%s', sql_field, SQL(field._column_type[1]))
             # here the specified value for a company might be NULL e.g. '{"1": null}'::jsonb
             # the result of current sql_field might be 'null'::jsonb
             # ('null'::jsonb)::text == 'null'


### PR DESCRIPTION
Issue -->

For company dependant fields of type `boolean`, `integer`, `float`, `monetary`, casting a `null` value leads to a `cannot cast jsonb null to type _` error on postgresql.

For example, consider the following ->
1. Database has two companies : 'a' and 'b'
2. has one res.partner record with no `credit_limit` set.
3. `credit_limit` (float or numeric) is not a required field and does not have a default value

`credit_limit` on the backend looks like `{"a.id": null, "b.id": null}`

Fetching the value for this field leads to method `_field_to_sql` which builds the select query, while also casting the type to each field. In this case, with no fallback default value and a float field, the query is `SELECT ("res_partner"."credit_limit"->'a.id')::double precision FROM res_partner` which resolves to `null(jsonb)::double precision` which unfortunately, is not supported on Postgresql.

Solution -->

Remove the condition for the types `boolean`, `integer`, `float`, `monetary` and use the `field->company_id->>0` logic instead. This works because the `->>` operator returns a text object; the text `null` value can be cast into the types mentioned above.
https://github.com/odoo/odoo/blob/2ed38db47ac3152eef1a0e328c8ff572474d079f/odoo/models.py#L2964-L2967

opw-4313425




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
