### PR TITLE
[FIX] l10n_id_efatkur: various fixes

### DIFF
--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -29,6 +29,7 @@ class AccountMove(models.Model):
     l10n_id_efaktur_range = fields.Many2one("l10n_id_efaktur.efaktur.range", string="E-faktur Range", copy=False, domain="[('company_id', '=', company_id), ('available', '>', 0)]")
     l10n_id_need_kode_transaksi = fields.Boolean(compute='_compute_need_kode_transaksi')
     l10n_id_available_range_count = fields.Integer(compute="_compute_available_range_count", compute_sudo=True)
+    l10n_id_show_kode_transaksi = fields.Boolean(compute='_compute_show_kode_transaksi')
 
     @api.depends('company_id')
     def _compute_available_range_count(self):
@@ -73,6 +74,15 @@ class AccountMove(models.Model):
                 and move.invoice_line_ids.tax_ids
             )
 
+    @api.depends('commercial_partner_id')
+    def _compute_show_kode_transaksi(self):
+        for move in self:
+            move.l10n_id_show_kode_transaksi = (
+                move.commercial_partner_id.l10n_id_pkp
+                and move.move_type == 'out_invoice'
+                and move.country_code == 'ID'
+            )
+
     @api.constrains('l10n_id_kode_transaksi', 'line_ids', 'partner_id')
     def _constraint_kode_ppn(self):
         ppn_tag = self.env.ref('l10n_id.ppn_tag')
@@ -100,6 +110,9 @@ class AccountMove(models.Model):
         """Set E-Faktur number after validation."""
         for move in self:
             if move.l10n_id_need_kode_transaksi:
+                # If the code was set on the partner after the invoice was created, we set it on the move at this step so that it triggers the constrains if needed.
+                if not move.l10n_id_kode_transaksi and move.commercial_partner_id.l10n_id_kode_transaksi:
+                    move.l10n_id_kode_transaksi = move.commercial_partner_id.l10n_id_kode_transaksi
                 if not move.l10n_id_kode_transaksi:
                     raise ValidationError(_('You need to put a Kode Transaksi for this partner.'))
                 if move.l10n_id_replace_invoice_id.l10n_id_tax_number:

--- a/addons/l10n_id_efaktur/models/efaktur_document.py
+++ b/addons/l10n_id_efaktur/models/efaktur_document.py
@@ -143,7 +143,7 @@ class EfakturDocument(models.Model):
             eTax['TANGGAL_FAKTUR'] = move.invoice_date.strftime("%-d/%-m/%Y")
             eTax['NPWP'] = invoice_npwp
             eTax['NAMA'] = etax_name
-            eTax['ALAMAT_LENGKAP'] = move.partner_id.contact_address.replace('\n', '').strip()
+            eTax['ALAMAT_LENGKAP'] = move.partner_id._display_address(without_company=True).replace('\n', ' ').replace('  ', ' ').strip()
             eTax['JUMLAH_DPP'] = int(float_round(move.amount_untaxed, 0))  # currency rounded to the unit
             eTax['JUMLAH_PPN'] = int(float_round(move.amount_tax, 0, rounding_method="DOWN"))  # tax amount ALWAYS rounded down
             eTax['ID_KETERANGAN_TAMBAHAN'] = '1' if move.l10n_id_kode_transaksi == '07' else ''

--- a/addons/l10n_id_efaktur/models/res_partner.py
+++ b/addons/l10n_id_efaktur/models/res_partner.py
@@ -24,6 +24,7 @@ class ResPartner(models.Model):
         string='Invoice Transaction Code',
         help='Dua digit pertama nomor pajak',
         default='01',
+        tracking=True,
     )
 
     @api.depends('vat', 'country_code')

--- a/addons/l10n_id_efaktur/views/account_move_views.xml
+++ b/addons/l10n_id_efaktur/views/account_move_views.xml
@@ -8,14 +8,14 @@
             <field name="arch" type="xml">
                 <field name="partner_shipping_id" position="before">
                     <field name="l10n_id_need_kode_transaksi" invisible="1"/>
-                    <field name="l10n_id_kode_transaksi" invisible="country_code != 'ID' or not l10n_id_need_kode_transaksi" readonly="state in ['cancel', 'posted']" required="l10n_id_need_kode_transaksi"/>
-                    <field name="l10n_id_efaktur_range" invisible="country_code != 'ID' or state != 'draft' or l10n_id_available_range_count &lt; 2 or not l10n_id_need_kode_transaksi" options="{'no_create': True}"/>
                 </field>
                 <button name="button_draft" position="after">
                     <button name="reset_efaktur" string="Reset E-Faktur" type="object" invisible="country_code != 'ID' or not l10n_id_tax_number or state != 'cancel' or l10n_id_efaktur_document"/>
                 </button>
                 <xpath expr=".//group[@id='other_tab_group']" position="inside">
                     <group string="Electronic Tax" invisible="country_code != 'ID'">
+                        <field name="l10n_id_kode_transaksi" invisible="not l10n_id_show_kode_transaksi" readonly="l10n_id_tax_number" required="l10n_id_need_kode_transaksi"/>
+                        <field name="l10n_id_efaktur_range" invisible="state != 'draft' or l10n_id_available_range_count &lt; 2 or not l10n_id_show_kode_transaksi" readonly="l10n_id_tax_number" options="{'no_create': True}"/>
                         <field name="l10n_id_tax_number" invisible="move_type == 'entry'" readonly="move_type in ('out_invoice', 'out_refund', 'out_receipt')"/>
                         <field name="l10n_id_efaktur_document"/>
                         <field name="l10n_id_replace_invoice_id" readonly="state != 'draft'" options="{'m2o_dialog': False, 'no_create': True}"/>


### PR DESCRIPTION
Fixes a few issues with the module in order to
improve its usability.
* Move the tax transaction code and the range from the main page to the other info page.
* Tax transaction code will now be visible even when no taxes are set on the invoice.
* Fixes an issue where the customer name would appear in the address column in the csv export.
* Handle cases where the code is set on the partner after the creation of an invoice. It will now be automatically set on the invoice upon posting.
* Make the tax transaction code field editable as long as it has not yet been used to compute a tax number. This will avoid getting stuck in the event of a posted invoice without tax code and number.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
