### PR TITLE
[FIX] mrp: workorder planning inconsistent duration

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -402,9 +402,10 @@ class MrpWorkorder(models.Model):
         if self.date_start and self.workcenter_id:
             self.date_finished = self._calculate_date_finished()
 
-    def _calculate_date_finished(self, date_finished=False):
-        return self.workcenter_id.resource_calendar_id.plan_hours(
-            self.duration_expected / 60.0, date_finished or self.date_start,
+    def _calculate_date_finished(self, date_start=False):
+        workcenter = self.env.context.get('new_workcenter_id') or self.workcenter_id
+        return workcenter.resource_calendar_id.plan_hours(
+            self.duration_expected / 60.0, date_start or self.date_start,
             compute_leaves=True, domain=[('time_type', 'in', ['leave', 'other'])]
         )
 
@@ -431,17 +432,19 @@ class MrpWorkorder(models.Model):
                 return res
 
     def write(self, values):
+        new_workcenter = False
         if 'production_id' in values and any(values['production_id'] != w.production_id.id for w in self):
             raise UserError(_('You cannot link this work order to another manufacturing order.'))
         if 'workcenter_id' in values:
+            new_workcenter = self.env['mrp.workcenter'].browse(values['workcenter_id'])
             for workorder in self:
                 if workorder.workcenter_id.id != values['workcenter_id']:
                     if workorder.state in ('progress', 'done', 'cancel'):
                         raise UserError(_('You cannot change the workcenter of a work order that is in progress or done.'))
-                    workorder.leave_id.resource_id = self.env['mrp.workcenter'].browse(values['workcenter_id']).resource_id
+                    workorder.leave_id.resource_id = new_workcenter.resource_id
                     workorder.duration_expected = workorder._get_duration_expected()
                     if workorder.date_start:
-                        workorder.date_finished = workorder._calculate_date_finished()
+                        workorder.date_finished = workorder.with_context(new_workcenter_id=new_workcenter)._calculate_date_finished()
         if 'date_start' in values or 'date_finished' in values:
             for workorder in self:
                 date_start = fields.Datetime.to_datetime(values.get('date_start', workorder.date_start))
@@ -450,7 +453,7 @@ class MrpWorkorder(models.Model):
                     raise UserError(_('The planned end date of the work order cannot be prior to the planned start date, please correct this to save the work order.'))
                 if 'duration_expected' not in values and not self.env.context.get('bypass_duration_calculation'):
                     if values.get('date_start') and values.get('date_finished'):
-                        computed_finished_time = workorder._calculate_date_finished(date_start)
+                        computed_finished_time = workorder.with_context(new_workcenter_id=new_workcenter)._calculate_date_finished(date_start=date_start)
                         values['date_finished'] = computed_finished_time
                     elif date_start and date_finished:
                         computed_duration = workorder._calculate_duration_expected(date_start=date_start, date_finished=date_finished)

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4285,6 +4285,59 @@ class TestMrpOrder(TestMrpCommon):
             {'product_id': kit_bom.bom_line_ids[1].product_id.id, 'product_uom_qty': 3, 'product_uom': kit_bom.bom_line_ids[1].product_id.uom_id.id},
         ])
 
+    @freeze_time('2024-11-26 9:00')
+    def test_workorder_planning_validity_with_workcenters(self):
+        # Create a workcenter with no pauses
+        week_days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+        resource_calendar = self.env['resource.calendar'].create({
+            'name': 'Default Calendar',
+            'company_id': False,
+            'hours_per_day': 24,
+            'attendance_ids': [
+                (0, 0, {
+                    'name': f'{day}',
+                    'dayofweek': str(week_days.index(day)),
+                    'hour_from': 0,
+                    'hour_to': 24,
+                })
+                for day in week_days
+            ],
+        })
+        workcenter_5 = self.env['mrp.workcenter'].create({
+            'name': 'Workcenter no pause',
+            'default_capacity': 1,
+            'time_start': 0,
+            'time_stop': 0,
+            'time_efficiency': 100,
+            'resource_calendar_id': resource_calendar.id
+        })
+
+        bom = self.env['mrp.bom'].create({
+            'product_id': self.product_6.id,
+            'product_tmpl_id': self.product_6.product_tmpl_id.id,
+            'ready_to_produce': 'asap',
+            'consumption': 'flexible',
+            'product_qty': 1.0,
+            'operation_ids': [
+                (0, 0, {'name': 'Cutting Machine', 'workcenter_id': self.workcenter_2.id, 'time_cycle': 1, 'sequence': 1, 'time_cycle_manual': 360}),
+            ],
+            'type': 'normal'
+            })
+
+        production_form = Form(self.env['mrp.production'])
+        production_form.bom_id = bom
+        production = production_form.save()
+
+        production.action_confirm()
+        production.button_plan()
+
+        self.assertEqual(fields.Datetime.now(), production.workorder_ids.date_start)
+        self.assertEqual(fields.Datetime.now() + timedelta(hours=7), production.workorder_ids.date_finished, "The time difference should be 7 hours: 6 for the shift and 1 for the lunch pause")
+
+        production.workorder_ids.workcenter_id = workcenter_5
+        self.assertEqual(fields.Datetime.now(), production.workorder_ids.date_start)
+        self.assertEqual(fields.Datetime.now() + timedelta(hours=6), production.workorder_ids.date_finished, "The time difference should be 6 hours: 6 for the shift and 0 for the lunch pause")
+
 
 @tagged('post_install', '-at_install')
 class TestMrpSynchronization(HttpCase):


### PR DESCRIPTION
Steps to reproduce:

- create two workcenters, one having a shift with a lunch pause (WC A) (i.e. the default 40hours week will do the job), the other having no lunch pause (WC B).
- create a MO with a work order of a sufficient duration to be splitted in two part (before and after lunch) (6h for instance) and add it on the WC A.
- plan the MO
- go to the planning by workcenter view
- move the WO from WC A to WC B (in the same day)
- move it back to WC A (in the same day)
- move the WO a day later (on the same WC)

Problem:
The duration displayed changes from 6h (correct one) to 7h on the first step, which is incorrect.
Moving the MO back to it's original WC will change the time to 5h which is also incorrect, but moving it a day later fixes the issue (6h)

The problem is that computing the date_finished in the write method is incorrect when `workcenter_id` is in vals, as calling `_calculate_date_finished` will return the value computed with the non-modified yet workcenter

opw-4321104


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
