### PR TITLE
[FIX] web_editor: correctly check node type for cross-context compatibility

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3575,7 +3575,7 @@ export class OdooEditor extends EventTarget {
      * @returns {boolean}
      */
     _isWhitelisted(item) {
-        if (item instanceof Attr) {
+        if (item && item.nodeType === Node.ATTRIBUTE_NODE) {
             return CLIPBOARD_WHITELISTS.attributes.includes(item.name);
         } else if (typeof item === 'string') {
             return CLIPBOARD_WHITELISTS.classes.some(okClass =>


### PR DESCRIPTION
**Problem**:
When items come from a different JavaScript context (e.g., an iframe, a web worker, or a shadow DOM), their prototype chain may not match the `Attr` class in the current global scope. This mismatch leads to issues in detecting node types correctly.

**Solution**:
Use `attr.nodeType === Node.ATTRIBUTE_NODE` to check for attribute nodes. This approach is more resilient and works across different JavaScript contexts.

**Steps to reproduce**:
1. Navigate to the Email Marketing app.
2. Copy text with a hyperlink from any website.
3. Paste the copied text into the email body.
4. Observe that the text is pasted, but the link is empty due to incorrect node type detection.

opw-4345535

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
