### PR TITLE
[IMP] mail: open search conversation with ctrl+F

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -8,6 +8,7 @@ import { Component, useState, useSubEnv } from "@odoo/owl";
 
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
@@ -213,6 +214,7 @@ export class DiscussSidebarCategories extends Component {
         useSubEnv({
             filteredThreads: (threads) => this.filteredThreads(threads),
         });
+        useHotkey("control+F", this.onClickFindOrStartConversation.bind(this));
     }
 
     filteredThreads(threads) {


### PR DESCRIPTION
Discuss recently added a way to search among conversations from the sidebar. However, it can be cumbersome to click this input.

This PR adds the ctrl+F shortcut which is more natural.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
