### PR TITLE
[FIX] stock_picking_batch: don't auto batch

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -59,7 +59,7 @@ class StockPickingType(models.Model):
     @api.model
     def _is_auto_wave_grouped(self):
         self.ensure_one()
-        return any(self[key] for key in self._get_wave_group_by_keys())
+        return self.auto_batch and any(self[key] for key in self._get_wave_group_by_keys())
 
     @api.model
     def _get_batch_group_by_keys(self):


### PR DESCRIPTION
Issue
=====

When one of the operation type settings for auto-batch/auto-wave is enable, the move lines will be batched even if `auto_batch` is disabled. The options for grouping by contact, product or whatever should be used only to define how we want to batch move lines, but at the end, only "Automatic Batches" option should define if we batch or not.

How to reproduce
================

- For receipts' operation type, check "Automatic Batches" and "Wavre Grouping" by "Product";
- Once it's done, uncheck "Automatic Batches";
- Create a PO for two different products and confirm it -> You can see two receipts (one for each product) were created.

Solution
========

The method `_is_auto_wave_grouped` defines if we need to group by wave or not. To fix the issue, this method also check `auto_batch`, exactly like `_is_auto_batch_grouped` already does.

OPW-4349586