### PR TITLE
[FIX] google_calendar: handle missing entryPointType in conferenceData

### DIFF
--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -224,8 +224,8 @@ class GoogleEvent(abc.Set):
     def get_meeting_url(self):
         if not self.conferenceData:
             return False
-        video_meeting = list(filter(lambda entryPoints: entryPoints['entryPointType'] == 'video', self.conferenceData['entryPoints']))
-        return video_meeting[0]['uri'] if video_meeting else False
+        video_meeting = list(filter(lambda entryPoints: entryPoints.get('entryPointType') == 'video', self.conferenceData.get('entryPoints', [])))
+        return video_meeting[0].get('uri') if video_meeting else False
 
     def is_available(self):
         return self.transparency == 'transparent'


### PR DESCRIPTION
Before this commit, a KeyError would occur if 'entryPointType' was missing in the entryPoints dictionary.

opw-4009884

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
