### PR TITLE
[IMP] website_event: separate controller logic in a prepare function for extensibility

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -221,8 +221,7 @@ class WebsiteEventController(http.Controller):
             'quantity': count,
         } for tid, count in ticket_order.items() if count]
 
-    @http.route(['/event/<model("event.event"):event>/registration/new'], type='json', auth="public", methods=['POST'], website=True)
-    def registration_new(self, event, **post):
+    def _prepare_registration_new_values(self, event, **post):
         tickets = self._process_tickets_form(event, post)
         availability_check = True
         if event.seats_limited:
@@ -248,12 +247,18 @@ class WebsiteEventController(http.Controller):
                     "email": visitor.email,
                     "phone": visitor.mobile,
                 }
-        return request.env['ir.ui.view']._render_template("website_event.registration_attendee_details", {
+
+        return {
             'tickets': tickets,
             'event': event,
             'availability_check': availability_check,
             'default_first_attendee': default_first_attendee,
-        })
+        }
+
+    @http.route(['/event/<model("event.event"):event>/registration/new'], type='json', auth="public", methods=['POST'], website=True)
+    def registration_new(self, event, **post):
+        values = self._prepare_registration_new_values(event, **post)
+        return request.env['ir.ui.view']._render_template("website_event.registration_attendee_details", values)
 
     def _process_attendees_form(self, event, form_details):
         """ Process data posted from the attendee details form.


### PR DESCRIPTION
Since this controller returns raw markup, it is impossible to inherit. This way one can inherit the _prepare function instead.

Description of the issue/feature this PR addresses:
It is impossible to inject new values to the  `registrations_new` controller thus making inheritance limited

Current behavior before PR:
`registrations_new` returns a raw Markup object, where the parameters are already rendered into the template.

Desired behavior after PR is merged:
`registrations_new` stays the same but an additional function is used to prepare the values and can be inherited


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
