### PR TITLE
[FIX] web_editor: prevents the removal of the header's CTA button

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -533,5 +533,5 @@ export class LinkTools extends Link {
 }
 
 export function shouldUnlink(link, colorCombinationClass) {
-    return !link.getAttribute('href') && !colorCombinationClass;
+    return (!link.getAttribute("href") && !link.matches(".oe_unremovable")) && !colorCombinationClass;
 }


### PR DESCRIPTION
Steps to reproduce:

- Enter in Website edit mode.
- Click on the "Contact Us" button in the header.
- In the text toolbar, select "Link" as the "Style" option.
- In the text toolbar, clear the URL input (remove "/contactus").
- Click anywhere on the page.
- Save the page.
- A traceback occurs: "Template fallback - An error occurred while rendering the template website.template_header_mobile"

The header's CTA button cannot be removed because it has the class "oe_unremovable". However, when the URL is cleared from the input field (see step 4 above), the "shouldUnlink" function in "link_tools.js" determines that the link around the "Contact Us" text should be removed.

In this commit, we prevent links with the "oe_unremovable" class from being removed in this situation.

opw-4308023