### PR TITLE
[FIX] mail: wrap chatter content inside div

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -534,9 +534,10 @@ export class Composer extends Component {
             mentionedChannels: this.props.composer.mentionedChannels,
             mentionedPartners: this.props.composer.mentionedPartners,
         });
+        const default_body = await prettifyMessageContent(body, validMentions);
         const context = {
             default_attachment_ids: attachmentIds,
-            default_body: await prettifyMessageContent(body, validMentions),
+            default_body: "<div>" + default_body + "</div>", // as to not wrap in <p> by html_sanitize,
             default_model: this.thread.model,
             default_partner_ids:
                 this.props.type === "note"

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -93,11 +93,12 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         {
             content: "Click on the mail template selector",
             trigger: ".mail-composer-template-dropdown-btn",
-            run: "click"
+            run: "click",
         },
         {
             content: "Check a template is listed",
-            trigger: '.mail-composer-template-dropdown.popover .o-dropdown-item:contains("Test template")',
+            trigger:
+                '.mail-composer-template-dropdown.popover .o-dropdown-item:contains("Test template")',
         },
         {
             content: "Send message",
@@ -149,6 +150,38 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
                     );
                 }
             },
+        },
+        // Test text input lines are each wrapped in <p> in editor
+        // this makes each line editable without impacting the other lines
+        {
+            content: "Write first line",
+            trigger: ".o-mail-Composer-input",
+            run: "edit abc",
+        },
+        {
+            content: "Press enter to go to next line",
+            trigger: ".o-mail-Composer-input",
+            run: "press enter",
+        },
+        {
+            content: "write second line",
+            trigger: ".o-mail-Composer-input",
+            run: "fill efg",
+        },
+        {
+            content: "Open full composer",
+            trigger: "button[aria-label='Full composer']",
+            run: "click",
+        },
+        {
+            content: "Check the content of the editor",
+            trigger:
+                ".o_mail_composer_form_view .odoo-editor-editable > p:contains(abc):not(:contains(efg))",
+        },
+        {
+            content: "Check the content of the editor",
+            trigger:
+                ".o_mail_composer_form_view .odoo-editor-editable > p:contains(efg):not(:contains(abc))",
         },
     ],
 });


### PR DESCRIPTION
Steps to reproduce the issue:
=============================
- Go to chatter
- Write content on 2 lines
- Open composer
- Select first line and change the heading
- Both lines are changed

Origin of the issue:
====================
The content of the textarea sent to the server is `abc<br>efg`. 

In 17.4: We don't sanitize the content so it stays the same and we put that content into the editor. The editor will create the `p` elements to wrap the inline elements at root.

In 18.0: We sanitize the content and it will pass by `lxml.html.fromstring` and it will wrap the content in a `p` element. Now we put `<p> abc<br> efg</p>` in the editor which is valid but it's considered all as the same block. Applying block-level commands like list and heading will change the whole content.

Solution:
=========
Wrap the textarea content inside a div when we open the mail composer.

opw-4350430
opw-4346348