### PR TITLE
[FIX] account_payment: fix singleton error when post processing tx

### DIFF
--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -169,8 +169,10 @@ class PaymentTransaction(models.Model):
             **extra_create_values,
         }
 
-        if self.invoice_ids:
-            next_payment_values = self.invoice_ids._get_invoice_next_payment_values()
+        for invoice in self.invoice_ids:
+            if invoice.state != 'posted':
+                continue
+            next_payment_values = invoice._get_invoice_next_payment_values()
             if next_payment_values['installment_state'] == 'epd' and self.amount == next_payment_values['amount_due']:
                 aml = next_payment_values['epd_line']
                 epd_aml_values_list = [({
@@ -185,6 +187,7 @@ class PaymentTransaction(models.Model):
                         aml_vl = aml_values_list[0]
                         aml_vl['partner_id'] = self.partner_id.id
                         payment_values['write_off_line_vals'] += [aml_vl]
+                break
 
         payment = self.env['account.payment'].create(payment_values)
         payment.action_post()


### PR DESCRIPTION
When post-processing a payment transaction, if could happen that the transaction is linked to multiple invoices.

Several things can happen while a customer is redirect to a payment provider up to when we post-process the payment (we may long delay for some webhooks), like salesman create multiple downpayment invoices, accountant cancel a pre-existing invoice, etc...

  In such case we were crashing with a singleton error because
`_get_invoice_next_payment_values()` only accept a single recordset.

This commit ensure we only match a single posted invoice.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
