### PR TITLE
[FIX] stock: prevent dup product name on delivery slip

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -220,7 +220,10 @@
             <t t-if="not description and description != ''">
                 <t t-set="description" t-value="move_line.move_id.description_picking"/>
             </t>
-            <p t-if="description !='' and description != move_line.product_id.name">
+            <p t-if="description != '' and
+                     description != move_line.product_id.display_name and
+                     description != move_line.product_id.name"
+            >
                 <span t-esc="description"/>
             </p>
         </td>


### PR DESCRIPTION
**Current behavior:**
Enabling the "Display Lots & Serial Numbers on Delivery Slips" setting, then creating an RFQ for a product with lot/SN tracking and a reference (`default_code`) + receiving the product, and finally printing the delivery slip will result in the product display name appearing twice on the delivery slip.

**Expected behavior:**
One time, the name.

**Steps to reproduce:**
1. Enable "Display Lots & Serial Numbers on Delivery Slips"

2. Create a SN/Lot tracked product with a reference

3. Create a purchase order, confirm and receive the product

4. On the receipt, click the `Print` button -> 2x name

**Cause of the issue:**
`description != move_line.product_id.name">`
Won't ever be true if there is a reference, as the description at this point is like:
`product_id.default_code + product_id.name`

**Fix:**
Compare description to the `display_name` which will include this kind of extra stuff.

opw-4165301