### PR TITLE
[FIX] website: prevent nested forms in the website editor

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3193,6 +3193,12 @@ var SnippetsMenu = Widget.extend({
      * @param {jQuery}
      */
     _patchForComputeSnippetTemplates($html) {
+        // TODO: Remove in master and add it in template s_website_form
+        const websiteFormEditorOptionsEl = $html.find('[data-js="WebsiteFormEditor"]')[0];
+        if (websiteFormEditorOptionsEl) {
+            websiteFormEditorOptionsEl.dataset.dropExcludeAncestor = "form";
+        }
+
         // TODO: Remove in master and add it back in the template.
         const $vAlignOption = $html.find("#row_valign_snippet_option");
         $vAlignOption[0].dataset.js = "vAlignment";

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -899,6 +899,23 @@
         ...wTourUtils.clickOnSave(),
     ]);
 
+    wTourUtils.registerWebsitePreviewTour("website_form_nested_forms", {
+        test: true,
+        url: "/my/account",
+        edition: true,
+    },
+    () => [
+        {
+            ...wTourUtils.dragNDrop({ id: "s_website_form", name: "Form" }),
+            run: "drag_and_drop_native iframe #wrap .o_portal_details",
+        },
+        {
+            content: "Check the form was not dropped into another form",
+            trigger: "iframe form:not(:has([data-snippet='s_website_form']))",
+            isCheck: true,
+        },
+    ]);
+
     wTourUtils.registerWebsitePreviewTour("website_form_special_characters", {
         test: true,
         url: "/",

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -63,6 +63,8 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
         self.assertIn('Test1&#34;&#39;', mail.body_html, 'The single quotes and double quotes characters should be visible on the received mail')
         self.assertIn('Test2`\\', mail.body_html, 'The backtick and backslash characters should be visible on the received mail')
 
+    def test_website_form_nested_forms(self):
+        self.start_tour('/my/account', 'website_form_nested_forms', login='admin')
 
 @tagged('post_install', '-at_install')
 class TestWebsiteForm(TransactionCase):


### PR DESCRIPTION
Steps to reproduce:

- Navigate to Website
- Open the user dropdown menu and select "My Account".
- On the right-hand side of the page, click on "Edit information".
- Enter edit mode.
- Drag and drop a form inside the existing form.
- Save the changes.
- Re-enter edit mode.
- Click on any field within the newly added form.
- A traceback is triggered.

HTML5, as defined by the W3C, prohibits the use of nested \<form\> elements, as they are invalid and lead to undefined behavior in browsers. To address this, the website_form snippet has been updated to prevent it from being dropped inside another form.

This fix ensures compliance with HTML5 specifications and prevents invalid document structures from being created within the website builder.

Due to this commit [1], buttons were added as inline building blocks. As a result, you could insert blocks either directly before or after the button. Since this wasn't the case before, we never encountered any issues in forms, as nothing could be inserted there.

[1]: https://github.com/odoo/odoo/commit/507b80a12574c

opw-4305352