### PR TITLE
[REF] *: resequence route returns web_read

### DIFF
--- a/addons/web/controllers/dataset.py
+++ b/addons/web/controllers/dataset.py
@@ -37,28 +37,3 @@ class DataSet(http.Controller):
         if isinstance(action, dict) and action.get('type') != '':
             return clean_action(action, env=request.env)
         return False
-
-    @http.route('/web/dataset/resequence', type='jsonrpc', auth="user")
-    def resequence(self, model, ids, field='sequence', offset=0, context=None):
-        """ Re-sequences a number of records in the model, by their ids
-
-        The re-sequencing starts at the first model of ``ids``, the sequence
-        number is incremented by one after each record and starts at ``offset``
-
-        :param ids: identifiers of the records to resequence, in the new sequence order
-        :type ids: list(id)
-        :param str field: field used for sequence specification, defaults to
-                          "sequence"
-        :param int offset: sequence number for first record in ``ids``, allows
-                           starting the resequencing from an arbitrary number,
-                           defaults to ``0``
-        """
-        if context:
-            request.update_context(**context)
-        m = request.env[model]
-        if not m.fields_get([field]):
-            return False
-        # python 2.6 has no start parameter
-        for i, record in enumerate(m.browse(ids)):
-            record.write({field: i + offset})
-        return True

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -224,6 +224,31 @@ class Base(models.AbstractModel):
 
         return values_list
 
+    def web_resequence(self, specification: dict[str, dict], field_name: str = 'sequence', offset: int = 0) -> list[dict]:
+        """ Re-sequences a number of records in the model, by their ids.
+
+        The re-sequencing starts at the first record of ``ids``, the sequence
+        number starts at ``offset`` and is incremented by one after each record.
+
+        The returning value is a read of the resequenced records with the specification given
+        in the parameter.
+
+        :param ids: identifiers of the records to resequence, in the new sequence order
+        :type ids: list(id)
+        :param str field: field used for sequence specification, defaults to
+                          "sequence"
+        :param int offset: sequence number for first record in ``ids``, allows
+                           starting the resequencing from an arbitrary number,
+                           defaults to ``0``
+        :param dict[str, dict] specification: specification for the read of the resequenced records
+        """
+        if field_name not in self._fields:
+            return []
+
+        for i, record in enumerate(self, start=offset):
+            record.write({field_name: i})
+        return self.web_read(specification)
+
     @api.model
     @api.readonly
     def web_read_group(self, domain, fields, groupby, limit=None, offset=0, orderby=False, lazy=True):

