### PR TITLE
[FIX] product_matrix: avoid crash on generated PO lines

### DIFF
--- a/addons/product_matrix/static/src/js/product_matrix_dialog.js
+++ b/addons/product_matrix/static/src/js/product_matrix_dialog.js
@@ -28,9 +28,16 @@ export class ProductMatrixDialog extends Component {
         onMounted(() => {
             if(this.props.editedCellAttributes.length) {
                 const inputs = document.getElementsByClassName('o_matrix_input');
-                Array.from(inputs).filter((matrixInput) =>
+                const relevantInput = Array.from(inputs).filter((matrixInput) =>
                     matrixInput.attributes.ptav_ids.nodeValue === this.props.editedCellAttributes
-                )[0].select();
+                )[0];
+                if (relevantInput) {
+                    relevantInput.select();
+                } else {
+                    // Based on the record creation, it may ignore the 'no_variant' attributes
+                    // (e.g. from a stock.move), thus finding no match in the matrix.
+                    inputs[0].select();
+                }
             } else {
                 document.getElementsByClassName('o_matrix_input')[0].select();
             }


### PR DESCRIPTION
Steps to reproduce:
- Create a product having the following attributes:
  - Color, which has `create_variant`: 'always'
  - Custom, which has `create_variant`: 'no_variant'
- For each attribute, add a few values
- Create a sale order for that product, using a combination of both attributes
- Go to Inventory/Operation/Procurement/Replenishment
- On the corresponding product, click on 'Order Once'
- On the created Purchase Order, try to edit the product through the configurator

Issue:
A traceback will appear, as the generated matrix for this product will be a collection of pairs from [Color,Custom] values. But as the moves have no `product_no_variant_attribute_value_ids` to store that information, that part of the information will be lost and the generated orderpoint from which the PO is made will only be using an existing product.product.

While this does not solve the issue, it at least allows to open the product configurator even though the line is faulty.

Note: Same issue appear through a MTO flow, although in this case the product description will be correct. But trying to open the configurator would still lead to a traceback anyway.

opw-4197302

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
