### PR TITLE
[REF] web_tour: replace _legacyIsVisible by hoot isVisible

### DIFF
--- a/addons/crm/static/tests/tours/crm_rainbowman.js
+++ b/addons/crm/static/tests/tours/crm_rainbowman.js
@@ -89,7 +89,10 @@ registry.category("web_tour.tours").add("crm_rainbowman", {
             content: "move lead to won stage",
             run: "click",
         },
-        ...stepUtils.saveForm(),
+        {
+            content: "wait for save completion",
+            trigger: ".o_form_readonly, .o_form_saved",
+        },
         {
             trigger: ".o_reward_rainbow",
         },
@@ -103,7 +106,10 @@ registry.category("web_tour.tours").add("crm_rainbowman", {
             content: "click button mark won",
             run: "click",
         },
-        ...stepUtils.saveForm(),
+        {
+            content: "wait for save completion",
+            trigger: ".o_form_readonly, .o_form_saved",
+        },
         {
             trigger: ".o_reward_rainbow",
         },

--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -3,165 +3,173 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
-registry.category("web_tour.tours").add('hr_skills_tour', {
-    url: '/odoo',
+registry.category("web_tour.tours").add("hr_skills_tour", {
+    url: "/odoo",
     steps: () => [
-    stepUtils.showAppsMenuItem(),
-    {
-        content: "Open Employees app",
-        trigger: ".o_app[data-menu-xmlid='hr.menu_hr_root']",
-        run: "click",
-    },
-    {
-        content: "Create a new employee",
-        trigger: ".o-kanban-button-new",
-        run: "click",
-    },
-    {
-        content: "Pick a name",
-        trigger: ".o_field_widget[name='name'] input",
-        run: "edit Jony McHallyFace",
-    },
-    {
-        content: "Save",
-        trigger: ".o_form_button_save",
-        run: "click",
-    },
-    {
-        content: "Add a new Resume experience",
-        trigger: ".o_field_resume_one2many tr.o_resume_group_header button.btn-secondary",
-        run: "click",
-    },
-    {
-        content: "Enter some company name",
-        trigger: ".modal:contains(new resume line) .modal-body .o_field_widget[name='name'] input",
-        run: "edit Mamie Rock",
-    },
-    {
-        content: "Set start date",
-        trigger: ".modal:contains(new resume line) .o_field_widget[name='date_start'] input",
-        run: "edit 12/05/2017",
-    },
-    {
-        content: "Give some description",
-        trigger: ".modal:contains(new resume line) .o_field_html[name='description'] p",
-        run: "editor Sang some songs and played some music",
-    },
-    {
-        content: "Save it",
-        trigger: ".modal:contains(new resume line) .o_form_button_save:contains(save)",
-        run: "click",
-    },
-    {
-        trigger: "body:not(:has(.modal:contains(new resume line)))",
-    },
-    {
-        content: "Edit newly created experience",
-        trigger: ".o_resume_line_title:contains(Mamie Rock)",
-        run: "click",
-    },
-    {
-        content: "Change type",
-        trigger: ".modal:contains(new resume line) .o_field_widget[name='line_type_id'] input",
-        run: "edit Experience",
-    },
-    {
-        content: "Choose experience",
-        trigger: '.ui-autocomplete .ui-menu-item a:contains("Experience")',
-        run: "click",
-    },
-    {
-        content: "Save experience change",
-        trigger: ".modal:contains(new resume line) .o_form_button_save:contains(save)",
-        run: "click",
-    },
-    {
-        trigger: "body:not(:has(.modal:contains(new resume line)))",
-    },
-    {
-        content: "Add a new Skill",
-        trigger: ".o_field_skills_one2many button:contains('Pick a skill from the list')",
-        run: "click",
-    },
-    {
-        content: "Select Music",
-        trigger: ".modal:contains(select skills) .o_field_widget[name='skill_type_id'] label:contains('Best Music')",
-        run: "click",
-    },
-    {
-        content: "Select a song",
-        trigger: ".modal:contains(select skills) .o_field_widget[name='skill_id'] input",
-        run: "edit Fortun",
-    },
-    {
-        content: "Choose the song",
-        trigger: '.ui-autocomplete .ui-menu-item a:contains("Fortunate Son")',
-        run: "click",
-    },
-    {
-        content: "Select a level",
-        trigger: ".modal:contains(select skills) .o_field_widget[name='skill_level_id'] input",
-        run: "edit Level",
-    },
-    {
-        content: "Choose the level",
-        trigger: '.ui-autocomplete .ui-menu-item a:contains("Level 2")',
-        run: "click",
-    },
-    {
-        content: "Save new skill",
-        trigger: ".modal:contains(select skills) .o_form_button_save:contains(save & close)",
-        run: "click",
-    },
-    {
-        content: "Wait the new skill is completely saved. Ensure also the modal is closed before open a new one.",
-        trigger: "body:not(:has(.modal))",
-    },
-    {
-        content: "Check if item is added",
-        trigger: ".o_data_row td.o_data_cell:contains('Fortunate Son')",
-    },
-    {
-        content: "Add a new Skill",
-        trigger: ".o_field_skills_one2many button:contains('ADD')",
-        run: "click",
-    },
-    {
-        content: "Music should be already selected",
-        trigger: ".modal:contains(select skills) .o_field_widget[name=skill_id] input:value(Fortunate Son)",
-    },
-    {
-        content: "Select a song",
-        trigger: ".modal:contains(select skills) .o_field_widget[name='skill_id'] input",
-        run: "edit Mary",
-    },
-    {
-        content: "Choose the song",
-        trigger: '.ui-autocomplete .ui-menu-item a:contains("Oh Mary")',
-        run: "click",
-    },
-    {
-        content: "Select a level",
-        trigger: ".modal:contains(select skills) .o_field_widget[name='skill_level_id'] input",
-        run: "edit Level 7",
-    },
-    {
-        content: "Choose the level",
-        trigger: '.ui-autocomplete .ui-menu-item a:contains("Level 7")',
-        run: "click",
-    },
-    {
-        content: "Save new skill",
-        trigger: ".modal:contains(select skills) .o_form_button_save:contains(save & close)",
-        run: "click",
-    },
-    {
-        content: "Wait the new skill is completely saved",
-        trigger: "body:not(:has(.modal))",
-    },
-    {
-        content: "Check if item is added",
-        trigger: ".o_data_row td.o_data_cell:contains('Oh Mary')",
-    },
-    ...stepUtils.saveForm(),
-]});
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Employees app",
+            trigger: ".o_app[data-menu-xmlid='hr.menu_hr_root']",
+            run: "click",
+        },
+        {
+            content: "Create a new employee",
+            trigger: ".o-kanban-button-new",
+            run: "click",
+        },
+        {
+            content: "Pick a name",
+            trigger: ".o_field_widget[name='name'] input",
+            run: "edit Jony McHallyFace",
+        },
+        {
+            content: "Save",
+            trigger: ".o_form_button_save",
+            run: "click",
+        },
+        {
+            content: "Add a new Resume experience",
+            trigger: ".o_field_resume_one2many tr.o_resume_group_header button.btn-secondary",
+            run: "click",
+        },
+        {
+            content: "Enter some company name",
+            trigger:
+                ".modal:contains(new resume line) .modal-body .o_field_widget[name='name'] input",
+            run: "edit Mamie Rock",
+        },
+        {
+            content: "Set start date",
+            trigger: ".modal:contains(new resume line) .o_field_widget[name='date_start'] input",
+            run: "edit 12/05/2017",
+        },
+        {
+            content: "Give some description",
+            trigger: ".modal:contains(new resume line) .o_field_html[name='description'] p",
+            run: "editor Sang some songs and played some music",
+        },
+        {
+            content: "Save it",
+            trigger: ".modal:contains(new resume line) .o_form_button_save:contains(save)",
+            run: "click",
+        },
+        {
+            trigger: "body:not(:has(.modal:contains(new resume line)))",
+        },
+        {
+            content: "Edit newly created experience",
+            trigger: ".o_resume_line_title:contains(Mamie Rock)",
+            run: "click",
+        },
+        {
+            content: "Change type",
+            trigger: ".modal:contains(new resume line) .o_field_widget[name='line_type_id'] input",
+            run: "edit Experience",
+        },
+        {
+            content: "Choose experience",
+            trigger: '.ui-autocomplete .ui-menu-item a:contains("Experience")',
+            run: "click",
+        },
+        {
+            content: "Save experience change",
+            trigger: ".modal:contains(new resume line) .o_form_button_save:contains(save)",
+            run: "click",
+        },
+        {
+            trigger: "body:not(:has(.modal:contains(new resume line)))",
+        },
+        {
+            content: "Add a new Skill",
+            trigger: ".o_field_skills_one2many button:contains('Pick a skill from the list')",
+            run: "click",
+        },
+        {
+            content: "Select Music",
+            trigger:
+                ".modal:contains(select skills) .o_field_widget[name='skill_type_id'] label:contains('Best Music')",
+            run: "click",
+        },
+        {
+            content: "Select a song",
+            trigger: ".modal:contains(select skills) .o_field_widget[name='skill_id'] input",
+            run: "edit Fortun",
+        },
+        {
+            content: "Choose the song",
+            trigger: '.ui-autocomplete .ui-menu-item a:contains("Fortunate Son")',
+            run: "click",
+        },
+        {
+            content: "Select a level",
+            trigger: ".modal:contains(select skills) .o_field_widget[name='skill_level_id'] input",
+            run: "edit Level",
+        },
+        {
+            content: "Choose the level",
+            trigger: '.ui-autocomplete .ui-menu-item a:contains("Level 2")',
+            run: "click",
+        },
+        {
+            content: "Save new skill",
+            trigger: ".modal:contains(select skills) .o_form_button_save:contains(save & close)",
+            run: "click",
+        },
+        {
+            content:
+                "Wait the new skill is completely saved. Ensure also the modal is closed before open a new one.",
+            trigger: "body:not(:has(.modal))",
+        },
+        {
+            content: "Check if item is added",
+            trigger: ".o_data_row td.o_data_cell:contains('Fortunate Son')",
+        },
+        {
+            content: "Add a new Skill",
+            trigger: ".o_field_skills_one2many button:contains('ADD')",
+            run: "click",
+        },
+        {
+            content: "Music should be already selected",
+            trigger:
+                ".modal:contains(select skills) .o_field_widget[name=skill_id] input:value(Fortunate Son)",
+        },
+        {
+            content: "Select a song",
+            trigger: ".modal:contains(select skills) .o_field_widget[name='skill_id'] input",
+            run: "edit Mary",
+        },
+        {
+            content: "Choose the song",
+            trigger: '.ui-autocomplete .ui-menu-item a:contains("Oh Mary")',
+            run: "click",
+        },
+        {
+            content: "Select a level",
+            trigger: ".modal:contains(select skills) .o_field_widget[name='skill_level_id'] input",
+            run: "edit Level 7",
+        },
+        {
+            content: "Choose the level",
+            trigger: '.ui-autocomplete .ui-menu-item a:contains("Level 7")',
+            run: "click",
+        },
+        {
+            content: "Save new skill",
+            trigger: ".modal:contains(select skills) .o_form_button_save:contains(save & close)",
+            run: "click",
+        },
+        {
+            content: "Wait the new skill is completely saved",
+            trigger: "body:not(:has(.modal))",
+        },
+        {
+            content: "Check if item is added",
+            trigger: ".o_data_row td.o_data_cell:contains('Oh Mary')",
+        },
+        {
+            content: "wait for save completion",
+            trigger: ".o_form_readonly, .o_form_saved",
+        },
+    ],
+});

