### PR TITLE
[IMP] web: remove useless DIV with d-contents

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -13,7 +13,7 @@
 }
 
 // Form view rules to break the default table layout
-@mixin form-break-table($-is-editable: false) {
+@mixin form-break-table() {
     --fieldWidget-margin-bottom: 0;
 
     grid-template-columns: 1fr;
@@ -44,11 +44,12 @@
             }
         }
     }
+}
 
-    @if $-is-editable {
-        .o_address_type, .o_address_format {
-            --fieldWidget-margin-bottom: #{$o-form-spacing-unit * 2};
-        }
+
+@mixin editable-form-break-table() {
+    .o_address_type, .o_address_format {
+        --fieldWidget-margin-bottom: #{$o-form-spacing-unit * 2};
     }
 }
 
@@ -1080,7 +1081,7 @@
         }
 
         .o_form_editable .o_inner_group {
-            @include form-break-table($-is-editable: true);
+            @include editable-form-break-table();
         }
     }
 }
@@ -1154,7 +1155,7 @@
     }
 
     .o_form_editable .o_inner_group {
-        @include form-break-table($-is-editable: true);
+        @include editable-form-break-table();
     }
 }
 

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -18,30 +18,36 @@
 
     grid-template-columns: 1fr;
     margin-bottom: $o-form-spacing-unit * 4;
-    row-gap: 0;
 
-    .o_wrap_field {
-        .o_cell {
+    .o_cell {
+        max-width: 100%;
+
+        &.o_wrap_label {
+            line-height: $o-label-font-size-factor;
+        }
+
+        .o_field_widget {
+            &:not(.o_field_boolean){
+                width: 100%;
+            }
+
+            &.o_field_boolean {
+                margin-right: 0;
+            }
+        }
+
+        .o_input_dropdown {
+            width: auto;
             max-width: 100%;
+        }
 
-            &.o_wrap_label {
-                line-height: $o-label-font-size-factor;
-            }
+    }
 
-            .o_field_widget {
-                &:not(.o_field_boolean){
-                    width: 100%;
-                }
-
-                &.o_field_boolean {
-                    margin-right: 0;
-                }
-            }
-
-            .o_input_dropdown {
-                width: auto;
-                max-width: 100%;
-            }
+    @include media-breakpoint-down(md) {
+        .o_cell:has(+ :is(.o_wrap_label, .o_wrap_field_boolean)),
+        .o_wrap_field_boolean,
+        .o_cell:first-child:last-child {
+            margin-bottom: map-get($spacers, 3);
         }
     }
 }
@@ -462,13 +468,18 @@
         gap: map-get($spacers, 2) $o-horizontal-padding;
         margin-bottom: map-get($spacers, 2);
 
-        .o_cell:first-child:last-child {
-            grid-column: span 2;
-        }
-
         span, .o_field_boolean, .oe_avatar, .o_form_uri {
             &.o_field_widget {
                 width: auto;
+            }
+        }
+    }
+
+    & .o_form_renderer:not(.o_kanban_quick_create_form) .o_inner_group {
+        @include media-breakpoint-up(sm) {
+            .o_cell:first-child:last-child,
+            .o_cell:not(.o_wrap_label):not(.o_wrap_input) {
+                grid-column: span 2;
             }
         }
     }
@@ -779,9 +790,6 @@
             }
         }
 
