### PR TITLE
[FIX] sale: not change unit price when update order line quantity

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -431,7 +431,7 @@ class SaleOrderLine(models.Model):
                     date=line.order_id.date_order,
                 )
 
-    @api.depends('product_id', 'product_uom', 'product_uom_qty')
+    @api.depends('product_id', 'product_uom')
     def _compute_price_unit(self):
         for line in self:
             # check if there is already invoiced amount. if so, the price shouldn't change as it might have been


### PR DESCRIPTION
#### Steps to Reproduce:
* Install the Sales and Stock modules
* Create a new Sales Order
* Add a product to a sales order line
* Change the unit price to a value different from the product's default price
* Modify the quantity of the sales order line

#### Current Behaviour:
* The unit price is overridden by the default product price defined in the product form, disregarding the manual value set by the user on the sales order line.

#### Expected Behaviour:
The unit price manually defined by the user should remain unchanged.

#### Reason:
This issue occurs because the compute method for the unit price includes an unecessary dependency on the
field. Changing the quantity triggers the compute method, which overwrites the user-defined value. The fix is to remove this dependency from the compute method.

opw-4285889


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
