### PR TITLE
[FIX] mail: mention should not overlap in multi-lines on Safari

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -110,6 +110,7 @@ a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention {
     padding: 0rem 0.1875rem;
     border: 1px solid;
     font-weight: $font-weight-bold;
+    display: inline-block;
 }
 
 a.o_mail_redirect, a.o_channel_redirect {


### PR DESCRIPTION
Before this commit, rendering of `@`mentions in Discuss on Safari was bigger than line height, which results in unintended UI overlap. This is mostly visible and problematic when 2 successive text lines have mentions in the same horizontal range.

This happens because discuss mentions are `<a>` and anchor links have `display: inline`. As a reminder, `inline` does not respect top/bottom padding and margin of element in its container so this is very likely prone to overlap vertically with sibling nodes. `inline-block`, on the other hand, take vertical padding and margin into account so it doesn't overlap. If the element takes more space, then siblings are pushed accordingly.

This commit fixes the issue by setting `display: inline-block` to all discuss mentions, so that there's no risk of overlap in multi-line especially on Safari.

Before / After
<img width="520" alt="Screenshot 2024-11-20 at 12 54 31" src="https://github.com/user-attachments/assets/c1888680-e579-4573-930b-69bdf400f8e8">
<img width="523" alt="Screenshot 2024-11-20 at 12 54 12" src="https://github.com/user-attachments/assets/acfdfe8c-b6ef-49cc-8baf-816cf3058516">
