### PR TITLE
[FIX] stock: adapt `_onchange_location_in` for New records

### DIFF
--- a/addons/stock/models/product_strategy.py
+++ b/addons/stock/models/product_strategy.py
@@ -79,14 +79,8 @@ class StockPutawayRule(models.Model):
 
     @api.onchange('location_in_id')
     def _onchange_location_in(self):
-        child_location_count = 0
-        if self.location_out_id:
-            child_location_count = self.env['stock.location'].search_count([
-                ('id', '=', self.location_out_id.id),
-                ('id', 'child_of', self.location_in_id.id),
-                ('id', '!=', self.location_in_id.id),
-            ])
-        if not child_location_count or not self.location_out_id:
+        loc_in, loc_out = self.location_in_id, self.location_out_id
+        if not loc_out or not (loc_out._child_of(loc_in)):
             self.location_out_id = self.location_in_id
 
     @api.model_create_multi

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -450,6 +450,10 @@ class Location(models.Model):
 
         return result
 
+    def _child_of(self, other_location):
+        self.ensure_one()
+        return self.parent_path.startswith(other_location.parent_path)
+
 
 class StockRoute(models.Model):
     _name = 'stock.route'


### PR DESCRIPTION
### Steps to reproduce:

- Enable Multi-Steps Routes in the settings
- Inventory > Configuration > Warehouse Management > Locations
- Pick any location
- With studio add the one2Many field `Store to sublocation` (`location_out_id` of `stock.putaway.rule`) > Close studio
- Try to add a line on the associated list
#### > Traceback

### Cause of the issue:

Adding a line will trigger an onchange of the`stock.putaway.rule` model in order to compute the default data of the new subrecord. However, the code will crash during the `_search_count` of the `_onchange_location_in` because of an invalid domain: https://github.com/odoo/odoo/blob/29939aa5fb1455af89a37293d2f76541ff1645ef/addons/stock/models/product_strategy.py#L80-L88 THis crashed since in our case the `location_out_id` will be a new record created during the onchange to represent the 'stock.location' and from which we are looking at the form. As such, a NewId will be given and treated as an integer in the domain leading to a traceback when the db is served.

### Fix:

Onchange method should be robust with respect to the usage of New records and hence the records used here should be replace by their origin if it even exists.

opw-4126731
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
