### PR TITLE
[IMP] core: res.users: Merge `UsersImplied` into `ResUsers`

### DIFF
--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1449,7 +1449,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "name": "OdooBot",
                                     "userId": self.env.user.id,
                                     "write_date": fields.Datetime.to_string(
-                                        self.env.user.write_date
+                                        self.env.user.partner_id.write_date
                                     ),
                                 },
                             ),
@@ -1552,7 +1552,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "name": "OdooBot",
                                     "userId": self.env.user.id,
                                     "write_date": fields.Datetime.to_string(
-                                        self.env.user.write_date
+                                        self.env.user.partner_id.write_date
                                     ),
                                 },
                             ),

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -697,6 +697,14 @@ class ResUsers(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        for values in vals_list:
+            if 'groups_id' in values:
+                # complete 'groups_id' with implied groups
+                user = self.new(values)
+                gs = user.groups_id._origin
+                gs = gs | gs.trans_implied_ids
+                values['groups_id'] = self._fields['groups_id'].convert_to_write(gs, user)
+
         users = super().create(vals_list)
         setting_vals = []
         for user in users:
@@ -744,10 +752,12 @@ class ResUsers(models.Model):
                 self = self.sudo()
 
         old_groups = []
-        if 'groups_id' in values and self._apply_groups_to_existing_employees():
-            # if modify groups_id content, compute the delta of groups to apply
-            # the new ones to other existing users
-            old_groups = self._default_groups()
+        if 'groups_id' in values:
+            users_before = self.filtered(lambda u: u._is_internal())
+            if self._apply_groups_to_existing_employees():
+                # if modify groups_id content, compute the delta of groups to apply
+                # the new ones to other existing users
+                old_groups = self._default_groups()
 
         res = super().write(values)
 
@@ -774,11 +784,25 @@ class ResUsers(models.Model):
                 if env.user in self:
                     lazy_property.reset_all(env)
 
-        # clear caches linked to the users
-        if self.ids and 'groups_id' in values:
-            # DLE P139: Calling invalidate_cache on a new, well you lost everything as you wont be able to take it back from the cache
-            # `test_00_equipment_multicompany_user`
-            self.env['ir.model.access'].call_cache_clearing_methods()
+        if 'groups_id' in values:
+            # Do not use `_is_internal` as it relies on the ormcache which is not yet invalidated
+            internal_group_id = self.env['ir.model.data']._xmlid_to_res_id("base.group_user")
+            demoted_users = users_before.filtered(lambda u: internal_group_id not in u.groups_id.ids)
+            if demoted_users:
+                # demoted users are restricted to the assigned groups only
+                vals = {'groups_id': [Command.clear()] + values['groups_id']}
+                super(ResUsers, demoted_users).write(vals)
+            # add implied groups for all users (in batches)
+            users_batch = defaultdict(self.browse)
+            for user in self:
+                users_batch[user.groups_id] += user
+            for groups, users in users_batch.items():
+                gs = set(concat(g.trans_implied_ids for g in groups))
+                vals = {'groups_id': [Command.link(g.id) for g in gs]}
+                super(ResUsers, users).write(vals)
+            # clear caches linked to the users
+            if self.ids:
+                self.env['ir.model.access'].call_cache_clearing_methods()
 
         # per-method / per-model caches have been removed so the various
         # clear_cache/clear_caches methods pretty much just end up calling
@@ -1559,41 +1583,6 @@ class ResGroups(models.Model):  # noqa: F811
         return SetDefinitions(data)
 
 
-class UsersImplied(models.Model):
-    _name = 'res.users'
-    _inherit = ['res.users']
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        for values in vals_list:
-            if 'groups_id' in values:
-                # complete 'groups_id' with implied groups
-                user = self.new(values)
-                gs = user.groups_id._origin
-                gs = gs | gs.trans_implied_ids
-                values['groups_id'] = self._fields['groups_id'].convert_to_write(gs, user)
-        return super().create(vals_list)
-
-    def write(self, values):
-        if not values.get('groups_id'):
-            return super().write(values)
-        users_before = self.filtered(lambda u: u._is_internal())
-        res = super().write(values)
-        demoted_users = users_before.filtered(lambda u: not u._is_internal())
-        if demoted_users:
-            # demoted users are restricted to the assigned groups only
-            vals = {'groups_id': [Command.clear()] + values['groups_id']}
-            super(UsersImplied, demoted_users).write(vals)
-        # add implied groups for all users (in batches)
-        users_batch = defaultdict(self.browse)
-        for user in self:
-            users_batch[user.groups_id] += user
-        for groups, users in users_batch.items():
-            gs = set(concat(g.trans_implied_ids for g in groups))
-            vals = {'groups_id': [Command.link(g.id) for g in gs]}
-            super(UsersImplied, users).write(vals)
-        return res
-
 #
 # Virtual checkbox and selection for res.user form view
 #
@@ -1853,8 +1842,7 @@ class IrModuleCategory(models.Model):
         return res
 
 
-# pylint: disable=E0102
-class ResUsers(models.Model):  # noqa: F811
+class UsersView(models.Model):
     _inherit = 'res.users'
 
     user_group_warning = fields.Text(string="User Group Warning", compute="_compute_user_group_warning")
@@ -2240,8 +2228,7 @@ KEY_CRYPT_CONTEXT = CryptContext(
 )
 
 
-# pylint: disable=E0102
-class ResUsers(models.Model):  # noqa: F811
+class APIKeysUser(models.Model):
     _inherit = 'res.users'
 
     api_key_ids = fields.One2many('res.users.apikeys', 'user_id', string="API Keys")


### PR DESCRIPTION
`res.users` is inherited 3 times within the same file `base/models/res_users.py`

Merging all inherits into the base model
`_name = 'res.users'` allows:

- Reducing the number of method hops:
  - making clearer the stack trace / tracebacks as less hops
  - strictly speaking improved performances as less call hops
- Making the code clearer
  - for instance regarding the order of the operations done in create / write. Currently it's hard to determine what will be done in which order because of all calls to `super`
  - use common variables in the different overrides create/write/onchange instead of re-computing them in each overrides
- Currently, some overrides share the same class names `ResUsers` leading to infinite loops when calling `super` with the class name e.g. `super(ResUsers, modified_self)` as the variable `ResUsers` might not hold the class you expect, within with you are currently calling `super`
- To remove the pylint/noqa exceptions E0102/F811 related to the re-definition of the same class name

To ease the review, the merge of these 4 ResUsers classes together will be done progressively, class per class or even feature by feature, as merging all of them at the same time would result in an unreviewable big mess.

Hence, we start first with the merge of `UsersImplied` into the base `ResUsers`.

While doing so, the problem regarding the re-definition of the same class name `ResUsers` and the call to `super` is demonstrated with `super(ResUsers, demoted_users).write(vals)`: An infinite loop occurs because it calls `super` on the last defined `ResUsers` class rather than the current one.

I therefore re-name these class names as before
8785ff45962cc9b34b2582d9ba17a9261907ebc0
to force having different names and mitigating the problem.

Regarding the change in `test_mail/tests/test_performance.py`, it's actually a bug in the test
This `write_date` actually comes from the `res.partner` instead of the `res.users`:
https://github.com/odoo/odoo/blob/73e5a54b9ebad85b42cd2e827b9e5531b8716406/addons/mail/models/res_partner.py#L218-L225

The fact this revision triggers the change in that test is because the order of the operations slightly changed,
`self.env['ir.model.access'].call_cache_clearing_methods()`, invalidating the whole cache and flushing,
is not called exactly at the same time than before. Before it was called before the computation of the implied groups, as the inherit was calling `super` right away.
Now it is called after, as it's a more logical place, to invalidate the cache after a change of groups occurs, **including the implied ones**. It was not the case before. But this has as side effect to not write `partner_share` on the `res.partner`, hence it doesn't change the `write_date` of the `res.partner`, and the `write_date`
of the `res.users` and `res.partner` are now different, hence triggering the slight change in that unit test.

Executing the unit test
`--test-tags .test_message_to_store_multi_followers_inbox` `_compute_partner_share` on the partner of the superuser (id:3) is called
- 4 times before this revision
- 2 times after this revision Also it doesn't write the value of `partner_share` in database because the ORM see the value didn't change, while before it considered a change occured and it was writting the value hence changing the write date.

The fact it recomputes this field on the partner of the admin in the first place is because of
- https://github.com/odoo/odoo/blob/bbfa8666036a174365dbfc2269967695a0838e41/addons/mail/tests/common.py#L1332
- https://github.com/odoo/odoo/blob/bbfa8666036a174365dbfc2269967695a0838e41/addons/mail/models/res_users.py#L56

and the fact to write on `groups_id` trigger the recompute of the `share` flag on `res.users` which triggers the recompute of `res.partner.partner_share`.

So, there is an actual observed performance improvement of merging this `_inherit` in the base class.
Compute methods depending on `groups_id` are called less often, and less UPDATE operations are occurring in database.

This is covered in the added unit test `test_write_groups_id_performance`. While adding a group on a user (e.g. adding `Contact Creation`):
- The number of queries reduces
  - all modules: 40 -> 29
  - base: 26 -> 17
  
I measured the impact on the total runbot, suming queries,
- [without the patch](https://runbot.odoo.com/runbot/batch/1698279/build/70881186)
- [with the patch](https://runbot.odoo.com/runbot/batch/1698206/build/70879622)

On the total build / tests suite
- at install: ~ 2% less queries
- post install ~1% less queries
In total ~ -150.000 queries.
