### PR TITLE
[FIX] l10n_in: correct the tax percentage with sale RC tax

### DIFF
--- a/addons/l10n_in/models/account_tax.py
+++ b/addons/l10n_in/models/account_tax.py
@@ -61,13 +61,13 @@ class AccountTax(models.Model):
                 rounding_method='round_per_line',
                 product=product,
             )
-
             # Rate.
-            rate = sum(
-                tax_data['tax'].amount
+            unique_taxes_data = set(
+                tax_data['tax']
                 for tax_data in taxes_computation['taxes_data']
                 if tax_data['tax']['l10n_in_tax_type'] in ('igst', 'cgst', 'sgst')
             )
+            rate = sum(tax.amount for tax in unique_taxes_data)
 
             key = frozendict({
                 'l10n_in_hsn_code': l10n_in_hsn_code,

--- a/addons/l10n_in/static/src/helpers/hsn_summary.js
+++ b/addons/l10n_in/static/src/helpers/hsn_summary.js
@@ -36,8 +36,10 @@ patch(accountTaxHelpers, {
             const gst_tax_amounts = taxes_computation.taxes_data
                 .filter((x) => ["igst", "cgst", "sgst"].includes(x.tax.l10n_in_tax_type))
                 .map((x) => [x.tax.id, x.tax.amount]);
+            const unique_gst_tax_amounts = Array.from(new Set(gst_tax_amounts.map(JSON.stringify)))
+                .map(JSON.parse);
             let rate = 0;
-            for (const [, tax_amount] of gst_tax_amounts) {
+            for (const [, tax_amount] of unique_gst_tax_amounts) {
                 rate += tax_amount;
             }
 

--- a/addons/l10n_in/tests/test_hsn_summary.py
+++ b/addons/l10n_in/tests/test_hsn_summary.py
@@ -26,13 +26,15 @@ class TestHSNsummary(TestTaxCommon):
             'property_account_income_id': cls.company_data['default_account_revenue'].id,
         })
 
-        cls.gst_5 = cls.env['account.chart.template'].ref('sgst_sale_5')
-        cls.gst_18 = cls.env['account.chart.template'].ref('sgst_sale_18')
-        cls.igst_0 = cls.env['account.chart.template'].ref('igst_sale_0')
-        cls.igst_5 = cls.env['account.chart.template'].ref('igst_sale_5')
-        cls.igst_18 = cls.env['account.chart.template'].ref('igst_sale_18')
-        cls.cess_5_plus_1591 = cls.env['account.chart.template'].ref('cess_5_plus_1591_sale')
-        cls.exempt_0 = cls.env['account.chart.template'].ref('exempt_sale')
+        ChartTemplate = cls.env['account.chart.template']
+        cls.gst_5 = ChartTemplate.ref('sgst_sale_5')
+        cls.gst_18 = ChartTemplate.ref('sgst_sale_18')
+        cls.igst_0 = ChartTemplate.ref('igst_sale_0')
+        cls.igst_5 = ChartTemplate.ref('igst_sale_5')
+        cls.igst_18 = ChartTemplate.ref('igst_sale_18')
+        cls.cess_5_plus_1591 = ChartTemplate.ref('cess_5_plus_1591_sale')
+        cls.exempt_0 = ChartTemplate.ref('exempt_sale')
+        cls.igst_18_rc = ChartTemplate.ref('igst_sale_18_rc')
 
     def _jsonify_tax(self, tax):
         values = super()._jsonify_tax(tax)
@@ -597,6 +599,36 @@ class TestHSNsummary(TestTaxCommon):
                         'uom_name': self.uom_unit.name,
                         'rate': 0.0,
                         'amount_untaxed': 90.0,
+                        'tax_amount_igst': 0.0,
+                        'tax_amount_cgst': 0.0,
+                        'tax_amount_sgst': 0.0,
+                        'tax_amount_cess': 0.0,
+                    },
+                ],
+            },
+        )
+        self._run_js_tests()
+
+    def test_l10n_in_hsn_summary_6(self):
+        """ Test with Sale RC tax. """
+        base_lines = [
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 100.0, 0.0, self.uom_unit, self.igst_18_rc),
+        ]
+        self.assert_l10n_in_hsn_summary(
+            base_lines,
+            {
+                'has_igst': True,
+                'has_gst': False,
+                'has_cess': False,
+                'nb_columns': 6,
+                'display_uom': False,
+                'items': [
+                    {
+                        'l10n_in_hsn_code': self.test_hsn_code_1,
+                        'quantity': 1.0,
+                        'uom_name': self.uom_unit.name,
+                        'rate': 18.0,
+                        'amount_untaxed': 100.0,
                         'tax_amount_igst': 0.0,
                         'tax_amount_cgst': 0.0,
                         'tax_amount_sgst': 0.0,


### PR DESCRIPTION
Steps to re-produce in Invoicing app:
1. Create an customer invoice with `18% IGST RC` tax
2. Post the invoice
3. Print the PDF

In the HSN Summary the expected tax percentage should be 18% but instead it displays 36%

Steps to re-produce in Point Of Sale:
follow the similar steps as above by creating
a sale receipt in POS with `18% IGST RC` tax

In the receipt HSN Summary the expected tax percentage should be 18% but instead it displays 72%

By this commit we resolve the above mentioned issues



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
