### PR TITLE
[FIX] web_editor: fix required fields

### DIFF
--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -190,7 +190,7 @@ class Field(models.AbstractModel):
 
     @api.model
     def from_html(self, model, field, element):
-        return self.value_from_string(element.text_content().strip())
+        return self.value_from_string(element.text_content().strip()) or False
 
 
 class Integer(models.AbstractModel):


### PR DESCRIPTION
Prior to this commit, any empty field saved from the website would write an empty string as the value, thus bypassing the required constraints. Functionally, this is surprising because an empty required field on a form view would trigger an error but would save without issue in website.

This commit fixes that issue by replacing the empty string by False which will trigger the required constraint.