### PR TITLE
[FIX] core: fix company dependent flush

### DIFF
--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -1615,6 +1615,25 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         company_records = self.env['test_new_api.company'].search([('foo', '=', 'DEF')])
         self.assertEqual(len(company_records), 1)
 
+    def test_27_company_dependent_bool_integer_float(self):
+         company0 = self.env.ref('base.main_company')
+         company1 = self.env['res.company'].create({'name': 'A'})
+         Model = self.env['test_new_api.company']
+         record = Model.create({})
+         record.invalidate_recordset()
+         cr = self.env.cr
+         cr.execute("SELECT truth, count, phi FROM test_new_api_company WHERE id = %s", (record.id,))
+         self.assertEqual(cr.fetchone(), (None, None, None))
+         for company in [company0, company1]:
+             record_company = record.with_company(company)
+             self.assertEqual(record_company.truth, False)
+             self.assertEqual(record_company.count, 0)
+             self.assertEqual(record_company.phi, 0.0)
+         record.write({'truth': False, 'count': 0, 'phi': 0})  # write fallback equivalent
+         record.invalidate_recordset()
+         cr.execute("SELECT truth, count, phi FROM test_new_api_company WHERE id = %s", (record.id,))
+         self.assertEqual(cr.fetchone(), (None, None, None))
+
     def test_28_company_dependent_search(self):
         """ Test the search on company-dependent fields in all corner cases.
             This assumes that filtered_domain() correctly filters records when

--- a/odoo/orm/fields_misc.py
+++ b/odoo/orm/fields_misc.py
@@ -19,6 +19,11 @@ class Boolean(Field[bool]):
 
     def convert_to_column(self, value, record, values=None, validate=True):
         return bool(value)
+    
+    def convert_to_column_update(self, value, record):
+         if self.company_dependent:
+             value = {k: bool(v) for k, v in value.items()}
+         return super().convert_to_column_update(value, record)
 
     def convert_to_cache(self, value, record, validate=True):
         return bool(value)

--- a/odoo/orm/fields_numeric.py
+++ b/odoo/orm/fields_numeric.py
@@ -23,6 +23,11 @@ class Integer(Field[int]):
 
     def convert_to_column(self, value, record, values=None, validate=True):
         return int(value or 0)
+    
+    def convert_to_column_update(self, value, record):
+         if self.company_dependent:
+             value = {k: int(v or 0) for k, v in value.items()}
+         return super().convert_to_column_update(value, record)
 
     def convert_to_cache(self, value, record, validate=True):
         if isinstance(value, dict):
@@ -129,6 +134,11 @@ class Float(Field[float]):
         if self.company_dependent:
             return value_float
         return value
+    
+    def convert_to_column_update(self, value, record):
+         if self.company_dependent:
+             value = {k: float(v or 0.0) for k, v in value.items()}
+         return super().convert_to_column_update(value, record)
 
     def convert_to_cache(self, value, record, validate=True):
         # apply rounding here, otherwise value in cache may be wrong!

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -2873,7 +2873,7 @@ class BaseModel(metaclass=MetaModel):
                     fallback=fallback,
                     column_type=SQL(field._column_type[1]),
                 )
-            if field.type in ('boolean', 'integer', 'float', 'monetary'):
+            if field.type in ('boolean', 'integer', 'float'):
                 return SQL('(%s)::%s', sql_field, SQL(field._column_type[1]))
             # here the specified value for a company might be NULL e.g. '{"1": null}'::jsonb
             # the result of current sql_field might be 'null'::jsonb


### PR DESCRIPTION
The problem is caused by https://github.com/odoo/odoo/pull/184275 For company dependent Boolean/Integer/Float fields, if fallback is unset or falsy, the value filled to cache can be `None` after fetch. When `_flush` `None` in cache for these fields should be converted to the logical equivalent `False`/`0`/`0.0` to allow SQL to compare with the fallback value and drop them when UPDATE

fix for [18.0](https://github.com/odoo/odoo/pull/187820)

[upgrade](https://github.com/odoo/upgrade/pull/6791)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
