### PR TITLE
[IMP] html_editor: split over block segments 

### DIFF
--- a/addons/html_editor/static/src/core/base_container_plugin.js
+++ b/addons/html_editor/static/src/core/base_container_plugin.js
@@ -12,7 +12,6 @@ import { Plugin } from "../plugin";
 import { fillEmpty } from "@html_editor/utils/dom";
 import {
     BASE_CONTAINER_CLASS,
-    SUPPORTED_BASE_CONTAINER_NAMES,
     baseContainerGlobalSelector,
     createBaseContainer,
 } from "../utils/base_container";
@@ -74,7 +73,7 @@ export class BaseContainerPlugin extends Plugin {
             (node) =>
                 !node ||
                 node.nodeType !== Node.ELEMENT_NODE ||
-                !SUPPORTED_BASE_CONTAINER_NAMES.includes(node.tagName) ||
+                !this.config.baseContainers.includes(node.tagName) ||
                 isProtected(node) ||
                 isProtecting(node) ||
                 isMediaElement(node),
@@ -112,7 +111,7 @@ export class BaseContainerPlugin extends Plugin {
         let anchorNode = node.parentElement;
         if (
             anchorNode === closestEditable(node) ||
-            !SUPPORTED_BASE_CONTAINER_NAMES.includes(anchorNode.nodeName) ||
+            !this.config.baseContainers.includes(anchorNode.nodeName) ||
             this.getResource("unremovable_node_predicates").some((p) => p(anchorNode))
         ) {
             return;

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -580,9 +580,15 @@ export class DomPlugin extends Plugin {
     }
 
     getBlocksToSet() {
-        const targetedBlocks = [...this.dependencies.selection.getTargetedBlocks()];
+        const isCollapsed = this.dependencies.selection.getEditableSelection().isCollapsed;
+        const targetedNodes = this.dependencies.selection.getTargetedNodes();
+        const lastTargetedNode = targetedNodes.slice(-1)[0];
+        const targetedBlocks = [...new Set(targetedNodes.map(closestBlock).filter(Boolean))];
         return targetedBlocks.filter(
             (block) =>
+                // If the selection ends in a block, the block is not visibly
+                // selected so exclude it.
+                (isCollapsed || block !== lastTargetedNode) &&
                 this.isRetaggingSafe(block) &&
                 !descendants(block).some((descendant) => targetedBlocks.includes(descendant)) &&
                 block.isContentEditable
@@ -599,17 +605,22 @@ export class DomPlugin extends Plugin {
      * @param {string} [param0.extraClass]
      */
     setBlock({ tagName, extraClass = "" }) {
-        let newCandidate = this.document.createElement(tagName.toUpperCase());
-        if (extraClass) {
-            newCandidate.classList.add(extraClass);
-        }
-        if (this.dependencies.baseContainer.isCandidateForBaseContainer(newCandidate)) {
-            const baseContainer = this.dependencies.baseContainer.createBaseContainer(
-                newCandidate.nodeName
-            );
-            this.copyAttributes(newCandidate, baseContainer);
-            newCandidate = baseContainer;
-        }
+        const createNewCandidate = () => {
+            let newCandidate = this.document.createElement(tagName.toUpperCase());
+            if (extraClass) {
+                newCandidate.classList.add(extraClass);
+            }
+            if (this.dependencies.baseContainer.isCandidateForBaseContainer(newCandidate)) {
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer(
+                    newCandidate.nodeName
+                );
+                this.copyAttributes(newCandidate, baseContainer);
+                newCandidate = baseContainer;
+            }
+            return newCandidate;
+        };
+        let newCandidate = createNewCandidate();
+        this.dependencies.split.splitBlockSegments();
         const cursors = this.dependencies.selection.preserveSelection();
         const newEls = [];
         for (const block of this.getBlocksToSet()) {
@@ -643,6 +654,7 @@ export class DomPlugin extends Plugin {
                 newCandidate.append(...childNodes(block));
                 block.append(newCandidate);
                 cursors.remapNode(block, newCandidate);
+                newCandidate = createNewCandidate();
             }
         }
         cursors.restore();

--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -98,7 +98,7 @@ export class ShortCutPlugin extends Plugin {
         }
         const precedingText = blockEl.textContent.substring(0, spaceOffset - 1);
         const matchedShortcut = this.getResource("shorthands").find(({ pattern }) =>
-            pattern.test(precedingText)
+            pattern.test(precedingText.trim())
         );
         if (matchedShortcut) {
             const command = this.dependencies.userCommand.getCommand(matchedShortcut.commandId);

--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -36,7 +36,7 @@ import { leftLeafOnlyNotBlockPath } from "@html_editor/utils/dom_state";
 
 export class ShortCutPlugin extends Plugin {
     static id = "shortcut";
-    static dependencies = ["userCommand", "selection"];
+    static dependencies = ["userCommand", "selection", "split"];
 
     /** @type {import("plugins").EditorResources} */
     resources = {
@@ -85,24 +85,38 @@ export class ShortCutPlugin extends Plugin {
             return;
         }
         const selection = this.dependencies.selection.getEditableSelection();
-        const blockEl = closestBlock(selection.anchorNode);
+        let blockEl = closestBlock(selection.anchorNode);
         const leftDOMPath = leftLeafOnlyNotBlockPath(selection.anchorNode);
         let spaceOffset = selection.anchorOffset;
+        let lineBreak;
+        let lineOffset = 0;
         let leftLeaf = leftDOMPath.next().value;
         while (leftLeaf) {
             // Calculate spaceOffset by adding lengths of previous text nodes
             // to correctly find offset position for selection within inline
             // elements. e.g. <p>ab<strong>cd []e</strong></p>
-            spaceOffset += leftLeaf.length;
+            spaceOffset += leftLeaf.length || 0;
+            // Similarly, calculate lineOffset to find the beginning of the line
+            // by adding lengths of previous nodes from the moment a line break
+            // is found.
+            if (lineBreak) {
+                lineOffset += leftLeaf.length || 0;
+            } else if (leftLeaf.nodeName === "BR") {
+                lineBreak = leftLeaf;
+            }
             leftLeaf = leftDOMPath.next().value;
         }
-        const precedingText = blockEl.textContent.substring(0, spaceOffset - 1);
+        const precedingText = blockEl.textContent.substring(lineOffset, spaceOffset - 1);
         const matchedShortcut = this.getResource("shorthands").find(({ pattern }) =>
             pattern.test(precedingText.trim())
         );
         if (matchedShortcut) {
             const command = this.dependencies.userCommand.getCommand(matchedShortcut.commandId);
             if (command) {
+                if (lineBreak) {
+                    this.dependencies.split.splitBlockSegments();
+                    blockEl = closestBlock(selection.anchorNode);
+                }
                 this.dependencies.selection.setSelection({
                     anchorNode: blockEl.firstChild,
                     anchorOffset: 0,

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -1,16 +1,39 @@
+import { isListItem } from "@html_editor/main/list/utils";
 import { Plugin } from "../plugin";
-import { isBlock } from "../utils/blocks";
+import { isBlock, closestBlock } from "../utils/blocks";
 import { fillEmpty, splitTextNode } from "../utils/dom";
 import {
+    allowsParagraphRelatedElements,
     isContentEditable,
     isContentEditableAncestor,
+    isPhrasingContent,
     isTextNode,
     isVisible,
 } from "../utils/dom_info";
-import { prepareUpdate } from "../utils/dom_state";
-import { childNodes, closestElement, firstLeaf, lastLeaf } from "../utils/dom_traversal";
+import { prepareUpdate, isFakeLineBreak } from "../utils/dom_state";
+import {
+    childNodes,
+    closestElement,
+    firstLeaf,
+    lastLeaf,
+    ancestors,
+    createDOMPathGenerator,
+} from "../utils/dom_traversal";
 import { DIRECTIONS, childNodeIndex, nodeSize } from "../utils/position";
 import { isProtected, isProtecting } from "@html_editor/utils/dom_info";
+
+const isInList = (node, editable) =>
+    ancestors(node, editable).find((ancestor) => isListItem(ancestor));
+const isLineBreak = (node) => node.nodeName === "BR" && !isFakeLineBreak(node);
+const [getPreviousLeavesInBlock, getNextLeavesInBlock] = [DIRECTIONS.LEFT, DIRECTIONS.RIGHT]
+    .map((direction) =>
+        createDOMPathGenerator(direction, {
+            leafOnly: true,
+            stopTraverseFunction: isBlock,
+            stopFunction: isBlock,
+        })
+    )
+    .map((path) => (node, offset) => [...path(node, offset)]);
 
 /**
  * @typedef { Object } SplitShared
@@ -21,6 +44,7 @@ import { isProtected, isProtecting } from "@html_editor/utils/dom_info";
  * @property { SplitPlugin['splitElement'] } splitElement
  * @property { SplitPlugin['splitElementBlock'] } splitElementBlock
  * @property { SplitPlugin['splitSelection'] } splitSelection
+ * @property { SplitPlugin['splitBlockSegments'] } splitBlockSegments
  */
 
 /**
@@ -43,6 +67,7 @@ export class SplitPlugin extends Plugin {
         "splitAroundUntil",
         "splitSelection",
         "isUnsplittable",
+        "splitBlockSegments",
     ];
     /** @type {import("plugins").EditorResources} */
     resources = {
@@ -321,6 +346,98 @@ export class SplitPlugin extends Plugin {
                       focusOffset: startOffset,
                   };
         return this.dependencies.selection.setSelection(selection, { normalize: false });
+    }
+
+    /**
+     * Split in order to isolate any block segment in the selection. A block
+     * segment forms a deliberate line in the content, separated using line
+     * breaks. A line break in a list item cannot create block segments as the
+     * list item visually marks its own segment (with a bullet point).
+     *
+     * eg: `<p>a<br>b<br>[c<br>d<br>e]<br>f<br>g</p>` marks seven line segments
+     * (one per letter). The selection contains 3 line segments, which will be
+     * isolated like this:
+     * `<p>a<br>b</p><p>[c</p><p>d</p><p>e]</p><p>f<br>g</p>`.
+     */
+    splitBlockSegments() {
+        const { setSelection, getEditableSelection } = this.dependencies.selection;
+        const { startContainer, startOffset, endContainer, endOffset } = getEditableSelection();
+
+        const brs = [
+            // BR before the selection:
+            getPreviousLeavesInBlock(startContainer, startOffset).find(isLineBreak),
+            // Selected BRs:
+            ...this.dependencies.selection.getTargetedNodes(),
+            // BR after the selection:
+            getNextLeavesInBlock(endContainer, endOffset).find(isLineBreak),
+        ].filter((node) => node && isLineBreak(node) && !isInList(node, this.editable));
+        for (const br of brs) {
+            let block = closestBlock(br);
+            if (!block?.isContentEditable) {
+                continue;
+            }
+
+            // Check if we can split at this line break.
+            const unsplittable = ancestors(br, block).find(this.isUnsplittable.bind(this));
+            const canWrapInUnsplittable = allowsParagraphRelatedElements(unsplittable);
+            if (unsplittable) {
+                if (canWrapInUnsplittable) {
+                    // If splitting here would split an unsplittable element,
+                    // remove the line break and wrap the content around it in
+                    // new base containers.
+                    const cursors = this.dependencies.selection.preserveSelection();
+                    const children = [...unsplittable.childNodes];
+                    const brIndex = childNodeIndex(br);
+                    // Wrap only until the first node that can't be wrapped, in
+                    // both directions.
+                    const isInvalid = (node) => !isPhrasingContent(node);
+                    const startInvalid = children.slice(0, brIndex).findLast(isInvalid);
+                    const endInvalid = children.slice(brIndex + 1).find(isInvalid);
+                    const childrenToInsert = children.slice(
+                        startInvalid ? childNodeIndex(startInvalid) + 1 : 0,
+                        endInvalid ? childNodeIndex(endInvalid) : children.length
+                    );
+                    // The new base container will become the new block parent
+                    // of the BR.
+                    block = this.dependencies.baseContainer.createBaseContainer();
+                    childrenToInsert[0]?.before(block);
+                    block.append(...childrenToInsert);
+                    cursors.restore();
+                } else {
+                    // If we can't insert a base container here, there's nothing
+                    // we can do.
+                    continue;
+                }
+            }
+
+            // Now let's split at the line break.
+            const cursors = this.dependencies.selection.preserveSelection();
+            let { anchorNode, anchorOffset, focusNode, focusOffset } = getEditableSelection();
+            const brIndex = childNodeIndex(br);
+            const oldParent = br.parentElement;
+            const [before, after] = this.splitElementUntil(oldParent, brIndex, block.parentElement);
+            br.remove();
+            [before, after].forEach(fillEmpty);
+
+            // Restore the selection.
+            if ([anchorNode, focusNode].some((node) => node === oldParent)) {
+                // We can't use `cursors.remapNode` here because the old parent
+                // was split into two new nodes.
+                // eg, `<p>[a<br>b]</p>` with selection (p, 0, p, 3) ->
+                // `<p>[a</p><p>b]</p>` -> anchor p !== focus p.
+                const remapPos = (i) => (i <= brIndex ? [before, 0] : [after, i - brIndex - 1]);
+                [[anchorNode, anchorOffset], [focusNode, focusOffset]] = [
+                    [anchorNode, anchorOffset],
+                    [focusNode, focusOffset],
+                ].map(([node, offset]) => (node === oldParent ? remapPos(offset) : [node, offset]));
+                setSelection(
+                    { anchorNode, anchorOffset, focusNode, focusOffset },
+                    { normalize: false }
+                );
+            } else {
+                cursors.restore();
+            }
+        }
     }
 
     onBeforeInput(e) {

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -266,6 +266,8 @@ export class ListPlugin extends Plugin {
             throw new Error(`listStyle is not compatible with "CL" list type`);
         }
 
+        this.dependencies.split.splitBlockSegments();
+
         // @todo @phoenix: original implementation removed whitespace-only text nodes from targetedNodes.
         // Check if this is necessary.
 

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -842,6 +842,7 @@ export class ListPlugin extends Plugin {
     }
 
     handleTab() {
+        this.dependencies.split.splitBlockSegments();
         const selection = this.dependencies.selection.getEditableSelection();
         const closestLI = closestElement(selection.anchorNode, "LI");
         if (closestLI) {

--- a/addons/html_editor/static/src/main/tabulation_plugin.js
+++ b/addons/html_editor/static/src/main/tabulation_plugin.js
@@ -42,7 +42,7 @@ function isIndentationTab(tab) {
 
 export class TabulationPlugin extends Plugin {
     static id = "tabulation";
-    static dependencies = ["dom", "selection", "history", "delete"];
+    static dependencies = ["dom", "selection", "history", "delete", "split"];
     static shared = ["indentBlocks", "outdentBlocks"];
     /** @type {import("plugins").EditorResources} */
     resources = {
@@ -83,6 +83,7 @@ export class TabulationPlugin extends Plugin {
         if (selection.isCollapsed) {
             this.insertTab();
         } else {
+            this.dependencies.split.splitBlockSegments();
             const targetedBlocks = this.dependencies.selection.getTargetedBlocks();
             this.indentBlocks(targetedBlocks);
         }

--- a/addons/html_editor/static/tests/list/automatic_list_detection.test.js
+++ b/addons/html_editor/static/tests/list/automatic_list_detection.test.js
@@ -13,6 +13,14 @@ test("typing '1. ' should create number list", async () => {
     expect(getContent(el)).toBe(`<ol><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ol>`);
 });
 
+test("typing '1. ' should create number list (with whitespace)", async () => {
+    const { el, editor } = await setupEditor(`<p>
+        []abc
+    </p>`);
+    await insertText(editor, "1. ");
+    expect(unformat(getContent(el))).toBe(unformat(`<ol><li>[]abc</li></ol>`));
+});
+
 test("typing '1) ' should create number list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
     await insertText(editor, "1) ");

--- a/addons/html_editor/static/tests/list/automatic_list_detection.test.js
+++ b/addons/html_editor/static/tests/list/automatic_list_detection.test.js
@@ -21,6 +21,12 @@ test("typing '1. ' should create number list (with whitespace)", async () => {
     expect(unformat(getContent(el))).toBe(unformat(`<ol><li>[]abc</li></ol>`));
 });
 
+test("typing '1. ' should create number list (with linebreak)", async () => {
+    const { el, editor } = await setupEditor(`<p>abc<br>[]def<br>ghi</p>`);
+    await insertText(editor, "1. ");
+    expect(unformat(getContent(el))).toBe(unformat(`<p>abc</p><ol><li>[]def</li></ol><p>ghi</p>`));
+});
+
 test("typing '1) ' should create number list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
     await insertText(editor, "1) ");

--- a/addons/html_editor/static/tests/list/toggle_cl.test.js
+++ b/addons/html_editor/static/tests/list/toggle_cl.test.js
@@ -32,7 +32,32 @@ describe("Range collapsed", () => {
             });
         });
 
-        test("should turn a ordered list into a checklist", async () => {
+        test("should turn a first line into a checklist", async () => {
+            await testEditor({
+                contentBefore: "<p>a[]<br>b<br>c<br>d<br>e</p>",
+                stepFunction: toggleCheckList,
+                contentAfter: '<ul class="o_checklist"><li>a[]</li></ul><p>b<br>c<br>d<br>e</p>',
+            });
+        });
+
+        test("should turn a middle line into a checklist", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>b<br>AB[]cDE<br>d<br>e</p>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>a<br>b</p><ul class="o_checklist"><li>AB[]cDE</li></ul><p>d<br>e</p>',
+            });
+        });
+
+        test("should turn a last line into a checklist", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>b<br>c<br>d<br>AB[]e</p>",
+                stepFunction: toggleCheckList,
+                contentAfter: '<p>a<br>b<br>c<br>d</p><ul class="o_checklist"><li>AB[]e</li></ul>',
+            });
+        });
+
+        test("should turn an ordered list into a checklist", async () => {
             await testEditor({
                 contentBefore: "<ol><li>ab[]cd</li></ol>",
                 stepFunction: toggleCheckList,
@@ -40,11 +65,27 @@ describe("Range collapsed", () => {
             });
         });
 
-        test("should turn a unordered list into a checklist", async () => {
+        test("should turn an ordered list into a checklist, with line breaks", async () => {
+            await testEditor({
+                contentBefore: "<ol><li>a<br>b<br>ABc[]DE<br>d<br>e</li></ol>",
+                stepFunction: toggleCheckList,
+                contentAfter: '<ul class="o_checklist"><li>a<br>b<br>ABc[]DE<br>d<br>e</li></ul>',
+            });
+        });
+
+        test("should turn an unordered list into a checklist", async () => {
             await testEditor({
                 contentBefore: "<ul><li>ab[]cd</li></ul>",
                 stepFunction: toggleCheckList,
                 contentAfter: '<ul class="o_checklist"><li>ab[]cd</li></ul>',
+            });
+        });
+
+        test("should turn an unordered list into a checklist, with line breaks", async () => {
+            await testEditor({
+                contentBefore: "<ul><li>a<br>b<br>ABc[]DE<br>d<br>e</li></ul>",
+                stepFunction: toggleCheckList,
+                contentAfter: '<ul class="o_checklist"><li>a<br>b<br>ABc[]DE<br>d<br>e</li></ul>',
             });
         });
 
@@ -78,6 +119,15 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should turn a line in a paragraph in a div into a checklist", async () => {
+            await testEditor({
+                contentBefore: "<div><p>a<br>b<br>ABc[]<br>d<br>e</p></div>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<div><p>a<br>b</p><ul class="o_checklist"><li>ABc[]</li></ul><p>d<br>e</p></div>',
+            });
+        });
+
         test("should turn a paragraph with formats into a checklist", async () => {
             await testEditor({
                 contentBefore: "<p><span><b>ab</b></span> <span><i>cd</i></span> ef[]gh</p>",
@@ -87,7 +137,17 @@ describe("Range collapsed", () => {
             });
         });
 
-        test("should turn a paragraph between 2 checklist into a checklist item", async () => {
+        test("should turn a line in a paragraph with formats into a checklist", async () => {
+            await testEditor({
+                contentBefore:
+                    "<p><span><b>a<br>b<br>c</b></span> <span><i>d[]<br>e</i></span> f<br>g</p>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p><span><b>a<br>b</b></span></p><ul class="o_checklist"><li><span><b>c</b></span> <span><i>d[]</i></span></li></ul><p><span><i>e</i></span> f<br>g</p>',
+            });
+        });
+
+        test("should turn a paragraph between 2 checklists into a checklist item", async () => {
             await testEditor({
                 contentBefore:
                     '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>d[]ef</p><ul class="o_checklist"><li class="o_checked">ghi</li></ul>',
@@ -97,7 +157,17 @@ describe("Range collapsed", () => {
             });
         });
 
-        test("should turn a unordered list into a checklist between 2 checklists inside a checklist", async () => {
+        test("should turn a line in a paragraph between 2 checklists into a new checklist", async () => {
+            await testEditor({
+                contentBefore:
+                    '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>d<br>[]e<br>f</p><ul class="o_checklist"><li class="o_checked">ghi</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>d</p><ul class="o_checklist"><li>[]e</li></ul><p>f</p><ul class="o_checklist"><li class="o_checked">ghi</li></ul>',
+            });
+        });
+
+        test("should turn an unordered list into a checklist between 2 checklists inside a checklist", async () => {
             await testEditor({
                 contentBefore: unformat(`
                     <ul class="o_checklist">
@@ -289,11 +359,28 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should turn a checklist into a paragraph, with line breaks", async () => {
+            await testEditor({
+                contentBefore: '<ul class="o_checklist"><li>a<br>b<br>[]c<br>d<br>e</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter: "<p>a<br>b<br>[]c<br>d<br>e</p>",
+            });
+        });
+
         test("should turn a checklist into a heading", async () => {
             await testEditor({
                 contentBefore: '<ul class="o_checklist"><li><h1>ab[]cd</h1></li></ul>',
                 stepFunction: toggleCheckList,
                 contentAfter: "<h1>ab[]cd</h1>",
+            });
+        });
+
+        test("should turn a checklist into a heading, with line breaks", async () => {
+            await testEditor({
+                contentBefore:
+                    '<ul class="o_checklist"><li><h1>a<br>b<br>[]c<br>d<br>e</h1></li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter: "<h1>a<br>b<br>[]c<br>d<br>e</h1>",
             });
         });
 
@@ -305,12 +392,32 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should turn a checklist item into a paragraph, with line breaks", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p>ab</p><ul class="o_checklist"><li>cd</li><li>e<br>f<br>[]g<br>h<br>i</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>ab</p><ul class="o_checklist"><li>cd</li></ul><p>e<br>f<br>[]g<br>h<br>i</p>',
+            });
+        });
+
         test("should turn a checklist with formats into a paragraph", async () => {
             await testEditor({
                 contentBefore:
                     '<ul class="o_checklist"><li><span><b>ab</b></span> <span><i>cd</i></span> ef[]gh</li></ul>',
                 stepFunction: toggleCheckList,
                 contentAfter: "<p><span><b>ab</b></span> <span><i>cd</i></span> ef[]gh</p>",
+            });
+        });
+
+        test("should turn a checklist with formats into a paragraph, with line breaks", async () => {
+            await testEditor({
+                contentBefore:
+                    '<ul class="o_checklist"><li><span><b>ab</b></span> <span><i>cd</i></span> e<br>f<br>[]g<br>h<br>i</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    "<p><span><b>ab</b></span> <span><i>cd</i></span> e<br>f<br>[]g<br>h<br>i</p>",
             });
         });
 
@@ -334,6 +441,46 @@ describe("Range collapsed", () => {
                             <li><p>a</p></li>
                         </ul>
                         <p>[]b</p>
+                        <ul class="o_checklist">
+                            <li class="oe-nested">
+                                <ul class="o_checklist">
+                                    <li class="oe-nested">
+                                        <ul class="o_checklist">
+                                            <li class="o_checked">c</li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>`),
+            });
+        });
+
+        test("should turn nested list items into paragraphs, with line breaks", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                        <ul class="o_checklist">
+                            <li class="o_checked">a</li>
+                            <li class="oe-nested">
+                                <ul class="o_checklist">
+                                    <li class="o_checked">w<br>x<br>[]b<br>y<br>z</li>
+                                </ul>
+                            </li>
+                            <li class="oe-nested">
+                                <ul class="o_checklist">
+                                    <li class="oe-nested">
+                                        <ul class="o_checklist">
+                                            <li class="o_checked">c</li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>`),
+                stepFunction: toggleCheckList,
+                contentAfter: unformat(`
+                        <ul class="o_checklist">
+                            <li class="o_checked"><p>a</p></li>
+                        </ul>
+                        <p>w</p><p>x</p><p>[]b</p><p>y</p><p>z</p>
                         <ul class="o_checklist">
                             <li class="oe-nested">
                                 <ul class="o_checklist">
@@ -438,11 +585,155 @@ describe("Range not collapsed", () => {
             });
         });
 
+        test("should turn a multi-line paragraph into a checklist with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>[a<br>b<br>c<br>d<br>e]</p>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li>[a</li><li>b</li><li>c</li><li>d</li><li>e]</li></ul>',
+            });
+        });
+
+        test("should turn a multi-line paragraph into a checklist with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>]a<br>b<br>c<br>d<br>e[</p>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li>]a</li><li>b</li><li>c</li><li>d</li><li>e[</li></ul>',
+            });
+        });
+
+        test("should turn the first few lines of a paragraph into a checklist with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>[a<br>b<br>c]<br>d<br>e</p>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li>[a</li><li>b</li><li>c]</li></ul><p>d<br>e</p>',
+            });
+        });
+
+        test("should turn the first few lines of a paragraph into a checklist with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>]a<br>b<br>c[<br>d<br>e</p>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li>]a</li><li>b</li><li>c[</li></ul><p>d<br>e</p>',
+            });
+        });
+
+        test("should turn the middle few lines of a paragraph into a checklist with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>[b<br>c<br>d]<br>e</p>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>a</p><ul class="o_checklist"><li>[b</li><li>c</li><li>d]</li></ul><p>e</p>',
+            });
+        });
+
+        test("should turn the middle few lines of a paragraph into a checklist with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>]b<br>c<br>d[<br>e</p>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>a</p><ul class="o_checklist"><li>]b</li><li>c</li><li>d[</li></ul><p>e</p>',
+            });
+        });
+
+        test("should turn a last few lines of a paragraph into a checklist with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>b<br>[c<br>d<br>e]</p>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>a<br>b</p><ul class="o_checklist"><li>[c</li><li>d</li><li>e]</li></ul>',
+            });
+        });
+
+        test("should turn a last few lines of a paragraph into a checklist with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>b<br>]c<br>d<br>e[</p>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>a<br>b</p><ul class="o_checklist"><li>]c</li><li>d</li><li>e[</li></ul>',
+            });
+        });
+
         test("should turn a heading into a checklist", async () => {
             await testEditor({
                 contentBefore: "<p>ab</p><h1>cd[ef]gh</h1>",
                 stepFunction: toggleCheckList,
                 contentAfter: '<p>ab</p><ul class="o_checklist"><li><h1>cd[ef]gh</h1></li></ul>',
+            });
+        });
+
+        test("should turn a multi-line heading into a checklist with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>AB[a<br>b<br>c<br>d<br>e]FG</h1>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>xy</p><ul class="o_checklist"><li><h1>AB[a</h1></li><li><h1>b</h1></li><li><h1>c</h1></li><li><h1>d</h1></li><li><h1>e]FG</h1></li></ul>',
+            });
+        });
+
+        test("should turn a multi-line heading into a checklist with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>AB]a<br>b<br>c<br>d<br>e[FG</h1>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>xy</p><ul class="o_checklist"><li><h1>AB]a</h1></li><li><h1>b</h1></li><li><h1>c</h1></li><li><h1>d</h1></li><li><h1>e[FG</h1></li></ul>',
+            });
+        });
+
+        test("should turn the first few lines of a heading into a checklist with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>AB[a<br>b<br>c]<br>d<br>e</h1>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>xy</p><ul class="o_checklist"><li><h1>AB[a</h1></li><li><h1>b</h1></li><li><h1>c]</h1></li></ul><h1>d<br>e</h1>',
+            });
+        });
+
+        test("should turn the first few lines of a heading into a checklist with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>AB]a<br>b<br>c[<br>d<br>e</h1>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>xy</p><ul class="o_checklist"><li><h1>AB]a</h1></li><li><h1>b</h1></li><li><h1>c[</h1></li></ul><h1>d<br>e</h1>',
+            });
+        });
+
+        test("should turn the middle few lines of a heading into a checklist with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>a<br>AB[b<br>c<br>d]EF<br>e</h1>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>xy</p><h1>a</h1><ul class="o_checklist"><li><h1>AB[b</h1></li><li><h1>c</h1></li><li><h1>d]EF</h1></li></ul><h1>e</h1>',
+            });
+        });
+
+        test("should turn the middle few lines of a heading into a checklist with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>a<br>AB]b<br>c<br>d[EF<br>e</h1>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>xy</p><h1>a</h1><ul class="o_checklist"><li><h1>AB]b</h1></li><li><h1>c</h1></li><li><h1>d[EF</h1></li></ul><h1>e</h1>',
+            });
+        });
+
+        test("should turn a last few lines of a heading into a checklist with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>a<br>b<br>AB[c<br>d<br>e]EF</h1>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>xy</p><h1>a<br>b</h1><ul class="o_checklist"><li><h1>AB[c</h1></li><li><h1>d</h1></li><li><h1>e]EF</h1></li></ul>',
+            });
+        });
+
+        test("should turn a last few lines of a heading into a checklist with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>a<br>b<br>AB]c<br>d<br>e[EF</h1>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>xy</p><h1>a<br>b</h1><ul class="o_checklist"><li><h1>AB]c</h1></li><li><h1>d</h1></li><li><h1>e[EF</h1></li></ul>',
             });
         });
 
