### PR TITLE
[FIX] mrp: pass the current variant id to the bom overview when coming from product form

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -111,6 +111,15 @@ class MrpBom(models.Model):
             self.operation_ids.bom_product_template_attribute_value_ids = False
             self.byproduct_ids.bom_product_template_attribute_value_ids = False
 
+    def action_view_bom_overview(self):
+        action =  {
+            'type': 'ir.actions.client',
+            'tag': 'mrp_bom_report',
+            'context': {'model': 'report.mrp.report_bom_structure','variant_bom_id':self.env.context.get('default_product_id')}
+        }
+        
+        return action
+    
     @api.constrains('active', 'product_id', 'product_tmpl_id', 'bom_line_ids')
     def _check_bom_cycle(self):
         subcomponents_dict = dict()

--- a/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
+++ b/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
@@ -54,7 +54,9 @@ export class BomOverviewComponent extends Component {
         if (resModel === 'product.product' && variantId !== undefined) {
             this.state.currentVariantId = variantId;
         }
-
+        if (variantId == undefined && this.props.action.context.variant_bom_id) {
+            this.state.currentVariantId = this.props.action.context.variant_bom_id;
+        }    
         const bomData = await this.getBomData();
         this.state.bomQuantity = bomData["bom_qty"];
         this.state.showOptions.uom = bomData["is_uom_applied"];

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -44,8 +44,7 @@
                                     <span class="o_stat_text">Operations<br/>Performance</span>
                                 </div>
                             </button>
-                            <button name="%(action_report_mrp_bom)d" type="action"
-                                class="oe_stat_button" icon="fa-bars">
+                            <button name="action_view_bom_overview" type="object" class="oe_stat_button" icon="fa-bars">
                                 <div class="o_stat_info">
                                     <span class="o_stat_text">BoM Overview</span>
                                 </div>


### PR DESCRIPTION
### Before this PR
If you open the bom from product variant and than you open the bom overview the variant is not selected 

### After this PR
Opening bom overview from the product variant, the right variant is selected



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
