### PR TITLE
[FIX] account_edi_ubl_cii: _get_customization_ids not inherited

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_21.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_21.py
@@ -48,4 +48,7 @@ class AccountEdiXmlUBL21(models.AbstractModel):
             'ubl_sg': 'urn:cen.eu:en16931:2017#conformant#urn:fdc:peppol.eu:2017:poacc:billing:international:sg:3.0',
             'xrechnung': 'urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0',
             'ubl_a_nz': 'urn:cen.eu:en16931:2017#conformant#urn:fdc:peppol.eu:2017:poacc:billing:international:aunz:3.0',
+            'pint_jp': 'urn:peppol:pint:billing-1@jp-1',
+            'pint_sg': 'urn:peppol:pint:billing-1@sg-1',
+            'pint_my': 'urn:peppol:pint:billing-1@my-1',
         }

--- a/addons/l10n_jp_ubl_pint/models/account_edi_xml_pint_jp.py
+++ b/addons/l10n_jp_ubl_pint/models/account_edi_xml_pint_jp.py
@@ -75,11 +75,6 @@ class AccountEdiXmlUBLPINTJP(models.AbstractModel):
             vals_list.append(tax_totals_vals)
         return vals_list
 
-    def _get_customization_ids(self):
-        vals = super()._get_customization_ids()
-        vals['pint_jp'] = 'urn:peppol:pint:billing-1@jp-1'
-        return vals
-
     def _export_invoice_vals(self, invoice):
         # EXTENDS account_edi_ubl_cii
         vals = super()._export_invoice_vals(invoice)

--- a/addons/l10n_my_ubl_pint/models/account_edi_xml_pint_my.py
+++ b/addons/l10n_my_ubl_pint/models/account_edi_xml_pint_my.py
@@ -12,11 +12,6 @@ class AccountEdiXmlUBLPINTMY(models.AbstractModel):
     * PINT MY Official documentation: https://docs.peppol.eu/poac/my/pint-my
     """
 
-    def _get_customization_ids(self):
-        vals = super()._get_customization_ids()
-        vals['pint_my'] = 'urn:peppol:pint:billing-1@my-1'
-        return vals
-
     def _export_invoice_filename(self, invoice):
         # EXTENDS account_edi_ubl_cii
         return f"{invoice.name.replace('/', '_')}_pint_my.xml"

--- a/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
+++ b/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
@@ -56,12 +56,6 @@ class AccountEdiXmlUBLPINTSG(models.AbstractModel):
             vals['tax_scheme_vals'] = {'id': 'GST'}
         return vals_list
 
-    def _get_customization_ids(self):
-        # EXTENDS account_edi_ubl_cii
-        vals = super()._get_customization_ids()
-        vals['pint_sg'] = 'urn:peppol:pint:billing-1@sg-1'
-        return vals
-
     def _export_invoice_vals(self, invoice):
         # EXTENDS account_edi_ubl_cii
         vals = super()._export_invoice_vals(invoice)


### PR DESCRIPTION
The method _get_customization_ids is overriden in other modules to add their schema. The issue is that we call explicitely a specific model with _check_document_type_support. As we call it, the overrident part is not taken into account, as they are overriden in model that changed name. 
Ex: account.edi.xml.pint_jp is not account.edi.xml.ubl_21.

It causes issues if you create a company with an existing participant in the country of these other modules and with the default eas.

To reproduce:
Create a company with the module l10n_jp_ubl_pint and account_peppol installed. Put Japan as country and put as Tax number the endpoint of an existing participant When saving, it will traceback, as the key is not in the dict





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
