### PR TITLE
[IMP] profiler: add multiple options for profiler

### DIFF
--- a/addons/web/static/src/core/debug/profiling/profiling_item.js
+++ b/addons/web/static/src/core/debug/profiling/profiling_item.js
@@ -27,6 +27,9 @@ export class ProfilingItem extends Component {
             window.location = "/web/#action=base.action_menu_ir_profile";
         }
     }
+    checkIncompleteProfiles() {
+        this.profiling.checkIncompleteProfiles()
+    }
 }
 ProfilingItem.components = { DropdownItem };
 ProfilingItem.template = "web.DebugMenu.ProfilingItem";

--- a/addons/web/static/src/core/debug/profiling/profiling_item.xml
+++ b/addons/web/static/src/core/debug/profiling/profiling_item.xml
@@ -18,6 +18,14 @@
                                 t-att-checked="profiling.isCollectorEnabled('sql')"/>
                             <label class="form-check-label" for="profile_sql">Record sql</label>
                         </span>
+                        <div t-if="profiling.isCollectorEnabled('sql')" class="input-group input-group-sm mt-2" t-on-click.stop.prevent="">
+                            <div class="input-group-text">Constant Time</div>
+                            <select class="profile_param form-select" t-on-change="(ev) => this.changeParam('constant_time', ev)">
+                                <t t-set="constant_time" t-value="profiling.state.params.constant_time"/>
+                                <option value="False" t-att-selected="constant_time === 'True'" >False</option>
+                                <option value="True" t-att-selected="constant_time === 'True'">True</option>
+                            </select>
+                        </div>
                         <span class="o_profiling_switch form-check form-switch mt-2" t-on-click.stop.prevent="() => this.profiling.toggleCollector('traces_async')">
                             <input type="checkbox" class="form-check-input" id="profile_traces_async"
                                 t-att-checked="profiling.isCollectorEnabled('traces_async')"/>

--- a/addons/web/static/src/core/debug/profiling/profiling_item.xml
+++ b/addons/web/static/src/core/debug/profiling/profiling_item.xml
@@ -12,6 +12,7 @@
                             <label class="form-check-label">Enable profiling</label>
                         </span>
                     </span>
+                    <button class="btn btn-secondary" t-on-click="() => this.profiling.checkIncompleteProfiles()">Check Incomplete Profiles</button>
                     <t t-if="profiling.state.isEnabled">
                         <span class="o_profiling_switch form-check form-switch mt-2" t-on-click.stop.prevent="() => this.profiling.toggleCollector('sql')">
                             <input type="checkbox" class="form-check-input" id="profile_sql"

--- a/addons/web/static/src/core/debug/profiling/profiling_service.js
+++ b/addons/web/static/src/core/debug/profiling/profiling_service.js
@@ -89,6 +89,9 @@ const profilingService = {
             async toggleProfiling() {
                 await setProfiling({ profile: !state.isEnabled });
             },
+            async checkIncompleteProfiles() {
+                await orm.call("ir.profile", "check_incomplete_profiles");
+            },
             async toggleCollector(collector) {
                 const nextCollectors = state.collectors.slice();
                 const index = nextCollectors.indexOf(collector);

--- a/odoo/addons/base/models/ir_profile.py
+++ b/odoo/addons/base/models/ir_profile.py
@@ -58,7 +58,7 @@ class IrProfile(models.Model):
             if execution.traces_sync:
                 sp.add('settrace', json.loads(execution.traces_sync))
 
-            result = json.dumps(sp.add_default().make())
+            result = json.dumps(sp.add_default(**request.session.get("profile_params",{})).make())
             execution.speedscope = base64.b64encode(result.encode('utf-8'))
 
     def _compute_speedscope_url(self):

--- a/odoo/tools/speedscope.py
+++ b/odoo/tools/speedscope.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import reprlib
+from .func import filter_kwargs
 
 shortener = reprlib.Repr()
 shortener.maxstring = 150
@@ -50,7 +51,8 @@ class Speedscope:
         for name in names:
             entries += self.profiles_raw[name]
         entries.sort(key=lambda e: e['start'])
-        result = self.process(entries, use_context=use_context, **params)
+        filtered_params = filter_kwargs(self.process, params)
+        result = self.process(entries, use_context=use_context, **filtered_params)
         if not result:
             return self
         start = result[0]['at']
@@ -84,18 +86,18 @@ class Speedscope:
         })
         return self
 
-    def add_default(self):
+    def add_default(self, **params):
         if len(self.profiles_raw) > 1:
-            self.add_output(self.profiles_raw, display_name='Combined')
-            self.add_output(self.profiles_raw, display_name='Combined no context', use_context=False)
+            self.add_output(self.profiles_raw, display_name='Combined', **params)
+            self.add_output(self.profiles_raw, display_name='Combined no context', use_context=False, **params)
         for key, profile in self.profiles_raw.items():
             sql = profile and profile[0].get('query')
             if sql:
-                self.add_output([key], hide_gaps=True, display_name=f'{key} (no gap)')
-                self.add_output([key], continuous=False, complete=False, display_name=f'{key} (density)')
+                self.add_output([key], hide_gaps=True, display_name=f'{key} (no gap)', **params)
+                self.add_output([key], continuous=False, complete=False, display_name=f'{key} (density)', **params)
 
             else:
-                self.add_output([key], display_name=key)
+                self.add_output([key], display_name=key, **params)
         return self
 
     def make(self):


### PR DESCRIPTION
=== Specs 
- Check what can be done to dump the profiler before a TimeoutError/MemoryError.
write the output to a temp file every N seconds and after the request finishes commit the file to the database.


- Memory Profiler:
  - Introduce a Memory profiler. POC here: https://github.com/odoo/odoo/pull/102031
- Form view:
  - From profiler ListView, select multiple profile and aggregate them. Combine profiles from multiple requests.
  - Download the profiler
- wizard:
  - popping up when clicking on the file.
  - set the sampling rate type. either auto, or a specific rate. Auto would need 
  - Specify the database where you want to save the profiles
  - aggregate the sql queries based on the string based on a choice
  - Add a way to configure the constant_time parameter here: https://github.com/odoo/odoo/blob/3585cfa41ea606713a38b04efd4cf7bbe89ab4f2/odoo/tools/speedscope.py#L148
- Edits to the profiler itself:
  - Speed up the parsing of the profiles



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
