### PR TITLE
[IMP] ewallet error dialog :  text message  improvement

### DIFF
--- a/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -29,9 +29,7 @@ patch(ControlButtons.prototype, {
         if (eWalletRewards.length === 0 && orderTotal >= 0) {
             this.dialog.add(AlertDialog, {
                 title: _t("No valid eWallet found"),
-                body: _t(
-                    "You either have not created an eWallet or all your eWallets have expired."
-                ),
+                body: _t("Please select a customer and a valid eWallet."),
             });
             return;
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- At this moment, we have only one error dialog appearing when facing an issue with the "eWallet" action button. This dialog warn the user to select a valid eWallet. But the issue could be that the user forgot to set a customer first. 

Current behavior before PR:

Desired behavior after PR is merged:

- Improve the quality of the error message for the user by warning him to add a valid customer.  




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
