### PR TITLE
[FIX] project, sale_timesheet: don't use label as helper

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -215,8 +215,13 @@ class Task(models.Model):
     company_id = fields.Many2one('res.company', string='Company', compute='_compute_company_id', store=True, readonly=False, recursive=True, copy=True, default=_default_company_id)
     color = fields.Integer(string='Color Index', export_string_translation=False)
     rating_active = fields.Boolean(string='Project Rating Status', related="project_id.rating_active")
-    attachment_ids = fields.One2many('ir.attachment', compute='_compute_attachment_ids', string="Attachments that don't come from a message",
-        export_string_translation=False)
+    attachment_ids = fields.One2many(
+        'ir.attachment',
+        compute='_compute_attachment_ids',
+        string="Attachments",
+        export_string_translation=False,
+        help="Attachments that don't come from a message",
+    )
     # In the domain of displayed_image_id, we couln't use attachment_ids because a one2many is represented as a list of commands so we used res_model & res_id
     displayed_image_id = fields.Many2one('ir.attachment', domain="[('res_model', '=', 'project.task'), ('res_id', '=', id), ('mimetype', 'ilike', 'image')]", string='Cover Image')
 

--- a/addons/sale_timesheet/models/project_project.py
+++ b/addons/sale_timesheet/models/project_project.py
@@ -32,8 +32,13 @@ class ProjectProject(models.Model):
         compute='_compute_pricing_type',
         search='_search_pricing_type',
         help='The task rate is perfect if you would like to bill different services to different customers at different rates. The fixed rate is perfect if you bill a service at a fixed rate per hour or day worked regardless of the employee who performed it. The employee rate is preferable if your employees deliver the same service at a different rate. For instance, junior and senior consultants would deliver the same service (= consultancy), but at a different rate because of their level of seniority.')
-    sale_line_employee_ids = fields.One2many('project.sale.line.employee.map', 'project_id', copy=False, export_string_translation=False,
-        string="Sales order item that will be selected by default on the timesheets of the corresponding employee. It bypasses the sales order item defined on the project and the task, and can be modified on each timesheet entry if necessary. In other words, it defines the rate at which an employee's time is billed based on their expertise, skills or experience, for instance.\n"
+    sale_line_employee_ids = fields.One2many(
+        'project.sale.line.employee.map',
+        'project_id',
+        'Sale line/Employee map',
+        copy=False,
+        export_string_translation=False,
+        help="Sales order item that will be selected by default on the timesheets of the corresponding employee. It bypasses the sales order item defined on the project and the task, and can be modified on each timesheet entry if necessary. In other words, it defines the rate at which an employee's time is billed based on their expertise, skills or experience, for instance.\n"
              "If you would like to bill the same service at a different rate, you need to create two separate sales order items as each sales order item can only have a single unit price at a time.\n"
              "You can also define the hourly company cost of your employees for their timesheets on this project specifically. It will bypass the timesheet cost set on the employee.")
     timesheet_product_id = fields.Many2one(


### PR DESCRIPTION
Before this commit, the #162167 PR changes the help into string for 2 fields since the string will not be translated and those fields are not displayed in the UI. However, those fields could be selected in custom search (when the user would like to add a custom field) and so the label displayed will be the helper.

This commit makes sure the helper is inside the help instead of `string` even if the field is a technical one since the field can be selected in the custom search.

opw-4348264