### PR TITLE
[FIX] l10n_cl: document type for "2nd category"

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -42,7 +42,7 @@ class AccountMove(models.Model):
         elif self.partner_id.l10n_cl_sii_taxpayer_type == '1' and self.partner_id_vat == '60805000-0':
             domain += [('code', 'not in', ['39', '70', '71'])]
         elif self.partner_id.l10n_cl_sii_taxpayer_type == '2':
-            domain += [('code', 'in', ['70', '71', '56', '61'])]
+            domain += [('code', '=', '71')]
         elif self.partner_id.l10n_cl_sii_taxpayer_type == '3':
             domain += [('code', 'in', ['35', '38', '39', '41', '56', '61'])]
         elif self.partner_id.country_id.code != 'CL' or self.partner_id.l10n_cl_sii_taxpayer_type == '4':


### PR DESCRIPTION
When creating a supplier invoice for a provider of type "2nd category voucher issuer," the system incorrectly defaults the document type to 56 (Electronic Debit Note) instead of 71 (Electronic Fee Receipt). This results in additional manual corrections and risks errors if the document type is not updated before confirmation.

This fix ensures the system automatically selects document type 71 for providers of this category, streamlining the process and reducing error potential.

opw-4217228




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
