### PR TITLE
[FIX] account_payment: prevent error when generate a payment link

### DIFF
--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -236,3 +236,17 @@ class TestAccountPayment(AccountPaymentCommon):
             copy_provider_pml = get_payment_method_line(copy_provider)
             with self.assertRaises(ValidationError):
                 journal.inbound_payment_method_line_ids = [Command.update(copy_provider_pml.id, {'payment_provider_id': provider.id})]
+
+    def test_generate_payment_link_with_no_invoice_line(self):
+        invoice = self.invoice
+        invoice.line_ids.unlink()
+        payment_values = invoice._get_default_payment_link_values()
+
+        self.assertDictEqual(payment_values, {
+            'currency_id': invoice.currency_id.id,
+            'partner_id': invoice.partner_id.id,
+            'open_installments': [],
+            'installment_state': None,
+            'amount': None,
+            'amount_max': None,
+        })


### PR DESCRIPTION
Currently, an error occurs when generating a payment link for an invoice without add an invoice line.

Step to produce:

- Install the ```account_payment``` module.
- Create a new invoice, Click on the 'Actions' button, and try to generate a payment link.

See Traceback:

```
KeyError: 'amount_due'
  File "odoo/http.py", line 2363, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1891, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1954, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1921, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2168, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 329, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 727, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 517, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 867, in onchange
    defaults = self.default_get(missing_names)
  File "addons/payment/wizards/payment_link_wizard.py", line 22, in default_get
    self.env[res_model].browse(res_id)._get_default_payment_link_values()
  File "addons/account_payment/models/account_move.py", line 105, in _get_default_payment_link_values
    amount_max = next_payment_values['amount_due']

```

An error occurs when the system attempts to get the next payment value at [1], But there is nothing to pay as an invoice line is not available.

Link [1]: https://github.com/odoo/odoo/blob/288d3926c5d011590aa25e9886cfa36377974dd6/addons/account_payment/models/account_move.py#L104-L105

To handle this issue, return an empty dictionary if the invoice line has not been added.

Sentry-6078809446

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