@@ -454,12 +745,48 @@ describe("Range not collapsed", () => {
             });
         });
 
+        test("should turn four lines over two paragraphs into a checklist with four items", async () => {
+            await testEditor({
+                contentBefore: "<p>ab</p><p>c<br>d[e<br>f</p><p>g<br>h]i<br>j</p>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>ab</p><p>c</p><ul class="o_checklist"><li>d[e</li><li>f</li><li>g</li><li>h]i</li></ul><p>j</p>',
+            });
+        });
+
+        test("should turn four lines over two paragraphs into a checklist with four items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>ab</p><p>c<br>d]e<br>f</p><p>g<br>h[i<br>j</p>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>ab</p><p>c</p><ul class="o_checklist"><li>d]e</li><li>f</li><li>g</li><li>h[i</li></ul><p>j</p>',
+            });
+        });
+
         test("should turn two paragraphs in a div into a checklist with two items", async () => {
             await testEditor({
                 contentBefore: "<div><p>ab[cd</p><p>ef]gh</p></div>",
                 stepFunction: toggleCheckList,
                 contentAfter:
                     '<div><ul class="o_checklist"><li>ab[cd</li><li>ef]gh</li></ul></div>',
+            });
+        });
+
+        test("should turn four lines over two paragraphs in a div into a checklist with four items", async () => {
+            await testEditor({
+                contentBefore: "<div><p>a<br>b[c<br>d</p><p>e<br>f]g<br>h</p></div>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<div><p>a</p><ul class="o_checklist"><li>b[c</li><li>d</li><li>e</li><li>f]g</li></ul><p>h</p></div>',
+            });
+        });
+
+        test("should turn four lines over two paragraphs in a div into a checklist with four items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<div><p>a<br>b]c<br>d</p><p>e<br>f[g<br>h</p></div>",
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<div><p>a</p><ul class="o_checklist"><li>b]c</li><li>d</li><li>e</li><li>f[g</li></ul><p>h</p></div>',
             });
         });
 
@@ -480,6 +807,76 @@ describe("Range not collapsed", () => {
             });
         });
 
+        test("should turn two lines of a paragraph and a checklist item into three list items", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p>a<br>x[b<br>y</p><ul class="o_checklist"><li class="o_checked">c]d</li><li>ef</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>a</p><ul class="o_checklist"><li>x[b</li><li>y</li><li class="o_checked">c]d</li><li>ef</li></ul>',
+            });
+            await testEditor({
+                contentBefore:
+                    '<p>a<br>x[b<br>y</p><ul class="o_checklist"><li class="o_checked">c]d</li><li class="o_checked">ef</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>a</p><ul class="o_checklist"><li>x[b</li><li>y</li><li class="o_checked">c]d</li><li class="o_checked">ef</li></ul>',
+            });
+        });
+
+        test("should turn two lines of a paragraph and a checklist item into three list items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p>a<br>x]b<br>y</p><ul class="o_checklist"><li class="o_checked">c[d</li><li>ef</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>a</p><ul class="o_checklist"><li>x]b</li><li>y</li><li class="o_checked">c[d</li><li>ef</li></ul>',
+            });
+            await testEditor({
+                contentBefore:
+                    '<p>a<br>x]b<br>y</p><ul class="o_checklist"><li class="o_checked">c[d</li><li class="o_checked">ef</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>a</p><ul class="o_checklist"><li>x]b</li><li>y</li><li class="o_checked">c[d</li><li class="o_checked">ef</li></ul>',
+            });
+        });
+
+        test("should turn two lines of a paragraph and two lines of a checklist item into four list items", async () => {
+            // TODO: is this what we want?
+            await testEditor({
+                contentBefore:
+                    '<p>a<br>x[b<br>y</p><ul class="o_checklist"><li class="o_checked">c<br>z]d<br>A</li><li>ef</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>a</p><ul class="o_checklist"><li>x[b</li><li>y</li><li class="o_checked">c<br>z]d<br>A</li><li>ef</li></ul>',
+            });
+            await testEditor({
+                contentBefore:
+                    '<p>a<br>x[b<br>y</p><ul class="o_checklist"><li class="o_checked">c<br>z]d<br>A</li><li class="o_checked">ef</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>a</p><ul class="o_checklist"><li>x[b</li><li>y</li><li class="o_checked">c<br>z]d<br>A</li><li class="o_checked">ef</li></ul>',
+            });
+        });
+
+        test("should turn two lines of a paragraph and two lines of a checklist item into four list items (reversed selection)", async () => {
+            // TODO: is this what we want?
+            await testEditor({
+                contentBefore:
+                    '<p>a<br>x]b<br>y</p><ul class="o_checklist"><li class="o_checked">c<br>z[d<br>A</li><li>ef</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>a</p><ul class="o_checklist"><li>x]b</li><li>y</li><li class="o_checked">c<br>z[d<br>A</li><li>ef</li></ul>',
+            });
+            await testEditor({
+                contentBefore:
+                    '<p>a<br>x]b<br>y</p><ul class="o_checklist"><li class="o_checked">c<br>z[d<br>A</li><li class="o_checked">ef</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<p>a</p><ul class="o_checklist"><li>x]b</li><li>y</li><li class="o_checked">c<br>z[d<br>A</li><li class="o_checked">ef</li></ul>',
+            });
+        });
+
         test("should turn a checklist item and a paragraph into two list items", async () => {
             await testEditor({
                 contentBefore:
@@ -487,6 +884,46 @@ describe("Range not collapsed", () => {
                 stepFunction: toggleCheckList,
                 contentAfter:
                     '<ul class="o_checklist"><li>ab</li><li class="o_checked">c[d</li><li>e]f</li></ul>',
+            });
+        });
+
+        test("should turn a checklist item and two lines of a paragraph into three list items", async () => {
+            await testEditor({
+                contentBefore:
+                    '<ul class="o_checklist"><li>ab</li><li class="o_checked">c[d</li></ul><p>e<br>x]f<br>g</p>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li>ab</li><li class="o_checked">c[d</li><li>e</li><li>x]f</li></ul><p>g</p>',
+            });
+        });
+
+        test("should turn a checklist item and two lines of a paragraph into three list items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore:
+                    '<ul class="o_checklist"><li>ab</li><li class="o_checked">c]d</li></ul><p>e<br>x[f<br>g</p>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li>ab</li><li class="o_checked">c]d</li><li>e</li><li>x[f</li></ul><p>g</p>',
+            });
+        });
+
+        test("should turn two lines of a checklist item and two lines of a paragraph into three list items", async () => {
+            await testEditor({
+                contentBefore:
+                    '<ul class="o_checklist"><li>ab</li><li class="o_checked">c[d<br>A</li></ul><p>e<br>x]f<br>g</p>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li>ab</li><li class="o_checked">c[d<br>A</li><li>e</li><li>x]f</li></ul><p>g</p>',
+            });
+        });
+
+        test("should turn two lines of a checklist item and two lines of a paragraph into three list items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore:
+                    '<ul class="o_checklist"><li>ab</li><li class="o_checked">c]d<br>A</li></ul><p>e<br>x[f<br>g</p>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li>ab</li><li class="o_checked">c]d<br>A</li><li>e</li><li>x[f</li></ul><p>g</p>',
             });
         });
 

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -32,7 +32,31 @@ describe("Range collapsed", () => {
             });
         });
 
