### PR TITLE
[FIX] account: ensure demo data has country set

### DIFF
--- a/addons/account/models/ir_module.py
+++ b/addons/account/models/ir_module.py
@@ -65,13 +65,13 @@ class IrModule(models.Model):
         is_installed = len(self) == 1 and self.state == 'installed'
         if (
             not was_installed and is_installed
-            and self.env.company.country_id.id
             and not self.env.company.chart_template
             and self.account_templates
             and (guessed := next((
                 tname
                 for tname, tvals in self.account_templates.items()
-                if tvals['country_id'] == self.env.company.country_id.id or tname == 'generic_coa'
+                if (self.env.company.country_id.id and tvals['country_id'] == self.env.company.country_id.id)
+                or tname == 'generic_coa'
             ), None))
         ):
             def try_loading(env):


### PR DESCRIPTION
Fix for 1c5cc23b5eb3b59da10926688fc350b56397b550

Generic CoA sets the country on the company. Without one many tests fail.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
