### PR TITLE
[FIX] hr_recruitment: company_id candidate applicant mismatch

### DIFF
--- a/addons/hr_recruitment/i18n/hr_recruitment.pot
+++ b/addons/hr_recruitment/i18n/hr_recruitment.pot
@@ -383,14 +383,6 @@ msgid ""
 msgstr ""
 
 #. module: hr_recruitment
-#. odoo-python
-#: code:addons/hr_recruitment/wizard/applicant_refuse_reason.py:0
-msgid ""
-"At least one applicant doesn't have a email; you can't use send email "
-"option."
-msgstr ""
-
-#. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__message_needaction
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_candidate__message_needaction
 msgid "Action Needed"
@@ -709,6 +701,14 @@ msgstr ""
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__date_open
 msgid "Assigned"
+msgstr ""
+
+#. module: hr_recruitment
+#. odoo-python
+#: code:addons/hr_recruitment/wizard/applicant_refuse_reason.py:0
+msgid ""
+"At least one applicant doesn't have a email; you can't use send email "
+"option."
 msgstr ""
 
 #. module: hr_recruitment
@@ -3322,6 +3322,13 @@ msgstr ""
 msgid ""
 "You can't select Send email option.\n"
 "The email will not be sent to the following applicant(s) as they don't have an email address:"
+msgstr ""
+
+#. module: hr_recruitment
+#. odoo-python
+#: code:addons/hr_recruitment/models/hr_applicant.py:0
+msgid ""
+"You cannot create an applicant in a different company than the candidate"
 msgstr ""
 
 #. module: hr_recruitment

--- a/addons/hr_recruitment/models/hr_candidate.py
+++ b/addons/hr_recruitment/models/hr_candidate.py
@@ -237,6 +237,17 @@ class HrCandidate(models.Model):
             else:
                 candidate.meeting_display_text = _('Last Meeting')
 
+    def write(self, vals):
+        res = super().write(vals)
+
+        if vals.get("company_id") and not self.env.context.get('do_not_propagate_company', False):
+            self.applicant_ids.with_context(do_not_propagate_company=True).write({"company_id": vals["company_id"]})
+            self.applicant_ids.filtered(
+                lambda a: a.job_id.company_id.id != vals["company_id"]
+            ).with_context(do_not_propagate_company=True).write({"company_id": vals['company_id'], "job_id": False})
+
+        return res
+
     def action_open_similar_candidates(self):
         self.ensure_one()
         domain = self._get_similar_candidates_domain()

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -111,7 +111,7 @@
                 <div class="oe_title pe-0">
                     <label for="candidate_id" class="oe_edit_only"/>
                     <h1 class="d-flex justify-content-between align-items-center">
-                        <field name="candidate_id" options="{'line_breaks': False}"/>
+                        <field name="candidate_id" options="{'line_breaks': False}" context="{'default_company_id': company_id}"/>
                     </h1>
                 </div>
                 <group>

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -352,12 +352,23 @@ class WebsiteHrRecruitment(WebsiteForm):
         return super()._should_log_authenticate_message(record)
 
     def extract_data(self, model, values):
-        candidate = False
+        candidate = request.env['hr.candidate']
         if model.model == 'hr.applicant':
             # pop the fields since there are only useful to generate a candidate record
             partner_name = values.pop('partner_name')
             partner_phone = values.pop('partner_phone', None)
             partner_email = values.pop('email_from', None)
+
+            company_id = (
+                request.env["hr.department"]
+                .sudo()
+                .search([("id", "=", values.get("department_id"))])
+                .company_id.id
+                or request.env["hr.job"]
+                .sudo()
+                .search([("id", "=", values.get("job_id"))])
+                .company_id.id
+            )
             if partner_phone and partner_email:
                 candidate = request.env['hr.candidate'].sudo().search([
                     ('email_from', '=', partner_email),
@@ -368,6 +379,7 @@ class WebsiteHrRecruitment(WebsiteForm):
                     'partner_name': partner_name,
                     'email_from': partner_email,
                     'partner_phone': partner_phone,
+                    'company_id': company_id,
                 })
         data = super().extract_data(model, values)
         if candidate:

--- a/addons/website_hr_recruitment/static/src/js/website_hr_applicant_form.js
+++ b/addons/website_hr_recruitment/static/src/js/website_hr_applicant_form.js
@@ -31,13 +31,13 @@ publicWidget.registry.hrRecruitment = publicWidget.Widget.extend({
 
     hideWarningMessage(targetEl, messageContainerId) {
         targetEl.classList.remove("border-warning");
-        document.querySelector(messageContainerId).classList.add("d-none");
+        document.querySelector(messageContainerId)?.classList.add("d-none");
     },
 
     showWarningMessage(targetEl, messageContainerId, message) {
         targetEl.classList.add("border-warning");
         document.querySelector(messageContainerId).textContent = message;
-        document.querySelector(messageContainerId).classList.remove("d-none");
+        document.querySelector(messageContainerId)?.classList.remove("d-none");
     },
 
     async _onFocusOutName(ev) {


### PR DESCRIPTION
The problem:
With the introduction candidate/applicant models in 18.0 a subtle bug got introduced. The core of the bug is that most of the field on an application are related/inherited from the candidate of that application except company_id. This means that both models have a company_id and those are not synced. This can become an issue in a multi company issue where a candidate is assigned to company A while their application is in company B. The recruiter in company B will then get constant access errors because they don't have write permission on a record(candidate) in a different company.

The fix:
This PR aims to fix this by doing 2 things.
1. Every time the company on a application gets changed the company of the candidate is also updated. This still means that if the company of the candidate is manually changed we will have this issue again but there's no way around that (that can be implemented in stable).
2. Makes sure that candidates created through the website are assigned to the company of the job posting or no company, preventing a mismatch from happening.

There was also trace-back happening on the job application form on odoo.com as a warning message div is missing there for some reason so I added a simple condition to check if that div exists to prevent the trace-back.

task-4350838

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
