### PR TITLE
[FIX] discuss: release microphone if no longer needed by the recorder

### DIFF
--- a/addons/mail/static/src/discuss/voice_message/common/voice_recorder.js
+++ b/addons/mail/static/src/discuss/voice_message/common/voice_recorder.js
@@ -1,5 +1,5 @@
 /* @odoo-module */
-import { Component, useState, onWillUnmount } from "@odoo/owl";
+import { Component, useState, onWillUnmount, status } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
@@ -82,6 +82,10 @@ export class VoiceRecorder extends Component {
                 this.microphone = await browser.navigator.mediaDevices.getUserMedia({
                     audio: this.userSettings.audioConstraints,
                 });
+                if (status(this) === "destroyed") {
+                    this.cleanUp({ unmounting: true });
+                    return;
+                }
             } catch {
                 this.notification.add(
                     _t('"%(hostname)s" needs to access your microphone', {


### PR DESCRIPTION
Before this commit, there was no check to see if the microphone was still needed when starting recording, which could leave the stream active with no reference to it.

This commit fixes this issue by checking if the component is destroyed when the microphone promise is resolved.

