### PR TITLE
[FIX] web: correctly handle errors occurs onMounted

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -25,6 +25,7 @@ import {
     useChildSubEnv,
     xml,
     reactive,
+    status,
 } from "@odoo/owl";
 import { downloadReport, getReportUrl } from "./reports/utils";
 import { omit, pick, shallowEqual } from "@web/core/utils/objects";
@@ -877,6 +878,19 @@ export function makeActionManager(env, router = _router) {
                 if (this.isMounted) {
                     // the error occurred on the controller which is
                     // already in the DOM, so simply show the error
+                    Promise.reject(error);
+                    return;
+                }
+                if (!this.isMounted && status(this) === "mounted") {
+                    // The error occured during an onMounted hook of one of the components.
+                    env.bus.trigger("ACTION_MANAGER:UPDATE", {
+                        id: ++id,
+                        Component: BlankComponent,
+                        componentProps: {
+                            onMounted: () => {},
+                            withControlPanel: action.type === "ir.actions.act_window",
+                        },
+                    });
                     Promise.reject(error);
                     return;
                 }


### PR DESCRIPTION
Before this commit, if a component raised an error on it's onMounted
hook, the rest of the onMounted hooks of all the other components would
not execute. This is a desired behaviour, if an error is raised, we need
to stop the execution. The issue with this, is that the error component
(and the others), are already in the DOM, and since the onMounted hook
functions haven't been executed, this leaves an inconsistent state.

This commit will allow the action service to identify this particular
case, and mount an BlanckComponent, to avoid having an inconsistent
view.
