### PR TITLE
[FIX] account: make proforma invoice titles correctly translatable

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -415,7 +415,6 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_template
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
-#: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 msgid "27.00"
 msgstr ""
 
@@ -941,7 +940,6 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
-#: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 msgid "<span> on </span>"
 msgstr ""
 
@@ -2778,6 +2776,11 @@ msgid "Automatic Entry Default Journal"
 msgstr ""
 
 #. module: account
+#: model:account.fiscal.position,name:account.1_account_fiscal_position_avatax_us
+msgid "Automatic Tax Mapping (AvaTax)"
+msgstr ""
+
+#. module: account
 #: model:ir.model,name:account.model_sequence_mixin
 msgid "Automatic sequence"
 msgstr ""
@@ -3174,10 +3177,6 @@ msgid "Billing"
 msgstr ""
 
 #. module: account
-msgid "Billing Administrator"
-msgstr ""
-
-#. module: account
 #. odoo-python
 #: code:addons/account/controllers/portal.py:0
 #: model:ir.actions.act_window,name:account.action_move_in_invoice_type
@@ -3372,6 +3371,16 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "Cancelled Invoice"
+msgstr ""
+
+#. module: account
+#: model_terms:ir.ui.view,arch_db:account.report_invoice_document
+msgid "Cancelled Proforma Credit Note"
+msgstr ""
+
+#. module: account
+#: model_terms:ir.ui.view,arch_db:account.report_invoice_document
+msgid "Cancelled Proforma Invoice"
 msgstr ""
 
 #. module: account
@@ -5723,6 +5732,16 @@ msgid "Draft Payment"
 msgstr ""
 
 #. module: account
+#: model_terms:ir.ui.view,arch_db:account.report_invoice_document
+msgid "Draft Proforma Credit Note"
+msgstr ""
+
+#. module: account
+#: model_terms:ir.ui.view,arch_db:account.report_invoice_document
+msgid "Draft Proforma Invoice"
+msgstr ""
+
+#. module: account
 #. odoo-python
 #: code:addons/account/models/account_move.py:0
 #, python-format
@@ -6658,15 +6677,6 @@ msgid ""
 "Formula in the form line_code.expression_label. This allows setting the "
 "target of the carryover for this expression (on a _carryover_*-labeled "
 "expression), in case it is different from the parent line."
-msgstr ""
-
-#. module: account
-msgid ""
-"Formula in the form line_code.expression_label. This allows setting the "
-"target of the carryover for this expression (on a _carryover_*-labeled "
-"expression), in case it is different from the parent line. 'custom' is also "
-"allowed as value in case the carryover destination requires more complex "
-"logic."
 msgstr ""
 
 #. module: account
@@ -8940,7 +8950,6 @@ msgid ""
 msgstr ""
 
 #. module: account
-#: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 #: model_terms:ir.ui.view,arch_db:account.report_statement
 msgid "Marc Demo"
 msgstr ""
@@ -10252,11 +10261,6 @@ msgid "PEPPOL eligible"
 msgstr ""
 
 #. module: account
-#: model_terms:ir.ui.view,arch_db:account.report_invoice_document
-msgid "PROFORMA"
-msgstr ""
-
-#. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Package"
 msgstr ""
@@ -10589,11 +10593,6 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 msgid "Payment Receipt:"
-msgstr ""
-
-#. module: account
-#: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
-msgid "Payment Ref"
 msgstr ""
 
 #. module: account
@@ -11136,6 +11135,26 @@ msgstr ""
 #: model:ir.model.fields,field_description:account.field_account_cash_rounding__profit_account_id
 #: model:ir.model.fields,field_description:account.field_account_journal__profit_account_id
 msgid "Profit Account"
+msgstr ""
+
+#. module: account
+#: model_terms:ir.ui.view,arch_db:account.report_invoice_document
+msgid "Proforma Credit Note"
+msgstr ""
+
+#. module: account
+#: model_terms:ir.ui.view,arch_db:account.report_invoice_document
+msgid "Proforma Invoice"
+msgstr ""
+
+#. module: account
+#: model_terms:ir.ui.view,arch_db:account.report_invoice_document
+msgid "Proforma Vendor Bill"
+msgstr ""
+
+#. module: account
+#: model_terms:ir.ui.view,arch_db:account.report_invoice_document
+msgid "Proforma Vendor Credit Note"
 msgstr ""
 
 #. module: account
@@ -11868,6 +11887,11 @@ msgid "STANDARD TERMS AND CONDITIONS OF SALE"
 msgstr ""
 
 #. module: account
+#: model:account.journal,name:account.1_hr_payroll_account_journal
+msgid "Salaries"
+msgstr ""
+
+#. module: account
 #: model:account.account,name:account.1_expense_salary
 msgid "Salary Expenses"
 msgstr ""
