### PR TITLE
[FIX] mail: can't open document when message log on channel

### DIFF
--- a/addons/mail/static/src/components/notification_message_view/notification_message_view.xml
+++ b/addons/mail/static/src/components/notification_message_view/notification_message_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.NotificationMessageView" owl="1">
-        <div class="o_NotificationMessageView d-flex justify-content-center" t-ref="root">
+        <div class="o_NotificationMessageView d-flex justify-content-center" t-ref="root" t-on-click="notificationMessageView.onClick">
             <div class="flex-grow-1"/>
             <div class="text-500 small px-3">
                 <span class="d-inline" t-esc="notificationMessageView.message.authorName"/> <t t-out="notificationMessageView.message.prettyBodyAsMarkup"/>

--- a/addons/mail/static/src/models/activity_view.js
+++ b/addons/mail/static/src/models/activity_view.js
@@ -15,19 +15,8 @@ registerModel({
          *
          * @param {MouseEvent} ev
          */
-        onClickActivity(ev) {
-            if (
-                ev.target.tagName === 'A' &&
-                ev.target.dataset.oeId &&
-                ev.target.dataset.oeModel
-            ) {
-                this.messaging.openProfile({
-                    id: Number(ev.target.dataset.oeId),
-                    model: ev.target.dataset.oeModel,
-                });
-                // avoid following dummy href
-                ev.preventDefault();
-            }
+        async onClickActivity(ev) {
+            await this.messaging.handleClickOnLink(ev);
         },
         /**
          * Handles the click on the cancel button

--- a/addons/mail/static/src/models/message_notification_view.js
+++ b/addons/mail/static/src/models/message_notification_view.js
@@ -14,6 +14,9 @@ registerModel({
                 this.messageListViewItemOwner.threadViewOwnerAsLastMessageListViewItem.handleVisibleMessage(this.message);
             }
         },
+        async onClick(ev) {
+            await this.messaging.handleClickOnLink(ev);
+        },
     },
     fields: {
         component: attr(),

--- a/addons/mail/static/src/models/message_view.js
+++ b/addons/mail/static/src/models/message_view.js
@@ -22,35 +22,7 @@ registerModel({
          * @param {MouseEvent} ev
          */
         async onClick(ev) {
-            if (ev.target.closest('.o_channel_redirect')) {
-                // avoid following dummy href
-                ev.preventDefault();
-                const channel = this.messaging.models['Thread'].insert({
-                    id: Number(ev.target.dataset.oeId),
-                    model: 'mail.channel',
-                });
-                if (!channel.isPinned) {
-                    await channel.join();
-                    channel.update({ isServerPinned: true });
-                }
-                channel.open();
-                return;
-            } else if (ev.target.closest('.o_mail_redirect')) {
-                ev.preventDefault();
-                this.messaging.openChat({
-                    partnerId: Number(ev.target.dataset.oeId)
-                });
-                return;
-            }
-            if (ev.target.tagName === 'A') {
-                if (ev.target.dataset.oeId && ev.target.dataset.oeModel) {
-                    // avoid following dummy href
-                    ev.preventDefault();
-                    this.messaging.openProfile({
-                        id: Number(ev.target.dataset.oeId),
-                        model: ev.target.dataset.oeModel,
-                    });
-                }
+            if (await this.messaging.handleClickOnLink(ev)) {
                 return;
             }
             if (

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -263,6 +263,40 @@ registerPatch({
                 this.soundEffects.incomingCall.stop();
             }
         },
+        async handleClickOnLink(ev) {
+            if (ev.target.closest('.o_channel_redirect')) {
+                // avoid following dummy href
+                ev.preventDefault();
+                const channel = this.models['Thread'].insert({
+                    id: Number(ev.target.dataset.oeId),
+                    model: 'mail.channel',
+                });
+                if (!channel.isPinned) {
+                    await channel.join();
+                    channel.update({ isServerPinned: true });
+                }
+                channel.open();
+                return true;
+            } else if (ev.target.closest('.o_mail_redirect')) {
+                ev.preventDefault();
+                this.openChat({
+                    partnerId: Number(ev.target.dataset.oeId)
+                });
+                return true;
+            }
+            if (ev.target.tagName === 'A') {
+                if (ev.target.dataset.oeId && ev.target.dataset.oeModel) {
+                    // avoid following dummy href
+                    ev.preventDefault();
+                    this.openProfile({
+                        id: Number(ev.target.dataset.oeId),
+                        model: ev.target.dataset.oeModel,
+                    });
+                }
+                return true;
+            }
+            return false;
+        },
     },
     fields: {
         /**


### PR DESCRIPTION
* STEP TO REPRODUCE: try to _message_log on a channel contain record link (an a tag with data-oe-model and data-oe-link) then click on it -> nothing happen
* REASON: when _message_log in mail.channel, it will consider that message as a NotificationMessageView model and we do not have onClick for it unlike MessageView model
* SOLUTION: implement onClick for NotificationMessageView just like MessageView

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
