### PR TITLE
[IMP] hr_recruitment: link the attachment

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -654,6 +654,11 @@ class HrApplicant(models.Model):
         self.ensure_one()
         action = self.candidate_id.create_employee_from_candidate()
         employee = self.env['hr.employee'].browse(action['res_id'])
+        employee_attachments = self.env['ir.attachment'].search([('res_model', '=','hr.employee'), ('res_id', '=', employee.id)])
+        unique_attachments = self.attachment_ids.filtered(
+            lambda attachment: attachment.datas not in employee_attachments.mapped('datas')
+        )
+        unique_attachments.copy({'res_model': 'hr.employee', 'res_id': employee.id})
         employee.write({
             'job_id': self.job_id.id,
             'job_title': self.job_id.name,

--- a/addons/hr_recruitment/models/hr_candidate.py
+++ b/addons/hr_recruitment/models/hr_candidate.py
@@ -334,6 +334,9 @@ class HrCandidate(models.Model):
 
         action = self.env['ir.actions.act_window']._for_xml_id('hr.open_view_employee_list')
         employee = self.env['hr.employee'].create(self._get_employee_create_vals())
+        attachments = self.env['ir.attachment'].search([('res_model', '=', self._name), ('res_id', '=', self.id)])
+        if attachments:
+            attachments.copy({'res_model': 'hr.employee', 'res_id': employee.id})
         action['res_id'] = employee.id
         return action
 


### PR DESCRIPTION
In this PR, when you create an employee using the 'Create Employee' button
after completing the signing process, the system will link the attachment to
the employee's profile.

This feature saves users time when searching for those documents.

Task-4342357
