### PR TITLE
Website : Remove outdated snippet warning

### DIFF
--- a/addons/test_website/__manifest__.py
+++ b/addons/test_website/__manifest__.py
@@ -44,6 +44,9 @@ models which only purpose is to run tests.""",
         'web.assets_tests': [
             'test_website/static/tests/tours/*',
         ],
+        'website.assets_wysiwyg': [
+            'test_website/static/src/js/editor/snippets.options.js'
+        ]
     },
     'license': 'LGPL-3',
 }

--- a/addons/test_website/static/src/js/editor/snippets.options.js
+++ b/addons/test_website/static/src/js/editor/snippets.options.js
@@ -1,0 +1,19 @@
+import options from "@web_editor/js/editor/snippets.options";
+
+/**
+ * Manage the visibility of snippets on mobile/desktop.
+ */
+options.registry.CrashSnippet = options.Class.extend({
+    //--------------------------------------------------------------------------
+    // Options
+    //--------------------------------------------------------------------------
+
+    /**
+     * Raise an error if the crash button is clicked.
+     *
+     * @see this.selectClass for parameters
+     */
+    async crashSnippet(previewMode, widgetValue, params) {
+        throw new Error("This option is made to raise an error.");
+    },
+});

--- a/addons/test_website/static/tests/tours/snippet_version_outdated.js
+++ b/addons/test_website/static/tests/tours/snippet_version_outdated.js
@@ -1,0 +1,45 @@
+import { registerWebsitePreviewTour, insertSnippet } from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "snippet_version_outdated",
+    {
+        edition: true,
+        url: "/",
+    },
+    () => [
+        ...insertSnippet({
+            id: "s_crashing_snippet",
+            name: "Test Crashing snip",
+            groupName: "Content",
+        }),
+        {
+            content: "Change s_crashing_snippet version",
+            trigger: ":iframe #wrap.o_editable .s_crashing_snippet",
+            run: function () {
+                const iframe = document.querySelector("iframe");
+                const snippet = iframe.contentDocument.querySelector(".s_crashing_snippet");
+                snippet.setAttribute("data-vxml", "999");
+            },
+        },
+        {
+            content: "Edit s_crashing_snippet",
+            trigger: ":iframe #wrap.o_editable .s_crashing_snippet",
+            run: "click",
+        },
+        {
+            trigger: ".snippet-option-CrashSnippet",
+        },
+        {
+            content: "Edit s_crashing_snippet",
+            trigger: ".snippet-option-CrashSnippet we-button.o_we_user_value_widget",
+            run: "click",
+        },
+        {
+            trigger: ".modal-dialog:contains(This snippet is outdated)",
+        },
+        {
+            content: "The snippet is outdated, an alert message was send",
+            trigger: "body",
+        },
+    ]
+);

--- a/addons/test_website/tests/test_error.py
+++ b/addons/test_website/tests/test_error.py
@@ -8,3 +8,16 @@ class TestWebsiteError(odoo.tests.HttpCase):
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_01_run_test(self):
         self.start_tour("/test_error_view", 'test_error_website')
+
+    def test_02_run_test(self):
+        website_snippets = self.env.ref('website.snippets')
+        self.env['ir.ui.view'].create([{
+            'type': 'qweb',
+            'inherit_id': website_snippets.id,
+            'arch': """
+                <xpath expr="//t[@t-snippet='website.s_parallax']" position="after">
+                    <t t-snippet="test_website.s_crashing_snippet" group="content"/>
+                </xpath>
+            """,
+        }])
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_version_outdated', login='admin')

--- a/addons/test_website/views/templates.xml
+++ b/addons/test_website/views/templates.xml
@@ -98,4 +98,19 @@
         </t>
     </template>
 
+    <template id="s_crashing_snippet" name="Crashing Snippet">
+        <section class="s_crashing_snippet">
+            <a href="#">Button</a>
+        </section>
+    </template>
+
+    <template id="s_crashing_snippet_options" inherit_id="website.snippet_options">
+        <xpath expr="." position="inside">
+            <div data-js="CrashSnippet" data-selector=".s_crashing_snippet">
+                <we-button-group string="Crashing option">
+                    <we-button title="Crash" data-crash-snippet="">Crash</we-button>
+                </we-button-group>
+            </div>
+        </xpath>
+    </template>
 </odoo>

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2,7 +2,7 @@
 
 import { attachComponent } from "@web_editor/js/core/owl_utils";
 import { MediaDialog } from "@web_editor/components/media_dialog/media_dialog";
-import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { ConfirmationDialog, AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { throttleForAnimation, debounce } from "@web/core/utils/timing";
 import { clamp } from "@web/core/utils/numbers";
 import { scrollTo } from "@web_editor/js/common/scrolling";
@@ -4529,7 +4529,36 @@ const SnippetOptionWidget = publicWidget.Widget.extend({
             }
 
             // Call widget option methods and update $target
-            await this._select(previewMode, widget);
+            try {
+                await this._select(previewMode, widget);
+            }
+            catch (error) {
+                const snippetElement = this.$target.closest("[data-snippet]");
+                const snippetName = snippetElement.length
+                        ? snippetElement[0].dataset.snippet
+                        : null;
+                this.trigger_up("get_snippet_versions", {
+                    snippetName: snippetName,
+                    onSuccess: snippetVersions => {
+                        const isUpToDate =
+                            snippetVersions &&
+                            ["vjs", "vcss", "vxml"].every(
+                                (key) => snippetElement[0].dataset[key] === snippetVersions[key]
+                            );
+                        if (!isUpToDate) {
+                            if (!controlledSnippets.has(snippetName)) {
+                                controlledSnippets.add(snippetName);
+                                this.dialog.add(AlertDialog, {
+                                    body: "This snippet is outdated, some options might have changed and cause issues. You can replace it by a newer version"
+                                });
+                            }
+                        }
+                        else {
+                            throw error;
+                        }
+                    },
+                });
+            }
 
             // If it is not preview mode, the user selected the option for good
             // (so record the action)
@@ -9357,92 +9386,6 @@ registry.many2one = SnippetOptionWidget.extend({
                     node.textContent = defaultText;
                 }
             }));
-    },
-});
-/**
- * Allows to display a warning message on outdated snippets.
- */
-registry.VersionControl = SnippetOptionWidget.extend({
-
-    //--------------------------------------------------------------------------
-    // Options
-    //--------------------------------------------------------------------------
-
-    /**
-     * Replaces an outdated snippet by its new version.
-     */
-    async replaceSnippet() {
-        // Getting the new block version.
-        let newBlockEl;
-        this.trigger_up("find_snippet_template", {
-            snippet: this.$target[0],
-            callback: (snippet) => {
-                newBlockEl = snippet.baseBody.cloneNode(true);
-            },
-        });
-        // Removing the eventual dialog previews.
-        newBlockEl.querySelectorAll(".s_dialog_preview").forEach(previewEl => previewEl.remove());
-        // Replacing the block.
-        this.options.wysiwyg.odooEditor.historyPauseSteps();
-        this.$target[0].classList.add("d-none"); // Hiding the block to replace it smoothly.
-        this.$target[0].insertAdjacentElement("beforebegin", newBlockEl);
-        // Initializing the new block as if it was dropped: the mutex needs to
-        // be free for that so we wait for it first.
-        this.options.wysiwyg.waitForEmptyMutexAction().then(async () => {
-            await new Promise((resolve) => {
-                this.options.wysiwyg.snippetsMenuBus.trigger("CALL_POST_SNIPPET_DROP", {
-                    $snippet: $(newBlockEl),
-                    onSuccess: resolve,
-                });
-            });
-            await new Promise(resolve => {
-                this.trigger_up("remove_snippet",
-                    {$snippet: this.$target, onSuccess: resolve, shouldRecordUndo: false}
-                );
-            });
-            this.options.wysiwyg.odooEditor.historyUnpauseSteps();
-            newBlockEl.classList.remove("oe_snippet_body");
-            this.options.wysiwyg.odooEditor.historyStep();
-        });
-    },
-    /**
-     * Allows to still access the options of an outdated block, despite the
-     * warning.
-     */
-    discardAlert() {
-        const alertEl = this.$el[0].querySelector("we-alert");
-        const optionsSectionEl = this.$overlay.data("$optionsSection")[0];
-        alertEl.remove();
-        optionsSectionEl.classList.remove("o_we_outdated_block_options");
-        // Preventing the alert to reappear at each render.
-        controlledSnippets.add(this.$target[0].dataset.snippet);
-    },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * @override
-     */
-    _renderCustomXML(uiFragment) {
-        const snippetName = this.$target[0].dataset.snippet;
-        // Do not display the alert if it was previously discarded.
-        if (controlledSnippets.has(snippetName)) {
-            return;
-        }
-        this.trigger_up("get_snippet_versions", {
-            snippetName: snippetName,
-            onSuccess: snippetVersions => {
-                const isUpToDate = snippetVersions && ["vjs", "vcss", "vxml"].every(key => this.$target[0].dataset[key] === snippetVersions[key]);
-                if (!isUpToDate) {
-                    uiFragment.prepend(renderToElement("web_editor.outdated_block_message"));
-                    // Hide the other options, to only have the alert displayed.
-                    const optionsSectionEl = this.$overlay.data("$optionsSection")[0];
-                    optionsSectionEl.classList.add("o_we_outdated_block_options");
-                }
-            },
-        });
     },
 });
 

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -955,22 +955,6 @@
                     }
                 }
             }
-
-            &.o_we_outdated_block_options {
-                // Outdated block options
-                padding: 0 !important;
-
-                > we-customizeblock-option {
-                    &:not(.snippet-option-VersionControl) {
-                        display: none !important;
-                    }
-
-                    &.snippet-option-VersionControl {
-                        // Outdated snippet alert
-                        padding: 0 !important;
-                    }
-                }
-            }
         }
 
         we-customizeblock-option {

--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -50,15 +50,6 @@
             </we-title>
         </we-customizeblock-options>
     </t>
-    <t t-name="web_editor.outdated_block_message">
-        <we-alert class="d-flex flex-column p-3 pt-4 align-items-center text-center text-white">
-            <we-title>This block is outdated.</we-title>
-            <span>You might not be able to customize it anymore.</span>
-            <we-button class="o_we_bg_brand_primary py-2 my-4 border-0" data-no-preview="true" data-replace-snippet="">REPLACE BY NEW VERSION</we-button>
-            <span>You can still access the block options but it might be ineffective.</span>
-            <we-button class="o_we_bg_brand_primary py-2 my-4 border-0" data-no-preview="true" data-discard-alert="">ACCESS OPTIONS ANYWAY</we-button>
-        </we-alert>
-    </t>
 
     <!-- options -->
     <div t-name="web_editor.ColorPalette" class="colorpicker" t-ref="el" t-on-click="this._onColorpickerClick">

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -388,13 +388,6 @@
     </t>
 </template>
 
-<template id="snippet_options_version_control">
-    <div data-js="VersionControl"
-        t-att-data-selector="selector"
-        t-att-data-exclude="exclude"
-        t-att-data-target="target"/>
-</template>
-
 <!-- options (data-selector, data-drop-in, data-drop-near, data-js to link js object ) -->
 <template id="snippet_options">
     <!-- t-field -->
@@ -404,10 +397,6 @@
 
     <div data-selector=".s_hr"
          data-drop-near="p, h1, h2, h3, blockquote, .s_hr"/>
-
-    <t t-call="web_editor.snippet_options_version_control">
-        <t t-set="selector" t-value="'[data-snippet]'"/>
-    </t>
 
     <!-- Replace a media -->
     <!-- TODO probably review this system once the new editor is merged to not duplicate the selector, etc -->

--- a/addons/website/static/tests/tours/snippet_version.js
+++ b/addons/website/static/tests/tours/snippet_version.js
@@ -36,38 +36,3 @@ registerWebsitePreviewTour("snippet_version_1", {
 },
     ...clickOnSave(),
 ]);
-registerWebsitePreviewTour("snippet_version_2", {
-    edition: true,
-    url: "/",
-}, () => [
-{
-    content: "Edit s_test_snip",
-    trigger: ':iframe #wrap.o_editable .s_test_snip',
-    run: "click",
-},
-{
-    trigger:
-        "we-customizeblock-options:contains(Test snip) .snippet-option-VersionControl > we-alert",
-},
-{
-    content: "Edit text_image",
-    trigger: ':iframe #wrap.o_editable .s_text_image',
-    run: "click",
-},
-{
-    trigger:
-        "we-customizeblock-options:contains(Text - Image) .snippet-option-VersionControl  > we-alert",
-},
-{
-    content: "Edit s_share",
-    trigger: ':iframe #wrap.o_editable .s_share',
-    run: "click",
-},
-{
-    trigger:
-        "we-customizeblock-options:contains(Share) .snippet-option-VersionControl > we-alert",
-},
-{
-    content: "s_share is outdated",
-    trigger: ':iframe body',
-}]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -359,7 +359,7 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_07_snippet_version(self):
         website_snippets = self.env.ref('website.snippets')
-        view_ids = self.env['ir.ui.view'].create([{
+        self.env['ir.ui.view'].create([{
             'name': 'Test snip',
             'type': 'qweb',
             'key': 'website.s_test_snip',
@@ -378,41 +378,6 @@ class TestUi(odoo.tests.HttpCase):
             """,
         }])
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_version_1', login='admin')
-
-        self.env['ir.ui.view'].create([
-            {
-                'name': 'Test snippet version 999',
-                'mode': 'extension',
-                'inherit_id': view_ids[0].id,
-                'arch': """
-                    <xpath expr="//section[hasclass('s_test_snip')]" position="attributes">
-                        <attribute name="data-vjs">999</attribute>
-                    </xpath>
-                """
-            },
-            {
-                'name': 'Share snippet version 999',
-                'mode': 'extension',
-                'inherit_id': self.env.ref("website.s_share").id,
-                'arch': """
-                    <xpath expr="//div" position="attributes">
-                        <attribute name="data-vcss">999</attribute>
-                    </xpath>
-                """
-            },
-            {
-                'name': 's_text_image version 999',
-                'mode': 'extension',
-                'inherit_id': self.env.ref("website.s_text_image").id,
-                'arch': """
-                    <xpath expr="//section[hasclass('s_text_image')]" position="attributes">
-                        <attribute name="data-vxml">999</attribute>
-                    </xpath>
-                """
-            }
-        ])
-
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_version_2', login='admin')
 
     def test_08_website_style_custo(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'website_style_edition', login='admin')

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -714,28 +714,6 @@
         </div>
     </xpath>
 
