### PR TITLE
[REF] *: sanitize run function in tours

### DIFF
--- a/addons/calendar/static/tests/tours/calendar_tour.js
+++ b/addons/calendar/static/tests/tours/calendar_tour.js
@@ -109,10 +109,7 @@ registry.category("web_tour.tours").add("test_calendar_delete_tour", {
         {
             content: "Validate the deletion",
             trigger: 'button:contains("Delete")',
-            async run() {
-                this.anchor.click();
-                await new Promise((r) => setTimeout(r, 1000));
-            },
+            run: "click",
         },
     ],
 });

--- a/addons/lunch/static/tests/tours/order_lunch.js
+++ b/addons/lunch/static/tests/tours/order_lunch.js
@@ -26,7 +26,6 @@ registry.category("web_tour.tours").add('order_lunch_tour', {
 },
 {
     trigger: '.lunch_location input:value("Farm 1")',
-    run: () => {},  // wait for article to be correctly loaded
 },
 {
     trigger: ".o_kanban_record",

--- a/addons/mass_mailing/static/tests/tours/mailing_editor.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor.js
@@ -20,9 +20,7 @@ registry.category("web_tour.tours").add('mailing_editor', {
 }, {
     content: 'choose the theme "empty" to edit the mailing with snippets',
     trigger: '[name="body_arch"] :iframe #empty',
-    run() {
-        this.anchor.click();
-    }
+    run: "click",
 }, {
     content: 'wait for the editor to be rendered',
     trigger: '[name="body_arch"] :iframe .o_editable[data-editor-message="DRAG BUILDING BLOCKS HERE"]',

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -324,7 +324,6 @@ registry.category("web_tour.tours").add("CheckProductInformation", {
             },
             {
                 trigger: ".section-product-info-title:not(:contains('On hand:'))",
-                run: () => {},
             },
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/tours/utils/ticket_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/ticket_screen_util.js
@@ -196,7 +196,6 @@ export function receiptChangeIs(amount) {
     return [
         {
             trigger: `.receipt-screen .receipt-change:contains("${amount}")`,
-            run: () => {},
         },
     ];
 }
@@ -212,7 +211,6 @@ export function nthColumnContains(nRow, nCol, string) {
     return [
         {
             trigger: `.ticket-screen .order-row:nth-last-child(${nRow}) > .col:nth-child(${nCol}):contains("${string}")`,
-            run: () => {},
         },
     ];
 }

--- a/addons/sale/static/tests/tours/product_attribute_value_tour.js
+++ b/addons/sale/static/tests/tours/product_attribute_value_tour.js
@@ -51,7 +51,6 @@ registry.category("web_tour.tours").add('delete_product_attribute_value_tour', {
         {
             content: 'Check test finished',
             trigger: 'a:contains("Attributes")',
-            run: () => { }, // check
         }
     ]
 });

--- a/addons/stock/static/tests/tours/stock_report_tests.js
+++ b/addons/stock/static/tests/tours/stock_report_tests.js
@@ -74,7 +74,6 @@ registry.category("web_tour.tours").add('test_multiple_warehouses_filter', {
         {
             trigger: '.o_graph_view',
             content: 'Wait for the Forecast page to load.',
-            run: () => {},
         },
     ],
 });

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -110,11 +110,7 @@ registerWebsitePreviewTour('edit_megamenu', {
         // If this step fails, it means that a patch inside bootstrap was lost.
         content: "Press the 'down arrow' key.",
         trigger: ':iframe .o_mega_menu h4',
-        run() {
-            this.anchor.dispatchEvent(
-                new window.KeyboardEvent("keydown", {key: "ArrowDown"})
-            );
-        },
+        run: "press ArrowDown",
     },
     ...clickOnSave(),
     clickOnExtraMenuItem({}, true),

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -21,10 +21,7 @@ registerWebsitePreviewTour('snippet_countdown', {
     {
         content: "Hover an option which has a preview",
         trigger: '[data-select-class="o_half_screen_height"]',
-        run() {
-            this.anchor.dispatchEvent(new MouseEvent("mouseover", {bubbles: true}));
-            this.anchor.dispatchEvent(new MouseEvent("mouseenter"));
-        },
+        run: "hover",
     },
     {
         content: "Check that the countdown message is still displayed",

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 
-import { queryOne } from "@odoo/hoot-dom";
 import {
     changeOption,
     clickOnEditAndWaitEditMode,
@@ -66,10 +65,7 @@ const selectButtonByData = function (data) {
     return [{
         content: "Open the select",
         trigger: `we-select:has(we-button[${data}]) we-toggler`,
-        run() {
-            // TODO: use run: "click", instead
-            this.anchor.click();
-        }
+        run: "click",
     }, {
         content: "Click on the option",
         trigger: `we-select we-button[${data}]`,
@@ -492,14 +488,22 @@ registerWebsitePreviewTour("website_form_editor_tour", {
     }, {
         content: "Change button's style",
         trigger: '.dropdown:has([name="link_style_color"]) > button',
-        run: () => {
-            queryOne('.dropdown:has([name="link_style_color"]) > button').click();
-            queryOne('[data-value="secondary"]').click();
-            queryOne('.dropdown:has([name="link_style_shape"]) > button').click();
-            queryOne('[data-value="rounded-circle"]').click();
-            queryOne('.dropdown:has([name="link_style_size"]) > button').click();
-            queryOne('[data-value="sm"]').click();
-        },
+        run: "click",
+    }, {
+        trigger: "[data-value=secondary]",
+        run: "click",
+    }, {
+        trigger: ".dropdown:has([name=link_style_shape]) > button",
+        run: "click",
+    }, {
+        trigger: "[data-value=rounded-circle]",
+        run: "click",
+    }, {
+        trigger: ".dropdown:has([name=link_style_size]) > button",
+        run: "click",
+    }, {
+        trigger: "[data-value=sm]",
+        run: "click",
     }, {
         content: "Check the resulting button",
         trigger: ':iframe .s_website_form_send.btn.btn-sm.btn-secondary.rounded-circle',

--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -45,12 +45,10 @@ registerWebsitePreviewTour('donation_snippet_edition', {
         {
             content: "Check if custom amount radio input is selected",
             trigger: ":iframe input#other_amount:checked",
-            run: () => {}, // This is a check
         },
         {
             content: "Check if custom amount radio input has value 55",
             trigger: ':iframe input#other_amount[value="55.0"]',
-            run: () => {}, // This is a check
         },
         {
             content: "Select the amount of 25",
@@ -60,12 +58,10 @@ registerWebsitePreviewTour('donation_snippet_edition', {
         {
             content: "Verify that amount_1 is checked",
             trigger: ":iframe input#amount_1:checked",
-            run: () => {}, // This is a check
         },
         {
             content: "Verify that other_amount is not checked",
             trigger: ":iframe input#other_amount:not(:checked)",
-            run: () => {}, // This is a check
         },
         {
             content: "Change custom amount to 67",
@@ -90,8 +86,7 @@ registerWebsitePreviewTour('donation_snippet_edition', {
         {
             content: "Verify that the amount displayed is 67",
             trigger: ':iframe span.oe_currency_value:contains("67.00")',
-            run: () => {}, // This is a check
-            timeout: 10000  // Make sure the payment process animation is finished
+            timeout: 10000, // Make sure the payment process animation is finished
         },
     ]
 );

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -67,32 +67,32 @@ export function assertProductPrice(attribute, value, productName) {
     };
 }
 
-export function fillAdressForm(adressParams = {
-    name: "John Doe",
-    phone: "123456789",
-    email: "johndoe@gmail.com",
-    street: "1 rue de la paix",
-    city: "Paris",
-    zip: "75000"
-}) {
-    let steps = [];
+export function fillAdressForm(
+    adressParams = {
+        name: "John Doe",
+        phone: "123456789",
+        email: "johndoe@gmail.com",
+        street: "1 rue de la paix",
+        city: "Paris",
+        zip: "75000",
+    }
+) {
+    const steps = [];
+    for (const arg of ["name", "phone", "email", "street", "city", "zip"]) {
+        steps.push({
+            content: `Address filling ${arg}`,
+            trigger: `form.checkout_autoformat input[name=${arg}]`,
+            run: `edit ${adressParams[arg]}`,
+        });
+    }
     steps.push({
-        content: "Address filling",
-        trigger: 'form.checkout_autoformat',
-        run() {
-            document.querySelector('input[name="name"]').value = adressParams.name;
-            document.querySelector('input[name="phone"]').value = adressParams.phone;
-            document.querySelector('input[name="email"]').value = adressParams.email;
-            document.querySelector('input[name="street"]').value = adressParams.street;
-            document.querySelector('input[name="city"]').value = adressParams.city;
-            document.querySelector('input[name="zip"]').value = adressParams.zip;
-            document.querySelectorAll("#o_country_id option")[1].selected = true;
-        }
+        trigger: "#o_country_id",
+        run: "selectByLabel Belgium",
     });
     steps.push({
         content: "Continue checkout",
-        trigger: '#save_address',
-        run: 'click',
+        trigger: "#save_address",
+        run: "click",
     });
     return steps;
 }

--- a/addons/website_sale/static/tests/tours/website_sale_update_address.js
+++ b/addons/website_sale/static/tests/tours/website_sale_update_address.js
@@ -23,9 +23,7 @@ registry.category("web_tour.tours").add('update_billing_shipping_address', {
         {
             content: "Empty the phone field",
             trigger: 'input[name="phone"]',
-            run: () => {
-                document.querySelector('input[name="phone"]').value = "";
-            },
+            run: "clear",
         },
         {
             content: "Save address",


### PR DESCRIPTION
In commit, we remove empty runs that no longer have a reason to exist.
We also prefer to use tour helpers ( hover ) instead of using
makeVisible functions in order to simulate user interactions as best as
possible.
We take advantage of this commit to remove the nextTick helper in
webStudio (we no longer need it since 3bfd2e9cf8 )

https://github.com/odoo/enterprise/pull/74252