### PR TITLE
[FIX] pos_online_payment: prevent error when making another payment

### DIFF
--- a/addons/pos_online_payment/models/pos_payment.py
+++ b/addons/pos_online_payment/models/pos_payment.py
@@ -20,7 +20,8 @@ class PosPayment(models.Model):
             pm_id = vals['payment_method_id']
             if pm_id not in online_account_payments_by_pm:
                 online_account_payments_by_pm[pm_id] = set()
-            online_account_payments_by_pm[pm_id].add(vals.get('online_account_payment_id'))
+            if vals.get('online_account_payment_id'):
+                online_account_payments_by_pm[pm_id].add(vals['online_account_payment_id'])
 
         opms_read_id = self.env['pos.payment.method'].search_read(['&', ('id', 'in', list(online_account_payments_by_pm.keys())), ('is_online_payment', '=', True)], ["id"])
         opms_id = {opm_read_id['id'] for opm_read_id in opms_read_id}

--- a/addons/pos_online_payment_self_order/__manifest__.py
+++ b/addons/pos_online_payment_self_order/__manifest__.py
@@ -18,6 +18,9 @@
             'pos_online_payment_self_order/static/src/**/*',
             'web/static/lib/zxing-library/zxing-library.js',
         ],
+        'web.assets_tests': [
+            'pos_online_payment_self_order/static/tests/tours/pos_online_payment_multi_table_order.js',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/pos_online_payment_self_order/static/tests/tours/pos_online_payment_multi_table_order.js
+++ b/addons/pos_online_payment_self_order/static/tests/tours/pos_online_payment_multi_table_order.js
@@ -1,0 +1,32 @@
+import * as ChromePos from "@point_of_sale/../tests/tours/utils/chrome_util";
+import * as ChromeRestaurant from "@pos_restaurant/../tests/tours/utils/chrome";
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import * as ProductScreenPos from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as ProductScreenResto from "@pos_restaurant/../tests/tours/utils/product_screen_util";
+import { registry } from "@web/core/registry";
+
+const Chrome = { ...ChromePos, ...ChromeRestaurant };
+const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
+
+registry.category("web_tour.tours").add("OnlinePaymentWithMultiTables", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("1"),
+            ProductScreen.orderBtnIsPresent(),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.clickOrderButton(),
+            ProductScreen.orderlinesHaveNoChange(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.totalIs("2.53"),
+            Chrome.createFloatingOrder(),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.totalIs("2.53"),
+            PaymentScreen.validateButtonIsHighlighted(true),
+            PaymentScreen.clickValidate(),
+        ].flat(),
+});

--- a/addons/pos_online_payment_self_order/tests/test_self_order_frontend.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_frontend.py
@@ -3,6 +3,9 @@
 from unittest.mock import patch
 
 import odoo.tests
+from odoo import Command
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.pos_online_payment.tests.online_payment_common import OnlinePaymentCommon
 from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
 # from odoo.addons.pos_online_payment.models.pos_payment_method import PosPaymentMethod
 
@@ -10,3 +13,55 @@ from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCom
 @odoo.tests.tagged("post_install", "-at_install")
 class TestSelfOrderFrontendMobile(SelfOrderCommonTest):
     pass
+
+@odoo.tests.tagged("post_install", "-at_install")
+class TestUi(OnlinePaymentCommon):
+    def _get_url(self):
+        return f"/pos/ui?config_id={self.pos_config.id}"
+
+    def start_pos_tour(self, tour_name, login="pos_admin", **kwargs):
+        self.start_tour(self._get_url(), tour_name, login=login, **kwargs)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.payment_provider = cls.provider # The dummy_provider used by the tests of the 'payment' module.
+
+        cls.payment_provider_old_company_id = cls.payment_provider.company_id.id
+        cls.payment_provider_old_journal_id = cls.payment_provider.journal_id.id
+        cls.payment_provider.write({
+            'company_id': cls.company.id,
+        })
+        cls.online_payment_method = cls.env['pos.payment.method'].create({
+            'name': 'Online payment',
+            'is_online_payment': True,
+            'online_payment_provider_ids': [Command.set([cls.payment_provider.id])],
+        })
+
+        cls.sales_journal = cls.env['account.journal'].create({
+            'name': 'Sales Journal for POS OP Test',
+            'code': 'POPSJ',
+            'type': 'sale',
+            'company_id': cls.company.id
+        })
+        cls.pos_config = cls.env['pos.config'].create({
+            'name': 'POS OP Test Shop',
+            'module_pos_restaurant': True,
+            'invoice_journal_id': cls.sales_journal.id,
+            'journal_id': cls.sales_journal.id,
+            'payment_method_ids': [Command.link(cls.online_payment_method.id)],
+        })
+        cls.pos_admin = mail_new_test_user(
+            cls.env,
+            groups="base.group_user,point_of_sale.group_pos_manager",
+            login="pos_admin",
+            name="POS Admin",
+            tz="Europe/Brussels",
+        )
+
+
+class TestSelfOrderOnlinePayment(TestUi):
+    def test_01_online_payment_with_multi_table(self):
+        self.pos_config.with_user(self.pos_admin).open_ui()
+        self.start_pos_tour('OnlinePaymentWithMultiTables', login="pos_admin")


### PR DESCRIPTION
This error occurs when a product is added to one table, and the payment screen is accessed where an online payment method is selected but the payment is not completed. Subsequently, switching to another table and attempting to make an online payment results in the issue.

Steps to reproduce:
---
- Install ``pos_online_payment`` and ``pos_restaurant`` module
- Create a new online payment in ``Payment Method(eg: Test)``
- In Configuration/Settings, add it for a restaurant in ``Payment Method``
- Now open a session in a restaurant > Select one table > Add products > Order > Payment > Click on Test
- Click on ``+`` > Add product > Payment
- Click on Test and Validate

Traceback:
---
``Expected singleton: pos.order('p', 'o', 's', '.', 'o', 'r', 'd', 'e', 'r', '_', '2')``

Previous Behaviour:
---
When an online payment is selected for the first table but exited without completing the transaction, an RPC error occurs, causing the system to switch to offline mode. Consequently, the order encounters an error when attempting to place an order and process an online payment at the second table. At that time, it creates a new order as ID ``pos.order_2`` and updates the previous order. Due to what we get ID like ``pos.order_2``, leading to the issue.

After Commit:
---
When creating a new order for another table at [1], the ``online_account_payment_id`` is set to false. If this value is false, we will assign an empty set to ``online_account_payments_by_pm[pm_id]``.

sentry-5703437687

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
