### PR TITLE
[FIX] point_of_sale: Fix wireless_ap.sh waiting for IP

### DIFF
--- a/addons/point_of_sale/tools/posbox/configuration/wireless_ap.sh
+++ b/addons/point_of_sale/tools/posbox/configuration/wireless_ap.sh
@@ -18,7 +18,7 @@ PASSWORD=$(get_conf "wifi_password" "${CONF_FILE}")
 
 # we need to wait to receive an ip address from the dhcp before enable the access point.
 # only if no configuration file for the wifi networks is recorded
-if [ "${ESSID}" ] && [ "${PASSWORD}" ] && [ -z "${FORCE_HOST_AP}" ] ; then
+if ! [ "${ESSID}" ] && [ "${PASSWORD}" ] && [ -z "${FORCE_HOST_AP}" ] ; then
 	while [ "$(hostname -I)" = '' ] && [ "$COUNTER" -le 10 ]; do sleep 2;((COUNTER++)); done
 fi
 


### PR DESCRIPTION
In #173866, the IoT configuration files were merged into one file. However, a logic check in `wireless_ap.sh` was inverted in the process, causing it not to wait for an IP. This PR simply restores the `!` to fix the check.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
