### PR TITLE
[FIX] web: allow event propagation on autocomplete input click

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -16,7 +16,7 @@
                 aria-haspopup="listbox"
                 t-model="state.value"
                 t-on-blur="onInputBlur"
-                t-on-click.stop="onInputClick"
+                t-on-click="onInputClick"
                 t-on-change="onInputChange"
                 t-on-input="onInput"
                 t-on-keydown="onInputKeydown"

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -12046,7 +12046,7 @@ QUnit.module("Views", (hooks) => {
             "o_readonly_modifier"
         );
 
-        await click(target.querySelector(".o_selected_row .o_field_many2one"));
+        await click(target.querySelector(".o_selected_row .o_field_many2one input"));
         assert.strictEqual(
             document.activeElement,
             target.querySelector(".o_selected_row .o_field_many2one input")


### PR DESCRIPTION
**Problem**:
This commit:
https://github.com/odoo/odoo/commit/655e1ea63cf469937c53762e93f93da40b6b9099
breaks the behavior of the `list_renderer` when an autocomplete is present in the same view. Specifically, it prevents discarding a row when clicking outside the input.

**Solution**:
Revert the commit, as the issue it aimed to fix (opw-3180055) is now resolved by the addition of the "Search more" functionality, rendering the commit unnecessary.

**Steps to reproduce**:
1. Open the *Purchase* tab on a product form.
2. Add a vendor line (with or without selecting a vendor).
3. Focus on the vendor line, then click to add *Vendor Taxes*.
4. After selecting a tax, observe that the focus incorrectly shifts back to the vendor line instead of remaining on the *Vendor Taxes* input.

opw-4263276
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
