### PR TITLE
[FIX] account: report builder line sequences

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -189,7 +189,7 @@ class AccountReport(models.Model):
     @api.constrains('line_ids')
     def _validate_parent_sequence(self):
         previous_lines = self.env['account.report.line']
-        for line in self.line_ids:
+        for line in self.line_ids.sorted('sequence'):
             if line.parent_id and line.parent_id not in previous_lines:
                 raise ValidationError(
                     _('Line "%(line)s" defines line "%(parent_line)s" as its parent, but appears before it in the report. '


### PR DESCRIPTION
Issue:
 When using the enterprise version, and configuring an accounting report with the report
 builder, issues might arise when changing the sequence of lines (using the drag and drop feature).
 Combined with the enterprise PR, this commit solves the issue by returning the lines ordered by sequence.

 Enterprise PR: https://github.com/odoo/odoo/pull/187907#pullrequestreview-2581564549

task-4328098
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
