### PR TITLE
[IMP] point_of_sale: Onboarding configurations & fixes

### DIFF
--- a/addons/l10n_be_pos_restaurant/__init__.py
+++ b/addons/l10n_be_pos_restaurant/__init__.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import models
+
+def post_init_hook(env):
+    for company in env['res.company'].search([('chart_template', '=like', 'be%')], order="parent_path"):
+        Template = env['account.chart.template'].with_company(company)
+        Template._load_data({
+            'account.tax': Template._get_be_pos_restaurant_account_tax(),
+        })

--- a/addons/l10n_be_pos_restaurant/__manifest__.py
+++ b/addons/l10n_be_pos_restaurant/__manifest__.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Belgian POS Restaurant Localization',
+    'version': '1.0',
+    'category': 'Localization/Point of Sale',
+    'depends': ['pos_restaurant', 'l10n_be'],
+    'auto_install': True,
+    'installable': True,
+    'license': 'LGPL-3',
+    'post_init_hook': 'post_init_hook',
+}

--- a/addons/l10n_be_pos_restaurant/data/template/account.tax-be.csv
+++ b/addons/l10n_be_pos_restaurant/data/template/account.tax-be.csv
@@ -1,0 +1,5 @@
+"id","sequence","description","invoice_label","name","amount","amount_type","type_tax_use","tax_group_id","tax_scope","active","repartition_line_ids/repartition_type","repartition_line_ids/document_type","repartition_line_ids/tag_ids","repartition_line_ids/account_id","repartition_line_ids/factor_percent","name@fr","name@nl"
+"tax_alcohol_luxury","10","21% VAT (Alcohol, luxury)","21%","21% Alcohol / luxury","21.0","percent","sale","tax_group_tva_21","consu","","base","invoice","+03","","","21% Alcool / luxe","21% Alcohol / luxe"
+"","","","","","","","","","","","tax","invoice","+54","a451","","",""
+"","","","","","","","","","","","base","refund","+49","","","",""
+"","","","","","","","","","","","tax","refund","+64","a451","","",""

--- a/addons/l10n_be_pos_restaurant/models/__init__.py
+++ b/addons/l10n_be_pos_restaurant/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import pos_config
+from . import template_be

--- a/addons/l10n_be_pos_restaurant/models/pos_config.py
+++ b/addons/l10n_be_pos_restaurant/models/pos_config.py
@@ -1,0 +1,46 @@
+from odoo import api, models
+
+class PosConfig(models.Model):
+    _inherit = 'pos.config'
+
+    def _create_takeaway_fiscal_position(self, config):
+        ChartTemplate = self.env['account.chart.template'].with_company(self.env.company)
+        tax_21 = ChartTemplate.ref('attn_VAT-OUT-21-L', raise_if_not_found=False)
+        tax_12 = ChartTemplate.ref('attn_VAT-OUT-12-L', raise_if_not_found=False)
+        tax_6 = ChartTemplate.ref('attn_VAT-OUT-06-L', raise_if_not_found=False)
+
+        if tax_21 and tax_12 and tax_6:
+            fp = self.env['account.fiscal.position'].create({
+                'name': 'Take out',
+            })
+            self.env['account.fiscal.position.tax'].create({
+                'tax_src_id': tax_21.id,
+                'tax_dest_id': tax_6.id,
+                'position_id': fp.id
+            })
+            self.env['account.fiscal.position.tax'].create({
+                'tax_src_id': tax_12.id,
+                'tax_dest_id': tax_6.id,
+                'position_id': fp.id
+            })
+            config.write({'takeaway': True, 'takeaway_fp_id': fp.id})
+
+    @api.model
+    def load_onboarding_bar_scenario(self):
+        super().load_onboarding_bar_scenario()
+        if (self.env.company.chart_template or '').startswith('be'):
+            ChartTemplate = self.env['account.chart.template'].with_company(self.env.company)
+            tax_alcohol = ChartTemplate.ref('tax_alcohol_luxury')
+            cocktails_category = self.env.ref('pos_restaurant.pos_category_cocktails', raise_if_not_found=False)
+            if cocktails_category:
+                self.env['product.template'].search([
+                    ('pos_categ_ids', 'in', [cocktails_category.id])
+                ]).write({'taxes_id': [(6, 0, [tax_alcohol.id])]})
+
+    @api.model
+    def load_onboarding_restaurant_scenario(self):
+        super().load_onboarding_restaurant_scenario()
+        if (self.env.company.chart_template or '').startswith('be'):
+            config = self.env.ref(self._get_suffixed_ref_name('pos_restaurant.pos_config_main_restaurant'), raise_if_not_found=False)
+            if config:
+                self._create_takeaway_fiscal_position(config)

