### PR TITLE
[FIX] hr_holidays: fix form view actions wizard

### DIFF
--- a/addons/hr_holidays/static/src/components/multi_time_off_generation_menu/multiple_time_off_generation_menu.js
+++ b/addons/hr_holidays/static/src/components/multi_time_off_generation_menu/multiple_time_off_generation_menu.js
@@ -35,6 +35,7 @@ export const multiTimeOffGenerationMenu = {
     groupNumber: STATIC_ACTIONS_GROUP_NUMBER,
     isDisplayed: async ({ config, searchModel }) => {
         return (
+            config.viewType !== "form" &&
             ["hr.leave", "hr.leave.allocation"].includes(searchModel.resModel) &&
             (await user.hasGroup("hr_holidays.group_hr_holidays_user"))
         );


### PR DESCRIPTION
Steps to reproduce:
---

Go in the Time Off app
Click on an allocation or a leave
Click on the action gear

Issue:
---
The gear action shows 2 times the "Multiple Requests", this comes from the fact that the wizard is in the xml and defined in the action_generate_allocations. So it is displayed twice in the form.

Fix:
---
Since the issue is only appearing in the form view, added the condition
on viewType.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
