### PR TITLE
[FIX] barcodes_gs1_nomenclature: clean FNC1

### DIFF
--- a/addons/barcodes_gs1_nomenclature/static/src/js/barcode_parser.js
+++ b/addons/barcodes_gs1_nomenclature/static/src/js/barcode_parser.js
@@ -100,6 +100,7 @@ BarcodeParser.include({
         const rules = this.nomenclature.rules.filter(rule => rule.encoding === 'gs1-128');
         const separatorReg = FNC1_CHAR + "?";
         barcode = this._convertGS1Separators(barcode);
+        barcode = this.cleanBarcode(barcode);
 
         while (barcode.length > 0) {
             const barcodeLength = barcode.length;
@@ -157,6 +158,19 @@ BarcodeParser.include({
         const fieldNames = this._super(...arguments);
         fieldNames.push('gs1_content_type', 'gs1_decimal_usage', 'associated_uom_id');
         return fieldNames;
+    },
+
+    /**
+     * Makes all needed operations to clean and prepare the barcode.
+     * @param {string} barcode
+     * @returns {string}
+     */
+    cleanBarcode(barcode) {
+        if (barcode[0] === FNC1_CHAR) {
+            // If first character is the separator, remove it to be able to parse the barcode.
+            barcode = barcode.slice(1);
+        }
+        return barcode;
     },
 
     /**

--- a/addons/barcodes_gs1_nomenclature/static/src/js/tests/barcode_parser_tests.js
+++ b/addons/barcodes_gs1_nomenclature/static/src/js/tests/barcode_parser_tests.js
@@ -208,7 +208,7 @@ QUnit.module('Barcode GS1 Parser', {
     });
 
     QUnit.test('Test gs1 decompose extanded', async function (assert) {
-        assert.expect(19);
+        assert.expect(37);
         const barcodeNomenclature = new BarcodeParser({'nomenclature_id': 2});
         await barcodeNomenclature.loaded;
 
@@ -232,21 +232,27 @@ QUnit.module('Barcode GS1 Parser', {
         assert.equal(res[3].value.getDate(), 18);
         assert.equal(res[3].value.getMonth() + 1, 10);
 
-        // (01)94019097685457(13)170119(30)17
-        code128 = "0194019097685457131701193017";
-        res = barcodeNomenclature.gs1_decompose_extanded(code128);
-        assert.equal(res.length, 3);
-        assert.equal(res[0].ai, "01");
+        // Check multiple variants of the same GS1, the result should be always the same.
+        // (01)94019097685457(30)17(13)170119
+        const gs1Barcodes = [
+            "0194019097685457300000001713170119",
+            "\x1D0194019097685457300000001713170119",
+            "01940190976854573017\x1D13170119",
+        ];
+        for (const gs1Barcode of gs1Barcodes) {
+            res = barcodeNomenclature.gs1_decompose_extanded(gs1Barcode);
+            assert.equal(res.length, 3);
+            assert.equal(res[0].ai, "01");
 
-        assert.equal(res[1].ai, "13");
-        assert.equal(typeof res[1].value.getFullYear, 'function');
-        assert.equal(res[1].value.getFullYear(), 2017);
-        assert.equal(res[1].value.getDate(), 19);
-        assert.equal(res[1].value.getMonth() + 1, 1);
+            assert.equal(res[1].ai, "30");
+            assert.equal(res[1].value, 17);
 
-        assert.equal(res[2].ai, "30");
-        assert.equal(res[2].value, 17);
-
+            assert.equal(res[2].ai, "13");
+            assert.equal(typeof res[2].value.getFullYear, "function");
+            assert.equal(res[2].value.getFullYear(), 2017);
+            assert.equal(res[2].value.getDate(), 19);
+            assert.equal(res[2].value.getMonth() + 1, 1);
+        }
     });
 
     QUnit.test('Test Alternative GS1 Separator (fnc1)', async function (assert) {


### PR DESCRIPTION
Issue
=====

When a GS1 barcode is scanned, if it starts with a FNC1, it can't be parsed.

How to reproduce
================

- In Inventory Settings, select "Default GS1 Nomenclature" as the used nomenclature;
- Create a product with a valid EAN13 as barcode (eg. 1234567891231);
- Open the Barcode app, then the Inventory Adjustments;
- Scan a GS1 barcode for the created product who start with the FNC1 (eg. "\x1D0101234567891231") -> The product's barcode is not decoded.

Solution
========

To fix this issue, before to be parsed, the given barcode will be cleaned and if it starts with a FNC1, it will be removed from the string.

opw-4118637