### PR TITLE
[FIX] mrp: allow a manufacture rule to determine the dest

### DIFF
--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -34,6 +34,7 @@
         'views/stock_orderpoint_views.xml',
         'views/stock_warehouse_views.xml',
         'views/stock_picking_views.xml',
+        'views/stock_rule_views.xml',
         'views/mrp_unbuild_views.xml',
         'views/ir_attachment_view.xml',
         'views/res_config_settings_views.xml',

--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -34,6 +34,15 @@ msgid " <br/><br/> The components will be taken from <b>%s</b>."
 msgstr ""
 
 #. module: mrp
+#. odoo-python
+#: code:addons/mrp/models/stock_rule.py:0
+msgid ""
+" <br/><br/> The manufactured products will be moved towards "
+"<b>%(destination)s</b>, <br/> as specified from <b>%(operation)s</b> "
+"destination."
+msgstr ""
+
+#. module: mrp
 #: model:ir.model.fields.selection,name:mrp.selection__mrp_bom__ready_to_produce__all_available
 msgid " When all components are available"
 msgstr ""

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -18,14 +18,15 @@ class StockRule(models.Model):
 
     def _get_message_dict(self):
         message_dict = super(StockRule, self)._get_message_dict()
-        source, destination, __, __ = self._get_message_values()
+        source, destination, direct_destination, operation = self._get_message_values()
         manufacture_message = _('When products are needed in <b>%s</b>, <br/> a manufacturing order is created to fulfill the need.', destination)
         if self.location_src_id:
             manufacture_message += _(' <br/><br/> The components will be taken from <b>%s</b>.', source)
+        if direct_destination and not self.location_dest_from_rule:
+            manufacture_message += _(' <br/><br/> The manufactured products will be moved towards <b>%(destination)s</b>, <br/> as specified from <b>%(operation)s</b> destination.', destination=direct_destination, operation=operation)
         message_dict['manufacture'] = manufacture_message
         return message_dict
 
-    @api.depends('action')
     def _compute_picking_type_code_domain(self):
         remaining = self.browse()
         for rule in self:
@@ -186,6 +187,8 @@ class StockRule(models.Model):
                 'procurement_group_id': values['group_id'].id,
                 'origin': origin,
             })
+        if self.location_dest_from_rule:
+            mo_values['location_dest_id'] = self.location_dest_id.id
         return mo_values
 
     def _get_date_planned(self, bom_id, values):

--- a/addons/mrp/views/stock_rule_views.xml
+++ b/addons/mrp/views/stock_rule_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_stock_rule_form" model="ir.ui.view">
+            <field name="name">stock.rule.form.inherit.mrp</field>
+            <field name="model">stock.rule</field>
+            <field name="inherit_id" ref="stock.view_stock_rule_form"/>
+            <field name="arch" type="xml">
+                <field name="location_dest_from_rule" position="attributes">
+                    <attribute name="invisible">action not in ['pull', 'pull_push', 'manufacture']</attribute>
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Following #156437, the destination location of a rule is now determined by the associated picking type destination. To keep compatibility with the old pull system (where each rule determined which destination it had, regardless of its picking type), a new field was added to force the destination defined on the rule to apply instead.

This was done for `pull` and `pull_push` rules, as it was mainly the pull rules that were affected, but the `manufacture` case was overlooked, as it would break existing manufacture rules having a different destination on the rule than the one in the related picking type.

To allow that back again, we enable that parameter to be set on `manufacture` rules as well.

opw-4300074

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
