### PR TITLE
[FIX] web_tour: move setupEventActions

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -585,7 +585,10 @@ export class LinkTools extends Link {
         }
         const protocolLessPrevUrl = previousUrl.replace(/^https?:\/\/|^mailto:/i, '');
         const content = weUtils.getLinkLabel(this.linkEl);
-        if (content === previousUrl || content === protocolLessPrevUrl) {
+        if (
+            (content === previousUrl || content === protocolLessPrevUrl) &&
+            this.linkComponentWrapperRef.el
+        ) {
             const newUrl = this.linkComponentWrapperRef.el.querySelector('input[name="url"]').value;
             const protocolLessNewUrl = newUrl.replace(/^https?:\/\/|^mailto:/i, '')
             const newContent = content.replace(protocolLessPrevUrl, protocolLessNewUrl);

--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -33,6 +33,7 @@ export class TourAutomatic {
     }
 
     start(pointer) {
+        setupEventActions(document.createElement("div"));
         const macroSteps = this.steps
             .filter((step) => step.index >= this.currentIndex)
             .flatMap((step) => {
@@ -41,7 +42,6 @@ export class TourAutomatic {
                     {
                         action: async () => {
                             await this.pause();
-                            setupEventActions(document.createElement("div"));
                             if (this.debugMode) {
                                 console.groupCollapsed(step.describeMe);
                                 console.log(step.stringify);

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -104,7 +104,7 @@ registerWebsitePreviewTour('link_tools', {
     {
         content: "Link tools, should be open, change the url",
         trigger: '#o_link_dialog_url_input',
-        run: "edit odoo.be && click body",
+        run: "edit odoo.be",
     },
 
     ...clickOnSave(),
@@ -372,9 +372,7 @@ registerWebsitePreviewTour('link_tools', {
     {
         content: "Edit link label",
         trigger: ":iframe .s_text_image p a",
-        run() {
-            // TODO: use run: "click", instead
-            this.anchor.click();
+        run: "click",
             // See SHOPS_STEP_DISABLED. TODO. These steps do not consistently
             // update the link for some reason... to investigate.
             /*
@@ -387,7 +385,6 @@ registerWebsitePreviewTour('link_tools', {
             // Trigger editor's '_onInput' handler, which leads to a history step.
             link.dispatchEvent(new InputEvent('input', {inputType: 'insertText', bubbles: true}));
             */
-        },
     },
     // See SHOPS_STEP_DISABLED. TODO.
     /*


### PR DESCRIPTION
The setupEventActions defines an element (environment) in which the
history of actions is retained. If this element changes at each step
of the tour, then it is for example not possible to "blur" a previously
altered input. This environment must be defined at the beginning of
the tour.