-        test("should turn a unordered list into a ordered list", async () => {
+        test("should turn a first line into a list", async () => {
+            await testEditor({
+                contentBefore: "<p>a[]<br>b<br>c<br>d<br>e</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>a[]</li></ol><p>b<br>c<br>d<br>e</p>",
+            });
+        });
+
+        test("should turn a middle line into a list", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>b<br>AB[]cDE<br>d<br>e</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<p>a<br>b</p><ol><li>AB[]cDE</li></ol><p>d<br>e</p>",
+            });
+        });
+
+        test("should turn a last line into a list", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>b<br>c<br>d<br>AB[]e</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<p>a<br>b<br>c<br>d</p><ol><li>AB[]e</li></ol>",
+            });
+        });
+
+        test("should turn an unordered list into an ordered list", async () => {
             await testEditor({
                 contentBefore: "<ul><li>ab[]cd</li></ul>",
                 stepFunction: toggleOrderedList,
@@ -40,11 +64,27 @@ describe("Range collapsed", () => {
             });
         });
 
-        test("should turn a checked list into a ordered list", async () => {
+        test("should turn an unordered list into an ordered list, with line breaks", async () => {
+            await testEditor({
+                contentBefore: "<ul><li>a<br>b<br>ABc[]DE<br>d<br>e</li></ul>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>a<br>b<br>ABc[]DE<br>d<br>e</li></ol>",
+            });
+        });
+
+        test("should turn a checked list into an ordered list", async () => {
             await testEditor({
                 contentBefore: '<ul class="o_checklist"><li>ab[]cd</li></ul>',
                 stepFunction: toggleOrderedList,
                 contentAfter: "<ol><li>ab[]cd</li></ol>",
+            });
+        });
+
+        test("should turn a checked list into an ordered list, with line breaks", async () => {
+            await testEditor({
+                contentBefore: '<ul class="o_checklist"><li>a<br>b<br>ABc[]DE<br>d<br>e</li></ul>',
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>a<br>b<br>ABc[]DE<br>d<br>e</li></ol>",
             });
         });
 
@@ -64,12 +104,30 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should turn a line in a paragraph in a div into a list", async () => {
+            await testEditor({
+                contentBefore: "<div><p>a<br>b<br>ABc[]<br>d<br>e</p></div>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<div><p>a<br>b</p><ol><li>ABc[]</li></ol><p>d<br>e</p></div>",
+            });
+        });
+
         test("should turn a paragraph with formats into a list", async () => {
             await testEditor({
                 contentBefore: "<p><span><b>ab</b></span> <span><i>cd</i></span> ef[]gh</p>",
                 stepFunction: toggleOrderedList,
                 contentAfter:
                     "<ol><li><span><b>ab</b></span> <span><i>cd</i></span> ef[]gh</li></ol>",
+            });
+        });
+
+        test("should turn a line in a paragraph with formats into a list", async () => {
+            await testEditor({
+                contentBefore:
+                    "<p><span><b>a<br>b<br>c</b></span> <span><i>d[]<br>e</i></span> f<br>g</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p><span><b>a<br>b</b></span></p><ol><li><span><b>c</b></span> <span><i>d[]</i></span></li></ol><p><span><i>e</i></span> f<br>g</p>",
             });
         });
 
@@ -181,11 +239,27 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should turn a list into a paragraph, with line breaks", async () => {
+            await testEditor({
+                contentBefore: "<ol><li>a<br>b<br>[]c<br>d<br>e</li></ol>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<p>a<br>b<br>[]c<br>d<br>e</p>",
+            });
+        });
+
         test("should turn a list into a heading", async () => {
             await testEditor({
                 contentBefore: "<ol><li><h1>ab[]cd</h1></li></ol>",
                 stepFunction: toggleOrderedList,
                 contentAfter: "<h1>ab[]cd</h1>",
+            });
+        });
+
+        test("should turn a list into a heading, with line breaks", async () => {
+            await testEditor({
+                contentBefore: "<ol><li><h1>a<br>b<br>[]c<br>d<br>e</h1></li></ol>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<h1>a<br>b<br>[]c<br>d<br>e</h1>",
             });
         });
 
@@ -197,12 +271,30 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should turn a list item into a paragraph, with line breaks", async () => {
+            await testEditor({
+                contentBefore: "<p>ab</p><ol><li>cd</li><li>e<br>f<br>[]g<br>h<br>i</li></ol>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<p>ab</p><ol><li>cd</li></ol><p>e<br>f<br>[]g<br>h<br>i</p>",
+            });
+        });
+
         test("should turn a list with formats into a paragraph", async () => {
             await testEditor({
                 contentBefore:
                     "<ol><li><span><b>ab</b></span> <span><i>cd</i></span> ef[]gh</li></ol>",
                 stepFunction: toggleOrderedList,
                 contentAfter: "<p><span><b>ab</b></span> <span><i>cd</i></span> ef[]gh</p>",
+            });
+        });
+
+        test("should turn a list with formats into a paragraph, with line breaks", async () => {
+            await testEditor({
+                contentBefore:
+                    "<ol><li><span><b>ab</b></span> <span><i>cd</i></span> e<br>f<br>[]g<br>h<br>i</li></ol>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p><span><b>ab</b></span> <span><i>cd</i></span> e<br>f<br>[]g<br>h<br>i</p>",
             });
         });
 
@@ -295,11 +387,147 @@ describe("Range not collapsed", () => {
             });
         });
 
+        test("should turn a multi-line paragraph into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>[a<br>b<br>c<br>d<br>e]</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>[a</li><li>b</li><li>c</li><li>d</li><li>e]</li></ol>",
+            });
+        });
+
+        test("should turn a multi-line paragraph into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>]a<br>b<br>c<br>d<br>e[</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>]a</li><li>b</li><li>c</li><li>d</li><li>e[</li></ol>",
+            });
+        });
+
+        test("should turn the first few lines of a paragraph into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>[a<br>b<br>c]<br>d<br>e</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>[a</li><li>b</li><li>c]</li></ol><p>d<br>e</p>",
+            });
+        });
+
+        test("should turn the first few lines of a paragraph into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>]a<br>b<br>c[<br>d<br>e</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>]a</li><li>b</li><li>c[</li></ol><p>d<br>e</p>",
+            });
+        });
+
+        test("should turn the middle few lines of a paragraph into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>[b<br>c<br>d]<br>e</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<p>a</p><ol><li>[b</li><li>c</li><li>d]</li></ol><p>e</p>",
+            });
+        });
+
+        test("should turn the middle few lines of a paragraph into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>]b<br>c<br>d[<br>e</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<p>a</p><ol><li>]b</li><li>c</li><li>d[</li></ol><p>e</p>",
+            });
+        });
+
+        test("should turn a last few lines of a paragraph into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>b<br>[c<br>d<br>e]</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<p>a<br>b</p><ol><li>[c</li><li>d</li><li>e]</li></ol>",
+            });
+        });
+
+        test("should turn a last few lines of a paragraph into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>b<br>]c<br>d<br>e[</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<p>a<br>b</p><ol><li>]c</li><li>d</li><li>e[</li></ol>",
+            });
+        });
+
         test("should turn a heading into a list", async () => {
             await testEditor({
                 contentBefore: "<p>ab</p><h1>cd[ef]gh</h1>",
                 stepFunction: toggleOrderedList,
                 contentAfter: "<p>ab</p><ol><li><h1>cd[ef]gh</h1></li></ol>",
+            });
+        });
+
+        test("should turn a multi-line heading into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>AB[a<br>b<br>c<br>d<br>e]FG</h1>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p>xy</p><ol><li><h1>AB[a</h1></li><li><h1>b</h1></li><li><h1>c</h1></li><li><h1>d</h1></li><li><h1>e]FG</h1></li></ol>",
+            });
+        });
+
+        test("should turn a multi-line heading into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>AB]a<br>b<br>c<br>d<br>e[FG</h1>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p>xy</p><ol><li><h1>AB]a</h1></li><li><h1>b</h1></li><li><h1>c</h1></li><li><h1>d</h1></li><li><h1>e[FG</h1></li></ol>",
+            });
+        });
+
+        test("should turn the first few lines of a heading into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>AB[a<br>b<br>c]<br>d<br>e</h1>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p>xy</p><ol><li><h1>AB[a</h1></li><li><h1>b</h1></li><li><h1>c]</h1></li></ol><h1>d<br>e</h1>",
+            });
+        });
+
+        test("should turn the first few lines of a heading into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>AB]a<br>b<br>c[<br>d<br>e</h1>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p>xy</p><ol><li><h1>AB]a</h1></li><li><h1>b</h1></li><li><h1>c[</h1></li></ol><h1>d<br>e</h1>",
+            });
+        });
+
+        test("should turn the middle few lines of a heading into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>a<br>AB[b<br>c<br>d]EF<br>e</h1>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p>xy</p><h1>a</h1><ol><li><h1>AB[b</h1></li><li><h1>c</h1></li><li><h1>d]EF</h1></li></ol><h1>e</h1>",
+            });
+        });
+
+        test("should turn the middle few lines of a heading into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>a<br>AB]b<br>c<br>d[EF<br>e</h1>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p>xy</p><h1>a</h1><ol><li><h1>AB]b</h1></li><li><h1>c</h1></li><li><h1>d[EF</h1></li></ol><h1>e</h1>",
+            });
+        });
+
+        test("should turn a last few lines of a heading into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>a<br>b<br>AB[c<br>d<br>e]EF</h1>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p>xy</p><h1>a<br>b</h1><ol><li><h1>AB[c</h1></li><li><h1>d</h1></li><li><h1>e]EF</h1></li></ol>",
+            });
+        });
+
+        test("should turn a last few lines of a heading into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>a<br>b<br>AB]c<br>d<br>e[EF</h1>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p>xy</p><h1>a<br>b</h1><ol><li><h1>AB]c</h1></li><li><h1>d</h1></li><li><h1>e[EF</h1></li></ol>",
             });
         });
 
@@ -311,11 +539,47 @@ describe("Range not collapsed", () => {
             });
         });
 
+        test("should turn four lines over two paragraphs into a list with four items", async () => {
+            await testEditor({
+                contentBefore: "<p>ab</p><p>c<br>d[e<br>f</p><p>g<br>h]i<br>j</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p>ab</p><p>c</p><ol><li>d[e</li><li>f</li><li>g</li><li>h]i</li></ol><p>j</p>",
+            });
+        });
+
+        test("should turn four lines over two paragraphs into a list with four items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>ab</p><p>c<br>d]e<br>f</p><p>g<br>h[i<br>j</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p>ab</p><p>c</p><ol><li>d]e</li><li>f</li><li>g</li><li>h[i</li></ol><p>j</p>",
+            });
+        });
+
         test("should turn two paragraphs in a div into a list with two items", async () => {
             await testEditor({
                 contentBefore: "<div><p>ab[cd</p><p>ef]gh</p></div>",
                 stepFunction: toggleOrderedList,
                 contentAfter: "<div><ol><li>ab[cd</li><li>ef]gh</li></ol></div>",
+            });
+        });
+
+        test("should turn four lines over two paragraphs in a div into a list with four items", async () => {
+            await testEditor({
+                contentBefore: "<div><p>a<br>b[c<br>d</p><p>e<br>f]g<br>h</p></div>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<div><p>a</p><ol><li>b[c</li><li>d</li><li>e</li><li>f]g</li></ol><p>h</p></div>",
+            });
+        });
+
+        test("should turn four lines over two paragraphs in a div into a list with four items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<div><p>a<br>b]c<br>d</p><p>e<br>f[g<br>h</p></div>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<div><p>a</p><ol><li>b]c</li><li>d</li><li>e</li><li>f[g</li></ol><p>h</p></div>",
             });
         });
 
@@ -327,11 +591,79 @@ describe("Range not collapsed", () => {
             });
         });
 
+        test("should turn two lines of a paragraph and a list item into three list items", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>x[b<br>y</p><ol><li>c]d</li><li>ef</li></ol>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<p>a</p><ol><li>x[b</li><li>y</li><li>c]d</li><li>ef</li></ol>",
+            });
+        });
+
+        test("should turn two lines of a paragraph and a list item into three list items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>x]b<br>y</p><ol><li>c[d</li><li>ef</li></ol>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<p>a</p><ol><li>x]b</li><li>y</li><li>c[d</li><li>ef</li></ol>",
+            });
+        });
+
+        test("should turn two lines of a paragraph and two lines of a list item into four list items", async () => {
+            // TODO: is this what we want?
+            await testEditor({
+                contentBefore: "<p>a<br>x[b<br>y</p><ol><li>c<br>z]d<br>A</li><li>ef</li></ol>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p>a</p><ol><li>x[b</li><li>y</li><li>c<br>z]d<br>A</li><li>ef</li></ol>",
+            });
+        });
+
+        test("should turn two lines of a paragraph and two lines of a list item into four list items (reversed selection)", async () => {
+            // TODO: is this what we want?
+            await testEditor({
+                contentBefore: "<p>a<br>x]b<br>y</p><ol><li>c<br>z[d<br>A</li><li>ef</li></ol>",
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    "<p>a</p><ol><li>x]b</li><li>y</li><li>c<br>z[d<br>A</li><li>ef</li></ol>",
+            });
+        });
+
         test("should turn a list item and a paragraph into two list items", async () => {
             await testEditor({
                 contentBefore: "<ol><li>ab</li><li>c[d</li></ol><p>e]f</p>",
                 stepFunction: toggleOrderedList,
                 contentAfter: "<ol><li>ab</li><li>c[d</li><li>e]f</li></ol>",
+            });
+        });
+
+        test("should turn a list item and two lines of a paragraph into three list items", async () => {
+            await testEditor({
+                contentBefore: "<ol><li>ab</li><li>c[d</li></ol><p>e<br>x]f<br>g</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>ab</li><li>c[d</li><li>e</li><li>x]f</li></ol><p>g</p>",
+            });
+        });
+
+        test("should turn a list item and two lines of a paragraph into three list items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<ol><li>ab</li><li>c]d</li></ol><p>e<br>x[f<br>g</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>ab</li><li>c]d</li><li>e</li><li>x[f</li></ol><p>g</p>",
+            });
+        });
+
+        test("should turn two lines of a list item and two lines of a paragraph into three list items", async () => {
+            await testEditor({
+                contentBefore: "<ol><li>ab</li><li>c[d<br>A</li></ol><p>e<br>x]f<br>g</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>ab</li><li>c[d<br>A</li><li>e</li><li>x]f</li></ol><p>g</p>",
+            });
+        });
+
+        test("should turn two lines of a list item and two lines of a paragraph into three list items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<ol><li>ab</li><li>c]d<br>A</li></ol><p>e<br>x[f<br>g</p>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>ab</li><li>c]d<br>A</li><li>e</li><li>x[f</li></ol><p>g</p>",
             });
         });
 

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -32,11 +32,43 @@ describe("Range collapsed", () => {
             });
         });
 
-        test("should turn a ordered list into a unordered list", async () => {
+        test("should turn a first line into a list", async () => {
+            await testEditor({
+                contentBefore: "<p>a[]<br>b<br>c<br>d<br>e</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>a[]</li></ul><p>b<br>c<br>d<br>e</p>",
+            });
+        });
+
+        test("should turn a middle line into a list", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>b<br>AB[]cDE<br>d<br>e</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<p>a<br>b</p><ul><li>AB[]cDE</li></ul><p>d<br>e</p>",
+            });
+        });
+
+        test("should turn a last line into a list", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>b<br>c<br>d<br>AB[]e</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<p>a<br>b<br>c<br>d</p><ul><li>AB[]e</li></ul>",
+            });
+        });
+
+        test("should turn an ordered list into a unordered list", async () => {
             await testEditor({
                 contentBefore: "<ol><li>ab[]cd</li></ol>",
                 stepFunction: toggleUnorderedList,
                 contentAfter: "<ul><li>ab[]cd</li></ul>",
+            });
+        });
+
+        test("should turn an ordered list into an unordered list, with line breaks", async () => {
+            await testEditor({
+                contentBefore: "<ol><li>a<br>b<br>ABc[]DE<br>d<br>e</li></ol>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>a<br>b<br>ABc[]DE<br>d<br>e</li></ul>",
             });
         });
 
@@ -45,6 +77,14 @@ describe("Range collapsed", () => {
                 contentBefore: '<ul class="o_checklist"><li>ab[]cd</li></ul>',
                 stepFunction: toggleUnorderedList,
                 contentAfter: "<ul><li>ab[]cd</li></ul>",
+            });
+        });
+
+        test("should turn a checked list into an unordered list, with line breaks", async () => {
+            await testEditor({
+                contentBefore: '<ul class="o_checklist"><li>a<br>b<br>ABc[]DE<br>d<br>e</li></ul>',
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>a<br>b<br>ABc[]DE<br>d<br>e</li></ul>",
             });
         });
 
@@ -72,12 +112,30 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should turn a line in a paragraph in a div into a list", async () => {
+            await testEditor({
+                contentBefore: "<div><p>a<br>b<br>ABc[]<br>d<br>e</p></div>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<div><p>a<br>b</p><ul><li>ABc[]</li></ul><p>d<br>e</p></div>",
+            });
+        });
+
         test("should turn a paragraph with formats into a list", async () => {
             await testEditor({
                 contentBefore: "<p><span><b>ab</b></span> <span><i>cd</i></span> ef[]gh</p>",
                 stepFunction: toggleUnorderedList,
                 contentAfter:
                     "<ul><li><span><b>ab</b></span> <span><i>cd</i></span> ef[]gh</li></ul>",
+            });
+        });
+
+        test("should turn a line in a paragraph with formats into a list", async () => {
+            await testEditor({
+                contentBefore:
+                    "<p><span><b>a<br>b<br>c</b></span> <span><i>d[]<br>e</i></span> f<br>g</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p><span><b>a<br>b</b></span></p><ul><li><span><b>c</b></span> <span><i>d[]</i></span></li></ul><p><span><i>e</i></span> f<br>g</p>",
             });
         });
 
@@ -188,11 +246,27 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should turn a list into a paragraph, with line breaks", async () => {
+            await testEditor({
+                contentBefore: "<ul><li>a<br>b<br>[]c<br>d<br>e</li></ul>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<p>a<br>b<br>[]c<br>d<br>e</p>",
+            });
+        });
+
         test("should turn a list into a heading", async () => {
             await testEditor({
                 contentBefore: "<ul><li><h1>ab[]cd</h1></li></ul>",
                 stepFunction: toggleUnorderedList,
                 contentAfter: "<h1>ab[]cd</h1>",
+            });
+        });
+
+        test("should turn a list into a heading, with line breaks", async () => {
+            await testEditor({
+                contentBefore: "<ul><li><h1>a<br>b<br>[]c<br>d<br>e</h1></li></ul>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<h1>a<br>b<br>[]c<br>d<br>e</h1>",
             });
         });
 
