### PR TITLE
[IMP] pos_restaurant: early receipt printing

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -5,8 +5,7 @@
             expr="//t[@t-if='props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
             position="before">
             <t t-if="pos.config.module_pos_restaurant">
-                <!-- All buttons always displayed -->
-                <button t-att-class="buttonClass"
+                <button t-if="pos.config.iface_printbill" t-att-class="buttonClass"
                     t-att-disabled="!pos.getOrder()?.getOrderlines()?.length"
                     t-on-click="clickPrintBill">
                     <i class="fa fa-print me-1"></i>Bill

--- a/addons/pos_restaurant/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_restaurant/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
@@ -2,10 +2,8 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="pos_restaurant.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('pos-receipt-order-data')]" position="inside">
-            <t t-if="props.data.isBill">
-                <div>PRO FORMA</div>
-            </t>
+        <xpath expr="//ReceiptHeader" position="after">
+            <div t-if="props.data.isBill" class="fs-2 mb-1">Pro forma receipt</div>
         </xpath>
         <xpath expr="//div[hasclass('receipt-change')]" position="attributes">
             <attribute name="t-if">!props.data.isBill</attribute>


### PR DESCRIPTION
Before this commit:
====================
The `Bill`control button was always visible in POS Restaurant

After this commit:
=======================
The visibility of the `Bill` control button is now determined by the
activation of the `Early Receipt Printing` setting in the Restaurant
configuration. and the receipt will have a label pro forma receipt if early
receipt print.

Task- 4342124