### PR TITLE
[FIX] html_editor: traceback on pressing tab in list

### DIFF
--- a/addons/html_editor/static/src/main/list/utils.js
+++ b/addons/html_editor/static/src/main/list/utils.js
@@ -28,7 +28,7 @@ export function insertListAfter(document, afterNode, mode, content = []) {
  * - container for nested lists (li.oe-nested)
  */
 export function compareListTypes(a, b) {
-    if (a.tagName !== b.tagName) {
+    if (!a || !b || a.tagName !== b.tagName) {
         return false;
     }
     if (a.classList.contains("o_checklist") !== b.classList.contains("o_checklist")) {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:  

The issue occurs when `mergeSimilarLists` is triggered, leading to a call to `compareListTypes`. If `a.firstElementChild` or `b.firstElementChild` is null, attempting to access their `tagName` causes an error.  

Desired behavior after PR is merged:  

The traceback no longer occurs.  