-     <!-- Version control -->
-    <xpath expr="//t[@t-call='web_editor.snippet_options_version_control']" position="replace">
-        <!-- General selector defining the parent elements of s_card snippets on
-             which the s_card options should be bound (instead of the s_card).
-             Note: defined here to be set above all the other options that might
-             need it. -->
-        <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div'"/>
-
-        <!-- Binding the option on the snippet if it is not a s_card with a
-             handler parent -->
-        <t t-call="web_editor.snippet_options_version_control">
-            <t t-set="selector" t-value="'[data-snippet]'"/>
-            <t t-set="exclude" t-valuef="div:is(#{card_parent_handlers}) > .s_card"/>
-        </t>
-
-        <!-- Binding the option on the s_card handler parent -->
-        <t t-call="web_editor.snippet_options_version_control">
-            <t t-set="selector" t-valuef="#{card_parent_handlers}"/>
-            <t t-set="target" t-value="'> .s_card'"/>
-        </t>
-    </xpath>
-
     <!-- Font Awesome icons -->
     <xpath expr="//div[@data-js='FontawesomeTools']" position="inside">
         <t t-call="website.snippet_options_border_line_widgets">
@@ -906,6 +884,8 @@
         <we-button class="fa fa-fw fa-angle-left" data-move-snippet="prev" data-no-preview="true" data-name="move_left_opt"/>
         <we-button class="fa fa-fw fa-angle-right" data-move-snippet="next" data-no-preview="true" data-name="move_right_opt"/>
     </div>
+
+    <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div'"/>
 
     <!-- Background -->
     <t t-set="only_bg_color_selector" t-value="'section .row > div, .s_text_highlight, .s_mega_menu_thumbnails_footer, .s_hr, .s_cta_badge'"/>


### PR DESCRIPTION
Currently when a user try to modify the options of an outdated snippet a warning block display on top of the options.
The block present two options : 'try to update the snippet' or 'access options anyway'.

This PR remove the warning on the options and suppose the 'access options anyway' is the default choice.
If an error occur, the snippet version is verified and an alert message is display if the snippet is outdated.

task-4297808

