### PR TITLE
[FIX] mail: mark messages as read when opening a channel on mobile

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -943,6 +943,8 @@ export class Thread extends Record {
         this.store.chatHub.opened.unshift(cw);
         if (!isMobileOS()) {
             cw.focus();
+        } else {
+            this.markAsRead();
         }
         this.state = "open";
         cw.notifyState();


### PR DESCRIPTION
**Current behavior before PR:**

Unread messages in a channel or chat are not marked as read when the user opens the channel in mobile view. This is due to `thread.markAsRead()` not being called since the focus on the composer is no longer triggered after [this commit](https://github.com/odoo/odoo/pull/176557/commits/9c552d1a194f1be75b98d06b4e7659ab21cd7d4e).

**Desired behavior after PR is merged:**

This commit resolves the issue by explicitly calling `thread.markAsRead()` when a chat or channel is opened.

Task-4320251


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
