### PR TITLE
[FIX] web,*: file viewer to show url attachment

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -69,9 +69,6 @@ export class AttachmentList extends Component {
      * @param {import("models").Attachment} attachment
      */
     getImageUrl(attachment) {
-        if (attachment.type === "url") {
-            return attachment.url;
-        }
         if (attachment.uploading && attachment.tmpUrl) {
             return attachment.tmpUrl;
         }

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -76,13 +76,14 @@
                             <i class="fa fa-trash" role="img" aria-label="Remove"/>
                         </button>
                         <t t-if="attachment.type === 'url'">
-                            <a class="btn d-flex align-items-center justify-content-center w-100 h-100 rounded-0" t-attf-class="{{ bg-300 }}" t-att-href="attachment.url" target='_blank' title="Open Link">
+                            <a class="btn d-flex align-items-center justify-content-center w-100 h-100 rounded-0" t-attf-class="bg-300" t-att-href="attachment.url" target='_blank' title="Open Link">
                                 <i class="fa fa-external-link" role="img" aria-label="Open Link"/>
                             </a>
                         </t>
                         <!-- t-attf-class overridden in extensions -->
                         <button t-elif="canDownload(attachment)" class="btn d-flex align-items-center justify-content-center w-100 h-100 rounded-0"
-                                t-attf-class="{{ bg-300 }}"
+                                t-attf-class="bg-300"
+                                t-att-data-download-url="attachment.downloadUrl"
                                 t-on-click.stop="() => this.onClickDownload(attachment)" title="Download"
                         >
                             <i class="fa fa-download" role="img" aria-label="Download"/>

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -33,10 +33,6 @@ export class Attachment extends FileModelMixin(Record) {
     message = Record.one("Message");
     /** @type {string} */
     create_date;
-    /** @type {'binary'|'url'} */
-    type;
-    /** @type {string} */
-    url;
 
     get isDeletable() {
         return true;

--- a/addons/mail/static/tests/thread/attachment_list_tests.js
+++ b/addons/mail/static/tests/thread/attachment_list_tests.js
@@ -4,7 +4,7 @@ import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
 import { start } from "@mail/../tests/helpers/test_utils";
 
-import { getOrigin } from "@web/core/utils/urls";
+import { getOrigin, url } from "@web/core/utils/urls";
 import { click, contains } from "@web/../tests/utils";
 
 QUnit.module("attachment list");
@@ -169,6 +169,36 @@ QUnit.test("view attachment", async () => {
     await contains(".o-mail-AttachmentImage img");
     await click(".o-mail-AttachmentImage");
     await contains(".o-FileViewer");
+});
+
+QUnit.test("can view pdf url", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "channel1",
+    });
+    const attachmentId = pyEnv["ir.attachment"].create({
+        name: "url.pdf.example",
+        mimetype: "application/pdf",
+        type: "url",
+        url: "https://pdfobject.com/pdf/sample.pdf",
+    });
+    pyEnv["mail.message"].create({
+        attachment_ids: [attachmentId],
+        body: "<p>Test</p>",
+        model: "discuss.channel",
+        res_id: channelId,
+        message_type: "comment",
+    });
+    const { openDiscuss } = await start();
+    await openDiscuss(channelId);
+    await click(".o-mail-AttachmentCard", { text: "url.pdf.example" });
+    await contains(".o-FileViewer");
+    await contains(
+        `iframe.o-FileViewer-view[data-src="/web/static/lib/pdfjs/web/viewer.html?file=${encodeURIComponent(
+            url(`/web/content/${attachmentId}`, { filename: "url.pdf.example" })
+        )}#pagemode=none"]`
+    );
 });
 
 QUnit.test("close attachment viewer", async () => {
@@ -395,5 +425,32 @@ QUnit.test("img file has proper src in discuss.channel", async () => {
     openDiscuss(channelId);
     await contains(
         `.o-mail-AttachmentImage[title='test.png'] img[data-src='${getOrigin()}/discuss/channel/${channelId}/image/${attachmentId}?filename=test.png&width=1920&height=300']`
+    );
+});
+
+QUnit.test("download url of non-viewable binary file", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "channel1",
+    });
+    const attachmentId = pyEnv["ir.attachment"].create({
+        name: "test.o",
+        mimetype: "application/octet-stream",
+        type: "binary",
+    });
+    pyEnv["mail.message"].create({
+        attachment_ids: [attachmentId],
+        body: "<p>Test</p>",
+        model: "discuss.channel",
+        res_id: channelId,
+        message_type: "comment",
+    });
+    const { openDiscuss } = await start();
+    await openDiscuss(channelId);
+    await contains(
+        `button[data-download-url="${url(
+            `/web/content/${attachmentId}?filename=test.o&download=true`
+        )}"]`
     );
 });

