### PR TITLE
[FIX] web_editor: fixed AttributeError when removing price of product.

### DIFF
--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -519,6 +519,10 @@ class Monetary(models.AbstractModel):
     def from_html(self, model, field, element):
         lang = self.user_lang()
 
+        span = element.find('span')
+        if span == None:
+            raise ValueError(_)
+
         value = element.find('span').text_content().strip()
 
         return float(value.replace(lang.thousands_sep or '', '')


### PR DESCRIPTION
Currently a `AttributeError` is arising when user edit the price of the product.

To get this error:
- Create the database in origin language, in this case, Vietnamese.
- Go to "Shop" section of the website.
- Click on any product, click "Sửa" and then click on product's price.
- Then click backspace and delete on keyboard.
- Hit the "Lưu" button, the error appears in the console log.

Error:  `AttributeError : 'NoneType' object has no attribute 'text_content'`

To fix this issue, checked the "element" if the "element" has "span" in it. If "span" is "None", raise "ValueError".

sentry-6065885784
