### PR TITLE
[FIX] pos_hr: basic user cannot close session

### DIFF
--- a/addons/pos_hr/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_hr/static/src/overrides/components/navbar/navbar.xml
@@ -4,13 +4,13 @@
     <t t-name="pos_hr.Navbar" t-inherit="point_of_sale.Navbar" t-inherit-mode="extension">
         <xpath expr="//li[hasclass('backend-button')]" position="attributes">
             <attribute name="t-if">
-                !pos.config.module_pos_hr or pos.get_cashier().role === 'manager' or pos.get_cashier_user_id() === pos.user.id
+                !pos.config.module_pos_hr or pos.get_cashier().role === 'manager' or pos.get_cashier_user_id() === pos.pos_session.user_id[0]
             </attribute>
         </xpath>
 
         <xpath expr="//li[hasclass('close-button')]" position="attributes">
             <attribute name="t-if">
-                !pos.config.module_pos_hr or pos.get_cashier().role === 'manager' or pos.get_cashier_user_id() === pos.user.id
+                !pos.config.module_pos_hr or pos.get_cashier().role === 'manager' or pos.get_cashier_user_id() === pos.pos_session.user_id[0]
             </attribute>
         </xpath>
 

--- a/addons/pos_hr/static/tests/tours/PosHrTour.js
+++ b/addons/pos_hr/static/tests/tours/PosHrTour.js
@@ -8,6 +8,7 @@ import * as ErrorPopup from "@point_of_sale/../tests/tours/helpers/ErrorPopupTou
 import * as NumberPopup from "@point_of_sale/../tests/tours/helpers/NumberPopupTourMethods";
 import * as SelectionPopup from "@point_of_sale/../tests/tours/helpers/SelectionPopupTourMethods";
 import { registry } from "@web/core/registry";
+import { negate } from "../../../../point_of_sale/static/tests/tours/helpers/utils";
 
 registry.category("web_tour.tours").add("PosHrTour", {
     test: true,
@@ -109,5 +110,22 @@ registry.category("web_tour.tours").add("CashierStayLogged", {
             PosHr.clickLockButton(),
             PosHr.refreshPage(),
             PosHr.loginScreenIsShown(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("CashierCannotClose", {
+    test: true,
+    steps: () =>
+        [
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            SelectionPopup.isShown(),
+            SelectionPopup.clickItem("Test Employee 3"),
+            PosHr.cashierNameIs("Test Employee 3"),
+            Chrome.clickMenuButton(),
+            {
+                trigger: negate(".close-button"),
+            },
+            PosHr.cashierNameIs("Test Employee 3"),
         ].flat(),
 });

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -45,8 +45,14 @@ class TestPosHrHttpCommon(TestPointOfSaleHttpCommon):
         emp2.write({"name": "Pos Employee2", "pin": "1234"})
         (admin + emp1 + emp2).company_id = cls.env.company
 
+        emp3 = cls.env['hr.employee'].create({
+            'name': 'Test Employee 3',
+            "user_id": cls.pos_user.id,
+            "company_id": cls.env.company.id,
+        })
+
         cls.main_pos_config.write({
-            'basic_employee_ids': [Command.link(emp1.id), Command.link(emp2.id)]
+            'basic_employee_ids': [Command.link(emp1.id), Command.link(emp2.id), Command.link(emp3.id)]
         })
 
 
@@ -70,4 +76,14 @@ class TestUi(TestPosHrHttpCommon):
             "/pos/ui?config_id=%d" % self.main_pos_config.id,
             "CashierStayLogged",
             login="pos_admin",
+        )
+
+    def test_basic_user_cannot_close_session(self):
+        # open a session, the /pos/ui controller will redirect to it
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "CashierCannotClose",
+            login="pos_user",
         )


### PR DESCRIPTION
Basic user can close a PoS session that they did not open if the user logged on the DB is the same as the one linked to the cashier

Steps to reproduce:
-------------------
* Setup Mitchell Admin as advanced right user on PoS
* Setup Marc Demo as basic right user on PoS
* Open PoS as Mitchell Admin and login as cashier Marc Demo
> Observation: You are not able to close the session
* Log out of the Db and log back in as Marc Demo
* Open the same PoS
> Observation: You are able to close the session

Why the fix:
------------
To check if a user was able to close the session we were checking if the user logged in the Db was the same as the one in the cashier. But we need to check who opened the PoS not the current logged in user.

opw-4215083