### PR TITLE
[FIX] bus, *: lost notifications when GC runs while disconnected

### DIFF
--- a/addons/bus/controllers/main.py
+++ b/addons/bus/controllers/main.py
@@ -11,3 +11,8 @@ class BusController(Controller):
         return request.make_response(json.dumps(
             request.env['ir.model']._get_model_definitions(json.loads(model_names_to_fetch)),
         ))
+
+    @route("/bus/get_autovacuum_info", type="json", auth="public")
+    def get_autovacuum_info(self):
+        # sudo - ir.cron: lastcall and nextcall of the autovacuum is not sensitive
+        return request.env.ref("base.autovacuum_job").sudo().read(["lastcall", "nextcall"])[0]

--- a/addons/bus/i18n/bus.pot
+++ b/addons/bus/i18n/bus.pot
@@ -126,6 +126,7 @@ msgstr ""
 
 #. module: bus
 #. odoo-javascript
+#: code:addons/bus/static/src/outdated_page_watcher_service.js:0
 #: code:addons/bus/static/src/services/assets_watchdog_service.js:0
 #: code:addons/bus/static/src/services/bus_service.js:0
 msgid "Refresh"
@@ -133,6 +134,7 @@ msgstr ""
 
 #. module: bus
 #. odoo-javascript
+#: code:addons/bus/static/src/outdated_page_watcher_service.js:0
 #: code:addons/bus/static/src/services/bus_service.js:0
 msgid ""
 "Save your work and refresh to get the latest updates and avoid potential "
@@ -147,6 +149,7 @@ msgstr ""
 
 #. module: bus
 #. odoo-javascript
+#: code:addons/bus/static/src/outdated_page_watcher_service.js:0
 #: code:addons/bus/static/src/services/bus_service.js:0
 msgid "The page is out of date"
 msgstr ""

--- a/addons/bus/static/src/outdated_page_watcher_service.js
+++ b/addons/bus/static/src/outdated_page_watcher_service.js
@@ -1,0 +1,84 @@
+import { browser } from "@web/core/browser/browser";
+import { deserializeDateTime } from "@web/core/l10n/dates";
+import { _t } from "@web/core/l10n/translation";
+import { rpc } from "@web/core/network/rpc";
+import { registry } from "@web/core/registry";
+
+const { DateTime } = luxon;
+export class OutdatedPageWatcherService {
+    constructor(env, services) {
+        this.setup(env, services);
+    }
+
+    /**
+     * @param {import("@web/env").OdooEnv}
+     * @param {Partial<import("services").Services>} services
+     */
+    setup(env, { bus_service, multi_tab, notification }) {
+        this.notification = notification;
+        const vacuumInfo = multi_tab.getSharedValue("bus.autovacuum_info");
+        this.lastAutovacuumDt = vacuumInfo ? deserializeDateTime(vacuumInfo.lastcall) : null;
+        this.nextAutovacuumDt = vacuumInfo ? deserializeDateTime(vacuumInfo.nextcall) : null;
+        this.lastDisconnectDt = null;
+        this.closeNotificationFn;
+        bus_service.addEventListener(
+            "disconnect",
+            () => (this.lastDisconnectDt = DateTime.now().toUTC())
+        );
+        bus_service.addEventListener("reconnect", async () => {
+            if (!multi_tab.isOnMainTab() || !this.lastDisconnectDt) {
+                return;
+            }
+            if (!this.lastAutovacuumDt || DateTime.now().toUTC() >= this.nextAutovacuumDt) {
+                const { lastcall, nextcall } = await rpc("/bus/get_autovacuum_info", {
+                    silent: true,
+                });
+                this.lastAutovacuumDt = deserializeDateTime(lastcall);
+                this.nextAutovacuumDt = deserializeDateTime(nextcall);
+                multi_tab.setSharedValue("bus.autovacuum_info", { lastcall, nextcall });
+            }
+            if (this.lastDisconnectDt <= this.lastAutovacuumDt) {
+                this.showOutdatedPageNotification();
+            }
+        });
+        multi_tab.bus.addEventListener("shared_value_updated", ({ detail: { key, newValue } }) => {
+            if (key !== "bus.autovacuum_info") {
+                return;
+            }
+            const infos = JSON.parse(newValue);
+            this.lastAutovacuumDt = deserializeDateTime(infos.lastcall);
+            this.nextAutovacuumDt = deserializeDateTime(infos.nextcall);
+            if (this.lastDisconnectDt <= this.lastAutovacuumDt) {
+                this.showOutdatedPageNotification();
+            }
+        });
+    }
+
+    showOutdatedPageNotification() {
+        this.closeNotificationFn?.();
+        this.closeNotificationFn = this.notification.add(
+            _t("Save your work and refresh to get the latest updates and avoid potential issues."),
+            {
+                title: _t("The page is out of date"),
+                type: "warning",
+                sticky: true,
+                buttons: [
+                    {
+                        name: _t("Refresh"),
+                        primary: true,
+                        onClick: () => browser.location.reload(),
+                    },
+                ],
+            }
+        );
+    }
+}
+
+export const outdatedPageWatcherService = {
+    dependencies: ["bus_service", "multi_tab", "notification"],
+    start(env, services) {
+        return new OutdatedPageWatcherService(env, services);
+    },
+};
+
+registry.category("services").add("bus.outdated_page_watcher", outdatedPageWatcherService);

