### PR TITLE
[FIX] mail: add one-letter domain support for links

### DIFF
--- a/addons/mail/static/src/js/utils.js
+++ b/addons/mail/static/src/js/utils.js
@@ -65,7 +65,7 @@ var _escapeEntities = (function () {
 // Suggested URL Javascript regex of http://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
 // Adapted to make http(s):// not required if (and only if) www. is given. So `should.notmatch` does not match.
 // And further extended to include Latin-1 Supplement, Latin Extended-A, Latin Extended-B and Latin Extended Additional.
-var urlRegexp = /\b(?:https?:\/\/\d{1,3}(?:\.\d{1,3}){3}|(?:https?:\/\/|(?:www\.))[-a-z0-9@:%._+~#=\u00C0-\u024F\u1E00-\u1EFF]{2,256}\.[a-z]{2,13})\b(?:[-a-z0-9@:%_+~#?&[\]^|{}`\\'$//=\u00C0-\u024F\u1E00-\u1EFF]|,(?!$| )|\.(?!$| |\.)|;(?!$| ))*/gi;
+var urlRegexp = /\b(?:https?:\/\/\d{1,3}(?:\.\d{1,3}){3}|(?:https?:\/\/|(?:www\.))[-a-z0-9@:%._+~#=\u00C0-\u024F\u1E00-\u1EFF]{1,256}\.[a-z]{2,13})\b(?:[-a-z0-9@:%_+~#?&[\]^|{}`\\'$//=\u00C0-\u024F\u1E00-\u1EFF]|,(?!$| )|\.(?!$| |\.)|;(?!$| ))*/gi;
 /**
  * @param {string} text
  * @param {Object} [attrs={}]

--- a/addons/mail/static/tests/qunit_suite_tests/utils/mail_utils_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/utils/mail_utils_tests.js
@@ -8,7 +8,7 @@ QUnit.module('mail', {}, function () {
 QUnit.module('Mail utils');
 
 QUnit.test('add_link utility function', function (assert) {
-    assert.expect(27);
+    assert.expect(29);
 
     var testInputs = {
         'http://admin:password@example.com:8/%2020': true,
@@ -30,6 +30,7 @@ QUnit.test('add_link utility function', function (assert) {
         'https://www.veryveryveryveryverylongdomainname.com/example': true,
         // Subdomain with numbers
         'https://www.45017478-master-all.runbot134.odoo.com/web': true,
+        "https://x.com": true,
     };
 
     _.each(testInputs, function (willLinkify, content) {


### PR DESCRIPTION
Before this PR, one-letter domain (like https://x.com) would not be linkified. This PR allows one-letter domain.

Task-4344826
