### PR TITLE
[FIX] {stock_}delivery: convert fixed_margin to sale order currency

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -195,7 +195,9 @@ class DeliveryCarrier(models.Model):
         self.ensure_one()
         if self.delivery_type == 'fixed':
             return float(price)
-        return float(price) * (1.0 + self.margin) + self.fixed_margin
+        order = self.env.context.get('order', self.env['sale.order'])
+        fixed_margin_in_sale_currency = self._compute_currency(order, self.fixed_margin, 'company_to_pricelist') if order else self.fixed_margin
+        return float(price) * (1.0 + self.margin) + fixed_margin_in_sale_currency
 
     # -------------------------- #
     # API for external providers #
@@ -226,7 +228,7 @@ class DeliveryCarrier(models.Model):
                 product_currency=company.currency_id
             )
             # apply margin on computed price
-            res['price'] = self._apply_margins(res['price'])
+            res['price'] = self.with_context(order=order)._apply_margins(res['price'])
             # save the real price in case a free_over rule overide it to 0
             res['carrier_price'] = res['price']
             # free when order is large enough

--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -570,7 +570,8 @@ class TestDeliveryCost(common.TransactionCase):
                 'max_value': 0,
                 'variable_factor': 'weight',
                 'list_base_price': 15,
-            })]
+            })],
+            'fixed_margin': 10,
         })
 
         # Create sale using the shipping method
@@ -597,4 +598,4 @@ class TestDeliveryCost(common.TransactionCase):
         # check delivery price was properly converted
         delivery_sol = so.order_line[-1]
         self.assertEqual(delivery_sol.product_id, delivery.product_id)
-        self.assertEqual(delivery_sol.price_subtotal, 7.5)
+        self.assertEqual(delivery_sol.price_subtotal, 12.5)

--- a/addons/stock_delivery/models/stock_picking.py
+++ b/addons/stock_delivery/models/stock_picking.py
@@ -189,7 +189,7 @@ class StockPicking(models.Model):
             amount_without_delivery = self.sale_id._compute_amount_total_without_delivery()
             if self.carrier_id._compute_currency(self.sale_id, amount_without_delivery, 'pricelist_to_company') >= self.carrier_id.amount:
                 res['exact_price'] = 0.0
-        self.carrier_price = self.carrier_id._apply_margins(res['exact_price'])
+        self.carrier_price = self.carrier_id.with_context(order=self.sale_id)._apply_margins(res['exact_price'])
         if res['tracking_number']:
             related_pickings = self.env['stock.picking'] if self.carrier_tracking_ref and res['tracking_number'] in self.carrier_tracking_ref else self
             accessed_moves = previous_moves = self.move_ids.move_orig_ids


### PR DESCRIPTION
**To reproduce:**
- Install sales, delivery
- Create currency DUM with value 5 DUM = 1 USD
- Enable pricelists
- Create shipping method based on rules with one rule: (shipping cost = 100 if price >=0) and fixed margin of 10
- Create new pricelist in DUM currency with a price for any product P
- Create SO with pricelist DUM for some quantity of product P
- Add shipping using above created shipping method

**Current behaviour:**
Calculated shipping cost 510 DUM.

**Expected behaviour:**
Calculated shipping cost 550 DUM as in (100 USD + 10 USD) * 5 DUM/USD.

**Reason:**
The fixed_margin field introduced in [1] is added to the shipping cost in the `_apply_margins` method added in [2] without any currency conversion. This will lead to mismatched currency additions in case the sale order currency doesn't match the shipping methods company currency.

[1] https://github.com/odoo/odoo/pull/108794
[2] https://github.com/odoo/odoo/pull/157452

opw-4289754

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
