### PR TITLE
[FIX] mail: hide New button when 'create' is false in the action context

### DIFF
--- a/addons/mail/static/src/views/web/activity/activity_controller.js
+++ b/addons/mail/static/src/views/web/activity/activity_controller.js
@@ -73,6 +73,7 @@ export class ActivityController extends Component {
             title: _t("Search: %s", this.props.archInfo.title),
             multiSelect: false,
             context: this.props.context,
+            noCreate: this.props.context?.create === false,
             onSelected: async (resIds) => {
                 await this.activity.schedule(this.props.resModel, resIds);
             },

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -1502,4 +1502,30 @@ QUnit.module("test_mail", {}, function () {
         await click(target, ".modal-footer button.o_form_button_cancel");
         assert.containsOnce(target, ".o_activity_summary_cell:not(.o_activity_empty_cell)");
     });
+
+    QUnit.test(
+        "Activity View: Hide 'New' button in SelectCreateDialog based on action context",
+        async function (assert) {
+            assert.expect(1);
+
+            Object.assign(serverData.views, {
+                "mail.test.activity,false,list":
+                    '<tree string="MailTestActivity"><field name="name"/></tree>',
+            });
+
+            const { openView } = await start({
+                serverData,
+            });
+            await openView({
+                res_model: "mail.test.activity",
+                views: [[false, "activity"]],
+                context: { create: false },
+            });
+
+            const activity = $(document);
+            await testUtils.dom.click(activity.find("table tfoot tr .o_record_selector"));
+
+            assert.containsNone(activity, ".o_create_button", "'New' button should be hidden.");
+        }
+    );
 });


### PR DESCRIPTION
When we pass create = false in the action context, a new record cannot be created in the kanban and list views. However, a new record could still be created in the activity view. In this commit, we have prevented that.

task-3887972