@@ -204,12 +278,30 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should turn a list item into a paragraph, with line breaks", async () => {
+            await testEditor({
+                contentBefore: "<p>ab</p><ul><li>cd</li><li>e<br>f<br>[]g<br>h<br>i</li></ul>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<p>ab</p><ul><li>cd</li></ul><p>e<br>f<br>[]g<br>h<br>i</p>",
+            });
+        });
+
         test("should turn a list with formats into a paragraph", async () => {
             await testEditor({
                 contentBefore:
                     "<ul><li><span><b>ab</b></span> <span><i>cd</i></span> ef[]gh</li></ul>",
                 stepFunction: toggleUnorderedList,
                 contentAfter: "<p><span><b>ab</b></span> <span><i>cd</i></span> ef[]gh</p>",
+            });
+        });
+
+        test("should turn a list with formats into a paragraph, with line breaks", async () => {
+            await testEditor({
+                contentBefore:
+                    "<ul><li><span><b>ab</b></span> <span><i>cd</i></span> e<br>f<br>[]g<br>h<br>i</li></ul>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p><span><b>ab</b></span> <span><i>cd</i></span> e<br>f<br>[]g<br>h<br>i</p>",
             });
         });
 
@@ -355,11 +447,147 @@ describe("Range not collapsed", () => {
             });
         });
 
+        test("should turn a multi-line paragraph into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>[a<br>b<br>c<br>d<br>e]</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>[a</li><li>b</li><li>c</li><li>d</li><li>e]</li></ul>",
+            });
+        });
+
+        test("should turn a multi-line paragraph into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>]a<br>b<br>c<br>d<br>e[</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>]a</li><li>b</li><li>c</li><li>d</li><li>e[</li></ul>",
+            });
+        });
+
+        test("should turn the first few lines of a paragraph into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>[a<br>b<br>c]<br>d<br>e</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>[a</li><li>b</li><li>c]</li></ul><p>d<br>e</p>",
+            });
+        });
+
+        test("should turn the first few lines of a paragraph into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>]a<br>b<br>c[<br>d<br>e</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>]a</li><li>b</li><li>c[</li></ul><p>d<br>e</p>",
+            });
+        });
+
+        test("should turn the middle few lines of a paragraph into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>[b<br>c<br>d]<br>e</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<p>a</p><ul><li>[b</li><li>c</li><li>d]</li></ul><p>e</p>",
+            });
+        });
+
+        test("should turn the middle few lines of a paragraph into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>]b<br>c<br>d[<br>e</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<p>a</p><ul><li>]b</li><li>c</li><li>d[</li></ul><p>e</p>",
+            });
+        });
+
+        test("should turn a last few lines of a paragraph into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>b<br>[c<br>d<br>e]</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<p>a<br>b</p><ul><li>[c</li><li>d</li><li>e]</li></ul>",
+            });
+        });
+
+        test("should turn a last few lines of a paragraph into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>b<br>]c<br>d<br>e[</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<p>a<br>b</p><ul><li>]c</li><li>d</li><li>e[</li></ul>",
+            });
+        });
+
         test("should turn a heading into a list", async () => {
             await testEditor({
                 contentBefore: "<p>ab</p><h1>cd[ef]gh</h1>",
                 stepFunction: toggleUnorderedList,
                 contentAfter: "<p>ab</p><ul><li><h1>cd[ef]gh</h1></li></ul>",
+            });
+        });
+
+        test("should turn a multi-line heading into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>AB[a<br>b<br>c<br>d<br>e]FG</h1>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p>xy</p><ul><li><h1>AB[a</h1></li><li><h1>b</h1></li><li><h1>c</h1></li><li><h1>d</h1></li><li><h1>e]FG</h1></li></ul>",
+            });
+        });
+
+        test("should turn a multi-line heading into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>AB]a<br>b<br>c<br>d<br>e[FG</h1>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p>xy</p><ul><li><h1>AB]a</h1></li><li><h1>b</h1></li><li><h1>c</h1></li><li><h1>d</h1></li><li><h1>e[FG</h1></li></ul>",
+            });
+        });
+
+        test("should turn the first few lines of a heading into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>AB[a<br>b<br>c]<br>d<br>e</h1>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p>xy</p><ul><li><h1>AB[a</h1></li><li><h1>b</h1></li><li><h1>c]</h1></li></ul><h1>d<br>e</h1>",
+            });
+        });
+
+        test("should turn the first few lines of a heading into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>AB]a<br>b<br>c[<br>d<br>e</h1>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p>xy</p><ul><li><h1>AB]a</h1></li><li><h1>b</h1></li><li><h1>c[</h1></li></ul><h1>d<br>e</h1>",
+            });
+        });
+
+        test("should turn the middle few lines of a heading into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>a<br>AB[b<br>c<br>d]EF<br>e</h1>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p>xy</p><h1>a</h1><ul><li><h1>AB[b</h1></li><li><h1>c</h1></li><li><h1>d]EF</h1></li></ul><h1>e</h1>",
+            });
+        });
+
+        test("should turn the middle few lines of a heading into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>a<br>AB]b<br>c<br>d[EF<br>e</h1>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p>xy</p><h1>a</h1><ul><li><h1>AB]b</h1></li><li><h1>c</h1></li><li><h1>d[EF</h1></li></ul><h1>e</h1>",
+            });
+        });
+
+        test("should turn a last few lines of a heading into a list with multiple items", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>a<br>b<br>AB[c<br>d<br>e]EF</h1>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p>xy</p><h1>a<br>b</h1><ul><li><h1>AB[c</h1></li><li><h1>d</h1></li><li><h1>e]EF</h1></li></ul>",
+            });
+        });
+
+        test("should turn a last few lines of a heading into a list with multiple items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>xy</p><h1>a<br>b<br>AB]c<br>d<br>e[EF</h1>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p>xy</p><h1>a<br>b</h1><ul><li><h1>AB]c</h1></li><li><h1>d</h1></li><li><h1>e[EF</h1></li></ul>",
             });
         });
 
@@ -371,11 +599,47 @@ describe("Range not collapsed", () => {
             });
         });
 
+        test("should turn four lines over two paragraphs into a list with four items", async () => {
+            await testEditor({
+                contentBefore: "<p>ab</p><p>c<br>d[e<br>f</p><p>g<br>h]i<br>j</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p>ab</p><p>c</p><ul><li>d[e</li><li>f</li><li>g</li><li>h]i</li></ul><p>j</p>",
+            });
+        });
+
+        test("should turn four lines over two paragraphs into a list with four items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>ab</p><p>c<br>d]e<br>f</p><p>g<br>h[i<br>j</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p>ab</p><p>c</p><ul><li>d]e</li><li>f</li><li>g</li><li>h[i</li></ul><p>j</p>",
+            });
+        });
+
         test("should turn two paragraphs in a div into a list with two items", async () => {
             await testEditor({
                 contentBefore: "<div><p>ab[cd</p><p>ef]gh</p></div>",
                 stepFunction: toggleUnorderedList,
                 contentAfter: "<div><ul><li>ab[cd</li><li>ef]gh</li></ul></div>",
+            });
+        });
+
+        test("should turn four lines over two paragraphs in a div into a list with four items", async () => {
+            await testEditor({
+                contentBefore: "<div><p>a<br>b[c<br>d</p><p>e<br>f]g<br>h</p></div>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<div><p>a</p><ul><li>b[c</li><li>d</li><li>e</li><li>f]g</li></ul><p>h</p></div>",
+            });
+        });
+
+        test("should turn four lines over two paragraphs in a div into a list with four items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<div><p>a<br>b]c<br>d</p><p>e<br>f[g<br>h</p></div>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<div><p>a</p><ul><li>b]c</li><li>d</li><li>e</li><li>f[g</li></ul><p>h</p></div>",
             });
         });
 
@@ -387,11 +651,79 @@ describe("Range not collapsed", () => {
             });
         });
 
+        test("should turn two lines of a paragraph and a list item into three list items", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>x[b<br>y</p><ul><li>c]d</li><li>ef</li></ul>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<p>a</p><ul><li>x[b</li><li>y</li><li>c]d</li><li>ef</li></ul>",
+            });
+        });
+
+        test("should turn two lines of a paragraph and a list item into three list items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<p>a<br>x]b<br>y</p><ul><li>c[d</li><li>ef</li></ul>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<p>a</p><ul><li>x]b</li><li>y</li><li>c[d</li><li>ef</li></ul>",
+            });
+        });
+
+        test("should turn two lines of a paragraph and two lines of a list item into four list items", async () => {
+            // TODO: is this what we want?
+            await testEditor({
+                contentBefore: "<p>a<br>x[b<br>y</p><ul><li>c<br>z]d<br>A</li><li>ef</li></ul>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p>a</p><ul><li>x[b</li><li>y</li><li>c<br>z]d<br>A</li><li>ef</li></ul>",
+            });
+        });
+
+        test("should turn two lines of a paragraph and two lines of a list item into four list items (reversed selection)", async () => {
+            // TODO: is this what we want?
+            await testEditor({
+                contentBefore: "<p>a<br>x]b<br>y</p><ul><li>c<br>z[d<br>A</li><li>ef</li></ul>",
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    "<p>a</p><ul><li>x]b</li><li>y</li><li>c<br>z[d<br>A</li><li>ef</li></ul>",
+            });
+        });
+
         test("should turn a list item and a paragraph into two list items", async () => {
             await testEditor({
                 contentBefore: "<ul><li>ab</li><li>c[d</li></ul><p>e]f</p>",
                 stepFunction: toggleUnorderedList,
                 contentAfter: "<ul><li>ab</li><li>c[d</li><li>e]f</li></ul>",
+            });
+        });
+
+        test("should turn a list item and two lines of a paragraph into three list items", async () => {
+            await testEditor({
+                contentBefore: "<ul><li>ab</li><li>c[d</li></ul><p>e<br>x]f<br>g</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>ab</li><li>c[d</li><li>e</li><li>x]f</li></ul><p>g</p>",
+            });
+        });
+
+        test("should turn a list item and two lines of a paragraph into three list items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<ul><li>ab</li><li>c]d</li></ul><p>e<br>x[f<br>g</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>ab</li><li>c]d</li><li>e</li><li>x[f</li></ul><p>g</p>",
+            });
+        });
+
+        test("should turn two lines of a list item and two lines of a paragraph into three list items", async () => {
+            await testEditor({
+                contentBefore: "<ul><li>ab</li><li>c[d<br>A</li></ul><p>e<br>x]f<br>g</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>ab</li><li>c[d<br>A</li><li>e</li><li>x]f</li></ul><p>g</p>",
+            });
+        });
+
+        test("should turn two lines of a list item and two lines of a paragraph into three list items (reversed selection)", async () => {
+            await testEditor({
+                contentBefore: "<ul><li>ab</li><li>c]d<br>A</li></ul><p>e<br>x[f<br>g</p>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>ab</li><li>c]d<br>A</li><li>e</li><li>x[f</li></ul><p>g</p>",
             });
         });
 

