### PR TITLE
[IMP] mrp: add warning message on canceling manufacturing orders

### DIFF
--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -24,6 +24,7 @@
         'wizard/mrp_consumption_warning_views.xml',
         'wizard/mrp_batch_produce.xml',
         'wizard/mrp_production_split.xml',
+        'wizard/mass_cancel_orders_views.xml',
         'views/mrp_views_menus.xml',
         'views/stock_move_views.xml',
         'views/mrp_workorder_views.xml',

--- a/addons/mrp/security/ir.model.access.csv
+++ b/addons/mrp/security/ir.model.access.csv
@@ -63,3 +63,4 @@ access_mrp_workcenter_capacity_manager,mrp.workcenter.capacity.manager,model_mrp
 access_mrp_workcenter_capacity_group_user,mrp.workcenter.capacity,model_mrp_workcenter_capacity,mrp.group_mrp_user,1,0,0,0
 access_mrp_batch_produce,access.mrp_batch_produce,model_mrp_batch_produce,mrp.group_mrp_user,1,1,1,0
 access_stock_move_mrp_user,stock.move mrp_user,stock.model_stock_move,mrp.group_mrp_user,1,1,1,1
+access_mrp_mass_cancel_orders,access.mrp.mass.cancel.orders,model_mrp_mass_cancel_orders,mrp.group_mrp_user,1,1,1,0

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -45,7 +45,7 @@
                     <header>
                         <button name="button_plan" type="object" string="Plan"/>
                         <button name="action_assign"  type="object" string="Check availability"/>
-                        <button name="action_cancel" type="object" string="Cancel"/>
+                        <button name="%(action_mass_cancel_orders)d" type="action" string="Cancel"/>
                     </header>
                     <field name="company_id" column_invisible="True"/>
                     <field name="product_uom_category_id" column_invisible="True"/>

--- a/addons/mrp/wizard/__init__.py
+++ b/addons/mrp/wizard/__init__.py
@@ -9,3 +9,4 @@ from . import product_replenish
 from . import mrp_batch_produce
 from . import mrp_production_split
 from . import stock_label_type
+from . import mass_cancel_orders

--- a/addons/mrp/wizard/mass_cancel_orders.py
+++ b/addons/mrp/wizard/mass_cancel_orders.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class MrpMassCancel(models.TransientModel):
+    _name = 'mrp.mass.cancel.orders'
+    _description = "Cancel multiple Manufacturing Orders"
+
+    mrp_production_count = fields.Integer(default=lambda self: len(self.env.context.get('active_ids')))
+
+    def mass_cancel(self):
+        mrp_production_ids = self.env['mrp.production'].browse(self.env.context.get('active_ids'))
+        mrp_production_ids.action_cancel()

--- a/addons/mrp/wizard/mass_cancel_orders_views.xml
+++ b/addons/mrp/wizard/mass_cancel_orders_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="mass_cancel_orders_view_form" model="ir.ui.view">
+        <field name="name">mrp.mass.cancel.orders.form</field>
+        <field name="model">mrp.mass.cancel.orders</field>
+        <field name="arch" type="xml">
+            <form string="Cancel Manufacturing Orders">
+                <field name="mrp_production_count" invisible="1"/>
+                <span invisible="mrp_production_count != 1">Are you sure you want to cancel this manufacturing order?</span>
+                <span invisible="mrp_production_count == 1">Are you sure you want to cancel these manufacturing orders?</span>
+                <footer>
+                    <button class="btn-primary"
+                            name="mass_cancel"
+                            type="object"
+                            string="Confirm"/>
+                    <button string="Discard" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_mass_cancel_orders" model="ir.actions.act_window">
+        <field name="name">Confirmation</field>
+        <field name="res_model">mrp.mass.cancel.orders</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="mass_cancel_orders_view_form"/>
+        <field name="target">new</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Before Commit:
======================

User could cancel one or multiple manufacturing orders directly from the list view without any warning message.

After Commit:
======================

Added a warning message to alert user before canceling one or multiple manufacturing orders for preventing accidental cancellations.

task-4294693
