### PR TITLE
[FIX] web_editor: fix toolbar appearing and disappearing

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1906,6 +1906,7 @@ var SnippetsMenu = Widget.extend({
         this.customizePanel = document.createElement('div');
         this.customizePanel.classList.add('o_we_customize_panel', 'd-none');
 
+        this.options.wysiwyg.toolbarEl.classList.add('d-none');
         this._toolbarWrapperEl = document.createElement('div');
         this._toolbarWrapperEl.classList.add('o_we_toolbar_wrapper');
         class WebsiteToolbar extends Component {
@@ -1932,7 +1933,6 @@ var SnippetsMenu = Widget.extend({
 
         const toolbarEl = this._toolbarWrapperEl.firstChild;
         toolbarEl.classList.remove('oe-floating');
-        this.options.wysiwyg.toolbarEl.classList.add('d-none');
         this.options.wysiwyg.setupToolbar(toolbarEl);
         this._addToolbar();
         this._checkEditorToolbarVisibilityCallback = this._checkEditorToolbarVisibility.bind(this);


### PR DESCRIPTION
Steps to reproduce:

- Go to a Website page.
- Enable the "Mobile" preview.
- Click on the "Edit" button to enter in edit mode.
- Bug: When entering edit mode, the toolbar briefly appears and then disappears on the page.

To fix this, we move the line that adds a "d-none" class to this toolbar earlier in the "start" of "snippetMenu".

opw-4321865
opw-4232082