--- a/addons/html_editor/static/tests/split/split_block_segments.test.js
+++ b/addons/html_editor/static/tests/split/split_block_segments.test.js
@@ -1,0 +1,451 @@
+import { describe, test, tick } from "@odoo/hoot";
+import { testEditor } from "../_helpers/editor";
+import { unformat } from "../_helpers/format";
+
+const splitBlockSegments = async (editor) => {
+    editor.shared.split.splitBlockSegments();
+    editor.shared.history.addStep();
+    await tick();
+};
+
+describe("basic", () => {
+    test("should isolate a line in a paragraph", async () => {
+        await testEditor({
+            contentBefore: `<p>a<br>b<br>[c]<br>d<br>e</p>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: `<p>a<br>b</p><p>[c]</p><p>d<br>e</p>`,
+        });
+    });
+
+    test("should isolate a line in a paragraph (collapsed)", async () => {
+        await testEditor({
+            contentBefore: `<p>a<br>b<br>[]c<br>d<br>e</p>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: `<p>a<br>b</p><p>[]c</p><p>d<br>e</p>`,
+        });
+    });
+
+    test("should isolate multiple lines in a paragraph (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: `<p>a<br>b<br>]c<br>d[<br>e<br>f</p>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: `<p>a<br>b</p><p>]c</p><p>d[</p><p>e<br>f</p>`,
+        });
+    });
+
+    test("should isolate all lines in a paragraph", async () => {
+        await testEditor({
+            contentBefore: `<p>[a<br>b<br>c<br>d<br>e]</p>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: `<p>[a</p><p>b</p><p>c</p><p>d</p><p>e]</p>`,
+        });
+    });
+
+    test("should isolate all lines in a paragraph (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: `<p>]a<br>b<br>c<br>d<br>e[</p>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: `<p>]a</p><p>b</p><p>c</p><p>d</p><p>e[</p>`,
+        });
+    });
+});
+
+describe("unbreakable", () => {
+    test("should isolate a line in an unbreakable block", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">a<br>b<br>[c]<br>d<br>e</div>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: `<div class="oe_unbreakable"><p>a<br>b</p><p>[c]</p><p>d<br>e</p></div>`,
+        });
+    });
+
+    test("should isolate a line in an unbreakable block (collapsed)", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">a<br>b<br>[]c<br>d<br>e</div>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: `<div class="oe_unbreakable"><p>a<br>b</p><p>[]c</p><p>d<br>e</p></div>`,
+        });
+    });
+
+    test("should isolate multiple lines in an unbreakable block", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">a<br>b<br>[c<br>d]<br>e<br>f</div>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: `<div class="oe_unbreakable"><p>a<br>b</p><p>[c</p><p>d]</p><p>e<br>f</p></div>`,
+        });
+    });
+
+    test("should isolate multiple lines in an unbreakable block (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">a<br>b<br>]c<br>d[<br>e<br>f</div>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: `<div class="oe_unbreakable"><p>a<br>b</p><p>]c</p><p>d[</p><p>e<br>f</p></div>`,
+        });
+    });
+
+    test("should isolate all lines in an unbreakable block", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">[a<br>b<br>c<br>d<br>e]</div>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: `<div class="oe_unbreakable"><p>[a</p><p>b</p><p>c</p><p>d</p><p>e]</p></div>`,
+        });
+    });
+
+    test("should isolate all lines in an unbreakable block (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">]a<br>b<br>c<br>d<br>e[</div>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: `<div class="oe_unbreakable"><p>]a</p><p>b</p><p>c</p><p>d</p><p>e[</p></div>`,
+        });
+    });
+
+    test("should isolate a line in an unbreakable block starting with a block (do not wrap said block)", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `<div class="oe_unbreakable">
+                    <div>do not wrap</div>
+                    a<br>b<br>[]c<br>d<br>e
+                </div>`
+            ),
+            stepFunction: splitBlockSegments,
+            contentAfter: unformat(
+                `<div class="oe_unbreakable">
+                    <div>do not wrap</div>
+                    <p>a<br>b</p>
+                    <p>[]c</p>
+                    <p>d<br>e</p>
+                </div>`
+            ),
+        });
+    });
+
+    test("should isolate a line in an unbreakable block ending with a block (do not wrap said block)", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `<div class="oe_unbreakable">
+                    a<br>b<br>[]c<br>d<br>e
+                    <div>do not wrap</div>
+                </div>`
+            ),
+            stepFunction: splitBlockSegments,
+            contentAfter: unformat(
+                `<div class="oe_unbreakable">
+                    <p>a<br>b</p>
+                    <p>[]c</p>
+                    <p>d<br>e</p>
+                    <div>do not wrap</div>
+                </div>`
+            ),
+        });
+    });
+
+    test("should isolate a line in an unbreakable block starting and ending with a block (do not wrap said blocks)", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `<div class="oe_unbreakable">
+                    <div>do not wrap</div>
+                    a<br>b<br>[]c<br>d<br>e
+                    <div>do not wrap</div>
+                </div>`
+            ),
+            stepFunction: splitBlockSegments,
+            contentAfter: unformat(
+                `<div class="oe_unbreakable">
+                    <div>do not wrap</div>
+                    <p>a<br>b</p>
+                    <p>[]c</p>
+                    <p>d<br>e</p>
+                    <div>do not wrap</div>
+                </div>`
+            ),
+        });
+    });
+
+    test("should isolate a line in an unbreakable block containing blocks (do not wrap said blocks)", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `<div class="oe_unbreakable">
+                    a<br>b
+                    <div>do not wrap</div>
+                    c<br>[]d<br>e
+                    <div>do not wrap</div>
+                    f<br>g
+                </div>`
+            ),
+            stepFunction: splitBlockSegments,
+            contentAfter: unformat(
+                `<div class="oe_unbreakable">
+                    a<br>b
+                    <div>do not wrap</div>
+                    <p>c</p>
+                    <p>[]d</p>
+                    <p>e</p>
+                    <div>do not wrap</div>
+                    f<br>g
+                </div>`
+            ),
+        });
+    });
+
+    test("should isolate all lines in an unbreakable block containing blocks (do not wrap said blocks)", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `<div class="oe_unbreakable">
+                    [a<br>b
+                    <div>do not wrap</div>
+                    c<br>d<br>e
+                    <div>do not wrap</div>
+                    f<br>g]
+                </div>`
+            ),
+            stepFunction: splitBlockSegments,
+            contentAfter: unformat(
+                `<div class="oe_unbreakable">
+                    <p>[a</p>
+                    <p>b</p>
+                    <div>do not wrap</div>
+                    <p>c</p>
+                    <p>d</p>
+                    <p>e</p>
+                    <div>do not wrap</div>
+                    <p>f</p>
+                    <p>g]</p>
+                </div>`
+            ),
+        });
+    });
+
+    test("should isolate all lines in an unbreakable block containing blocks (do not wrap said blocks) (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `<div class="oe_unbreakable">
+                    ]a<br>b
+                    <div>do not wrap</div>
+                    c<br>d<br>e
+                    <div>do not wrap</div>
+                    f<br>g[
+                </div>`
+            ),
+            stepFunction: splitBlockSegments,
+            contentAfter: unformat(
+                `<div class="oe_unbreakable">
+                    <p>]a</p>
+                    <p>b</p>
+                    <div>do not wrap</div>
+                    <p>c</p>
+                    <p>d</p>
+                    <p>e</p>
+                    <div>do not wrap</div>
+                    <p>f</p>
+                    <p>g[</p>
+                </div>`
+            ),
+        });
+    });
+
+    test("should not isolate a line in an unbreakable node that doesn't accept paragraph-related elements (inline)", async () => {
+        await testEditor({
+            contentBefore: `<p>a<br><span class="oe_unbreakable">b<br>[c]<br>d</span><br>e</p>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: `<p>a<br><span class="oe_unbreakable">b<br>[c]<br>d</span><br>e</p>`,
+        });
+    });
+
+    test("should not isolate a line in an unbreakable node that doesn't accept paragraph-related elements (paragraph)", async () => {
+        await testEditor({
+            contentBefore: `<p class="oe_unbreakable">a<br>b<br>[c]<br>d<br>e</p>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: `<p class="oe_unbreakable">a<br>b<br>[c]<br>d<br>e</p>`,
+        });
+    });
+
+    test("should isolate a line in an unbreakable block (deep)", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable"><span>a<br>b<br>[c]<br>d<br>e</span></div>`,
+            stepFunction: splitBlockSegments,
+            contentAfter: unformat(
+                `<div class="oe_unbreakable">
+                    <p><span>a<br>b</span></p>
+                    <p><span>[c]</span></p>
+                    <p><span>d<br>e</span></p>
+                </div>`
+            ),
+        });
+    });
+
+    test("should isolate lines in and out of an unbreakable block (at start)", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `<div class="oe_unbreakable">
+                    a<br>b<br>[c<br>d<br>e
+                </div>
+                <p>
+                    f<br>g<br>h]<br>i<br>j
+                </p>`
+            ),
+            stepFunction: splitBlockSegments,
+            contentAfter: unformat(
+                `<div class="oe_unbreakable">
+                    <p>a<br>b</p>
+                    <p>[c</p>
+                    <p>d</p>
+                    <p>e</p>
+                </div>
+                <p>f</p>
+                <p>g</p>
+                <p>h]</p>
+                <p>i<br>j</p>`
+            ),
+        });
+    });
+
+    test("should isolate lines in and out of an unbreakable block (at start) (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `<div class="oe_unbreakable">
+                    a<br>b<br>]c<br>d<br>e
+                </div>
+                <p>
+                    f<br>g<br>h[<br>i<br>j
+                </p>`
+            ),
+            stepFunction: splitBlockSegments,
+            contentAfter: unformat(
+                `<div class="oe_unbreakable">
+                    <p>a<br>b</p>
+                    <p>]c</p>
+                    <p>d</p>
+                    <p>e</p>
+                </div>
+                <p>f</p>
+                <p>g</p>
+                <p>h[</p>
+                <p>i<br>j</p>`
+            ),
+        });
+    });
+
+    test("should isolate lines in and out of an unbreakable block (at end)", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `<p>
+                    a<br>b<br>[c<br>d<br>e
+                </p>
+                <div class="oe_unbreakable">
+                    f<br>g<br>h]<br>i<br>j
+                </div>`
+            ),
+            stepFunction: splitBlockSegments,
+            contentAfter: unformat(
+                `<p>a<br>b</p>
+                <p>[c</p>
+                <p>d</p>
+                <p>e</p>
+                <div class="oe_unbreakable">
+                    <p>f</p>
+                    <p>g</p>
+                    <p>h]</p>
+                    <p>i<br>j</p>
+                </div>`
+            ),
+        });
+    });
+
+    test("should isolate lines in and out of an unbreakable block (at end) (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `<p>
+                    a<br>b<br>]c<br>d<br>e
+                </p>
+                <div class="oe_unbreakable">
+                    f<br>g<br>h[<br>i<br>j
+                </div>`
+            ),
+            stepFunction: splitBlockSegments,
+            contentAfter: unformat(
+                `<p>a<br>b</p>
+                <p>]c</p>
+                <p>d</p>
+                <p>e</p>
+                <div class="oe_unbreakable">
+                    <p>f</p>
+                    <p>g</p>
+                    <p>h[</p>
+                    <p>i<br>j</p>
+                </div>`
+            ),
+        });
+    });
+
+    test("should isolate lines in and out of an unbreakable block (at start and end)", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `<div class="oe_unbreakable">
+                    a<br>b<br>[c<br>d<br>e
+                </div>
+                <p>
+                    f<br>g<br>h<br>i<br>j
+                </p>
+                <div class="oe_unbreakable">
+                    k<br>l<br>m]<br>n<br>o
+                </div>`
+            ),
+            stepFunction: splitBlockSegments,
+            contentAfter: unformat(
+                `<div class="oe_unbreakable">
+                    <p>a<br>b</p>
+                    <p>[c</p>
+                    <p>d</p>
+                    <p>e</p>
+                </div>
+                <p>f</p>
+                <p>g</p>
+                <p>h</p>
+                <p>i</p>
+                <p>j</p>
+                <div class="oe_unbreakable">
+                    <p>k</p>
+                    <p>l</p>
+                    <p>m]</p>
+                    <p>n<br>o</p>
+                </div>`
+            ),
+        });
+    });
+
+    test("should isolate lines in and out of an unbreakable block (at start and end) (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `<div class="oe_unbreakable">
+                    a<br>b<br>]c<br>d<br>e
+                </div>
+                <p>
+                    f<br>g<br>h<br>i<br>j
+                </p>
+                <div class="oe_unbreakable">
+                    k<br>l<br>m[<br>n<br>o
+                </div>`
+            ),
+            stepFunction: splitBlockSegments,
+            contentAfter: unformat(
+                `<div class="oe_unbreakable">
+                    <p>a<br>b</p>
+                    <p>]c</p>
+                    <p>d</p>
+                    <p>e</p>
+                </div>
+                <p>f</p>
+                <p>g</p>
+                <p>h</p>
+                <p>i</p>
+                <p>j</p>
+                <div class="oe_unbreakable">
+                    <p>k</p>
+                    <p>l</p>
+                    <p>m[</p>
+                    <p>n<br>o</p>
+                </div>`
+            ),
+        });
+    });
+});

--- a/addons/html_editor/static/tests/tabs.test.js
+++ b/addons/html_editor/static/tests/tabs.test.js
@@ -29,6 +29,44 @@ describe("insert tabulation", () => {
         });
     });
 
+    test("should keep selection and insert a tab character at the beginning of the lines", async () => {
+        await testTabulation({
+            contentBefore: `<p>a<br>b<br>[x<br>x<br>x]c<br>d<br>e</p>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>a<br>b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}[x</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}x</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}x]c</p>` +
+                `<p>d<br>e</p>`,
+            contentAfter:
+                `<p>a<br>b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}[x</p>` +
+                `<p>${oeTab(TAB_WIDTH)}x</p>` +
+                `<p>${oeTab(TAB_WIDTH)}x]c</p>` +
+                `<p>d<br>e</p>`,
+        });
+    });
+
+    test("should keep selection and insert a tab character at the beginning of the lines (reversed selection)", async () => {
+        await testTabulation({
+            contentBefore: `<p>a<br>b<br>]x<br>x<br>x[c<br>d<br>e</p>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>a<br>b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}]x</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}x</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}x[c</p>` +
+                `<p>d<br>e</p>`,
+            contentAfter:
+                `<p>a<br>b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}]x</p>` +
+                `<p>${oeTab(TAB_WIDTH)}x</p>` +
+                `<p>${oeTab(TAB_WIDTH)}x[c</p>` +
+                `<p>d<br>e</p>`,
+        });
+    });
+
     test("should insert two tab characters", async () => {
         const expectedTabWidth = TAB_WIDTH - getCharWidth("p", "a");
         await testTabulation({
@@ -162,6 +200,40 @@ describe("insert tabulation", () => {
         });
     });
 
+    test("should insert tab characters at the beginning of four lines over two separate paragraphs", async () => {
+        await testTabulation({
+            contentBefore: `<p>a[b<br>c</p>` + `<p>d<br>e]f</p>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>${oeTab(TAB_WIDTH, false)}a[b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}c</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}d</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}e]f</p>`,
+            contentAfter:
+                `<p>${oeTab(TAB_WIDTH)}a[b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c</p>` +
+                `<p>${oeTab(TAB_WIDTH)}d</p>` +
+                `<p>${oeTab(TAB_WIDTH)}e]f</p>`,
+        });
+    });
+
+    test("should insert tab characters at the beginning of four lines over two separate paragraphs (reversed selection)", async () => {
+        await testTabulation({
+            contentBefore: `<p>a]b<br>c</p>` + `<p>d<br>e[f</p>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>${oeTab(TAB_WIDTH, false)}a]b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}c</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}d</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}e[f</p>`,
+            contentAfter:
+                `<p>${oeTab(TAB_WIDTH)}a]b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c</p>` +
+                `<p>${oeTab(TAB_WIDTH)}d</p>` +
+                `<p>${oeTab(TAB_WIDTH)}e[f</p>`,
+        });
+    });
+
     test("should insert tab characters at the beginning of two separate indented paragraphs", async () => {
         await testTabulation({
             contentBefore: `<p>${oeTab()}a[b</p>` + `<p>${oeTab()}c]d</p>`,
@@ -200,6 +272,68 @@ describe("insert tabulation", () => {
         });
     });
 
+    test("should insert tab characters at the beginning of two separate paragraphs (one indented, the other not), with line breaks", async () => {
+        await testTabulation({
+            contentBefore: `<p>${oeTab()}a[b<br>c</p>` + `<p>d<br>e]f</p>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}a[b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}c</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}d</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}e]f</p>`,
+            contentAfter:
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a[b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c</p>` +
+                `<p>${oeTab(TAB_WIDTH)}d</p>` +
+                `<p>${oeTab(TAB_WIDTH)}e]f</p>`,
+        });
+        await testTabulation({
+            contentBefore: `<p>a[b<br>c</p>` + `<p>${oeTab()}d<br>e]f</p>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>${oeTab(TAB_WIDTH, false)}a[b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}c</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}d</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}e]f</p>`,
+            contentAfter:
+                `<p>${oeTab(TAB_WIDTH)}a[b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c</p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}d</p>` +
+                `<p>${oeTab(TAB_WIDTH)}e]f</p>`,
+        });
+    });
+
+    test("should insert tab characters at the beginning of two separate paragraphs (one indented, the other not), with line breaks (reversed selection)", async () => {
+        await testTabulation({
+            contentBefore: `<p>${oeTab()}a]b<br>c</p>` + `<p>d<br>e[f</p>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}a]b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}c</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}d</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}e[f</p>`,
+            contentAfter:
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a]b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c</p>` +
+                `<p>${oeTab(TAB_WIDTH)}d</p>` +
+                `<p>${oeTab(TAB_WIDTH)}e[f</p>`,
+        });
+        await testTabulation({
+            contentBefore: `<p>a]b<br>c</p>` + `<p>${oeTab()}d<br>e[f</p>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>${oeTab(TAB_WIDTH, false)}a]b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}c</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}d</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}e[f</p>`,
+            contentAfter:
+                `<p>${oeTab(TAB_WIDTH)}a]b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c</p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}d</p>` +
+                `<p>${oeTab(TAB_WIDTH)}e[f</p>`,
+        });
+    });
+
     test("should insert tab characters at the beginning of two separate paragraphs with tabs in them", async () => {
         const tabAfterA = TAB_WIDTH - getCharWidth("p", "a");
         const tabAfterB = TAB_WIDTH - getCharWidth("p", "b");
@@ -214,6 +348,44 @@ describe("insert tabulation", () => {
                 `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a[${oeTab(tabAfterA)}b${oeTab(
                     tabAfterB
                 )}</p>` + `<p>${oeTab(TAB_WIDTH)}c${oeTab(tabAfterC)}]d${oeTab(tabAfterD)}</p>`,
+        });
+    });
+
+    test("should insert tab characters at the beginning of two separate paragraphs with tabs in them, with line breaks", async () => {
+        const tabAfterA = TAB_WIDTH - getCharWidth("p", "a");
+        const tabAfterB = TAB_WIDTH - getCharWidth("p", "b");
+        const tabAfterC = TAB_WIDTH - getCharWidth("p", "c");
+        const tabAfterD = TAB_WIDTH - getCharWidth("p", "d");
+
+        await testTabulation({
+            contentBefore:
+                `<p>${oeTab()}a[${oeTab()}<br>b${oeTab()}</p>` +
+                `<p>c${oeTab()}<br>]d${oeTab()}</p>`,
+            stepFunction: keydownTab,
+            contentAfter:
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a[${oeTab(tabAfterA)}</p>` +
+                `<p>${oeTab(TAB_WIDTH)}b${oeTab(tabAfterB)}</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c${oeTab(tabAfterC)}</p>` +
+                `<p>${oeTab(TAB_WIDTH)}]d${oeTab(tabAfterD)}</p>`,
+        });
+    });
+
+    test("should insert tab characters at the beginning of two separate paragraphs with tabs in them, with line breaks (reversed selection)", async () => {
+        const tabAfterA = TAB_WIDTH - getCharWidth("p", "a");
+        const tabAfterB = TAB_WIDTH - getCharWidth("p", "b");
+        const tabAfterC = TAB_WIDTH - getCharWidth("p", "c");
+        const tabAfterD = TAB_WIDTH - getCharWidth("p", "d");
+
+        await testTabulation({
+            contentBefore:
+                `<p>${oeTab()}a]${oeTab()}<br>b${oeTab()}</p>` +
+                `<p>c${oeTab()}<br>[d${oeTab()}</p>`,
+            stepFunction: keydownTab,
+            contentAfter:
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a]${oeTab(tabAfterA)}</p>` +
+                `<p>${oeTab(TAB_WIDTH)}b${oeTab(tabAfterB)}</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c${oeTab(tabAfterC)}</p>` +
+                `<p>${oeTab(TAB_WIDTH)}[d${oeTab(tabAfterD)}</p>`,
         });
     });
 
@@ -239,6 +411,70 @@ describe("insert tabulation", () => {
                 `<p>${oeTab(TAB_WIDTH)}a[b</p>` +
                 `<h1>${oeTab(TAB_WIDTH)}cd</h1>` +
                 `<blockquote>${oeTab(tabInBlockquote)}e]f</blockquote>` +
+                `<h4>zzz</h4>`,
+        });
+    });
+
+    test("should insert tab characters at the beginning of three separate blocks, with line breaks", async () => {
+        const tabInBlockquote = TAB_WIDTH - getIndentWidth("blockquote");
+
+        await testTabulation({
+            contentBefore:
+                `<p>xxx</p>` +
+                `<p>a[b<br>c</p>` +
+                `<h1>d<br>e</h1>` +
+                `<blockquote>f]<br>g</blockquote>` +
+                `<h4>zzz</h4>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}a[b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}c</p>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}d</h1>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}e</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote, false)}f]</blockquote>` +
+                `<blockquote>g</blockquote>` +
+                `<h4>zzz</h4>`,
+            contentAfter:
+                `<p>xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH)}a[b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c</p>` +
+                `<h1>${oeTab(TAB_WIDTH)}d</h1>` +
+                `<h1>${oeTab(TAB_WIDTH)}e</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote)}f]</blockquote>` +
+                `<blockquote>g</blockquote>` +
+                `<h4>zzz</h4>`,
+        });
+    });
+
+    test("should insert tab characters at the beginning of three separate blocks, with line breaks (reversed selection)", async () => {
+        const tabInBlockquote = TAB_WIDTH - getIndentWidth("blockquote");
+
+        await testTabulation({
+            contentBefore:
+                `<p>xxx</p>` +
+                `<p>a]b<br>c</p>` +
+                `<h1>d<br>e</h1>` +
+                `<blockquote>f[<br>g</blockquote>` +
+                `<h4>zzz</h4>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}a]b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}c</p>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}d</h1>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}e</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote, false)}f[</blockquote>` +
+                `<blockquote>g</blockquote>` +
+                `<h4>zzz</h4>`,
+            contentAfter:
+                `<p>xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH)}a]b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c</p>` +
+                `<h1>${oeTab(TAB_WIDTH)}d</h1>` +
+                `<h1>${oeTab(TAB_WIDTH)}e</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote)}f[</blockquote>` +
+                `<blockquote>g</blockquote>` +
                 `<h4>zzz</h4>`,
         });
     });
@@ -272,6 +508,76 @@ describe("insert tabulation", () => {
         });
     });
 
+    test("should insert tab characters at the beginning of three separate indented blocks, with line breaks", async () => {
+        const tabInBlockquote = TAB_WIDTH - getIndentWidth("blockquote");
+
+        await testTabulation({
+            contentBefore:
+                `<p>${oeTab()}xxx</p>` +
+                `<p>${oeTab()}a[b<br>c</p>` +
+                `<h1>${oeTab()}d<br>e</h1>` +
+                `<blockquote>${oeTab()}f]<br>g</blockquote>` +
+                `<h4>${oeTab()}zzz</h4>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>${oeTab(TAB_WIDTH, false)}xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}a[b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}c</p>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}d</h1>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}e</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote, false)}${oeTab(
+                    TAB_WIDTH,
+                    false
+                )}f]</blockquote>` +
+                `<blockquote>g</blockquote>` +
+                `<h4>${oeTab(TAB_WIDTH, false)}zzz</h4>`,
+            contentAfter:
+                `<p>${oeTab(TAB_WIDTH)}xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a[b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c</p>` +
+                `<h1>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}d</h1>` +
+                `<h1>${oeTab(TAB_WIDTH)}e</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote)}${oeTab(TAB_WIDTH)}f]</blockquote>` +
+                `<blockquote>g</blockquote>` +
+                `<h4>${oeTab(TAB_WIDTH)}zzz</h4>`,
+        });
+    });
+
+    test("should insert tab characters at the beginning of three separate indented blocks, with line breaks (reversed selection)", async () => {
+        const tabInBlockquote = TAB_WIDTH - getIndentWidth("blockquote");
+
+        await testTabulation({
+            contentBefore:
+                `<p>${oeTab()}xxx</p>` +
+                `<p>${oeTab()}a]b<br>c</p>` +
+                `<h1>${oeTab()}d<br>e</h1>` +
+                `<blockquote>${oeTab()}f[<br>g</blockquote>` +
+                `<h4>${oeTab()}zzz</h4>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>${oeTab(TAB_WIDTH, false)}xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}a]b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}c</p>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}d</h1>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}e</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote, false)}${oeTab(
+                    TAB_WIDTH,
+                    false
+                )}f[</blockquote>` +
+                `<blockquote>g</blockquote>` +
+                `<h4>${oeTab(TAB_WIDTH, false)}zzz</h4>`,
+            contentAfter:
+                `<p>${oeTab(TAB_WIDTH)}xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a]b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c</p>` +
+                `<h1>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}d</h1>` +
+                `<h1>${oeTab(TAB_WIDTH)}e</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote)}${oeTab(TAB_WIDTH)}f[</blockquote>` +
+                `<blockquote>g</blockquote>` +
+                `<h4>${oeTab(TAB_WIDTH)}zzz</h4>`,
+        });
+    });
+
     test("should insert tab characters at the beginning of three separate blocks of mixed indentation", async () => {
         const tabInBlockquote = TAB_WIDTH - getIndentWidth("blockquote");
 
@@ -297,6 +603,76 @@ describe("insert tabulation", () => {
                 `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a[b</p>` +
                 `<h1>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}cd</h1>` +
                 `<blockquote>${oeTab(tabInBlockquote)}e]f</blockquote>` +
+                `<h4>zzz</h4>`,
+        });
+    });
+
+    test("should insert tab characters at the beginning of three separate blocks of mixed indentation, with line breaks", async () => {
+        const tabInBlockquote = TAB_WIDTH - getIndentWidth("blockquote");
+
+        await testTabulation({
+            contentBefore:
+                `<p>xxx</p>` +
+                `<p>${oeTab()}${oeTab()}a[b<br>c</p>` +
+                `<h1>${oeTab()}d<br>e</h1>` +
+                `<blockquote>f]<br>g</blockquote>` +
+                `<h4>zzz</h4>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}${oeTab(
+                    TAB_WIDTH,
+                    false
+                )}a[b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}c</p>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}d</h1>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}e</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote, false)}f]</blockquote>` +
+                `<blockquote>g</blockquote>` +
+                `<h4>zzz</h4>`,
+            contentAfter:
+                `<p>xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a[b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c</p>` +
+                `<h1>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}d</h1>` +
+                `<h1>${oeTab(TAB_WIDTH)}e</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote)}f]</blockquote>` +
+                `<blockquote>g</blockquote>` +
+                `<h4>zzz</h4>`,
+        });
+    });
+
+    test("should insert tab characters at the beginning of three separate blocks of mixed indentation, with line breaks (reversed selection)", async () => {
+        const tabInBlockquote = TAB_WIDTH - getIndentWidth("blockquote");
+
+        await testTabulation({
+            contentBefore:
+                `<p>xxx</p>` +
+                `<p>${oeTab()}${oeTab()}a]b<br>c</p>` +
+                `<h1>${oeTab()}d<br>e</h1>` +
+                `<blockquote>f[<br>g</blockquote>` +
+                `<h4>zzz</h4>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}${oeTab(
+                    TAB_WIDTH,
+                    false
+                )}a]b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}c</p>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}d</h1>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}e</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote, false)}f[</blockquote>` +
+                `<blockquote>g</blockquote>` +
+                `<h4>zzz</h4>`,
+            contentAfter:
+                `<p>xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a]b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}c</p>` +
+                `<h1>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}d</h1>` +
+                `<h1>${oeTab(TAB_WIDTH)}e</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote)}f[</blockquote>` +
+                `<blockquote>g</blockquote>` +
                 `<h4>zzz</h4>`,
         });
     });
@@ -341,6 +717,90 @@ describe("insert tabulation", () => {
                 `<blockquote>${oeTab(tabInBlockquote)}e${oeTab(
                     tabAfterEinBlockquote
                 )}]f</blockquote>` +
+                `<h4>zzz</h4>`,
+        });
+    });
+
+    test("should insert tab characters at the beginning of three separate blocks with tabs in them, with line breaks", async () => {
+        const tabAfterA = TAB_WIDTH - getCharWidth("p", "a");
+        const tabAfterCinH1 = TAB_WIDTH - getCharWidth("h1", "c");
+        const tabAfterDinH1 = TAB_WIDTH - getCharWidth("h1", "d");
+        const tabInBlockquote = TAB_WIDTH - getIndentWidth("blockquote");
+        const tabAfterEinBlockquote = TAB_WIDTH - getCharWidth("blockquote", "e"); // in bloquote, after a tab
+
+        await testTabulation({
+            contentBefore:
+                `<p>xxx</p>` +
+                `<p>${oeTab()}a[${oeTab()}b<br>${oeTab()}</p>` +
+                `<h1>c${oeTab()}<br>d${oeTab()}</h1>` +
+                `<blockquote>e${oeTab()}]f</blockquote>` +
+                `<h4>zzz</h4>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}a[${oeTab(
+                    tabAfterA,
+                    false
+                )}b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}<br></p>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}c${oeTab(tabAfterCinH1, false)}</h1>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}d${oeTab(tabAfterDinH1, false)}</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote, false)}e${oeTab(
+                    tabAfterEinBlockquote,
+                    false
+                )}]f</blockquote>` +
+                `<h4>zzz</h4>`,
+            contentAfter:
+                `<p>xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a[${oeTab(tabAfterA)}b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}<br></p>` +
+                `<h1>${oeTab(TAB_WIDTH)}c${oeTab(tabAfterCinH1)}</h1>` +
+                `<h1>${oeTab(TAB_WIDTH)}d${oeTab(tabAfterDinH1)}</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote)}e${oeTab(
+                    tabAfterEinBlockquote
+                )}]f</blockquote>` +
+                `<h4>zzz</h4>`,
+        });
+    });
+
+    test("should insert tab characters at the beginning of three separate blocks with tabs in them, with line breaks (reversed selection)", async () => {
+        const tabAfterA = TAB_WIDTH - getCharWidth("p", "a");
+        const tabAfterCinH1 = TAB_WIDTH - getCharWidth("h1", "c");
+        const tabAfterDinH1 = TAB_WIDTH - getCharWidth("h1", "d");
+        const tabInBlockquote = TAB_WIDTH - getIndentWidth("blockquote");
+        const tabAfterEinBlockquote = TAB_WIDTH - getCharWidth("blockquote", "e"); // in bloquote, after a tab
+
+        await testTabulation({
+            contentBefore:
+                `<p>xxx</p>` +
+                `<p>${oeTab()}a]${oeTab()}b<br>${oeTab()}</p>` +
+                `<h1>c${oeTab()}<br>d${oeTab()}</h1>` +
+                `<blockquote>e${oeTab()}[f</blockquote>` +
+                `<h4>zzz</h4>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}a]${oeTab(
+                    tabAfterA,
+                    false
+                )}b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}<br></p>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}c${oeTab(tabAfterCinH1, false)}</h1>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}d${oeTab(tabAfterDinH1, false)}</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote, false)}e${oeTab(
+                    tabAfterEinBlockquote,
+                    false
+                )}[f</blockquote>` +
+                `<h4>zzz</h4>`,
+            contentAfter:
+                `<p>xxx</p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a]${oeTab(tabAfterA)}b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}<br></p>` +
+                `<h1>${oeTab(TAB_WIDTH)}c${oeTab(tabAfterCinH1)}</h1>` +
+                `<h1>${oeTab(TAB_WIDTH)}d${oeTab(tabAfterDinH1)}</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote)}e${oeTab(
+                    tabAfterEinBlockquote
+                )}[f</blockquote>` +
                 `<h4>zzz</h4>`,
         });
     });
@@ -398,6 +858,126 @@ describe("insert tabulation", () => {
                     `</li>` +
                 `</ul>` +
                 `<blockquote>${oeTab(tabInBlockquote)}f${oeTab(tabAfterFinBlockquote)}]g</blockquote>`,
+        });
+    });
+
+    test("should insert tab characters in blocks and indent lists, with line breaks", async () => {
+        const tabAfterCinNestedLI =
+            TAB_WIDTH - ((2 * getIndentWidth("li") + getCharWidth("li", "c")) % TAB_WIDTH);
+        const tabAfterDinNestedLI = TAB_WIDTH - (getCharWidth("li", "d") % TAB_WIDTH); // in LI, after a tab
+        const tabInDoubleNestedList = TAB_WIDTH - ((3 * getIndentWidth("li")) % TAB_WIDTH);
+        const tabAfterE = TAB_WIDTH - getCharWidth("li", "e"); // in LI, after a tab
+        const tabInBlockquote = TAB_WIDTH - getIndentWidth("blockquote");
+        const tabAfterFinBlockquote = TAB_WIDTH - getCharWidth("blockquote", "f"); // in blockquote, after a tab
+
+        // prettier-ignore
+        await testTabulation({
+            // Obs: cannot use `unformat` for tests with tabs (as it removes the \t chars)
+            contentBefore:
+                `<p>${oeTab()}a<br>[${oeTab()}b<br>${oeTab()}</p>` +
+                `<ul>` +
+                    `<li><p>c${oeTab()}d${oeTab()}</p>` +
+                        `<ul>` +
+                            `<li>${oeTab()}e${oeTab()}</li>` +
+                        `</ul>` +
+                    `</li>` +
+                `</ul>` +
+                `<blockquote>f${oeTab()}<br>]g</blockquote>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>${oeTab(TAB_WIDTH, false)}a</p>` +
+                `<p>[${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}<br></p>` +
+                `<ul>` +
+                    `<li class="oe-nested">` +
+                        `<ul>` +
+                            `<li><p>c${oeTab(tabAfterCinNestedLI, false)}d${oeTab(tabAfterDinNestedLI, false)}</p>` +
+                                `<ul>` +
+                                    `<li>${oeTab(tabInDoubleNestedList, false)}e${oeTab(tabAfterE, false)}</li>` +
+                                `</ul>` +
+                            `</li>` +
+                        `</ul>` +
+                    `</li>` +
+                `</ul>` +
+                `<blockquote>${oeTab(tabInBlockquote, false)}f${oeTab(tabAfterFinBlockquote, false)}</blockquote>` +
+                `<blockquote>${oeTab(tabInBlockquote, false)}]g</blockquote>`,
+            contentAfter:
+                `<p>${oeTab(TAB_WIDTH)}a</p>` +
+                `<p>[${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}<br></p>` +
+                `<ul>` +
+                    `<li class="oe-nested">` +
+                        `<ul>` +
+                            `<li><p>c${oeTab(tabAfterCinNestedLI)}d${oeTab(tabAfterDinNestedLI)}</p>` +
+                                `<ul>` +
+                                    `<li>${oeTab(tabInDoubleNestedList)}e${oeTab(tabAfterE)}</li>` +
+                                `</ul>` +
+                            `</li>` +
+                        `</ul>` +
+                    `</li>` +
+                `</ul>` +
+                `<blockquote>${oeTab(tabInBlockquote)}f${oeTab(tabAfterFinBlockquote)}</blockquote>` +
+                `<blockquote>${oeTab(tabInBlockquote)}]g</blockquote>`,
+        });
+    });
+
+    test("should insert tab characters in blocks and indent lists, with line breaks (reversed selection)", async () => {
+        const tabAfterCinNestedLI =
+            TAB_WIDTH - ((2 * getIndentWidth("li") + getCharWidth("li", "c")) % TAB_WIDTH);
+        const tabAfterDinNestedLI = TAB_WIDTH - (getCharWidth("li", "d") % TAB_WIDTH); // in LI, after a tab
+        const tabInDoubleNestedList = TAB_WIDTH - ((3 * getIndentWidth("li")) % TAB_WIDTH);
+        const tabAfterE = TAB_WIDTH - getCharWidth("li", "e"); // in LI, after a tab
+        const tabInBlockquote = TAB_WIDTH - getIndentWidth("blockquote");
+        const tabAfterFinBlockquote = TAB_WIDTH - getCharWidth("blockquote", "f"); // in blockquote, after a tab
+
+        // prettier-ignore
+        await testTabulation({
+            // Obs: cannot use `unformat` for tests with tabs (as it removes the \t chars)
+            contentBefore:
+                `<p>${oeTab()}a<br>]${oeTab()}b<br>${oeTab()}</p>` +
+                `<ul>` +
+                    `<li><p>c${oeTab()}d${oeTab()}</p>` +
+                        `<ul>` +
+                            `<li>${oeTab()}e${oeTab()}</li>` +
+                        `</ul>` +
+                    `</li>` +
+                `</ul>` +
+                `<blockquote>f${oeTab()}<br>[g</blockquote>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>${oeTab(TAB_WIDTH, false)}a</p>` +
+                `<p>]${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}b</p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}<br></p>` +
+                `<ul>` +
+                    `<li class="oe-nested">` +
+                        `<ul>` +
+                            `<li><p>c${oeTab(tabAfterCinNestedLI, false)}d${oeTab(tabAfterDinNestedLI, false)}</p>` +
+                                `<ul>` +
+                                    `<li>${oeTab(tabInDoubleNestedList, false)}e${oeTab(tabAfterE, false)}</li>` +
+                                `</ul>` +
+                            `</li>` +
+                        `</ul>` +
+                    `</li>` +
+                `</ul>` +
+                `<blockquote>${oeTab(tabInBlockquote, false)}f${oeTab(tabAfterFinBlockquote, false)}</blockquote>` +
+                `<blockquote>${oeTab(tabInBlockquote, false)}[g</blockquote>`,
+            contentAfter:
+                `<p>${oeTab(TAB_WIDTH)}a</p>` +
+                `<p>]${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}b</p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}<br></p>` +
+                `<ul>` +
+                    `<li class="oe-nested">` +
+                        `<ul>` +
+                            `<li><p>c${oeTab(tabAfterCinNestedLI)}d${oeTab(tabAfterDinNestedLI)}</p>` +
+                                `<ul>` +
+                                    `<li>${oeTab(tabInDoubleNestedList)}e${oeTab(tabAfterE)}</li>` +
+                                `</ul>` +
+                            `</li>` +
+                        `</ul>` +
+                    `</li>` +
+                `</ul>` +
+                `<blockquote>${oeTab(tabInBlockquote)}f${oeTab(tabAfterFinBlockquote)}</blockquote>` +
+                `<blockquote>${oeTab(tabInBlockquote)}[g</blockquote>`,
         });
     });
 });

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -19,6 +19,32 @@ describe("to paragraph", () => {
         });
     });
 
+    test("should turn part of a heading 1 into a paragraph", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>c[]<br>d<br>e</h1>",
+            stepFunction: setTag("p"),
+            contentAfter: "<h1>a<br>b</h1><p>c[]</p><h1>d<br>e</h1>",
+        });
+    });
+
+    test("should turn part of a heading 1 into a paragraph (2)", async () => {
+        await testEditor({
+            contentBefore: "<h1>[<i>a</i>b<br><br>]<br></h1>",
+            stepFunction: setTag("p"),
+            // The third line remains a h1. It wasn't visibly selected.
+            contentAfter: "<p>[<i>a</i>b</p><p><br></p><h1>]<br></h1>",
+        });
+    });
+
+    test("should turn part of a heading 1 into a paragraph (2) (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<h1>]<i>a</i>b<br><br>[<br></h1>",
+            stepFunction: setTag("p"),
+            // The third line remains a h1. It wasn't visibly selected.
+            contentAfter: "<p>]<i>a</i>b</p><p><br></p><h1>[<br></h1>",
+        });
+    });
+
     test("should turn a heading 1 into a paragraph (character selected)", async () => {
         await testEditor({
             contentBefore: "<h1>a[b]c</h1>",
@@ -27,11 +53,51 @@ describe("to paragraph", () => {
         });
     });
 
+    test("should turn part of a heading 1 into a paragraph (character selected)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>[c]<br>d<br>e</h1>",
+            stepFunction: setTag("p"),
+            contentAfter: "<h1>a<br>b</h1><p>[c]</p><h1>d<br>e</h1>",
+        });
+    });
+
+    test("should turn part of a heading 1 into several paragraphs (characters selected)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>[c<br><br>d]<br>e<br>f</h1>",
+            stepFunction: setTag("p"),
+            contentAfter: "<h1>a<br>b</h1><p>[c</p><p><br></p><p>d]</p><h1>e<br>f</h1>",
+        });
+    });
+
+    test("should turn part of a heading 1 into several paragraphs (characters selected) (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>]c<br><br>d[<br>e<br>f</h1>",
+            stepFunction: setTag("p"),
+            contentAfter: "<h1>a<br>b</h1><p>]c</p><p><br></p><p>d[</p><h1>e<br>f</h1>",
+        });
+    });
+
     test("should turn a heading 1, a paragraph and a heading 2 into three paragraphs", async () => {
         await testEditor({
             contentBefore: "<h1>a[b</h1><p>cd</p><h2>e]f</h2>",
             stepFunction: setTag("p"),
             contentAfter: "<p>a[b</p><p>cd</p><p>e]f</p>",
+        });
+    });
+
+    test("should turn part of a heading 1, a paragraph and part of a heading 2 into three paragraphs", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>x<br>y[b</h1><p>cd</p><h2>e]f<br>g<br>h</h2>",
+            stepFunction: setTag("p"),
+            contentAfter: "<h1>a<br>x</h1><p>y[b</p><p>cd</p><p>e]f</p><h2>g<br>h</h2>",
+        });
+    });
+
+    test("should turn part of a heading 1, a paragraph and part of a heading 2 into three paragraphs (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>x<br>y]b</h1><p>cd</p><h2>e[f<br>g<br>h</h2>",
+            stepFunction: setTag("p"),
+            contentAfter: "<h1>a<br>x</h1><p>y]b</p><p>cd</p><p>e[f</p><h2>g<br>h</h2>",
         });
     });
 
@@ -81,11 +147,45 @@ describe("to paragraph", () => {
         });
     });
 
+    test("should not turn a div into a paragraph (if div isn't eligible for a baseContainer), with line breaks", async () => {
+        await testEditor({
+            contentBefore: `<div>[a<br>b]</div>`,
+            stepFunction: setTag("p"),
+            contentAfter: `<div><p>[a</p><p>b]</p></div>`,
+            config: { baseContainers: ["P"] },
+        });
+    });
+
+    test("should not turn a div into a paragraph (if div isn't eligible for a baseContainer), with line breaks (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: `<div>]a<br>b[</div>`,
+            stepFunction: setTag("p"),
+            contentAfter: `<div><p>]a</p><p>b[</p></div>`,
+            config: { baseContainers: ["P"] },
+        });
+    });
+
     test("should not turn an unbreakable div into a paragraph", async () => {
         await testEditor({
             contentBefore: `<div class="oe_unbreakable">[ab]</div>`,
             stepFunction: setTag("p"),
             contentAfter: `<div class="oe_unbreakable"><p>[ab]</p></div>`,
+        });
+    });
+
+    test("should not turn an unbreakable div into a paragraph, with line breaks", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
+            stepFunction: setTag("p"),
+            contentAfter: `<div class="oe_unbreakable"><p>[a</p><p>b]</p></div>`,
+        });
+    });
+
+    test("should not turn an unbreakable div into a paragraph, with line breaks (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">]a<br>b[</div>`,
+            stepFunction: setTag("p"),
+            contentAfter: `<div class="oe_unbreakable"><p>]a</p><p>b[</p></div>`,
         });
     });
 
