### PR TITLE
[FIX] mail: livechat window of visitor correct header avatar spacing

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -76,6 +76,15 @@ export class ChatWindow extends Component {
         return undefined;
     }
 
+    get hasActionsMenu() {
+        return (
+            this.partitionedActions.group.length > 0 ||
+            this.partitionedActions.other.length > 0 ||
+            (this.ui.isSmall && this.partitionedActions.quick.length > 2) ||
+            (!this.ui.isSmall && this.partitionedActions.quick.length > 3)
+        );
+    }
+
     get thread() {
         return this.props.chatWindow.thread;
     }

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -14,7 +14,7 @@
         tabindex="1"
     >
         <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall and thread and !state.actionsDisabled, 'pt-2': !thread }">
-            <t t-if="partitionedActions.group.length > 0 or partitionedActions.other.length > 0 or (ui.isSmall and partitionedActions.quick.length > 2) or (!ui.isSmall and partitionedActions.quick.length > 3)">
+            <t t-if="hasActionsMenu">
                 <div class="d-flex text-truncate">
                     <Dropdown position="'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="'d-flex flex-column py-0'">
                         <button
@@ -126,10 +126,12 @@
 </t>
 
 <t t-name="mail.ChatWindow.headerContent">
-    <div class="o-mail-ChatWindow-threadAvatar my-0 me-1 py-1" t-att-class="{
+    <div class="o-mail-ChatWindow-threadAvatar my-0 me-1" t-att-class="{
+        'py-1': !thread or threadActions.actions.length gt 3,
         'py-2': thread and threadActions.actions.length lte 3,
         'ms-1': thread,
         'ms-3': !thread,
+        'ps-2': !hasActionsMenu,
     }">
         <img t-if="thread" class="rounded o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
         <i t-else="" class="fa fa-pencil fa-lg fa-fw py-1"/>


### PR DESCRIPTION
In the backend, the avatar and conversation name is a clickable button to show more thread actions. When this is clickable, there's some spacing to align avatar nicely.

In livechat from visitor perspective, however, the avatar was not spaced properly. This come from avatar and conversation name not being clickable to show more actions, because all actions are available in quick on the right side of header.

This commit adds some spacing at beginning of header content of chat window when there's no actions menu, to compensate with the padding of the actions menu button.

Before / After
<img width="361" alt="Screenshot 2024-11-20 at 15 07 07" src="https://github.com/user-attachments/assets/0cbf75af-df85-4509-8ec3-31ed0893025b"> <img width="363" alt="Screenshot 2024-11-20 at 15 06 49" src="https://github.com/user-attachments/assets/2197a159-a64e-4b80-a5df-cd1b8fe3d578">
