### PR TITLE
[FIX] mrp: prevent error when clicking Produce All button in MO

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -400,6 +400,9 @@ class MrpWorkorder(models.Model):
 
     def _calculate_date_finished(self, date_start=False):
         workcenter = self.env.context.get('new_workcenter_id') or self.workcenter_id
+        if not workcenter.resource_calendar_id:
+            duration_in_seconds = self.duration_expected * 60
+            return (date_start or self.date_start) + timedelta(seconds=duration_in_seconds)
         return workcenter.resource_calendar_id.plan_hours(
             self.duration_expected / 60.0, date_start or self.date_start,
             compute_leaves=True, domain=[('time_type', 'in', ['leave', 'other'])]
@@ -414,6 +417,8 @@ class MrpWorkorder(models.Model):
                               "You should unplan the Manufacturing Order instead in order to unplan all the linked operations."))
 
     def _calculate_duration_expected(self, date_start=False, date_finished=False):
+        if not self.workcenter_id.resource_calendar_id:
+            return ((date_finished or self.date_finished) - (date_start or self.date_start)).total_seconds() / 60
         interval = self.workcenter_id.resource_calendar_id.get_work_duration_data(
             date_start or self.date_start, date_finished or self.date_finished,
             domain=[('time_type', 'in', ['leave', 'other'])]

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4373,6 +4373,28 @@ class TestMrpOrder(TestMrpCommon):
         production = production_form.save()
         self.assertEqual(production.workorder_ids[0].duration_expected, 15)
 
+    def test_mo_without_resource_calendar(self):
+        self.workcenter_1.resource_calendar_id = False
+
+        mo = self.env['mrp.production'].create({
+            'product_id': self.product_1.id,
+            'workorder_ids': [Command.create({
+                'name': 'Test Workorder',
+                'product_uom_id': self.product_1.uom_id.id,
+                'workcenter_id': self.workcenter_1.id,
+            })],
+        })
+
+        dt_start = datetime(2024, 12, 12, 8, 30)
+        dt_finished = datetime(2024, 12, 13, 8, 30)
+
+        mo.workorder_ids[0].date_start = dt_start
+        mo.workorder_ids[0].date_finished = dt_finished
+        mo.action_confirm()
+        mo.button_mark_done()
+
+        self.assertEqual(mo.state, 'done')
+        self.assertEqual(mo.workorder_ids[0].duration_expected, 1440.0)
 
 @tagged('post_install', '-at_install')
 class TestMrpSynchronization(HttpCase):


### PR DESCRIPTION
When the user creates a manufacturing order with a work center
that does not have working hours and the user clicks on ``Produce All`` or
``Start`` button, a traceback will appear.

Steps to reproduce the error:
- Open resources > Open Assembly Line 1 > Remove Working Time
- Create a MO > Add Work order > Select  Assembly Line 1 in Work center >
  Confirm > ``Produce All`` or click ``Start`` button in work orders

Traceback:
```
File "addons/mrp_account/models/mrp_production.py", line 109, in button_mark_done
    res = super().button_mark_done()
  File "addons/mrp/models/mrp_production.py", line 2026, in button_mark_done
    self.workorder_ids.button_finish()
  File "addons/mrp/models/mrp_workorder.py", line 661, in button_finish
    workorder.with_context(bypass_duration_calculation=True).write(vals)
  File "addons/mrp/models/mrp_workorder.py", line 485, in write
    return super(MrpWorkorder, self).write(values)
  File "odoo/models.py", line 4760, in write
    fields[0].determine_inverse(real_recs)
  File "odoo/fields.py", line 1478, in determine_inverse
    determine(self.inverse, records)
  File "odoo/fields.py", line 109, in determine
    return needle(*args)
  File "addons/mrp/models/mrp_workorder.py", line 263, in _set_dates
    wo.date_finished = wo._calculate_date_finished()
  File "addons/mrp/models/mrp_workorder.py", line 421, in _calculate_date_finished
    return workcenter.resource_calendar_id.plan_hours(
  File "addons/resource/models/resource_calendar.py", line 691, in plan_hours
    for start, stop, meta in get_intervals(dt, dt + delta)[resource_id]:
  File "addons/resource/models/resource_calendar.py", line 446, in _work_intervals_batch
    attendance_intervals = self._attendance_intervals_batch(start_dt, end_dt, resources, tz=tz or self.env.context.get("employee_timezone"))
  File "addons/resource/models/resource_calendar.py", line 285, in _attendance_intervals_batch
    self.ensure_one()
  File "odoo/models.py", line 6191, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: resource.calendar()
```

https://github.com/odoo/odoo/blob/fa375ffa4467efe99d53a7546f4dcf0553f51190/addons/mrp/models/mrp_workorder.py#L403
Here, ``resource_calendar_id`` will be False,
Eventually, it will lead to the above traceback.

sentry-6041123993

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