@@ -113,11 +213,43 @@ describe("to paragraph", () => {
         });
     });
 
+    test("should not add paragraph tag when selection is changed to normal in list with line breaks", async () => {
+        await testEditor({
+            contentBefore: "<ul><li><h1>[ab<br>cd]</h1></li></ul>",
+            stepFunction: setTag("p"),
+            contentAfter: `<ul><li><p>[ab<br>cd]</p></li></ul>`,
+        });
+    });
+
+    test("should not add paragraph tag when selection is changed to normal in list with line breaks (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<ul><li><h1>]ab<br>cd[</h1></li></ul>",
+            stepFunction: setTag("p"),
+            contentAfter: `<ul><li><p>]ab<br>cd[</p></li></ul>`,
+        });
+    });
+
     test("should not add paragraph tag to normal text in list", async () => {
         await testEditor({
             contentBefore: "<ul><li>[abcd]</li></ul>",
             stepFunction: setTag("p"),
             contentAfter: `<ul><li>[abcd]</li></ul>`,
+        });
+    });
+
+    test("should not add paragraph tag to normal text in list, with line breaks", async () => {
+        await testEditor({
+            contentBefore: "<ul><li>[ab<br>cd]</li></ul>",
+            stepFunction: setTag("p"),
+            contentAfter: `<ul><li>[ab<br>cd]</li></ul>`,
+        });
+    });
+
+    test("should not add paragraph tag to normal text in list, with line breaks (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<ul><li>]ab<br>cd[</li></ul>",
+            stepFunction: setTag("p"),
+            contentAfter: `<ul><li>]ab<br>cd[</li></ul>`,
         });
     });
 
