### PR TITLE
[FIX] mail: discuss style tweaks

### DIFF
--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -3,11 +3,11 @@
 }
 
 a.o_mail_redirect, a.o_channel_redirect {
-    @include o-mention-variant(rgba(lighten($o-action, 5%), .1), rgba(lighten($o-action, 5%), .15), lighten($o-action, 5%), rgba(lighten($o-action, 5%), .2), rgba(lighten($o-action, 5%), .3), lighten($o-action, 10%));
+    @include o-mention-variant(rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%), rgba(lighten($o-action, 5%), .2), rgba(lighten($o-action, 5%), .3), lighten($o-action, 10%));
 }
 
 a.o-discuss-mention {
-    @include o-mention-variant(rgba(lighten($o-action, 5%), .1), rgba(lighten($o-action, 5%), .15), lighten($o-action, 5%), rgba(lighten($o-action, 5%), .1), rgba(lighten($o-action, 5%), .15), lighten($o-action, 5%));
+    @include o-mention-variant(rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%), rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%));
 }
 
 .o-mail-DiscussSystray-class {

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -11,15 +11,28 @@
 }
 
 .o-mail-Message-bubble {
-    --border-opacity: 0;
-
     &.o-blue {
         background-color: mix($gray-100, $info, 87.5%) !important;
+        border-color: lighten(mix($gray-100, $info, 87.5%), 5%) !important;
+
+        &.o-muted {
+            background-color: mix($gray-100, mix($gray-100, $info, 87.5%)) !important;
+        }
     }
     &.o-green {
         background-color: mix($gray-100, $success, 87.5%) !important;
+        border-color: lighten(mix($gray-100, $success, 87.5%), 5%) !important;
+
+        &.o-muted {
+            background-color: mix($gray-100, mix($gray-100, $success, 87.5%)) !important;
+        }
     }
     &.o-orange {
         background-color: mix($gray-100, $warning, 72.5%) !important;
+        border-color: lighten(mix($gray-100, $warning, 72.5%), 5%) !important;
+
+        &.o-muted {
+            background-color: mix($gray-100, mix($gray-100, $warning, 72.5%), 85%) !important;
+        }
     }
 }

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -97,16 +97,29 @@
 }
 
 .o-mail-Message-bubble {
-    --border-opacity: .075;
-
     &.o-blue {
         background-color: mix($o-view-background-color, $info, 87.5%) !important;
+        border-color: darken(mix($o-view-background-color, $info, 87.5%), 10%) !important;
+
+        &.o-muted {
+            background-color: mix($white, mix($o-view-background-color, $info, 87.5%)) !important;
+        }
     }
     &.o-green {
         background-color: mix($o-view-background-color, $success, 87.5%) !important;
+        border-color: darken(mix($o-view-background-color, $success, 87.5%), 10%) !important;
+
+        &.o-muted {
+            background-color: mix($white, mix($o-view-background-color, $success, 87.5%)) !important;
+        }
     }
     &.o-orange {
         background-color: mix($o-view-background-color, $warning, 75%) !important;
+        border-color: darken(mix($o-view-background-color, $warning, 75%), 10%) !important;
+
+        &.o-muted {
+            background-color: mix($white, mix($o-view-background-color, $warning, 75%), 85%) !important;
+        }
     }
 }
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -69,7 +69,7 @@
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="false"/>
                                         <t t-else="">
                                             <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
