### PR TITLE
[FIX] Website CSS grid bug fix

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -58,7 +58,7 @@
 @include media-breakpoint-up(lg) {
     .o_grid_mode {
         display: grid !important;
-        grid-auto-rows: 50px;
+        grid-auto-rows: minmax(50px,auto);
         grid-template-columns: repeat(12, 1fr);
         row-gap: 0px;
         column-gap: 0px;


### PR DESCRIPTION
 Website CSS grid bug fix affecting responsiveness to smaller screen resolutions.

**Description of the issue/feature this PR addresses:**
Having `grid-auto-rows` fixed at 50px stops the grid cells from expanding vertically in order to accommodate it's content when the content narrows and increases in height.

**Current behavior before PR:**
Div does not respond to changes in screen resolution or changes caused by the content being translated to a different language.

**Desired behavior after PR is merged:**
Using the `minmax()` CSS function allows the grid cells to expand vertically to accommodate content that exceeds the minimum height of 50px, improving responsiveness on smaller screens.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
