### PR TITLE
[IMP] base, {website_}mail: read-only controllers

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -560,9 +560,11 @@ class MailActivity(models.Model):
 
         return messages, next_activities
 
+    @api.readonly
     def action_close_dialog(self):
         return {'type': 'ir.actions.act_window_close'}
 
+    @api.readonly
     def action_open_document(self):
         """ Opens the related record based on the model and ID """
         self.ensure_one()

--- a/addons/website_mail/controllers/main.py
+++ b/addons/website_mail/controllers/main.py
@@ -40,7 +40,7 @@ class WebsiteMail(http.Controller):
             record.sudo().message_subscribe(partner_ids)
             return True
 
-    @http.route(['/website_mail/is_follower'], type='json', auth="public", website=True)
+    @http.route(['/website_mail/is_follower'], type='json', auth="public", website=True, readonly=True)
     def is_follower(self, records, **post):
         """ Given a list of `models` containing a list of res_ids, return
             the res_ids for which the user is follower and some practical info.

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1150,6 +1150,7 @@ class Users(models.Model):
         devices.filtered(lambda d: not d.is_current)._revoke()
         return {'type': 'ir.actions.client', 'tag': 'reload'}
 
+    @api.readonly
     def has_groups(self, group_spec: str) -> bool:
         """ Return whether user ``self`` satisfies the given group restrictions
         ``group_spec``, i.e., whether it is member of at least one of the groups,
@@ -1181,6 +1182,7 @@ class Users(models.Model):
             return True
         return not positives
 
+    @api.readonly
     def has_group(self, group_ext_id: str) -> bool:
         """ Return whether user ``self`` belongs to the given group (given by its
         fully-qualified external ID).


### PR DESCRIPTION
Another pass of marking some routes/methods as read-only, as a follow-up to #186319 and #186786
