### PR TITLE
[IMP] point_of_sale: update iotbox .gitignore

### DIFF
--- a/addons/point_of_sale/tools/posbox/.gitignore
+++ b/addons/point_of_sale/tools/posbox/.gitignore
@@ -1,3 +1,4 @@
-kernel-qemu
-posbox.img
-raspbian.img
+raspios.img
+iotbox.img
+root_mount/
+overwrite_before_init/usr/bin/ngrok


### PR DESCRIPTION
The `.gitignore` in `tools/posbox` was out of
date, resulting in many untracked files
appearing while building an image. This
commit brings it up to date.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
