### PR TITLE
[FIX] core: fix company dependent flush

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1490,6 +1490,11 @@ class Boolean(Field[bool]):
     def convert_to_column(self, value, record, values=None, validate=True):
         return bool(value)
 
+    def convert_to_column_update(self, value, record):
+        if self.company_dependent:
+            value = {k: bool(v) for k, v in value.items()}
+        return super().convert_to_column_update(value, record)
+
     def convert_to_cache(self, value, record, validate=True):
         return bool(value)
 
@@ -1513,6 +1518,11 @@ class Integer(Field[int]):
 
     def convert_to_column(self, value, record, values=None, validate=True):
         return int(value or 0)
+
+    def convert_to_column_update(self, value, record):
+        if self.company_dependent:
+            value = {k: int(v or 0) for k, v in value.items()}
+        return super().convert_to_column_update(value, record)
 
     def convert_to_cache(self, value, record, validate=True):
         if isinstance(value, dict):
@@ -1619,6 +1629,11 @@ class Float(Field[float]):
         if self.company_dependent:
             return value_float
         return value
+
+    def convert_to_column_update(self, value, record):
+        if self.company_dependent:
+            value = {k: float(v or 0.0) for k, v in value.items()}
+        return super().convert_to_column_update(value, record)
 
     def convert_to_cache(self, value, record, validate=True):
         # apply rounding here, otherwise value in cache may be wrong!

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2961,8 +2961,6 @@ class BaseModel(metaclass=MetaModel):
                     fallback=fallback,
                     column_type=SQL(field._column_type[1]),
                 )
-            if field.type in ('boolean', 'integer', 'float', 'monetary'):
-                return SQL('(%s)::%s', sql_field, SQL(field._column_type[1]))
             # here the specified value for a company might be NULL e.g. '{"1": null}'::jsonb
             # the result of current sql_field might be 'null'::jsonb
             # ('null'::jsonb)::text == 'null'


### PR DESCRIPTION
The problem is caused by https://github.com/odoo/odoo/pull/184275
For company dependent Boolean/Integer/Float fields, if fallback is unset or
falsy, the value filled to cache can be `None` after fetch.
When `_flush` `None` in cache for these fields should be converted to the
logical equivalent `False`/`0`/`0.0` to allow SQL to compare with the fallback
value and drop them when UPDATE


opw-4313425

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
