### PR TITLE
[FIX] mail: members back icon shouldn't look disabled

### DIFF
--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -13,7 +13,7 @@
     <t t-name="mail.ActionPanel.content">
         <div class="o-mail-ActionPanel-header position-sticky top-0 pt-2 pb-1 d-flex flex-column bg-inherit small" t-att-class="{ 'px-1': env.inChatWindow, 'px-2': !env.inChatWindow }">
             <div class="d-flex align-items-baseline gap-1">
-                <button t-if="env.closeActionPanel" class="btn p-1 opacity-25 opacity-100-hover" title="Close panel" t-on-click.stop="env.closeActionPanel">
+                <button t-if="env.closeActionPanel" class="btn p-1 opacity-75 opacity-100-hover" title="Close panel" t-on-click.stop="env.closeActionPanel">
                     <i class="oi oi-arrow-left fa-fw"/>
                 </button>
                 <i t-if="props.icon" class="text-muted opacity-50" t-att-class="props.icon"/>


### PR DESCRIPTION
**Current behavior before PR:**

The back icon in members looked disabled even though it wasn't

**Desired behavior after PR is merged:**

The back icon in members no longer looks disabled and has proper opacity

task-id:[4354084](https://www.odoo.com/odoo/project/1519/tasks/4354084)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
