### PR TITLE
[FIX] html_editor: prevent selection change on Powerbox menu interaction

### DIFF
--- a/addons/html_editor/static/src/main/powerbox/powerbox.xml
+++ b/addons/html_editor/static/src/main/powerbox/powerbox.xml
@@ -9,6 +9,7 @@
                 <div class="o-we-command d-flex align-items-center px-3 py-2 cursor-pointer"
                     t-att-class="{active: command_index === currentIndex}"
                     t-on-mouseenter="() => this.onMouseEnter(command_index)"
+                    t-on-mousedown="(ev) => ev.preventDefault()"
                     t-on-click="() => this.props.applyCommand(command)">
                     <div class="border rounded">
                         <i class="o-we-command-img d-flex align-items-center justify-content-center fa" t-att-class="command.icon"/>


### PR DESCRIPTION
**Problem**:
When the Powerbox menu is open (triggered by `/`), clicking on a command changes the selection inside the editor to the clicked element. For certain commands (e.g., "Button" or "Link"), this behavior disrupts functionality by preventing the popover from being properly linked to the newly added element (e.g., `<a>` tag), leading to misbehavior.

**Solution**:
Prevent selection changes when clicking on the Powerbox menu items, This fix aligns with the solution implemented in version 17.0: https://github.com/odoo/odoo/blob/cd989d4bf0cc4cedf43ec1d1d5a652beed105e23/addons/web_editor/static/src/js/editor/odoo-editor/src/powerbox/Powerbox.js#L51

**Steps to reproduce**:
1. Open the editor and trigger the Powerbox using `/`.
2. Click on "Button" or "Link".
3. Observe that no popover appears to configure the button/link.

opw-4333891

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
