### PR TITLE
[FIX] website: fix partially non editable invisible snippet

### DIFF
--- a/addons/website/static/src/scss/website.wysiwyg.scss
+++ b/addons/website/static/src/scss/website.wysiwyg.scss
@@ -65,6 +65,7 @@ html[data-edit_translations="1"] {
         z-index: 100;
         background-color: $o-we-accent;
         font-size: 0px;
+        pointer-events: none;
         content: "."; // Content is mandatory.
     }
     &.d-md-none::before, &.d-lg-none::before {


### PR DESCRIPTION
Before this commit:
- The `::before` pseudo-element had `width: -webkit-fill-available`
and `width: -moz-available`, causing it to span the entire width
of its container.
- Its `z-index: 100` made it overlap with other elements,
preventing interaction with underlying elements.

After this commit:
- `pointer-events: none` was applied to the pseudo-element.
- This allows interactions with underlying elements while
retaining the visual styling.

task-4313526

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
