### PR TITLE
[IMP] hr_skills, mail: review avatar card layout

### DIFF
--- a/addons/hr/static/tests/web/m2x_avatar_user.test.js
+++ b/addons/hr/static/tests/web/m2x_avatar_user.test.js
@@ -64,7 +64,7 @@ test("avatar card preview with hr", async () => {
     expect.verifySteps(["user read"]);
     expect(".o_avatar_card").toHaveCount(1);
     expect(".o_avatar_card span[data-tooltip='Work Location'] .fa-building-o").toHaveCount(1);
-    expect(queryAllTexts(".o_card_user_infos > *")).toEqual([
+    expect(queryAllTexts(".o_card_user_infos > *:not(.o_avatar_card_buttons)")).toEqual([
         "Mario",
         "sub manager",
         "Management",

--- a/addons/hr_skills/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
+++ b/addons/hr_skills/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="resource_mail.AvatarCardResourcePopover" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('o_card_user_infos')]" position="inside">
-            <div t-if="skills?.length" class="d-flex align-items-start pt-1">
-                <i class="fa fa-fw fa-graduation-cap me-1" data-tooltip="Skills"/>
-                <div class="d-flex flex-wrap gap-1 o_employee_skills_tags overflow-hidden">
+        <xpath expr="//div[hasclass('o_avatar_card_details')]" position="inside">
+            <div t-if="skills?.length">
+                <span class="fw-bold">Skills</span>
+                <div class="d-flex flex-wrap gap-1 o_employee_skills_tags mt-1 overflow-hidden">
                     <TagsList tags="skillTags" visibleItemsLimit="5"/>
                 </div>
             </div>
-        </xpath>
-        <xpath expr="//div[hasclass('o_avatar_card_buttons')]" position="attributes">
-            <attribute t-if="skills?.length" name="class" add="pt-1" separator=" "/>
         </xpath>
     </t>
 </templates>

--- a/addons/hr_skills/static/src/components/avatar_card_resource/avatar_card_resource_popover_patch.js
+++ b/addons/hr_skills/static/src/components/avatar_card_resource/avatar_card_resource_popover_patch.js
@@ -23,6 +23,9 @@ export const patchAvatarCardResourcePopover = {
             "employee_skill_ids",
         ];
     },
+    get hasFooter() {
+        return this.skills?.length > 0 || super.hasFooter;
+    },
     get skillTags() {
         return this.skills.map(({ id, display_name, color }) => ({
             id,

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.dark.scss
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.dark.scss
@@ -1,7 +1,0 @@
-.o_avatar_card {
-    background-color: $gray-100;
-}
-
-.o_popover:has(.o_avatar_card) {
-    --popover-border-color: #{$gray-300};
-}

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
@@ -35,6 +35,10 @@ export class AvatarCardPopover extends Component {
         return true;
     }
 
+    get hasFooter() {
+        return false;
+    }
+
     async getProfileAction() {
         return {
             res_id: this.user.partner_id[0],

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.scss
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.scss
@@ -14,12 +14,11 @@
 }
 
 .o_avatar_card {
+    --card-bg: #{$popover-bg};
+    --card-border-color: #{$popover-border-color};
+
     max-width: 380px;
     @media screen  and (max-width: 480px) {
         max-width: 90vw;
-    }
-
-    .card-body {
-        padding: $card-spacer-y $card-spacer-x;
     }
 }

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.AvatarCardPopover">
-        <div class="o_avatar_card rounded bg-inherit">
-            <div class="card-body rounded bg-inherit">
+        <div class="o_avatar_card card border-0 rounded bg-inherit">
+            <div class="card-body bg-inherit">
                 <div class="d-flex align-items-start gap-2 bg-inherit">
                     <span class="o_avatar pt-1 position-relative o_card_avatar bg-inherit">
                         <img t-if="props.id"
@@ -26,17 +26,14 @@
                         <a t-if="phone" class="o-mail-avatar-card-tel text-truncate" t-att-title="phone" t-att-href="'tel:'+phone">
                             <i class="fa fa-fw fa-phone me-1"/><t t-esc="phone"/>
                         </a>
-                    </div>
-                </div>
-                <div class="flex-wrap gap-2 mt-2">
-                    <div class="justify-content-end d-flex align-items-baseline">
-                        <div class="d-flex gap-2 o_avatar_card_buttons">
+                        <div class="o_avatar_card_buttons d-flex gap-2 mt-2">
                             <button t-if="!user.share" class="btn btn-secondary btn-sm" t-on-click.stop="onSendClick">Send message</button>
                             <button t-if="showViewProfileBtn" class="btn btn-secondary btn-sm" t-custom-click.stop="(ev, isMiddleClick) => this.onClickViewProfile(isMiddleClick)" t-ref="viewProfileBtn">View Profile</button>
                         </div>
                     </div>
                 </div>
             </div>
+            <div t-if="hasFooter" class="o_avatar_card_details card-footer d-flex flex-column gap-3 rounded-bottom bg-100"/>
         </div>
     </t>
 </templates>

--- a/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.js
+++ b/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.js
@@ -27,8 +27,15 @@ export class AvatarCardResourcePopover extends AvatarCardPopover {
     }
 
     async onWillStart() {
-        [this.record] = await this.orm.read(this.props.recordModel, [this.props.id], this.fieldNames);
-        await Promise.all(this.loadAdditionalData());
+        try {
+            [this.record] = await this.orm.read(this.props.recordModel, [this.props.id], this.fieldNames);
+            await Promise.all(this.loadAdditionalData());
+        } catch (err) {
+            if (err.message === "Component is destroyed") {
+                return;
+            }
+            throw err;
+        }
     }
 
     loadAdditionalData() {


### PR DESCRIPTION
This PR reviews the layout of the avatar card in order to match all the use cases.

- requires https://github.com/odoo/enterprise/pull/74279

The employee avatar card recently received an update aiming to display skills and roles within its content. While this added extra information and value to the component, its layout wasn't really meant to contain that much information, which led to a crowded visual result.

With this PR, we review the hierarchy of the card by adding clear separations to its content and reviewing the use of white space.

| Master | This PR |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/c2a05f86-8174-439c-8d5b-43cea0ccd834) | <img width="402" alt="image" src="https://github.com/user-attachments/assets/4b8df28f-f3c5-4815-9002-215f5f2ffa02"> | 

task-3810438

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