--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -260,6 +260,24 @@ export class ORM {
 
     /**
      * @param {string} model
+     * @param {number[]} ids
+     * @param {object} [kwargs={}]
+     * @param {object} [kwargs.context]
+     * @param {string} [kwargs.field_name]
+     * @param {number} [kwargs.offset]
+     * @param {object} [kwargs.specification]
+     * @returns {Promise<any[]>}
+     */
+    webResequence(model, ids, kwargs = {}) {
+        validatePrimitiveList("ids", "number", ids);
+        return this.call(model, "web_resequence", [ids], {
+            ...kwargs,
+            specification: kwargs.specification || {},
+        });
+    }
+
+    /**
+     * @param {string} model
      * @param {import("@web/core/domain").DomainListRepr} domain
      * @param {any} [kwargs={}]
      * @returns {Promise<any[]>}
@@ -320,6 +338,7 @@ export const ormService = {
         "search",
         "searchRead",
         "unlink",
+        "webResequence",
         "webSearchRead",
         "write",
     ],

--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -328,14 +328,12 @@ export class DynamicList extends DataPoint {
             getSequence,
             getResId,
         });
-        if (resequencedRecords) {
-            for (const dpData of resequencedRecords) {
-                const dp = originalList.find((d) => getResId(d) === dpData.id);
-                if (dp instanceof Record) {
-                    dp._applyValues(dpData);
-                } else {
-                    dp[handleField] = dpData[handleField];
-                }
+        for (const dpData of resequencedRecords) {
+            const dp = originalList.find((d) => getResId(d) === dpData.id);
+            if (dp instanceof Record) {
+                dp._applyValues(dpData);
+            } else {
+                dp[handleField] = dpData[handleField];
             }
         }
     }

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -14,7 +14,6 @@ import { omit } from "@web/core/utils/objects";
 import { effect } from "@web/core/utils/reactive";
 import { batched } from "@web/core/utils/timing";
 import { orderByToString } from "@web/search/utils/order_by";
-import { rpc } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
 
@@ -823,30 +822,19 @@ export async function resequence({
 
     const resIds = toReorder.map((d) => getResId(d)).filter((id) => id && !isNaN(id));
     const sequences = toReorder.map(getSequence);
-    const offset = sequences.length && Math.min(...sequences);
+    const offset = Math.min(...sequences) || 0;
 
     // Try to write new sequences on the affected records/groups
-    const params = {
-        model: resModel,
-        ids: resIds,
-        context: context,
-        field: fieldName,
-    };
-    if (offset) {
-        params.offset = offset;
-    }
     try {
-        const wasResequenced = await rpc("/web/dataset/resequence", params);
-        if (!wasResequenced) {
-            return;
-        }
+        return await orm.webResequence(resModel, resIds, {
+            field_name: fieldName,
+            offset,
+            context,
+            specification: { [fieldName]: {} },
+        });
     } catch (error) {
         // If the server fails to resequence, rollback the original list
         records.splice(0, records.length, ...originalOrder);
         throw error;
     }
-
-    // Read the actual values set by the server and update the records/groups
-    const kwargs = { context };
-    return orm.read(resModel, resIds, [fieldName], kwargs);
 }

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -2588,6 +2588,28 @@ export class Model extends Array {
 
     /**
      * @param {MaybeIterable<number>} idOrIds
+     * @param {Record<string, any>} specification
+     * @param {string} fieldName
+     * @param {number} offset
+     */
+    web_resequence(idOrIds, specification, fieldName, offset) {
+        const kwargs = getKwArgs(arguments, "ids", "field_name", "offset", "specification");
+        ({ ids: idOrIds, field_name: fieldName, offset = 0, specification } = kwargs);
+
+        if (!(fieldName in this._fields)) {
+            return [];
+        }
+
+        const ids = ensureArray(idOrIds);
+        for (const [index, id] of ids.entries()) {
+            this.write(id, { [fieldName]: offset + index });
+        }
+
+        return this.web_read(ids, specification);
+    }
+
+    /**
+     * @param {MaybeIterable<number>} idOrIds
      * @param {Partial<ModelRecord>} values
      * @param {Record<string, any>} specification
      * @param {MaybeIterable<number>} [nextId]

--- a/addons/web/static/tests/_framework/mock_server/mock_server.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_server.js
@@ -395,7 +395,6 @@ export class MockServer {
             this.callKw,
             { final: true }
         );
-        this._onRoute(["/web/dataset/resequence"], this.resequence);
         this._onRoute(["/web/image/<string:model>/<int:id>/<string:field>"], this.loadImage, {
             pure: true,
         });
@@ -1205,23 +1204,6 @@ export class MockServer {
             modules: this.modules,
             multi_lang: serverState.multiLang,
         };
-    }
-
-    /**
-     * @type {RouteCallback}
-     */
-    async resequence(request) {
-        const { params } = await request.json();
-        const offset = params.offset ? Number(params.offset) : 0;
-        const field = params.field || "sequence";
-        if (!(field in this.env[params.model]._fields)) {
-            return false;
-        }
-        for (const index in params.ids) {
-            const record = this.env[params.model].find((r) => r.id === params.ids[index]);
-            record[field] = Number(index) + offset;
-        }
-        return true;
     }
 }
 

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -593,8 +593,6 @@ export class MockServer {
                 return this.mockLoadAction(args);
             case "/web/action/load_breadcrumbs":
                 return this.mockLoadBreadcrumbs(args);
-            case "/web/dataset/resequence":
-                return this.mockResequence(args);
         }
         if (
             route.indexOf("/web/image") >= 0 ||
@@ -2084,19 +2082,6 @@ export class MockServer {
             length: nbRecords,
             records,
         };
-    }
-
-    mockResequence(args) {
-        const offset = args.offset ? Number(args.offset) : 0;
-        const field = args.field || "sequence";
-        if (!(field in this.models[args.model].fields)) {
-            return false;
-        }
-        for (const index in args.ids) {
-            const record = this.models[args.model].records.find((r) => r.id === args.ids[index]);
-            record[field] = Number(index) + offset;
-        }
-        return true;
     }
 
     mockWrite(modelName, args) {

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -3413,9 +3413,6 @@ test("search more in many2one: cannot resequence inside dialog", async () => {
     onRpc("web_search_read", ({ kwargs }) => {
         expect(kwargs.domain).toEqual([]);
     });
-    onRpc("/web/dataset/resequence", () => {
-        expect.step("/web/dataset/resequence");
-    });
     onRpc(({ method }) => {
         expect.step(method);
     });

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -9604,18 +9604,8 @@ test(`list with handle widget`, async () => {
     onRpc("web_search_read", ({ kwargs }) => {
         expect.step(`web_search_read: order: ${kwargs.order}`);
     });
-    onRpc("/web/dataset/resequence", async (request) => {
-        const { params } = await request.json();
-        expect.step("resequence");
-        expect(params.offset).toBe(9, {
-            message: "should write the sequence starting from the lowest current one",
-        });
-        expect(params.field).toBe("int_field", {
-            message: "should write the right field as sequence",
-        });
-        expect(params.ids).toEqual([3, 2, 1], {
-            message: "should write the sequence in correct order",
-        });
+    onRpc("web_resequence", async ({ args, kwargs }) => {
+        expect.step(["web_resequence", args[0], kwargs.field_name, kwargs.offset]);
     });
 
     await mountView({
@@ -9644,7 +9634,7 @@ test(`list with handle widget`, async () => {
 
     // Drag and drop the fourth line in second position
     await contains(`tbody tr:eq(3) .o_handle_cell`).dragAndDrop(queryFirst(`tbody tr:eq(1)`));
-    expect.verifySteps(["resequence"]);
+    expect.verifySteps([["web_resequence", [3, 2, 1], "int_field", 9]]);
     expect(`.o_data_row:eq(0) [name='amount']`).toHaveText("0", {
         message: "new second record should have amount 0",
     });
@@ -9673,53 +9663,19 @@ test(`result of consecutive resequences is correctly sorted`, async () => {
     }
     defineModels([MyFoo]);
 
-    let moves = 0;
-    const context = {
-        lang: "en",
-        tz: "taht",
-        uid: 7,
-        allowed_company_ids: [1],
+    const kwargs = {
+        context: {
+            lang: "en",
+            tz: "taht",
+            uid: 7,
+            allowed_company_ids: [1],
+        },
+        specification: { int_field: {} },
+        field_name: "int_field",
     };
-    onRpc("/web/dataset/resequence", async (request) => {
-        expect.step("resequence");
-        const { params } = await request.json();
-        if (moves === 0) {
-            expect(params).toEqual({
-                context,
-                model: "my.foo",
-                ids: [4, 3],
-                offset: 13,
-                field: "int_field",
-            });
-        }
-        if (moves === 1) {
-            expect(params).toEqual({
-                context,
-                model: "my.foo",
-                ids: [4, 2],
-                offset: 12,
-                field: "int_field",
-            });
-        }
-        if (moves === 2) {
-            expect(params).toEqual({
-                context,
-                model: "my.foo",
-                ids: [2, 4],
-                offset: 12,
-                field: "int_field",
-            });
-        }
-        if (moves === 3) {
-            expect(params).toEqual({
-                context,
-                model: "my.foo",
-                ids: [4, 2],
-                offset: 12,
-                field: "int_field",
-            });
-        }
-        moves += 1;
+
+    onRpc("my.foo", "web_resequence", async ({ args, kwargs }) => {
+        expect.step({ args, kwargs });
     });
 
     await mountView({
@@ -9739,7 +9695,7 @@ test(`result of consecutive resequences is correctly sorted`, async () => {
     await contains(`.o_list_view tbody tr:eq(3) .o_handle_cell`).dragAndDrop(
         ".o_list_view tbody tr:eq(2)"
     );
-    expect.verifySteps(["resequence"]);
+    expect.verifySteps([{ args: [[4, 3]], kwargs: { ...kwargs, offset: 13 } }]);
     expect(queryAllTexts(`tbody tr td[name=id]`)).toEqual(["1", "2", "4", "3"], {
         message: "the int_field (sequence) should have been correctly updated",
     });
@@ -9747,7 +9703,7 @@ test(`result of consecutive resequences is correctly sorted`, async () => {
     await contains(`.o_list_view tbody tr:eq(2) .o_handle_cell`).dragAndDrop(
         ".o_list_view tbody tr:eq(1)"
     );
-    expect.verifySteps(["resequence"]);
+    expect.verifySteps([{ args: [[4, 2]], kwargs: { ...kwargs, offset: 12 } }]);
     expect(queryAllTexts(`tbody tr td[name=id]`)).toEqual(["1", "4", "2", "3"], {
         message: "the int_field (sequence) should have been correctly updated",
     });
@@ -9755,7 +9711,7 @@ test(`result of consecutive resequences is correctly sorted`, async () => {
     await contains(`.o_list_view tbody tr:eq(1) .o_handle_cell`).dragAndDrop(
         ".o_list_view tbody tr:eq(2)"
     );
-    expect.verifySteps(["resequence"]);
+    expect.verifySteps([{ args: [[2, 4]], kwargs: { ...kwargs, offset: 12 } }]);
     expect(queryAllTexts(`tbody tr td[name=id]`)).toEqual(["1", "2", "4", "3"], {
         message: "the int_field (sequence) should have been correctly updated",
     });
@@ -9763,7 +9719,7 @@ test(`result of consecutive resequences is correctly sorted`, async () => {
     await contains(`.o_list_view tbody tr:eq(2) .o_handle_cell`).dragAndDrop(
         ".o_list_view tbody tr:eq(1)"
     );
-    expect.verifySteps(["resequence"]);
+    expect.verifySteps([{ args: [[4, 2]], kwargs: { ...kwargs, offset: 12 } }]);
     expect(queryAllTexts(`tbody tr td[name=id]`)).toEqual(["1", "4", "2", "3"], {
         message: "the int_field (sequence) should have been correctly updated",
     });
@@ -9805,10 +9761,9 @@ test("resequence with NULL values", async () => {
         return res;
     });
 
-    onRpc("/web/dataset/resequence", async (request) => {
-        const { params } = await request.json();
-        for (let i = 0; i < params.ids.length; i++) {
-            serverValues[params.ids[i]] = i;
+    onRpc("web_resequence", async ({ args }) => {
+        for (let i = 0; i < args[0].length; i++) {
+            serverValues[args[0][i]] = i;
         }
     });
 
@@ -9861,10 +9816,9 @@ test("resequence with only NULL values", async () => {
         return res;
     });
 
-    onRpc("/web/dataset/resequence", async (request) => {
-        const { params } = await request.json();
-        for (let i = 0; i < params.ids.length; i++) {
-            serverValues[params.ids[i]] = i;
+    onRpc("web_resequence", async ({ args }) => {
+        for (let i = 0; i < args[0].length; i++) {
+            serverValues[args[0][i]] = i;
         }
     });
 
@@ -9895,18 +9849,8 @@ test(`editable list with handle widget`, async () => {
     Foo._records[2].int_field = 2;
     Foo._records[3].int_field = 3;
 
-    onRpc("/web/dataset/resequence", async (request) => {
-        expect.step("resequence");
-        const { params } = await request.json();
-        expect(params.offset).toBe(1, {
-            message: "should write the sequence starting from the lowest current one",
-        });
-        expect(params.field).toBe("int_field", {
-            message: "should write the right field as sequence",
-        });
-        expect(params.ids).toEqual([4, 2, 3], {
-            message: "should write the sequence in correct order",
-        });
+    onRpc("web_resequence", async ({ args, kwargs }) => {
+        expect.step(["web_resequence", args[0], kwargs.field_name, kwargs.offset]);
     });
 
     await mountView({
@@ -9934,7 +9878,7 @@ test(`editable list with handle widget`, async () => {
 
     // Drag and drop the fourth line in second position
     await contains(`tbody tr:eq(3) .o_handle_cell`).dragAndDrop(queryFirst(`tbody tr:eq(1)`));
-    expect.verifySteps(["resequence"]);
+    expect.verifySteps([["web_resequence", [4, 2, 3], "int_field", 1]]);
     expect(`tbody tr:eq(0) td:last`).toHaveText("1,200", {
         message: "new first record should have amount 1,200",
     });
@@ -10034,18 +9978,8 @@ test(`editable list with handle widget with slow network`, async () => {
     Foo._records[3].int_field = 3;
 
     const deferred = new Deferred();
-    onRpc("/web/dataset/resequence", async (request) => {
-        expect.step("resequence");
-        const { params } = await request.json();
-        expect(params.offset).toBe(1, {
-            message: "should write the sequence starting from the lowest current one",
-        });
-        expect(params.field).toBe("int_field", {
-            message: "should write the right field as sequence",
-        });
-        expect(params.ids).toEqual([4, 2, 3], {
-            message: "should write the sequence in correct order",
-        });
+    onRpc("web_resequence", async ({ args, kwargs }) => {
+        expect.step(["web_resequence", args[0], kwargs.field_name, kwargs.offset]);
         await deferred;
     });
 
@@ -10063,7 +9997,7 @@ test(`editable list with handle widget with slow network`, async () => {
 
     // drag and drop the fourth line in second position
     await contains(`tbody tr:eq(3) .o_handle_cell`).dragAndDrop(`tbody tr:eq(1)`);
-    expect.verifySteps(["resequence"]);
+    expect.verifySteps([["web_resequence", [4, 2, 3], "int_field", 1]]);
 
     // edit moved row before the end of resequence
     await contains(`tbody tr:eq(3) .o_field_widget[name='amount']`).click();

--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -193,10 +193,9 @@
          * @private
          */
         _reorderQuestions: function () {
-            rpc('/web/dataset/resequence', {
-                model: "slide.question",
-                ids: this._getQuestionsIds()
-            }).then(this._modifyQuestionsSequence.bind(this))
+            this.orm
+                .webResequence("slide.question", this._getQuestionsIds())
+                .then(this._modifyQuestionsSequence.bind(this))
         },
         /*
          * @private

--- a/addons/website_slides/static/src/js/slides_course_slides_list.js
+++ b/addons/website_slides/static/src/js/slides_course_slides_list.js
@@ -1,10 +1,14 @@
 import publicWidget from '@web/legacy/js/public/public_widget';
 import { _t } from "@web/core/l10n/translation";
-import { rpc } from "@web/core/network/rpc";
 import { SlideCoursePage } from '@website_slides/js/slides_course_page';
 
 publicWidget.registry.websiteSlidesCourseSlidesList = SlideCoursePage.extend({
     selector: '.o_wslides_slides_list',
+
+    init: function () {
+        this._super(...arguments);
+        this.orm = this.bindService("orm");
+    },
 
     start: function () {
         this._super.apply(this,arguments);
@@ -105,12 +109,11 @@ publicWidget.registry.websiteSlidesCourseSlidesList = SlideCoursePage.extend({
     },
     _reorderSlides: function (){
         var self = this;
-        rpc('/web/dataset/resequence', {
-            model: "slide.slide",
-            ids: self._getSlides(),
-        }).then(function (res) {
-            self._checkForEmptySections();
-        });
+        this.orm
+            .webResequence("slide.slide", this._getSlides())
+            .then(function (res) {
+                self._checkForEmptySections();
+            });
     },
 
     /**


### PR DESCRIPTION
This commit introduces `web_resequence`, a method to resequence the records and return these records with a given specification.

Before this commit, the resequence did not return the resequenced records and we needed to read them afterwards. That caused to send two RPC (1 for resequence and 1 for read).

task-3790638