### PR TITLE
[FIX] html_editor: prevent `setSelection` on elements outside the editor

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -142,6 +142,7 @@ export class SelectionPlugin extends Plugin {
         "resetActiveSelection",
         "focusEditable",
         // "collapseIfZWS",
+        "isSelectionInEditable",
     ];
     resources = {
         user_commands: { id: "selectAll", run: this.selectAll.bind(this) },

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -475,6 +475,9 @@ export class TablePlugin extends Plugin {
     hanldeFirefoxSelection(ev = null) {
         const selection = this.document.getSelection();
         if (isBrowserFirefox()) {
+            if (!this.dependencies.selection.isSelectionInEditable(selection)) {
+                return false;
+            }
             if (selection.rangeCount > 1) {
                 // In Firefox, selecting multiple cells within a table using the mouse can create multiple ranges.
                 // This behavior can cause the original selection (where the selection started) to be lost.


### PR DESCRIPTION
**Problem**:
When selecting nodes outside the editor in chatter, attempting to set the selection results in a traceback. This issue occurs because the `setSelection` logic does not properly handle cases where the selected node falls outside the editor's context.

**Solution**:
Add a check to ensure that the `setSelection` logic does not execute if the selection is outside the editor. same as what we have in 17.0: https://github.com/odoo/odoo/blob/288f815382f6d4f857c233c4627774f1992af5ba/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js#L2608-L2610

**Steps to reproduce**:
1. Open any form with chatter in Firefox.
2. Select text across multiple messages in the chatter.
3. A traceback occurs due to improper handling of selections outside the editor.

opw-4345728

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
