### PR TITLE
[FIX] html_editor: applied color should be selected in solid tab

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -316,7 +316,7 @@ export class ColorPlugin extends Plugin {
         const usedCustomColors = new Set();
         for (const font of allFont) {
             if (isCSSColor(font.style[mode])) {
-                usedCustomColors.add(font.style[mode]);
+                usedCustomColors.add(rgbToHex(font.style[mode]));
             }
         }
         return usedCustomColors;

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -74,7 +74,7 @@ export class ColorPlugin extends Plugin {
      * @param {'foreground'|'background'} type
      */
     getPropsForColorSelector(type) {
-        const mode = type === "foreground" ? "color" : "background";
+        const mode = type === "foreground" ? "color" : "backgroundColor";
         return {
             type,
             getUsedCustomColors: () => this.getUsedCustomColors(mode),

--- a/addons/html_editor/static/src/main/font/color_selector.scss
+++ b/addons/html_editor/static/src/main/font/color_selector.scss
@@ -18,7 +18,7 @@
     margin-bottom: 3px;
 }
 
-.o_colorpicker_section .o_color_button.selected {
+.o_font_color_selector .o_color_button.selected {
     // todo: check web_editor
     border: 3px solid $o-enterprise-action-color;
 }

--- a/addons/html_editor/static/src/main/font/color_selector.xml
+++ b/addons/html_editor/static/src/main/font/color_selector.xml
@@ -50,7 +50,7 @@
                                 <t t-foreach="DEFAULT_COLORS" t-as="line" t-key="line_index">
                                     <div class="o_color_section d-flex">
                                         <t t-foreach="line" t-as="color" t-key="color_index">
-                                            <button class="o_color_button btn" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
+                                            <button class="o_color_button btn" t-att-class="{'selected': color === this.currentCustomColor.color.toUpperCase()}" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
                                         </t>
                                     </div>
                                 </t>

--- a/addons/html_editor/static/src/main/font/color_selector.xml
+++ b/addons/html_editor/static/src/main/font/color_selector.xml
@@ -60,7 +60,7 @@
                             <div class="p-1">
                                 <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut">
                                     <t t-foreach="this.usedCustomColors" t-as="color" t-key="color_index">
-                                        <button class="o_color_button btn" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
+                                        <button t-if="color !== this.currentCustomColor.color.toLowerCase()" class="o_color_button btn" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
                                     </t>
                                     <button class="o_color_button btn selected" t-att-data-color="this.currentCustomColor.color" t-attf-style="background-color: {{this.currentCustomColor.color}}"/>
                                 </div>

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -97,7 +97,7 @@ test("can render and apply gradient color", async () => {
     });
 });
 
-test("custom colors used in the editor are shown in the colorpicker", async () => {
+test("custom text-colors used in the editor are shown in the colorpicker", async () => {
     await setupEditor(
         `<p>
             <font style="color: rgb(255, 0, 0);">test</font>
@@ -107,6 +107,31 @@ test("custom colors used in the editor are shown in the colorpicker", async () =
     await waitFor(".o-we-toolbar");
     expect(".o_font_color_selector").toHaveCount(0);
     await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    await click(".btn:contains('Custom')");
+    await animationFrame();
+    expect(".o_hex_input").toHaveValue("#00FF00");
+    expect(queryAllValues(".o_rgba_div input")).toEqual(["0", "255", "0", "100"]);
+    expect("button[data-color='rgb(255, 0, 0)']").toHaveCount(1);
+    expect(queryOne("button[data-color='rgb(255, 0, 0)']").style.backgroundColor).toBe(
+        "rgb(255, 0, 0)"
+    );
+    expect("button[data-color='rgb(0, 255, 0)']").toHaveCount(1);
+    expect(queryOne("button[data-color='rgb(0, 255, 0)']").style.backgroundColor).toBe(
+        "rgb(0, 255, 0)"
+    );
+});
+
+test("custom background colors used in the editor are shown in the colorpicker", async () => {
+    await setupEditor(
+        `<p>
+            <font style="background-color: rgb(255, 0, 0);">test</font>
+            <font style="background-color: rgb(0, 255, 0);">[test]</font>
+        </p>`
+    );
+    await waitFor(".o-we-toolbar");
+    expect(".o_font_color_selector").toHaveCount(0);
+    await click(".o-we-toolbar .o-select-color-background");
     await animationFrame();
     await click(".btn:contains('Custom')");
     await animationFrame();

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -181,6 +181,27 @@ test("always show the current custom color", async () => {
     );
 });
 
+test("show applied text color selected in solid color tab", async () => {
+    setupEditor(`<p><font style="color: rgb(255, 0, 0);">[test]</font></p>`);
+    await waitFor(".o-we-toolbar");
+    await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    expect(".o_color_section .o_color_button.selected").toHaveCount(1);
+    expect(queryOne(".o_color_section .o_color_button.selected").style.backgroundColor).toBe(
+        "rgb(255, 0, 0)"
+    );
+    await contains("button[data-color='#0000FF']").click();
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(0);
+    await click(".o-we-toolbar .o-select-color-foreground"); // Open color selector again
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(1);
+    expect(".o_color_section .o_color_button.selected").toHaveCount(1);
+    expect(queryOne(".o_color_section .o_color_button.selected").style.backgroundColor).toBe(
+        "rgb(0, 0, 255)"
+    );
+});
+
 test("Can reset a color", async () => {
     const { editor } = await setupEditor(
         `<p class="tested">

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -8,6 +8,7 @@ import {
     waitUntil,
     edit,
     queryAllValues,
+    queryAll,
 } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
@@ -112,14 +113,10 @@ test("custom text-colors used in the editor are shown in the colorpicker", async
     await animationFrame();
     expect(".o_hex_input").toHaveValue("#00FF00");
     expect(queryAllValues(".o_rgba_div input")).toEqual(["0", "255", "0", "100"]);
-    expect("button[data-color='rgb(255, 0, 0)']").toHaveCount(1);
-    expect(queryOne("button[data-color='rgb(255, 0, 0)']").style.backgroundColor).toBe(
-        "rgb(255, 0, 0)"
-    );
-    expect("button[data-color='rgb(0, 255, 0)']").toHaveCount(1);
-    expect(queryOne("button[data-color='rgb(0, 255, 0)']").style.backgroundColor).toBe(
-        "rgb(0, 255, 0)"
-    );
+    expect(queryAll("button[data-color='#ff0000']")).toHaveCount(1);
+    expect(queryOne("button[data-color='#ff0000']").style.backgroundColor).toBe("rgb(255, 0, 0)");
+    expect(queryAll("button[data-color='#00ff00']")).toHaveCount(1);
+    expect(queryOne("button[data-color='#00ff00']").style.backgroundColor).toBe("rgb(0, 255, 0)");
 });
 
 test("custom background colors used in the editor are shown in the colorpicker", async () => {
@@ -137,14 +134,10 @@ test("custom background colors used in the editor are shown in the colorpicker",
     await animationFrame();
     expect(".o_hex_input").toHaveValue("#00FF00");
     expect(queryAllValues(".o_rgba_div input")).toEqual(["0", "255", "0", "100"]);
-    expect("button[data-color='rgb(255, 0, 0)']").toHaveCount(1);
-    expect(queryOne("button[data-color='rgb(255, 0, 0)']").style.backgroundColor).toBe(
-        "rgb(255, 0, 0)"
-    );
-    expect("button[data-color='rgb(0, 255, 0)']").toHaveCount(1);
-    expect(queryOne("button[data-color='rgb(0, 255, 0)']").style.backgroundColor).toBe(
-        "rgb(0, 255, 0)"
-    );
+    expect(queryAll("button[data-color='#ff0000']")).toHaveCount(1);
+    expect(queryOne("button[data-color='#ff0000']").style.backgroundColor).toBe("rgb(255, 0, 0)");
+    expect(queryAll("button[data-color='#00ff00']")).toHaveCount(1);
+    expect(queryOne("button[data-color='#00ff00']").style.backgroundColor).toBe("rgb(0, 255, 0)");
 });
 
 test("select hex color and apply it", async () => {


### PR DESCRIPTION
**Current behavior before PR:**

When there is a text having a text-color or background color, opening color selector doesn't highlight the button matching with that
selected color in solid color tab.

**Desired behavior before PR is merged:**

Opening color selector highlights the button matching with that
selected color in solid color tab.

task-4341528


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
