### PR TITLE
[IMP] account: Improve accounting tours

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -2157,6 +2157,12 @@ msgid ""
 msgstr ""
 
 #. module: account
+#. odoo-javascript
+#: code:addons/account/static/src/js/tours/account.js:0
+msgid "Add a description to your item."
+msgstr ""
+
+#. module: account
 #: model_terms:ir.actions.act_window,help:account.action_account_journal_form
 msgid "Add a journal"
 msgstr ""
@@ -4103,6 +4109,12 @@ msgstr ""
 
 #. module: account
 #. odoo-javascript
+#: code:addons/account/static/src/js/tours/account.js:0
+msgid "Click here to add a description to your product."
+msgstr ""
+
+#. module: account
+#. odoo-javascript
 #: code:addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml:0
 msgid "Click or press enter to add a description"
 msgstr ""
@@ -4325,7 +4337,7 @@ msgstr ""
 #. module: account
 #. odoo-javascript
 #: code:addons/account/static/src/js/tours/account.js:0
-msgid "Complete the partner data with email"
+msgid "Complete the partner data with email."
 msgstr ""
 
 #. module: account
@@ -4362,12 +4374,6 @@ msgstr ""
 #. module: account
 #: model:onboarding.onboarding.step,button_text:account.onboarding_onboarding_step_fiscal_year
 msgid "Configure"
-msgstr ""
-
-#. module: account
-#. odoo-javascript
-#: code:addons/account/static/src/js/tours/account.js:0
-msgid "Configure document layout."
 msgstr ""
 
 #. module: account
@@ -4768,6 +4774,12 @@ msgstr ""
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.rounding_list_action
 msgid "Create the first cash rounding"
+msgstr ""
+
+#. module: account
+#. odoo-javascript
+#: code:addons/account/static/src/js/tours/account.js:0
+msgid "Create the product."
 msgstr ""
 
 #. module: account
@@ -6855,7 +6867,7 @@ msgstr ""
 #. module: account
 #. odoo-javascript
 #: code:addons/account/static/src/js/tours/account.js:0
-msgid "Fill in the details of the line."
+msgid "Fill in the details of the product or see the suggestion."
 msgstr ""
 
 #. module: account
@@ -13312,7 +13324,7 @@ msgstr ""
 #. module: account
 #. odoo-javascript
 #: code:addons/account/static/src/js/tours/account.js:0
-msgid "Set a price"
+msgid "Set a price."
 msgstr ""
 
 #. module: account
@@ -16639,6 +16651,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.view_account_invoice_report_search
 #: model_terms:ir.ui.view,arch_db:account.view_partner_bank_search_inherit
 msgid "Vendors"
+msgstr ""
+
+#. module: account
+#. odoo-javascript
+#: code:addons/account/static/src/js/tours/account.js:0
+msgid "Verify the price and update if necessary."
 msgstr ""
 
 #. module: account

