### PR TITLE
[FIX] stock: set the current sn location on sml

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -536,9 +536,13 @@ Please change the quantity done or the rounding precision of your unit of measur
                         }))
                         mls_without_lots -= move_line
                     else:  # No line without serial number, creates a new one.
-                        move_line_vals = self._prepare_move_line_vals(quantity=0)
-                        move_line_vals['lot_id'] = lot.id
-                        move_line_vals['lot_name'] = lot.name
+                        reserved_quants = self.env['stock.quant']._get_reserve_quantity(move.product_id, move.location_id, 1.0, lot)
+                        if reserved_quants:
+                            move_line_vals = self._prepare_move_line_vals(quantity=0, reserved_quant=reserved_quants[0][0])
+                        else:
+                            move_line_vals = self._prepare_move_line_vals(quantity=0)
+                            move_line_vals['lot_id'] = lot.id
+                            move_line_vals['lot_name'] = lot.name
                         move_line_vals['product_uom_id'] = move.product_id.uom_id.id
                         move_line_vals['quantity'] = 1
                         move_lines_commands.append((0, 0, move_line_vals))
@@ -1160,11 +1164,10 @@ Please change the quantity done or the rounding precision of your unit of measur
         quantity = sum(ml.quantity_product_uom for ml in self.move_line_ids.filtered(lambda ml: not ml.lot_id and ml.lot_name))
         quantity += self.product_id.uom_id._compute_quantity(len(self.lot_ids), self.product_uom)
         self.update({'quantity': quantity})
-
         quants = self.env['stock.quant'].search([('product_id', '=', self.product_id.id),
                                                  ('lot_id', 'in', self.lot_ids.ids),
                                                  ('quantity', '!=', 0),
-                                                 ('location_id', '!=', self.location_id.id),# Exclude the source location
+                                                 '!', ('location_id', 'child_of', self.location_id.id),
                                                  '|', ('location_id.usage', '=', 'customer'),
                                                       '&', ('company_id', '=', self.company_id.id),
                                                            ('location_id.usage', 'in', ('internal', 'transit'))])

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6286,6 +6286,34 @@ class StockMove(TransactionCase):
         self.assertTrue(warning, 'Reuse of existing serial number (record) not detected')
         self.assertEqual(list(warning.keys())[0], 'warning', 'Warning message was not returned')
 
+    def test_move_sn_redirect(self):
+        lot1 = self.env['stock.lot'].create({
+            'name': 'serial1',
+            'product_id': self.product_serial.id,
+            'company_id': self.env.company.id,
+        })
+        shelf = self.env['stock.location'].create({
+            'name': 'shelf',
+            'usage': 'internal',
+            'location_id': self.stock_location.id,
+        })
+        self.env['stock.quant']._update_available_quantity(self.product_serial, shelf, 1, lot_id=lot1)
+
+        move = self.env['stock.move'].create({
+            'name': 'test sn',
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'product_id': self.product_serial.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 0.0,
+        })
+        move.lot_ids = lot1
+        warning = move._onchange_lot_ids()
+
+        self.assertFalse(warning, 'Warning should not trigger for sublocation')
+        self.assertTrue(move.move_line_ids, 'A stock.move.line should be created for the SN')
+        self.assertEqual(move.move_line_ids.location_id, shelf, 'The stock.move.line should be prefilled with the lot location')
+
     def test_forecast_availability(self):
         """ Make an outgoing picking in dozens for a product stored in units.
         Check that reserved_availabity is expressed in move uom and forecast_availability is in product base uom


### PR DESCRIPTION
Using the fields `lot_ids` on `stock.move` will create a line with the given serial. However, it will use the move's location as reference. But the serial could be in a sublocation.

Currently the user has a warning that display the real location of the serial but it's annoying to do it when the sytem know. So set the current location as default and remove the warning for this case.

opw-4342448

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
