### PR TITLE
[REV] stock: remove picking type filters

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -358,6 +358,9 @@
                     <filter name="waiting" string="Waiting" domain="[('state', 'in', ('confirmed', 'waiting'))]" help="Waiting Moves"/>
                     <filter name="available" string="Ready" domain="[('state', '=', 'assigned')]" help="Assigned Moves"/>
                     <separator/>
+                    <filter name="reception" invisible="1" string="Receipts" domain="[('picking_type_code', '=', 'incoming')]"/>
+                    <filter name="delivery" invisible="1" string="Deliveries" domain="[('picking_type_code', '=', 'outgoing')]"/>
+                    <filter name="internal" invisible="1" string="Internal" domain="[('picking_type_code', '=', 'internal')]"/>
                     <filter invisible="1" name="before" string="Before" domain="[('search_date_category', '=', 'before')]"/>
                     <filter name="yesterday" string="Yesterday" domain="[('search_date_category', '=', 'yesterday')]"/>
                     <filter name="today" string="Today" domain="[('search_date_category', '=', 'today')]"/>

--- a/addons/stock_dropshipping/views/stock_picking_views.xml
+++ b/addons/stock_dropshipping/views/stock_picking_views.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <record id="view_picking_internal_search_inherit_stock_dropshipping" model="ir.ui.view">
+        <field name="name">stock.picking.search</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_internal_search"/>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='internal']" position="after">
+                <filter name="dropships" invisible="1" string="Dropships" domain="[('picking_type_code', '=', 'dropship')]"/>
+            </xpath>
+        </field>
+    </record>
+
     <record id="action_picking_tree_dropship" model="ir.actions.act_window">
         <field name="name">Dropships</field>
         <field name="res_model">stock.picking</field>


### PR DESCRIPTION
This reverts commit 846177859ea67cd2908bf3836df537a11cef6c96.

It breaks the redirection, so make the field invisible instead.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
