### PR TITLE
[FIX] pos_sale: allow downpayment invoicing for non pos user

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -122,5 +122,5 @@ class SaleOrderLine(models.Model):
 
     def _get_downpayment_line_price_unit(self, invoices):
         return super()._get_downpayment_line_price_unit(invoices) + sum(
-            pol.price_unit for pol in self.pos_order_line_ids
+            pol.price_unit for pol in self.sudo().pos_order_line_ids
         )


### PR DESCRIPTION
Steps to reproduce:
-------------------
- Make a sale order in the **Sale** app
- Confirm sale order
- Create invoice of Downpayment
- Type 50%
- Confirm invoice
> Observation: Access error: pos_order_line_ids (allowed for groups 'Point of sale / Users')

Why the fix:
------------
Users who do not belong to the point_of_sale.group_pos_user group get the error
when they try to confirm an invoice of downpayment.

User that have admin rights on accounting but are not users of pos should still
be able to invoice downpayments.

Introduced here:
https://github.com/odoo/odoo/commit/370f3bc

opw-[4352799](https://www.odoo.com/web#id=4352799&view_type=form&model=project.task)
