### PR TITLE
[MOV] mail: move some leftover code in their section

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -297,7 +297,7 @@ class MailMail(models.Model):
                         'failure_type': failure_type,
                         'failure_reason': failure_reason,
                     })
-                    messages = notifications.mapped('mail_message_id').filtered(lambda m: m.is_thread_message())
+                    messages = notifications.mapped('mail_message_id').filtered(lambda m: m._is_thread_message())
                     # TDE TODO: could be great to notify message-based, not notifications-based, to lessen number of notifs
                     messages._notify_message_notification_update()  # notify user that we have a failure
         if not failure_type or failure_type in ['mail_email_invalid', 'mail_email_missing']:  # if we have another error, we want to keep the mail.

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -337,6 +337,9 @@ class MailMessage(models.Model):
         allowed = self.browse(id_ for id_ in ids if id_ in allowed_ids)
         return allowed._as_query(order)
 
+    def _get_search_domain_share(self):
+        return ['&', '&', ('is_internal', '=', False), ('subtype_id', '!=', False), ('subtype_id.internal', '=', False)]
+
     @api.model
     def _find_allowed_model_wise(self, doc_model, doc_dict):
         doc_ids = list(doc_dict)
@@ -831,6 +834,34 @@ class MailMessage(models.Model):
             "mail.message/toggle_star", {"message_ids": [self.id], "starred": starred}
         )
 
