### PR TITLE
[FIX] account: give an empty string if there is no payment method line name

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -276,7 +276,7 @@ class AccountPayment(models.Model):
             ]
         """
         self.ensure_one()
-        label = self.payment_method_line_id.name if self.payment_method_line_id else _("No Payment Method")
+        label = (self.payment_method_line_id.name or '') if self.payment_method_line_id else _("No Payment Method")
 
         if self.memo:
             return [

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -593,3 +593,23 @@ class TestAccountPayment(AccountTestInvoicingCommon):
         invoice_2.action_post()
         register_payment_and_assert_state(invoice_2, 100.0, is_community=False)
         self.assertFalse(invoice_2.matched_payment_ids.move_id)
+
+    def test_account_payment_without_method_line_id_name(self):
+        """
+        Test the account payment with payment method line having no name
+        """
+        journal = self.company_data['default_journal_bank']
+        # Make the first payment method line id name as false
+        journal.outbound_payment_method_line_ids[0].name = False
+        # Create a new payment with payment type as outbound
+        payment = self.env['account.payment'].create({
+            'amount': 50.0,
+            'payment_type': 'outbound',
+            'partner_type': 'customer',
+            'partner_id': self.partner_a.id,
+            'journal_id': journal.id,
+        })
+        # Confirm the payment
+        payment.action_post()
+        # Validate line_ids name. As it shuld be an empty string if there is no name in payment_method_line_id
+        self.assertEqual(payment.move_id.line_ids[0].name, '')


### PR DESCRIPTION
Currently, a traceback occurs when the user tries to create a payment with a payment method line having no name.

To reproduce this issue:

1) Install `Invoicing`
2) Open the `Bank` journal outgoing payments from `configuration/journals`
3) Remove the `name` of the first payment method
4) Now create a new payment with type as `send` and journals as `Bank`
   from `Customers/ Payments`
5) Confirm it

Error:-
```
TypeError: sequence item 0: expected str instance, bool found
```

This issue arises because we get the `paymnet_method_line_id.name` value as False.
When the user removes the name of that `payment_method_line_id`.

https://github.com/odoo/odoo/blob/3485abaa313263ea1946b9bdbffec5928d31fd72/addons/account/models/account_payment.py#L279

This leads to a traceback when `join()` is used between an empty string and a bool value.

https://github.com/odoo/odoo/blob/3485abaa313263ea1946b9bdbffec5928d31fd72/addons/account/models/account_payment.py#L337

To resolve this issue, we can give a fallback value of an empty string.

sentry-6067383068
