### PR TITLE
[FIX] web_editor: link popover position

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing.wysiwyg.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.wysiwyg.scss
@@ -8,6 +8,11 @@
     }
 }
 .o_mass_mailing_iframe body {
+    #oe_manipulators {
+       // Sidebar is already in + 1
+       z-index: $o-we-overlay-zindex + 2;
+    }
+
     .modal:not(.o_technical_modal) {
         top: 0 !important;
         // set z-index so customize options visible on dialog.


### PR DESCRIPTION
Current behavior before PR:

- In mass mailing, when the link popover opens, clicking on a link that is available near the edge of the mailing template beside the sidebar would sometimes cause the popover to appear behind the sidebar.

Desired behavior after PR is merged:

- Clicking on a link near the edge of the mailing template now ensures that the link popover opens correctly within the body of the mailing template.

task-4237091
