### PR TITLE
ORM: Model.filtered prefetch

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -821,7 +821,7 @@ class AccountMoveLine(models.Model):
         AccountTax = self.env['account.tax']
         for line in self:
             # TODO remove the need of cogs lines to have a price_subtotal/price_total
-            if line.display_type not in ('product', 'cogs'):
+            if line.display_type not in ('product', 'cogs') or not line.move_id:
                 line.price_total = line.price_subtotal = False
                 continue
 

--- a/addons/account/models/account_root.py
+++ b/addons/account/models/account_root.py
@@ -14,10 +14,10 @@ class AccountRoot(models.Model):
     name = fields.Char(compute='_compute_root')
     parent_id = fields.Many2one('account.root', compute='_compute_root')
 
-    def browse(self, ids=()):
+    def browse(self, ids=(), prefetch_ids=()):
         if isinstance(ids, str):
             ids = (ids,)
-        return super().browse(ids)
+        return super().browse(ids, prefetch_ids)
 
     def _search(self, domain, offset=0, limit=None, order=None) -> Query:
         match domain:

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -323,12 +323,12 @@ class TestAPI(SavepointCaseWithUserDemo):
         def diff_prefetch(a, b):
             self.assertNotEqual(set(a._prefetch_ids), set(b._prefetch_ids))
 
-        # the recordset operations below use different prefetch sets
         diff_prefetch(partners, partners.browse())
-        diff_prefetch(partners, partners[0])
-        diff_prefetch(partners, partners[:5])
+        diff_prefetch(partners, partners.browse(partners.ids[0]))
+        same_prefetch(partners, partners.browse(partners.ids[0], partners._prefetch_ids))
+        same_prefetch(partners, partners[0])
+        same_prefetch(partners, partners[:5])
 
-        # the recordset operations below share the prefetch set
         same_prefetch(partners, partners.browse(partners.ids))
         same_prefetch(partners, partners.with_user(self.user_demo))
         same_prefetch(partners, partners.with_context(active_test=False))
@@ -602,6 +602,9 @@ class TestAPI(SavepointCaseWithUserDemo):
             ps.filtered(lambda p: p.parent_id.employee),
             ps.filtered('parent_id.employee')
         )
+
+        # check the prefetch
+        self.assertIs(ps.filtered(lambda rec: False)._prefetch_ids, ps._prefetch_ids)
 
     @mute_logger('odoo.models')
     def test_80_map(self):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -6170,7 +6170,7 @@ class BaseModel(metaclass=MetaModel):
         self._ids = ids
         self._prefetch_ids = prefetch_ids
 
-    def browse(self, ids: int | typing.Iterable[IdType] = ()) -> Self:
+    def browse(self, ids: int | typing.Iterable[IdType] = (), prefetch_ids: Reversible[IdType] = ()) -> Self:
         """ browse([ids]) -> records
 
         Returns a recordset for the ids provided as parameter in the current
@@ -6191,7 +6191,7 @@ class BaseModel(metaclass=MetaModel):
             ids = (ids,)
         else:
             ids = tuple(ids)
-        return self.__class__(self.env, ids, ids)
+        return self.__class__(self.env, ids, prefetch_ids or ids)
 
     #
     # Internal properties, for manipulating the instance's implementation

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -6490,10 +6490,10 @@ class BaseModel(metaclass=MetaModel):
             return self
         if isinstance(func, str):
             if '.' in func:
-                return self.browse(rec.id for rec in self if any(rec.mapped(func)))
+                return self.browse((rec.id for rec in self if any(rec.mapped(func))), self._prefetch_ids)
             # avoid costly mapped
             func = self._fields[func].__get__
-        return self.browse(rec.id for rec in self if func(rec))
+        return self.browse((rec.id for rec in self if func(rec)), self._prefetch_ids)
 
     def grouped(self, key):
         """Eagerly groups the records of ``self`` by the ``key``, returning a
@@ -6676,7 +6676,7 @@ class BaseModel(metaclass=MetaModel):
             stack.append(stack.pop() & stack.pop())
 
         [result_ids] = stack
-        return self.browse(id_ for id_ in self._ids if id_ in result_ids)
+        return self.browse((id_ for id_ in self._ids if id_ in result_ids), self._prefetch_ids)
 
     def sorted(self, key=None, reverse=False) -> Self:
         """Return the recordset ``self`` ordered by ``key``.
@@ -7022,9 +7022,9 @@ class BaseModel(metaclass=MetaModel):
             # important: one must call the field's getter
             return self._fields[key].__get__(self)
         elif isinstance(key, slice):
-            return self.browse(self._ids[key])
+            return self.browse(self._ids[key], self._prefetch_ids)
         else:
-            return self.browse((self._ids[key],))
+            return self.browse((self._ids[key],), self._prefetch_ids)
 
     def __setitem__(self, key, value):
         """ Assign the field ``key`` to ``value`` in record ``self``. """

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1049,7 +1049,7 @@ class StackMap(MutableMapping[K, T], typing.Generic[K, T]):
         return self._maps.pop()
 
 
-class OrderedSet(MutableSet[T], typing.Generic[T]):
+class OrderedSet(MutableSet[T], Reversible[T], typing.Generic[T]):
     """ A set collection that remembers the elements first insertion order. """
     __slots__ = ['_map']
 
@@ -1064,6 +1064,9 @@ class OrderedSet(MutableSet[T], typing.Generic[T]):
 
     def __len__(self):
         return len(self._map)
+
+    def __reversed__(self):
+        return reversed(self._map)
 
     def add(self, elem):
         self._map[elem] = None


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Keep the prefetch when filtering. To break it, you can always use `with_prefetch`.

Current behavior before PR:
Using `filtered`, `filtered_domain`, or slicing breaks the prefetch.

Desired behavior after PR is merged:
Keep the original prefetch when doing these operations.

task-4280637


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
