### PR TITLE
[FIX] mail: counter bubble in the discuss sidebar should be rounded

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -19,7 +19,6 @@ $o-discuss-talkingColor: lighten($success, 5%);
     background-color: var(--o-discuss-badge-bg) !important;
     align-items: center;
     justify-content: center;
-    min-width: 2.1ch;
 
     &.o-muted {
         --o-discuss-badge-bg: #{$gray-400};

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -183,7 +183,7 @@
                 </div>
             </t>
             <t t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>
-            <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
+            <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge flex-shrink-0 fw-bold {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
         </button>
     </t>
 


### PR DESCRIPTION
This commit sets the `flex-shrink` of the counter element to `0` so it won't
be reduced when a sidebar item has a long name. We can also remove the
`min-width` from `o-discuss-badge` as all `.o-discuss-badge` cases use `.badge`
which has a `min-width: 2.7ch`.