### PR TITLE
[FIX] stock: soft correct unsynch between quant and stock.move.line

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1080,7 +1080,7 @@ class StockQuant(models.Model):
             if quantity:
                 vals['quantity'] = quant.quantity + quantity
             if reserved_quantity:
-                vals['reserved_quantity'] = quant.reserved_quantity + reserved_quantity
+                vals['reserved_quantity'] = max(0, quant.reserved_quantity + reserved_quantity)
             quant.write(vals)
         else:
             vals = {
@@ -1133,6 +1133,41 @@ class StockQuant(models.Model):
         quants.sudo().unlink()
 
     @api.model
+    def _clean_reservations(self):
+        reserved_quants = self.env['stock.quant']._read_group(
+            [('reserved_quantity', '!=', 0)],
+            ['product_id', 'location_id', 'lot_id', 'package_id', 'owner_id'],
+            ['reserved_quantity:sum', 'id:recordset'],
+        )
+        reserved_move_lines = self.env['stock.move.line']._read_group(
+            [
+                ('state', 'in', ['assigned', 'partially_available', 'waiting', 'confirmed']),
+                ('quantity', '!=', 0),
+                ('product_id.is_storable', '=', True),
+            ],
+            ['product_id', 'location_id', 'lot_id', 'package_id', 'owner_id'],
+            ['quantity:sum'],
+        )
+        reserved_move_lines = {
+            (product, location, lot, package, owner): reserved_quantity
+            for product, location, lot, package, owner, reserved_quantity in reserved_move_lines
+        }
+        for product, location, lot, package, owner, reserved_quantity, quants in reserved_quants:
+            ml_reserved_qty = reserved_move_lines.get((product, location, lot, package, owner), 0)
+            if location.should_bypass_reservation():
+                quants._update_reserved_quantity(product, location, -reserved_quantity, lot_id=lot, package_id=package, owner_id=owner)
+            elif float_compare(reserved_quantity, ml_reserved_qty, precision_rounding=product.uom_id.rounding) != 0:
+                quants._update_reserved_quantity(product, location, ml_reserved_qty - reserved_quantity, lot_id=lot, package_id=package, owner_id=owner)
+            if ml_reserved_qty:
+                del reserved_move_lines[(product, location, lot, package, owner)]
+
+        for (product, location, lot, package, owner), reserved_quantity in reserved_move_lines.items():
+            if location.should_bypass_reservation():
+                continue
+            else:
+                self.env['stock.quant']._update_reserved_quantity(product, location, reserved_quantity, lot_id=lot, package_id=package, owner_id=owner)
+
+    @api.model
     def _merge_quants(self):
         """ In a situation where one transaction is updating a quant via
         `_update_available_quantity` and another concurrent one calls this function with the same
@@ -1144,7 +1179,7 @@ class StockQuant(models.Model):
                         dupes AS (
                             SELECT min(id) as to_update_quant_id,
                                 (array_agg(id ORDER BY id))[2:array_length(array_agg(id), 1)] as to_delete_quant_ids,
-                                SUM(reserved_quantity) as reserved_quantity,
+                                GREATEST(0, SUM(reserved_quantity)) as reserved_quantity,
                                 SUM(inventory_quantity) as inventory_quantity,
                                 SUM(quantity) as quantity,
                                 MIN(in_date) as in_date
@@ -1182,6 +1217,7 @@ class StockQuant(models.Model):
     @api.model
     def _quant_tasks(self):
         self._merge_quants()
+        self._clean_reservations()
         self._unlink_zero_quants()
 
     @api.model


### PR DESCRIPTION
It happens due to many reasons that the `stock.quant` object and `stock.move.line` loose their synchronisation and it could have a difference between the sum of `stock.move.line` and the quantity/reserved quantity on the `stock.quant`

It's important to keep tracking why the desycnh happens and to fix all the root causes of it.

However, it's hard for the user to clean the data himself or even worst to lock him when it happens (as before 18.0).

For quantity: It's not a big deal to have a huge difference between the quantity and all the long time history. As in real life, the inventory adjustement can help to clean the data.

For reserved quantity: It's a bigger problem since the user can't edit it. A first step would be to never write it to a negative value (since it should never happen). That way when the user empty the stock, it will also probably clean the reserved quantity. But in case where there is more reservation than on `stock.move.line`. We should also clean it to be able to reserve them. Currently, we will try in the scheduler for that part

A last step, could be to create a constraint during test that ensure the synch is never broken and it could raise directly if the developer made a mistake

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
