### PR TITLE
[FIX] sale_timesheet: protect timesheet product company id

### DIFF
--- a/addons/sale_timesheet/i18n/sale_timesheet.pot
+++ b/addons/sale_timesheet/i18n/sale_timesheet.pot
@@ -1159,6 +1159,15 @@ msgstr ""
 
 #. module: sale_timesheet
 #. odoo-python
+#: code:addons/sale_timesheet/models/product.py:0
+#, python-format
+msgid ""
+"The %s product is required by the Timesheets app and cannot be linked to a "
+"company."
+msgstr ""
+
+#. module: sale_timesheet
+#. odoo-python
 #: code:addons/sale_timesheet/wizard/project_create_sale_order.py:0
 #, python-format
 msgid ""

--- a/addons/sale_timesheet/models/product.py
+++ b/addons/sale_timesheet/models/product.py
@@ -104,15 +104,20 @@ class ProductTemplate(models.Model):
     def _unlink_except_master_data(self):
         time_product = self.env.ref('sale_timesheet.time_product')
         if time_product.product_tmpl_id in self:
-            raise ValidationError(_('The %s product is required by the Timesheets app and cannot be archived nor deleted.') % time_product.name)
+            raise ValidationError(_('The %s product is required by the Timesheets app and cannot be archived nor deleted.', time_product.name))
 
     def write(self, vals):
-        # timesheet product can't be archived
+        # timesheet product can't be archived or linked to a company
         test_mode = getattr(threading.current_thread(), 'testing', False) or self.env.registry.in_test_mode()
         if not test_mode and 'active' in vals and not vals['active']:
             time_product = self.env.ref('sale_timesheet.time_product')
             if time_product.product_tmpl_id in self:
-                raise ValidationError(_('The %s product is required by the Timesheets app and cannot be archived nor deleted.') % time_product.name)
+                raise ValidationError(_('The %s product is required by the Timesheets app and cannot be archived nor deleted.', time_product.name))
+        # TODO: avoid duplicate code by joining both conditions in master
+        if not test_mode and 'company_id' in vals and vals['company_id']:
+            time_product = self.env.ref('sale_timesheet.time_product')
+            if time_product.product_tmpl_id in self:
+                raise ValidationError(_('The %s product is required by the Timesheets app and cannot be linked to a company.', time_product.name))
         return super(ProductTemplate, self).write(vals)
 
 


### PR DESCRIPTION
Issue:
When the product "Service on Timesheet" is linked to company A, archiving products in any other company causes an error to occur.

Steps to reproduce:
- Install both Sales & Timesheets modules
- Create a second company
- On the product form, link the "Service on Timesheet" product to the second company
- Archive a product from the first company

Cause:
The "Service on Timesheet" product is necessary for the Timesheets app to work. Having linked it to one company restricts its access to others.

Solution:
While this is expected behaviour, I suggest blocking the user from linking the product to a company to prevent similar issues. I propose doing so since archiving and deletion are already blocked. This change still allows unlinking from the company through the UI.

Ticket:
opw-4270086

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
