### PR TITLE
[FIX] mrp: recompute notebook columns widths on components changes

### DIFF
--- a/addons/mrp/static/src/widgets/mrp_production_components_x2many.js
+++ b/addons/mrp/static/src/widgets/mrp_production_components_x2many.js
@@ -3,8 +3,40 @@
 import { registry } from "@web/core/registry";
 import { X2ManyField } from "@web/views/fields/x2many/x2many_field";
 import { ListRenderer } from "@web/views/list/list_renderer";
+import { onPatched } from "@odoo/owl";
 
 export class MrpProductionComponentsListRenderer extends ListRenderer {
+    setup() {
+        super.setup();
+        let hasNewLineListener = false;
+        let isNewLineClicked = false;
+        let currentStatusBar = null;
+
+        const updateStatusBar = () => {
+            const newStatusBar = document.querySelector('.state');
+            if (isNewLineClicked && currentStatusBar !== newStatusBar) {
+                this.keepColumnWidths = false;
+                currentStatusBar = newStatusBar;
+            }
+        };
+
+        const attachNewLineListener = () => {
+            const addLineButton = document.querySelector('.o_field_x2many_list_row_add a');
+            if (addLineButton && !hasNewLineListener) {
+                addLineButton.addEventListener('click', () => {
+                    isNewLineClicked = true;
+                    currentStatusBar = document.querySelector('.o_statusbar_status');
+                });
+                hasNewLineListener = true;
+            }
+        };
+    
+        onPatched(() => {
+            updateStatusBar();
+            attachNewLineListener();
+        });
+    }
+
     getCellClass(column, record) {
         let classNames = super.getCellClass(...arguments);
         if (column.name == "quantity_done" && !record.data.manual_consumption) {


### PR DESCRIPTION
**Issue:**
When creating a new Manufacturing Order, if a component is added before confirming, the columns of the notebook don't show all data.

**Expected:**
Notebook columns should all be directly visible, at least on a classic-size screen and in full mode.

**Steps to reproduce:**
- Activate Manufaturing app;
- Navigate to Manufacturing Orders and create a new one with any product (preferably having a BoM);
- Add a component line (that can be left empty if there are other components) in the notebook;
- Confirm the order and watch the "Consumed" column having a 4px width;
- Resize the window or refresh and the column appears correctly

**Cause:**
Columns' widths are not recomputed when needed.
When a line is added, it triggers a `useEffect` asking the list renderer not to recompute columns' widths. This instruction is kept by the renderer even if the object's stage changes.

**Fix:**
Trigger column width computation when components are patched (backport of https://github.com/odoo/odoo/blob/a64dc4d8f20709c147e70d23a080da29c433d33a/addons/stock/static/src/views/picking_form/stock_move_one2many.js#L11-L19).


opw-4273036

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
