### PR TITLE
[IMP] purchase_*: remove locked status and simplify lock settings

### DIFF
--- a/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
+++ b/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
@@ -5,7 +5,7 @@
             <table>
                 <tr t-if="o.name">
                     <td t-if="o.state == 'draft'">Request for Quotation No.:</td>
-                    <td t-elif="o.state in {'sent', 'to approve', 'purchase', 'done'}">Purchase Order No.:</td>
+                    <td t-elif="o.state in {'sent', 'to approve', 'purchase'}">Purchase Order No.:</td>
                     <td t-elif="o.state == 'cancel'">Cancelled Purchase Order No.:</td>
                     <td><t t-out="o.name"/></td>
                 </tr>
@@ -47,7 +47,7 @@
     <template id="report_common_purchase_din5008_template_document_title">
         <span t-if="o and o._name == 'purchase.order'">
             <t t-if="o.state in {'draft', 'sent', 'to approve'}">Request for Quotation</t>
-            <t t-elif="o.state in {'purchase', 'done'}">Purchase Order</t>
+            <t t-elif="o.state == 'purchase'">Purchase Order</t>
             <t t-elif="o.state == 'cancel'">Cancelled Purchase Order</t>
         </span>
     </template>

--- a/addons/mrp/static/src/components/mo_overview_line/mo_overview_colors.js
+++ b/addons/mrp/static/src/components/mo_overview_line/mo_overview_colors.js
@@ -12,7 +12,6 @@ const PURCHASE_DECORATORS = {
     sent: "info",
     ['to approve']: "info",
     purchase: "info",
-    done: "info",
     cancel: "secondary",
 };
 

--- a/addons/purchase/controllers/portal.py
+++ b/addons/purchase/controllers/portal.py
@@ -25,7 +25,7 @@ class CustomerPortal(portal.CustomerPortal):
             ]) if PurchaseOrder.has_access('read') else 0
         if 'purchase_count' in counters:
             values['purchase_count'] = PurchaseOrder.search_count([
-                ('state', 'in', ['purchase', 'done', 'cancel'])
+                ('state', 'in', ['purchase', 'cancel'])
             ]) if PurchaseOrder.has_access('read') else 0
         return values
 
@@ -130,10 +130,9 @@ class CustomerPortal(portal.CustomerPortal):
             page, date_begin, date_end, sortby, filterby,
             [],
             {
-                'all': {'label': _('All'), 'domain': [('state', 'in', ['purchase', 'done', 'cancel'])]},
+                'all': {'label': _('All'), 'domain': [('state', 'in', ['purchase', 'cancel'])]},
                 'purchase': {'label': _('Purchase Order'), 'domain': [('state', '=', 'purchase')]},
                 'cancel': {'label': _('Cancelled'), 'domain': [('state', '=', 'cancel')]},
-                'done': {'label': _('Locked'), 'domain': [('state', '=', 'done')]},
             },
             'all',
             "/my/purchase",

--- a/addons/purchase/data/purchase_data.xml
+++ b/addons/purchase/data/purchase_data.xml
@@ -12,11 +12,6 @@
             <field name="default" eval="False"/>
             <field name="res_model">purchase.order</field>
         </record>
-        <record id="mt_rfq_done" model="mail.message.subtype">
-            <field name="name">RFQ Done</field>
-            <field name="default" eval="False"/>
-            <field name="res_model">purchase.order</field>
-        </record>
         <record id="mt_rfq_sent" model="mail.message.subtype">
             <field name="name">RFQ Sent</field>
             <field name="default" eval="False"/>

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -360,7 +360,7 @@ class AccountMove(models.Model):
 
         common_domain = [
             ('company_id', '=', self.company_id.id),
-            ('state', 'in', ('purchase', 'done')),
+            ('state', '=', 'purchase'),
             ('invoice_status', 'in', ('to invoice', 'no'))
         ]
 

--- a/addons/purchase/models/product.py
+++ b/addons/purchase/models/product.py
@@ -49,7 +49,7 @@ class ProductTemplate(models.Model):
 
     def action_view_po(self):
         action = self.env["ir.actions.actions"]._for_xml_id("purchase.action_purchase_history")
-        action['domain'] = ['&', ('state', 'in', ['purchase', 'done']), ('product_id', 'in', self.product_variant_ids.ids)]
+        action['domain'] = ['&', ('state', '=', 'purchase'), ('product_id', 'in', self.product_variant_ids.ids)]
         action['display_name'] = _("Purchase History for %s", self.display_name)
         return action
 
@@ -68,7 +68,7 @@ class ProductProduct(models.Model):
     def _compute_purchased_product_qty(self):
         date_from = fields.Datetime.to_string(fields.Date.context_today(self) - relativedelta(years=1))
         domain = [
-            ('order_id.state', 'in', ['purchase', 'done']),
+            ('order_id.state', '=', 'purchase'),
             ('product_id', 'in', self.ids),
             ('order_id.date_approve', '>=', date_from)
         ]
@@ -106,7 +106,7 @@ class ProductProduct(models.Model):
 
     def action_view_po(self):
         action = self.env["ir.actions.actions"]._for_xml_id("purchase.action_purchase_history")
-        action['domain'] = ['&', ('state', 'in', ['purchase', 'done']), ('product_id', 'in', self.ids)]
+        action['domain'] = ['&', ('state', '=', 'purchase'), ('product_id', 'in', self.ids)]
         action['display_name'] = _("Purchase History for %s", self.display_name)
         return action
 

--- a/addons/purchase/models/purchase_bill_line_match.py
+++ b/addons/purchase/models/purchase_bill_line_match.py
@@ -94,7 +94,7 @@ class PurchaseBillLineMatch(models.Model):
                    po.state as state
               FROM purchase_order_line pol
          LEFT JOIN purchase_order po ON pol.order_id = po.id
