### PR TITLE
[FIX] pos_mrp: Prevent stock move duplication in BOM processing

### DIFF
--- a/addons/pos_mrp/models/pos_order.py
+++ b/addons/pos_mrp/models/pos_order.py
@@ -13,7 +13,7 @@ class PosOrderLine(models.Model):
             return super()._get_stock_moves_to_consider(stock_moves, product)
         _dummy, components = bom.explode(product, self.qty)
         ml_product_to_consider = (product.bom_ids and [comp[0].product_id.id for comp in components]) or [product.id]
-        return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and ml.bom_line_id)
+        return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and ml.bom_line_id and ml.bom_line_id.bom_id.id == bom.id)
 
 class PosOrder(models.Model):
     _inherit = "pos.order"


### PR DESCRIPTION
Added an additional condition in the lambda filter of the `_get_stock_moves_to_consider` method to avoid considering the same `stock.move` record multiple times when processing different products sharing the same components in their BOM. This change ensures accurate handling of stock moves and avoids calculation errors in inventory valuation.

__Steps to reproduce this on rubnot__

1. Create a component product to be in the BoM of two other products and set it as storable

2. Create 2 storable products

3. Set the first product as the bom line in the other products and set the BoM type to kit

4. Ensure the Picking orders are created in real time (pos inventory settings)

5. sell the two products in POS and observe the pos.order total_cost discrepency with the inventory valuation values.

opw-4201935