### PR TITLE
[FIX] point_of_sale: use correct identifier for lot/sn lines of order lines

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -146,7 +146,7 @@ export class PosOrderline extends Base {
         const lotLinesToRemove = [];
 
         for (const lotLine of this.pack_lot_ids) {
-            const modifiedLotName = modifiedPackLotLines[lotLine.uuid];
+            const modifiedLotName = modifiedPackLotLines[lotLine.id];
             if (modifiedLotName) {
                 lotLine.lot_name = modifiedLotName;
             } else {
@@ -156,7 +156,7 @@ export class PosOrderline extends Base {
 
         // Remove those that needed to be removed.
         for (const lotLine of lotLinesToRemove) {
-            this.pack_lot_ids = this.pack_lot_ids.filter((pll) => pll.uuid !== lotLine.uuid);
+            this.pack_lot_ids = this.pack_lot_ids.filter((pll) => pll.id !== lotLine.id);
         }
 
         for (const newLotLine of newPackLotLines) {
@@ -342,6 +342,9 @@ export class PosOrderline extends Base {
     merge(orderline) {
         this.order_id.assert_editable();
         this.set_quantity(this.get_quantity() + orderline.get_quantity());
+        this.update({
+            pack_lot_ids: [["link", ...orderline.pack_lot_ids]],
+        });
     }
 
     set_unit_price(price) {

--- a/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
@@ -239,3 +239,36 @@ registry.category("web_tour.tours").add("RefundFewQuantities", {
             Order.hasLine("Sugar", "-0.02", "-0.06"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("LotTour", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            ProductScreen.enterLotNumber("1"),
+            ProductScreen.selectedOrderlineHas("Product A", "1.00"),
+            inLeftSide(
+                [
+                    ProductScreen.clickLotIcon(),
+                    ProductScreen.enterLotNumber("2"),
+                    Order.hasLine({
+                        productName: "Product A",
+                        quantity: 1.0,
+                    }),
+                    ProductScreen.clickLotIcon(),
+                    ProductScreen.enterLastLotNumber("1"),
+                    Order.hasLine({
+                        productName: "Product A",
+                        quantity: 2.0,
+                    }),
+                ].flat()
+            ),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            ProductScreen.enterLastLotNumber("3"),
+            ProductScreen.selectedOrderlineHas("Product A", "3.00"),
+            inLeftSide({
+                trigger: ".info-list:contains('SN 3')",
+            }),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -372,6 +372,16 @@ export function enterLotNumber(number) {
         Dialog.confirm(),
     ];
 }
+export function enterLastLotNumber(number) {
+    return [
+        {
+            content: "enter lot number",
+            trigger: ".edit-list-inputs .input-group:last-child input",
+            run: "edit " + number,
+        },
+        Dialog.confirm(),
+    ];
+}
 
 export function isShown() {
     return [

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1587,6 +1587,17 @@ class TestUi(TestPointOfSaleHttpCommon):
             self.main_pos_config.open_ui()
             self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'SearchMoreCustomer', login="pos_user")
 
+    def test_lot(self):
+        self.product1 = self.env['product.product'].create({
+            'name': 'Product A',
+            'is_storable': True,
+            'tracking': 'serial',
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'available_in_pos': True,
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'LotTour', login="pos_user")
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
 - for model 'pos.pack.operation.lot', `id` is the [identifier](https://github.com/odoo/odoo/blob/18.0/addons/point_of_sale/static/src/app/models/data_service_options.js#L21) but `setPackLotLines` method [uses](https://github.com/odoo/odoo/blob/saas-17.4/addons/point_of_sale/static/src/app/models/pos_order_line.js#L144) `uuid`, making operation weird and faulty.
 - As `eg: lotline.uuid => undefined`  
 - This pr attempts to fix the issue linked with modifying orderlines with sn/lots

Steps to reproduce considering [this diff](https://github.com/odoo/odoo/pull/187796/files#diff-3bfb78fa74ffa64630e11266674f185a18e3c97587590b4b55da6388cb8ba487R148) :

    - Open POS.
    - Add a products which is tracked by sn and add two sn
![image](https://github.com/user-attachments/assets/2f4ea89c-df31-40db-8bd9-9c972aa12d2a)

    - removing the last sn, will remove all sn from orderline
![image](https://github.com/user-attachments/assets/ecd36dfd-5481-4ac8-9a86-b255a3e1d27a)


Note: this pr would make more sense if [this pr](https://github.com/odoo/odoo/pull/187796) is backporterd to saas-17.4,
      as there is an oversight in replacing all `uuid` references to `id` the mentioned commit. [see](https://github.com/odoo/odoo/pull/187796/files#diff-3bfb78fa74ffa64630e11266674f185a18e3c97587590b4b55da6388cb8ba487R148) 
     Also, root issue was in saas-17.4, while a fix was made in v18.0


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