--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -31,22 +31,15 @@ registry.category("web_tour.tours").add('account_tour', {
     ...accountTourSteps.onboarding(),
     ...accountTourSteps.newInvoice(),
     {
-        isActive: ["auto"],
-        trigger: "[name=move_type] [raw-value=out_invoice]",
-    },
-    {
         trigger: "div[name=partner_id] .o_input_dropdown",
         content: markup(_t("Write a customer name to <b>create one</b> or <b>see suggestions</b>.")),
         tooltipPosition: "right",
         run: "click",
-    }, {
-        isActive: ["auto"],
-        trigger: "div[name=partner_id] input",
-        run: "edit Test",
     },
     {
         isActive: ["auto"],
-        trigger: "[name=move_type] [raw-value=out_invoice]",
+        trigger: "div[name=partner_id] input",
+        run: "edit Test Customer",
     },
     {
         isActive: ["auto"],
@@ -56,17 +49,9 @@ registry.category("web_tour.tours").add('account_tour', {
     },
     {
         isActive: ["auto"],
-        trigger: "[name=move_type] [raw-value=out_invoice]",
-    },
-    {
-        isActive: ["auto"],
         trigger: ".modal-content button.btn-primary",
         content: markup(_t("Once everything is set, you are good to continue. You will be able to edit this later in the <b>Customers</b> menu.")),
         run: "click",
-    },
-    {
-        isActive: ["auto"],
-        trigger: "[name=move_type] [raw-value=out_invoice]",
     },
     {
         trigger: "div[name=invoice_line_ids] .o_field_x2many_list_row_add a",
@@ -74,38 +59,61 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "click",
     },
     {
-        isActive: ["auto"],
-        trigger: "[name=move_type] [raw-value=out_invoice]",
+        trigger: "div[name=invoice_line_ids] div[name=product_id]",
+        content: _t("Fill in the details of the product or see the suggestion."),
+        tooltipPosition: "bottom",
+        run: "click",
     },
     {
+        isActive: ["auto"],
         trigger: "div[name=invoice_line_ids] div[name=product_id] input",
-        content: _t("Fill in the details of the line."),
-        tooltipPosition: "bottom",
-        run: "edit Test",
+        run: "edit Test Product",
     },
     {
         isActive: ["auto"],
-        trigger: "[name=move_type] [raw-value=out_invoice]",
+        trigger: "div[name=invoice_line_ids] div[name=product_id] .o_m2o_dropdown_option_create a:contains(create)",
+        content: _t("Create the product."),
+        run: "click",
     },
     {
+        trigger: "div[name=invoice_line_ids] div[name=product_id] button[id=labelVisibilityButtonId]",
+        content: _t("Click here to add a description to your product."),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: "div[name=invoice_line_ids] div[name=product_id] textarea",
+        content: _t("Add a description to your item."),
+        tooltipPosition: "bottom",
+        run: "edit A very useful description.",
+    },
+    {
+        isActive: ["auto"],
+        trigger: "div[name=invoice_line_ids] div[name=product_id] textarea",
+        run: function () {
+            // Since the t-on-change of the input is not triggered by the run: "edit" action,
+            // we need to dispatch the event manually requiring a function.
+            const input = this.anchor;
+            input.dispatchEvent(new InputEvent("input"));
+            input.dispatchEvent(new Event("change"));
+        },
+    },
+    {
+        trigger: "div[name=invoice_line_ids] td[name=price_unit]",
+        content: _t("Verify the price and update if necessary."),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        isActive: ["auto"],
         trigger: "div[name=invoice_line_ids] div[name=price_unit] input",
-        content: _t("Set a price"),
-        tooltipPosition: "bottom",
+        content: _t("Set a price."),
         run: "edit 100",
-    },
-    ...stepUtils.saveForm(),
-    {
-        isActive: ["auto"],
-        trigger: "button.o_form_button_create",
     },
     {
         trigger: "button[name=action_post]",
         content: _t("Once your invoice is ready, confirm it."),
         run: "click",
-    },
-    {
-        isActive: ["auto"],
-        trigger: "[name=move_type] [raw-value=out_invoice]",
     },
     {
         trigger: "button[name=action_invoice_sent]:contains(print & send)",
@@ -115,23 +123,17 @@ registry.category("web_tour.tours").add('account_tour', {
     },
     {
         isActive: ["auto"],
-        trigger: "div.modal-dialog",
-    },
-    {
-        trigger: ".modal button[name=document_layout_save]",
-        content: _t("Configure document layout."),
-        run: "click",
-    },
-    {
         content: "Check sending method: 'email'",
         trigger: "input[id='email']",
         run: "click",
     },
     {
+        isActive: ["auto"],
         trigger: "div[name=account_missing_email] a",
-        content: _t("Complete the partner data with email"),
+        content: _t("Complete the partner data with email."),
         run: "click",
-    }, {
+    },
+    {
         isActive: ["auto"],
         trigger: ".o_field_widget[name=email] input, input[name=email]",
         content: markup(_t("Write here <b>your own email address</b> to test the flow.")),
@@ -139,37 +141,21 @@ registry.category("web_tour.tours").add('account_tour', {
     },
     ...stepUtils.saveForm(),
     {
+        isActive: ["auto"],
         trigger: '.breadcrumb .o_back_button',
         content: _t('Go back'),
-        tooltipPosition: 'bottom',
         run: "click",
     },
     {
         isActive: ["auto"],
-        trigger: "[name=move_type] [raw-value=out_invoice], [name=move_type][raw-value=out_invoice]",
-    },
-    {
         trigger: "button[name=action_invoice_sent]:contains(print & send)",
         content: _t("Send the invoice and check what the customer will receive."),
         run: "click",
-    },
-    {
-        isActive: ["auto"],
-        trigger: "[name=move_type] [raw-value=out_invoice]",
-    },
+    },    
     {
         trigger: ".modal button[name=action_send_and_print]",
         content: _t("Let's send the invoice."),
         tooltipPosition: "top",
         run: "click",
-    },
-    {
-        isActive: ["auto"],
-        trigger: "body:has(.o_form_saved)",
-    },
-    {
-        trigger: "button[name=action_register_payment]:contains(pay):enabled",
-        content: _t("The button priority shifted since the invoice has been sent. Let's register the payment now."),
-        tooltipPosition: "bottom",
     },
 ]});

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -40,6 +40,7 @@ class TestUi(AccountTestInvoicingHttpCommon):
             'country_id': None, # Also resets account_fiscal_country_id
             'account_sale_tax_id': None,
             'account_purchase_tax_id': None,
+            'external_report_layout_id': self.env.ref('web.external_layout_standard').id,
         })
 
         account_with_taxes = self.env['account.account'].search([('tax_ids', '!=', False), ('company_ids', '=', self.env.company.id)])


### PR DESCRIPTION
Problem
---------
The account tour had some troublesome steps such the one waiting for the user to select a template. If this had already been done before, it meant that the tour would be on stand by. The Send & Print wizard steps were also quite heavy with extra steps being taken to add an email to the partner, this would stop the tour if the selected partner already had a email address.

Solution
---------
This commit removes
- the steps related to the template selection (for both the manual and automatic tours)
- the extra steps in the send and print, asking the user to select add an address for the partner without one and simply asks him to Send & Print directly (only for the manual tour, the automatic tour maintain those steps since the automatic tour creates a new partner without email address during the run).

This commit adds
- Steps to add a description of a product (for both manual and auto)

task-4309716
odoo/enterprise/pull/74092

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
