### PR TITLE
[FIX] website: prevent escaping menu bar from a modal

### DIFF
--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { registry } from '@web/core/registry';
+import { isVisible } from "@web/core/utils/ui";
 import { getWysiwygClass } from 'web_editor.loader';
 
 import { FullscreenIndication } from '../components/fullscreen_indication/fullscreen_indication';
@@ -57,10 +58,14 @@ export const websiteService = {
 
         hotkey.add("escape", () => {
             // Toggle fullscreen mode when pressing escape.
-            if (!currentWebsiteId && !fullscreen) {
+            if (
+                (!currentWebsiteId && !fullscreen)
+                || (pageDocument && isVisible(pageDocument.querySelector(".modal")))
+            ) {
                 // Only allow to use this feature while on the website app, or
                 // while it is already fullscreen (in case you left the website
-                // app in fullscreen mode, thanks to CTRL-K).
+                // app in fullscreen mode, thanks to CTRL-K), or if a modal
+                // is open within the preview and could be closed with escape.
                 return;
             }
             fullscreen = !fullscreen;


### PR DESCRIPTION
When in preview mode and a modal is open in the preview, pressing escape hides both the modal and the top menu bar. We want to prevent that.

Steps to reproduce:
1. Connect as Admin and go on the website homepage
2. Edit the page, add a popup and save
3. Make sure to be in preview mode
4. Wait for the popup to show.
5. Click on it (just to be sure it's focused)
6. Press escape

task-4351982