### PR TITLE
[IMP] pos_restuarant: orderlines should stick to tables during table unmerge

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1311,6 +1311,7 @@ class PosOrderLine(models.Model):
     refunded_qty = fields.Float('Refunded Quantity', compute='_compute_refund_qty', help='Number of items refunded in this orderline.')
     uuid = fields.Char(string='Uuid', readonly=True, default=lambda self: str(uuid4()), copy=False)
     note = fields.Char('Product Note')
+    origin_order_id = fields.Many2one('pos.order', string='Origin Order', help='Tracks the original order from which this orderline was created.', readonly=True)
 
     combo_parent_id = fields.Many2one('pos.order.line', string='Combo Parent') # FIXME rename to parent_line_id
     combo_line_ids = fields.One2many('pos.order.line', 'combo_parent_id', string='Combo Lines') # FIXME rename to child_line_ids
@@ -1325,7 +1326,7 @@ class PosOrderLine(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return [
-            'qty', 'attribute_value_ids', 'custom_attribute_value_ids', 'price_unit', 'skip_change', 'uuid', 'price_subtotal', 'price_subtotal_incl', 'order_id', 'note', 'price_type',
+            'qty', 'attribute_value_ids', 'custom_attribute_value_ids', 'price_unit', 'skip_change', 'uuid', 'price_subtotal', 'price_subtotal_incl', 'order_id', 'origin_order_id', 'note', 'price_type',
             'product_id', 'discount', 'tax_ids', 'pack_lot_ids', 'customer_note', 'refunded_qty', 'price_extra', 'full_product_name', 'refunded_orderline_id', 'combo_parent_id', 'combo_line_ids', 'combo_item_id', 'refund_orderline_ids'
         ]
 

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -269,7 +269,14 @@ export class PosOrder extends Base {
     }
 
     hasSkippedChanges() {
-        return this.lines.find((orderline) => orderline.skip_change) ? true : false;
+        return Boolean(
+            this.lines.find(
+                (orderline) =>
+                    orderline.skip_change &&
+                    !orderline.uiState.hideSkipChangeClass &&
+                    !orderline.origin_order_id
+            )
+        );
     }
 
     isEmpty() {

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -377,7 +377,8 @@ export class PosStore extends WithLazyGetterTrap {
             if (order && (await this._onBeforeDeleteOrder(order))) {
                 if (
                     typeof order.id === "number" &&
-                    Object.keys(order.last_order_preparation_change).length > 0
+                    Object.keys(order.last_order_preparation_change).length > 0 &&
+                    !order.isTransferedOrder
                 ) {
                     await this.sendOrderInPreparation(order, true);
                 }

--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -9,6 +9,7 @@ class PosOrder(models.Model):
     table_id = fields.Many2one('restaurant.table', string='Table', help='The table where this order was served', index='btree_not_null', readonly=True)
     customer_count = fields.Integer(string='Guests', help='The amount of customers that have been served by this order.', readonly=True)
     takeaway = fields.Boolean(string="Take Away", default=False)
+    origin_table_id = fields.Many2one('restaurant.table', string='Original Table', help='The table where the order was originally created', readonly=True)
 
     @api.model
     def remove_from_ui(self, server_ids):

--- a/addons/pos_restaurant/static/src/app/models/pos_order_line.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order_line.js
@@ -18,11 +18,14 @@ patch(PosOrderline.prototype, {
             this.skip_change = !this.skip_change;
         }
     },
+    showSkipChange() {
+        return this.skip_change && !this.uiState.hideSkipChangeClass && !this.origin_order_id;
+    },
     getDisplayClasses() {
         return {
             ...super.getDisplayClasses(),
             "has-change": this.uiState.hasChange && this.config.module_pos_restaurant,
-            "skip-change": this.skip_change && this.config.module_pos_restaurant,
+            "skip-change": this.showSkipChange() && this.config.module_pos_restaurant,
         };
     },
 });

--- a/addons/pos_restaurant/static/src/app/models/restaurant_table.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_table.js
@@ -85,5 +85,15 @@ export class RestaurantTable extends Base {
     getName() {
         return this.table_number.toString();
     }
+    get children() {
+        return this["<-restaurant.table.parent_id"];
+    }
+    get rootTable() {
+        let table = this;
+        while (table.parent_id) {
+            table = table.parent_id;
+        }
+        return table;
+    }
 }
 registry.category("pos_available_models").add(RestaurantTable.pythonModel, RestaurantTable);

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
@@ -141,9 +141,8 @@ export class FloorScreen extends Component {
                 table.position_h = table.getX();
                 table.position_v = table.getY();
                 if (table.parent_id) {
-                    this.pos.data.write("restaurant.table", [table.id], {
-                        parent_id: null,
-                    });
+                    this.unMergeTable(table);
+                    this.pos.data.write("restaurant.table", [table.id], { parent_id: null });
                 }
             },
             onWillStartDrag: ({ element, x, y }) => {
@@ -218,7 +217,7 @@ export class FloorScreen extends Component {
                 }
                 const oToTrans = this.pos.getActiveOrdersOnTable(table)[0];
                 if (oToTrans) {
-                    this.pos.transferOrder(oToTrans.uuid, this.state.potentialLink.parent);
+                    this.pos.mergeTableOrders(oToTrans.uuid, this.state.potentialLink.parent);
                 }
                 this.pos.data.write("restaurant.table", [table.id], {
                     parent_id: this.state.potentialLink.parent.id,
@@ -529,6 +528,23 @@ export class FloorScreen extends Component {
         newTableData.active = true;
         const table = await this.pos.data.create("restaurant.table", [newTableData]);
         return table[0];
+    }
+    async unMergeTable(table) {
+        const mainOrder = this.pos.getActiveOrdersOnTable(table.rootTable)?.[0];
+        const orderToRestore =
+            table["<-pos.order.origin_table_id"].find((o) => !o.finalized) ||
+            table["<-pos.order.table_id"].find((o) => !o.finalized);
+        if (orderToRestore) {
+            // If no active order on the destination table, restore the original order
+            if (!mainOrder || mainOrder.id === orderToRestore.id) {
+                const order = this.pos.models["pos.order"].getBy("uuid", orderToRestore.uuid);
+                order.table_id = table;
+                this.pos.setOrder(order);
+                this.pos.addPendingOrder([order.id]);
+            } else {
+                await this.pos.restoreOrdersToOriginalTable(orderToRestore, mainOrder);
+            }
+        }
     }
     _getNewTableNumber() {
         let firstNum = 1;
@@ -927,9 +943,6 @@ export class FloorScreen extends Component {
         }
 
         return changeCount;
-    }
-    getChildren(table) {
-        return this.pos.models["restaurant.table"].filter((t) => t.parent_id?.id === table.id);
     }
     async uploadImage(event) {
         const file = event.target.files[0];

--- a/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
@@ -113,6 +113,20 @@ export function linkTables(child, parent) {
         },
     };
 }
+export function unlinkTables(child, parent) {
+    return {
+        content: `Drag table ${child} away from table ${parent} to unlink them`,
+        trigger: table({ name: child }).trigger,
+        async run(helpers) {
+            await helpers.drag_and_drop(`div.floor-map`, {
+                position: {
+                    bottom: 0,
+                },
+                relative: true,
+            });
+        },
+    };
+}
 export function isChildTable(child) {
     return {
         content: `Verify that table ${child} is a child table`,

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -241,6 +241,7 @@ class TestFrontend(TestFrontendCommon):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('SplitBillScreenTour')
         self.start_pos_tour('FloorScreenTour', login="pos_admin")
+        self.start_pos_tour('TableMergeUnmergeTour', login="pos_admin")
 
     def test_02_others_bis(self):
         self.pos_config.with_user(self.pos_admin).open_ui()


### PR DESCRIPTION
Before this commit:
===================
- If items were ordered on Table 1 and then merged into Table 2, those items
  had to be reordered for Table 2.
- When unmerging Table 1 from Table 2, Table 1 would lose its original orders,
  resulting in an empty table.
- A traceback occurred when attempting to merge more than two tables, each
  containing orders.

After this commit:
=============
- Items ordered on Table 1 remain ordered when merged into Table 2, eliminating
  the need to reorder.
- When unmerging, Table 1 regains its original orders. Items retain their status
  as ordered or not ordered based on their state(ordered or unorderd).
- The traceback issue when merging more than two tables with existing orders
  has been resolved.

Task- 4224207

Related Enterprise PR: https://github.com/odoo/enterprise/pull/74342