### PR TITLE
[FIX] payment_worldline: add idempotence key for token payments

### DIFF
--- a/addons/payment_worldline/models/payment_transaction.py
+++ b/addons/payment_worldline/models/payment_transaction.py
@@ -184,7 +184,13 @@ class PaymentTransaction(models.Model):
         }
 
         # Make the payment request to Worldline.
-        response_content = self.provider_id._worldline_make_request('payments', payload=payload)
+        response_content = self.provider_id._worldline_make_request(
+            'payments',
+            payload=payload,
+            idempotency_key=payment_utils.generate_idempotency_key(
+                self, scope='payment_request_token'
+            )
+        )
 
         # Handle the payment request response.
         _logger.info(


### PR DESCRIPTION
[FIX] payment_worldline: add idempotence key for token payments

Prevents a same 'request for payment' transaction to be considered
as different by the provider.
This avoids multiple payment for a same transaction when the
webhook's response causes a concurrent update leading to a
reprocess of the initial request.

task-2894752