### PR TITLE
[FIX] base: fix test retry

### DIFF
--- a/odoo/addons/base/tests/test_test_retry.py
+++ b/odoo/addons/base/tests/test_test_retry.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo.tests import BaseCase, TransactionCase, tagged
+from odoo.tests import BaseCase, TransactionCase, tagged, BaseCase
 from odoo.tests.common import _logger as test_logger
 
 import logging
@@ -27,7 +27,7 @@ class TestRetryCommon(BaseCase):
         cls.startClassPatcher(patcher)
 
     def get_tests_run_count(self):
-        return int(os.environ.get('ODOO_TEST_FAILURE_RETRIES', 0)) + 1
+        return BaseCase._tests_run_count
 
     def update_count(self):
         self.count = getattr(self, 'count', 0) + 1


### PR DESCRIPTION
Since auto retry was disabled after the first failure (see #162990), the test_retry test suite will systematically fail if another test fails before, adding confusing logs.

Fix the way the retry count is detected to solve the issue.
