### PR TITLE
[FIX] point_of_sale,pos_sms : prevent error while sending POS attachment

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -108,12 +108,10 @@ export class ReceiptScreen extends Component {
         }
         const fullTicketImage = await this.generateTicketImage();
         const basicTicketImage = await this.generateTicketImage(true);
-        await this.pos.data.call("pos.order", action, [
-            [order.id],
-            destination,
-            fullTicketImage,
-            this.pos.basic_receipt ? basicTicketImage : null,
-        ]);
+        await this.pos.data.call("pos.order", action, [[order.id], destination], {
+            ticket_image: fullTicketImage,
+            basic_image: this.pos.basic_receipt ? basicTicketImage : null,
+        });
     }
 }
 

--- a/addons/pos_sms/models/pos_order.py
+++ b/addons/pos_sms/models/pos_order.py
@@ -4,7 +4,7 @@ from odoo import models
 class PosOrder(models.Model):
     _inherit = 'pos.order'
 
-    def action_sent_message_on_sms(self, phone, _):
+    def action_sent_message_on_sms(self, phone, _, **kwargs):
         if not (self and self.config_id.module_pos_sms and self.config_id.sms_receipt_template_id and phone):
             return
         self.ensure_one()


### PR DESCRIPTION
Currently, an exception is generated when the user tries to send a POS order receipt on WhatsApp.

Error
```
TypeError: PosOrder.action_sent_receipt_on_whatsapp() takes 3 positional arguments but 4 were given
  File "odoo/http.py", line 2363, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1891, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1954, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1921, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2168, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 329, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 727, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 517, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
```

This is because of the recent refacre code with the commit [1]. method `_sendReceiptToCustomer` calls Python RPC where 4 arguments passed see [2], but the Python method was not dapted with chages of commit [1].

This commit fixes the above issue by setting `ticket_image` and `basic_image` as optional arguments and adapting the Python method according to these changes.

[1] - https://github.com/odoo/odoo/commit/47ec8957334aa37fd9b1d2267681fbd44064809f
[2] - https://github.com/odoo/odoo/blob/2eec78d10380893bd9dbfcef407de50c231cc3bb/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js#L111-L116

sentry-5662499209

Related ent  PR- https://github.com/odoo/enterprise/pull/74145

