### PR TITLE
[FIX] sale_pdf_quote_builder: don't raise for pdf warnings

### DIFF
--- a/addons/sale_pdf_quote_builder/utils.py
+++ b/addons/sale_pdf_quote_builder/utils.py
@@ -24,6 +24,6 @@ def _get_form_fields_from_pdf(pdf_data):
     :return: set of form fields that are in the pdf.
     :rtype: set
     """
-    reader = pdf.PdfFileReader(io.BytesIO(base64.b64decode(pdf_data)))
+    reader = pdf.PdfFileReader(io.BytesIO(base64.b64decode(pdf_data)), strict=False)
 
     return set(reader.getFormTextFields() or {})


### PR DESCRIPTION
Trying to upload a PDF, in some circumstances (e.g. multiple info due to pypdf being exported multiple times), would raise some warnings that were caught instead of being ignored.
