### PR TITLE
[FIX] l10n_din5008{,stock}: add company address on delivery slip

### DIFF
--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -70,13 +70,6 @@
                                         <span>|</span> <span t-field="company.country_id.name"/>
                                     </t>
                                     <hr class="company_invoice_line" />
-                                    <t t-if="o and 'l10n_din5008_addresses' in o" t-set="address">
-                                        <address class="mb-0" t-field="o.partner_id.commercial_partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
-                                        <div t-if="o.partner_id.commercial_partner_id.vat" id="partner_vat_address_same_as_shipping">
-                                            <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
-                                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.commercial_partner_id.vat"/>
-                                        </div>
-                                    </t>
                                     <div t-if="address">
                                         <t t-out="address"/>
                                     </div>

--- a/addons/l10n_din5008_stock/report/din5008_stock_templates.xml
+++ b/addons/l10n_din5008_stock/report/din5008_stock_templates.xml
@@ -8,7 +8,7 @@
                         <span class="fw-bold" t-if="o.picking_type_id.code == 'incoming'">Vendor Address:</span>
                         <span class="fw-bold" t-if="o.picking_type_id.code == 'internal'">Warehouse Address:</span>
                         <span class="fw-bold" t-if="o.picking_type_id.code == 'outgoing' and o.move_ids_without_package and o.move_ids_without_package[0].partner_id and o.move_ids_without_package[0].partner_id.id != o.partner_id.id">Customer Address:</span>
-                        <address t-esc="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                        <address t-esc="o.partner_id.commercial_partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
                     </td>
                 </tr>
             </t>


### PR DESCRIPTION
Commit 1c96b8687d9b6b36eff98644ca084e4693718293 remove the field `l10n_din5008_addresses` but still test its existence in the report. It was replaced by XML template but changed
`parter_id.commercial_partner_id` into `partner_id` that lead to a duplication of the delivery address on delivery slips for company following din5008 rules.

OPW: 4217638

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
