### PR TITLE
[FIX] mail,web: fix disabled on quick action dropdown

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -174,7 +174,7 @@
 
 <t t-name="mail.Composer.dropdownActions">
     <t t-foreach="partitionedActions.other" t-as="action" t-key="action.id">
-        <DropdownItem class="'btn rounded-0 d-flex align-items-center px-2 py-2 m-0'" onSelected="(ev) => action.onClick?.(ev)" attrs="{ 'name': action.id, 'data-hotkey': action.hotkey, 'disabled': action.disabledCondition or areAllActionsDisabled }">
+        <DropdownItem tag="'button'" class="'btn rounded-0 d-flex align-items-center px-2 py-2 m-0'" onSelected="(ev) => action.onClick?.(ev)" attrs="{ 'name': action.id, 'data-hotkey': action.hotkey, 'disabled': action.disabledCondition or areAllActionsDisabled }">
             <i class="ms-1" t-att-class="action.icon"/>
             <span class="mx-2" t-out="action.name"/>
         </DropdownItem>

--- a/addons/web/static/src/core/dropdown/dropdown_item.js
+++ b/addons/web/static/src/core/dropdown/dropdown_item.js
@@ -10,6 +10,10 @@ const ClosingMode = {
 export class DropdownItem extends Component {
     static template = "web.DropdownItem";
     static props = {
+        tag: {
+            type: String,
+            optional: true,
+        },
         class: {
             type: [String, Object],
             optional: true,

--- a/addons/web/static/src/core/dropdown/dropdown_item.xml
+++ b/addons/web/static/src/core/dropdown/dropdown_item.xml
@@ -3,7 +3,7 @@
 
   <t t-name="web.DropdownItem">
     <t
-      t-tag="props.attrs and props.attrs.href ? 'a' : 'span'"
+      t-tag="props.tag ?? (props.attrs and props.attrs.href ? 'a' : 'span')"
       class="o-dropdown-item dropdown-item o-navigable"
       t-att-class="props.class"
       t-on-click.stop="onClick"

--- a/addons/web/static/tests/core/dropdown/dropdown_item.test.js
+++ b/addons/web/static/tests/core/dropdown/dropdown_item.test.js
@@ -23,6 +23,17 @@ test("can be rendered as <span/>", async () => {
     expect(".dropdown-item").toHaveAttribute("role", "menuitem");
 });
 
+test("can be rendered using the tag prop", async () => {
+    class Parent extends Component {
+        static components = { DropdownItem };
+        static props = [];
+        static template = xml`<DropdownItem tag="'button'">coucou</DropdownItem>`;
+    }
+    await mountWithCleanup(Parent);
+
+    expect("button.dropdown-item").toHaveCount(1);
+});
+
 test("(with href prop) can be rendered as <a/>", async () => {
     class Parent extends Component {
         static components = { DropdownItem };


### PR DESCRIPTION
Before this PR, disabled condition where not working on the composer quick action button:

- DropdownItem creates `span` element, `disabled` attribute has no effect on span
- Dropdown has a disabled prop to disable it properly

This PR fix those issue
