### PR TITLE
[FIX] tools: float round mult

### DIFF
--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -96,7 +96,7 @@ def float_round(value, precision_digits=None, precision_rounding=None, rounding_
         normalized_value += math.copysign(epsilon, normalized_value)
         rounded_value = round(normalized_value)     # round to integer
 
-    result = rounded_value * rounding_factor # de-normalize
+    result = rounded_value / (1.0 / rounding_factor) # de-normalize
     return result
 
 def float_is_zero(value, precision_digits=None, precision_rounding=None):


### PR DESCRIPTION
Steps to Reproduce
* Install sales and stock modules
* Enable product packaging in the settings tab
* Create a product with packaging
* Add a packaging line with a quantity of 14.48
* Go to the sales app
* Create a quotation and add the newly created product as an order line.
* Add the newly created packaging in the sales order line
* change the packaging quantity to 30
* change the unit price to 2.0
* Save the quotation
* Go to the other info tab.
* Change the delivery date and save it.

Current behavior

The unit price is unexpectedly changed

Expected behavior

The unit price should not be changed

Reason

This is a rather complicated scenario. However, the core issue comes from the 43440 * 0.01 multiplication, which results in 434.4000000000003. This small difference affects the float_round method, causing incorrect rounding. If we change the packaging quantity to 20.0, for example, the issue would not occur. With this difference in value, the system detects a change and triggers the onchange method, cascading into other methods, resulting in the issue described above.

Fix

To solve this, we avoid using multiplication and instead use division.

opw-4285889

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