-             WHERE po.state in ('purchase', 'done')
+             WHERE po.state = 'purchase'
                AND pol.product_qty > pol.qty_invoiced
                 OR ((pol.display_type = '' OR pol.display_type IS NULL) AND pol.is_downpayment AND pol.qty_invoiced > 0)
         """)

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -137,7 +137,7 @@ class PurchaseOrderLine(models.Model):
             line.qty_invoiced = qty
 
             # compute qty_to_invoice
-            if line.order_id.state in ['purchase', 'done']:
+            if line.order_id.state == 'purchase':
                 if line.product_id.purchase_method == 'purchase':
                     line.qty_to_invoice = line.product_qty - line.qty_invoiced
                 else:
@@ -220,9 +220,9 @@ class PurchaseOrderLine(models.Model):
         return super(PurchaseOrderLine, self).write(values)
 
     @api.ondelete(at_uninstall=False)
-    def _unlink_except_purchase_or_done(self):
+    def _unlink_except_purchase(self):
         for line in self:
-            if line.order_id.state in ['purchase', 'done']:
+            if line.order_id.state == 'purchase':
                 state_description = {state_desc[0]: state_desc[1] for state_desc in self._fields['state']._description_selection(self.env)}
                 raise UserError(_('Cannot delete a purchase order line which is in state “%s”.', state_description.get(line.state)))
 

--- a/addons/purchase/report/purchase_bill.py
+++ b/addons/purchase/report/purchase_bill.py
@@ -38,7 +38,7 @@ class PurchaseBillUnion(models.Model):
                     NULL as vendor_bill_id, id as purchase_order_id
                 FROM purchase_order
                 WHERE
-                    state in ('purchase', 'done') AND
+                    state = 'purchase' AND
                     invoice_status in ('to invoice', 'no')
             )""")
 

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -23,7 +23,7 @@
             <div class="mt-4">
                 <t t-set="layout_document_title">
                     <t t-if="o.state in ['draft', 'sent', 'to approve']">Request for Quotation #<span t-field="o.name"/></t>
-                    <t t-if="o.state in ['purchase', 'done']">Purchase Order #<span t-field="o.name"/></t>
+                    <t t-if="o.state == 'purchase'">Purchase Order #<span t-field="o.name"/></t>
                     <t t-if="o.state == 'cancel'">Cancelled Purchase Order #<span t-field="o.name"/></t>
                 </t>
             </div>
@@ -37,7 +37,7 @@
                     <strong>Your Order Reference</strong>
                     <div t-field="o.partner_ref"/>
                 </div>
-                <div t-if="o.state in ['purchase','done'] and o.date_approve" class="col-3 bm-2">
+                <div t-if="o.state == 'purchase' and o.date_approve" class="col-3 bm-2">
                     <strong>Order Date:</strong>
                     <p t-field="o.date_approve" t-options="{'date_only': 'true'}" class="m-0"/>
                 </div>

--- a/addons/purchase/report/purchase_report.py
+++ b/addons/purchase/report/purchase_report.py
@@ -22,7 +22,6 @@ class PurchaseReport(models.Model):
         ('sent', 'RFQ Sent'),
         ('to approve', 'To Approve'),
         ('purchase', 'Purchase Order'),
-        ('done', 'Done'),
         ('cancel', 'Cancelled')
     ], 'Status', readonly=True)
     product_id = fields.Many2one('product.product', 'Product', readonly=True)

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -111,9 +111,6 @@
                           <span t-if="order.state == 'cancel'" class="badge rounded-pill text-bg-secondary">
                               <i class="fa fa-fw fa-remove" role="img" aria-label="Cancelled" title="Cancelled"></i><span class="d-none d-md-inline"> Cancelled</span>
                           </span>
-                          <span t-if="order.state == 'done'" class="badge rounded-pill text-bg-success">
-                              <i class="fa fa-fw fa-check" role="img" aria-label="Done" title="Done"></i><span class="d-none d-md-inline"> Done</span>
-                          </span>
                       </td>
                       <td id="order_total" class="text-end"><span t-field="order.amount_total"/></td>
                   </tr>
@@ -235,7 +232,7 @@
                     <t t-if="order.state in ['draft', 'sent']">
                       <strong>Request For Quotation Date:</strong>
                     </t>
-                    <t t-if="order.state in ['purchase', 'done', 'cancel']">
+                    <t t-if="order.state in ['purchase', 'cancel']">
                       <strong>Order Date:</strong>
                     </t>
                     <span t-field="order.date_order" t-options='{"widget": "date"}'/>
@@ -283,7 +280,7 @@
 
               <div class="table-responsive">
                 <table t-att-data-order-id="order.id" t-att-data-token="order.access_token" class="table table-sm" id="purchase_order_table">
-                    <t t-set="display_price_and_taxes" t-value="not update_dates and order.state in ['purchase', 'done']"/>
+                    <t t-set="display_price_and_taxes" t-value="not update_dates and order.state == 'purchase'"/>
                     <thead class="bg-100">
                         <tr>
                             <th class="text-start">Products</th>
@@ -346,7 +343,7 @@
                                     <td t-if="display_price_and_taxes" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
                                         <div t-field="line.discount" class="text-end"/>
                                     </td>
-                                    <td class="text-end" t-if="not update_dates and order.state in ['purchase', 'done']">
+                                    <td class="text-end" t-if="not update_dates and order.state == 'purchase'">
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>
                                     </td>
                                 </t>
@@ -364,7 +361,7 @@
                                 </t>
                             </tr>
 
-                            <t t-if="current_section and (line_last or order.order_line[line_index+1].display_type == 'line_section') and order.state in ['purchase', 'done']">
+                            <t t-if="current_section and (line_last or order.order_line[line_index+1].display_type == 'line_section') and order.state == 'purchase'">
                                 <tr class="is-subtotal text-end">
                                     <td colspan="99">
                                         <strong class="mr16">Subtotal</strong>
@@ -380,7 +377,7 @@
                 </table>
               </div>
 
-              <div id="total" t-if="order.state in ['purchase', 'done']" class="row" name="total" style="page-break-inside: avoid;">
+              <div id="total" t-if="order.state == 'purchase'" class="row" name="total" style="page-break-inside: avoid;">
                   <div t-attf-class="#{'col-4' if report_type != 'html' else 'col-sm-7 col-md-5'} ms-auto">
                       <t t-call="purchase.purchase_order_portal_content_totals_table"/>
                   </div>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -129,20 +129,22 @@
             <field name="arch" type="xml">
                 <form string="Purchase Order" class="o_purchase_order">
                 <header>