--- a/addons/l10n_be_pos_restaurant/models/template_be.py
+++ b/addons/l10n_be_pos_restaurant/models/template_be.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+from odoo.addons.account.models.chart_template import template
+
+class AccountChartTemplate(models.AbstractModel):
+    _inherit = 'account.chart.template'
+
+    @template('be', 'account.tax')
+    def _get_be_pos_restaurant_account_tax(self):
+        pos_taxes = self._parse_csv('be', 'account.tax', module='l10n_be_pos_restaurant')
+        self._deref_account_tags('be_comp', pos_taxes)
+        return pos_taxes

--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -3028,7 +3028,7 @@ msgstr ""
 #. module: point_of_sale
 #. odoo-javascript
 #: code:addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js:0
-msgid "Furnitures"
+msgid "Furniture"
 msgstr ""
 
 #. module: point_of_sale
@@ -4302,9 +4302,14 @@ msgstr ""
 #. module: point_of_sale
 #. odoo-javascript
 #: code:addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml:0
-#: code:addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml:0
 #: code:addons/point_of_sale/static/src/app/store/select_lot_popup/select_lot_popup.xml:0
 msgid "Ok"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-javascript
+#: code:addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml:0
+msgid "Add"
 msgstr ""
 
 #. module: point_of_sale

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
@@ -143,7 +143,7 @@
                         class="btn btn-primary btn-lg lh-lg o-default-button"
                         t-att-class="{'disabled': isArchivedCombination()}"
                         t-on-click="confirm">
-                        Ok
+                        Add
                     </button>
                 <button class="btn btn-secondary btn-lg lh-lg o-default-button" t-on-click="close">Discard</button>
             </t>

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
@@ -63,6 +63,13 @@ export class PosKanbanRenderer extends KanbanRenderer {
         });
     }
 
+    async clickLoadScenario(item) {
+        await this.loadScenario.call(item);
+        if (this.loadScenario.status == "error") {
+            throw this.loadScenario.result;
+        }
+    }
+
     checkDisplayedResult() {
         this.posState.show_predefined_scenarios = this.props.list.count === 0;
     }
