### PR TITLE
[FIX] purchase_stock: decrease received quantity if no return

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -55,7 +55,7 @@ class PurchaseOrderLine(models.Model):
                 for move in line._get_po_line_moves():
                     if move.state == 'done':
                         if move._is_purchase_return():
-                            if move.to_refund:
+                            if not move.origin_returned_move_id or move.to_refund:
                                 total -= move.product_uom._compute_quantity(move.quantity, line.product_uom, rounding_method='HALF-UP')
                         elif move.origin_returned_move_id and move.origin_returned_move_id._is_dropshipped() and not move._is_dropshipped_returned():
                             # Edge case: the dropship is returned to the stock, no to the supplier.
@@ -364,7 +364,7 @@ class PurchaseOrderLine(models.Model):
         incoming_moves = self.env['stock.move']
 
         for move in self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrapped and self.product_id == r.product_id):
-            if move._is_purchase_return() and move.to_refund:
+            if move._is_purchase_return() and (move.to_refund or not move.origin_returned_move_id):
                 outgoing_moves |= move
             elif move.location_dest_id.usage != "supplier":
                 if not move.origin_returned_move_id or (move.origin_returned_move_id and move.to_refund):


### PR DESCRIPTION
In case the quantity of a purchase order line is negative the generated picking will be a delivery but not a return. Meaning validating this delivery will not update quantity received on the purchase order line. This commit makes sur the `to_refund` key on stock move impact the value of `qty_received` only if the stock move is actually a return.

opw: 4259022

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
