### PR TITLE
[FIX] website_project: remove tracking on partner_name field

### DIFF
--- a/addons/website_project/models/project_task.py
+++ b/addons/website_project/models/project_task.py
@@ -9,6 +9,6 @@ class ProjectTask(models.Model):
     # Need this field to check there is no email loops when Odoo reply automatically
     email_from = fields.Char('Email From')
     # Used to submit tasks from a contact form
-    partner_name = fields.Char(string='Customer Name', related="partner_id.name", store=True, readonly=False)
+    partner_name = fields.Char(string='Customer Name', related="partner_id.name", store=True, readonly=False, tracking=False)
     partner_phone = fields.Char(string='Customer Phone', related="partner_id.phone", store=True, readonly=False)
     partner_company_name = fields.Char(string='Company Name', related="partner_id.company_name", store=True, readonly=False)


### PR DESCRIPTION
Before this commit, the `partner_name` was tracked in `project.task` model because `name` of `res.partner` model is tracked and so the related setup will keep the value set on `name` field of `res.partner` to also make the related field tracked.

This commit removes the tracking on the related field in task since it was not expected. Moreover, we will get a duplicated tracking message with `partner_id` field which is also tracked in `project.task` model.
