### PR TITLE
[FIX] l10n_pe_pos : autofill the partner on refund

### DIFF
--- a/addons/l10n_pe_pos/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/l10n_pe_pos/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -9,7 +9,7 @@ patch(TicketScreen.prototype, {
         if (
             partner &&
             (!destinationOrder.get_partner() ||
-                destinationOrder.get_partner().id === this.pos.consumidorFinalAnonimoId)
+                destinationOrder.get_partner().id === this.pos.session._consumidor_final_anonimo_id)
         ) {
             return destinationOrder.set_partner(partner);
         }


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_pe_pos"
- Switch to a Peruvian company and open a POS session
- Sell a product with a partner specified (different from "Consumidor Final")
- Try to refund the order
- The partner is back to "Consumidor Final" and can't be changed

### Cause:
The code supposed to put back the right partner is checking a wrong field (`this.pos.consumidorFinalAnonimoId` is undifined) so the partner is not correctly set.

### Solution:
Use the correct field : `this.pos.session._consumidor_final_anonimo_id`

opw-4282195
