### PR TITLE
[FIX] tools: fix PdfFileReader overwrite

### DIFF
--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -38,7 +38,7 @@ else:
     raise ImportError("pypdf implementation not found") from error
 del error
 
-PdfReader, PdfWriter, filters, generic, errors, create_string_object =\
+PdfReaderBase, PdfWriter, filters, generic, errors, create_string_object =\
     pypdf.PdfReader, pypdf.PdfWriter, pypdf.filters, pypdf.generic, pypdf.errors, pypdf.create_string_object
 # because they got re-exported
 ArrayObject, BooleanObject, ByteStringObject, DecodedStreamObject, DictionaryObject, IndirectObject, NameObject, NumberObject =\
@@ -59,18 +59,17 @@ pypdf.filters.decompress = lambda data: decompressobj().decompress(data)
 
 
 # monkey patch to discard unused arguments as the old arguments were not discarded in the transitional class
+# This keep the old default value of the `strict` argument
+# https://github.com/py-pdf/pypdf/blob/1.26.0/PyPDF2/pdf.py#L1061
 # https://pypdf2.readthedocs.io/en/2.0.0/_modules/PyPDF2/_reader.html#PdfReader
-class PdfFileReader(PdfReader):
-    def __init__(self, *args, **kwargs):
-        if "strict" not in kwargs and len(args) < 2:
-            kwargs["strict"] = True  # maintain the default
-        kwargs = {k: v for k, v in kwargs.items() if k in ('strict', 'stream')}
-        super().__init__(*args, **kwargs)
+class PdfReader(PdfReaderBase):
+    def __init__(self, stream, strict=True, *args, **kwargs):
+        super().__init__(stream, strict)
 
 
-if 'PyPDF2' in sys.modules:
-    pypdf.PdfFileReader = PdfFileReader
-    pypdf.PdfFileWriter = PdfWriter
+# Ensure that PdfFileReader and PdfFileWriter are available in case it's still used somewhere
+PdfFileReader = pypdf.PdfFileReader = PdfReader
+pypdf.PdfFileWriter = PdfWriter
 
 _logger = getLogger(__name__)
 DEFAULT_PDF_DATETIME_FORMAT = "D:%Y%m%d%H%M%S+00'00'"

--- a/odoo/tools/pdf/_pypdf2_1.py
+++ b/odoo/tools/pdf/_pypdf2_1.py
@@ -10,13 +10,7 @@ __all__ = [
     "generic",
 ]
 
-
-# by default PdfFileReader will overwrite warnings.showwarning which is what
-# logging.captureWarnings does, meaning it essentially reverts captureWarnings
-# every time it's called which is undesirable
-class PdfReader(PdfFileReader):
-    def __init__(self, stream, strict=True, warndest=None, overwriteWarnings=True):
-        super().__init__(stream, strict=True, warndest=None, overwriteWarnings=False)
+PdfReader = PdfFileReader
 
 
 class PdfWriter(PdfFileWriter):

--- a/odoo/tools/pdf/_pypdf2_1.py
+++ b/odoo/tools/pdf/_pypdf2_1.py
@@ -1,4 +1,4 @@
-from PyPDF2 import filters, generic, utils as errors, PdfFileReader, PdfFileWriter
+from PyPDF2 import filters, generic, utils as errors, PdfFileReader as PdfReader, PdfFileWriter
 from PyPDF2.generic import createStringObject as create_string_object
 
 __all__ = [
@@ -9,8 +9,6 @@ __all__ = [
     "filters",
     "generic",
 ]
-
-PdfReader = PdfFileReader
 
 
 class PdfWriter(PdfFileWriter):


### PR DESCRIPTION
In #183165 the override of the PdfReader constructor was forcing the `strict` parameter to True[1][1] in the pdf shim for PyPDF2 1.x.

So, when a PdfReader is instanciated with strict set to False, with that PyPDF version installed, the strict parameter is not taken into account. In that case, it impossible to upload some PDF documents that were allowed before the shims.

With this commit, the override of the constructor is removed in the 1.x shim and the PdfReader override is only made once at the upper level. The `strict` parameter is defaulting to True but not enforced as it was the default behavior in PyPDF2 1.x. It should be changed later to follow the behavior of PyPDF2 >= 2.x.

Also, any other parameter of the constructor are discarded as they are useless in PyPDF 1.x and not compatible at all with PyPDF >= 2.x. On the other hand, the new `password` parameter of 2.x is not backward compatible.

[1]: odoo/odoo@f03a12c9296c90e6e371f0970fc3760eb5514ab1/odoo/tools/pdf/_pypdf2_1.py#L19