### PR TITLE
[FIX] project: remove access token when privacy is changed

### DIFF
--- a/addons/project/tests/test_project_sharing_portal_access.py
+++ b/addons/project/tests/test_project_sharing_portal_access.py
@@ -86,6 +86,7 @@ class TestProjectSharingPortalAccess(TestProjectSharingCommon):
 class TestProjectSharingChatterAccess(TestProjectSharingCommon, HttpCase):
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_post_chatter_as_portal_user(self):
+        self.project_no_collabo.privacy_visibility = 'portal'
         self.env['project.share.wizard'].create({
             'res_model': 'project.project',
             'res_id': self.project_no_collabo.id,

--- a/addons/website_form_project/tests/test_project_portal_access.py
+++ b/addons/website_form_project/tests/test_project_portal_access.py
@@ -12,6 +12,7 @@ from odoo.addons.website.tools import MockRequest
 
 class TestProjectPortalAccess(TestProjectSharingCommon, HttpCase):
     def test_post_chatter_as_portal_user(self):
+        self.project_no_collabo.privacy_visibility = 'portal'
         self.env['project.share.wizard'].create({
             'res_model': 'project.project',
             'res_id': self.project_no_collabo.id,


### PR DESCRIPTION
Previously, it was still possible to access a project with an access_token even if that project is no longer in privacy="portal".

This was not consistant with the front-end that disable the access to the portal share wizard when privacy is set to anything else than 'portal'.

This change remove the token when the privacy is changed at the time of the write()

This change is done in the project module because it depends on "portal", and not the other way around.

This change can also be used as an invalidation mecanism in case of a token leak. Changing the privacy to
'private' then to 'portal' will allow for an invalidation of the previous token and the creation of new one.

opw-4104804
task-4354145

Closes #176177