+                    <field name="locked" invisible="1"/>
+                    <field name="lock_confirmed_po" invisible="1"/>
                     <button name="action_rfq_send" invisible="state != 'draft'" string="Send RFQ" type="object" context="{'send_rfq':True}" class="oe_highlight" data-hotkey="g"/>
                     <button name="button_confirm" type="object" invisible="state != 'sent'" string="Confirm Order" context="{'validate_analytic': True}" class="oe_highlight" id="bid_confirm" data-hotkey="q"/>
                     <button name="button_approve" type="object" invisible="state != 'to approve'" string="Approve Order" class="oe_highlight" groups="purchase.group_purchase_manager" data-hotkey="z"/>
-                    <button name="action_create_invoice" string="Create Bill" type="object" class="oe_highlight" context="{'create_bill':True}" invisible="state not in ('purchase', 'done') or invoice_status in ('no', 'invoiced')" data-hotkey="w"/>
+                    <button name="action_create_invoice" string="Create Bill" type="object" class="oe_highlight" context="{'create_bill':True}" invisible="state != 'purchase' or invoice_status in ('no', 'invoiced')" data-hotkey="w"/>
                     <button name="action_rfq_send" invisible="state != 'sent'" string="Send RFQ" type="object" context="{'send_rfq':True}" data-hotkey="g"/>
                     <button name="button_confirm" type="object" invisible="state != 'draft'" context="{'validate_analytic': True}" string="Confirm Order" id="draft_confirm" data-hotkey="q"/>
                     <button name="action_rfq_send" invisible="state != 'purchase'" string="Send PO" type="object" context="{'send_rfq':False}" data-hotkey="g"/>
-                    <button name="action_create_invoice" string="Create Bill" type="object" context="{'create_bill':True}" invisible="state not in ('purchase', 'done') or invoice_status not in ('no', 'invoiced') or not order_line" data-hotkey="w"/>
+                    <button name="action_create_invoice" string="Create Bill" type="object" context="{'create_bill':True}" invisible="state != 'purchase' or invoice_status not in ('no', 'invoiced') or not order_line" data-hotkey="w"/>
                     <button name="action_acknowledge" string="Acknowledge" type="object" invisible="acknowledged or state != 'purchase'"/>
                     <button name="button_draft" invisible="state != 'cancel'" string="Set to Draft" type="object" data-hotkey="o"/>
                     <button name="print_quotation" string="Print" type="object" groups="base.group_user" data-hotkey="k"/>
                     <button name="button_cancel" invisible="state not in ('draft', 'to approve', 'sent', 'purchase')" string="Cancel" type="object" data-hotkey="x" />
-                    <button name="button_done" type="object" string="Lock" invisible="state != 'purchase'" data-hotkey="l"/>
-                    <button name="button_unlock" type="object" string="Unlock" invisible="state != 'done'" groups="purchase.group_purchase_manager" data-hotkey="l"/>
+                    <button name="button_lock" type="object" string="Lock" invisible="locked or state != 'purchase' or not lock_confirmed_po == 'lock'" data-hotkey="l"/>
+                    <button name="button_unlock" type="object" string="Unlock" invisible="not locked" groups="purchase.group_purchase_manager" data-hotkey="l"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,sent,purchase" readonly="1"/>
                 </header>
                 <sheet>
@@ -152,7 +154,7 @@
                                 type="object"
                                 groups="account.group_account_invoice"
                                 icon="fa-bullseye"
-                                invisible="not partner_id or state not in ('purchase', 'done') or not partner_bill_count or invoice_status == 'invoiced'">
+                                invisible="not partner_id or state != 'purchase' or not partner_bill_count or invoice_status == 'invoiced'">
                             <div class="o_field_statinfo">
                                 <span class="o_stat_text">Bill Matching</span>
                             </div>
@@ -172,6 +174,11 @@
                             <field name="show_comparison" invisible="1"/>
                         </button>
                     </div>
+                    <div class="badge rounded-pill text-bg-secondary float-end fs-6 border-0"
+                        invisible="not locked">
+                        <i class="fa fa-lock"/>
+                        Locked
+                    </div>
                     <div class="oe_title">
                         <span class="o_form_label" invisible="state not in ('draft', 'sent')">Request for Quotation </span>
                         <span class="o_form_label" invisible="state in ('draft', 'sent')">Purchase Order </span>
@@ -184,18 +191,18 @@
                         <group>
                             <field name="partner_id" widget="res_partner_many2one" context="{'res_partner_search_mode': 'supplier', 'show_vat': True}"
                                 placeholder="Name, TIN, Email, or Reference"
-                             readonly="state in ['cancel', 'done', 'purchase']"/>
+                             readonly="state in ['cancel', 'purchase']"/>
                             <field name="partner_ref"/>
-                            <field name="currency_id" groups="base.group_multi_currency" force_save="1" readonly="state in ['cancel', 'done', 'purchase']"/>
+                            <field name="currency_id" groups="base.group_multi_currency" force_save="1" readonly="state in ['cancel', 'purchase']"/>
                             <field name="id" invisible="1"/>
-                            <field name="company_id" invisible="1" readonly="state in ['cancel', 'done', 'purchase']"/>
-                            <field name="currency_id" invisible="1" readonly="state in ['cancel', 'done', 'purchase']" groups="!base.group_multi_currency"/>
+                            <field name="company_id" invisible="1" readonly="state in ['cancel', 'purchase']"/>
+                            <field name="currency_id" invisible="1" readonly="state in ['cancel', 'purchase']" groups="!base.group_multi_currency"/>
                             <field name="tax_calculation_rounding_method" invisible="1"/>
                         </group>
                         <group>
