### PR TITLE
[IMP] account: Lock Dates Wizard UX improvement

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -2717,6 +2717,29 @@ msgid "Another entry with the same name already exists."
 msgstr ""
 
 #. module: account
+#: model:ir.model.fields,help:account.field_res_company__hard_lock_date
+msgid ""
+"Any entry up to and including that date will be postponed to a later time, "
+"in accordance with its journal sequence. This lock date is irreversible and "
+"does not allow any exception."
+msgstr ""
+
+#. module: account
+#: model:ir.model.fields,help:account.field_res_company__fiscalyear_lock_date
+msgid ""
+"Any entry up to and including that date will be postponed to a later time, "
+"in accordance with its journal's sequence."
+msgstr ""
+
+#. module: account
+#: model:ir.model.fields,help:account.field_res_company__tax_lock_date
+msgid ""
+"Any entry with taxes up to and including that date will be postponed to a "
+"later time, in accordance with its journal's sequence. The tax lock date is "
+"automatically set when the tax closing entry is posted."
+msgstr ""
+
+#. module: account
 #. odoo-python
 #: code:addons/account/models/account_move_line.py:0
 msgid ""
@@ -2729,6 +2752,20 @@ msgstr ""
 msgid ""
 "Any journal item on a receivable account must have a due date and vice "
 "versa."
+msgstr ""
+
+#. module: account
+#: model:ir.model.fields,help:account.field_res_company__purchase_lock_date
+msgid ""
+"Any purchase entry prior to and including this date will be postponed to a "
+"later date, in accordance with its journal's sequence."
+msgstr ""
+
+#. module: account
+#: model:ir.model.fields,help:account.field_res_company__sale_lock_date
+msgid ""
+"Any sales entry prior to and including this date will be postponed to a "
+"later date, in accordance with its journal's sequence."
 msgstr ""
 
 #. module: account
@@ -9416,7 +9453,6 @@ msgid "Liability"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,help:account.field_res_company__hard_lock_date
 msgid "Like the \"Global Lock Date\", but no exceptions are possible."
 msgstr ""
 
@@ -10284,14 +10320,12 @@ msgid "No possible action found with the selected lines."
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,help:account.field_res_company__fiscalyear_lock_date
 msgid ""
 "No users can edit accounts prior to and inclusive of this date. Use it for "
 "fiscal year locking for example."
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,help:account.field_res_company__tax_lock_date
 msgid ""
 "No users can edit journal entries related to a tax prior and inclusive of "
 "this date."
@@ -11819,14 +11853,12 @@ msgid ""
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,help:account.field_res_company__purchase_lock_date
 msgid ""
 "Prevents creation and modification of entries in purchase journals up to the"
 " defined date inclusive."
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,help:account.field_res_company__sale_lock_date
 msgid ""
 "Prevents creation and modification of entries in sales journals up to the "
 "defined date inclusive."

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -59,26 +59,29 @@ class ResCompany(models.Model):
     fiscalyear_lock_date = fields.Date(
         string="Global Lock Date",
         tracking=True,
-        help="No users can edit accounts prior to and inclusive of this date."
-             " Use it for fiscal year locking for example.")
+        help="Any entry up to and including that date will be postponed to a later time, in accordance with its journal's sequence.",
+    )
     tax_lock_date = fields.Date(
         string="Tax Return Lock Date",
         tracking=True,
-        help="No users can edit journal entries related to a tax prior and inclusive of this date.")
+        help="Any entry with taxes up to and including that date will be postponed to a later time, in accordance with its journal's sequence. "
+             "The tax lock date is automatically set when the tax closing entry is posted.",
+    )
     sale_lock_date = fields.Date(
         string='Sales Lock Date',
         tracking=True,
-        help='Prevents creation and modification of entries in sales journals up to the defined date inclusive.'
+        help="Any sales entry prior to and including this date will be postponed to a later date, in accordance with its journal's sequence.",
     )
     purchase_lock_date = fields.Date(
         string='Purchase Lock date',
         tracking=True,
-        help='Prevents creation and modification of entries in purchase journals up to the defined date inclusive.'
+        help="Any purchase entry prior to and including this date will be postponed to a later date, in accordance with its journal's sequence.",
     )
     hard_lock_date = fields.Date(
         string='Hard Lock Date',
         tracking=True,
-        help='Like the "Global Lock Date", but no exceptions are possible.'
+        help="Any entry up to and including that date will be postponed to a later time, in accordance with its journal sequence. "
+             "This lock date is irreversible and does not allow any exception.",
     )
     # The user lock date fields are explicitly invalidated when
     #   * writing the corresponding lock date field on any company


### PR DESCRIPTION
This commit is part of a bigger commit in the enterprise PR.

This commit improves the UX of the Lock Dates Wizard with the following changes:

- Reworded the tooltips of all 5 lock date fields
- Change label for "Lock Everyone" to "Lock Everything"
- Move the Exception to the bottom and highlight it in an alert
- Make it so that the relevant field of the exceptions are highlighted with an info class (using `decoration-info`)

In addition, it also changes the help and string of other related invisible fields (even though it's not needed) to keep it the same everywhere in the code.

related enterprise-PR: https://github.com/odoo/enterprise/pull/74262
task-id: 4297145