### PR TITLE
[FIX] point_of_sale: show internal reference for products

### DIFF
--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
@@ -4,7 +4,7 @@
         <div t-attf-class="{{ bannerClass }}"
             class="section-product-info-title d-flex text-info bg-opacity-25 mx-n3 mt-n3 px-3 pb-2 pt-3 mb-3">
             <div class="d-flex flex-column">
-                <span class="h4" t-esc="props.product.name"/>
+                <span class="h4" t-esc="props.product.productDisplayName"/>
                 <span t-if="this.props.product.is_storable" class="h4">
                     <span>On hand: </span>
                     <span class="section-product-info-title-quantity" t-if="this.fetchStock.status === 'success' || this.props.info"><t t-esc="this.state.available_quantity"/> Units</span>

--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -242,5 +242,9 @@ export class ProductProduct extends Base {
         });
         return isCombinationArchived;
     }
+
+    get productDisplayName() {
+        return this.default_code ? `[${this.default_code}] ${this.name}` : this.name;
+    }
 }
 registry.category("pos_available_models").add(ProductProduct.pythonModel, ProductProduct);

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
@@ -26,10 +26,6 @@ export class ProductInfoPopup extends Component {
         this.props.close();
     }
     get isVariant() {
-        return (
-            this.pos.models["product.product"].filter(
-                (p) => p.raw.product_tmpl_id === this.props.product.raw.product_tmpl_id
-            ).length > 1
-        );
+        return this.pos.isProductVariant(this.props.product);
     }
 }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1745,6 +1745,14 @@ export class PosStore extends Reactive {
         const { start_category, iface_start_categ_id } = this.config;
         this.setSelectedCategory((start_category && iface_start_categ_id?.[0]) || 0);
     }
+
+    isProductVariant(product) {
+        return (
+            this.models["product.product"].filter(
+                (p) => p.raw.product_tmpl_id === product.raw.product_tmpl_id
+            ).length > 1
+        );
+    }
 }
 
 PosStore.prototype.electronic_payment_interfaces = {};

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
@@ -8,12 +8,15 @@ export class BaseProductAttribute extends Component {
     static template = "";
     static props = ["attributeLine"];
     setup() {
-        this.env.attribute_components.push(this);
         this.attributeLine = this.props.attributeLine;
         this.values = this.attributeLine.product_template_value_ids;
         this.state = useState({
             attribute_value_ids: parseFloat(this.values[0].id),
             custom_value: "",
+        });
+        onMounted(() => {
+            this.env.attribute_components.push(this);
+            this.env.computeProductProduct();
         });
     }
 
@@ -113,7 +116,10 @@ export class ProductConfiguratorPopup extends Component {
     static props = ["product", "getPayload", "close"];
 
     setup() {
-        useSubEnv({ attribute_components: [] });
+        useSubEnv({
+            attribute_components: [],
+            computeProductProduct: this.computeProductProduct.bind(this),
+        });
         this.pos = usePos();
         this.ui = useState(useService("ui"));
         this.inputArea = useRef("input-area");
@@ -121,8 +127,6 @@ export class ProductConfiguratorPopup extends Component {
             product: this.props.product,
             payload: this.env.attribute_components,
         });
-
-        this.computeProductProduct();
         useRefListener(this.inputArea, "touchend", this.computeProductProduct.bind(this));
         useRefListener(this.inputArea, "click", this.computeProductProduct.bind(this));
     }

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
@@ -122,6 +122,9 @@
 
     <t t-name="point_of_sale.ProductConfiguratorPopup">
         <Dialog title="'Attribute selection'">
+            <div class="section-product-info-title d-flex text-info bg-opacity-25 mx-n3 mt-n3 px-3 pb-2 pt-3 mb-3 bg-info">
+                <span class="h4" t-esc="this.state.product.productDisplayName"/>
+            </div>
             <div t-ref="input-area">
                 <div t-if="isArchivedCombination()" class="alert alert-warning mt-3">
                     <span>This combination does not exist.</span>

--- a/addons/point_of_sale/static/tests/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_configurator_tour.js
@@ -37,7 +37,7 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
 
             // Check that the product has been added to the order with correct attributes and price
             ProductScreen.selectedOrderlineHas(
-                "Configurable Chair (Red, Metal, Fabrics: Other: Custom Fabric)",
+                "Configurable Chair (Fabrics: Other: Custom Fabric, Metal, Red)",
                 "1.0",
                 "11.0"
             ),
@@ -50,7 +50,7 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
             ProductConfigurator.fillCustomAttribute("Custom Fabric"),
             Dialog.confirm(),
             ProductScreen.selectedOrderlineHas(
-                "Configurable Chair (Red, Metal, Fabrics: Other: Custom Fabric)",
+                "Configurable Chair (Fabrics: Other: Custom Fabric, Metal, Red)",
                 "2.0",
                 "22.0"
             ),
@@ -62,7 +62,7 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
             ProductConfigurator.pickRadio("Leather"),
             Dialog.confirm(),
             ProductScreen.selectedOrderlineHas(
-                "Configurable Chair (Blue, Metal, Leather)",
+                "Configurable Chair (Leather, Metal, Blue)",
                 "1.0",
                 "10.0"
             ),

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -122,7 +122,7 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
                 content: "validate the variant dialog (with default values)",
             },
             ProductScreen.selectedOrderlineHas("Desk Organizer"),
-            checkOrderChanges([{ name: "Desk Organizer (S, Leather)", quantity: 1 }]),
+            checkOrderChanges([{ name: "Desk Organizer (Leather, S)", quantity: 1 }]),
             ProductScreen.clickOrderButton(),
             {
                 ...Dialog.confirm(),


### PR DESCRIPTION
Before this commit, the internal reference was not displayed. With this commit, the internal reference will be shown in the product info popup and for products with variants in the product configurator.

opw-4334505

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