--- a/addons/bus/static/tests/legacy/outdated_page_watcher_tests.js
+++ b/addons/bus/static/tests/legacy/outdated_page_watcher_tests.js
@@ -1,0 +1,45 @@
+/** @odoo-module alias=@bus/../tests/assets_watchdog_tests default=false */
+
+import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+import { addBusServicesToRegistry } from "@bus/../tests/helpers/test_utils";
+import { waitForBusEvent } from "@bus/../tests/helpers/websocket_event_deferred";
+import { outdatedPageWatcherService } from "@bus/outdated_page_watcher_service";
+import { WEBSOCKET_CLOSE_CODES } from "@bus/workers/websocket_worker";
+import { patchWithCleanup } from "@web/../tests/legacy/helpers/utils";
+import { assertSteps, click, contains, step } from "@web/../tests/legacy/utils";
+import { createWebClient } from "@web/../tests/webclient/helpers";
+import { browser } from "@web/core/browser/browser";
+import { serializeDateTime } from "@web/core/l10n/dates";
+import { registry } from "@web/core/registry";
+
+const { DateTime } = luxon;
+QUnit.test("disconnect during vacuum should ask for reload", async () => {
+    // vacuum permanently clears notifs, so reload might be required to recover coherent state in apps like Discuss
+    addBusServicesToRegistry();
+    registry.category("services").add("bus.outdated_page_watcher", outdatedPageWatcherService);
+    const pyEnv = await startServer();
+    const { env } = await createWebClient({
+        mockRPC(route) {
+            if (route === "/bus/get_autovacuum_info") {
+                return {
+                    lastcall: serializeDateTime(lastDisconnectDt.plus({ minute: 1 })),
+                    nextcall: serializeDateTime(DateTime.now().plus({ day: 1 })),
+                };
+            }
+        },
+    });
+    let lastDisconnectDt;
+    env.services.bus_service.addEventListener(
+        "disconnect",
+        () => (lastDisconnectDt = DateTime.now())
+    );
+    env.services.bus_service.start();
+    await waitForBusEvent(env, "connect");
+    pyEnv.simulateConnectionLost(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
+    await contains(".o_notification", {
+        text: "Save your work and refresh to get the latest updates and avoid potential issues.",
+    });
+    patchWithCleanup(browser.location, { reload: () => step("reload") });
+    await click(".o_notification button", { text: "Refresh" });
+    await assertSteps(["reload"]);
+});

--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -120,6 +120,7 @@ Help your customers with this chat, and analyse their feedback.
             'bus/static/src/services/**/*.js',
             'bus/static/src/workers/websocket_worker.js',
             'bus/static/src/workers/websocket_worker_utils.js',
+            ('remove', 'bus/static/src/outdated_page_watcher_service.js'),
             ('remove', 'bus/static/src/services/assets_watchdog_service.js'),
             ('remove', 'bus/static/src/simple_notification_service.js'),
             ('include', 'im_livechat.assets_embed_core'),


### PR DESCRIPTION
Before this PR, the UI could become outdated if the garbage collection (GC) of bus notifications occurred while the WebSocket was disconnected. This typically happens when the PC is asleep overnight. Notifications sent between the WebSocket disconnection and the GC were lost, resulting in an outdated UI (e.g., missing messages).

While it is not possible to retrieve those lost notifications, we should at least inform the user that some data may be missing. This PR introduces a notification prompting the user to refresh the page if GC ran during the disconnection.