--- a/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
+++ b/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import { stepUtils } from '@web_tour/tour_service/tour_utils';
 
 registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_sml_synchronization', {
     steps: () => [
@@ -158,6 +157,10 @@ registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_
             trigger: ".modal .modal-footer .o_form_button_save",
             run: "click",
         },
-        ...stepUtils.saveForm(),
+        {
+            isActive: ["auto"],
+            content: "wait for save completion",
+            trigger: ".o_form_readonly, .o_form_saved",
+        },
     ]
 });

--- a/addons/point_of_sale/static/tests/tours/utils/generic_components/order_widget_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/generic_components/order_widget_util.js
@@ -106,6 +106,6 @@ export function hasTax(amount) {
 export function hasNoTax() {
     return {
         content: "order has not tax",
-        trigger: ".order-summary .tax:empty",
+        trigger: ".order-summary .tax:empty:not(:visible)",
     };
 }

--- a/addons/project/static/tests/tours/project_burndown_chart_tour.js
+++ b/addons/project/static/tests/tours/project_burndown_chart_tour.js
@@ -10,8 +10,8 @@ registry.category("web_tour.tours").add('burndown_chart_tour', {
     run: "click",
 }, {
     content: 'Open "Burndown Chart Test" project menu',
-    trigger: '.o_kanban_record:contains("Burndown Chart Test") .o_dropdown_kanban .dropdown-toggle',
-    run: "click",
+            trigger: ".o_kanban_record:contains(Burndown Chart Test)",
+    run: `hover && click .o_kanban_record:contains(Burndown Chart Test) .o_dropdown_kanban .dropdown-toggle`,
 }, {
     content: `Open "Burndown Chart Test" project's "Burndown Chart" view`,
     trigger: '.o_kanban_manage_reporting div[role="menuitem"] a:contains("Burndown Chart")',
@@ -26,8 +26,8 @@ registry.category("web_tour.tours").add('burndown_chart_tour', {
     run: "click",
 }, {
     content: 'Remove the project search "Burndown Chart Test"',
-    trigger: '.o_searchview_facet:contains("Burndown Chart Test") .o_facet_remove',
-    run: "click",
+    trigger: ".o_searchview_facet:contains(Burndown Chart Test)",
+    run: "hover && click .o_facet_remove",
 }, {
     content: 'Search Burndown Chart',
     trigger: 'input.o_searchview_input',

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -2,9 +2,9 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 const projectSharingSteps = [...stepUtils.goToAppSteps("project.menu_main_pm", 'Go to the Project App.'), {
-    trigger: '.o_kanban_record:contains("Project Sharing") .o_dropdown_kanban .dropdown-toggle',
+    trigger: ".o_kanban_record:contains(Project Sharing)",
     content: 'Open the project dropdown.',
-    run: "click",
+    run: "hover && click .o_kanban_record:contains(Project Sharing) .o_dropdown_kanban .dropdown-toggle",
 }, {
     trigger: '.dropdown-menu a:contains("Share")',
     content: 'Start editing the project.',

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -82,8 +82,8 @@ registry.category("web_tour.tours").add('project_update_tour', {
     trigger: '.o_kanban_quick_create .o_kanban_add',
     run: "click",
 }, {
-    trigger: '.o_kanban_group:nth-child(2) .o_kanban_header .o_kanban_config .dropdown-toggle',
-    run: "click",
+    trigger: ".o_kanban_group:nth-child(2) .o_kanban_header",
+    run: "hover && click .o_kanban_group:nth-child(2) .o_kanban_header .dropdown-toggle",
 }, {
     trigger: ".dropdown-item.o_column_edit",
     run: "click",

--- a/addons/sale_project/static/tests/tours/project_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/project_create_sol_tour.js
@@ -9,9 +9,9 @@ registry.category("web_tour.tours").add('project_create_sol_tour', {
         content: 'Select Project main menu.',
         run: "click",
     }, {
-        trigger: ".o_kanban_record:contains('Test History Project'):first .o_dropdown_kanban .dropdown-toggle",
+        trigger: ".o_kanban_record:contains(Test History Project):first",
         content: "Open the project dropdown of project name 'Test History Project'.",
-        run: "click",
+        run: "hover && click .o_kanban_record:contains(Test History Project):first .o_dropdown_kanban .dropdown-toggle",
     }, {
         trigger: ".o_kanban_card_manage_settings a:contains('Settings')",
         content: 'Start editing the project.',

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -214,9 +214,9 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: 'Select Project main menu',
     run: "click",
 }, {
-    trigger: '.o_kanban_record:contains("Project for Freeman") .o_dropdown_kanban .dropdown-toggle',
     content: 'Open the project dropdown',
-    run: "click",
+    trigger: ".o_kanban_record:contains(Project for Freeman)",
+    run: "hover && click .o_kanban_record:contains(Project for Freeman) .o_dropdown_kanban .dropdown-toggle",
 }, {
     trigger: '.dropdown-menu a:contains("Settings")',
     content: 'Start editing the project',

--- a/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
+++ b/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import { stepUtils } from '@web_tour/tour_service/tour_utils';
 
 registry.category("web_tour.tours").add('test_stock_picking_batch_sm_to_sml_synchronization', {
     steps: () => [
@@ -100,6 +99,9 @@ registry.category("web_tour.tours").add('test_stock_picking_batch_sm_to_sml_sync
             trigger: ".modal .o_form_button_save",
             run: "click",
         },
-        ...stepUtils.saveForm(),
+        {
+            content: "wait for save completion",
+            trigger: ".o_form_readonly, .o_form_saved",
+        },
     ]
 });

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -480,9 +480,6 @@ registry.category("web_tour.tours").add("test_form_view_resequence_actions", {
         {
             trigger: "body:not(:has(.modal-content))",
         },
-        {
-            trigger: ".o_form_button_cancel",
-        },
     ],
 });
 

--- a/addons/web/static/src/core/utils/ui.js
+++ b/addons/web/static/src/core/utils/ui.js
@@ -56,42 +56,6 @@ export function isVisible(el) {
 }
 
 /**
- * This function only exists because some tours currently rely on the fact that
- * we can click on elements with a non null width *xor* height (not both). However,
- * if one of these is 0, the element is not visible. We thus keep this function
- * to ease the transition to the more robust "isVisible" helper, which requires
- * both a non null width *and* height.
- *
- * @deprecated use isVisible instead
- * @param {Element} el
- * @returns {boolean}
- */
-export function _legacyIsVisible(el) {
-    if (el === document || el === window) {
-        return true;
-    }
-    if (!el) {
-        return false;
-    }
-    let _isVisible = false;
-    if ("offsetWidth" in el && "offsetHeight" in el) {
-        _isVisible = el.offsetWidth > 0 || el.offsetHeight > 0;
-    } else if ("getBoundingClientRect" in el) {
-        // for example, svgelements
-        const rect = el.getBoundingClientRect();
-        _isVisible = rect.width > 0 || rect.height > 0;
-    }
-    if (!_isVisible && getComputedStyle(el).display === "contents") {
-        for (const child of el.children) {
-            if (isVisible(child)) {
-                return true;
-            }
-        }
-    }
-    return _isVisible;
-}
-
-/**
  * @param {DOMRect} rect
  * @param {Position} pos
  * @returns {number}

--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -102,8 +102,7 @@ export class TourAutomatic {
             checkDelay: this.checkDelay || 500,
             steps: macroSteps,
             onError: (error) => {
-                this.throwError(error);
-                console.error("tour not succeeded");
+                this.throwError([error]);
                 end();
             },
             onComplete: () => {
@@ -117,8 +116,10 @@ export class TourAutomatic {
                 end();
             },
             onTimeout: (timeout) => {
-                this.throwError(`TIMEOUT: The step failed to complete within ${timeout} ms.`);
-                console.error("tour not succeeded");
+                this.throwError([
+                    ...this.currentStep.describeWhyIFailed,
+                    `TIMEOUT: The step failed to complete within ${timeout} ms.`,
+                ]);
                 end();
             },
         });
@@ -154,16 +155,11 @@ export class TourAutomatic {
     /**
      * @param {string} [error]
      */
-    throwError(error = ``) {
+    throwError(errors = []) {
         console.groupEnd();
         tourState.setCurrentTourOnError();
         // console.error notifies the test runner that the tour failed.
-        const errors = [
-            `FAILED: ${this.currentStep.describeMe}.`,
-            ...this.currentStep.describeWhyIFailed,
-            error,
-        ];
-        browser.console.error(errors.filter(Boolean).join("\n"));
+        browser.console.error([`FAILED: ${this.currentStep.describeMe}.`, ...errors].join("\n"));
         // The logged text shows the relative position of the failed step.
         // Useful for finding the failed step.
         browser.console.dir(this.describeWhereIFailed);

--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -293,10 +293,8 @@ test("a failing tour logs the step that failed in run", async () => {
         `log: [2/2] Tour tour2 → Step .button1`,
         [
             "error: FAILED: [2/2] Tour tour2 → Step .button1.",
-            "Element has been found.",
             "ERROR IN ACTION: Cannot read properties of null (reading 'click')",
         ].join("\n"),
-        "error: tour not succeeded",
     ];
     expect.verifySteps(expectedError);
 });
@@ -344,9 +342,8 @@ test("a failing tour with disabled element", async () => {
     const expectedError = [
         `error: FAILED: [2/3] Tour tour3 → Step .button1.
 Element has been found.
-BUT: Element is not enabled.
+BUT: Element is not enabled. TIP: You can use :enable to wait the element is enabled before doing action on it.
 TIMEOUT: The step failed to complete within 10000 ms.`,
-        `error: tour not succeeded`,
     ];
     expect.verifySteps(expectedError);
 });
@@ -443,10 +440,9 @@ test("a failing tour logs the step that failed", async () => {
         "log: [4/9] Tour tour1 → Step content (trigger: .button3)",
         "log: [5/9] Tour tour1 → Step content (trigger: .wrong_selector)",
         `error: FAILED: [5/9] Tour tour1 → Step content (trigger: .wrong_selector).
-The cause is that trigger (.wrong_selector) element cannot be found in DOM. TIP: You can use :not(:visible) to force the search for an invisible element.
+Element (.wrong_selector) has not been found.
 TIMEOUT: The step failed to complete within 111 ms.`,
         `runbot: {"content":"content","trigger":".button1","run":"click"},{"content":"content","trigger":".button2","run":"click"},{"content":"content","trigger":".button3","run":"click"},FAILED:[5/9]Tourtour1→Stepcontent(trigger:.wrong_selector){"content":"content","trigger":".wrong_selector","run":"click","timeout":111},{"content":"content","trigger":".button4","run":"click"},{"content":"content","trigger":".button5","run":"click"},{"content":"content","trigger":".button6","run":"click"},`,
-        `error: tour not succeeded`,
     ]);
 });
 
@@ -891,9 +887,9 @@ test("automatic tour with invisible element", async () => {
     await advanceTime(10000);
     expect.verifySteps([
         `error: FAILED: [2/3] Tour tour_de_wallonie → Step .button1.
-The cause is that trigger (.button1) element cannot be found in DOM. TIP: You can use :not(:visible) to force the search for an invisible element.
+Element has been found.
+BUT: Element is not visible. TIP: You can use :not(:visible) to force the search for an invisible element.
 TIMEOUT: The step failed to complete within 10000 ms.`,
-        `error: tour not succeeded`,
     ]);
 });
 
@@ -1498,7 +1494,6 @@ test("check not possible to click below modal", async () => {
 Element has been found.
 BUT: It is not allowed to do action on an element that's below a modal.
 TIMEOUT: The step failed to complete within 10000 ms.`,
-        `error: tour not succeeded`,
     ]);
 });
 
@@ -1540,8 +1535,6 @@ test("a tour where hoot trigger failed", async () => {
     await waitForStep();
     expect.verifySteps([
         `error: FAILED: [2/2] Tour tour_hoot_failed → Step content (trigger: .button1:brol(:machin)).
-HOOT: Failed to execute 'querySelectorAll' on 'Element': '.button1:brol(:machin)' is not a valid selector.
-TypeError: Cannot read properties of undefined (reading 'find')`,
-        "error: tour not succeeded",
+SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '.button1:brol(:machin)' is not a valid selector.`,
     ]);
 });

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -67,7 +67,7 @@ registerWebsitePreviewTour('rte_translator', {
     run: "click",
 }, {
     content: "click on Use this template",
-    trigger: ".o_page_template .o_button_area",
+    trigger: ".o_page_template .o_button_area:not(:visible)",
     run: "click",
 }, {
     content: "insert file name",
@@ -99,7 +99,7 @@ registerWebsitePreviewTour('rte_translator', {
     run: "click",
 }, {
     content: "click on Use this template",
-    trigger: ".o_page_template .o_button_area",
+    trigger: ".o_page_template .o_button_area:not(:visible)",
     run: "click",
 }, {
     content: "insert page name",

--- a/addons/website/static/tests/tours/skip_website_configurator.js
+++ b/addons/website/static/tests/tours/skip_website_configurator.js
@@ -28,18 +28,9 @@ registry.category("web_tour.tours").add('skip_website_configurator', {
         run: "click",
     },
     {
-        content: "make hover button appear",
-        trigger: '.o_theme_preview',
-        run() {
-            const el = document.querySelector(".o_theme_preview .o_button_area");
-            el.style.visibility = "visible";
-            el.style.opacity = 1;
-        },
-    },
-    {
         content: "Install a theme",
-        trigger: 'button[name="button_choose_theme"]',
-        run: "click",
+        trigger: ".o_theme_preview_top",
+        run: "hover && click button[name=button_choose_theme]",
     },
     {
         trigger: ".o_menu_systray .o_user_menu",


### PR DESCRIPTION
In this commit, we replace the use of _legacyIsVisible by the visible option of hoot which refers to isVisible function of hoot-dom.js. This change implies changes in a few tours.
For information, _legacyIsVisible accepts elements with a width of 0 or a length of 0 (which is a bit absurd) while isVisible does not, which implies the changes where we just add :not(:visible) to the trigger. The other main modifications implies tours where you have to hover the trigger to then see the element you want to click on.

In this commit, we also improve error logs.

task~3974087

https://github.com/odoo/enterprise/pull/74171