### PR TITLE
[FIX] stock_account: avoid changing property_val for any setting change

### DIFF
--- a/addons/stock_account/models/res_config_settings.py
+++ b/addons/stock_account/models/res_config_settings.py
@@ -17,6 +17,6 @@ class ResConfigSettings(models.TransientModel):
     def set_values(self):
         automatic_before = self.env.user.has_group('stock_account.group_stock_accounting_automatic')
         super().set_values()
-        if automatic_before and not self.group_stock_accounting_automatic:
+        if automatic_before and not self.env.user.has_group('stock_account.group_stock_accounting_automatic'):
             self.env['product.category'].sudo().with_context(active_test=False).search([
                 ('property_valuation', '=', 'real_time')]).property_valuation = 'manual_periodic'


### PR DESCRIPTION
If we only use the community module, there is no interface to activate the automated stock accounting feature on the accounting page. Instead, we have to manually assign group_stock_accounting_automatic to each user.
However, from PR odoo/odoo#133254, any setting changes will change all of the property_valuations to
'manual_periodic'.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
