### PR TITLE
[FIX] point_of_sale: prevent showing delete button for paid orders

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -454,6 +454,7 @@ export class TicketScreen extends Component {
         return (
             (this.ui.isSmall && order != this.state.selectedOrder) ||
             this.isDefaultOrderEmpty(order) ||
+            order.finalized ||
             order.payment_ids.some(
                 (payment) => payment.is_electronic() && payment.get_payment_status() === "done"
             )


### PR DESCRIPTION
Before this commit, in the ticket screen, when you filtered paid orders, you could press the delete button, which was useless and confusing.

opw-4339996

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
