### PR TITLE
[IMP] core: avoid user specific company dependent fallback

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -42,6 +42,7 @@ from .tools.mimetypes import guess_mimetype
 from .tools.misc import unquote, has_list_types, Sentinel, SENTINEL
 from .tools.translate import html_translate
 
+from odoo import SUPERUSER_ID
 from odoo.exceptions import CacheMiss
 from odoo.osv import expression
 
@@ -783,7 +784,10 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
 
     def get_company_dependent_fallback(self, records):
         assert self.company_dependent
-        fallback = records.env['ir.default']._get_model_defaults(records._name).get(self.name)
+        fallback = records.env['ir.default'] \
+            .with_user(SUPERUSER_ID) \
+            .with_company(records.env.company) \
+            ._get_model_defaults(records._name).get(self.name)
         fallback = self.convert_to_cache(fallback, records, validate=False)
         return self.convert_to_record(fallback, records)
 


### PR DESCRIPTION
when an ir.default record with user_id is created, the result will be used as
the fallback value for undefined company-dependent column value. It will cause
user-dependent fallback which is logically wrong.

This commit forces the fallback value to be fetched with SUPERUSER to make
fallback always not user-dependent and increase the cache hit rate for
_get_model_defaults

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