@@ -132,12 +264,60 @@ describe("to paragraph", () => {
         });
     });
 
+    test("should turn three table cells with heading 1 and line breaks to table cells with paragraphs", async () => {
+        await testEditor({
+            contentBefore:
+                "<table><tbody><tr><td><h1>a<br>b<br>[c<br>d</h1></td><td><h1>e<br>f</h1></td><td><h1>g<br>h]<br>i<br>j</h1></td></tr></tbody></table>",
+            stepFunction: setTag("p"),
+            // Having selected across several table cells, the custom table
+            // selection is set over the whole cells, which means we transform
+            // every line in them and not just the ones we selected.
+            // The custom table selection is removed in cleanForSave and the selection is collapsed.
+            contentAfter:
+                "<table><tbody><tr><td><p>a</p><p>b</p><p>[c</p><p>d</p></td><td><p>e</p><p>f</p></td><td><p>g</p><p>h]</p><p>i</p><p>j</p></td></tr></tbody></table>",
+        });
+    });
+
+    test("should turn three table cells with heading 1 and line breaks to table cells with paragraphs (reversed selection)", async () => {
+        await testEditor({
+            contentBefore:
+                "<table><tbody><tr><td><h1>a<br>b<br>]c<br>d</h1></td><td><h1>e<br>f</h1></td><td><h1>g<br>h[<br>i<br>j</h1></td></tr></tbody></table>",
+            stepFunction: setTag("p"),
+            // Having selected across several table cells, the custom table
+            // selection is set over the whole cells, which means we transform
+            // every line in them and not just the ones we selected.
+            // The custom table selection is removed in cleanForSave and the selection is collapsed.
+            contentAfter:
+                "<table><tbody><tr><td><p>a</p><p>b</p><p>]c</p><p>d</p></td><td><p>e</p><p>f</p></td><td><p>g</p><p>h[</p><p>i</p><p>j</p></td></tr></tbody></table>",
+        });
+    });
+
     test("should not set the tag of non-editable elements", async () => {
         await testEditor({
             contentBefore:
                 '<h1>[before</h1><h1 contenteditable="false">noneditable</h1><h1>after]</h1>',
             stepFunction: setTag("p"),
             contentAfter: '<p>[before</p><h1 contenteditable="false">noneditable</h1><p>after]</p>',
+        });
+    });
+
+    test("should not set the tag of non-editable elements, with line breaks", async () => {
+        await testEditor({
+            contentBefore:
+                '<h1>very<br>much<br>[be<br>fore</h1><h1 contenteditable="false">non<br>editable</h1><h1>after]<br>as<br>well</h1>',
+            stepFunction: setTag("p"),
+            contentAfter:
+                '<h1>very<br>much</h1><p>[be</p><p>fore</p><h1 contenteditable="false">non<br>editable</h1><p>after]</p><h1>as<br>well</h1>',
+        });
+    });
+
+    test("should not set the tag of non-editable elements, with line breaks (reversed selection)", async () => {
+        await testEditor({
+            contentBefore:
+                '<h1>very<br>much<br>]be<br>fore</h1><h1 contenteditable="false">non<br>editable</h1><h1>after[<br>as<br>well</h1>',
+            stepFunction: setTag("p"),
+            contentAfter:
+                '<h1>very<br>much</h1><p>]be</p><p>fore</p><h1 contenteditable="false">non<br>editable</h1><p>after[</p><h1>as<br>well</h1>',
         });
     });
 
@@ -149,6 +329,28 @@ describe("to paragraph", () => {
 
         await press("enter");
         expect(getContent(el)).toBe("<p>ab[]cd</p>");
+    });
+
+    test("apply 'Text' command, with line breaks", async () => {
+        const { el, editor } = await setupEditor("<h1>a<br>b<br>[]c<br>d<br>e</h1>");
+        await insertText(editor, "/text");
+        await animationFrame();
+        expect(".active .o-we-command-name").toHaveText("Text");
+
+        await press("enter");
+        expect(getContent(el)).toBe("<h1>a<br>b</h1><p>[]c</p><h1>d<br>e</h1>");
+    });
+
+    test("apply 'Text' command to empty line", async () => {
+        const { el, editor } = await setupEditor("<h1>ab<br>[]<br>cd</h1>");
+        await insertText(editor, "/text");
+        await animationFrame();
+        expect(".active .o-we-command-name").toHaveText("Text");
+
+        await press("enter");
+        expect(getContent(el)).toBe(
+            `<h1>ab</h1><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p><h1>cd</h1>`
+        );
     });
 
     test("should remove current font-size formatting when changing to a paragraph", async () => {
@@ -170,11 +372,43 @@ describe("to heading 1", () => {
         });
     });
 
+    test("should turn part of a paragraph into a heading 1", async () => {
+        await testEditor({
+            contentBefore: "<p>a<br>b<br>c[]<br>d<br>e</p>",
+            stepFunction: setTag("h1"),
+            contentAfter: "<p>a<br>b</p><h1>c[]</h1><p>d<br>e</p>",
+        });
+    });
+
     test("should turn a paragraph into a heading 1 (character selected)", async () => {
         await testEditor({
             contentBefore: "<p>a[b]c</p>",
             stepFunction: setTag("h1"),
             contentAfter: "<h1>a[b]c</h1>",
+        });
+    });
+
+    test("should turn part of a paragraph into a heading 1 (character selected)", async () => {
+        await testEditor({
+            contentBefore: "<p>a<br>b<br>[c]<br>d<br>e</p>",
+            stepFunction: setTag("h1"),
+            contentAfter: "<p>a<br>b</p><h1>[c]</h1><p>d<br>e</p>",
+        });
+    });
+
+    test("should turn part of a paragraph into several heading 1s (characters selected)", async () => {
+        await testEditor({
+            contentBefore: "<p>a<br>b<br>[c<br><br>d]<br>e<br>f</p>",
+            stepFunction: setTag("h1"),
+            contentAfter: "<p>a<br>b</p><h1>[c</h1><h1><br></h1><h1>d]</h1><p>e<br>f</p>",
+        });
+    });
+
+    test("should turn part of a paragraph into several heading 1s (characters selected) (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<p>a<br>b<br>]c<br><br>d[<br>e<br>f</p>",
+            stepFunction: setTag("h1"),
+            contentAfter: "<p>a<br>b</p><h1>]c</h1><h1><br></h1><h1>d[</h1><p>e<br>f</p>",
         });
     });
 
@@ -252,6 +486,40 @@ describe("to heading 1", () => {
         });
     });
 
+    test("should not turn a div into a heading 1 (if div isn't eligible for a baseContainer), with line breaks", async () => {
+        await testEditor({
+            contentBefore: "<div>[a<br>b]</div>",
+            stepFunction: setTag("h1"),
+            contentAfter: "<div><h1>[a</h1><h1>b]</h1></div>",
+            config: { baseContainers: ["P"] },
+        });
+    });
+
+    test("should not turn a div into a heading 1 (if div isn't eligible for a baseContainer), with line breaks (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<div>]a<br>b[</div>",
+            stepFunction: setTag("h1"),
+            contentAfter: "<div><h1>]a</h1><h1>b[</h1></div>",
+            config: { baseContainers: ["P"] },
+        });
+    });
+
+    test("should not turn an unbreakable div into a heading 1, with line breaks", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
+            stepFunction: setTag("h1"),
+            contentAfter: `<div class="oe_unbreakable"><h1>[a</h1><h1>b]</h1></div>`,
+        });
+    });
+
+    test("should not turn an unbreakable div into a heading 1, with line breaks (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">]a<br>b[</div>`,
+            stepFunction: setTag("h1"),
+            contentAfter: `<div class="oe_unbreakable"><h1>]a</h1><h1>b[</h1></div>`,
+        });
+    });
+
     test("should turn three table cells with paragraph to table cells with heading 1", async () => {
         await testEditor({
             contentBefore:
@@ -260,6 +528,34 @@ describe("to heading 1", () => {
             // The custom table selection is removed in cleanForSave and the selection is collapsed.
             contentAfter:
                 "<table><tbody><tr><td><h1>[a</h1></td><td><h1>b</h1></td><td><h1>c]</h1></td></tr></tbody></table>",
+        });
+    });
+
+    test("should turn three table cells with paragraph and line breaks to table cells with heading 1", async () => {
+        await testEditor({
+            contentBefore:
+                "<table><tbody><tr><td><p>a<br>b<br>[c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h]<br>i<br>j</p></td></tr></tbody></table>",
+            stepFunction: setTag("h1"),
+            // Having selected across several table cells, the custom table
+            // selection is set over the whole cells, which means we transform
+            // every line in them and not just the ones we selected.
+            // The custom table selection is removed in cleanForSave and the selection is collapsed.
+            contentAfter:
+                "<table><tbody><tr><td><h1>a</h1><h1>b</h1><h1>[c</h1><h1>d</h1></td><td><h1>e</h1><h1>f</h1></td><td><h1>g</h1><h1>h]</h1><h1>i</h1><h1>j</h1></td></tr></tbody></table>",
+        });
+    });
+
+    test("should turn three table cells with paragraph and line breaks to table cells with heading 1 (reversed selection)", async () => {
+        await testEditor({
+            contentBefore:
+                "<table><tbody><tr><td><p>a<br>b<br>]c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h[<br>i<br>j</p></td></tr></tbody></table>",
+            stepFunction: setTag("h1"),
+            // Having selected across several table cells, the custom table
+            // selection is set over the whole cells, which means we transform
+            // every line in them and not just the ones we selected.
+            // The custom table selection is removed in cleanForSave and the selection is collapsed.
+            contentAfter:
+                "<table><tbody><tr><td><h1>a</h1><h1>b</h1><h1>]c</h1><h1>d</h1></td><td><h1>e</h1><h1>f</h1></td><td><h1>g</h1><h1>h[</h1><h1>i</h1><h1>j</h1></td></tr></tbody></table>",
         });
     });
 
@@ -290,6 +586,14 @@ describe("to heading 2", () => {
         });
     });
 
+    test("should turn part of a heading 1 into a heading 2", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>c[]<br>d<br>e</h1>",
+            stepFunction: setTag("h2"),
+            contentAfter: "<h1>a<br>b</h1><h2>c[]</h2><h1>d<br>e</h1>",
+        });
+    });
+
     test("should turn a heading 1 into a heading 2 (character selected)", async () => {
         await testEditor({
             contentBefore: "<h1>a[b]c</h1>",
@@ -298,11 +602,51 @@ describe("to heading 2", () => {
         });
     });
 
+    test("should turn part of a heading 1 into a heading 2 (character selected)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>[c]<br>d<br>e</h1>",
+            stepFunction: setTag("h2"),
+            contentAfter: "<h1>a<br>b</h1><h2>[c]</h2><h1>d<br>e</h1>",
+        });
+    });
+
+    test("should turn part of a heading 1 into several heading 2s (characters selected)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>[c<br><br>d]<br>e<br>f</h1>",
+            stepFunction: setTag("h2"),
+            contentAfter: "<h1>a<br>b</h1><h2>[c</h2><h2><br></h2><h2>d]</h2><h1>e<br>f</h1>",
+        });
+    });
+
+    test("should turn part of a heading 1 into several heading 2s (characters selected) (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>]c<br><br>d[<br>e<br>f</h1>",
+            stepFunction: setTag("h2"),
+            contentAfter: "<h1>a<br>b</h1><h2>]c</h2><h2><br></h2><h2>d[</h2><h1>e<br>f</h1>",
+        });
+    });
+
     test("should turn a heading 1, a heading 2 and a paragraph into three headings 2", async () => {
         await testEditor({
             contentBefore: "<h1>a[b</h1><h2>cd</h2><p>e]f</p>",
             stepFunction: setTag("h2"),
             contentAfter: "<h2>a[b</h2><h2>cd</h2><h2>e]f</h2>",
+        });
+    });
+
+    test("should turn parts of a heading 1, a heading 2 and parts of a paragraph into headings 2", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>[b</h1><h2>cd</h2><p>e]<br>f</p>",
+            stepFunction: setTag("h2"),
+            contentAfter: "<h1>a</h1><h2>[b</h2><h2>cd</h2><h2>e]</h2><p>f</p>",
+        });
+    });
+
+    test("should turn parts of a heading 1, a heading 2 and parts of a paragraph into headings 2 (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>]b</h1><h2>cd</h2><p>e[<br>f</p>",
+            stepFunction: setTag("h2"),
+            contentAfter: "<h1>a</h1><h2>]b</h2><h2>cd</h2><h2>e[</h2><p>f</p>",
         });
     });
 
@@ -322,6 +666,40 @@ describe("to heading 2", () => {
         });
     });
 
+    test("should not turn a div into a heading 2 (if div isn't eligible for a baseContainer), with line breaks", async () => {
+        await testEditor({
+            contentBefore: "<div>[a<br>b]</div>",
+            stepFunction: setTag("h2"),
+            contentAfter: "<div><h2>[a</h2><h2>b]</h2></div>",
+            config: { baseContainers: ["P"] },
+        });
+    });
+
+    test("should not turn a div into a heading 2 (if div isn't eligible for a baseContainer), with line breaks (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<div>]a<br>b[</div>",
+            stepFunction: setTag("h2"),
+            contentAfter: "<div><h2>]a</h2><h2>b[</h2></div>",
+            config: { baseContainers: ["P"] },
+        });
+    });
+
+    test("should not turn an unbreakable div into a heading 2, with line breaks", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
+            stepFunction: setTag("h2"),
+            contentAfter: `<div class="oe_unbreakable"><h2>[a</h2><h2>b]</h2></div>`,
+        });
+    });
+
+    test("should not turn an unbreakable div into a heading 2, with line breaks (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">]a<br>b[</div>`,
+            stepFunction: setTag("h2"),
+            contentAfter: `<div class="oe_unbreakable"><h2>]a</h2><h2>b[</h2></div>`,
+        });
+    });
+
     test("should turn three table cells with paragraph to table cells with heading 2", async () => {
         await testEditor({
             contentBefore:
@@ -330,6 +708,34 @@ describe("to heading 2", () => {
             // The custom table selection is removed in cleanForSave and the selection is collapsed.
             contentAfter:
                 "<table><tbody><tr><td><h2>[a</h2></td><td><h2>b</h2></td><td><h2>c]</h2></td></tr></tbody></table>",
+        });
+    });
+
+    test("should turn three table cells with paragraph and line breaks to table cells with heading 2", async () => {
+        await testEditor({
+            contentBefore:
+                "<table><tbody><tr><td><p>a<br>b<br>[c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h]<br>i<br>j</p></td></tr></tbody></table>",
+            stepFunction: setTag("h2"),
+            // Having selected across several table cells, the custom table
+            // selection is set over the whole cells, which means we transform
+            // every line in them and not just the ones we selected.
+            // The custom table selection is removed in cleanForSave and the selection is collapsed.
+            contentAfter:
+                "<table><tbody><tr><td><h2>a</h2><h2>b</h2><h2>[c</h2><h2>d</h2></td><td><h2>e</h2><h2>f</h2></td><td><h2>g</h2><h2>h]</h2><h2>i</h2><h2>j</h2></td></tr></tbody></table>",
+        });
+    });
+
+    test("should turn three table cells with paragraph and line breaks to table cells with heading 2 (reversed selection)", async () => {
+        await testEditor({
+            contentBefore:
+                "<table><tbody><tr><td><p>a<br>b<br>]c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h[<br>i<br>j</p></td></tr></tbody></table>",
+            stepFunction: setTag("h2"),
+            // Having selected across several table cells, the custom table
+            // selection is set over the whole cells, which means we transform
+            // every line in them and not just the ones we selected.
+            // The custom table selection is removed in cleanForSave and the selection is collapsed.
+            contentAfter:
+                "<table><tbody><tr><td><h2>a</h2><h2>b</h2><h2>]c</h2><h2>d</h2></td><td><h2>e</h2><h2>f</h2></td><td><h2>g</h2><h2>h[</h2><h2>i</h2><h2>j</h2></td></tr></tbody></table>",
         });
     });
 
@@ -360,11 +766,43 @@ describe("to heading 3", () => {
         });
     });
 
+    test("should turn part of a heading 1 into a heading 3", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>c[]<br>d<br>e</h1>",
+            stepFunction: setTag("h3"),
+            contentAfter: "<h1>a<br>b</h1><h3>c[]</h3><h1>d<br>e</h1>",
+        });
+    });
+
     test("should turn a heading 1 into a heading 3 (character selected)", async () => {
         await testEditor({
             contentBefore: "<h1>a[b]c</h1>",
             stepFunction: setTag("h3"),
             contentAfter: "<h3>a[b]c</h3>",
+        });
+    });
+
+    test("should turn part of a heading 1 into a heading 3 (character selected)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>[c]<br>d<br>e</h1>",
+            stepFunction: setTag("h3"),
+            contentAfter: "<h1>a<br>b</h1><h3>[c]</h3><h1>d<br>e</h1>",
+        });
+    });
+
+    test("should turn part of a heading 1 into several heading 3s (characters selected)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>[c<br><br>d]<br>e<br>f</h1>",
+            stepFunction: setTag("h3"),
+            contentAfter: "<h1>a<br>b</h1><h3>[c</h3><h3><br></h3><h3>d]</h3><h1>e<br>f</h1>",
+        });
+    });
+
+    test("should turn part of a heading 1 into several heading 3s (characters selected) (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>]c<br><br>d[<br>e<br>f</h1>",
+            stepFunction: setTag("h3"),
+            contentAfter: "<h1>a<br>b</h1><h3>]c</h3><h3><br></h3><h3>d[</h3><h1>e<br>f</h1>",
         });
     });
 
