### PR TITLE
[IMP] point_of_sale: enhance _generate_pos_order_invoice method to support viewing multiple invoices

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -871,17 +871,27 @@ class PosOrder(models.Model):
         if not moves:
             return {}
 
-        return {
+        action_vals = {
             'name': _('Customer Invoice'),
-            'view_mode': 'form',
-            'view_id': self.env.ref('account.view_move_form').id,
             'res_model': 'account.move',
             'context': "{'move_type':'out_invoice'}",
             'type': 'ir.actions.act_window',
             'nodestroy': True,
             'target': 'current',
-            'res_id': moves and moves.ids[0] or False,
+            'domain': [('id', 'in', moves.ids)],
         }
+        if len(moves) == 1:
+            action_vals.update({
+                'views': [(self.env.ref('account.view_move_form').id, 'form')],
+                'view_mode': 'form',
+                'res_id': moves.id,
+            })
+        else:
+            action_vals.update({
+                'views': [(False, 'tree'), (self.env.ref('account.view_move_form').id, 'form')],
+                'view_mode': 'tree,form',
+            })
+        return action_vals
 
     # this method is unused, and so is the state 'cancel'
     def action_pos_order_cancel(self):


### PR DESCRIPTION
Previously, this method supported creating multiple invoices but only opened the first one, limiting both the user experience, prefetching and the ability to access all invoices in other methods. This enhancement resolves these issues by providing a complete and flexible solution.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
