### PR TITLE
[FIX] web_editor: required model strings are mandatory in website editor

### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -70,6 +70,8 @@ class IrUiView(models.Model):
         try:
             value = converter.from_html(Model, Model._fields[field], el)
             if value is not None:
+                if (Model._fields[field].required and isinstance(value, str) and not value.strip()):
+                    return
                 # TODO: batch writes?
                 record = Model.browse(int(el.get('data-oe-id')))
                 if not self.env.context.get('lang') and self.get_default_lang_code():


### PR DESCRIPTION
Before the change a user changing a model fields using the editor would be able to enter empty strings in model fields that are marked as required, potentially causing serious issues to business logic.

Steps to reproduce:
- Log in Odoo with a user that can access the website editor
- Enter the Website
- Install the shop app if not installed
- Open the shop app
- Click on any product
- Open the Website Editor
- Edit the product name to be empty
- Save the changes

After the change empty strings on required fields are no longer accepted.

task-3959887
