### PR TITLE
[IMP] mail: no message actions on transient thread

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -132,7 +132,7 @@
     </t>
 
 <t t-name="mail.Message.actions">
-    <div t-if="props.hasActions and message.hasActions and !state.isEditing" class="o-mail-Message-actions d-print-none"
+    <div t-if="props.hasActions and message.hasActions and !state.isEditing and !message.thread.isTransient" class="o-mail-Message-actions d-print-none"
         t-att-class="{
             'start-0': isAlignedRight,
             'mx-1': !isMobileOS,


### PR DESCRIPTION
When a chatter thread is transient, the messages within it are also transient. As a result, rendering message actions in such threads is unnecessary. This commit removes the rendering of message actions for transient messages.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
