### PR TITLE
[FIX] stock: avoid error when apply putaway strategy on packages

### DIFF
--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1942,3 +1942,45 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
 
         validate_picking(return_2)
         self.assertEqual(so.order_line[0].qty_delivered, 0)
+
+    def test_package_with_moves_to_different_location_dest(self):
+        """
+        Create a two-step delivery with two products, and package both products together.
+        Ensure that the destination location is different for the two moves in the second
+        picking. check that the first picking can be validated.
+        """
+        # Set-up multi-step routes
+        self.env.user.groups_id += self.env.ref('stock.group_stock_multi_locations')
+        self.env.user.groups_id += self.env.ref('stock.group_adv_location')
+        warehouse = self.company_data['default_warehouse']
+        # Create two child locations.
+        parent_location = warehouse.lot_stock_id
+        child_location_1 = self.env['stock.location'].create({
+                'name': 'child_1',
+                'location_id': parent_location.id,
+        })
+        child_location_2 = self.env['stock.location'].create({
+                'name': 'child_2',
+                'location_id': parent_location.id,
+        })
+        # Enable 2-steps delivery
+        with Form(warehouse) as w:
+            w.delivery_steps = 'pick_ship'
+        so = self._get_new_sale_order(product=self.product_a)
+        self.env['sale.order.line'].create({
+            'product_id': self.product_b.id,
+            'order_id': so.id,
+        })
+        self.assertEqual(len(so.order_line), 2)
+        so.action_confirm()
+        self.assertEqual(len(so.picking_ids), 2)
+        so.picking_ids[1].move_ids[0].location_dest_id = child_location_1
+        so.picking_ids[1].move_ids[1].location_dest_id = child_location_2
+        # Pack the moves of the first picking together.
+        package = so.picking_ids[0].action_put_in_pack()
+        # a new package is made and done quantities should be in same package
+        self.assertTrue(package)
+        so.picking_ids[0].button_validate()
+        self.assertEqual(so.picking_ids[0].state, 'done')
+        self.assertEqual(so.picking_ids[1].move_ids.move_line_ids[0].location_dest_id, child_location_1)
+        self.assertEqual(so.picking_ids[1].move_ids.move_line_ids[1].location_dest_id, child_location_2)

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -264,7 +264,8 @@ class StockMoveLine(models.Model):
                     excluded_smls.discard(sml.id)
                     used_locations.add(sml.location_dest_id)
                 if len(used_locations) > 1:
-                    smls.location_dest_id = smls.move_id.location_dest_id
+                    for move, grouped_smls in smls.grouped('move_id').items():
+                        grouped_smls.location_dest_id = move.location_dest_id
                 else:
                     smls.package_level_id.location_dest_id = smls.location_dest_id
             else:


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1” and “P2”
- Create two route:
    - route 1: - rule 1: Pull from “WH/Stock” to “WH/Stock/Shelf 1” -> Trigger another action
                    - rule 2: Pull from “WH/Stock/Shelf 1” to “customer -> Trigger another action

    - route 2:
        - rule 1: Pull from “WH/Stock” to “WH/Stock/Shelf 2” -> Trigger another action
        - rule 2: Pull from “WH/Stock/Shelf 2” to “customer -> Trigger another action

- P1 -> route 1 + buy (add azure interior as vendor)
- P2 -> route 2 + buy (add azure interior as vendor)

- Create a SO: - vendor: Azure interior
    - One unit of P1 and P2

- Confirm the SO
- Go to the created PO
- Confirm the PO and go to the reception
- put in pack the products together
- Try to validate the picking

Probelm:
An User Error is triggered:
ValueError: Expected singleton: stock.location(3694, 3696)

Because we have two moves with different destination locations, and we are trying to set them in all the move lines.

opw-4291067
