### PR TITLE
[FIX] pos_restaurant: prevent error when splitting floating order

### DIFF
--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -59,7 +59,11 @@ export class SplitBillScreen extends Component {
         const originalOrder = this.pos.models["pos.order"].find((o) => o.uuid === curOrderUuid);
         this.pos.selectedTable = null;
         const newOrder = this.pos.add_new_order();
-        newOrder.note = `${newOrder.tracking_number} Split from ${originalOrder.table_id.name}`;
+        newOrder.note = `${newOrder.tracking_number} Split from ${
+            originalOrder.table_id
+                ? originalOrder.table_id.name
+                : originalOrder.getFloatingOrderName()
+        }`;
         newOrder.uiState.splittedOrderUuid = curOrderUuid;
         await this.preSplitOrder(originalOrder, newOrder);
         // Create lines for the new order


### PR DESCRIPTION
Before this commit, splitting a floating order would cause an error.

opw-4348537

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