@@ -396,6 +834,40 @@ describe("to heading 3", () => {
         });
     });
 
+    test("should not turn a div into a heading 1 (if div isn't eligible for a baseContainer), with line breaks", async () => {
+        await testEditor({
+            contentBefore: "<div>[a<br>b]</div>",
+            stepFunction: setTag("h3"),
+            contentAfter: "<div><h3>[a</h3><h3>b]</h3></div>",
+            config: { baseContainers: ["P"] },
+        });
+    });
+
+    test("should not turn a div into a heading 1 (if div isn't eligible for a baseContainer), with line breaks (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<div>]a<br>b[</div>",
+            stepFunction: setTag("h3"),
+            contentAfter: "<div><h3>]a</h3><h3>b[</h3></div>",
+            config: { baseContainers: ["P"] },
+        });
+    });
+
+    test("should not turn an unbreakable div into a heading 3, with line breaks", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
+            stepFunction: setTag("h3"),
+            contentAfter: `<div class="oe_unbreakable"><h3>[a</h3><h3>b]</h3></div>`,
+        });
+    });
+
+    test("should not turn an unbreakable div into a heading 3, with line breaks (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">]a<br>b[</div>`,
+            stepFunction: setTag("h3"),
+            contentAfter: `<div class="oe_unbreakable"><h3>]a</h3><h3>b[</h3></div>`,
+        });
+    });
+
     test("should turn three table cells with paragraph to table cells with heading 3", async () => {
         await testEditor({
             contentBefore:
@@ -404,6 +876,34 @@ describe("to heading 3", () => {
             // The custom table selection is removed in cleanForSave and the selection is collapsed.
             contentAfter:
                 "<table><tbody><tr><td><h3>[a</h3></td><td><h3>b</h3></td><td><h3>c]</h3></td></tr></tbody></table>",
+        });
+    });
+
+    test("should turn three table cells with paragraph and line breaks to table cells with heading 1", async () => {
+        await testEditor({
+            contentBefore:
+                "<table><tbody><tr><td><p>a<br>b<br>[c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h]<br>i<br>j</p></td></tr></tbody></table>",
+            stepFunction: setTag("h3"),
+            // Having selected across several table cells, the custom table
+            // selection is set over the whole cells, which means we transform
+            // every line in them and not just the ones we selected.
+            // The custom table selection is removed in cleanForSave and the selection is collapsed.
+            contentAfter:
+                "<table><tbody><tr><td><h3>a</h3><h3>b</h3><h3>[c</h3><h3>d</h3></td><td><h3>e</h3><h3>f</h3></td><td><h3>g</h3><h3>h]</h3><h3>i</h3><h3>j</h3></td></tr></tbody></table>",
+        });
+    });
+
+    test("should turn three table cells with paragraph and line breaks to table cells with heading 1 (reversed selection)", async () => {
+        await testEditor({
+            contentBefore:
+                "<table><tbody><tr><td><p>a<br>b<br>]c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h[<br>i<br>j</p></td></tr></tbody></table>",
+            stepFunction: setTag("h3"),
+            // Having selected across several table cells, the custom table
+            // selection is set over the whole cells, which means we transform
+            // every line in them and not just the ones we selected.
+            // The custom table selection is removed in cleanForSave and the selection is collapsed.
+            contentAfter:
+                "<table><tbody><tr><td><h3>a</h3><h3>b</h3><h3>]c</h3><h3>d</h3></td><td><h3>e</h3><h3>f</h3></td><td><h3>g</h3><h3>h[</h3><h3>i</h3><h3>j</h3></td></tr></tbody></table>",
         });
     });
 
@@ -434,6 +934,14 @@ describe("to pre", () => {
         });
     });
 
+    test("should turn part of a heading 1 into a pre", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>c[]<br>d<br>e</h1>",
+            stepFunction: setTag("pre"),
+            contentAfter: "<h1>a<br>b</h1><pre>c[]</pre><h1>d<br>e</h1>",
+        });
+    });
+
     test("should turn a heading 1 into a pre (character selected)", async () => {
         await testEditor({
             contentBefore: "<h1>a[b]c</h1>",
@@ -442,11 +950,51 @@ describe("to pre", () => {
         });
     });
 
-    test("should turn a heading 1 a pre and a paragraph into three pres", async () => {
+    test("should turn part of a heading 1 into a pre (character selected)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>[c]<br>d<br>e</h1>",
+            stepFunction: setTag("pre"),
+            contentAfter: "<h1>a<br>b</h1><pre>[c]</pre><h1>d<br>e</h1>",
+        });
+    });
+
+    test("should turn part of a heading 1 into several pres (characters selected)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>[c<br><br>d]<br>e<br>f</h1>",
+            stepFunction: setTag("pre"),
+            contentAfter: "<h1>a<br>b</h1><pre>[c</pre><pre><br></pre><pre>d]</pre><h1>e<br>f</h1>",
+        });
+    });
+
+    test("should turn part of a heading 1 into several pres (characters selected) (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>]c<br><br>d[<br>e<br>f</h1>",
+            stepFunction: setTag("pre"),
+            contentAfter: "<h1>a<br>b</h1><pre>]c</pre><pre><br></pre><pre>d[</pre><h1>e<br>f</h1>",
+        });
+    });
+
+    test("should turn a heading 1, a pre and a paragraph into three pres", async () => {
         await testEditor({
             contentBefore: "<h1>a[b</h1><pre>cd</pre><p>e]f</p>",
             stepFunction: setTag("pre"),
             contentAfter: "<pre>a[b</pre><pre>cd</pre><pre>e]f</pre>",
+        });
+    });
+
+    test("should turn parts of a heading 1, a pre and parts of a paragraph into pres", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>[b</h1><pre>cd</pre><p>e]<br>f</p>",
+            stepFunction: setTag("pre"),
+            contentAfter: "<h1>a</h1><pre>[b</pre><pre>cd</pre><pre>e]</pre><p>f</p>",
+        });
+    });
+
+    test("should turn parts of a heading 1, a pre and parts of a paragraph into pres (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>]b</h1><pre>cd</pre><p>e[<br>f</p>",
+            stepFunction: setTag("pre"),
+            contentAfter: "<h1>a</h1><pre>]b</pre><pre>cd</pre><pre>e[</pre><p>f</p>",
         });
     });
 
@@ -461,11 +1009,39 @@ describe("to pre", () => {
         });
     });
 
+    test("should turn three table cells with paragraph and line breaks to table cells with pre", async () => {
+        await testEditor({
+            contentBefore:
+                "<table><tbody><tr><td><p>a<br>b<br>[c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h]<br>i<br>j</p></td></tr></tbody></table>",
+            stepFunction: setTag("pre"),
+            // Having selected across several table cells, the custom table
+            // selection is set over the whole cells, which means we transform
+            // every line in them and not just the ones we selected.
+            // The custom table selection is removed in cleanForSave and the selection is collapsed.
+            contentAfter:
+                "<table><tbody><tr><td><pre>a</pre><pre>b</pre><pre>[c</pre><pre>d</pre></td><td><pre>e</pre><pre>f</pre></td><td><pre>g</pre><pre>h]</pre><pre>i</pre><pre>j</pre></td></tr></tbody></table>",
+        });
+    });
+
+    test("should turn three table cells with paragraph and line breaks to table cells with pre (reversed selection)", async () => {
+        await testEditor({
+            contentBefore:
+                "<table><tbody><tr><td><p>a<br>b<br>]c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h[<br>i<br>j</p></td></tr></tbody></table>",
+            stepFunction: setTag("pre"),
+            // Having selected across several table cells, the custom table
+            // selection is set over the whole cells, which means we transform
+            // every line in them and not just the ones we selected.
+            // The custom table selection is removed in cleanForSave and the selection is collapsed.
+            contentAfter:
+                "<table><tbody><tr><td><pre>a</pre><pre>b</pre><pre>]c</pre><pre>d</pre></td><td><pre>e</pre><pre>f</pre></td><td><pre>g</pre><pre>h[</pre><pre>i</pre><pre>j</pre></td></tr></tbody></table>",
+        });
+    });
+
     test("should turn a paragraph into pre preserving the cursor position", async () => {
         await testEditor({
             contentBefore: "<p>abcd<br>[]<br></p>",
             stepFunction: setTag("pre"),
-            contentAfter: "<pre>abcd<br>[]<br></pre>",
+            contentAfter: "<p>abcd</p><pre>[]<br></pre>",
         });
     });
 
@@ -487,6 +1063,28 @@ describe("to pre", () => {
         expect(getContent(el)).toBe("<pre>ab[]cd</pre>");
     });
 
+    test("apply 'Code' command, with line breaks", async () => {
+        const { el, editor } = await setupEditor("<h1>a<br>b<br>[]c<br>d<br>e</h1>");
+        await insertText(editor, "/code");
+        await animationFrame();
+        expect(".active .o-we-command-name").toHaveText("Code");
+
+        await press("enter");
+        expect(getContent(el)).toBe("<h1>a<br>b</h1><pre>[]c</pre><h1>d<br>e</h1>");
+    });
+
+    test("apply 'Code' command to empty line", async () => {
+        const { el, editor } = await setupEditor("<h1>ab<br>[]<br>cd</h1>");
+        await insertText(editor, "/code");
+        await animationFrame();
+        expect(".active .o-we-command-name").toHaveText("Code");
+
+        await press("enter");
+        expect(getContent(el)).toBe(
+            '<h1>ab</h1><pre o-we-hint-text="Code" class="o-we-hint">[]<br></pre><h1>cd</h1>'
+        );
+    });
+
     test("should remove current font-size formatting when changing to a pre", async () => {
         await testEditor({
             contentBefore:
@@ -498,11 +1096,19 @@ describe("to pre", () => {
 });
 
 describe("to blockquote", () => {
-    test("should turn a blockquote into a paragraph", async () => {
+    test("should turn a heading 1 into a blockquote", async () => {
         await testEditor({
             contentBefore: "<h1>ab[]cd</h1>",
             stepFunction: setTag("blockquote"),
             contentAfter: "<blockquote>ab[]cd</blockquote>",
+        });
+    });
+
+    test("should turn part of a heading 1 into a blockquote", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>c[]<br>d<br>e</h1>",
+            stepFunction: setTag("blockquote"),
+            contentAfter: "<h1>a<br>b</h1><blockquote>c[]</blockquote><h1>d<br>e</h1>",
         });
     });
 
@@ -511,6 +1117,32 @@ describe("to blockquote", () => {
             contentBefore: "<h1>a[b]c</h1>",
             stepFunction: setTag("blockquote"),
             contentAfter: "<blockquote>a[b]c</blockquote>",
+        });
+    });
+
+    test("should turn part of a heading 1 into a blockquote (character selected)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>[c]<br>d<br>e</h1>",
+            stepFunction: setTag("blockquote"),
+            contentAfter: "<h1>a<br>b</h1><blockquote>[c]</blockquote><h1>d<br>e</h1>",
+        });
+    });
+
+    test("should turn part of a heading 1 into several blockquotes (characters selected)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>[c<br><br>d]<br>e<br>f</h1>",
+            stepFunction: setTag("blockquote"),
+            contentAfter:
+                "<h1>a<br>b</h1><blockquote>[c</blockquote><blockquote><br></blockquote><blockquote>d]</blockquote><h1>e<br>f</h1>",
+        });
+    });
+
+    test("should turn part of a heading 1 into several blockquotes (characters selected) (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<h1>a<br>b<br>]c<br><br>d[<br>e<br>f</h1>",
+            stepFunction: setTag("blockquote"),
+            contentAfter:
+                "<h1>a<br>b</h1><blockquote>]c</blockquote><blockquote><br></blockquote><blockquote>d[</blockquote><h1>e<br>f</h1>",
         });
     });
 
@@ -543,6 +1175,40 @@ describe("to blockquote", () => {
         });
     });
 
+    test("should not turn a div into a heading 1 (if div isn't eligible for a baseContainer), with line breaks", async () => {
+        await testEditor({
+            contentBefore: "<div>[a<br>b]</div>",
+            stepFunction: setTag("blockquote"),
+            contentAfter: "<div><blockquote>[a</blockquote><blockquote>b]</blockquote></div>",
+            config: { baseContainers: ["P"] },
+        });
+    });
+
+    test("should not turn a div into a heading 1 (if div isn't eligible for a baseContainer), with line breaks (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: "<div>]a<br>b[</div>",
+            stepFunction: setTag("blockquote"),
+            contentAfter: "<div><blockquote>]a</blockquote><blockquote>b[</blockquote></div>",
+            config: { baseContainers: ["P"] },
+        });
+    });
+
+    test("should not turn an unbreakable div into a blockquote, with line breaks", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">[a<br>b]</div>`,
+            stepFunction: setTag("blockquote"),
+            contentAfter: `<div class="oe_unbreakable"><blockquote>[a</blockquote><blockquote>b]</blockquote></div>`,
+        });
+    });
+
+    test("should not turn an unbreakable div into a blockquote, with line breaks (reversed selection)", async () => {
+        await testEditor({
+            contentBefore: `<div class="oe_unbreakable">]a<br>b[</div>`,
+            stepFunction: setTag("blockquote"),
+            contentAfter: `<div class="oe_unbreakable"><blockquote>]a</blockquote><blockquote>b[</blockquote></div>`,
+        });
+    });
+
     test("should turn three table cells with paragraph to table cells with blockquote", async () => {
         await testEditor({
             contentBefore:
@@ -551,6 +1217,34 @@ describe("to blockquote", () => {
             // The custom table selection is removed in cleanForSave and the selection is collapsed.
             contentAfter:
                 "<table><tbody><tr><td><blockquote>[a</blockquote></td><td><blockquote>b</blockquote></td><td><blockquote>c]</blockquote></td></tr></tbody></table>",
+        });
+    });
+
+    test("should turn three table cells with paragraph and line breaks to table cells with blockquotes", async () => {
+        await testEditor({
+            contentBefore:
+                "<table><tbody><tr><td><p>a<br>b<br>[c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h]<br>i<br>j</p></td></tr></tbody></table>",
+            stepFunction: setTag("blockquote"),
+            // Having selected across several table cells, the custom table
+            // selection is set over the whole cells, which means we transform
+            // every line in them and not just the ones we selected.
+            // The custom table selection is removed in cleanForSave and the selection is collapsed.
+            contentAfter:
+                "<table><tbody><tr><td><blockquote>a</blockquote><blockquote>b</blockquote><blockquote>[c</blockquote><blockquote>d</blockquote></td><td><blockquote>e</blockquote><blockquote>f</blockquote></td><td><blockquote>g</blockquote><blockquote>h]</blockquote><blockquote>i</blockquote><blockquote>j</blockquote></td></tr></tbody></table>",
+        });
+    });
+
+    test("should turn three table cells with paragraph and line breaks to table cells with blockquotes (reversed selection)", async () => {
+        await testEditor({
+            contentBefore:
+                "<table><tbody><tr><td><p>a<br>b<br>]c<br>d</p></td><td><p>e<br>f</p></td><td><p>g<br>h[<br>i<br>j</p></td></tr></tbody></table>",
+            stepFunction: setTag("blockquote"),
+            // Having selected across several table cells, the custom table
+            // selection is set over the whole cells, which means we transform
+            // every line in them and not just the ones we selected.
+            // The custom table selection is removed in cleanForSave and the selection is collapsed.
+            contentAfter:
+                "<table><tbody><tr><td><blockquote>a</blockquote><blockquote>b</blockquote><blockquote>]c</blockquote><blockquote>d</blockquote></td><td><blockquote>e</blockquote><blockquote>f</blockquote></td><td><blockquote>g</blockquote><blockquote>h[</blockquote><blockquote>i</blockquote><blockquote>j</blockquote></td></tr></tbody></table>",
         });
     });
 

--- a/addons/html_editor/static/tests/unbreakable/split_element_block.test.js
+++ b/addons/html_editor/static/tests/unbreakable/split_element_block.test.js
@@ -48,6 +48,22 @@ test("should insert a newline instead of splitting an explicit contenteditable='
         contentAfter: `<div contenteditable="false"><p contenteditable="true">ab<br>[]<br></p></div>`,
     });
 });
+test("should split a div (if it is eligible for baseContainer)", async () => {
+    await testEditor({
+        contentBefore: `<div>a[]b</div>`,
+        stepFunction: splitBlock,
+        contentAfter: `<div>a</div><div>[]b</div>`,
+        config: { baseContainers: ["P", "DIV"] },
+    });
+});
+test("should not split a div (if it isn't eligible for baseContainer)", async () => {
+    await testEditor({
+        contentBefore: `<div>a[]b</div>`,
+        stepFunction: splitBlock,
+        contentAfter: `<div>a<br>[]b</div>`,
+        config: { baseContainers: ["P"] },
+    });
+});
 test("should keep the last line break in the old paragraph", async () => {
     await testEditor({
         contentBefore: "<div><p>abc<br>[]<br></p></div>",


### PR DESCRIPTION
This adds a new method to the split plugin, which splits the selection in order to isolate any block segment in it. A block segment forms a deliberate line in the content, separated using line breaks. A line break in a list item cannot create block segments as the list item visually marks its own segment (with a bullet point).

For instance,

```html
<p>a<br>b<br>[c<br>d<br>e]<br>f<br>g</p>
```

marks seven line segments
(one per letter). The selection contains 3 line segments, which will be isolated like this:

```html
<p>a<br>b</p>
<p>[c</p>
<p>d</p>
<p>e]</p>
<p>f<br>g</p>
```

We then use the new method before toggling a list, so that multiple block segments will create multiple list items:

```html
<p>a<br>b<br>[c<br>d<br>e]<br>f<br>g</p>
```

-> toggle unordered list

->

```html
<p>a<br>b</p>
<ul>
    <li>[c</li>
    <li>d</li>
    <li>e]</li>
</ul>
<p>f<br>g</p>
```

We also use the new method before setting a tag, so that multiple block segments will create multiple blocks of that tag:

```html
<p>a<br>b<br>[c<br>d<br>e]<br>f<br>g</p>
```

-> set h1 tag

->

```html
<p>a<br>b</p>
<h1>[c</h1>
<h1>d</h1>
<h1>e]</h1>
<p>f<br>g</p>
```

Finally, we also use it before setting a tag, so that multiple block segments will create multiple tabulations:

```html
<p>a<br>b<br>[c<br>d<br>e]<br>f<br>g</p>
```

-> tab

->

```html
<p>a<br>b</p>
<p><span class="oe-tabs" contenteditable="false">\u0009</span>\u200B[c</p>
<p><span class="oe-tabs" contenteditable="false">\u0009</span>\u200Bd</p>
<p><span class="oe-tabs" contenteditable="false">\u0009</span>\u200Be]</p>
<p>f<br>g</p>
```

task-4636426

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