-                            <field name="date_order" invisible="state in ('purchase', 'done')" readonly="state in ['cancel', 'done', 'purchase']"/>
-                            <label for="date_approve" invisible="state not in ('purchase', 'done')"/>
-                            <div name="date_approve" invisible="state not in ('purchase', 'done')" class="o_row">
+                            <field name="date_order" invisible="state  == 'purchase'" readonly="state in ['cancel', 'purchase']"/>
+                            <label for="date_approve" invisible="state != 'purchase'"/>
+                            <div name="date_approve" invisible="state != 'purchase'" class="o_row">
                                 <field name="date_approve"/>
                             </div>
                             <label for="date_planned"/>
@@ -221,7 +228,7 @@
                                 widget="product_label_section_and_note_field_o2m"
                                 mode="list,kanban"
                                 context="{'default_state': 'draft'}"
-                                readonly="state in ('done', 'cancel')">
+                                readonly="state == 'cancel' or locked">
                                 <list string="Purchase Order Lines" editable="bottom" limit="200">
                                     <control>
                                         <create name="add_product_control" string="Add a product"/>
@@ -241,7 +248,7 @@
                                     <field
                                         name="product_id"
                                         widget="product_label_section_and_note_field"
-                                        readonly="state in ('purchase', 'to approve', 'done', 'cancel') or is_downpayment"
+                                        readonly="state in ('purchase', 'to approve', 'cancel') or is_downpayment"
                                         required="not display_type and not is_downpayment"
                                         context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id}"
                                         force_save="1" domain="[('purchase_ok', '=', True), '|', ('company_id', '=', False), ('company_id', 'parent_of', parent.company_id)]"/>
@@ -254,10 +261,10 @@
                                     <field name="product_qty" readonly="is_downpayment"/>
                                     <field name="qty_received_manual" column_invisible="True"/>
                                     <field name="qty_received_method" column_invisible="True"/>
-                                    <field name="qty_received" string="Received" column_invisible="parent.state not in ('purchase', 'done')" readonly="qty_received_method != 'manual' or is_downpayment" optional="show"/>
-                                    <field name="qty_invoiced" string="Billed" column_invisible="parent.state not in ('purchase', 'done')" optional="show"/>
+                                    <field name="qty_received" string="Received" column_invisible="parent.state != 'purchase'" readonly="qty_received_method != 'manual' or is_downpayment" optional="show"/>
+                                    <field name="qty_invoiced" string="Billed" column_invisible="parent.state != 'purchase'" optional="show"/>
                                     <field name="product_uom_id" groups="uom.group_uom"
-                                        readonly="state in ('purchase', 'done', 'cancel') or is_downpayment"
+                                        readonly="state in ('purchase', 'cancel') or is_downpayment"
                                         required="not display_type and not is_downpayment"
                                         options="{'no_open': True, 'quantity_field': 'product_qty'}"
                                         widget="many2one_uom"
@@ -278,7 +285,7 @@
                                                        context="{'partner_id': parent.partner_id}"
                                                        widget="many2one_barcode"
                                                        domain="[('purchase_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"
-                                                       readonly="state in ('purchase', 'to approve', 'done', 'cancel')"
+                                                       readonly="state in ('purchase', 'to approve', 'cancel')"
                                                 />
                                                 <label for="product_qty"/>
                                                 <div class="o_row">
@@ -286,8 +293,8 @@
                                                     <field name="product_uom_id" groups="uom.group_uom" required="not display_type and not is_downpayment" widget="many2one_uom"/>
                                                 </div>
                                                 <field name="qty_received_method" invisible="1"/>
-                                                <field name="qty_received" string="Received Quantity" invisible="parent.state not in ('purchase', 'done')" readonly="qty_received_method != 'manual'"/>
-                                                <field name="qty_invoiced" string="Billed Quantity" invisible="parent.state not in ('purchase', 'done')"/>
+                                                <field name="qty_received" string="Received Quantity" invisible="parent.state != 'purchase'" readonly="qty_received_method != 'manual'"/>
+                                                <field name="qty_invoiced" string="Billed Quantity" invisible="parent.state != 'purchase'"/>
                                                 <field name="price_unit"/>
                                                 <field name="discount"/>
                                                 <field name="tax_ids" widget="many2many_tax_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]" options="{'no_create': True}"/>
@@ -366,13 +373,13 @@
                             <group>
                                 <group name="other_info">
                                     <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
-                                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" readonly="state in ['cancel', 'done', 'purchase']"/>
+                                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" readonly="state in ['cancel', 'purchase']"/>
                                     <field name="origin"/>
                                 </group>
                                 <group name="invoice_info">
                                     <field name="invoice_status" invisible="state in ('draft', 'sent', 'to approve', 'cancel')"/>
-                                    <field name="payment_term_id" readonly="invoice_status == 'invoiced' or state == 'done'" options="{'no_create': True}"/>
-                                    <field name="fiscal_position_id" options="{'no_create': True}" readonly="invoice_status == 'invoiced' or state == 'done'"/>
+                                    <field name="payment_term_id" readonly="invoice_status == 'invoiced' or locked" options="{'no_create': True}"/>
+                                    <field name="fiscal_position_id" options="{'no_create': True}" readonly="invoice_status == 'invoiced' or locked"/>
                                 </group>
                             </group>
                         </page>
@@ -399,7 +406,7 @@
                     <separator/>
                     <filter name="draft" string="RFQs" domain="[('state', 'in', ('draft', 'sent', 'to approve'))]"/>
                     <separator/>
-                    <filter name="approved" string="Purchase Orders" domain="[('state', 'in', ('purchase', 'done'))]"/>
+                    <filter name="approved" string="Purchase Orders" domain="[('state', '=', 'purchase')]"/>
                     <filter name="to_approve" string="To Approve" domain="[('state', '=', 'to approve')]" invisible="1"/>
                     <separator/>
                     <filter name="order_date" string="Order Date" date="date_order"/>
@@ -488,7 +495,7 @@
                                     <field name="date_order" options="{'show_time': false}"/>
                                     <field name="activity_ids" widget="kanban_activity"/>
                                 </div>
