### PR TITLE
[FIX] point_of_sale: fix traceback when using printWeb fallback

### DIFF
--- a/addons/point_of_sale/static/src/app/printer/pos_printer_service.js
+++ b/addons/point_of_sale/static/src/app/printer/pos_printer_service.js
@@ -38,10 +38,10 @@ export class PosPrinterService extends PrinterService {
         try {
             return await super.printHtml(...arguments);
         } catch (error) {
-            return this.printHtmlAlternative(error);
+            return this.printHtmlAlternative(error, ...arguments);
         }
     }
-    async printHtmlAlternative(error) {
+    async printHtmlAlternative(error, ...printArguments) {
         const confirmed = await ask(this.dialog, {
             title: error.title || _t("Printing error"),
             body: error.body + _t("Do you want to print using the web printer? "),
@@ -50,7 +50,7 @@ export class PosPrinterService extends PrinterService {
             // We want to call the _printWeb when the dialog is fully gone
             // from the screen which happens after the next animation frame.
             await new Promise(requestAnimationFrame);
-            this.printWeb(...arguments);
+            this.printWeb(...printArguments);
         }
     }
 }


### PR DESCRIPTION
Introduced in #184138. When you try to print a receipt using an IoT box that isn't available, there is the option to print using the browser as a fallback. However, clicking this option produces a traceback.

Steps to reproduce:
- Configure a POS to use an IoT Box Receipt Printer (e.g. the default [Shop] Receipt Printer)
- Make sure the IoT box is not reachable
- Make an order and try to print the receipt, it should fail and the dialog will appear asking if you would like to use the web printer
- Select OK, and a traceback will appear

Expected behaviour:
- There is no traceback and the browser printing dialog appears

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
