### PR TITLE
[FIX] web_editor: remove translate button in toolbar for public users

### DIFF
--- a/addons/web_editor/static/src/js/editor/toolbar.js
+++ b/addons/web_editor/static/src/js/editor/toolbar.js
@@ -12,6 +12,7 @@ import {
 } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
+import { user } from "@web/core/user";
 import { loadLanguages } from "@web/core/l10n/translation";
 
 export class Toolbar extends Component {
@@ -106,9 +107,13 @@ export class Toolbar extends Component {
             }
         });
         onWillStart(() => {
-            loadLanguages(this.orm).then(res => {
-                this.state.languages = res;
-            });
+            this.state.isPublicUser = !user.userId;
+
+            if (!this.state.isPublicUser) {
+                loadLanguages(this.orm).then((res) => {
+                    this.state.languages = res;
+                });
+            }
         });
     }
 

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -225,7 +225,7 @@
                     <span class="fa fa-magic fa-fw"></span>
                 </div>
             </div>
-            <div id="translate" t-attf-class="btn-group {{ props.dropDirection }}">
+            <div t-if="!state.isPublicUser" id="translate" t-attf-class="btn-group {{ props.dropDirection }}">
                 <div t-if="state.languages.length === 1" class="btn lang" title="Translate with AI" t-att-data-value="state.languages[0][1]">
                     Translate
                 </div>


### PR DESCRIPTION
Before this commit: When a public user accessed a forum page, a "Odoo session expired" notification would appear unnecessarily.

After this commit: The loadLanguages RPC call is now executed only for authenticated (non-public) users. The "Translate" button in the toolbar is hidden for public users.

task-4348290



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
