### PR TITLE
[FIX] calendar: fix issue with start and stop date

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -401,16 +401,24 @@ class Meeting(models.Model):
                 # because fullcalendar just drops times for full day events.
                 # i.e. Christmas is on 25/12 for everyone
                 # even if people don't celebrate it simultaneously
-                enddate = fields.Datetime.from_string(meeting.stop_date)
+                enddate = fields.Datetime.from_string(meeting.stop_date or meeting.stop)
                 enddate = enddate.replace(hour=18)
 
-                startdate = fields.Datetime.from_string(meeting.start_date)
+                startdate = fields.Datetime.from_string(meeting.start_date or meeting.start)
                 startdate = startdate.replace(hour=8)  # Set 8 AM
 
-                meeting.write({
-                    'start': startdate.replace(tzinfo=None),
-                    'stop': enddate.replace(tzinfo=None)
-                })
+                if meeting.start_date and meeting.stop_date:
+                    # If start_date or stop_date is set, use start_date and stop_date;
+                    # otherwise, use start and stop.
+                    meeting.write({
+                        'start': startdate.replace(tzinfo=None),
+                        'stop': enddate.replace(tzinfo=None)
+                    })
+                else:
+                    meeting.write({
+                        'start_date': startdate.replace(tzinfo=None),
+                        'stop_date': enddate.replace(tzinfo=None)
+                    })
 
     @api.constrains('start', 'stop', 'start_date', 'stop_date')
     def _check_closing_date(self):

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -480,6 +480,25 @@ class TestCalendar(SavepointCaseWithUserDemo):
             'partner_ids': [Command.link(new_partner) for new_partner in new_partners]
         })
         self.assertTrue(set(new_partners) == set(self.event_tech_presentation.videocall_channel_id.channel_partner_ids.ids), 'new partners must be invited to the channel')
+
+    def test_event_duplication_allday(self):
+        """Test that a calendar event is successfully duplicated with dates."""
+        # Create an event
+        calendar_event = self.env['calendar.event'].create({
+            'name': 'All Day',
+            'start': "2018-10-16 00:00:00",
+            'start_date': "2018-10-16",
+            'stop': "2018-10-18 00:00:00",
+            'stop_date': "2018-10-18",
+            'allday': True,
+        })
+        # Duplicate the event with explicit defaults for start_date and stop_date
+        new_calendar_event = calendar_event.copy()
+        # Ensure the copied event exists and retains the correct dates
+        self.assertTrue(new_calendar_event, "Event should be duplicated.")
+        self.assertEqual(new_calendar_event.start_date, calendar_event.start_date, "Start date should match the original.")
+        self.assertEqual(new_calendar_event.stop_date, calendar_event.stop_date, "Stop date should match the original.")
+
 @tagged('post_install', '-at_install')
 class TestCalendarTours(HttpCaseWithUserDemo):
     def test_calendar_month_view_start_hour_displayed(self):

--- a/addons/google_calendar/tests/test_sync_common.py
+++ b/addons/google_calendar/tests/test_sync_common.py
@@ -58,6 +58,15 @@ class TestSyncGoogle(HttpCase):
         self.assertEqual(args[1:], expected_args) # skip Google service arg
         self.assertEqual(kwargs, expected_kwargs)
 
+    def assertGoogleEventInsertedMultiTime(self, values, timeout=None):
+        expected_args = (values,)
+        expected_kwargs = {'timeout': timeout} if timeout else {}
+        GoogleSync._google_insert.assert_called()
+        args, kwargs = GoogleSync._google_insert.call_args
+        args[1:][0].pop('conferenceData', None)
+        self.assertEqual(args[1:], expected_args) # skip Google service arg
+        self.assertEqual(kwargs, expected_kwargs)
+
     def assertGoogleEventNotInserted(self):
         GoogleSync._google_insert.assert_not_called()
 

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -933,3 +933,43 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: recurrence.id}},
             'transparency': 'opaque',
         }, timeout=3)
