### PR TITLE
[FIX] web: EN is doubled on hover for ir.ui.views

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -659,7 +659,7 @@
             .btn {
                 width: 100% !important;
                 margin-left: 0px;
-                visibility: hidden;
+                visibility: hidden !important;
             }
 
             .btn:after {


### PR DESCRIPTION
The button is doubled because the visibility is overriden. 
Let's force it.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
