### PR TITLE
[FIX] web: many2many_tags_avatar: wrong background color

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.scss
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.scss
@@ -17,8 +17,6 @@
         flex: 1 0 50px;
 
         .o_input {
-            --o-input-background-color: transparent;
-
             height: 100%;
             border: none;
         }
@@ -40,6 +38,12 @@
             @include o-text-overflow(inline-block);
             max-width: 200px;
         }
+    }
+}
+
+.o_field_widget.o_field_many2many_tags, .o_field_widget.o_field_many2many_tags_avatar {
+    .o_field_many2many_selection .o_input {
+        --o-input-background-color: transparent;
     }
 }
 


### PR DESCRIPTION
Before this commit, the invalid `many2many_tags_avatar` input has two layers of transparent background-color so the two colors stack one uppon the other one and so we had a inconsitancy color with others invalid field.

This commit adds the `.o_field_many2many_tags_avatar` so the following CSS rules are also apply like on the `.o_field_many2many_tags`. And so the child input has `background-color: transparent` when the input is invalid.
```css
.o_input {
  --o-input-background-color: transparent;
}
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
