### PR TITLE
[FIX] l10n_*: auto install syscohada based on account

### DIFF
--- a/addons/l10n_bf/__manifest__.py
+++ b/addons/l10n_bf/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_bj/__manifest__.py
+++ b/addons/l10n_bj/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_cd/__manifest__.py
+++ b/addons/l10n_cd/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_cf/__manifest__.py
+++ b/addons/l10n_cf/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_cg/__manifest__.py
+++ b/addons/l10n_cg/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_ci/__manifest__.py
+++ b/addons/l10n_ci/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_cm/__manifest__.py
+++ b/addons/l10n_cm/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_ga/__manifest__.py
+++ b/addons/l10n_ga/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_gn/__manifest__.py
+++ b/addons/l10n_gn/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_gq/__manifest__.py
+++ b/addons/l10n_gq/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_gw/__manifest__.py
+++ b/addons/l10n_gw/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_km/__manifest__.py
+++ b/addons/l10n_km/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_ml/__manifest__.py
+++ b/addons/l10n_ml/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_ne/__manifest__.py
+++ b/addons/l10n_ne/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_sn/__manifest__.py
+++ b/addons/l10n_sn/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_td/__manifest__.py
+++ b/addons/l10n_td/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_tg/__manifest__.py
+++ b/addons/l10n_tg/__manifest__.py
@@ -11,8 +11,9 @@ The Chart of Accounts is from SYSCOHADA.
     """,
     'depends': [
         'l10n_syscohada',
+        'account',
     ],
-    'auto_install': ['l10n_syscohada'],
+    'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml'
     ],


### PR DESCRIPTION
The dependency `l10n_syscohada` doesn't get installed automatically when account is installed, therefore these l10n don't get installed either.

Each localization that had `countries` set in the manifest should have an `auto_install` containing the main app it is for.

