### PR TITLE
[FIX] stock: make lot visible on pickings if not hidden

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -319,7 +319,7 @@
                                     <field name="lot_ids" widget="many2many_tags"
                                         column_invisible="parent.state == 'draft'"
                                         groups="stock.group_production_lot"
-                                        invisible="not show_details_visible or has_tracking != 'serial'"
+                                        invisible="not show_details_visible or has_tracking == 'none'"
                                         optional="hide"
                                         options="{'create': [('parent.use_create_lots', '=', True)]}"
                                         context="{'default_company_id': company_id, 'default_product_id': product_id, 'active_picking_id': parent.id}"


### PR DESCRIPTION
### Steps to reproduce:

- Create a product tracked by lot: Lot Product
- Create and Mark as todo a receipt with a move: 1 x Lot Product
- Click on the burger icon on the move and add a lot name LOT001
- Save > Save the picking > Validate the picking
- Unhide the Serial Numbers field
#### > While a lot with that lot name was created in DB and is used both by the move and its move line it i snot visible on the picking

### Cause of the issue:

The field is smply invisible for lots (while it is not for SN): https://github.com/odoo/odoo/blob/066834aafd7f904c4a9c0cf4a82b4bdfbb011f0b/addons/stock/views/stock_picking_views.xml#L319-L322

### Fix:

The issue is not reproducible on 17.2+ because the view has been updated. We simply backport one line from 98f1992f9ce5cb9eb590bd50b42ce07e24c3b919

opw-4338150
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
