### PR TITLE
[FIX] tests: wait for browser process

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1118,6 +1118,7 @@ class ChromeBrowser:
         if self.chrome:
             self._logger.info("Terminating chrome headless with pid %s", self.chrome.pid)
             self.chrome.terminate()
+            self.chrome.wait(5)
 
         if self.user_data_dir and os.path.isdir(self.user_data_dir) and self.user_data_dir != '/':
             self._logger.info('Removing chrome user profile "%s"', self.user_data_dir)


### PR DESCRIPTION
Some tests using `browser_js` trigger `ResourceWarning` on exit.

This is because while `ChromeBrowser.stop` terminates the browser the time to execute `_wait_remaining_requests` might not be sufficient for the browser to actually shut down (e.g. if there are no outstanding requests, or the scheduler just happens not to run the browser). This results in `browser_js` returning, `ChromeBrowser` being GC'd, triggering `Popen.__del__` which triggers the warning.

This is normally ignored as even with `-Werror` Python can't / won't raise exceptions in `__del__`, but in pytest that triggers a followup `PytestUnraisableExceptionWarning` which *can* be raised later on and fail the test suite.
