### PR TITLE
[FIX] point_of_sale: show search when going back from payment

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1987,7 +1987,10 @@ export class PosStore extends Reactive {
     }
 
     showSearchButton() {
-        return this.mainScreen.component === ProductScreen && this.mobile_pane === "right";
+        if (this.mainScreen.component === ProductScreen) {
+            return this.ui.isSmall ? this.mobile_pane === "right" : true;
+        }
+        return false;
     }
 
     doNotAllowRefundAndSales() {


### PR DESCRIPTION
Before this commit, when going back from the payment screen to the product screen, the search bar wasn't visible.

opw-4318710

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
