### PR TITLE
[FIX] web: reload page when restoring from cache

### DIFF
--- a/addons/web/static/src/core/browser/router_service.js
+++ b/addons/web/static/src/core/browser/router_service.js
@@ -142,6 +142,13 @@ function makeRouter(env) {
         current = getRoute(loc);
         bus.trigger("ROUTE_CHANGE");
     });
+    browser.addEventListener("pageshow", (ev) => {
+        // To avoid rendering inconsistencies, we need to reload when loading from a `bfcache'.
+        if (ev.persisted) {
+            browser.clearTimeout(pushTimeout);
+            bus.trigger("ROUTE_CHANGE");
+        }
+    });
 
     /**
      * @param {string} mode


### PR DESCRIPTION
Use the Safari browser (MacOS or iOS):
- Open a record (e.g. a SO);
- Go to an external website (e.g. [www.google.com](http://www.google.com/));
- Return to the record using the browser's back button;

Before this commit, the editable fields were not rendered correctly (in
the SO example, the delivery address, the invoicing address were empty).
This is because Safari used the `bfcache` to restore the page, but Odoo
wasn't designed to be compatible with this cache.

Now, when the `bfcache` is used to restore a page, we reload the current
page, to be sure that all the elements have been rendered correctly.

Note that, a similar issue has been solved similarly in [1].

[1]: https://github.com/odoo/odoo/commit/fd0c2a18ac469239fe5d9c837f2fee8aa33f846b

task-4281443