### PR TITLE
[FIX] stock: avoid merging moves coming from diffrent kit

### DIFF
--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
 from odoo.tests import common, Form
 from odoo.exceptions import UserError
@@ -2465,3 +2466,51 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         self.bom_kit_1.write({'type': 'normal'})
         self.bom_kit_1.write({'type': 'phantom'})
         self.bom_kit_1.unlink()
+
+    def test_merge_move_kit_on_adding_new_sol(self):
+        """
+        Create and confirm an SO for 2 similar kit products.
+        Add a new sale order line for an other unrelated prodcut.
+
+        Check that the delivery kit moves were not merged by the confirmation of the new move.
+        """
+        # grp_uom = self.env.ref('uom.group_uom')
+        warehouse = self.company_data['default_warehouse']
+        warehouse.delivery_steps = 'pick_ship'
+        kit = self.kit_3
+        # create a similar kit
+        bom_copy = kit.bom_ids[0].copy()
+        kit_copy = kit.copy()
+        bom_copy.product_tmpl_id = kit_copy.product_tmpl_id
+        # put component in stock: 10 kit = 10 x comp_f + 20 x comp_g
+        self.env['stock.quant']._update_available_quantity(self.component_f, warehouse.lot_stock_id, 10)
+        self.env['stock.quant']._update_available_quantity(self.component_g, warehouse.lot_stock_id, 20)
+        self.env['stock.quant']._update_available_quantity(self.component_a, warehouse.lot_stock_id, 5)
+
+        so_form = Form(self.env['sale.order'])
+        so_form.partner_id = self.partner_a
+        with so_form.order_line.new() as line:
+            line.product_id = kit
+            line.product_uom_qty = 2
+        with so_form.order_line.new() as line:
+            line.product_id = kit_copy
+            line.product_uom_qty = 3
+        so = so_form.save()
+        so.action_confirm()
+
+        pick = so.picking_ids.filtered(lambda p: p.picking_type_id == warehouse.pick_type_id)
+        expected_pick_moves = [
+            { 'quantity': 2.0, 'product_id': self.component_f.id, 'bom_line_id': kit.bom_ids[0].bom_line_ids.filtered(lambda bl: bl.product_id == self.component_f).id},
+            { 'quantity': 3.0, 'product_id': self.component_f.id, 'bom_line_id': bom_copy.bom_line_ids.filtered(lambda bl: bl.product_id == self.component_f).id},
+            { 'quantity': 4.0, 'product_id': self.component_g.id, 'bom_line_id': kit.bom_ids[0].bom_line_ids.filtered(lambda bl: bl.product_id == self.component_g).id},
+            { 'quantity': 6.0, 'product_id': self.component_g.id, 'bom_line_id': bom_copy.bom_line_ids.filtered(lambda bl: bl.product_id == self.component_g).id},
+        ]
+        self.assertRecordValues(pick.move_ids.sorted(lambda m: m.quantity), expected_pick_moves)
+        with Form(so) as so_form:
+            with so_form.order_line.new() as line:
+                line.product_id = self.component_a
+                line.product_uom_qty = 1
+        expected_pick_moves = [
+            { 'quantity': 1.0, 'product_id': self.component_a.id, 'bom_line_id': False},
+        ] + expected_pick_moves
+        self.assertRecordValues(pick.move_ids.sorted(lambda m: m.quantity), expected_pick_moves)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1018,13 +1018,14 @@ Please change the quantity done or the rounding precision of your unit of measur
         :return: Recordset of moves passed to this method. If some of the passed moves were merged
         into another existing one, return this one and not the (now unlinked) original.
         """
-        distinct_fields = self._prepare_merge_moves_distinct_fields()
 
         candidate_moves_set = set()
         if not merge_into:
             self._update_candidate_moves_list(candidate_moves_set)
         else:
             candidate_moves_set.add(merge_into | self)
+
+        distinct_fields = (self | self.env['stock.move'].concat(*candidate_moves_set))._prepare_merge_moves_distinct_fields()
 
         # Move removed after merge
         moves_to_unlink = self.env['stock.move']


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable Multi-Steps Routes
- Inventory > Configuration > Warehouse Management > Warehouses
- Put you warehouse in delivery in 2 steps
- Create 4 storable products: Kit 1, Kit 2, content, foo
- Create 2 boms of type kit: one for Kit 1 and one for Kit 2, both with:
  - 1 x content
- Create and confirm a sale order with two lines:
  - 1 x Kit 1
  - 1 x Kit 2
> On the associated pick, you can see 2 distinct moves: one per kit
- On the SO add a line for 1 unit of foo and save the SO
#### > On the associated pick both kit moves were merged.

### Cause of the issue:

When you add 1 unit of foo, the `_action_launch_stock_rule` will be called in order to create and confirm the associated stock moves. During the `_action_confirm` of this move a `_merge_moves` will be called to determine if the move can be merged with any other already existing one. However, this merge operation will actually be performed on each of the move present in the "candidate_move_set" which includes all the moves of the already existing picking:
https://github.com/odoo/odoo/blob/8c5ad7621fe8370da4c28d42a51ba06e15ce42ee/addons/stock/models/stock_move.py#L1015-L1027 https://github.com/odoo/odoo/blob/8c5ad7621fe8370da4c28d42a51ba06e15ce42ee/addons/stock/models/stock_move.py#L1011-L1013 This is problematic since the `disting_fields` used as a merging criterion are based solely on the records present in self and not on the candidates on which the merging might be performed: https://github.com/odoo/odoo/blob/8c5ad7621fe8370da4c28d42a51ba06e15ce42ee/addons/stock/models/stock_move.py#L1021 In our case, the reason why the two kit moves where not merged the first time that they were confirmed was because the `bom_line_id` was added to the distinct fields by:
https://github.com/odoo/odoo/blob/8c5ad7621fe8370da4c28d42a51ba06e15ce42ee/addons/mrp/models/stock_move.py#L605-L609 But on the action confirm of the foo move and since this move is not assocaited with a `bom_line_id` of phantom type, it will not and the two kit moves will be considered as good condidates to merge into one an other.

### Fix:

The `distinct_fields` used as a merging criterion should be based on the set of all moves that are  considered to be merged rather than to the moves that we initially wanted to merge.

opw-4337128
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
