### PR TITLE
[FIX] html_editor: open image preview on double click

### DIFF
--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -183,6 +183,11 @@ export class ImagePlugin extends Plugin {
     };
 
     setup() {
+        this.addDomListener(this.editable, "dblclick", (e) => {
+            if (e.target.tagName === "IMG") {
+                this.previewImage();
+            }
+        });
         this.addDomListener(this.editable, "pointerup", (e) => {
             if (e.target.tagName === "IMG") {
                 const [anchorNode, anchorOffset, focusNode, focusOffset] = boundariesOut(e.target);

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, press, queryOne, waitFor, waitUntil } from "@odoo/hoot-dom";
+import { click, press, queryOne, waitFor, waitUntil, dblclick } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { contains } from "@web/../tests/web_test_helpers";
@@ -431,4 +431,13 @@ test("can undo link removing of an image", async () => {
     undo(editor);
     await animationFrame();
     expect(img.parentElement.tagName).toBe("A");
+});
+
+test.tags("desktop")("Preview an image on dblclick", async () => {
+    await setupEditor(`
+        <img class="img-fluid test-image" src="${base64Img}">
+    `);
+    await dblclick("img.test-image");
+    await animationFrame();
+    expect(".o-FileViewer").toHaveCount(1);
 });


### PR DESCRIPTION
**Current behavior before PR:**

- Double clicking on an image opens the image toolbar.

**Desired behavior after PR is merged:**

- Now, double clicking on an image opens the image preview instead of toolbar.

task:4350231