### PR TITLE
[FIX] Website CSS grid bug affecting responsiveness 

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -58,7 +58,7 @@
 @include media-breakpoint-up(lg) {
     .o_grid_mode {
         display: grid !important;
-        grid-auto-rows: 50px;
+        grid-auto-rows: minmax(50px,auto);
         grid-template-columns: repeat(12, 1fr);
         row-gap: 0px;
         column-gap: 0px;

--- a/doc/cla/individual/jamesbcn.md
+++ b/doc/cla/individual/jamesbcn.md
@@ -1,0 +1,9 @@
+Spain, 2024-11-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+James Quinlan jamesquinlan@hotmail.co.uk https://github.com/jamesbcn


### PR DESCRIPTION
Website CSS grid bug fix affecting responsiveness to smaller screen resolutions.

**Description of the issue/feature this PR addresses:**
Having `grid-auto-rows` fixed at 50px stops the grid cells from growing in a responsive manner.

**Current behavior before PR:**
Grid cells don't respond to changes in screen resolution or changes caused by the content being translated to a different language.

**Desired behavior after PR is merged:**
Using the `minmax()` CSS function allows the grid cells to expand vertically to accommodate content that exceeds the minimum height of 50px, improving responsiveness on smaller screens.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
