### PR TITLE
[15.0][FIX] stock_account: Valuation is zero after return even with owner set

### DIFF
--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -74,7 +74,8 @@ class StockValuationLayer(models.Model):
                 continue
             candidate_quantity = abs(candidate.quantity)
             returned_qty = sum([sm.product_uom._compute_quantity(sm.quantity_done, self.uom_id)
-                                for sm in candidate.stock_move_id.returned_move_ids if sm.state == 'done'])
+                                for sm in candidate.stock_move_id.returned_move_ids if sm.state == 'done' and (
+                                    sm.restrict_partner_id.id in (False, sm.company_id.partner_id.id))])
             candidate_quantity -= returned_qty
             if float_is_zero(candidate_quantity, precision_rounding=rounding):
                 continue


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Valuation is zero after return even with owner set in the return.
The method _compute_purchase_price uses _compute_average_price and this uses _consume_specific_qty to get real valuation of moves.


**Current behavior before PR:**

The valuation of the cost is zero if a return is made by assigning an owner.

**Desired behavior after PR is merged:**

This return with owner set should not be taken into account for this calculation, as the goods are not ours, so the cost should continue to be that of the departure of the goods.


@Tecnativa TT51835
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
