### PR TITLE
[FIX] website_sale: avoid unsupported operand type error when writing country_id in test

### DIFF
--- a/addons/website_sale/tests/test_website_sale_add_to_cart_snippet.py
+++ b/addons/website_sale/tests/test_website_sale_add_to_cart_snippet.py
@@ -77,7 +77,7 @@ class TestAddToCartSnippet(HttpCase):
             'street2': "",
             'city': "Ramillies",
             'zip': 1367,
-            'country_id': self.env.ref('base.be')
+            'country_id': self.env.ref('base.be').id
         })
         self.env.ref('base.user_admin').country_id = self.env.ref('base.be')
         self.start_tour("/", 'add_to_cart_snippet_tour', login="admin")


### PR DESCRIPTION
UserWarning: unsupported operand type(s) for "==": 'res.country()' == '233'





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
