### PR TITLE
[FIX] base_import: stop importing when everything has been imported

### DIFF
--- a/addons/base_import/static/src/import_model.js
+++ b/addons/base_import/static/src/import_model.js
@@ -374,8 +374,14 @@ export class BaseImportModel {
             }
         }
 
-        this.setOption("skip", nextrow || 0);
-        importRes.nextrow = nextrow;
+        // Check if we should continue
+        if (nextrow) {
+            this.setOption("skip", nextrow);
+            importRes.nextrow = nextrow;
+        } else {
+            // Falsy `nextrow` signals there's nothing left to import
+            this.stopImport();
+        }
         return false;
     }
 

--- a/addons/base_import/static/tests/import_action_tests.js
+++ b/addons/base_import/static/tests/import_action_tests.js
@@ -93,6 +93,8 @@ async function executeImport(data, shouldWait = false) {
     }
     if (data[3].skip + 1 < (data[3].has_headers ? totalRows - 1 : totalRows)) {
         res.nextrow = data[3].skip + data[3].limit;
+    } else {
+        res.nextrow = 0;
     }
     if (shouldWait) {
         // make sure the progress bar is shown
@@ -1305,6 +1307,88 @@ QUnit.module("Base Import Tests", (hooks) => {
             );
         }
     );
+
+    QUnit.test("Import view: batch import relational fields", async function (assert) {
+        let executeImportCount = 0;
+        registerFakeHTTPService();
+
+        patchWithCleanup(ImportAction.prototype, {
+            get isBatched() { // Make sure the UI displays the batched import options
+                return true;
+            },
+        });
+
+        await createImportAction({
+            "base_import.import/parse_preview": (route, args) => {
+                // Parse a file where all rows besides the first are used for relational data
+                return customParsePreview(args[1], {
+                    fields: [
+                        { id: "id", name: "id", string: "External ID", fields: [], type: "id" },
+                        {
+                            id: "display_name",
+                            name: "display_name",
+                            string: "Display Name",
+                            fields: [],
+                            type: "id",
+                        },
+                        {
+                            id: "many2many_field",
+                            name: "many2many_field",
+                            string: "Many2Many",
+                            fields: [
+                                {
+                                    id: "id",
+                                    name: "id",
+                                    string: "External ID",
+                                    fields: [],
+                                    type: "id",
+                                },
+                            ],
+                            type: "id",
+                        },
+                    ],
+                    headers: ["id", "display_name", "many2many_field/id"],
+                    rowCount: 6,
+                    matches: {
+                        0: ["id"],
+                        1: ["display_name"],
+                        2: ["many2many_field", "id"],
+                    },
+                    preview: [
+                        ["1"],
+                        ["Record Name"],
+                        ["1", "2", "3", "4", "5"],
+                    ],
+                });
+            },
+            "base_import.import/execute_import": async (route, args) => {
+                ++executeImportCount;
+                const res = await executeImport(args);
+                // Import batch limit doesn't apply to relational fields, so set `nextrow`
+                // to 0 to indicate all rows were imported on first call
+                res.nextrow = 0;
+                return res;
+            },
+        });
+
+        const file = new File(["fake_file"], "fake_file.xlsx", { type: "text/plain" });
+        await editInput(target, ".o_control_panel_main_buttons .d-none input[type='file']", file);
+
+        // Set batch limit to 1
+        await editInput(target, "input#o_import_batch_limit", 1);
+
+        // Start test
+        await click(
+            target.querySelector(".o_control_panel_main_buttons .d-none button:nth-child(2)")
+        );
+
+        assert.strictEqual(
+            target.querySelector(".o_import_data_content .alert-info").textContent,
+            "Everything seems valid.",
+            "A message should indicate the import test was successful"
+        );
+        assert.strictEqual(executeImportCount, 1, "Execute import should finish in 1 step");
+    });
 
     QUnit.test("Import view: import errors with relational fields", async function (assert) {
         registerFakeHTTPService();


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Create a pricelist with 200 price rules;
2. export pricelist to xlsx;
3. delete original pricelist;
4. import pricelist, setting batch size to 100.

Test files ready for import:
- [200_products.xlsx](https://github.com/user-attachments/files/17848187/200_products.xlsx)
- [200_pricelist_rules.xlsx](https://github.com/user-attachments/files/17848188/200_pricelist_rules.xlsx)

Issue
-----
Pricelist is imported with 400 price rules.

Cause
-----
The back-end signals there's nothing left to import by having `nextrow` be falsy[^1]. The front-end ignores this, and continues looping until it's taken as many steps as it initially planned.

The upfront `totalSteps` calculation is too high when an imported record has a number of nested relational records that's larger than the batch size.

Solution
--------
If the ORM returns a falsy `nextrow` value, call `stopImport`.

opw-4164056

[^1]: see note on f58368210c9c