### PR TITLE
[FIX] web,*: align checkbox with label text in mobile and form view

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -527,7 +527,7 @@
             <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
                 <div name="options" position="inside">
-                    <span class="d-inline-block">
+                    <span class="d-inline-flex">
                         <field name="can_be_expensed"/>
                         <label for="can_be_expensed"/>
                     </span>

--- a/addons/pos_loyalty/views/loyalty_program_views.xml
+++ b/addons/pos_loyalty/views/loyalty_program_views.xml
@@ -16,9 +16,9 @@
                 <attribute name="invisible">0</attribute>
             </xpath>
             <xpath expr="//div[@id='o_loyalty_program_availabilities']" position="inside">
-                <span class="d-inline-block">
-                    <field name="pos_ok" class="w-auto me-0"/>
-                    <label for="pos_ok" class="me-3"/>
+                <span class="d-inline-flex text-break">
+                    <field name="pos_ok"/>
+                    <label for="pos_ok"/>
                 </span>
             </xpath>
             <xpath expr="//div[@id='o_loyalty_program_availabilities']" position="after">

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -55,11 +55,11 @@
                         </h1>
                     </div>
                     <div name="options">
-                        <span class="d-inline-block">
+                        <span class="d-inline-flex">
                             <field name="sale_ok"/>
                             <label for="sale_ok"/>
                         </span>
-                        <span class="d-inline-block">
+                        <span class="d-inline-flex">
                             <field name="purchase_ok"/>
                             <label for="purchase_ok"/>
                         </span>

--- a/addons/sale_loyalty/views/loyalty_program_views.xml
+++ b/addons/sale_loyalty/views/loyalty_program_views.xml
@@ -13,9 +13,9 @@
                 <attribute name="invisible">0</attribute>
             </xpath>
             <xpath expr="//div[@id='o_loyalty_program_availabilities']" position="inside">
-                <span class="d-inline-block">
-                    <field name="sale_ok" class="w-auto me-0"/>
-                    <label for="sale_ok" class="me-3"/>
+                <span class="d-inline-flex text-break">
+                    <field name="sale_ok"/>
+                    <label for="sale_ok"/>
                 </span>
             </xpath>
         </field>

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -447,7 +447,6 @@
         display: flex;
 
         @include media-breakpoint-down(sm) {
-            flex-wrap: wrap;
             .o_field_boolean {
                 order: -1;
             }

--- a/addons/web/static/src/views/form/form_group/form_group.xml
+++ b/addons/web/static/src/views/form/form_group/form_group.xml
@@ -50,7 +50,7 @@
         </div>
     </t>
     <t t-else="">
-        <div class="o_wrap_field_boolean d-flex flex-wrap d-sm-contents flex-sm-nowrap">
+        <div class="o_wrap_field_boolean d-flex d-sm-contents">
             <div class="o_cell o_wrap_label flex-sm-grow-0 text-break text-900">
                 <t t-component="cell.Component" t-if="cell.isVisible" t-props="cell.props"/>
             </div>

--- a/addons/website_sale_loyalty/views/loyalty_program_views.xml
+++ b/addons/website_sale_loyalty/views/loyalty_program_views.xml
@@ -13,9 +13,9 @@
                 <attribute name="invisible">0</attribute>
             </xpath>
             <xpath expr="//div[@id='o_loyalty_program_availabilities']" position="inside">
-                <span class="d-inline-block">
-                    <field name="ecommerce_ok" class="w-auto me-0"/>
-                    <label for="ecommerce_ok" string="Website" class="me-3"/>
+                <span class="d-inline-flex text-break">
+                    <field name="ecommerce_ok"/>
+                    <label for="ecommerce_ok" string="Website"/>
                 </span>
             </xpath>
             <xpath expr="//div[@id='o_loyalty_program_availabilities']" position="after">


### PR DESCRIPTION
`*` = [hr_expense, pos_loyalty, product, sale_loyalty , website_sale_loyalty]

Before this commit:
In the mobile and form view, when a checkbox field had a long label, the
checkbox would appear on top, with the label text displayed below.

Also, Long labels extend beyond the boundaries of the form view, appearing
outside of it.

After this commit:
Checkbox fields with long labels are now properly
aligned in the mobile and form views. The checkbox and its label text are
displayed correctly,

Task-4269578