### PR TITLE
[FIX] sms: fix traceback when user changes the url in sms iap

### DIFF
--- a/addons/sms/tools/sms_api.py
+++ b/addons/sms/tools/sms_api.py
@@ -56,7 +56,7 @@ class SmsApi:
         We prefer a dict instead of a message-per-error-state based method so that we only call
         config parameters getters once and avoid extra RPC calls."""
         buy_credits_url = self.env['iap.account'].sudo().get_credits_url(service_name='sms')
-        buy_credits = f'<a href="{buy_credits_url}" target="_blank">%s</a>' % _('Buy credits.')
+        buy_credits = '<a href="{}" target="_blank">{}</a>'.format(buy_credits_url, _("Buy credits."))
 
         sms_endpoint = self.env['ir.config_parameter'].sudo().get_param('sms.endpoint', self.DEFAULT_ENDPOINT)
         sms_account_token = self.env['iap.account'].sudo().get('sms').account_token


### PR DESCRIPTION
Currently, a traceback occurs when the user changes the SMS iap URL and tries to test SMS mailing.

To reproduce this issue:
1) Install `mass_mailing_sms`
2) Add 'B' in the SMS `IAP` URL from the `settings/technical/iap` 
3) Open any SMS marketing record and click on the `Test` button

Error:-
```
ValueError: unsupported format character 'B' (0x42) at index 152
```

When the user gives the 'B' in the URL string, it is converted to `%B%` in the URL. 
As it leads to a traceback as `%s` is used to format two strings.

https://github.com/odoo/odoo/blob/a98a8859696f5a69afe2954a3f5493b611ee252b/addons/sms/tools/sms_api.py#L59

This error occurs when using the old-style string formatting (%s) within an f-string. 
When using f-strings, we don't need to mix them with the % formatting method.

We can replace the `%` formatting with the `format` method.

sentry-6072287605
