### PR TITLE
[FIX] web_editor: popup disappears on Enter

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4257,6 +4257,9 @@ export class OdooEditor extends EventTarget {
                     ev.stopPropagation();
                 }
             }
+        } else if (ev.key === "Enter") {
+            ev.preventDefault();
+            this._applyCommand("oEnter");
         }
     }
     /**


### PR DESCRIPTION
This PR fixes the issue where a popup closes unexpectedly upon pressing the Enter key while in edit mode.

The bug occurs only in edit mode when editing a popup. If you focus on an input field within the popup and press Enter, the popup immediately disappears. However, if you make changes first without pressing Enter and then press Enter, the popup behaves as expected, adding a new line for editing instead of closing.

With this fix, when in edit mode and editing a popup immediately after opening it, pressing Enter will correctly add a new line for editing, as intended.

Task: 4255083

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
