### PR TITLE
Website : Remove outdated snippet warning

### DIFF
--- a/addons/test_website/__manifest__.py
+++ b/addons/test_website/__manifest__.py
@@ -44,6 +44,9 @@ models which only purpose is to run tests.""",
         'web.assets_tests': [
             'test_website/static/tests/tours/*',
         ],
+        'website.assets_wysiwyg': [
+            'test_website/static/src/js/editor/snippets.options.js'
+        ]
     },
     'license': 'LGPL-3',
 }

--- a/addons/test_website/static/src/js/editor/snippets.options.js
+++ b/addons/test_website/static/src/js/editor/snippets.options.js
@@ -1,0 +1,22 @@
+import options from "@web_editor/js/editor/snippets.options";
+
+
+/**
+ * Manage the visibility of snippets on mobile/desktop.
+ */
+options.registry.CrashSnippet = options.Class.extend({
+
+    //--------------------------------------------------------------------------
+    // Options
+    //--------------------------------------------------------------------------
+
+    /**
+     * Raise an error if the crash button is clicked.
+     *
+     * @see this.selectClass for parameters
+     */
+    async crashSnippet(previewMode, widgetValue, params) {
+        throw new Error('This option is made to raise an error.')
+    },
+
+});

--- a/addons/test_website/static/tests/tours/snippet_version_outdated.js
+++ b/addons/test_website/static/tests/tours/snippet_version_outdated.js
@@ -1,0 +1,44 @@
+import {
+    registerWebsitePreviewTour,
+    insertSnippet
+} from '@website/js/tours/tour_utils';
+
+registerWebsitePreviewTour("snippet_version_outdated", {
+    edition: true,
+    url: "/",
+}, () => [
+    ...insertSnippet({
+        id: 's_crashing_snippet',
+        name: 'Test Crashing snip',
+        groupName: "Content",
+    }),
+    {
+        content: "Change s_crashing_snippet version",
+        trigger: ':iframe #wrap.o_editable .s_crashing_snippet',
+        run: function () {
+            const iframe = document.querySelector('iframe');
+            const snippet = iframe.contentDocument.querySelector('.s_crashing_snippet');
+            snippet.setAttribute('data-vxml', "999");
+        }
+    },
+    {
+        content: "Edit s_crashing_snippet",
+        trigger: ':iframe #wrap.o_editable .s_crashing_snippet',
+        run: "click"
+    },
+    {
+        trigger: ".snippet-option-CrashSnippet",
+    },
+    {
+        content: "Edit s_crashing_snippet",
+        trigger: '.snippet-option-CrashSnippet we-button.o_we_user_value_widget',
+        run: "click"
+    },
+    {
+        trigger: ".modal-dialog:contains(This snippet is outdated)",
+    },
+    {
+        content: "The snippet is outdated, an alert message was send",
+        trigger: 'body'
+    }
+]);

--- a/addons/test_website/tests/test_error.py
+++ b/addons/test_website/tests/test_error.py
@@ -8,3 +8,16 @@ class TestWebsiteError(odoo.tests.HttpCase):
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_01_run_test(self):
         self.start_tour("/test_error_view", 'test_error_website')
+
+    def test_02_run_test(self):
+        website_snippets = self.env.ref('website.snippets')
+        self.env['ir.ui.view'].create([{
+            'type': 'qweb',
+            'inherit_id': website_snippets.id,
+            'arch': """
+                <xpath expr="//t[@t-snippet='website.s_parallax']" position="after">
+                    <t t-snippet="test_website.s_crashing_snippet" group="content"/>
+                </xpath>
+            """,
+        }])
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_version_outdated', login='admin')

--- a/addons/test_website/views/templates.xml
+++ b/addons/test_website/views/templates.xml
@@ -89,4 +89,20 @@
             </xpath>
         </field>
     </record>
+
+    <template id="s_crashing_snippet" name="Crashing Snippet">
+        <section class="s_crashing_snippet">
+            <a href="#">Button</a>
+        </section>
+    </template>
+    
+    <template id="s_crashing_snippet_options" inherit_id="website.snippet_options">
+        <xpath expr="." position="inside">
+            <div  data-js="CrashSnippet" data-selector=".s_crashing_snippet">
+                <we-button-group string="Crashing option">
+                    <we-button title="Crash" data-crash-snippet="">Crash</we-button>
+                </we-button-group>
+            </div>
+        </xpath>
+    </template>
 </odoo>

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -950,22 +950,6 @@
                     }
                 }
             }
-
-            &.o_we_outdated_block_options {
-                // Outdated block options
-                padding: 0 !important;
-
-                > we-customizeblock-option {
-                    &:not(.snippet-option-VersionControl) {
-                        display: none !important;
-                    }
-
-                    &.snippet-option-VersionControl {
-                        // Outdated snippet alert
-                        padding: 0 !important;
-                    }
-                }
-            }
         }
 
         we-customizeblock-option {

--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -50,15 +50,6 @@
             </we-title>
         </we-customizeblock-options>
     </t>
-    <t t-name="web_editor.outdated_block_message">
-        <we-alert class="d-flex flex-column p-3 pt-4 align-items-center text-center text-white">
-            <we-title>This block is outdated.</we-title>
-            <span>You might not be able to customize it anymore.</span>
-            <we-button class="o_we_bg_brand_primary py-2 my-4 border-0" data-no-preview="true" data-replace-snippet="">REPLACE BY NEW VERSION</we-button>
-            <span>You can still access the block options but it might be ineffective.</span>
-            <we-button class="o_we_bg_brand_primary py-2 my-4 border-0" data-no-preview="true" data-discard-alert="">ACCESS OPTIONS ANYWAY</we-button>
-        </we-alert>
-    </t>
 
     <!-- options -->
     <div t-name="web_editor.ColorPalette" class="colorpicker" t-ref="el" t-on-click="this._onColorpickerClick">

--- a/addons/website/static/tests/tours/snippet_version.js
+++ b/addons/website/static/tests/tours/snippet_version.js
@@ -34,38 +34,3 @@ registerWebsitePreviewTour("snippet_version_1", {
 },
     ...clickOnSave(),
 ]);
-registerWebsitePreviewTour("snippet_version_2", {
-    edition: true,
-    url: "/",
-}, () => [
-{
-    content: "Edit s_test_snip",
-    trigger: ':iframe #wrap.o_editable .s_test_snip',
-    run: "click",
-},
-{
-    trigger:
-        "we-customizeblock-options:contains(Test snip) .snippet-option-VersionControl > we-alert",
-},
-{
-    content: "Edit text_image",
-    trigger: ':iframe #wrap.o_editable .s_text_image',
-    run: "click",
-},
-{
-    trigger:
-        "we-customizeblock-options:contains(Text - Image) .snippet-option-VersionControl  > we-alert",
-},
-{
-    content: "Edit s_share",
-    trigger: ':iframe #wrap.o_editable .s_share',
-    run: "click",
-},
-{
-    trigger:
-        "we-customizeblock-options:contains(Share) .snippet-option-VersionControl > we-alert",
-},
-{
-    content: "s_share is outdated",
-    trigger: ':iframe body',
-}]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -314,7 +314,7 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_07_snippet_version(self):
         website_snippets = self.env.ref('website.snippets')
-        view_ids = self.env['ir.ui.view'].create([{
+        self.env['ir.ui.view'].create([{
             'name': 'Test snip',
             'type': 'qweb',
             'key': 'website.s_test_snip',
@@ -333,41 +333,6 @@ class TestUi(odoo.tests.HttpCase):
             """,
         }])
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_version_1', login='admin')
-
-        self.env['ir.ui.view'].create([
-            {
-                'name': 'Test snippet version 999',
-                'mode': 'extension',
-                'inherit_id': view_ids[0].id,
-                'arch': """
-                    <xpath expr="//section[hasclass('s_test_snip')]" position="attributes">
-                        <attribute name="data-vjs">999</attribute>
-                    </xpath>
-                """
-            },
-            {
-                'name': 'Share snippet version 999',
-                'mode': 'extension',
-                'inherit_id': self.env.ref("website.s_share").id,
-                'arch': """
-                    <xpath expr="//div" position="attributes">
-                        <attribute name="data-vcss">999</attribute>
-                    </xpath>
-                """
-            },
-            {
-                'name': 's_text_image version 999',
-                'mode': 'extension',
-                'inherit_id': self.env.ref("website.s_text_image").id,
-                'arch': """
-                    <xpath expr="//section[hasclass('s_text_image')]" position="attributes">
-                        <attribute name="data-vxml">999</attribute>
-                    </xpath>
-                """
-            }
-        ])
-
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_version_2', login='admin')
 
     def test_08_website_style_custo(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'website_style_edition', login='admin')


### PR DESCRIPTION
Currently when a user try to modify the options of an outdated snippet a warning block display on top of the options.
The block present two options : 'try to update the snippet' or 'access options anyway'.

This PR remove the warning on the options and suppose the 'access options anyway' is the default choice. 
If an error occur, the snippet version is verified and an alert message is display if the snippet is outdated.

task-4297808

