### PR TITLE
[FIX] website: ensure proper URL encoding for background-image

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -984,7 +984,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
         this.__savedCovers[resModel].push(resID);
 
         const imageEl = el.querySelector('.o_record_cover_image');
-        let cssBgImage = imageEl.style.backgroundImage;
+        let cssBgImage = getComputedStyle(imageEl)["backgroundImage"];
         if (imageEl.classList.contains("o_b64_image_to_save")) {
             imageEl.classList.remove("o_b64_image_to_save");
             const groups = cssBgImage.match(/url\("data:(?<mimetype>.*);base64,(?<imageData>.*)"\)/)?.groups;


### PR DESCRIPTION
In a prior commit [1], a jQuery call was replaced with a vanilla JS implementation, inadvertently introducing an issue where unencoded URLs in background-image caused rendering or validation errors, such as "Invalid property value."

The `style.backgroundImage` property in vanilla JavaScript returns the raw value of the attribute, unlike jQuery's `.css('background-image')`, which automatically encodes URLs.

This fix ensures that URLs extracted are properly encoded using `getComputedStyle`.

Steps to reproduce:

- Install the Blog module.
- Configure your credentials in the Unsplash settings.
- Create a new post within a blog.
- Change the background of the post by searching for "electrical wire" on Unsplash. Select the first image in the results, noting that its filename contains a space.
- Click the "Add" button to set the background image.
- Save the changes.
- Observe that the background image is not applied. Inspect the style attribute of the div, and you will find: background-image: url(/unsplash/hokONTrHIAQ/electrical wire.jpg?unique=6015d8d5); This value is invalid for the background-image property due to the unencoded space in the URL.

[1]: https://github.com/odoo/odoo/commit/f9c9d6c4058086849b7e87174afd7f97d514baad

opw-4233483
opw-4271093
