### PR TITLE
[FIX] sale_management: refresh quotation template on partner change

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import timedelta
+from itertools import chain, starmap, zip_longest
 
 from odoo import SUPERUSER_ID, api, fields, models, _
 from odoo.exceptions import ValidationError
@@ -117,6 +118,37 @@ class SaleOrder(models.Model):
         ]
 
         self.sale_order_option_ids = option_lines_data
+
+    @api.onchange('partner_id')
+    def _onchange_partner_id(self):
+        """Reload template for unsaved orders with unmodified lines & orders."""
+        if self._origin or not self.sale_order_template_id:
+            return
+
+        def line_eqv(line, t_line):
+            return line and t_line and (
+                line.product_id == t_line.product_id
+                and line.display_type == t_line.display_type
+                and line.product_uom == t_line.product_uom_id
+                and line.product_uom_qty == t_line.product_uom_qty
+            )
+
+        def option_eqv(option, t_option):
+            return option and t_option and all(
+                option[fname] == t_option[fname]
+                for fname in ['product_id', 'uom_id', 'quantity']
+            )
+
+        lines = self.order_line
+        options = self.sale_order_option_ids
+        t_lines = self.sale_order_template_id.sale_order_template_line_ids
+        t_options = self.sale_order_template_id.sale_order_template_option_ids
+
+        if all(chain(
+            starmap(line_eqv, zip_longest(lines, t_lines)),
+            starmap(option_eqv, zip_longest(options, t_options)),
+        )):
+            self._onchange_sale_order_template_id()
 
     #=== ACTION METHODS ===#
 

--- a/addons/sale_management/tests/test_sale_order.py
+++ b/addons/sale_management/tests/test_sale_order.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from itertools import chain
+
 from odoo.fields import Command
 from odoo.tests import Form, tagged
 
@@ -336,3 +338,96 @@ class TestSaleOrder(SaleManagementCommon):
         # after changing the quantity of the product, the price unit should not be recomputed
         sale_order_with_option.order_line.product_uom_qty = 10
         self.assertEqual(sale_order_with_option.sale_order_option_ids.price_unit, 10)
+
+    def test_reload_template_translations(self):
+        """
+        Check that quotation template gets reloaded with correct translations on partner change.
+        """
+        # Add some display type lines to the template
+        self.quotation_template_no_discount.sale_order_template_line_ids = [
+            Command.create({
+                'name': "Section 1",
+                'display_type': 'line_section',
+            }),
+            Command.create({
+                'name': "Note 1",
+                'display_type': 'line_note',
+            }),
+        ]
+
+        # Commence activation of Dutch vernacular
+        self.env['res.lang']._activate_lang('nl_NL')
+        partner_NL = self.partner.copy({'lang': 'nl_NL', 'name': "Pieter-Jan Hollandman"})
+        names_EN = ["Product 1", "Section 1", "Note 1", "Optional product"]
+        names_NL = ["Artikel 1", "Sectie 1", "Nota 1", "Optioneel artikel"]
+        trans_dict = dict(zip(names_EN, names_NL))
+        for record in chain(
+            self.quotation_template_no_discount.sale_order_template_line_ids,
+            self.quotation_template_no_discount.sale_order_template_option_ids,
+        ):
+            record.with_context(lang='nl_NL').name = trans_dict[record.name]
+
+        # Create sale order form (and a way to retrieve line names)
+        def get_form_field_names(form):
+            return [
+                form.order_line.edit(0).name,
+                form.order_line.edit(1).name,
+                form.order_line.edit(2).name,
+                form.sale_order_option_ids.edit(0).name,
+            ]
+
+        order_form = Form(self.sale_order.browse())
+        order_form.sale_order_template_id = self.quotation_template_no_discount
+
+        # Sanity check English names
+        self.assertSequenceEqual(
+            get_form_field_names(order_form),
+            names_EN,
+            "Lines should be displayed in English for an American partner",
+        )
+
+        # Go Dutch
+        order_form.partner_id = partner_NL
+        self.assertSequenceEqual(
+            get_form_field_names(order_form),
+            names_NL,
+            "Lines should be displayed in Dutch for a Dutch partner",
+        )
+
+        # Edit a line & change back to American partner
+        with order_form.order_line.edit(0) as order_line:
+            order_line.product_uom_qty += 1
+        order_form.partner_id = self.partner
+        self.assertSequenceEqual(
+            get_form_field_names(order_form),
+            names_NL,
+            "Lines shouldn't change when edited",
+        )
+
+        # Reload template manually
+        order_form.sale_order_template_id = self.quotation_template_no_discount
+        self.assertSequenceEqual(
+            get_form_field_names(order_form),
+            names_EN,
+            "Lines should change after manual template reload",
+        )
+
+        # Add a line & return to Dutch
+        with order_form.sale_order_option_ids.new() as optional_product:
+            optional_product.product_id = self.product
+        order_form.partner_id = partner_NL
+        self.assertSequenceEqual(
+            get_form_field_names(order_form),
+            names_EN,
+            "Lines shouldn't change after a new one was added",
+        )
+
+        # Reload template, save, and change partner again
+        order_form.sale_order_template_id = self.quotation_template_no_discount
+        order_form.save()
+        order_form.partner_id = self.partner
+        self.assertSequenceEqual(
+            get_form_field_names(order_form),
+            names_NL,
+            "Lines shouldn't change once saved",
+        )


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Activate a second language;
2. create a new quotation template;
3. add a note & save change;
4. add a translation for the note & save change;
5. create a new sales order;
6. select the created quotation template;
7. set customer to a partner using the second language.

Issue
-----
The note is still displayed in English.

Cause
-----
The translation is saved on the `sale.order.template.line` model, so it has to get fetched from there. Currently there is no logic in place to do this when changing the customer.

Solution
--------
Add an `onchange` method which reloads the template if no lines were added or removed.

opw-4260006