### PR TITLE
[FIX] l10n_be_pos_sale: force invoice for intracom

### DIFF
--- a/addons/l10n_be_pos_sale/__init__.py
+++ b/addons/l10n_be_pos_sale/__init__.py
@@ -1,1 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/l10n_be_pos_sale/i18n/l10n_be_pos_sale.pot
+++ b/addons/l10n_be_pos_sale/i18n/l10n_be_pos_sale.pot
@@ -20,8 +20,9 @@ msgstr ""
 #: code:addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js:0
 #, python-format
 msgid ""
-"If you do not invoice imported orders you will encounter issues in your "
-"accounting. Especially in the EC Sale List report"
+"If you do not invoice imported orders containing intra-community taxes you "
+"will encounter issues in your accounting. Especially in the EC Sales List "
+"report"
 msgstr ""
 
 #. module: l10n_be_pos_sale

--- a/addons/l10n_be_pos_sale/models/__init__.py
+++ b/addons/l10n_be_pos_sale/models/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_session

--- a/addons/l10n_be_pos_sale/models/pos_session.py
+++ b/addons/l10n_be_pos_sale/models/pos_session.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class PosSession(models.Model):
+    _inherit = 'pos.session'
+
+    def _pos_data_process(self, loaded_data):
+        res = super()._pos_data_process(loaded_data)
+        if self.company_id.country_code == 'BE':
+            intracom_fpos = self.env.ref(f"l10n_be.{self.env.company.id}_fiscal_position_template_3", False)
+            if intracom_fpos:
+                loaded_data['intracom_tax_ids'] = intracom_fpos.tax_ids.tax_dest_id.ids
+        return res

--- a/addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js
+++ b/addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js
@@ -6,11 +6,20 @@ import Registries from 'point_of_sale.Registries';
 export const PoSSaleBePaymentScreen = (PaymentScreen) =>
     class extends PaymentScreen {
         toggleIsToInvoice() {
-            const has_origin_order = this.currentOrder.get_orderlines().some(line => line.sale_order_origin_id);
-            if(this.currentOrder.is_to_invoice() && this.env.pos.company.country && this.env.pos.company.country.code === "BE" && has_origin_order){
+            const orderLines = this.currentOrder.get_orderlines();
+            const has_origin_order = orderLines.some((line) => line.sale_order_origin_id);
+            const has_intracom_taxes = orderLines.some((line) =>
+                line.tax_ids && this.env.pos.intracom_tax_ids && line.tax_ids.some((tax) => this.env.pos.intracom_tax_ids.includes(tax))
+            );
+            if (
+                this.currentOrder.is_to_invoice() &&
+                this.env.pos.company.country.code === "BE" &&
+                has_origin_order &&
+                has_intracom_taxes
+            ) {
                 this.showPopup('ErrorPopup', {
                     title: this.env._t('This order needs to be invoiced'),
-                    body: this.env._t('If you do not invoice imported orders you will encounter issues in your accounting. Especially in the EC Sale List report'),
+                    body: this.env._t('If you do not invoice imported orders containing intra-community taxes you will encounter issues in your accounting. Especially in the EC Sales List report'),
                 });
             }
             else{

--- a/addons/l10n_be_pos_sale/static/src/js/models.js
+++ b/addons/l10n_be_pos_sale/static/src/js/models.js
@@ -1,0 +1,17 @@
+odoo.define("l10n_be_pos_sale.models", function (require) {
+    "use strict";
+
+    var { PosGlobalState } = require("point_of_sale.models");
+    const Registries = require("point_of_sale.Registries");
+
+    const PoSSaleBeGlobalState = (PosGlobalState) =>
+        class PoSSaleBeGlobalState extends PosGlobalState {
+            async _processData(loadedData) {
+                await super._processData(...arguments);
+                if (this.company.country && this.company.country.code == "BE") {
+                    this.intracom_tax_ids = loadedData["intracom_tax_ids"];
+                }
+            }
+        };
+    Registries.Model.extend(PosGlobalState, PoSSaleBeGlobalState);
+});

--- a/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
+++ b/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
@@ -3,6 +3,7 @@
 import odoo
 
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+from odoo.addons.l10n_be_pos_sale.models.pos_session import PosSession
 from odoo import Command
 
 @odoo.tests.tagged('post_install_l10n', 'post_install', '-at_install')
@@ -13,6 +14,27 @@ class TestPoSSaleL10NBe(TestPointOfSaleHttpCommon):
         super().setUpClass(chart_template_ref=chart_template_ref)
 
     def test_settle_order_is_invoice(self):
+
+        intracom_fpos = self.env.ref(f"l10n_be.{self.env.company.id}_fiscal_position_template_3", False)
+
+        intracom_tax = self.env['account.tax'].create({
+            'name': 'test_intracom_taxes_computation_0_1',
+            'amount_type': 'percent',
+            'amount': 21,
+            'invoice_repartition_line_ids': [
+                (0, 0, {'repartition_type': 'base', 'factor_percent': 100.0}),
+                (0, 0, {'repartition_type': 'tax', 'factor_percent': 100.0}),
+                (0, 0, {'repartition_type': 'tax', 'factor_percent': -100.0}),
+            ],
+            'refund_repartition_line_ids': [
+                (0, 0, {'repartition_type': 'base', 'factor_percent': 100.0}),
+                (0, 0, {'repartition_type': 'tax', 'factor_percent': 100.0}),
+                (0, 0, {'repartition_type': 'tax', 'factor_percent': -100.0}),
+            ],
+        })
+
+        intracom_fpos.tax_ids.tax_dest_id = intracom_tax
+
         #Change company country to Belgium
         self.env.user.company_id.country_id = self.env.ref('base.be')
 
@@ -31,7 +53,7 @@ class TestPoSSaleL10NBe(TestPointOfSaleHttpCommon):
                 'product_uom_qty': 10,
                 'product_uom': self.product_a.uom_id.id,
                 'price_unit': 10,
-                'tax_id': False,
+                'tax_id': intracom_tax,
             })],
         })
 


### PR DESCRIPTION
Previously, settling a sale.order from the POS of a Belgian company would require the creation of an invoice.

Steps to reproduce:
-------------------
* Install `l10n_be_pos_cert`
* Switch to the Beligian company
* Crete a quotation in **Sale** app
* Add any partner and any product, remove all taxes for the product line
* Save
* Open pos shop
* Settle the order
* de-select the invoice button
> Observation: Error message appears: If you do not invoice imported orders you will encounter issues in your
accounting. Especially in the EC Sale List report.

Why the fix:
------------
This error message originates from this commit: https://github.com/odoo/odoo/commit/c760fbb1bd2e7725b5e759198684a07060612033

This was added in 16.0. It was added to avoid accounting errors when settling sale orders and not invoicing it.

The following commit https://github.com/odoo/odoo/commit/3a5e22218708b4b6c9aedfa965d9f3c279edbd46 update the previous one as the invoice enforcement is only needed when we have intracom taxes on the SO.

Since the last commit was added in 17.0, we backport it here for 16.0

opw-4299983