### PR TITLE
[FIX] account: Fix issue for infinite loop

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -966,7 +966,7 @@ class AccountGroup(models.Model):
                        child.id AS child_id,
                        parent.id AS parent_id
                   FROM account_group parent
-                  JOIN account_group child
+            RIGHT JOIN account_group child
                     ON char_length(parent.code_prefix_start) < char_length(child.code_prefix_start)
                    AND parent.code_prefix_start <= LEFT(child.code_prefix_start, char_length(parent.code_prefix_start))
                    AND parent.code_prefix_end >= LEFT(child.code_prefix_end, char_length(parent.code_prefix_end))

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -486,6 +486,13 @@ class TestAccountAccount(AccountTestInvoicingCommon):
         self.assertEqual(group_100.parent_id, group_10)
         self.assertEqual(group_101.parent_id, group_10)
 
+        # The root becomes a child and vice versa
+        group_3 = create_account_group('group_3', 3, self.env.company)
+        group_31 = create_account_group('group_31', 31, self.env.company)
+        group_3.code_prefix_start = 312
+        self.assertEqual(len(group_31.parent_id), 0)
+        self.assertEqual(group_3.parent_id, group_31)
+
     def test_muticompany_account_groups(self):
         """
             Ensure that account groups are always in a root company


### PR DESCRIPTION
This [fixed](https://github.com/odoo/odoo/pull/156423) proposed to avoid infinite loop but still issue is reproducable

**steps to reproduce:-**
 account group is create with ``3 code_prefix``  another account group create with ``31 code_prefix`` and if change the ``3 code_prefix`` something like ``312``  code prefix is changed  so it will cyclic parent child relation

```
test_rr=# select id,parent_id,code_prefix_end,code_prefix_start,parent_path from account_group;
 id | parent_id | code_prefix_end | code_prefix_start | parent_path
----+-----------+-----------------+-------------------+-------------
 12 |        11 | 31              | 31                |
 11 |        12 | 312             | 312               |

```

 because this constraint that is introduced in above mentioned  pr will not apply on because this is sql update and it will not go
 check due to python [constraint](https://github.com/odoo/odoo/blob/e20263c4bba3e3cff5b8c7d68f07ce6c7e0bd9aa/addons/account/models/account_account.py#L870). For resolving this checking and reverting the wrong changes done in ``parent_id`` because of the update [query](https://github.com/odoo/odoo/blob/d1be9e4a4ec2cf6eaafe982b5b0036afa5421207/addons/account/models/account_account.py#L911-L927) and preventing  from infinite [loop](https://github.com/odoo/enterprise/blob/077d5a0f2bb8d4b1602e993b3e84c5ca9fd877d1/account_reports/models/account_report.py#L1006C15-L1009C44).

opw-4342094
upg-2144655

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
