### PR TITLE
[FIX] sale: do not recompute zero priced products

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1306,8 +1306,7 @@ class SaleOrder(models.Model):
     def _recompute_prices(self):
         lines_to_recompute = self._get_update_prices_lines()
         lines_to_recompute.invalidate_recordset(['pricelist_item_id'])
-        lines_to_recompute.technical_price_unit = 0.0
-        lines_to_recompute._compute_price_unit()
+        lines_to_recompute.with_context(force_price_recomputation=True)._compute_price_unit()
         # Special case: we want to overwrite the existing discount on _recompute_prices call
         # i.e. to make sure the discount is correctly reset
         # if pricelist rule is different than when the price was first computed.

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -544,13 +544,14 @@ class SaleOrderLine(models.Model):
             # check if the price has been manually set or there is already invoiced amount.
             # if so, the price shouldn't change as it might have been manually edited.
             if (
-                line.technical_price_unit not in (0.0, line.price_unit)
+                (line.technical_price_unit != line.price_unit and not line.env.context.get('force_price_recomputation'))
                 or line.qty_invoiced > 0
                 or (line.product_id.expense_policy == 'cost' and line.is_expense)
             ):
                 continue
             if not line.product_uom or not line.product_id:
                 line.price_unit = 0.0
+                line.technical_price_unit = 0.0
             else:
                 line = line.with_company(line.company_id)
                 price = line._get_display_price()

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -538,6 +538,22 @@ class TestSalePrices(SaleCommon):
             "Price should remain 100.0 after changing the quantity"
         )
 
+        zero_price_product = self._create_product(list_price=0.0)
+        self.assertEqual(zero_price_product.list_price, 0.0)
+        so_line = self.env['sale.order.line'].create({
+            'product_id': zero_price_product.id,
+            'order_id': self.sale_order.id,
+        })
+        self.assertEqual(so_line.price_unit, 0.0)
+        self.assertEqual(so_line.technical_price_unit, 0.0)
+
+        with Form(so_line) as so_line:
+            so_line.price_unit = 10.0
+            so_line.product_uom_qty = 2.0
+            so_line.save()
+
+        self.assertEqual(so_line.price_unit, 10.0)
+
     # Taxes tests:
     # We do not rely on accounting common on purpose to avoid
     # all the useless setup not needed here.


### PR DESCRIPTION
Recent commit c584a61697e4f4d196b4a485411135a96b0f6006 introduced a mechanism to avoid recomputing prices manually defined on sale order lines.  Nevertheless, it didn't consider zero-priced products.  If a product whose price was 0 (after pricelist computation) was set on the line, even if the price was manually changed to another amount, it was still recomputed when quantities or uom where changed.

opw-4329474
