### PR TITLE
[FIX] product: backport uom_category_id to match purchase/sale UoMs

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -103,9 +103,11 @@ class ProductTemplate(models.Model):
         default=_get_default_uom_id, required=True,
         help="Default unit of measure used for all stock operations.")
     uom_name = fields.Char(string='Unit of Measure Name', related='uom_id.name', readonly=True)
+    uom_category_id = fields.Many2one('uom.category', string='UoM Category', related="uom_id.category_id")
     uom_po_id = fields.Many2one(
         'uom.uom', 'Purchase Unit',
         compute='_compute_uom_po_id', required=True, readonly=False, store=True, precompute=True,
+        domain="[('category_id', '=', uom_category_id)]",
         help="Default unit of measure used for purchase orders. It must be in the same category as the default unit of measure.")
     company_id = fields.Many2one(
         'res.company', 'Company', index=True)


### PR DESCRIPTION
In the purchase tab of the sale view, the user can see UoMs of all categories for the vendor bill, but can only pick the one in the same category as the sales price unit, as other options will get silently reverted by an onchange. This is logical, but confusing for the user. The addition of a domain for the UoM category prevents units of other categories from appearing in the view.

Partial backport of 33d7474b07abf8ae161364bcf29ae72cd04384ba

opw: [4212814](https://www.odoo.com/odoo/project/966/tasks/4212814)
