### PR TITLE
[FIX] discuss: ensure aspect ratio of call invitation avatars

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_invitation.xml
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.xml
@@ -4,7 +4,7 @@
     <t t-name="discuss.CallInvitation">
         <div class="o-discuss-CallInvitation d-flex flex-column m-2 p-5 border border-dark rounded-1 text-bg-900" t-attf-class="{{ className }}" t-ref="root">
             <div t-if="props.thread.rtcInvitingSession" class="o-discuss-CallInvitation-correspondent d-flex flex-column justify-content-around align-items-center text-nowrap">
-                <img class="mb-2 rounded-circle cursor-pointer"
+                <img class="o-discuss-CallInvitation-avatar mb-2 rounded-circle cursor-pointer"
                     t-att-src="threadService.avatarUrl(props.thread.rtcInvitingSession?.channelMember?.persona, props.thread)"
                     t-on-click="onClickAvatar"
                     alt="Avatar"/>

--- a/addons/mail/static/src/discuss/call/common/call_invitations.scss
+++ b/addons/mail/static/src/discuss/call/common/call_invitations.scss
@@ -1,3 +1,7 @@
 .o-discuss-CallInvitations {
     z-index: $zindex-modal;
 }
+
+.o-discuss-CallInvitation-avatar {
+    aspect-ratio: 1;
+}


### PR DESCRIPTION
Before this commit, the profile picture of a user would affect the dimensions of the image element. This commit fixes the issue by enforcing an aspect ratio of 1.