@@ -94,7 +101,7 @@ export class PosKanbanRenderer extends KanbanRenderer {
                 iconFile: "clothes-icon.png",
             },
             {
-                name: _t("Furnitures"),
+                name: _t("Furniture"),
                 description: _t("Stock, product configurator, replenishment, discounts"),
                 functionName: "load_onboarding_furniture_scenario",
                 iconFile: "furniture-icon.png",

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
@@ -42,7 +42,9 @@
                         </div>
                     </div>
                     <p class="text-large">
-                        <a role="button" class="btn btn-lg btn-secondary fw-bolder" t-on-click="createNewProducts">
+                        <a role="button" class="btn btn-lg btn-secondary fw-bolder"
+                            t-on-click="createNewProducts"
+                            t-att-class="{ 'disabled': !posState.has_chart_template || loadScenario.status === 'loading' }">
                             Create my own products
                         </a>
                     </p>
@@ -53,7 +55,8 @@
 
     <t t-name="point_of_sale.ScenarioCard">
         <div class="col-lg-4">
-            <div class="card mb-3 rounded-3 scenario-card" style="max-width: 540px;" t-on-click="() => this.loadScenario.call(item)">
+            <div class="card mb-3 rounded-3 scenario-card" style="max-width: 540px;"
+                t-on-click="() => this.clickLoadScenario(item)">
                 <div class="row g-0">
                     <div class="col-lg-4">
                         <div class="img-container m-2 d-flex align-items-center justify-content-center">

--- a/addons/point_of_sale/static/src/scss/pos_dashboard.scss
+++ b/addons/point_of_sale/static/src/scss/pos_dashboard.scss
@@ -5,12 +5,12 @@
 }
 
 .scenario-card:hover {
-    background-color: $o-gray-100;
+    background-color: $o-gray-200;
     cursor: pointer;
     border: 1px solid $o-gray-300;
 
-    .card-body {
-        background-color: $o-gray-100 !important;
+    .img-container {
+        background-color: $o-gray-200 !important;
     }
 }
 

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -278,7 +278,7 @@ registry.category("web_tour.tours").add("MultiProductOptionsTour", {
             ProductScreen.clickDisplayedProduct("Product A"),
             ProductConfiguratorPopup.isOptionShown("Value 1"),
             ProductConfiguratorPopup.isOptionShown("Value 2"),
-            Dialog.confirm("Ok"),
+            Dialog.confirm("Add"),
 
             Chrome.endTour(),
         ].flat(),

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -82,7 +82,6 @@ class PosConfig(models.Model):
         ref_name = 'pos_restaurant.pos_config_main_bar'
         if not self.env.ref(ref_name, raise_if_not_found=False):
             self._load_bar_data()
-
         journal, payment_methods_ids = self._create_journal_and_payment_methods(cash_journal_vals={'name': 'Cash Bar', 'show_on_dashboard': False})
         bar_categories = self.get_categories([
             'pos_restaurant.pos_category_cocktails',

--- a/addons/pos_self_order/static/src/overrides/components/product_info_banner/product_info_banner.js
+++ b/addons/pos_self_order/static/src/overrides/components/product_info_banner/product_info_banner.js
@@ -6,9 +6,4 @@ patch(ProductInfoBanner.prototype, {
         const result = super.bannerClass;
         return `${result} ${this.props.product.self_order_available ? "bg-success" : "bg-danger"}`;
     },
-    async switchSelfAvailability() {
-        await this.pos.data.write("product.product", [this.props.product.id], {
-            self_order_available: !this.props.product.self_order_available,
-        });
-    },
 });

--- a/addons/pos_self_order/static/src/overrides/components/product_info_popup/product_info_popup.js
+++ b/addons/pos_self_order/static/src/overrides/components/product_info_popup/product_info_popup.js
@@ -1,0 +1,10 @@
+import { ProductInfoPopup } from "@point_of_sale/app/screens/product_screen/product_info_popup/product_info_popup";
+import { patch } from "@web/core/utils/patch";
+
+patch(ProductInfoPopup.prototype, {
+    async switchSelfAvailability() {
+        await this.pos.data.write("product.product", [this.props.product.id], {
+            self_order_available: !this.props.product.self_order_available,
+        });
+    },
+});

--- a/addons/pos_self_order/static/src/overrides/components/product_info_popup/product_info_popup.xml
+++ b/addons/pos_self_order/static/src/overrides/components/product_info_popup/product_info_popup.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.ProductInfoBanner" t-inherit="point_of_sale.ProductInfoBanner" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('section-product-info-title')]" position="after">
-            <div class="section-self-order-availability mt-3 mb-4 pb-4 border-bottom text-start d-flex align-items-center">
+    <t t-name="pos_self_order.ProductInfoPopup" t-inherit="point_of_sale.ProductInfoPopup" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('section-inventory')]" position="before">
+            <div t-if="this.pos.config.self_ordering_mode != 'nothing'"
+                class="section-self-order-availability mt-3 mb-4 pb-4 border-bottom text-start d-flex align-items-center">
                 <h3 class="section-title">Self-ordering:</h3>
                 <div class="section-self-order-availability-body d-flex ms-auto">
                     <div class="form-check form-switch">


### PR DESCRIPTION
New module `l10n_be_pos_restaurant` added to overide "bar" and "restaurant" scenario in order to:
- Add new tax 21% alcohol / luxury is set on cocktails products
- Restaurant take away is set to True by default and there is a new fiscal position for take away (applying 6% tax)

Fixes:
- When clicking a demo data scenario to load:
    - Display correctly the errors (if any)
    - Disable button "Create my own products" when loading data
- Remove "Self-ordering" from the 'info' product if self_ordering is not activated in the current `pos_config`
- Replace "Ok" with "Add" in attribute selection popup

task-id: 4273866





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