+    @api.model
+    def _message_fetch(self, domain, search_term=None, before=None, after=None, around=None, limit=30):
+        res = {}
+        if search_term:
+            # we replace every space by a % to avoid hard spacing matching
+            search_term = search_term.replace(" ", "%")
+            domain = expression.AND([domain, expression.OR([
+                # sudo: access to attachment is allowed if you have access to the parent model
+                [("attachment_ids", "in", self.env["ir.attachment"].sudo()._search([("name", "ilike", search_term)]))],
+                [("body", "ilike", search_term)],
+                [("subject", "ilike", search_term)],
+                [("subtype_id.description", "ilike", search_term)],
+            ])])
+            domain = expression.AND([domain, [("message_type", "not in", ["user_notification", "notification"])]])
+            res["count"] = self.search_count(domain)
+        if around is not None:
+            messages_before = self.search(domain=[*domain, ('id', '<=', around)], limit=limit // 2, order="id DESC")
+            messages_after = self.search(domain=[*domain, ('id', '>', around)], limit=limit // 2, order='id ASC')
+            return {**res, "messages": (messages_after + messages_before).sorted('id', reverse=True)}
+        if before:
+            domain = expression.AND([domain, [('id', '<', before)]])
+        if after:
+            domain = expression.AND([domain, [('id', '>', after)]])
+        res["messages"] = self.search(domain, limit=limit, order='id ASC' if after else 'id DESC')
+        if after:
+            res["messages"] = res["messages"].sorted('id', reverse=True)
+        return res
+
     def _message_reaction(self, content, action, partner, guest, store: Store = None):
         self.ensure_one()
         # search for existing reaction
@@ -874,29 +905,8 @@ class MailMessage(models.Model):
         store.add(self, {"reactions": reaction_group})
 
     # ------------------------------------------------------
-    # MESSAGE READ / FETCH / FAILURE API
+    # STORE / NOTIFICATIONS
     # ------------------------------------------------------
-
-    def _records_by_model_name(self):
-        ids_by_model = defaultdict(OrderedSet)
-        prefetch_ids_by_model = defaultdict(OrderedSet)
-        prefetch_messages = self | self.browse(self._prefetch_ids)
-        for message in prefetch_messages.filtered(lambda m: m.model and m.res_id):
-            target = ids_by_model if message in self else prefetch_ids_by_model
-            target[message.model].add(message.res_id)
-        return {
-            model_name: self.env[model_name].browse(ids)
-            .with_prefetch(tuple(ids_by_model[model_name] | prefetch_ids_by_model[model_name]))
-            for model_name, ids in ids_by_model.items()
-        }
-
-    def _record_by_message(self):
-        records_by_model_name = self._records_by_model_name()
-        return {
-            message: self.env[message.model].browse(message.res_id)
-            .with_prefetch(records_by_model_name[message.model]._prefetch_ids)
-            for message in self.filtered(lambda m: m.model and m.res_id)
-        }
 
     def _to_store(self, store, /, *, fields=None, format_reply=True, msg_vals=None,
                   for_current_user=False, add_followers=False, followers=None):
@@ -1066,34 +1076,6 @@ class MailMessage(models.Model):
     def _extras_to_store(self, store: Store, format_reply):
         pass
 
-    @api.model
-    def _message_fetch(self, domain, search_term=None, before=None, after=None, around=None, limit=30):
-        res = {}
-        if search_term:
-            # we replace every space by a % to avoid hard spacing matching
-            search_term = search_term.replace(" ", "%")
-            domain = expression.AND([domain, expression.OR([
-                # sudo: access to attachment is allowed if you have access to the parent model
-                [("attachment_ids", "in", self.env["ir.attachment"].sudo()._search([("name", "ilike", search_term)]))],
-                [("body", "ilike", search_term)],
-                [("subject", "ilike", search_term)],
-                [("subtype_id.description", "ilike", search_term)],
-            ])])
-            domain = expression.AND([domain, [("message_type", "not in", ["user_notification", "notification"])]])
-            res["count"] = self.search_count(domain)
-        if around is not None:
-            messages_before = self.search(domain=[*domain, ('id', '<=', around)], limit=limit // 2, order="id DESC")
-            messages_after = self.search(domain=[*domain, ('id', '>', around)], limit=limit // 2, order='id ASC')
-            return {**res, "messages": (messages_after + messages_before).sorted('id', reverse=True)}
-        if before:
-            domain = expression.AND([domain, [('id', '<', before)]])
-        if after:
-            domain = expression.AND([domain, [('id', '>', after)]])
-        res["messages"] = self.search(domain, limit=limit, order='id ASC' if after else 'id DESC')
-        if after:
-            res["messages"] = res["messages"].sorted('id', reverse=True)
-        return res
-
     def _message_notifications_to_store(self, store: Store):
         """Returns the current messages and their corresponding notifications in
         the format expected by the web client.
@@ -1246,5 +1228,23 @@ class MailMessage(models.Model):
             if model in self.pool and issubclass(self.pool[model], self.pool['mail.thread']):
                 self.env[model].browse(res_id).invalidate_recordset(fnames)
 
-    def _get_search_domain_share(self):
-        return ['&', '&', ('is_internal', '=', False), ('subtype_id', '!=', False), ('subtype_id.internal', '=', False)]
+    def _records_by_model_name(self):
+        ids_by_model = defaultdict(OrderedSet)
+        prefetch_ids_by_model = defaultdict(OrderedSet)
+        prefetch_messages = self | self.browse(self._prefetch_ids)
+        for message in prefetch_messages.filtered(lambda m: m.model and m.res_id):
+            target = ids_by_model if message in self else prefetch_ids_by_model
+            target[message.model].add(message.res_id)
+        return {
+            model_name: self.env[model_name].browse(ids)
+            .with_prefetch(tuple(ids_by_model[model_name] | prefetch_ids_by_model[model_name]))
+            for model_name, ids in ids_by_model.items()
+        }
+
+    def _record_by_message(self):
+        records_by_model_name = self._records_by_model_name()
+        return {
+            message: self.env[message.model].browse(message.res_id)
+            .with_prefetch(records_by_model_name[message.model]._prefetch_ids)
+            for message in self.filtered(lambda m: m.model and m.res_id)
+        }

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -472,7 +472,7 @@ class MailMessage(models.Model):
                     messages_to_check.pop(mid)
         elif operation == 'create':
             for mid, message in list(messages_to_check.items()):
-                if not self.is_thread_message(message):
+                if not self._is_thread_message_visible(vals=message):
                     messages_to_check.pop(mid)
 
         if not messages_to_check:
@@ -682,7 +682,7 @@ class MailMessage(models.Model):
                 if other_cmd:
                     message.sudo().write({'tracking_value_ids': tracking_values_cmd})
 
-            if message.is_thread_message(values):
+            if message._is_thread_message_visible(vals=values):
                 message._invalidate_documents(values.get('model'), values.get('res_id'))
 
         return messages
@@ -1190,7 +1190,7 @@ class MailMessage(models.Model):
         email_from = values.get('email_from')
         message_type = values.get('message_type')
         records = None
-        if self.is_thread_message({'model': model, 'res_id': res_id, 'message_type': message_type}):
+        if self._is_thread_message(vals={'model': model, 'res_id': res_id, 'message_type': message_type}):
             records = self.env[model].browse([res_id])
         else:
             records = self.env[model] if model else self.env['mail.thread']
@@ -1200,23 +1200,28 @@ class MailMessage(models.Model):
     def _get_message_id(self, values):
         if values.get('reply_to_force_new', False) is True:
             message_id = tools.mail.generate_tracking_message_id('reply_to')
-        elif self.is_thread_message(values):
+        elif self._is_thread_message(vals=values):
             message_id = tools.mail.generate_tracking_message_id('%(res_id)s-%(model)s' % values)
         else:
             message_id = tools.mail.generate_tracking_message_id('private')
         return message_id
 
-    def is_thread_message(self, vals=None):
-        if vals:
-            res_id = vals.get('res_id')
-            model = vals.get('model')
-            message_type = vals.get('message_type')
-        else:
-            self.ensure_one()
-            res_id = self.res_id
-            model = self.model
-            message_type = self.message_type
-        return res_id and model and message_type != 'user_notification'
+    def _is_thread_message(self, vals=None, thread=None):
+        """ Tool method to compute thread validity in notification methods. """
+        if vals is None:
+            vals = {}
+        res_model = vals['model'] if 'model' in vals else thread._name if thread else self.model
+        res_id = vals['res_id'] if 'res_id' in vals else thread.ids[0] if thread and thread.ids else self.res_id
+        return bool(res_id) if (res_model and res_model != 'mail.thread') else False
+
+    def _is_thread_message_visible(self, vals=None, thread=None):
+        """ In addition to being a thread message, it should not be a user specific
+        notification that is recipient-specific. Used mainly for ACL purpose. """
+        is_thread = self._is_thread_message(vals=vals, thread=thread)
+        if is_thread:
+            message_type = (vals or {}).get('message_type') or self.message_type
+            return is_thread and message_type != 'user_notification'
+        return is_thread
 
     def _invalidate_documents(self, model=None, res_id=None):
         """ Invalidate the cache of the documents followed by ``self``. """

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3796,7 +3796,8 @@ class MailThread(models.AbstractModel):
             'is_follower': follows the message related document;
             'lang': partner lang;
             'groups': res.group IDs if linked to a user;
-            'notif': 'inbox', 'email', 'sms' (SMS App);
+            'notif': notification type, one of 'inbox', 'email', 'sms' (SMS App),
+                'whatsapp (WhatsAapp);
             'share': is partner a customer (partner.partner_share);
             'type': partner usage ('customer', 'portal', 'user');
             'uid': user ID (in case of multiple users, internal then first found
@@ -3904,7 +3905,7 @@ class MailThread(models.AbstractModel):
                 lambda pdata: pdata['type'] == 'user',
                 {
                     'active': True,
-                    'has_button_access': self._is_thread_message(msg_vals=msg_vals),
+                    'has_button_access': self.env['mail.message']._is_thread_message(vals=msg_vals, thread=self),
                 }
             ], [
                 'portal',
@@ -3950,7 +3951,7 @@ class MailThread(models.AbstractModel):
         else:
             view_title = _('View')
 
-        is_thread_message = self._is_thread_message(msg_vals=msg_vals)
+        is_thread_message = self.env['mail.message']._is_thread_message(vals=msg_vals, thread=self)
 
         # fill group_data with default_values if they are not complete
         for group_name, _group_func, group_data in groups:
@@ -4143,17 +4144,6 @@ class MailThread(models.AbstractModel):
         if not 'lang' in self.env.context:
             raise ValueError(_('At this point lang should be correctly set'))
         return self.env['ir.model']._get(model_name).display_name  # one query for display name
-
-    def _is_thread_message(self, msg_vals=None):
-        """ Tool method to compute thread validity in notification methods.
-        msg_vals is used as a replacement for self, allowing to force model
-        and res_id independently of current recordset. Void values in dict
-        are kept e.g. model=False is valid. """
-        if msg_vals is None:
-            msg_vals = {}
-        res_model = msg_vals['model'] if 'model' in msg_vals else self._name
-        res_id = msg_vals['res_id'] if 'res_id' in msg_vals else (self.ids[0] if self.ids else False)
-        return bool(res_id) if (res_model and res_model != 'mail.thread') else False
 
     def _truncate_payload(self, payload):
         """

--- a/addons/mail/wizard/mail_resend_message.py
+++ b/addons/mail/wizard/mail_resend_message.py
@@ -125,7 +125,7 @@ class MailResendPartner(models.TransientModel):
             if pid and pdata.get('notif', 'email') == 'email'
         ]
 
-        record = self.env[message.model].browse(message.res_id) if message.is_thread_message() else self.env['mail.thread']
+        record = self.env[message.model].browse(message.res_id) if message._is_thread_message() else self.env['mail.thread']
         record._notify_thread_by_email(
             message, email_partners_data,
             resend_existing=True,


### PR DESCRIPTION
Reorganize some internal code in mail.message and mail.thread to have code split / main usage in big files. Notably tools used once to hide methods details should be defined below their owner, global tools at the end of file, and main API globally at the same place.
