### PR TITLE
[FIX] stock: fix arrows direction in stock rule report in case of rtl

### DIFF
--- a/addons/stock/report/report_stock_rule.py
+++ b/addons/stock/report/report_stock_rule.py
@@ -69,6 +69,7 @@ class ReportStockRule(models.AbstractModel):
             'locations': locations,
             'header_lines': header_lines,
             'route_lines': route_lines,
+            'is_rtl': self.env['res.lang']._lang_get_direction(self.env.user.lang) == 'rtl',
         }
 
     @api.model

--- a/addons/stock/report/report_stock_rule.xml
+++ b/addons/stock/report/report_stock_rule.xml
@@ -158,14 +158,14 @@
         </div>
     </template>
     <template id="report_stock_rule_right_arrow">
-        <div class="o_report_stock_rule_arrow">
+        <div t-attf-class="o_report_stock_rule_arrow {{ 'o_report_stock_rule_rtl' if is_rtl else '' }}">
             <svg width="100%" height="100%" viewBox="0 0 10 10">
                 <polygon points="0,0 0,10 10,5" t-attf-style="stroke: #{color}; fill: #{color};"/>
             </svg>
         </div>
     </template>
     <template id="report_stock_rule_left_arrow">
-        <div class="o_report_stock_rule_arrow">
+        <div t-attf-class="o_report_stock_rule_arrow {{ 'o_report_stock_rule_rtl' if is_rtl else '' }}">
             <svg width="100%" height="100%" viewBox="0 0 10 10">
                 <polygon points="0,5 10,10 10,0" t-attf-style="stroke: #{color}; fill: #{color};"/>
             </svg>

--- a/addons/stock/static/src/scss/report_stock_rule.scss
+++ b/addons/stock/static/src/scss/report_stock_rule.scss
@@ -119,4 +119,8 @@
             }
         }
     }
+
+    .o_report_stock_rule_rtl {
+        transform: scaleX(-1);
+    }
 }


### PR DESCRIPTION
This commit fixes the direction of the arrows in the stock rules diagram if the user languange is right-to-left.

opw-4302429

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
