### PR TITLE
[REF] survey: simplify conditional questions check

### DIFF
--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -773,7 +773,6 @@ class SurveySurvey(models.Model):
             return Question
 
         # Conditional Questions Management
-        triggering_answers_by_question, _, selected_answers = user_input._get_conditional_values()
         inactive_questions = user_input._get_inactive_conditional_questions()
         if survey.questions_layout == 'page_per_question':
             question_candidates = pages_or_questions[0:current_page_index] if go_back \
@@ -786,8 +785,7 @@ class SurveySurvey(models.Model):
                     if contains_active_question or is_description_section:
                         return question
                 else:
-                    triggering_answers = triggering_answers_by_question.get(question)
-                    if not triggering_answers or triggering_answers & selected_answers:
+                    if question not in inactive_questions:
                         # question is visible because not conditioned or conditioned by a selected answer
                         return question
         elif survey.questions_layout == 'page_per_section':

--- a/doc/cla/individual/lightsystem.md
+++ b/doc/cla/individual/lightsystem.md
@@ -1,0 +1,11 @@
+Portugal, 2024-11-20
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+João Diogo Horta Alves joao.horta.alves@gmail.com https://github.com/LightSystem


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In `_get_next_page_or_question` when checking if a question is visible, it is redundantly calling `_get_conditional_values` along with `_get_inactive_conditional_questions`. Getting the `inactive_questions` should be all that is needed to do this check. This also has the nice benefit that it is much simpler to customize conditional question behaviour in this section of the code, as it becomes only necessary to override `_get_inactive_conditional_questions`.

Current behavior before PR:

Redundant call to `_get_conditional_values`.

Desired behavior after PR is merged:

Only call `_get_inactive_conditional_questions` and simplify customizing behaviour of conditional questions.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
