### PR TITLE
[FIX] core : _name_search on fields with inconsistent types

### DIFF
--- a/odoo/addons/base/tests/test_res_currency.py
+++ b/odoo/addons/base/tests/test_res_currency.py
@@ -21,3 +21,20 @@ class TestResConfig(TransactionCase):
                 node_inverse_company_rate = tree.xpath('//field[@name="inverse_company_rate"]')[0]
                 self.assertEqual(node_company_rate.get('string'), f'Unit per {expected_currency}')
                 self.assertEqual(node_inverse_company_rate.get('string'), f'{expected_currency} per Unit')
+
+    def test_res_currency_name_search(self):
+        currency_A, currency_B = self.env["res.currency"].create([
+            {"name": "cuA", "symbol": "A"},
+            {"name": "cuB", "symbol": "B"},
+        ])
+        self.env["res.currency.rate"].create([
+            {"name": "1971-01-01", "rate": 2.0, "currency_id": currency_A.id},
+            {"name": "1971-01-01", "rate": 1.5, "currency_id": currency_B.id},
+            {"name": "1972-01-01", "rate": 0.69, "currency_id": currency_B.id},
+        ])
+        # should not try to match field 'rate' (float field)
+        self.assertEqual(self.env["res.currency"].search_count([["rate_ids", "=", "1971-01-01"]]), 2)
+        # should not try to match field 'name' (date field)
+        self.assertEqual(self.env["res.currency"].search_count([["rate_ids", "=", "0.69"]]), 1)
+        # should not try to match any of 'name' and 'rate'
+        self.assertEqual(self.env["res.currency"].search_count([["rate_ids", "=", "irrelevant"]]), 0)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1632,13 +1632,31 @@ class BaseModel(metaclass=MetaModel):
         """
         args = list(args or [])
         search_fnames = self._rec_names_search or ([self._rec_name] if self._rec_name else [])
+
         if not search_fnames:
             _logger.warning("Cannot execute name_search, no _rec_name or _rec_names_search defined on %s", self._name)
+
         # optimize out the default criterion of ``like ''`` that matches everything
         elif not (name == '' and operator in ('like', 'ilike')):
             aggregator = expression.AND if operator in expression.NEGATIVE_TERM_OPERATORS else expression.OR
-            domain = aggregator([[(field_name, operator, name)] for field_name in search_fnames])
-            args += domain
+            domains = []
+            for field_name in search_fnames:
+                # field_name may be a sequence of field names (partner_id.name)
+                # retrieve the last field in the sequence
+                model = self
+                for fname in field_name.split('.'):
+                    field = model._fields[fname]
+                    model = self.env.get(field.comodel_name)
+                if field.relational:
+                    # relational fields will trigger a _name_search on their comodel
+                    domains.append([(field_name, operator, name)])
+                    continue
+                try:
+                    domains.append([(field_name, operator, field.convert_to_write(name, self))])
+                except ValueError:
+                    pass  # ignore that case if the value doesn't match the field type
+            args += aggregator(domains)
+
         return self._search(args, limit=limit, access_rights_uid=name_get_uid)
 
     @api.model


### PR DESCRIPTION
Steps to reproduce the issue:
- go to currencies;
- search for a rate with something else than a date;
- it crashes.

This happens because the currency rate model is searched with two fields, a date field (`name`) and a float field (`rate`).  This crashes when converting the value to match against, because the value cannot be serialized in SQL both as a date and a float.

What we do in such a case is to explicitly convert the value to the field's type.  If the conversion fails, we simply ignore that part of the domain.

opw-4278234
