### PR TITLE
[FIX] hr: fixup of 0baa908385

### DIFF
--- a/addons/hr/models/res_partner.py
+++ b/addons/hr/models/res_partner.py
@@ -49,5 +49,6 @@ class ResPartnerBank(models.Model):
         if not self.user_has_groups('hr.group_hr_user'):
             account_employee = self.sudo().filtered("partner_id.employee_ids")
             for account in account_employee:
-                account.display_name = account.acc_number[:2] + "*" * len(account.acc_number[2:-4]) + account.acc_number[-4:]
+                account.sudo(self.env.su).display_name = \
+                    account.acc_number[:2] + "*" * len(account.acc_number[2:-4]) + account.acc_number[-4:]
         super(ResPartnerBank, self - account_employee)._compute_display_name()

--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -218,3 +218,24 @@ class TestSelfAccessRights(TestHrCommon):
     def testSearchUserEMployee(self):
         # Searching user based on employee_id field should not raise bad query error
         self.env['res.users'].with_user(self.richard).search([('employee_id', 'ilike', 'Hubert')])
+
+    def test_access_employee_account(self):
+        hubert = new_test_user(self.env, login='hubert', groups='base.group_user', name='Hubert Bonisseur de La Bath', email='hubert@oss.fr')
+        hubert = hubert.with_user(hubert)
+        hubert_acc = self.env['res.partner.bank'].create({'acc_number': 'FR1234567890', 'partner_id': hubert.partner_id.id})
+        hubert_emp = self.env['hr.employee'].create({
+            'name': 'Hubert',
+            'user_id': hubert.id,
+            'bank_account_id': hubert_acc.id
+        })
+        hubert.partner_id.sudo().employee_ids = hubert_emp
+
+        self.assertFalse(hubert.user_has_groups('hr.group_hr_user'))
+        self.assertFalse(hubert.env.su)
+
+        self.assertEqual(hubert.read(['employee_bank_account_id'])[0]['employee_bank_account_id'][1], 'FR******7890')
+        self.assertEqual(hubert.sudo().employee_bank_account_id.display_name, 'FR******7890')
+        self.assertEqual(hubert_emp.with_user(hubert).sudo().bank_account_id.display_name, 'FR******7890')
+
+        hubert_acc.invalidate_recordset(["display_name"])
+        self.assertEqual(hubert_emp.with_user(hubert).sudo().bank_account_id.sudo(False).display_name, 'FR******7890')


### PR DESCRIPTION
Computing the field in su = False was not working as assigned the variable on the sudo environment. The test in 0baa908385 was working as the read computes the display_name in sudo.
