### PR TITLE
[FIX] payment_worldline: add missing statuses

### DIFF
--- a/addons/payment_worldline/const.py
+++ b/addons/payment_worldline/const.py
@@ -55,8 +55,10 @@ REDIRECT_PAYMENT_METHODS = {
 # Mapping of transaction states to Worldline's payment statuses.
 # See https://docs.direct.worldline-solutions.com/en/integration/api-developer-guide/statuses.
 PAYMENT_STATUS_MAPPING = {
-    'pending': ('CREATED', 'AUTHORIZATION_REQUESTED'),
+    'pending': (
+        'CREATED', 'REDIRECTED', 'AUTHORIZATION_REQUESTED', 'PENDING_CAPTURE', 'CAPTURE_REQUESTED'
+    ),
     'done': ('CAPTURED',),
     'cancel': ('CANCELLED',),
-    'declined': ('REJECTED',),
+    'declined': ('REJECTED', 'REJECTED_CAPTURE'),
 }


### PR DESCRIPTION
Adding missing payment statuses:
'REDIRECTED', 'PENDING_CAPTURE' and 'CAPTURE_REQUESTED' as 'pending' states,
'REJECTED_CAPTURE' as 'declined' state
as those statuses can effectively be received from Worldline. 