-                                <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'cancel': 'default', 'done': 'success', 'approved': 'warning'}}" class="ms-auto"/>
+                                <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'cancel': 'default', 'approved': 'warning'}}" class="ms-auto"/>
                             </footer>
                         </t>
                     </templates>
@@ -519,7 +526,7 @@
                     <field name="priority" optional="show" widget="priority" nolabel="1"/>
                     <field name="partner_ref" optional="hide"/>
                     <field name="name" string="Reference" readonly="1" decoration-info="state in ('draft','sent')"/>
-                    <field name="date_order" column_invisible="not context.get('quotation_only', False)" readonly="state in ['cancel', 'done', 'purchase']" optional="show"/>
+                    <field name="date_order" column_invisible="not context.get('quotation_only', False)" readonly="state in ['cancel', 'purchase']" optional="show"/>
                     <field name="date_approve" column_invisible="context.get('quotation_only', False)" optional="show"/>
                     <field name="partner_id" readonly="1"/>
                     <field name="company_id" readonly="1" options="{'no_create': True}"
@@ -528,7 +535,7 @@
                     <field name="origin" optional="hide"/>
                     <field name="amount_untaxed" sum="Total Untaxed amount" string="Untaxed" widget="monetary" optional="hide"/>
                     <field name="amount_total" sum="Total amount" widget="monetary" optional="show"/>
-                    <field name="currency_id" column_invisible="True" readonly="state in ['cancel', 'done', 'purchase']"/>
+                    <field name="currency_id" column_invisible="True" readonly="state in ['cancel', 'purchase']"/>
                     <field name="state" optional="show"/>
                     <field name="date_planned" column_invisible="context.get('quotation_only', False)" optional="show"/>
                     <field name="invoice_status" column_invisible="context.get('quotation_only', False)" optional="hide"/>
@@ -560,21 +567,21 @@
                     <field name="partner_id" readonly="1"/>
                     <field name="company_id" readonly="1" options="{'no_create': True}"
                         groups="base.group_multi_company" optional="show"/>
-                    <field name="company_id" groups="!base.group_multi_company" column_invisible="True" readonly="state in ['cancel', 'done', 'purchase']"/>
+                    <field name="company_id" groups="!base.group_multi_company" column_invisible="True" readonly="state in ['cancel', 'purchase']"/>
                     <field name="date_planned" column_invisible="context.get('quotation_only', False)" optional="show"/>
                     <field name="user_id" optional="show" widget="many2one_avatar_user"/>
                     <field name="date_order"
-                        invisible="state == 'purchase' or state == 'done' or state == 'cancel'"
+                        invisible="state == 'purchase' or state == 'cancel'"
                         column_invisible="not context.get('quotation_only', False)"
-                        readonly="state in ['cancel', 'done', 'purchase']" widget="remaining_days" optional="show"/>
+                        readonly="state in ['cancel', 'purchase']" widget="remaining_days" optional="show"/>
                     <field name="activity_ids" widget="list_activity" optional="show"/>
                     <field name="origin" optional="hide"/>
                     <field name="amount_untaxed" sum="Total Untaxed amount" string="Untaxed" widget="monetary" optional="hide"/>
-                    <field name="amount_total" sum="Total amount" widget="monetary" optional="show" decoration-bf="state in ['purchase', 'done']"/>
-                    <field name="currency_id" column_invisible="True" readonly="state in ['cancel', 'done', 'purchase']"/>
+                    <field name="amount_total" sum="Total amount" widget="monetary" optional="show" decoration-bf="state == 'purchase'"/>
+                    <field name="currency_id" column_invisible="True" readonly="state in ['cancel', 'purchase']"/>
                     <field name="amount_total_cc" sum="Total amount" widget="monetary" optional="hide"/>
                     <field name="company_currency_id" column_invisible="True"/>
-                    <field name="state" optional="show" widget="badge" decoration-success="state == 'purchase' or state == 'done'"
+                    <field name="state" optional="show" widget="badge" decoration-success="state == 'purchase'"
                         decoration-warning="state == 'to approve'" decoration-info="state == 'draft' or state == 'sent'"/>
                     <field name="invoice_status" optional="hide"/>
                 </list>
@@ -600,16 +607,16 @@
                     <field name="partner_ref" optional="hide"/>
                     <field name="name" string="Reference" readonly="1" decoration-bf="1" decoration-info="state in ('draft','sent')"/>
                     <field name="date_approve" column_invisible="context.get('quotation_only', False)" optional="show"/>
-                    <field name="partner_id" readonly="state in ['cancel', 'done', 'purchase']"/>
-                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="show" readonly="state in ['cancel', 'done', 'purchase']"/>
-                    <field name="company_id" groups="!base.group_multi_company" column_invisible="True" readonly="state in ['cancel', 'done', 'purchase']"/>
+                    <field name="partner_id" readonly="state in ['cancel', 'purchase']"/>
+                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="show" readonly="state in ['cancel', 'purchase']"/>
+                    <field name="company_id" groups="!base.group_multi_company" column_invisible="True" readonly="state in ['cancel', 'purchase']"/>
                     <field name="user_id" widget="many2one_avatar_user" optional="show"/>
-                    <field name="date_order" column_invisible="not context.get('quotation_only', False)" readonly="state in ['cancel', 'done', 'purchase']" optional="show"/>
+                    <field name="date_order" column_invisible="not context.get('quotation_only', False)" readonly="state in ['cancel', 'purchase']" optional="show"/>
                     <field name="activity_ids" widget="list_activity" optional="show"/>
                     <field name="origin" optional="show"/>
                     <field name="amount_untaxed" sum="Total Untaxed amount" string="Untaxed" widget="monetary" optional="hide"/>
                     <field name="amount_total" sum="Total amount" widget="monetary" optional="show" decoration-bf="1"/>
-                    <field name="currency_id" column_invisible="True" readonly="state in ['cancel', 'done', 'purchase']"/>
+                    <field name="currency_id" column_invisible="True" readonly="state in ['cancel', 'purchase']"/>
                     <field name="state" column_invisible="True"/>
                     <field name="amount_total_cc" sum="Total amount" widget="monetary" optional="hide"/>
                     <field name="company_currency_id" column_invisible="True"/>
