### PR TITLE
[FIX] stock_account: update lot valuation upon tracking change

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -20,6 +20,12 @@ class ProductTemplate(models.Model):
         help="If checked, the valuation will be specific by Lot/Serial number.",
     )
 
+    @api.onchange('tracking')
+    def _onchange_tracking(self):
+        if self.tracking == "none" and self.lot_valuated:
+            self.lot_valuated = False
+        super()._onchange_tracking()
+
     @api.onchange('standard_price')
     def _onchange_standard_price(self):
         if self.lot_valuated and any(p.quantity_svl for p in self.product_variant_ids):


### PR DESCRIPTION
Issue:
Cannot validate receipts for products whose tracking changed from lot to quantity.

Steps to reproduce:
- Install both Inventory & Purchase apps
- Create a new product
- Track the product's inventory by Lot and set it's valuation by Lot
- Set the product's tracking in inventory by quantity
- Create a Purchase Order for the product
- Confirm the PO
- Validate the linked Receipt

Cause:
Lot valuation is not set to False when changing the tracking of a product from lot to quantity.

Solution:
Add an onchange on the "[tracking](https://github.com/odoo/odoo/blob/78b8a1670b5272c820f64ef904f4bdf00760031e/addons/stock/models/product.py#L694-L700)" field to update "lot_valuated" to False when **lot_valuated is still True** despite **no tracking being specified**.

Ticket:
[4345571](https://www.odoo.com/odoo/project/49/tasks/4345571)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
