### PR TITLE
[FIX] l10n_id_efaktur: allow salesman to see invoice again

### DIFF
--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -28,7 +28,7 @@ class AccountMove(models.Model):
         compute="_compute_kode_transaksi", store=True)
     l10n_id_efaktur_range = fields.Many2one("l10n_id_efaktur.efaktur.range", string="E-faktur Range", copy=False, domain="[('company_id', '=', company_id), ('available', '>', 0)]")
     l10n_id_need_kode_transaksi = fields.Boolean(compute='_compute_need_kode_transaksi')
-    l10n_id_available_range_count = fields.Integer(compute="_compute_available_range_count")
+    l10n_id_available_range_count = fields.Integer(compute="_compute_available_range_count", compute_sudo=True)
 
     @api.depends('company_id')
     def _compute_available_range_count(self):


### PR DESCRIPTION
Salesman have access to see invoices (from orders) but when opening one, an access error it raised:

`You are not allowed to access 'Available E-faktur range' (l10n_id_efaktur.efaktur.range) records.`

This commit allow salesman without `Accounting / Billing` to see their invoices again.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
