### PR TITLE
[FIX] mail: mobile discuss conversation list less spacing

### DIFF
--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -7,7 +7,7 @@
             'o-important': props.muted === 0,
             'text-muted border-transparent': props.muted === 1,
             'opacity-50 border-transparent': props.muted === 2,
-            'py-3 o-small': ui.isSmall,
+            'py-2 o-small': ui.isSmall,
             'border-top-0': props.first,
             'px-3 py-2': !ui.isSmall,
             'o-active': props.isActive,


### PR DESCRIPTION
There was too much spacing in the mobile messaging menu and mobile discuss app. This PR reduces is so more item are visible while still being easily clickable with a thumb tap.

<img width="1236" alt="Screenshot 2024-11-20 at 17 09 06" src="https://github.com/user-attachments/assets/bccaef0e-150f-4365-a224-e405435afa26">
