### PR TITLE
[FIX] stock_account: avoid singleton error when checking company_id in Anglo-Saxon accounting

### DIFF
--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -63,8 +63,9 @@ class StockValuationLayer(models.Model):
         for product, svls in products_svl:
             svls = self.browse(svl.id for svl in svls)
             moves = svls.stock_move_id
-            if svls.company_id.anglo_saxon_accounting:
-                moves._get_related_invoices()._stock_account_anglo_saxon_reconcile_valuation(product=product)
+            anglo_saxon_svls = svls.filtered('company_id.anglo_saxon_accounting')
+            if anglo_saxon_svls:
+                anglo_saxon_svls.stock_move_id._get_related_invoices()._stock_account_anglo_saxon_reconcile_valuation(product=product)
             moves = (moves | moves.origin_returned_move_id).with_prefetch(chain(moves._prefetch_ids, moves.origin_returned_move_id._prefetch_ids))
             for aml in moves._get_all_related_aml():
                 if aml.reconciled or aml.move_id.state != "posted" or not aml.account_id.reconcile:


### PR DESCRIPTION
From https://github.com/odoo/odoo/commit/e862e3f7b52f322389dea16666d6e495e6f75aaf, a `ValueError: Expected singleton` occurs in the following scenario:
- The variable `svls` contains multiple stock valuation layers belonging to different companies.
- The code attempts to access `svls.company_id.anglo_saxon_accounting` in a conditional statement, causing a singleton error.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
