### PR TITLE
[FIX] hr: employees' bank accounts display name computation

### DIFF
--- a/addons/hr/models/res_partner.py
+++ b/addons/hr/models/res_partner.py
@@ -44,10 +44,11 @@ class ResPartnerBank(models.Model):
     _inherit = ['res.partner.bank']
 
     @api.depends_context('uid')
-    def _compute_display_name(self):
-        account_employee = self.browse()
+    def name_get(self):
+        res = super().name_get()
+        name_mapping = dict(res)
         if not self.user_has_groups('hr.group_hr_user'):
             account_employee = self.sudo().filtered("partner_id.employee_ids")
             for account in account_employee:
-                account.display_name = account.acc_number[:2] + "*" * len(account.acc_number[2:-4]) + account.acc_number[-4:]
-        super(ResPartnerBank, self - account_employee)._compute_display_name()
+                name_mapping[account.id] = account.acc_number[:2] + "*" * len(account.acc_number[2:-4]) + account.acc_number[-4:]
+        return list(name_mapping.items())


### PR DESCRIPTION
This is a fix for PR #187285. 

Without this PR, when having a user that does not belong to the 'hr.group_hr_user' group try to access the display name of an employee's bank account, we would get the following error.

![image](https://github.com/user-attachments/assets/cad5714e-93bb-4ae2-ada1-cdd748a5a7e3)

By using the method _name_get_ instead of __compute_display_name_, we avoid this error and can compute the field properly. Although the computation logic and end result is the same.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
