### PR TITLE
[IMP] base: Extending Qweb to support rendering xml from files only

### DIFF
--- a/odoo/addons/base/tests/file_template/file_expected_render.xml
+++ b/odoo/addons/base/tests/file_template/file_expected_render.xml
@@ -1,0 +1,9 @@
+<Document>
+    <Header>
+        <DocumentName>Test Document</DocumentName>
+    </Header>
+    <Body>
+        <Name>Jerry</Name>
+        <ForeName>Khan</ForeName>
+    </Body>
+</Document>

--- a/odoo/addons/base/tests/file_template/templates/file_template.xml
+++ b/odoo/addons/base/tests/file_template/templates/file_template.xml
@@ -1,0 +1,6 @@
+<Document>
+    <Header>
+        <DocumentName t-out="document_name"/>
+    </Header>
+    <t t-call="base/tests/file_template/templates/subdir/file_subtemplate.xml"/>
+</Document>

--- a/odoo/addons/base/tests/file_template/templates/subdir/file_subtemplate.xml
+++ b/odoo/addons/base/tests/file_template/templates/subdir/file_subtemplate.xml
@@ -1,0 +1,4 @@
+<Body>
+    <Name t-out="partner['name']"/>
+    <ForeName t-out="partner['forename']"/>
+</Body>

--- a/odoo/addons/base/tests/file_template/unreadable_file_template.xml
+++ b/odoo/addons/base/tests/file_template/unreadable_file_template.xml
@@ -1,0 +1,4 @@
+<Body>
+    <Name t-out="partner['name']"/>
+    <ForeName t-out="partner['forename']"/>
+</Body>


### PR DESCRIPTION
This commit add 1 new feature to Qweb that gives the possibilityto render templates from files using a path as template name.
This is used to prevent the user from changing templates. We want that specifically with calls to external api under our name as we want to keep our request as intended.
It also allows to change file template in stable and so avoid the stable policy.

A template name should look like this when targetting a file `l10n_uk_cis/documents/transaction_cis_body.xml`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
