### PR TITLE
[IMP] event_booth_sale: Constrain service_tracking for Event Booths products

### DIFF
--- a/addons/event_booth_sale/models/event_booth_category.py
+++ b/addons/event_booth_sale/models/event_booth_category.py
@@ -3,8 +3,9 @@
 
 import logging
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.addons.product.models.product_template import PRICE_CONTEXT_KEYS
+from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -34,6 +35,17 @@ class EventBoothCategory(models.Model):
         compute_sudo=True
     )
     image_1920 = fields.Image(compute='_compute_image_1920', readonly=False, store=True)
+
+    @api.constrains('product_id')
+    def _check_service_tracking(self):
+        for record in self:
+            if record.product_id and record.product_id.service_tracking != 'event_booth':
+                raise ValidationError(
+                    _(
+                        'The product, %(product_name)s , is used for Event Booth, it must have service_tracking set to "Event Booth".',
+                        product_name=record.product_id.name
+                    )
+                )
 
     @api.depends('product_id')
     def _compute_image_1920(self):

--- a/addons/event_booth_sale/models/product_product.py
+++ b/addons/event_booth_sale/models/product_product.py
@@ -1,4 +1,5 @@
-from odoo import api, models
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
 
 
 class ProductProduct(models.Model):
@@ -8,3 +9,17 @@ class ProductProduct(models.Model):
     def _onchange_type_event_booth(self):
         if self.service_tracking == 'event_booth':
             self.invoice_policy = 'order'
+
+    @api.constrains('service_tracking')
+    def _check_service_tracking_for_event_booths(self):
+        if product_not_event_booth := self.filtered(lambda p: p.service_tracking != 'event_booth'):
+            booth_category = self.env['event.booth.category'].search([('product_id', 'in', product_not_event_booth.ids)], limit=1)
+            if booth_category:
+                raise ValidationError(
+                    _(
+                        "You cannot change the service_tracking of the product %(product_name)s because it is already assigned "
+                        "to %(booth_category_name)s. The service_tracking must remain 'event_booth'.",
+                        product_name=product_not_event_booth.name,
+                        booth_category_name=booth_category.name,
+                    )
+                )

--- a/addons/event_booth_sale/models/product_template.py
+++ b/addons/event_booth_sale/models/product_template.py
@@ -1,4 +1,5 @@
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ProductTemplate(models.Model):
@@ -20,3 +21,23 @@ class ProductTemplate(models.Model):
 
     def _service_tracking_blacklist(self):
         return super()._service_tracking_blacklist() + ['event_booth']
+
+    @api.constrains('service_tracking')
+    def _check_service_tracking_for_event_booths(self):
+        """ Prevent changing the service_tracking field if the product template or any of its variants
+        is linked to an Event Booth Category.
+        """
+        if product_variants_not_event_booth := self.product_variant_ids.filtered(lambda p: p.service_tracking != 'event_booth'):
+            linked_booth_category = self.env['event.booth.category'].sudo().search([
+                ('product_id', 'in', product_variants_not_event_booth.ids)
+            ], limit=1)
+            if linked_booth_category:
+                raise ValidationError(
+                    _(
+                        'The "service_tracking" for the product template, %(product_template_name)s cannot be changed because '
+                        'one of its variants is assigned to the Event Booth Category, %(event_booth_category_name)s. '
+                        'The service_tracking must remain "Event Booth".',
+                        product_template_name=linked_booth_category.product_id.name,
+                        event_booth_category_name=linked_booth_category.name,
+                    )
+                )


### PR DESCRIPTION
 Using "event" service_tracking (attempting to create new event registration on booth booking) was leading breaking the flow described below. This commit is locking users from setting the event service tracking on products using event booths.

Reproduction steps
---
- -i website_event_booth_sale
- Create Product P
	- Product Type: Service
	- Create on Order: Event Registration
- Create a Booth Category BC with: Product P
- Have an Published Event E with:
	- Booth B of the category BC
	- Website Submenu and Booth Register
- Go to website-> event-> E -> select B -> "Go to Payment" -> BUG: page frozen

opw-4280158