### PR TITLE
[FIX] account: fix return type from int to bool

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3894,9 +3894,9 @@ class AccountMove(models.Model):
                     force_hash=force_hash, include_pre_last_hash=include_pre_last_hash, early_stop=early_stop
                 )
 
-                if chain_info is False:
+                if not chain_info:
                     continue
-                if early_stop and chain_info:
+                if early_stop:
                     return True
 
                 if 'unreconciled' in chain_info['warnings']:

--- a/addons/account/wizard/account_secure_entries_wizard.py
+++ b/addons/account/wizard/account_secure_entries_wizard.py
@@ -87,7 +87,7 @@ class AccountSecureEntries(models.TransientModel):
         for journal, journal_moves in moves.grouped('journal_id').items():
             for chain_moves in journal_moves.grouped('sequence_prefix').values():
                 chain_info = chain_moves._get_chain_info(force_hash=True)
-                if chain_info is False:
+                if not chain_info:
                     continue
 
                 last_move_hashed = chain_info['last_move_hashed']


### PR DESCRIPTION
- During the migration, the database was blocked, and the following issue occurred: [traceback](https://pad.odoo.com/p/issue_4352724_suba)
- This issue was caused by the method `_get_chain_info` returning an [integer value](https://github.com/odoo/odoo/blob/3485abaa313263ea1946b9bdbffec5928d31fd72/addons/account/models/account_move.py#L3847) If at least one account move is retrieved, `chain_info` contains some values, and the condition `if early_stop and chain_info:` is executed as expected.
- However, if no account moves are found (i.e., zero account moves), `chain_info` is assigned the value 0. In this case: 
    - The condition `if early_stop and chain_info:` is not executed because `chain_info` has no values.
    - Then subsequent condition `if 'unreconciled' in chain_info['warnings']:` is executed, which raises the error `TypeError: 'int'-object is not subscriptable` because `chain_info` is an integer(0) and does't have subscriptable attributes like ['warnings'].
- To resolve this issue, I converted the return values of `_get_chain_info` integer to boolean values

TBG - [1648](https://upgrade.odoo.com/web#id=1648&cids=1&menu_id=107&action=178&model=upgrade.request.traceback.group&view_type=form)
OPW - [4352724](https://www.odoo.com/odoo/project/70/tasks/4352724#)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
