### PR TITLE
Master hr revert remove multi company rule xbo

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -272,11 +272,6 @@ class HrEmployeeBase(models.AbstractModel):
             employee.is_flexible = employee.is_fully_flexible or employee.resource_calendar_id.flexible_hours
 
     @api.model
-    def search_panel_select_range(self, field_name, **kwargs):
-        # make sure all the companies/departments accessible by the current user are visible in the search panel since the user can see employees in other companies.
-        return super(HrEmployeeBase, self.with_context(allowed_company_ids=self.env.user._get_company_ids())).search_panel_select_range(field_name, **kwargs)
-
-    @api.model
     def _get_employee_working_now(self):
         working_now = []
         # We loop over all the employee tz and the resource calendar_id to detect working hours in batch.

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -25,10 +25,32 @@
         <field name="groups_id" eval="[(4,ref('group_hr_manager'))]"/>
     </record>
 
+    <record id="hr_employee_comp_rule" model="ir.rule">
+        <field name="name">Employee multi company rule</field>
+        <field name="model_id" ref="model_hr_employee"/>
+        <field name="domain_force">['|', '|', '|',
+            ('company_id', 'in', company_ids + [False]),
+            ('parent_id.user_id', '=', user.id),
+            ('id', '=', user.employee_id.parent_id.id),
+            ('user_id', '=', user.id)
+        ]</field>
+    </record>
+
     <record id="hr_dept_comp_rule" model="ir.rule">
         <field name="name">Department multi company rule</field>
         <field name="model_id" ref="model_hr_department"/>
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+    </record>
+
+    <record id="hr_employee_public_comp_rule" model="ir.rule">
+        <field name="name">Employee multi company rule</field>
+        <field name="model_id" ref="model_hr_employee_public"/>
+        <field name="domain_force">['|', '|', '|',
+            ('company_id', 'in', company_ids + [False]),
+            ('parent_id.user_id', '=', user.id),
+            ('id', '=', user.employee_id.parent_id.id),
+            ('user_id', '=', user.id)
+        ]</field>
     </record>
 
     <record id="hr_job_comp_rule" model="ir.rule">

--- a/addons/hr/tests/test_multi_company.py
+++ b/addons/hr/tests/test_multi_company.py
@@ -97,3 +97,11 @@ class TestMultiCompany(TestHrCommon):
 
         with self.assertRaises(AccessError):
             self.employee_a.with_user(self.user_b).name
+
+    def test_compute_presence_state(self):
+        self.user_a.company_ids = self.company_a
+        # user A should still read the employee since he is the manager of that employee
+        self.employee_b.with_user(self.user_a).with_company(self.company_a).name
+
+        # user A should still read hr_presence_state even if he does not have access to the company of the employee
+        self.employee_b.with_user(self.user_a).with_company(self.company_a).hr_presence_state

--- a/addons/hr/tests/test_multi_company.py
+++ b/addons/hr/tests/test_multi_company.py
@@ -1,6 +1,12 @@
+# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.hr.tests.common import TestHrCommon
+from odoo.addons.base.models.ir_qweb import QWebException
+
+from odoo.addons.mail.tests.common import mail_new_test_user
+
+from odoo.exceptions import AccessError
 
 
 class TestMultiCompanyReport(TestHrCommon):
@@ -30,3 +36,64 @@ class TestMultiCompanyReport(TestHrCommon):
         )._render_qweb_pdf('hr.hr_employee_print_badge', res_ids=self.employees.ids)
         self.assertIn(b'Bidule', content)
         self.assertIn(b'Machin', content)