--- a/addons/web/static/src/core/file_viewer/file_model.js
+++ b/addons/web/static/src/core/file_viewer/file_model.js
@@ -2,132 +2,133 @@
 
 import { url } from "@web/core/utils/urls";
 
-export const FileModelMixin = T => class extends T {
-    accessToken;
-    checksum;
-    extension;
-    filename;
-    id;
-    mimetype;
-    name;
-    type;
-    /** @type {string} */
-    tmpUrl;
-    /** @type {string} */
-    url;
-    /** @type {boolean} */
-    uploading;
+export const FileModelMixin = (T) =>
+    class extends T {
+        accessToken;
+        checksum;
+        extension;
+        filename;
+        id;
+        mimetype;
+        name;
+        type;
+        /** @type {string} */
+        tmpUrl;
+        /** @type {string} */
+        url;
+        /** @type {boolean} */
+        uploading;
 
-    get defaultSource() {
-        const route = url(this.urlRoute, this.urlQueryParams);
-        const encodedRoute = encodeURIComponent(route);
-        if (this.isPdf) {
-            return `/web/static/lib/pdfjs/web/viewer.html?file=${encodedRoute}#pagemode=none`;
+        get defaultSource() {
+            const route = url(this.urlRoute, this.urlQueryParams);
+            const encodedRoute = encodeURIComponent(route);
+            if (this.isPdf) {
+                return `/web/static/lib/pdfjs/web/viewer.html?file=${encodedRoute}#pagemode=none`;
+            }
+            if (this.isUrlYoutube) {
+                const urlArr = this.url.split("/");
+                let token = urlArr[urlArr.length - 1];
+                if (token.includes("watch")) {
+                    token = token.split("v=")[1];
+                    const amp = token.indexOf("&");
+                    if (amp !== -1) {
+                        token = token.substring(0, amp);
+                    }
+                }
+                return `https://www.youtube.com/embed/${token}`;
+            }
+            return route;
         }
-        if (this.isUrlYoutube) {
-            const urlArr = this.url.split("/");
-            let token = urlArr[urlArr.length - 1];
-            if (token.includes("watch")) {
-                token = token.split("v=")[1];
-                const amp = token.indexOf("&");
-                if (amp !== -1) {
-                    token = token.substring(0, amp);
+
+        get displayName() {
+            return this.name || this.filename;
+        }
+
+        get downloadUrl() {
+            return url(this.urlRoute, { ...this.urlQueryParams, download: true });
+        }
+
+        get isImage() {
+            const imageMimetypes = [
+                "image/bmp",
+                "image/gif",
+                "image/jpeg",
+                "image/png",
+                "image/svg+xml",
+                "image/tiff",
+                "image/x-icon",
+                "image/webp",
+            ];
+            return imageMimetypes.includes(this.mimetype);
+        }
+
+        get isPdf() {
+            return this.mimetype && this.mimetype.startsWith("application/pdf");
+        }
+
+        get isText() {
+            const textMimeType = [
+                "application/javascript",
+                "application/json",
+                "text/css",
+                "text/html",
+                "text/plain",
+            ];
+            return textMimeType.includes(this.mimetype);
+        }
+
+        get isUrl() {
+            return this.type === "url" && this.url;
+        }
+
+        get isUrlYoutube() {
+            return !!this.url && this.url.includes("youtu");
+        }
+
+        get isVideo() {
+            const videoMimeTypes = ["audio/mpeg", "video/x-matroska", "video/mp4", "video/webm"];
+            return videoMimeTypes.includes(this.mimetype);
+        }
+
+        get isViewable() {
+            return (
+                (this.isText || this.isImage || this.isVideo || this.isPdf || this.isUrlYoutube) &&
+                !this.uploading
+            );
+        }
+
+        /**
+         * @returns {Object}
+         */
+        get urlQueryParams() {
+            if (this.uploading && this.tmpUrl) {
+                return {};
+            }
+            const params = {
+                access_token: this.accessToken,
+                filename: this.name,
+                unique: this.checksum,
+            };
+            for (const prop in params) {
+                if (!params[prop]) {
+                    delete params[prop];
                 }
             }
-            return `https://www.youtube.com/embed/${token}`;
+            return params;
         }
-        return route;
-    }
 
-    get displayName() {
-        return this.name || this.filename;
-    }
-
-    get downloadUrl() {
-        return url(this.urlRoute, { ...this.urlQueryParams, download: true });
-    }
-
-    get isImage() {
-        const imageMimetypes = [
-            "image/bmp",
-            "image/gif",
-            "image/jpeg",
-            "image/png",
-            "image/svg+xml",
-            "image/tiff",
-            "image/x-icon",
-            "image/webp",
-        ];
-        return imageMimetypes.includes(this.mimetype);
-    }
-
-    get isPdf() {
-        return this.mimetype && this.mimetype.startsWith("application/pdf");
-    }
-
-    get isText() {
-        const textMimeType = [
-            "application/javascript",
-            "application/json",
-            "text/css",
-            "text/html",
-            "text/plain",
-        ];
-        return textMimeType.includes(this.mimetype);
-    }
-
-    get isUrl() {
-        return this.type === "url" && this.url;
-    }
-
-    get isUrlYoutube() {
-        return !!this.url && this.url.includes("youtu");
-    }
-
-    get isVideo() {
-        const videoMimeTypes = ["audio/mpeg", "video/x-matroska", "video/mp4", "video/webm"];
-        return videoMimeTypes.includes(this.mimetype);
-    }
-
-    get isViewable() {
-        return (
-            (this.isText || this.isImage || this.isVideo || this.isPdf || this.isUrlYoutube) &&
-            !this.uploading
-        );
-    }
-
-    /**
-     * @returns {Object}
-     */
-    get urlQueryParams() {
-        if (this.uploading && this.tmpUrl) {
-            return {};
-        }
-        const params = {
-            access_token: this.accessToken,
-            filename: this.name,
-            unique: this.checksum,
-        };
-        for (const prop in params) {
-            if (!params[prop]) {
-                delete params[prop];
+        /**
+         * @returns {string}
+         */
+        get urlRoute() {
+            if (this.isUrl) {
+                return this.url;
             }
+            if (this.uploading && this.tmpUrl) {
+                return this.tmpUrl;
+            }
+            return this.isImage ? `/web/image/${this.id}` : `/web/content/${this.id}`;
         }
-        return params;
-    }
-
-    /**
-     * @returns {string}
-     */
-    get urlRoute() {
-        if (this.isUrl) {
-            return this.url;
-        }
-        if (this.uploading && this.tmpUrl) {
-            return this.tmpUrl;
-        }
-        return this.isImage ? `/web/image/${this.id}` : `/web/content/${this.id}`;
-    }
-}
+    };
 
 export class FileModel extends FileModelMixin(Object) {}

--- a/addons/web/static/src/core/file_viewer/file_model.js
+++ b/addons/web/static/src/core/file_viewer/file_model.js
@@ -11,10 +11,16 @@ export const FileModelMixin = (T) =>
         id;
         mimetype;
         name;
+        /** @type {"binary"|"url"} */
         type;
         /** @type {string} */
         tmpUrl;
-        /** @type {string} */
+        /**
+         * This URL should not be used as the URL to serve the file. `urlRoute` should be used
+         * instead. The server will properly redirect to the correct URL when necessary.
+         *
+         * @type {string}
+         */
         url;
         /** @type {boolean} */
         uploading;
@@ -121,9 +127,6 @@ export const FileModelMixin = (T) =>
          * @returns {string}
          */
         get urlRoute() {
-            if (this.isUrl) {
-                return this.url;
-            }
             if (this.uploading && this.tmpUrl) {
                 return this.tmpUrl;
             }


### PR DESCRIPTION
The file viewer tries to show the document from the url obtained from the defaultSource function in file_model.js. This function builds the url using urlRoute.

Before the fix, the urlRoute is the url from the attachment. This causes the PDF viewer to fail because it has a same-origin policy.

This fix avoids to use the url to the one from the attachment's url directly so that the viewer can show the document correctly with the computed urlRoute.

The attachment url does not need to be used at all, as the odoo server will properly direct.