### PR TITLE
[FIX] mrp_account,purchase_mrp: ensure balanced unbuild valuation

### DIFF
--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -44,3 +44,28 @@ class StockMove(models.Model):
     def _is_production_consumed(self):
         self.ensure_one()
         return self.location_dest_id.usage == 'production' and self.location_id._should_be_valued()
+
+    def _get_out_svl_vals(self, forced_quantity):
+        unbuild_moves = self.filtered('unbuild_id')
+        # 'real cost' of finished product moves @ build time
+        price_unit_map = {
+            move.id: (
+                move.unbuild_id.mo_id.move_finished_ids.stock_valuation_layer_ids.filtered(
+                    lambda svl: svl.product_id == move.unbuild_id.mo_id.product_id
+                )[0].unit_cost,
+                move.company_id.currency_id.round,
+            )
+            for move in unbuild_moves.sudo()
+            if move.product_id.cost_method != 'standard' and
+            move.unbuild_id.mo_id.move_finished_ids.stock_valuation_layer_ids
+        }
+        svl_vals_list = super()._get_out_svl_vals(forced_quantity)
+        if price_unit_map:
+            for svl_vals in svl_vals_list:
+                if (move_id := svl_vals['stock_move_id']) in price_unit_map:
+                    unit_cost = price_unit_map[move_id][0]
+                    svl_vals.update({
+                        'unit_cost': unit_cost,
+                        'value': price_unit_map[move_id][1](unit_cost * svl_vals['quantity']),
+                    })
+        return svl_vals_list

--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.fields import Date, Datetime
-from odoo.tools import mute_logger
+from odoo.tools import float_is_zero, mute_logger
 from odoo.tests import Form, tagged
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
@@ -274,3 +274,75 @@ class TestAngloSaxonValuationPurchaseMRP(AccountTestInvoicingCommon):
         manufacturing_order.move_raw_ids.quantity = 1
 
         self.assertEqual(self.product_a.standard_price, 100)
+
+    def test_average_cost_unbuild_valuation(self):
+        """ Ensure that an unbuild for some avg cost product won't leave the `Cost of Production`
+        journal in an imbalanced state if the std price of that product has changed since the MO
+        was completed (i.e., since build time).
+        """
+        def make_purchase_and_production(product_ids, price_units):
+            purchase_orders = self.env['purchase.order'].create([{
+                'partner_id': self.partner_a.id,
+                'order_line': [(0, 0, {
+                    'product_id': prod_id,
+                    'product_qty': 2,
+                    'price_unit': price_unit
+                })],
+            } for prod_id, price_unit in zip(product_ids, price_units)])
+            purchase_orders.button_confirm()
+            purchase_orders.picking_ids.move_ids.quantity = 2
+            purchase_orders.picking_ids.button_validate()
+            production_form = Form(self.env['mrp.production'])
+            production_form.product_id = final_product
+            production_form.bom_id = final_product_bom
+            production_form.product_qty = 1
+            production = production_form.save()
+            production.action_confirm()
+            mo_form = Form(production)
+            mo_form.qty_producing = 1
+            production = mo_form.save()
+            production._post_inventory()
+            production.button_mark_done()
+            return production
+
+        cost_of_production_account = self.env['account.account'].search([
+            ('name', '=', 'Cost of Production'),
+            ('company_id', '=', self.env.company.id),
+        ], limit=1)
+        self.avco_category.property_stock_account_production_cost_id = cost_of_production_account.id
+        final_product = self.env['product.product'].create({
+            'name': 'final product',
+            'type': 'product',
+            'standard_price': 0,
+            'categ_id': self.avco_category.id,
+            'route_ids': [(6, 0, self.env['stock.route'].search([('name', '=', 'Manufacture')], limit=1).ids)],
+        })
+        comp_1, comp_2 = self.env['product.product'].create([{
+            'name': name,
+            'type': 'product',
+            'standard_price': 0,
+            'categ_id': self.avco_category.id,
+            'route_ids': [(4, self.env['stock.route'].search([('name', '=', 'Buy')], limit=1).id)],
+        } for name in ('comp_1', 'comp_2')])
+        final_product_bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': final_product.product_tmpl_id.id,
+            'type': 'normal',
+            'bom_line_ids': [(0, 0, {
+                'product_id': comp_prod_id,
+                'product_qty': 2,
+            }) for comp_prod_id in (comp_1.id, comp_2.id)],
+        })
+        production_1 = make_purchase_and_production([comp_1.id, comp_2.id], [50, 40])
+        make_purchase_and_production([comp_1.id, comp_2.id], [55, 45])
+        action = production_1.button_unbuild()
+        wizard = Form(self.env[action['res_model']].with_context(action['context']))
+        wizard.product_qty = 1
+        wizard = wizard.save()
+        wizard.action_validate()
+        self.assertTrue(float_is_zero(
+            sum(self.env['account.move.line'].search([
+                ('account_id', '=', cost_of_production_account.id),
+                ('product_id', 'in', (final_product.id, comp_1.id, comp_2.id)),
+            ]).mapped('balance')),
+            precision_rounding=self.env.company.currency_id.rounding
+        ))


### PR DESCRIPTION
**Current behavior:**
Having a manufactured product with components, all with
'average' costing, a series of receiptions for the components at
difference price points, followed by an MO, followed by another
reception at (again) a new price point will result in an
imbalanced "Cost of Production" journal if the aforementioned MO
is unbuilt.

**Expected behavior:**
The unbuild operation doesn't leave the journal imbalanced.

**Steps to reproduce:**
1. Create a stored product with average, real_time costing

2. Create a BoM for this product, with 2 stored components (also
with average, real_time costing)

3. Create a PO for the components (price is arbitrary), confirm
and receive the product

4. Create another PO for the components with a different price
from the previous PO, confirm and receive

5. Create an MO for the final product, confirm and
consume/produce all

6. Create a final PO for the components with prices different
from the previous two orders, confirm and receive

7. Create a second MO for the final product and
confirm/consume/produce-all

8. Unbuild the MO from step 5 -> in the "Cost of Production"
journal, observe that there is an outstanding balance

**Cause of the issue:**
When the unbuild operation happens, the current price of the
final product informs the SVL's `value` and `unit_price` fields-
which of course is not the same as when the MO was completed.

We end up with a `unit_price` on the SVL for the final product
which is not equal to the sum of the component SVLs'
`unit_price` which leads to the generation of account move lines
that won't be balanced.

**Fix:**
During an ubuild operation, stock moves for finished products
which may have this issue (i.e., have non-standard costing) with
linked SVL records will use that SVL's unit cost for the unbuild
SVL (and ensuing journal entries) as opposed to taking the
current cost.

opw-4062415