### PR TITLE
[PERF] base,web: improve (web_)load_menus performance

### DIFF
--- a/addons/web/models/ir_ui_menu.py
+++ b/addons/web/models/ir_ui_menu.py
@@ -39,15 +39,19 @@ class IrUiMenu(models.Model):
                     "backgroundImage": menu.get('backgroundImage'),
                 }
             else:
-                action = menu['action']
+                action_id = menu['action_id']
+                action_model = menu['action_model']
+                action_path = menu['action_path']
                 web_icon = menu['web_icon']
                 web_icon_data = menu['web_icon_data']
 
                 if menu['id'] == menu['app_id']:
                     # if it's an app take action of first (sub)child having one defined
                     child = menu
-                    while child and not action:
-                        action = child['action']
+                    while child and not action_id:
+                        action_id = child['action_id']
+                        action_model = child['action_model']
+                        action_path = child['action_path']
                         child = menus[child['children'][0]] if child['children'] else False
 
                     webIcon = menu.get('web_icon', '')
@@ -65,13 +69,6 @@ class IrUiMenu(models.Model):
                         web_icon = ",".join([iconClass or "", color or "", backgroundColor])
                     else:
                         web_icon_data = '/web/static/img/default_icon_app.png'
-
-                action_model, action_id = action.split(',') if action else (False, False)
-                action_id = int(action_id) if action_id else False
-                if action_model and action_id:
-                    action_path = self.env[action_model].browse(action_id).sudo().path
-                else:
-                    action_path = False
 
                 web_menus[menu['id']] = {
                     "id": menu['id'],

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -24,3 +24,4 @@ from . import test_res_users
 from . import test_webmanifest
 from . import test_ir_qweb
 from . import test_reports
+from . import test_perf_load_menu

--- a/addons/web/tests/test_load_menus.py
+++ b/addons/web/tests/test_load_menus.py
@@ -1,52 +1,80 @@
+from odoo import Command
 from odoo.tests.common import HttpCase
 
 class LoadMenusTests(HttpCase):
 
+    maxDiff = None
+
     def setUp(self):
         super().setUp()
         self.menu = self.env["ir.ui.menu"].create({
-            "name": "test_menu",
+            "name": "root menu (test)",
             "parent_id": False,
         })
+        self.action = self.env["ir.actions.act_window"].create({
+            "name": "action (test)",
+            "res_model": "res.users",
+            "view_ids": [Command.create({"view_mode": "form"})],
+        })
+        self.menu_child = self.env["ir.ui.menu"].create({
+            "name": "child menu (test)",
+            "parent_id": self.menu.id,
+            "action": f"{self.action._name},{self.action.id}",
+        })
 
-        def search(*args, **kwargs):
-            return self.menu
+        menus = self.menu + self.menu_child
 
-        self.patch(type(self.env["ir.ui.menu"]), "search", search)
+        # Patch search to only return these menus
+        origin_search_fetch = self.env.registry["ir.ui.menu"].search_fetch
+        def search_fetch(self, domain, *args, **kwargs):
+            return origin_search_fetch(self, domain + [('id', 'in', menus.ids)], *args, **kwargs)
+
+        self.patch(self.env.registry["ir.ui.menu"], "search_fetch", search_fetch)
         self.authenticate("admin", "admin")
 
     def test_load_menus(self):
         menu_loaded = self.url_open("/web/webclient/load_menus/1234")
         expected = {
             str(self.menu.id): {
-                "actionID": False,
-                "actionModel": False,
-                "actionPath": False,
-                "appID": self.menu.id,
-                "children": [],
-                "id": self.menu.id,
-                "name": "test_menu",
-                "webIcon": False,
-                "webIconData": "/web/static/img/default_icon_app.png",
-                "webIconDataMimetype": False,
-                "xmlid": ""
+                'actionID': self.action.id,  # Take the first action in children (see load_web_menus)
+                'actionModel': 'ir.actions.act_window',
+                'actionPath': False,
+                'appID': self.menu.id,
+                'children': [self.menu_child.id],
+                'id': self.menu.id,
+                'name': 'root menu (test)',
+                'webIcon': False,
+                'webIconData': '/web/static/img/default_icon_app.png',
+                'webIconDataMimetype': False,
+                'xmlid': '',
             },
-            "root": {
-                "actionID": False,
-                "actionModel": False,
-                "actionPath": False,
-                "appID": False,
-                "children": [
-                    self.menu.id,
-                ],
-                "id": "root",
-                "name": "root",
-                "webIcon": None,
-                "webIconData": None,
-                "webIconDataMimetype": None,
-                "xmlid": "",
-                "backgroundImage": None,
-            }
+            str(self.menu_child.id): {
+                'actionID': self.action.id,
+                'actionModel': 'ir.actions.act_window',
+                'actionPath': False,
+                'appID': self.menu.id,
+                'children': [],
+                'id': self.menu_child.id,
+                'name': 'child menu (test)',
+                'webIcon': False,
+                'webIconData': False,
+                'webIconDataMimetype': False,
+                'xmlid': '',
+            },
+            'root': {
+                'actionID': False,
+                'actionModel': False,
+                'actionPath': False,
+                'appID': False,
+                'backgroundImage': None,
+                'children': [self.menu.id],
+                'id': 'root',
+                'name': 'root',
+                'webIcon': None,
+                'webIconData': None,
+                'webIconDataMimetype': None,
+                'xmlid': '',
+            },
         }
 
         self.assertDictEqual(

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -1,0 +1,71 @@
+
+import json
+from uuid import uuid4
+
+from odoo.tests import common, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestPerfSessionInfo(common.HttpCase):
+
+    def test_performance_session_info(self):
+        user = common.new_test_user(
+            self.env,
+            "session",
+            email="session@in.fo",
+            tz="UTC",
+        )
+        self.authenticate(user.login, "info")
+
+        self.env.registry.clear_all_caches()
+        # cold ormcache (only web: 43, all module: 131)
+        with self.assertQueryCount(131):
+            self.url_open(
+                "/web/session/get_session_info",
+                data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),
+                headers={"Content-Type": "application/json"},
+            )
+
+        # cold fields cache - warm ormcache (only web: 7, all module: 22)
+        with self.assertQueryCount(22):
+            self.url_open(
+                "/web/session/get_session_info",
+                data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),
+                headers={"Content-Type": "application/json"},
+            )
+
+    def test_load_web_menus_perf(self):
+        self.env.registry.clear_all_caches()
+        self.env.invalidate_all()
+        # cold orm/fields cache (only web: 19, all module: 80)
+        with self.assertQueryCount(80):
+            self.env['ir.ui.menu'].load_web_menus(False)
+
+        # cold fields cache - warm orm cache (only web: 6, all module: 635)
+        self.env.invalidate_all()
+        with self.assertQueryCount(635):
+            self.env['ir.ui.menu'].load_web_menus(False)
+
+    def test_load_menus_perf(self):
+        self.env.registry.clear_all_caches()
+        self.env.invalidate_all()
+        # cold orm/fields cache (only web: 17, all module: 45)
+        with self.assertQueryCount(45):
+            self.env['ir.ui.menu'].load_menus(False)
+
+        # cold fields cache - warm orm cache (only web: 0, all module: 1)
+        self.env.invalidate_all()
+        with self.assertQueryCount(1):
+            self.env['ir.ui.menu'].load_menus(False)
+
+    def test_visible_menu_ids(self):
+        self.env.registry.clear_all_caches()
+        self.env.invalidate_all()
+        # cold ormcache (only web: 7, all module: 19)
+        with self.assertQueryCount(19):
+            self.env['ir.ui.menu']._visible_menu_ids()
+
+        # cold fields cache - warm orm cache (only web: 1, all module: 1)
+        self.env.invalidate_all()
+        with self.assertQueryCount(1):
+            self.env['ir.ui.menu']._visible_menu_ids()

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -18,7 +18,7 @@ class TestPerfSessionInfo(common.HttpCase):
         self.authenticate(user.login, "info")
 
         self.env.registry.clear_all_caches()
