### PR TITLE
[FIX] website_slides: preserve order of slides when duplicating

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -706,7 +706,8 @@ class Slide(models.Model):
         """Sets the sequence to zero so that it always lands at the beginning
         of the newly selected course as an uncategorized slide"""
         default = dict(default or {})
-        default['sequence'] = 0
+        if 'slide.channel' not in self._context.get('__copy_data_seen', {}) and 'sequence' not in default:
+            default['sequence'] = 0
         return super().copy_data(default=default)
 
     def unlink(self):

--- a/addons/website_slides/tests/test_slide_channel.py
+++ b/addons/website_slides/tests/test_slide_channel.py
@@ -416,3 +416,20 @@ class TestSequencing(slides_common.SlidesCase):
         copied_value = (channel1 + channel2).copy()
         self.assertEqual(copied_value[0].name, 'Test Course 1 (copy)')
         self.assertEqual(copied_value[1].name, 'Test Course 2 (copy)')
+
+    @users('user_officer')
+    def test_duplicate_course_preserves_slides_sequence(self):
+        self.slide_3.sequence = 0
+        self.slide.sequence = 5
+
+        self.assertEqual(
+            self.channel.copy().slide_ids.mapped('sequence'),
+            self.channel.slide_ids.mapped('sequence'),
+            "Sequence preserved when copying channel"
+        )
+
+    @users('user_officer')
+    def test_duplicate_slide_sets_sequence_to_zero(self):
+        self.assertEqual(self.slide.sequence, 1)
+        copied_slide = self.slide.copy()
+        self.assertEqual(copied_slide.sequence, 0, "When copying a single slide its sequence should be set to 0")


### PR DESCRIPTION
Steps to reproduce:

1. In elearning get a current course or create a new one.
2. Add or just reorder some of the slides/sections.
3. Duplicate the course.

After the changes applied to improve the batch call of copy in https://github.com/odoo/odoo/commit/4ac2702c31f0e95f33f9ad554e7350bef9dab8bd the values that we get after the copy are ordered by id instead of preserving the original order, so for this case we can make sure to reorder the values and mantain the proper sequence when duplicating inside copy_data().

opw-4240873