+
+    def test_single_company_report(self):
+        with self.assertRaises(QWebException):  # CacheMiss followed by AccessError
+            self.env['ir.actions.report'].with_user(self.res_users_hr_officer).with_company(
+                self.company_1
+            )._render_qweb_pdf('hr.hr_employee_print_badge', res_ids=self.employees.ids)
+
+
+class TestMultiCompany(TestHrCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.company_a = cls.env['res.company'].create({'name': 'Company A'})
+        cls.company_b = cls.env['res.company'].create({'name': 'Company B'})
+
+        cls.user_a = mail_new_test_user(cls.env, login='user_a', company_id=cls.company_a.id, company_ids=(cls.company_a | cls.company_b).ids)
+        cls.user_b = mail_new_test_user(cls.env, login='user_b', company_id=cls.company_b.id)
+
+        cls.employee_a = cls.env['hr.employee'].create({
+            'name': 'Employee A',
+            'company_id': cls.company_a.id,
+            'user_id': cls.user_a.id,
+        })
+
+        cls.employee_other_a = cls.env['hr.employee'].create({
+            'name': 'Employee Other A',
+            'company_id': cls.company_a.id,
+        })
+
+        cls.employee_b = cls.env['hr.employee'].create({
+            'name': 'Employee B',
+            'company_id': cls.company_b.id,
+            'user_id': cls.user_b.id,
+            'parent_id': cls.employee_a.id,
+        })
+
+        cls.employee_other_b = cls.env['hr.employee'].create({
+            'name': 'Employee Other B',
+            'company_id': cls.company_b.id,
+        })
+
+        cls.env.flush_all()
+        cls.env.invalidate_all()
+
+    def test_read_manager_employee(self):
+        # UserB should be able to read its manager's record - without being connected
+        # on company A
+        self.employee_a.with_user(self.user_b).with_company(self.company_b).name
+
+        self.employee_b.with_user(self.user_a).with_company(self.company_a).name
+
+        # UserB should not be able to read other employees in that company
+        with self.assertRaises(AccessError):
+            self.employee_other_a.with_user(self.user_b).with_company(self.company_b).name
+
+    def test_read_no_manager_company(self):
+        self.employee_b.parent_id = False
+
+        with self.assertRaises(AccessError):
+            self.employee_a.with_user(self.user_b).name

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -167,7 +167,7 @@
         <record id="hr_employee_public_action" model="ir.actions.act_window">
             <field name="name">Employees</field>
             <field name="res_model">hr.employee.public</field>
-            <field name="domain">[]</field>
+            <field name="domain">[('company_id', 'in', allowed_company_ids)]</field>
             <field name="context">{'chat_icon': True}</field>
             <field name="view_id" eval="False"/>
             <field name="search_view_id" ref="hr_employee_public_view_search"/>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -388,7 +388,7 @@
             <field name="name">Employees</field>
             <field name="path">employees</field>
             <field name="res_model">hr.employee</field>
-            <field name="domain">[]</field>
+            <field name="domain">[('company_id', 'in', allowed_company_ids)]</field>
             <field name="context">{'chat_icon': True, 'searchpanel_default_company_id': allowed_company_ids[0]}</field>
             <field name="view_id" eval="False"/>
             <field name="search_view_id" ref="view_employee_filter"/>

--- a/addons/web_hierarchy/static/src/hierarchy_model.js
+++ b/addons/web_hierarchy/static/src/hierarchy_model.js
@@ -790,12 +790,6 @@ export class HierarchyModel extends Model {
         if (!this.env.searchModel) {
             return true;
         }
-        if (this.env.searchModel.display?.searchPanel) {
-            const searchPanelDomain = this.env.searchModel._getSearchPanelDomain();
-            if (searchPanelDomain.toList(this.env.searchModel.context).length) {
-                return false;
-            }
-        }
         const isDisabledOptionalSearchMenuType = (type) => {
             return (
                 ["filter", "groupBy", "favorite"].includes(type) &&


### PR DESCRIPTION
## [REV] hr: remove multi-company rule for hr.employee model

This reverts commit https://github.com/odoo/odoo/commit/a3ade5876f488f298204c496cbee3a948ae93e0e because
without the multi-company rules in hr.employee model, it causes several
issues on others models linked to `hr.employee` model.

This commit re-introduces the multi-company rules on `hr.employee` and
`hr.employee.public` to avoid having multi-company issues when we try
to read a time off of an employee inside another company than the ones
selected in the company selector.

## [REV] hr: display all allowed companies in search panel of employee view

This reverts commit https://github.com/odoo/odoo/commit/99e9656f3ced113129ff5a0f6ee1a327b051986c since the
multi-company rule in `hr.employee` and `hr.employee.public` has been
re-introduced we no longer need the custom code done in that commit.

## [REV] web_hierarchy: take into account the search panel

This reverts commit https://github.com/odoo/odoo/commit/2780bc83c23901cc2658d637222a6150c1928262.

Before this commit, the default domain was not added once the search
panel applies an additional domain. That change impacts the way we build
the hierarchy tree since we could have too much records instead of the
root.

This commit makes sure the hierarchy view will first fetch the root even
if the search panel applies an additional domain, if no root is found
all records that satisfy the domain without the default one will be
fetched.

## [IMP] hr: add a unit test for sudo added in _compute_presence_status

Before this commit, no test has been added to justify why the sudo has
been added in `_compute_presence_status` by the commit https://github.com/odoo/odoo/commit/a3ade5876f488f298204c496cbee3a948ae93e0e
since the multi company ir.rule has been reintroduced, we could
think the sudo could also be removed but since the ir.rule will allow
the manager user to see his subordinates in other companies even the
ones inside the company the user has not access, the sudo is thus still
needed to avoid having any access error.

This commit adds a test to justify the adding of the sudo in
`_compute_presence_status`.

task-4313650