### PR TITLE
[IMP] mail: update template order in full mail composer

### DIFF
--- a/addons/mail/static/src/core/web/mail_composer_template_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_template_selector.js
@@ -2,6 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { sprintf } from "@web/core/utils/strings";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { user } from "@web/core/user";
 import { useService } from "@web/core/utils/hooks";
 
 import { Component, useState, onWillStart } from "@odoo/owl";
@@ -28,9 +29,18 @@ export class MailComposerTemplateSelector extends Component {
     }
 
     async fetchTemplates() {
-        const domain = [["model", "=", this.props.record.data.render_model]];
         const fields = ["display_name"];
-        this.state.templates = await this.orm.searchRead("mail.template", domain, fields, { limit: this.limit });
+        const templates = await this.orm.searchRead("mail.template", [
+            ["model", "=", this.props.record.data.render_model],
+            ["user_id", "=", user.userId]
+        ], fields, { limit: this.limit });
+        if (templates.length < this.limit) {
+            templates.push(...await this.orm.searchRead("mail.template", [
+                ["model", "=", this.props.record.data.render_model],
+                ["user_id", "!=", user.userId]
+            ], fields, { limit: this.limit - templates.length }));
+        }
+        this.state.templates = templates;
     }
 
     /**


### PR DESCRIPTION
In Odoo 18.0's full mail composer, we replaced the default template selector with a custom dropdown menu, enabling users to create, update, delete, or select mail templates directly within the composer. The dropdown initially suggests up to seven templates. When the template isn't among the suggestions, people have to click on the "Search More..." button to select the template they want. This adds a few additional steps in the process of selecting a template.

To avoid that, we'll prioritize displaying templates created by the user first, as they are more likely to be selected. This change is designed to enhance user efficiency by making the most relevant templates immediately accessible in the dropdown menu.

task-4348578

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
