### PR TITLE
[FIX] mail: request iOS push permission when actually promptable

### DIFF
--- a/addons/mail/static/src/core/common/notification_permission_service.js
+++ b/addons/mail/static/src/core/common/notification_permission_service.js
@@ -1,9 +1,22 @@
 import { reactive } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
-import { isAndroidApp, isIosApp } from "@web/core/browser/feature_detection";
+import {
+    isAndroidApp,
+    isDisplayStandalone,
+    isIOS,
+    isIosApp,
+} from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+
+async function getIosPwaPermission() {
+    if (browser.location.protocol !== "https:") {
+        return "denied";
+    }
+    const registration = await browser.navigator.serviceWorker?.getRegistration();
+    return (await registration?.pushManager.permissionState()) ?? "prompt";
+}
 
 export const notificationPermissionService = {
     dependencies: ["notification"],
@@ -27,9 +40,15 @@ export const notificationPermissionService = {
         const notification = services.notification;
         let permission;
         try {
-            permission = await browser.navigator?.permissions?.query({
-                name: "notifications",
-            });
+            if (isIOS() && isDisplayStandalone()) {
+                permission = { state: await getIosPwaPermission() };
+            } else if (isIOS()) {
+                permission = { state: "denied" };
+            } else {
+                permission = await browser.navigator?.permissions?.query({
+                    name: "notifications",
+                });
+            }
         } catch {
             // noop
         }
@@ -60,7 +79,7 @@ export const notificationPermissionService = {
                 }
             },
         });
-        if (permission) {
+        if (permission && !isIOS()) {
             permission.addEventListener("change", () => (state.permission = permission.state));
         }
         return state;

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -6,7 +6,6 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { MessagingMenuQuickSearch } from "@mail/core/web/messaging_menu_quick_search";
-import { isDisplayStandalone, isIOS, isIosApp } from "@web/core/browser/feature_detection";
 
 Object.assign(MessagingMenu.components, { MessagingMenuQuickSearch });
 
@@ -178,10 +177,6 @@ patch(MessagingMenu.prototype, {
         return this.store.discuss.activeTab !== "channel" && !this.state.adding;
     },
     get shouldAskPushPermission() {
-        if (isIOS() && !isDisplayStandalone() && !isIosApp()) {
-            // iOS browser apps do not have push notifications: Only PWA and apps have them.
-            return false;
-        }
         return this.notification.permission === "prompt";
     },
 });


### PR DESCRIPTION
Follow-up of [1] and [2]

iOS push notifications do not work on Safari: they only work in apps. The notifications are managed by the apps, whether with native mobile app or PWA.

With PWA, it should normally rely on `Notification.permission`, but somehow it doesn't work and always has value "default". Its showing has been limited to the PWA, but it keeps showing a persistent notification. Clicking on it the 1st time displays a prompt to either accept or deny the permissions. Afterwards, further clicks on the "odoobot has a request" automatically display "granted" or "denied" based on user initial choice.

iOS push permissions seem to necessarily rely on `serviceWorker.getRegistration().pushManager`, which works only on HTTPS, hence why iOS push notifications do not work on HTTP. Also actual push permission state are correct there whereas on Notification.permission they are wrong.

This commit fixes the issue by computing the push notification permisssion state correctly on iOS, using
`serviceWorker.getRegistration().pushManager`.

[1]: https://github.com/odoo/odoo/pull/178057
[2]: https://github.com/odoo/odoo/pull/187038