-                                                <div class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100" t-att-class="{
+                                                <div class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
                                                     'o-blue': message.bubbleColor === 'blue',
                                                     'o-green': message.bubbleColor === 'green',
                                                     'o-orange': message.bubbleColor === 'orange',

--- a/addons/mail/static/src/core/common/message_in_reply.dark.scss
+++ b/addons/mail/static/src/core/common/message_in_reply.dark.scss
@@ -1,14 +1,13 @@
 .o-mail-MessageInReply-core {
-    --border-opacity: 0;
     background-color: rgba($gray-100, .35) !important;
 
-    &.o-otherMessageBlue {
+    &.o-blue {
         border-left-color: mix($gray-100, $info, 50%) !important
     }
-    &.o-otherMessageGreen {
+    &.o-green {
         border-left-color: mix($gray-100, $success, 50%) !important
     }
-    &.o-otherMessageOrange {
+    &.o-orange {
         border-left-color: mix($gray-100, $warning, 40%) !important
     }
 

--- a/addons/mail/static/src/core/common/message_in_reply.scss
+++ b/addons/mail/static/src/core/common/message_in_reply.scss
@@ -6,16 +6,15 @@
 .o-mail-MessageInReply-core {
     border-left: 3px solid transparent !important;
     background-color: rgba($o-view-background-color, .5) !important;
-    --border-opacity: 0.15;
 
-    &.o-otherMessageBlue {
-        border-left-color: mix($o-view-background-color, $info, 50%) !important
+    &.o-blue {
+        border-left-color: mix($o-view-background-color, $info, 50%) !important;
     }
-    &.o-otherMessageGreen {
-        border-left-color: mix($o-view-background-color, $success, 50%) !important
+    &.o-green {
+        border-left-color: mix($o-view-background-color, $success, 50%) !important;
     }
-    &.o-otherMessageOrange {
-        border-left-color: mix($o-view-background-color, $warning, 40%) !important
+    &.o-orange {
+        border-left-color: mix($o-view-background-color, $warning, 40%) !important;
     }
     &:hover {
         filter: brightness(.975);

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
     <t t-name="mail.MessageInReply">
         <div class="o-mail-MessageInReply mx-2 mt-1 p-1 pb-0">
-            <small class="o-mail-MessageInReply-core position-relative d-flex px-2 py-1" t-att-class="{
-                'o-otherMessageBlue': props.message.parentMessage.bubbleColor === 'blue',
-                'o-otherMessageGreen': props.message.parentMessage.bubbleColor === 'green',
-                'o-otherMessageOrange': props.message.parentMessage.bubbleColor === 'orange',
+            <small class="o-mail-MessageInReply-core o-mail-Message-bubble o-muted border position-relative d-flex px-2 py-1 rounded-3 rounded-start-0" t-att-class="{
+                'o-blue': props.message.parentMessage.bubbleColor === 'blue',
+                'o-green': props.message.parentMessage.bubbleColor === 'green',
+                'o-orange': props.message.parentMessage.bubbleColor === 'orange',
             }">
                 <span t-if="!props.message.parentMessage.isEmpty" class="d-inline-flex align-items-center text-muted" t-att-class="{ 'cursor-pointer': props.onClick }" t-on-click="() => this.props.onClick?.()">
                     <img class="o-mail-MessageInReply-avatar me-2 rounded o_object_fit_cover" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>

--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -10,7 +10,7 @@
     </t>
     
     <t t-name="mail.MessageReactionList.button">
-        <button class="position-relative o-mail-MessageReaction btn d-flex p-0 border rounded-2 mb-1 fs-4 px-1 gap-1 align-items-center" t-on-click="() => this.onClickReaction(props.reaction)" t-on-contextmenu="onContextMenu" t-on-mouseenter="loadEmoji" t-ref="reactionButton" t-att-class="{
+        <button class="position-relative o-mail-MessageReaction btn d-flex p-0 border rounded-2 mb-1 fs-5 px-1 gap-1 align-items-center" t-on-click="() => this.onClickReaction(props.reaction)" t-on-contextmenu="onContextMenu" t-on-mouseenter="loadEmoji" t-ref="reactionButton" t-att-class="{
             'o-selfReacted border-primary text-primary fw-bold': hasSelfReacted(props.reaction),
             'bg-view': !hasSelfReacted(props.reaction),
             'ms-1': env.inChatWindow and env.alignedRight,

--- a/addons/mail/static/src/core/public_web/notification_item.dark.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.dark.scss
@@ -3,7 +3,8 @@
     --mail-MessagingMenu-bg: #{mix($gray-100, $gray-200)};
 
     &.o-important {
-        background-color: mix($o-gray-200, $o-info, 87.5%) !important;
+        background-color: mix($o-gray-200, $o-info, 90%) !important;
+        border-color: lighten(mix($o-gray-200, $o-info, 90%), 5%) !important;
     }
     &:hover, &.o-active {
         background-color: mix($o-gray-200, $o-gray-300) !important;

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -19,6 +19,14 @@
     }
 }
 
+.o-mail-NotificationItem-avatarContainer {
+    margin-top: map-get($spacers, 1) / 2;
+    margin-bottom: map-get($spacers, 1) / 2;
+
+    &.o-small {
+        margin: map-get($spacers, 1);
+    }
+}
 
 .o-mail-NotificationItem-badge {
     padding: 3px 6px !important;
@@ -40,13 +48,17 @@
     }
 }
 
-.o-mail-NotificationItem-text:before {
-    // invisible character so that typing status bar has constant height, regardless of text content.
-    content: "\200b"; /* unicode zero width space character */
+.o-mail-NotificationItem-text {
+    font-family: "text-emoji", $font-family-base;
+
+    &:before {
+        // invisible character so that typing status bar has constant height, regardless of text content.
+        content: "\200b"; /* unicode zero width space character */
+    }
 }
 
 .o-mail-NotificationItem-unreadIndicator {
     color: darken($info, 5%);
     font-size: 0.5rem;
-    left: map-get($spacers, 2);
+    left: map-get($spacers, 1);
 }

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -13,7 +13,7 @@
             'o-active': props.isActive,
         }">
             <span class="o-mail-NotificationItem-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': props.muted, 'opacity-50': !props.muted }"><i class="fa fa-circle"/></span>
-            <div class="position-relative bg-inherit m-1 flex-shrink-0" style="width:40px;height:40px;">
+            <div class="o-mail-NotificationItem-avatarContainer position-relative bg-inherit flex-shrink-0" t-att-class="{ 'o-small': ui.isSmall }" style="width:40px;height:40px;">
                 <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>
             </div>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -21,7 +21,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebarQuickSearchInput">
-        <div class="o-mail-DiscussSidebarQuickSearchInput d-flex align-items-center justify-content-center rounded gap-1" t-att-class="{ 'o-active': state.quickSearchVal.length, 'mx-2': !store.discuss.isSidebarCompact }">
+        <div class="o-mail-DiscussSidebarQuickSearchInput d-flex align-items-center justify-content-center rounded gap-1" t-att-class="{ 'o-active': state.quickSearchVal.length, 'mx-3 mt-1': !store.discuss.isSidebarCompact }">
             <input class="form-control rounded-3 border-0" placeholder="Quick search…" t-model="state.quickSearchVal" t-ref="root"/>
             <button t-if="state.quickSearchVal.length" class="btn btn-light p-1 rounded-0" t-on-click="() => state.quickSearchVal = ''"><i class="oi oi-close" title="Clear quick search"/></button>
         </div>


### PR DESCRIPTION
- message bubble more distinct from background with darkened border
- messaging menu item have less horizontal spacing in desktop
- messaging menu item preview has bigger emojis like messages
- messaging menu dark theme spacing matches white theme (was missing border color)
- message reactions have slightly smaller emoji size
- discuss sidebar quick search is more aligned with other items
- message in reply background matches original message color and has is more distinct from replied message
- mention in dark theme is shinier, somewhat same contrast with regular text content than in white theme

Before / After (white)

<img width="2555" alt="0-before-white" src="https://github.com/user-attachments/assets/a99a0873-ae93-4c8d-a3f3-a1c30f232c29">
<img width="1280" alt="0-after-white" src="https://github.com/user-attachments/assets/c826f29c-ed2c-47fe-bac3-77c967aeb39b">

Before / After (dark)

<img width="2558" alt="0-before-dark" src="https://github.com/user-attachments/assets/f523a131-8765-4d57-b167-d8f370ca33b5">
<img width="2556" alt="0-after-dark" src="https://github.com/user-attachments/assets/06cb3cf5-ed2e-4527-bd57-27b54fe89bea">
