### PR TITLE
[FIX] account: Fix loading demo data for branches.

### DIFF
--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -77,7 +77,7 @@ class AccountChartTemplate(models.AbstractModel):
         )
         default_receivable = self.env.ref('base.res_partner_3').with_company(company).property_account_receivable_id
         income_account = self.env['account.account'].search([
-            ('company_id', '=', cid),
+            *self.env['account.account']._check_company_domain(cid),
             ('account_type', '=', 'income'),
             ('id', '!=', (company or self.env.company).account_journal_early_pay_discount_gain_account_id.id)
         ], limit=1)

--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -602,6 +602,20 @@ class TestChartTemplate(TransactionCase):
             # silently ignore if the field doesn't exist (yet)
             self.env['account.chart.template'].try_loading('test', company=company, install_demo=False)
 
+    def test_branch(self):
+        # Test the auto-installation of a chart template (including demo data) on a branch
+        # Create a new main company, because install_demo doesn't do anything when reloading data
+        company = self.env['res.company'].create([{'name': 'Test Company'}])
+        branch = self.env['res.company'].create([{
+            'name': 'Test Branch',
+            'parent_id': company.id,
+        }])
+
+        with patch.object(AccountChartTemplate, '_get_chart_template_data', side_effect=test_get_data, autospec=True):
+            self.env['account.chart.template'].try_loading('test', company=company, install_demo=True)
+        self.assertEqual(company.chart_template, 'test')
+        self.assertEqual(branch.chart_template, 'test')
+
     def test_change_coa(self):
         def _get_chart_template_mapping(self, get_all=False):
             return {'other_test': {


### PR DESCRIPTION
The chart template loading process involves loading demo data for branches [^1], but at the moment this is not tested and broken.

This commit fixes the flow and adds a test.

[^1]: https://github.com/odoo/odoo/blob/b79bcb0574354a17a2aa64e2fe8d05da95535257/addons/account/models/chart_template.py#L232

Enterprise PR: https://github.com/odoo/enterprise/pull/74409

task-none