### PR TITLE
[FIX] website_sale_collect: button disabled

### DIFF
--- a/addons/website_sale_collect/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml
+++ b/addons/website_sale_collect/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml
@@ -5,7 +5,7 @@
         <button id="submit_location_small" position="attributes">
             <attribute
                 name="t-att-disabled"
-                add="!selectedLocation?.additional_data?.in_store_stock?.in_stock"
+                add="!(selectedLocation?.additional_data?.in_store_stock?.in_stock ?? true)"
                 separator=" || "
             />
         </button>

--- a/addons/website_sale_collect/static/src/js/location_selector/map_container/map_container.xml
+++ b/addons/website_sale_collect/static/src/js/location_selector/map_container/map_container.xml
@@ -5,14 +5,14 @@
         <button id="submit_location_large" position="attributes">
             <attribute
                 name="t-att-disabled"
-                add="!selectedLocation?.additional_data?.in_store_stock?.in_stock"
+                add="!(selectedLocation?.additional_data?.in_store_stock?.in_stock ?? true)"
                 separator=" || "
             />
         </button>
         <button id="submit_location_medium" position="attributes">
             <attribute
                 name="t-att-disabled"
-                add="!selectedLocation?.additional_data?.in_store_stock?.in_stock"
+                add="!(selectedLocation?.additional_data?.in_store_stock?.in_stock ?? true)"
                 separator=" || "
             />
         </button>


### PR DESCRIPTION
Steps to reproduce:
- install website_sale_collect
- setup a sendcloud delivery method with pickup points
- try to select a location

Bug:
The `Choose this location` button is disabled

This is a tiny partial revert of https://github.com/odoo/odoo/pull/180754. The replacement of the chain of `and` cannot be replaced by the ?. operator, as they will return !False and thus disable the button even if `additionalData` (and the other following items of the ?. chain) is not present on the selected location.

opw-4283739


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