@@ -636,7 +643,7 @@
                                 <field name="partner_id" muted="1" display="full" class="o_text_block"/>
                                 <div class="m-1"/>
                                 <field name="state" widget="badge"
-                                   decoration-success="state == 'purchase' or state == 'done'"
+                                   decoration-success="state == 'purchase'"
                                    decoration-warning="state == 'to approve'"
                                    decoration-info="state == 'draft' or state == 'sent'"/>
                             </div>
@@ -677,7 +684,7 @@
                 (0, 0, {'view_mode': 'list', 'view_id': ref('purchase.purchase_order_view_tree')}),
                 (0, 0, {'view_mode': 'kanban', 'view_id': ref('purchase.purchase_order_view_kanban_without_dashboard')}),
             ]"/>
-            <field name="domain">[('state','in',('purchase', 'done'))]</field>
+            <field name="domain">[('state','=', 'purchase')]</field>
             <field name="search_view_id" ref="purchase_order_view_search"/>
             <field name="context">{}</field>
             <field name="help" type="html">

--- a/addons/purchase_product_matrix/views/purchase_views.xml
+++ b/addons/purchase_product_matrix/views/purchase_views.xml
@@ -12,7 +12,7 @@
             <xpath expr="//list/field[@name='product_id']" position="after">
                 <field name="product_template_id"
                     string="Product"
-                    readonly="state in ('purchase', 'to approve', 'done', 'cancel')"
+                    readonly="state in ('purchase', 'to approve', 'cancel')"
                     required="not display_type"
                     context="{'partner_id': parent.partner_id}"
                     widget="pol_product_many2one"/>

--- a/addons/purchase_requisition/models/purchase.py
+++ b/addons/purchase_requisition/models/purchase.py
@@ -214,7 +214,7 @@ class PurchaseOrder(models.Model):
         po_alternatives = self | self.alternative_po_ids
 
         for line in po_alternatives.order_line:
-            if not line.product_qty or not line.price_total_cc or line.state in ['cancel', 'purchase', 'done']:
+            if not line.product_qty or not line.price_total_cc or line.state in ['cancel', 'purchase']:
                 continue
 
             # if no best price line => no best price unit line either
@@ -303,7 +303,7 @@ class PurchaseOrderLine(models.Model):
         super(PurchaseOrderLine, po_lines_without_requisition)._compute_price_unit_and_date_planned_and_name()
 
     def action_clear_quantities(self):