-        # cold ormcache (only web: 43, all module: 131)
+        # cold ormcache (only web: 42, all module: 131)
         with self.assertQueryCount(131):
             self.url_open(
                 "/web/session/get_session_info",
@@ -49,7 +49,7 @@ class TestPerfSessionInfo(common.HttpCase):
     def test_load_menus_perf(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
-        # cold orm/fields cache (only web: 17, all module: 45)
+        # cold orm/fields cache (only web: 12, all module: 45)
         with self.assertQueryCount(45):
             self.env['ir.ui.menu'].load_menus(False)
 
@@ -61,7 +61,7 @@ class TestPerfSessionInfo(common.HttpCase):
     def test_visible_menu_ids(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
-        # cold ormcache (only web: 7, all module: 19)
+        # cold ormcache (only web: 5, all module: 19)
         with self.assertQueryCount(19):
             self.env['ir.ui.menu']._visible_menu_ids()
 

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -18,15 +18,15 @@ class TestPerfSessionInfo(common.HttpCase):
         self.authenticate(user.login, "info")
 
         self.env.registry.clear_all_caches()
-        # cold ormcache (only web: 42, all module: 131)
-        with self.assertQueryCount(131):
+        # cold ormcache (only web: 42, all module: 112)
+        with self.assertQueryCount(112):
             self.url_open(
                 "/web/session/get_session_info",
                 data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),
                 headers={"Content-Type": "application/json"},
             )
 
-        # cold fields cache - warm ormcache (only web: 7, all module: 22)
+        # cold fields cache - warm ormcache (only web: 6, all module: 22)
         with self.assertQueryCount(22):
             self.url_open(
                 "/web/session/get_session_info",
@@ -37,20 +37,20 @@ class TestPerfSessionInfo(common.HttpCase):
     def test_load_web_menus_perf(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
-        # cold orm/fields cache (only web: 19, all module: 80)
-        with self.assertQueryCount(80):
+        # cold orm/fields cache (only web: 10, all module: 38)
+        with self.assertQueryCount(38):
             self.env['ir.ui.menu'].load_web_menus(False)
 
-        # cold fields cache - warm orm cache (only web: 6, all module: 635)
+        # cold fields cache - warm orm cache (only web: 0, all module: 1)
         self.env.invalidate_all()
-        with self.assertQueryCount(635):
+        with self.assertQueryCount(1):
             self.env['ir.ui.menu'].load_web_menus(False)
 
     def test_load_menus_perf(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
-        # cold orm/fields cache (only web: 12, all module: 45)
-        with self.assertQueryCount(45):
+        # cold orm/fields cache (only web: 10, all module: 38)
+        with self.assertQueryCount(38):
             self.env['ir.ui.menu'].load_menus(False)
 
         # cold fields cache - warm orm cache (only web: 0, all module: 1)
@@ -61,11 +61,11 @@ class TestPerfSessionInfo(common.HttpCase):
     def test_visible_menu_ids(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
-        # cold ormcache (only web: 5, all module: 19)
-        with self.assertQueryCount(19):
+        # cold ormcache (only web: 5, all module: 14)
+        with self.assertQueryCount(14):
             self.env['ir.ui.menu']._visible_menu_ids()
 
-        # cold fields cache - warm orm cache (only web: 1, all module: 1)
+        # cold fields cache - warm orm cache (only web: 0, all module: 0)
         self.env.invalidate_all()
-        with self.assertQueryCount(1):
+        with self.assertQueryCount(0):
             self.env['ir.ui.menu']._visible_menu_ids()

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -234,92 +234,89 @@ class IrUiMenu(models.Model):
     @api.model
     @tools.ormcache_context('self._uid', 'debug', keys=('lang',))
     def load_menus(self, debug):
-        """ Loads all menu items (all applications and their sub-menus).
-
-        :return: the menu root
-        :rtype: dict('children': menu_nodes)
-        """
-        fields = ['name', 'sequence', 'parent_id', 'action', 'web_icon']
-        menu_roots = self.get_user_roots()
-        menu_roots_data = menu_roots.read(fields) if menu_roots else []
-        menu_root = {
-            'id': False,
-            'name': 'root',
-            'parent_id': [-1, ''],
-            'children': [menu['id'] for menu in menu_roots_data],
-        }
-
-        all_menus = {'root': menu_root}
-
-        if not menu_roots_data:
-            return all_menus
-
-        # menus are loaded fully unlike a regular tree view, cause there are a
-        # limited number of items (752 when all 6.1 addons are installed)
-        menus_domain = [('id', 'child_of', menu_roots.ids)]
         blacklisted_menu_ids = self._load_menus_blacklist()
-        if blacklisted_menu_ids:
-            menus_domain = expression.AND([menus_domain, [('id', 'not in', blacklisted_menu_ids)]])
-        menus = self.search(menus_domain)._filter_visible_menus()
-        menu_items = menus.read(fields)
-        xmlids = (menu_roots + menus)._get_menuitems_xmlids()
+        visible_menus = self.search_fetch(
+            [('id', 'not in', blacklisted_menu_ids)],
+            ['name', 'parent_id', 'action', 'web_icon'],
+        )._filter_visible_menus()
 
-        # add roots at the end of the sequence, so that they will overwrite
-        # equivalent menu items from full menu read when put into id:item
-        # mapping, resulting in children being correctly set on the roots.
-        menu_items.extend(menu_roots_data)
+        children_dict = defaultdict(list)  # {parent_id: []} / parent_id == False for root menus
+        for menu in visible_menus:
+            children_dict[menu.parent_id.id].append(menu.id)
 
-        mi_attachments = self.env['ir.attachment'].sudo().search_read(
+        app_info = {}
+        # recursively set app ids to related children
+        def _set_app_id(menu_app_id, menu_id):
+            app_info[menu_id] = menu_app_id
+            for child_id in children_dict[menu_id]:
+                _set_app_id(menu_app_id, child_id)
+
+        for root_menu_id in children_dict[False]:
+            _set_app_id(root_menu_id, root_menu_id)
+
+        # Filter out menus not related to an app (+ keep root menu), it happens when
+        # some parent menu are not visible for group.
+        visible_menus = visible_menus.filtered(lambda menu: menu.id in app_info)
+
+        xmlids = visible_menus._get_menuitems_xmlids()
+        icon_attachments = self.env['ir.attachment'].sudo().search_read(
             domain=[('res_model', '=', 'ir.ui.menu'),
-                    ('res_id', 'in', [menu_item['id'] for menu_item in menu_items if menu_item['id']]),
+                    ('res_id', 'in', visible_menus._ids),
                     ('res_field', '=', 'web_icon_data')],
             fields=['res_id', 'datas', 'mimetype'])
+        icon_attachments_res_id = {attachment['res_id']: attachment for attachment in icon_attachments}
 
-        mi_attachment_by_res_id = {attachment['res_id']: attachment for attachment in mi_attachments}
+        menus_dict = {}
+        action_ids_by_type = defaultdict(list)
+        for menu in visible_menus:
 
-        # set children ids and xmlids
-        menu_items_map = {menu_item["id"]: menu_item for menu_item in menu_items}
-        for menu_item in menu_items:
-            menu_item.setdefault('children', [])
-            parent = menu_item['parent_id'] and menu_item['parent_id'][0]
-            menu_item['xmlid'] = xmlids.get(menu_item['id'], "")
-            if parent in menu_items_map:
-                menu_items_map[parent].setdefault(
-                    'children', []).append(menu_item['id'])
-            attachment = mi_attachment_by_res_id.get(menu_item['id'])
-            if attachment:
-                menu_item['web_icon_data'] = attachment['datas'].decode()
-                menu_item['web_icon_data_mimetype'] = attachment['mimetype']
+            menu_id = menu.id
+            attachment = icon_attachments_res_id.get(menu_id)
+
+            if action := menu.action:
+                action_model = action._name
+                action_id = action.id
+                action_ids_by_type[action_model].append(action_id)
             else:
-                menu_item['web_icon_data'] = False
-                menu_item['web_icon_data_mimetype'] = False
-        all_menus.update(menu_items_map)
+                action_model = False
+                action_id = False
 
-        # sort by sequence
-        for menu_id in all_menus:
-            all_menus[menu_id]['children'].sort(key=lambda id: all_menus[id]['sequence'])
+            menus_dict[menu_id] = {
+                'id': menu_id,
+                'name': menu.name,
+                'app_id': app_info[menu_id],
+                'action_model': action_model,
+                'action_id': action_id,
+                'web_icon': menu.web_icon,
+                'web_icon_data': attachment['datas'].decode() if attachment else False,
+                'web_icon_data_mimetype': attachment['mimetype'] if attachment else False,
+                'xmlid': xmlids.get(menu_id, ""),
+            }
 
-        # recursively set app ids to related children
-        def _set_app_id(app_id, menu):
-            menu['app_id'] = app_id
-            for child_id in menu['children']:
-                _set_app_id(app_id, all_menus[child_id])
+        # prefetch action.path
+        for model_name, action_ids in action_ids_by_type.items():
+            self.env[model_name].sudo().browse(action_ids).fetch(['path'])
 
-        for app in menu_roots_data:
-            app_id = app['id']
-            _set_app_id(app_id, all_menus[app_id])
+        # set children + model_path
+        for menu_dict in menus_dict.values():
+            if menu_dict['action_model']:
+                menu_dict['action_path'] = self.env[menu_dict['action_model']].sudo().browse(menu_dict['action_id']).path
+            else:
+                menu_dict['action_path'] = False
+            menu_dict['children'] = children_dict[menu_dict['id']]
 
-        # filter out menus not related to an app (+ keep root menu)
-        all_menus = {menu['id']: menu for menu in all_menus.values() if menu.get('app_id')}
-        all_menus['root'] = menu_root
-
-        return all_menus
+        menus_dict['root'] = {
+            'id': False,
+            'name': 'root',
+            'children': children_dict[False],
+        }
+        return menus_dict
 
     def _get_menuitems_xmlids(self):
-        menuitems = self.env['ir.model.data'].sudo().search([
-                ('res_id', 'in', self.ids),
-                ('model', '=', 'ir.ui.menu')
-            ])
+        menuitems = self.env['ir.model.data'].sudo().search_fetch(
+            [('res_id', 'in', self.ids), ('model', '=', 'ir.ui.menu')],
+            ['res_id', 'complete_name'],
+        )
 
         return {
             menu.res_id: menu.complete_name

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -77,57 +77,67 @@ class IrUiMenu(models.Model):
     @tools.ormcache('frozenset(self.env.user._get_group_ids())', 'debug')
     def _visible_menu_ids(self, debug=False):
         """ Return the ids of the menu items visible to the user. """
-        # retrieve all menus, and determine which ones are visible
-        menus = self.with_context({}).search_fetch([], ['action', 'parent_id'], order='id').sudo()
-        # first discard all menus with groups the user does not have
         group_ids = set(self.env.user._get_group_ids())
         if not debug:
-            group_ids = group_ids - {self.env['ir.model.data']._xmlid_to_res_id('base.group_no_one', raise_if_not_found=False)}
-        menus = menus.filtered(
-            lambda menu: not (menu.groups_id and group_ids.isdisjoint(menu.groups_id._ids)))
+            group_ids.discard(self.env['ir.model.data']._xmlid_to_res_id('base.group_no_one', raise_if_not_found=False))
+
+        # retrieve menus with a domain to filter out menus with groups the user does not have.
+        # It will be used to determine which ones are visible
+        menus = self.with_context({}).search_fetch(
+            # Don't use 'any' operator in the domain to avoid ir.rule
+            ['|', ('groups_id', '=', False), ('groups_id', 'in', tuple(group_ids))],
+            ['parent_id', 'action'], order='id',
+        ).sudo()
 
         # take apart menus that have an action
-        actions_by_model = defaultdict(set)
+        action_ids_by_model = defaultdict(list)
         for action in menus.mapped('action'):
             if action:
-                actions_by_model[action._name].add(action.id)
-        existing_actions = {
-            action
-            for model_name, action_ids in actions_by_model.items()
-            for action in self.env[model_name].browse(action_ids).exists()
-        }
-        action_menus = menus.filtered(lambda m: m.action and m.action in existing_actions)
-        folder_menus = menus - action_menus
-        visible = self.browse()
+                action_ids_by_model[action._name].append(action.id)
 
-        # process action menus, check whether their action is allowed
-        access = self.env['ir.model.access']
         MODEL_BY_TYPE = {
             'ir.actions.act_window': 'res_model',
             'ir.actions.report': 'model',
             'ir.actions.server': 'model_name',
         }
+        def exists_actions(model_name, action_ids):
+            """ Return existing actions and fetch model name field if exists"""
+            if model_name not in MODEL_BY_TYPE:
+                return self.env[model_name].browse(action_ids).exists()
+            records = self.env[model_name].sudo().with_context(active_test=False).search_fetch(
+                [('id', 'in', action_ids)], [MODEL_BY_TYPE[model_name]], order='id',
+            )
+            if model_name == 'ir.actions.server':
+                # Because it is computed, `search_fetch` doesn't fill the cache for it
+                records.mapped('model_name')
+            return records
 
-        # performance trick: determine the ids to prefetch by type
-        prefetch_ids = defaultdict(list)
-        for action in action_menus.mapped('action'):
-            prefetch_ids[action._name].append(action.id)
-
-        for menu in action_menus:
+        existing_actions = {
+            action
+            for model_name, action_ids in action_ids_by_model.items()
+            for action in exists_actions(model_name, action_ids)
+        }
+        menu_ids = set(menus._ids)
+        visible_ids = set()
+        access = self.env['ir.model.access']
+        # process action menus, check whether their action is allowed
+        for menu in menus:
             action = menu.action
-            action = action.with_prefetch(prefetch_ids[action._name])
-            model_name = action._name in MODEL_BY_TYPE and action[MODEL_BY_TYPE[action._name]]
-            if not model_name or access.check(model_name, 'read', False):
-                # make menu visible, and its folder ancestors, too
-                visible += menu
+            if not action or action not in existing_actions:
+                continue
+            model_fname = MODEL_BY_TYPE.get(action._name)
+            # action[model_fname] has been fetched in batch in `exists_actions`
+            if model_fname and not access.check(action[model_fname], 'read', False):
+                continue
+            # make menu visible, and its folder ancestors, too
+            menu_id = menu.id
+            while menu_id not in visible_ids and menu_id in menu_ids:
+                visible_ids.add(menu_id)
                 menu = menu.parent_id
-                while menu and menu in folder_menus and menu not in visible:
-                    visible += menu
-                    menu = menu.parent_id
+                menu_id =  menu.id
 
-        return frozenset(visible.ids)
+        return frozenset(visible_ids)
 
-    @api.returns('self')
     def _filter_visible_menus(self):
         """ Filter `self` to only keep the menu items that should be visible in
             the menu hierarchy of the current user.

--- a/odoo/addons/base/models/res_users_settings.py
+++ b/odoo/addons/base/models/res_users_settings.py
@@ -39,9 +39,8 @@ class ResUsersSettings(models.Model):
         return res
 
     def _format_settings(self, fields_to_format):
-        res = self._read_format(fnames=fields_to_format)[0]
+        res = self._read_format(fnames=[fname for fname in fields_to_format if fname != 'user_id'])[0]
         if 'user_id' in fields_to_format:
-            res = self._read_format(fnames=fields_to_format)[0]
             res['user_id'] = {'id': self.user_id.id}
         return res
 


### PR DESCRIPTION
## Rationals

The first request to the Odoo backend has to compute the `session_info` (ir.http) of the current user. 
In this calculation, most of the time is used to compute `load_menus`, which is cached, but not with a good hit rate, since it depends on the current user. The calculation of `load_menus` in `session_info` is only done to generate a hash to the webclient which is used for caching purposes (see `web_load_menus`).

The purpose of this PR is to improve and refactor the code of `load_menus` to be faster when the ormcache is cold (due to the low hit rate). A second PR will follow to avoid calling `load_menus` to create the cache key for the webclient in the first place (it will mostly add a new ormcache key attached to a SQL sequence that is sent back to the webclient and shared for menus and actions).

The speedscope didn't/doesn't a specific bottleneck but a lot of small ones. It is why we refactor `_visible_menu_ids` and `load_menus` completely for sake of performance and simplicity.

## Commits

### [IMP] web: add assertQueryCount for methods involved with load_menus

### [IMP] web: improve test_loaded_menu

For the next commit, it is important to have a realistic behavior and avoid patching the `search` method without calling the original one, as the current implementation only works with the override of `search_fetch`.

### [REF] base: refactor ir.ui.menu search_fetch()

The `search_fetch` of ir.ui.menu is overridden by default to filter the visible menu for the current user by default. It's not standard, and adds complexity to disable this behavior in many places.

### [REF] base: improve performance of `_visible_menu_ids`

Refactor and improve the performance of `_visible_menu_ids` to speed up load_menus() when the orm cache is cold.

Performance test:
```
from odoo.tools import mute_logger

def visible_menu():
    with mute_logger('odoo.registry'):
        self.env.registry.clear_all_caches()
    self.env.invalidate_all()
    self.env['ir.ui.menu']._visible_menu_ids()

%timeit visible_menu()
```
On the runbot database:
Before:
25.5 ms ± 203 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
After:
11 ms ± 148 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)


### [REF] base: refactor load_menus

Refactor `load_menus` for sake of performance and simplicity. Remove unused keys (parent_id, sequence and action), add action_path, action_id, action_model to avoid the very inefficient calculation of it in `load_web_menus`. In fact, `load_web_menus` doesn't set a prefetch set and then read the action path from the database one by one.
This makes `load_web_menus` less efficient when the ormcache is hot than when the ormcache is cold (because all path actions are already fetched from `_visible_menus_ids`, see changes no query count).

Note that one idea was to change the ormcache to depend on the list of the user groups, but `_load_menus_blacklist` depends on the user data (company_ids/employee_ids) inside some overrides. Also, the next step is to have a cache on the user's browser side, then, this ormcache might be useless in the future. Then, for the sake of simplicity, keep it that way for now.

Performance test:
```python
from odoo.tools import mute_logger

def load_menus():
    with mute_logger('odoo.registry'):
        self.env.registry.clear_all_caches()
    self.env.invalidate_all()
    self.env['ir.ui.menu'].load_menus(False)

%timeit load_menus()
```
Before previous commit on _visible_menu_ids:
59.7 ms ± 472 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
Just before this commit:
46.1 ms ± 140 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
After (also compute more values for the web_load_menu()):
35.3 ms ± 363 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)


## Performance of session_info after this PR

```python
from odoo.http import _request_stack
from odoo.tools import DotDict
from odoo.tools import mute_logger

fake_req = DotDict(dict(
    db=self.env.cr.dbname,
    registry=env.registry,
    uid=env.uid,
    lang=env['res.lang']._get_data(code='en_US'),
    session=DotDict(
        {
            'context': {'lang': 'en_US'},
            'db': self.env.cr.dbname,
            'debug': '',
            'uid': env.uid,
        }
    ),
    cookies={
        "cids": '1'
    }
))
_request_stack.push(fake_req)

def session_info():
    with mute_logger('odoo.registry'):
        self.env.registry.clear_all_caches()
    self.env.invalidate_all()
    self.env['ir.http'].session_info()

%timeit session_info()
```
Before:
70.7 ms ± 603 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
After:
45.5 ms ± 688 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

See https://github.com/odoo/enterprise/pull/74394

task-4360403