### PR TITLE
[FIX] l10n_{cz,sk}: View company_registry based on country_code on res.partner view

### DIFF
--- a/addons/l10n_cz/views/res_partner_views.xml
+++ b/addons/l10n_cz/views/res_partner_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='vat']" position="before">
-                <field name="company_registry" invisible="'CZ' not in fiscal_country_codes"/>
+                <field name="company_registry" invisible="country_code != 'CZ'"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_sk/views/res_partner_views.xml
+++ b/addons/l10n_sk/views/res_partner_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='vat']" position="before">
-                <field name="company_registry" invisible="'SK' not in fiscal_country_codes"/>
+                <field name="company_registry" invisible="country_code != 'SK'"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Using fiscal_country_codes in the invisible condition can result in the field being displayed multiple times, as multiple countries may meet the condition. Instead, we are using country_code, as it is more logical for the field to be visible only if the company is located in that specific country.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr