### PR TITLE
[FIX] html_editor: start collaboration after focus

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -44,6 +44,7 @@ export class HtmlField extends Component {
     static props = {
         ...standardFieldProps,
         isCollaborative: { type: Boolean, optional: true },
+        collaborativeTrigger: { type: String, optional: true },
         dynamicPlaceholder: { type: Boolean, optional: true, default: false },
         dynamicPlaceholderModelReferenceField: { type: String, optional: true },
         cssReadonlyAssetId: { type: String, optional: true },
@@ -214,6 +215,7 @@ export class HtmlField extends Component {
             collaboration: this.props.isCollaborative && {
                 busService: this.busService,
                 ormService: this.ormService,
+                collaborativeTrigger: this.props.collaborativeTrigger,
                 collaborationChannel: {
                     collaborationModelName: this.props.record.resModel,
                     collaborationFieldName: this.props.name,
@@ -315,6 +317,7 @@ export const htmlField = {
         return {
             editorConfig,
             isCollaborative: options.collaborative,
+            collaborativeTrigger: options.collaborative_trigger,
             dynamicPlaceholder: options.dynamic_placeholder,
             dynamicPlaceholderModelReferenceField:
                 options.dynamic_placeholder_model_reference_field,

--- a/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
@@ -86,9 +86,12 @@ export class CollaborationOdooPlugin extends Plugin {
 
         const collaborativeTrigger = this.config.collaboration.collaborativeTrigger;
         this.joinPeerToPeer = this.joinPeerToPeer.bind(this);
-        if (collaborativeTrigger === "start" || typeof collaborativeTrigger === "undefined") {
+        if (collaborativeTrigger === "start") {
             this.joinPeerToPeer();
-        } else if (collaborativeTrigger === "focus") {
+        } else if (
+            collaborativeTrigger === "focus" ||
+            typeof collaborativeTrigger === "undefined"
+        ) {
             // Wait until editor is focused to join the peer to peer network.
             this.editable.addEventListener("focus", this.joinPeerToPeer);
         }


### PR DESCRIPTION
Issue:
    The Editor connect to the collaboration BUS
    directly when initialized, resulting in
    performances struggle on the server.

Fix:
    Restore the previous default behavior to wait for the
    focus before initializing the BUS connection.

task-4348299



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