-        .o_wrap_field:first-child > .o_cell {
-            padding-top: 4px;
-        }
         .oe_subtotal_footer_separator {
             width: 100%;
             text-align: right;
@@ -1078,6 +1086,7 @@
     &.modal-sm .o_form_view {
         .o_inner_group {
             @include form-break-table;
+            row-gap: 0;
         }
 
         .o_form_editable .o_inner_group {
@@ -1131,14 +1140,6 @@
         .o_inner_group {
             margin-bottom: $o-form-spacing-unit * 4;
 
-            // Target XXS form view on mobile devices in portrait mode
-            @include media-breakpoint-down(md) {
-                &:not(.oe_subtotal_footer) > .o_cell {
-                    > .o_field_widget {
-                        --fieldWidget-margin-bottom: #{$o-form-spacing-unit * 4};
-                    }
-                }
-            }
         }
 
         .o_form_label {

--- a/addons/web/static/src/views/form/form_group/form_group.xml
+++ b/addons/web/static/src/views/form/form_group/form_group.xml
@@ -16,7 +16,7 @@
         <div t-if="props.slots and props.slots.title" t-attf-class="g-col-sm-{{ props.maxCols }}">
             <t t-slot="title" />
         </div>
-        <div t-foreach="getRows()" t-as="row" t-key="row_index" class="o_wrap_field d-flex d-sm-contents flex-column mb-3 mb-sm-0" t-if="row.isVisible">
+        <t t-foreach="getRows()" t-as="row" t-key="row_index" t-if="row.isVisible">
             <t t-foreach="row" t-as="cell" t-key="cell_index">
 
                 <t t-if="cell.subType === 'item_component'">
@@ -34,7 +34,7 @@
                 </t>
 
             </t>
-        </div>
+        </t>
     </div>
 </t>
 

--- a/addons/web/static/src/views/kanban/kanban_record_quick_create.scss
+++ b/addons/web/static/src/views/kanban/kanban_record_quick_create.scss
@@ -1,16 +1,10 @@
 .o_form_view.o_xxs_form_view.o_kanban_quick_create_form {
-    .o_inner_group {
-        row-gap: map-get($spacers, 2);
-    }
+    .o_cell {
+        .o_field_widget {
+            margin-bottom: $o-form-spacing-unit * 2;
 
-    .o_wrap_field {
-        .o_cell {
-            .o_field_widget {
-                margin-bottom: $o-form-spacing-unit * 2;
-
-                > .o_field_widget {
-                    margin-bottom: 0;
-                }
+            > .o_field_widget {
+                margin-bottom: 0;
             }
         }
     }

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -2159,7 +2159,7 @@ test(`two mutually exclusive labels with a dynamic invisible attribute`, async (
     });
     expect(`label.o_form_label`).toHaveCount(1);
     expect(`label.o_form_label`).toHaveText("label2");
-    expect(`.o_inner_group > div`).toHaveCount(1);
+    expect(`.o_cell`).toHaveCount(2);
 });
 
 test(`label is not rendered when invisible and not at top-level in a group`, async () => {
@@ -4783,8 +4783,9 @@ test(`nolabel`, async () => {
     expect(`label.o_form_label:eq(0)`).toHaveText("Product");
     expect(`label.o_form_label:eq(1)`).toHaveText("Bar");
     expect(`.firstgroup div`).toHaveStyle("");
-    expect(`.secondgroup div.o_wrap_field`).toHaveCount(2);
-    expect(`.secondgroup div.o_wrap_field:first div.o_cell`).toHaveCount(2);
+    expect(`.secondgroup div.o_wrap_label`).toHaveCount(1);
+    expect(`.secondgroup div.o_wrap_input`).toHaveCount(1);
+    expect(`.secondgroup div.o_cell`).toHaveCount(4);
 });
 
 test(`many2one in a one2many`, async () => {
@@ -8407,52 +8408,26 @@ test(`form rendering with groups with col/colspan`, async () => {
     expect(`.parent_group > *:eq(1)`).toHaveClass("col-lg-8");
 
     // Verify .group_4 content
-    expect(`.group_4 > div.o_wrap_field`).toHaveCount(3);
-    expect(`.group_4 > div.o_wrap_field:eq(0) div.o_cell`).toHaveCount(1);
-    expect(`.group_4 > div.o_wrap_field:eq(0) div.o_cell`).toHaveAttribute(
-        "style",
-        "grid-column: span 3;"
-    );
-    expect(`.group_4 > div.o_wrap_field:eq(1) div.o_cell`).toHaveCount(2);
-    expect(`.group_4 > div.o_wrap_field:eq(1) div.o_cell:eq(0)`).toHaveAttribute(
-        "style",
-        "grid-column: span 2;"
-    );
-    expect(`.group_4 > div.o_wrap_field:eq(2) div.o_cell`).toHaveCount(1);
-    expect(`.group_4 > div.o_wrap_field:eq(2) div.o_cell`).toHaveAttribute(
-        "style",
-        "grid-column: span 4;"
-    );
+    expect(`.group_4 > div.o_cell`).toHaveCount(4);
+    expect(`.group_4 > div.o_cell:first-child`).toHaveAttribute("style", "grid-column: span 3;");
+    expect(`.group_4 > div.o_cell:nth-child(2)`).toHaveAttribute("style", "grid-column: span 2;");
+    expect(`.group_4 > div.o_cell:last-child`).toHaveAttribute("style", "grid-column: span 4;");
 
     // Verify .group_3 content
     expect(`.group_3 > *`).toHaveCount(3);
     expect(`.group_3 > .col-lg-4`).toHaveCount(3);
 
     // Verify .group_1 content
-    expect(`.group_1 > .o_wrap_field`).toHaveCount(3);
+    expect(`.group_1 > .o_cell`).toHaveCount(3);
 
     // Verify .field_group content
-    expect(`.field_group > .o_wrap_field`).toHaveCount(5);
-    expect(`.field_group > .o_wrap_field:eq(0) .o_cell`).toHaveCount(2);
-    expect(`.field_group > .o_wrap_field:eq(0) .o_cell:eq(0)`).toHaveClass("o_wrap_label");
-    expect(`.field_group > .o_wrap_field:eq(0) .o_cell:eq(1)`).toHaveAttribute(
-        "style",
-        "grid-column: span 2;"
-    );
+    expect(`.field_group > .o_cell`).toHaveCount(10);
+    expect(`.field_group > .o_cell:first-child`).toHaveClass("o_wrap_label");
+    expect(`.field_group > .o_cell:nth-child(2)`).toHaveAttribute("style", "grid-column: span 2;");
 
-    expect(`.field_group > .o_wrap_field:eq(1) .o_cell`).toHaveCount(2);
+    expect(`.field_group > .o_cell:nth-child(5)`).toHaveClass("o_wrap_label");
 
-    expect(`.field_group > .o_wrap_field:eq(2) .o_cell`).toHaveCount(2);
-    expect(`.field_group > .o_wrap_field:eq(2) .o_cell:eq(0)`).toHaveClass("o_wrap_label");
-
-    expect(`.field_group > .o_wrap_field:eq(3) .o_cell`).toHaveCount(1);
-    expect(`.field_group > .o_wrap_field:eq(3) .o_cell`).toHaveAttribute(
-        "style",
-        "grid-column: span 3;"
-    );
-
-    expect(`.field_group > .o_wrap_field:eq(4) .o_cell`).toHaveCount(3);
-    expect(`.field_group > .o_wrap_field:eq(4) .o_cell:eq(1)`).toHaveClass("o_wrap_label");
+    expect(`.field_group > .o_cell:nth-child(9)`).toHaveClass("o_wrap_label");
 });
 
 test(`form rendering innergroup: separator should take one line`, async () => {
@@ -8476,11 +8451,10 @@ test(`form rendering innergroup: separator should take one line`, async () => {
         `,
         resId: 1,
     });
-    expect(`.o_inner_group > div:eq(0) > .o_cell`).toHaveCount(1);
-    expect(`.o_inner_group > div:eq(0) .o_horizontal_separator`).toHaveCount(1);
-    expect(`.o_inner_group > div:eq(1) > .o_cell`).toHaveCount(2);
-    expect(`.o_inner_group > div:eq(1) label[for=display_name_0]`).toHaveCount(1);
-    expect(`.o_inner_group > div:eq(1) div[name=display_name]`).toHaveCount(1);
+    expect(`.o_inner_group > .o_cell`).toHaveCount(3);
+    expect(`.o_inner_group > .o_cell:first-child .o_horizontal_separator`).toHaveCount(1);
+    expect(`.o_inner_group > .o_cell:nth-child(2) label[for=display_name_0]`).toHaveCount(1);
+    expect(`.o_inner_group > .o_cell:last-child div[name=display_name]`).toHaveCount(1);
 });
 
 test(`outer and inner groups string attribute`, async () => {
@@ -8526,19 +8500,16 @@ test(`inner group with invisible cells`, async () => {
     });
 
     await contains(`[name='foo'] input`).edit("1");
-    expect(`.o_wrap_field`).toHaveCount(1);
-    expect(`.o_wrap_field .cell1`).toHaveCount(0);
-    expect(`.o_wrap_field .cell2`).toHaveCount(1);
+    expect(`.cell1`).toHaveCount(0);
+    expect(`.cell2`).toHaveCount(1);
 
     await contains(`[name='foo'] input`).edit("2");
-    expect(`.o_wrap_field`).toHaveCount(1);
-    expect(`.o_wrap_field .cell1`).toHaveCount(1);
-    expect(`.o_wrap_field .cell2`).toHaveCount(0);
+    expect(`.cell1`).toHaveCount(1);
+    expect(`.cell2`).toHaveCount(0);
 
     await contains(`[name='foo'] input`).edit("3");
-    expect(`.o_wrap_field`).toHaveCount(1);
-    expect(`.o_wrap_field .cell1`).toHaveCount(1);
-    expect(`.o_wrap_field .cell2`).toHaveCount(1);
+    expect(`.cell1`).toHaveCount(1);
+    expect(`.cell2`).toHaveCount(1);
 });
 
 test(`form group with newline tag inside`, async () => {
@@ -8578,11 +8549,14 @@ test(`form group with newline tag inside`, async () => {
     });
 
     // Inner group
-    expect(`.main_inner_group > .o_wrap_field`).toHaveCount(2);
-    expect(`.main_inner_group > .o_wrap_field:first > .o_wrap_label`).toHaveCount(1);
-    expect(`.main_inner_group > .o_wrap_field:first .o_field_widget`).toHaveCount(1);
-    expect(`.main_inner_group > .o_wrap_field:last .o_wrap_label`).toHaveCount(2);
-    expect(`.main_inner_group > .o_wrap_field:last .o_field_widget`).toHaveCount(2);
+    expect(`.main_inner_group .o_cell`).toHaveCount(6);
+    expect(`.main_inner_group > .o_cell.o_wrap_label:first-child`).toHaveCount(1);
+    expect(`.main_inner_group > .o_cell.o_wrap_input:nth-child(2)`).toHaveCount(1);
+    expect(`.main_inner_group > .o_wrap_field_boolean:nth-child(3)`).toHaveCount(1);
+    expect(`.main_inner_group > .o_wrap_field_boolean:nth-child(3) > .o_wrap_label`).toHaveCount(1);
+    expect(`.main_inner_group > .o_wrap_field_boolean:nth-child(3) > .o_wrap_input`).toHaveCount(1);
+    expect(`.main_inner_group > .o_cell.o_wrap_label:nth-child(4)`).toHaveCount(1);
+    expect(`.main_inner_group > .o_cell.o_wrap_input:nth-child(5)`).toHaveCount(1);
 
     // Outer group
     const bottomGroupRect = queryFirst(`.bottom_group`).getBoundingClientRect();


### PR DESCRIPTION
This commit removes `DIV.o_wrap_field` element as it's a useless wrap
element to be in `flex` mode on small screen and in `grid` mode in other
case, but it can be done with grid too and was already implemented.

task-4330704

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