-        zeroed_lines = self.filtered(lambda l: l.state not in ['cancel', 'purchase', 'done'])
+        zeroed_lines = self.filtered(lambda l: l.state not in ['cancel', 'purchase'])
         zeroed_lines.write({'product_qty': 0})
         if len(self) > len(zeroed_lines):
             return {

--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -185,7 +185,7 @@ class PurchaseRequisitionLine(models.Model):
         line_found = defaultdict(set)
         for line in self:
             total = 0.0
-            for po in line.requisition_id.purchase_ids.filtered(lambda purchase_order: purchase_order.state in ['purchase', 'done']):
+            for po in line.requisition_id.purchase_ids.filtered(lambda purchase_order: purchase_order.state == 'purchase'):
                 for po_line in po.order_line.filtered(lambda order_line: order_line.product_id == line.product_id):
                     if po_line.product_uom_id != line.product_uom_id:
                         total += po_line.product_uom_id._compute_quantity(po_line.product_qty, line.product_uom_id)

--- a/addons/purchase_requisition/views/purchase_views.xml
+++ b/addons/purchase_requisition/views/purchase_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <field name="partner_id" position="replace">
                 <field name="requisition_type" invisible="1"/>
-                <field name="partner_id" widget="res_partner_many2one" context="{'res_partner_search_mode': 'supplier', 'show_vat': True}" readonly="requisition_type == 'blanket_order' or state in ['purchase', 'done', 'cancel']" placeholder="Name, TIN, Email, or Reference" force_save="1"/>
+                <field name="partner_id" widget="res_partner_many2one" context="{'res_partner_search_mode': 'supplier', 'show_vat': True}" readonly="requisition_type == 'blanket_order' or state in ['purchase', 'cancel']" placeholder="Name, TIN, Email, or Reference" force_save="1"/>
             </field>
             <field name="partner_ref" position="after">
                 <field name="requisition_id" domain="[('state', '=', 'confirmed'), ('vendor_id', 'in', (partner_id, False)), ('company_id', '=', company_id)]"
@@ -30,12 +30,12 @@
                         </group>
                     </group>
                     <field name="alternative_po_ids" readonly="not id" widget="many2many_alt_pos" context="{'quotation_only': True}">
-                        <list string="Alternative Purchase Order" decoration-muted="state in ['cancel', 'purchase', 'done']" decoration-bf="id == parent.id">
+                        <list string="Alternative Purchase Order" decoration-muted="state in ['cancel', 'purchase']" decoration-bf="id == parent.id">
                             <control>
                                 <create string="Link to Existing RfQ"/>
                             </control>
                             <field name="currency_id" column_invisible="1"/>
-                            <field name="partner_id" readonly="state in ['cancel', 'done', 'purchase']"/>
+                            <field name="partner_id" readonly="state in ['cancel', 'purchase']"/>
                             <field name="name" string="Reference"/>
                             <field name="date_planned"/>
                             <field name="amount_total" widget="monetary"/>
@@ -81,7 +81,7 @@
         <field name="priority">1000</field>
         <field name="arch" type="xml">
             <list string="Purchase Order Lines"
-            decoration-muted="state in ['cancel', 'purchase', 'done']"
+            decoration-muted="state in ['cancel', 'purchase']"
                 create="0" delete="0" edit="0" expand="1"
                 js_class="purchase_order_line_compare">
                 <header>
@@ -103,7 +103,7 @@
                 <button name="action_choose" string="Choose" type="object" class="o_clear_qty_buttons" icon="fa-bullseye"
                     invisible="product_qty &lt;= 0.0"/>
                 <button name="action_clear_quantities" string="Clear" type="object" class="o_clear_qty_buttons" icon="fa-times"
-                    invisible="product_qty &lt;= 0.0 or state in ['cancel', 'purchase', 'done']"/>
+                    invisible="product_qty &lt;= 0.0 or state in ['cancel', 'purchase']"/>
             </list>
         </field>
     </record>

--- a/addons/purchase_requisition/wizard/purchase_requisition_alternative_warning.xml
+++ b/addons/purchase_requisition/wizard/purchase_requisition_alternative_warning.xml
@@ -9,7 +9,7 @@
                     <field name="alternative_po_ids" nolabel="1" readonly="1">
                         <list create="0" delete="0" edit="0">
                             <field name="currency_id" column_invisible="1"/>
-                            <field name="partner_id" readonly="state in ['cancel', 'done', 'purchase']"/>
+                            <field name="partner_id" readonly="state in ['cancel', 'purchase']"/>
                             <field name="name" string="Reference"/>
                             <field name="date_planned"/>
                             <field name="amount_total"/>

--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -99,7 +99,7 @@ class ProductSupplierinfo(models.Model):
     def _compute_last_purchase_date(self):
         self.last_purchase_date = False
         purchases = self.env['purchase.order'].search([
-            ('state', 'in', ('purchase', 'done')),
+            ('state', '=', 'purchase'),
             ('order_line.product_id', 'in',
              self.product_tmpl_id.product_variant_ids.ids),
             ('partner_id', 'in', self.partner_id.ids),

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -186,7 +186,7 @@ class PurchaseOrder(models.Model):
         three_months_ago = fields.Datetime.to_string(fields.Datetime.now() - relativedelta(months=3))
 
         purchases = self.env['purchase.order'].search_fetch(
-            [('state', 'in', ['purchase', 'done']), ('date_planned', '>=', three_months_ago)],
+            [('state', '=', 'purchase'), ('date_planned', '>=', three_months_ago)],
             ['date_planned', 'effective_date', 'user_id'])
 
         otd_purchase_count = 0
@@ -309,7 +309,7 @@ class PurchaseOrder(models.Model):
 
     def _create_picking(self):
         StockPicking = self.env['stock.picking']
-        for order in self.filtered(lambda po: po.state in ('purchase', 'done')):
+        for order in self.filtered(lambda po: po.state == 'purchase'):
             if any(product.type == 'consu' for product in order.order_line.product_id):
                 order = order.with_company(order.company_id)
                 pickings = order.picking_ids.filtered(lambda x: x.state not in ('done', 'cancel'))

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -394,7 +394,7 @@ class PurchaseOrderLine(models.Model):
     @api.model
     def _update_qty_received_method(self):
         """Update qty_received_method for old PO before install this module."""
-        self.search(['!', ('state', 'in', ['purchase', 'done'])])._compute_qty_received_method()
+        self.search(['!', ('state', '=', 'purchase')])._compute_qty_received_method()
 
     def _merge_po_line(self, rfq_line):
         super()._merge_po_line(rfq_line)

--- a/addons/purchase_stock/models/res_partner.py
+++ b/addons/purchase_stock/models/res_partner.py
@@ -23,7 +23,7 @@ class ResPartner(models.Model):
             ('partner_id', 'in', self.ids),
             ('date_order', '>', fields.Date.today() - timedelta(date_order_days_delta)),
             ('qty_received', '!=', 0),
-            ('order_id.state', 'in', ['done', 'purchase']),
+            ('order_id.state', '=', 'purchase'),
             ('product_id', 'in', self.env['product.product'].sudo()._search([('type', '!=', 'service')]))
         ])
         lines_quantity = defaultdict(lambda: 0)

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -225,10 +225,10 @@ class StockMove(models.Model):
         self.write({'created_purchase_line_ids': [Command.clear()]})
 
     def _get_upstream_documents_and_responsibles(self, visited):
-        created_pl = self.created_purchase_line_ids.filtered(lambda cpl: cpl.state not in ('done', 'cancel') and (cpl.state != 'draft' or self._context.get('include_draft_documents')))
+        created_pl = self.created_purchase_line_ids.filtered(lambda cpl: cpl.state != 'cancel' and (cpl.state != 'draft' or self._context.get('include_draft_documents')))
         if created_pl:
             return [(pl.order_id, pl.order_id.user_id, visited) for pl in created_pl]
-        elif self.purchase_line_id and self.purchase_line_id.state not in ('done', 'cancel'):
+        elif self.purchase_line_id and self.purchase_line_id.state != 'cancel':
             return[(self.purchase_line_id.order_id, self.purchase_line_id.order_id.user_id, visited)]
         else:
             return super(StockMove, self)._get_upstream_documents_and_responsibles(visited)

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -9,7 +9,7 @@
             <xpath expr="//header/button[@name='action_rfq_send']" position="after">
                 <button name="action_view_picking"
                     string="Receive" class="oe_highlight" type="object"
-                    invisible="is_shipped or state not in ('purchase', 'done') or incoming_picking_count == 0"
+                    invisible="is_shipped or state != 'purchase' or incoming_picking_count == 0"
                     data-hotkey="y" groups="stock.group_stock_user"/>
             </xpath>
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
@@ -33,7 +33,7 @@
             </xpath>
             <xpath expr="//div[@name='date_planned_div']" position="inside">
                 <div>
-                    <button name="%(action_purchase_vendor_delay_report)d" class="oe_link" type="action" context="{'search_default_partner_id': partner_id}" invisible="state in ['purchase', 'done'] or not partner_id">
+                    <button name="%(action_purchase_vendor_delay_report)d" class="oe_link" type="action" context="{'search_default_partner_id': partner_id}" invisible="state == 'purchase' or not partner_id">
                         <span invisible="on_time_rate &lt; 0"><field name="on_time_rate" digits="[42, 0]" class="oe_inline"/>% On-Time Delivery</span>
                         <span invisible="on_time_rate &gt;= 0">No data yet</span>
                     </button>
@@ -52,7 +52,7 @@
                 <field name="move_ids"/>
             </xpath>
             <field name="invoice_status" position="before">
-                <field name="receipt_status" invisible="state not in ('purchase', 'done')"/>
+                <field name="receipt_status" invisible="state != 'purchase'"/>
             </field>
             <xpath expr="//field[@name='order_line']/form//field[@name='analytic_distribution']" position="before">
                 <field name="propagate_cancel" groups="base.group_no_one"/>
@@ -61,17 +61,17 @@
                 <field name="propagate_cancel" groups="base.group_no_one" optional="hide"/>
             </xpath>
             <xpath expr="//field[@name='order_line']/list//field[@name='qty_received']" position="attributes">
-                <attribute name="column_invisible">parent.state not in ('purchase', 'done')</attribute>
+                <attribute name="column_invisible">parent.state != 'purchase'</attribute>
                 <attribute name="readonly">product_type == 'consu'</attribute>
             </xpath>
             <xpath expr="//page[@name='purchase_delivery_invoice']/group/group" position="inside">
                 <field name="default_location_dest_id_usage" invisible="1"/>
-                <field name="incoterm_id" readonly="state == 'done'"/>
-                <field name="incoterm_location"  readonly="state == 'done'"/>
+                <field name="incoterm_id" readonly="locked"/>
+                <field name="incoterm_location"  readonly="locked"/>
             </xpath>
             <xpath expr="//div[@name='reminder']" position="after">
-                <field name="picking_type_id" domain="[('code','=','incoming'), '|', ('warehouse_id', '=', False), ('warehouse_id.company_id', '=', company_id)]" options="{'no_create': True}" readonly="state in ['cancel', 'done', 'purchase']"/>
-                <field name="dest_address_id" invisible="default_location_dest_id_usage != 'customer'" readonly="state == 'done'" required="default_location_dest_id_usage == 'customer'"/>
+                <field name="picking_type_id" domain="[('code','=','incoming'), '|', ('warehouse_id', '=', False), ('warehouse_id.company_id', '=', company_id)]" options="{'no_create': True}" readonly="state in ['cancel', 'purchase']"/>
+                <field name="dest_address_id" invisible="default_location_dest_id_usage != 'customer'" readonly="locked" required="default_location_dest_id_usage == 'customer'"/>
             </xpath>
         </field>
     </record>

--- a/addons/purchase_stock/views/stock_lot_views.xml
+++ b/addons/purchase_stock/views/stock_lot_views.xml
@@ -24,8 +24,8 @@
                            invisible="not purchase_order_ids or display_complete">
                         <list>
                             <field name="name"/>
-                            <field name="partner_id" readonly="state in ['cancel', 'done', 'purchase']"/>
-                            <field name="date_order" readonly="state in ['cancel', 'done', 'purchase']"/>
+                            <field name="partner_id" readonly="state in ['cancel', 'purchase']"/>
+                            <field name="date_order" readonly="state in ['cancel', 'purchase']"/>
                             <field name="state" column_invisible="True"/>
                         </list>
                     </field>

--- a/addons/sale_purchase/models/sale_order_line.py
+++ b/addons/sale_purchase/models/sale_order_line.py
@@ -107,7 +107,7 @@ class SaleOrderLine(models.Model):
             if last_purchase_line.state in ['draft', 'sent', 'to approve']:  # update qty for draft PO lines
                 quantity = line.product_uom_id._compute_quantity(new_qty, last_purchase_line.product_uom_id)
                 last_purchase_line.write({'product_qty': quantity})
-            elif last_purchase_line.state in ['purchase', 'done', 'cancel']:  # create new PO, by forcing the quantity as the difference from SO line
+            elif last_purchase_line.state in ['purchase', 'cancel']:  # create new PO, by forcing the quantity as the difference from SO line
                 quantity = line.product_uom_id._compute_quantity(new_qty - origin_values.get(line.id, 0.0), last_purchase_line.product_uom_id)
                 line._purchase_service_create(quantity=quantity)
 

--- a/addons/sale_purchase/tests/test_sale_purchase.py
+++ b/addons/sale_purchase/tests/test_sale_purchase.py
@@ -182,11 +182,11 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
         """ Test the purchase order behovior when changing the ordered quantity on the sale order line.
             Increase of qty on the SO
             - If PO is draft ['draft', 'sent', 'to approve'] : increase the quantity on the PO
-            - If PO is confirmed ['purchase', 'done', 'cancel'] : create a new PO
+            - If PO is confirmed ['purchase', 'cancel'] : create a new PO
 
             Decrease of qty on the SO
             - If PO is draft  ['draft', 'sent', 'to approve'] : next activity on the PO
-            - If PO is confirmed ['purchase', 'done', 'cancel'] : next activity on the PO
+            - If PO is confirmed ['purchase', 'cancel'] : next activity on the PO
         """
         self.sale_order_1.action_confirm()
 

--- a/addons/sale_purchase_stock/views/purchase_order_views.xml
+++ b/addons/sale_purchase_stock/views/purchase_order_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="purchase_stock.purchase_order_view_form_inherit"/>
             <field name="arch" type="xml">
                 <field name="dest_address_id" position="attributes">
-                    <attribute name="readonly">state == 'done' or has_sale_order</attribute>
+                    <attribute name="readonly">locked or has_sale_order</attribute>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Before this commit:
---------------------------------
The 'done' state in purchase orders was inconsistently used, leading to confusion and unnecessary dependencies. Both 'purchase' and 'done' states were required to filter confirmed POs, despite minimal differences. The 'done' state mainly indicated that the PO was locked and couldn't be modified.

The Lock Confirmed Orders setting in `res.config.settings` automated transitioning POs from 'purchase' to 'done' upon confirmation but allowed manual locking via the Lock button even if the setting was disabled, adding inconsistency.

After this Commit:
---------------------------------
This change removes the 'done' state and introduces a boolean field, locked, to indicate locked PO. Filtering now relies solely on state 'purchase'. The Lock button is visible only when the Lock Confirmed Orders setting is enabled, making POs editable otherwise.

This simplifies workflows, enhances clarity, and retains functionality for managing locked POs.

task-4328798