+
+    @patch_api
+    def test_event_duplication_allday_google_calendar(self):
+        event = self.env['calendar.event'].with_user(self.organizer_user).create({
+            'name': "Event",
+            'allday': True,
+            'partner_ids': [(4, self.organizer_user.partner_id.id), (4, self.attendee_user.partner_id.id)],
+            'start': datetime(2020, 1, 15),
+            'stop': datetime(2020, 1, 15),
+            'need_sync': False,
+        })
+        event._sync_odoo2google(self.google_service)
+        event_response_data = {
+             'id': False,
+            'start': {'date': '2020-01-15', 'dateTime': None},
+            'end': {'date': '2020-01-16', 'dateTime': None},
+            'summary': 'Event',
+            'description': '',
+            'location': '',
+            'guestsCanModify': True,
+            'organizer': {'email': self.organizer_user.email, 'self': True},
+            'attendees': [
+                            {'email': self.attendee_user.email, 'responseStatus': 'needsAction'},
+                            {'email': self.organizer_user.email, 'responseStatus': 'accepted'}
+                         ],
+            'reminders': {'overrides': [], 'useDefault': False},
+            'visibility': 'public',
+            'transparency': 'opaque',
+        }
+        self.assertGoogleEventInsertedMultiTime({
+            **event_response_data,
+            'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.id}},
+        })
+
+        event2 = event.copy()
+        event2._sync_odoo2google(self.google_service)
+        self.assertGoogleEventInsertedMultiTime({
+            **event_response_data,
+            'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event2.id}},
+        })

--- a/addons/microsoft_calendar/tests/test_create_events.py
+++ b/addons/microsoft_calendar/tests/test_create_events.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, call
 from datetime import timedelta, datetime
 
 from odoo import Command
@@ -518,3 +518,34 @@ class TestCreateEvents(TestCommon):
         # Synchronize the calendar of user A, then make sure insert was not called.
         event.with_user(self.organizer_user).sudo()._sync_odoo2microsoft()
         mock_insert.assert_not_called()
+
+    @patch.object(MicrosoftCalendarService, 'get_events')
+    @patch.object(MicrosoftCalendarService, 'insert')
+    def test_create_duplicate_event_microsoft_calendar(self, mock_insert, mock_get_events):
+        """
+        Test syncing an event from Odoo to Microsoft Calendar.
+        """
+        record = self.env["calendar.event"].with_user(self.organizer_user).create(self.simple_event_values)
+
+        # Mock values to simulate Microsoft event creation
+        event_id = "123"
+        event_iCalUId = "456"
+        mock_insert.return_value = (event_id, event_iCalUId)
+        record2 = record.copy()
+        # Prepare the mock event response from Microsoft
+        self.response_from_outlook_organizer = {
+            **self.simple_event_from_outlook_organizer,
+            '_odoo_id': record.id,
+        }
+        self.response_from_outlook_organizer_1 = {
+            **self.simple_event_from_outlook_organizer,
+            '_odoo_id': record2.id,
+        }
+        mock_get_events.return_value = (MicrosoftEvent([self.response_from_outlook_organizer, self.response_from_outlook_organizer_1]), None)
+        self.organizer_user.with_user(self.organizer_user).sudo()._sync_microsoft_calendar()
+        self.call_post_commit_hooks()
+        record.invalidate_recordset()
+        record2.invalidate_recordset()
+
+        # Check that Microsoft insert was called exactly once
+        mock_insert.assert_called()


### PR DESCRIPTION
Version:
- 17.0

Steps to Reproduce:
- Install the Calendar app.
- Create an event and enable the "All Day" option.
- Duplicate the event.

Issue:
- When duplicating an All Day event, a traceback error occurs because the start_date and stop_date values are missing.

Solution:
- The start_date and stop_date are now properly set when duplicating an event resolving the traceback error.

task-4353039
