### PR TITLE
[FIX] html_editor: fix getPeerMetadata traceback

### DIFF
--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
@@ -69,8 +69,11 @@ export class CollaborationSelectionAvatarPlugin extends Plugin {
      */
     drawPeerAvatar(selectionInfo) {
         const { selection, peerId } = selectionInfo;
-        const { avatarUrl, peerName = _t("Anonymous") } =
-            this.dependencies.collaborationOdoo.getPeerMetadata(peerId);
+        const peerMetadata = this.dependencies.collaborationOdoo.getPeerMetadata(peerId);
+        if (!peerMetadata) {
+            return;
+        }
+        const { avatarUrl, peerName = _t("Anonymous") } = peerMetadata;
         const anchorNode = this.dependencies.history.getNodeById(selection.anchorNodeId);
         const focusNode = this.dependencies.history.getNodeById(selection.focusNodeId);
         if (!anchorNode || !focusNode) {

--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_plugin.js
@@ -47,8 +47,11 @@ export class CollaborationSelectionPlugin extends Plugin {
      * @param {import("./collaboration_odoo_plugin").CollaborationSelection} selection
      */
     drawPeerSelection({ selection, peerId }) {
-        const { selectionColor, peerName = _t("Anonymous") } =
-            this.dependencies.collaborationOdoo.getPeerMetadata(peerId);
+        const peerMetadata = this.dependencies.collaborationOdoo.getPeerMetadata(peerId);
+        if (!peerMetadata) {
+            return;
+        }
+        const { selectionColor, peerName = _t("Anonymous") } = peerMetadata;
         this.multiselectionRemove(peerId);
         let clientRects;
 


### PR DESCRIPTION
The `getPeerMetadata` function can return a falsy value and that was not taken into account.