@@ -11963,11 +11987,6 @@ msgid "Sample Memo"
 msgstr ""
 
 #. module: account
-#: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
-msgid "Sample Ref"
-msgstr ""
-
-#. module: account
 #. odoo-python
 #: code:addons/account/models/account_journal_dashboard.py:0
 #: code:addons/account/models/account_journal_dashboard.py:0
@@ -11993,7 +12012,6 @@ msgstr ""
 #. module: account
 #. odoo-python
 #: code:addons/account/models/account_payment.py:0
-#: code:addons/account/wizard/account_payment_register.py:0
 #, python-format
 msgid "Scan me with your banking app."
 msgstr ""
@@ -12527,10 +12545,6 @@ msgid ""
 msgstr ""
 
 #. module: account
-msgid "Show Accounting Features - Readonly"
-msgstr ""
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_res_partner__show_credit_limit
 #: model:ir.model.fields,field_description:account.field_res_users__show_credit_limit
 msgid "Show Credit Limit"
@@ -12558,10 +12572,6 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_line__show_force_tax_included
 msgid "Show Force Tax Included"
-msgstr ""
-
-#. module: account
-msgid "Show Full Accounting Features"
 msgstr ""
 
 #. module: account
@@ -16125,24 +16135,6 @@ msgstr ""
 msgid ""
 "You cannot create a fiscal position with a foreign VAT within your fiscal "
 "country without assigning it a state."
-msgstr ""
-
-#. module: account
-#. odoo-python
-#: code:addons/account/models/partner.py:0
-#, python-format
-msgid ""
-"You cannot create a fiscal position with a foreign VAT within your fiscal "
-"country."
-msgstr ""
-
-#. module: account
-#. odoo-python
-#: code:addons/account/models/partner.py:0
-#, python-format
-msgid ""
-"You cannot create a fiscal position within your fiscal country with the same"
-" VAT number as the main one set on your company."
 msgstr ""
 
 #. module: account

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -51,16 +51,22 @@
                 <div class="mt-5 clearfix">
                     <div class="page mb-4">
                         <h2>
-                            <span t-if="not proforma"></span>
-                            <span t-else="">PROFORMA</span>
-                            <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">Invoice</span>
-                            <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Invoice</span>
-                            <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled Invoice</span>
-                            <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">Credit Note</span>
-                            <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">Draft Credit Note</span>
-                            <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">Cancelled Credit Note</span>
-                            <span t-elif="o.move_type == 'in_refund'">Vendor Credit Note</span>
-                            <span t-elif="o.move_type == 'in_invoice'">Vendor Bill</span>
+                            <span t-if="o.move_type == 'out_invoice' and o.state == 'posted' and not proforma">Invoice</span>
+                            <span t-elif="o.move_type == 'out_invoice' and o.state == 'posted'">Proforma Invoice</span>
+                            <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft' and not proforma">Draft Invoice</span>
+                            <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Proforma Invoice</span>
+                            <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel' and not proforma">Cancelled Invoice</span>
+                            <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled Proforma Invoice</span>
+                            <span t-elif="o.move_type == 'out_refund' and o.state == 'posted' and not proforma">Credit Note</span>
+                            <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">Proforma Credit Note</span>
+                            <span t-elif="o.move_type == 'out_refund' and o.state == 'draft' and not proforma">Draft Credit Note</span>
+                            <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">Draft Proforma Credit Note</span>
+                            <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel' and not proforma">Cancelled Credit Note</span>
+                            <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">Cancelled Proforma Credit Note</span>
+                            <span t-elif="o.move_type == 'in_refund' and not proforma">Vendor Credit Note</span>
+                            <span t-elif="o.move_type == 'in_refund'">Proforma Vendor Credit Note</span>
+                            <span t-elif="o.move_type == 'in_invoice' and not proforma">Vendor Bill</span>
+                            <span t-elif="o.move_type == 'in_invoice'">Proforma Vendor Bill</span>
                             <span t-if="o.name != '/'" t-field="o.name">INV/2023/0001</span>
                         </h2>
                         <div class="oe_structure"></div>
@@ -322,7 +328,7 @@
                     <span t-out="tax_totals.get('formatted_rounding_amount')">0</span>
                 </td>
             </tr>
-            
+
             <!--Total amount with all taxes-->
             <tr class="border-black o_total">
                 <td><strong>Total</strong></td>


### PR DESCRIPTION
Currently the word "PROFORMA" was put before any invoice type title without considering the order of the total title, e.g. "PROFORMA Draft Invoice" instead of "Draft Proforma Invoice".

Also this is a problem for translations, since other languages cannot change the order of the full title either.

This commit makes the titles with "Proforma" as full terms that can be translated as a whole and reordered accordingly.

It might break the translation of the title in case of proforma invoices when people would update the translations without updating the `account` module. Since it's an edge case and the "Proforma" titles shouldn't be used often, it's an acceptable limitation.