### PR TITLE
[IMP] website_sale_collect: correct delivery address

### DIFF
--- a/addons/website_sale/views/delivery_form_templates.xml
+++ b/addons/website_sale/views/delivery_form_templates.xml
@@ -33,7 +33,7 @@
             t-set="is_pickup_needed"
             t-value="delivery_type in dm.fields_get() and dm[delivery_type]"
         />
-        <div class="row flex-column flex-md-row flex-grow-1 gap-lg-3">
+        <div name="delivery_method" class="row flex-column flex-md-row flex-grow-1 gap-lg-3">
             <div class="col">
                 <div class="d-flex form-check mb-0 gap-2">
                     <!-- === Radio button === -->

--- a/addons/website_sale_collect/models/delivery_carrier.py
+++ b/addons/website_sale_collect/models/delivery_carrier.py
@@ -91,6 +91,7 @@ class DeliveryCarrier(models.Model):
                     'street': wh_location['street'].title(),
                     'city': wh_location.city.title(),
                     'zip_code': wh_location.zip,
+                    'country': wh_location.country_id.name,
                     'country_code': wh_location.country_code,
                     'state': wh_location.state_id.code,
                     'latitude': wh_location.partner_latitude,

--- a/addons/website_sale_collect/static/src/scss/click_and_collect.scss
+++ b/addons/website_sale_collect/static/src/scss/click_and_collect.scss
@@ -3,3 +3,8 @@
         background-color: $gray-100;
     }
 }
+
+.o_address_find_store{
+    min-height: 12.5rem;
+    border: 1px dashed;
+}

--- a/addons/website_sale_collect/tests/test_delivery_carrier.py
+++ b/addons/website_sale_collect/tests/test_delivery_carrier.py
@@ -83,6 +83,7 @@ class TestDeliveryCarrier(ClickAndCollectCommon, WebsiteSaleStockCommon):
                     'name': wh_address_partner['name'].title(),
                     'street': wh_address_partner['street'].title(),
                     'city': wh_address_partner.city.title(),
+                    'country': wh_address_partner.country_id.name,
                     'zip_code': wh_address_partner.zip,
                     'state': wh_address_partner.state_id.code,
                     'country_code': wh_address_partner.country_code,

--- a/addons/website_sale_collect/views/delivery_form_templates.xml
+++ b/addons/website_sale_collect/views/delivery_form_templates.xml
@@ -69,7 +69,10 @@
                 />
             </t>
         </t>
-        <div name="o_pickup_location" position="after">
+        <div name="o_pickup_location" position="attributes">
+            <attribute name="t-attf-class" add="d-none" separator=" "/>
+        </div>
+        <div name="delivery_method" position="after">
             <t t-if="dm.delivery_type=='in_store' and pickup_location_data">
                 <t
                     t-if="unavailable_order_lines"

--- a/addons/website_sale_collect/views/templates.xml
+++ b/addons/website_sale_collect/views/templates.xml
@@ -39,4 +39,68 @@
         </xpath>
     </template>
 
+    <template id="delivery_location_selector" inherit_id="website_sale.delivery_address_row">
+        <div id="delivery_address_row" position="inside">
+            <div name="o_pickup_location" class="o_portal_address_row d-none">
+                <t t-set="pickup_location_data" t-value="order.pickup_location_data or {}"/>
+                <a
+                    t-if="not pickup_location_data"
+                    name="o_pickup_location_selector"
+                    role="button"
+                    class="o_address_find_store d-flex align-items-center justify-content-center rounded no-decoration"
+                >
+                    <div>
+                        <span class="d-md-inline">
+                            <i class="fa fa-search"/>
+                        </span>
+                        <span>
+                            Choose Store
+                        </span>
+                    </div>
+                </a>
+                <span
+                    name="o_pickup_location_selector"
+                    t-attf-class="card position-relative
+                        {{'bg-primary border border-primary js_change_address'
+                        if pickup_location_data else 'border border-0 d-none'}}"
+                    t-att-data-location-id="pickup_location_data.get('id')"
+                    t-att-data-zip-code="pickup_location_data.get('zip_code')"
+                    t-att-data-pickup-location-data="json.dumps(pickup_location_data)"
+                >
+                    <div t-attf-class="card-body d-flex flex-column align-items-start">
+                        <div class="d-flex justify-content-between w-100">
+                            <span
+                                name="o_pickup_location_name"
+                                class="d-block fw-bold"
+                                t-out="pickup_location_data.get('name', '')"
+                            />
+                            <a
+                                name="edit_pickup_address"
+                                t-attf-class="js_edit_address btn btn-link p-0 mt-auto
+                                    {{'d-none' if not pickup_location_data else ''}}"
+                                role="button"
+                            >
+                                <i class="fa fa-search me-1"/>Change Store
+                            </a>
+                        </div>
+                        <span name="o_pickup_location_address" class="lh-sm">
+                            <t t-out="pickup_location_data.get('street', '')"/>
+                            <br/>
+                            <t
+                                t-out="pickup_location_data.get('city', '')
+                                + ' ' + pickup_location_data.get('zip_code', '')"
+                            />
+                            <br/>
+                            <t t-out="pickup_location_data.get('country', '')"/>
+                        </span>
+                        <span name="o_pickup_location_details"></span>
+                    </div>
+                </span>
+            </div>
+        </div>
+        <div id="delivery_address_row" position="attributes">
+            <attribute name="class" separator=" " add="delivery_address_row"/>
+        </div>
+    </template>
+
 </odoo>


### PR DESCRIPTION
prior this commit:
- When click and collect is enabled and user chooses pick up in store in checkout it would show two addresses, delivery address and store address

post this commit:
- in checkout stage if pick up in store is selected then only store address is required      
- User can select the store using find a store button in the delivery address row

task-4193856