### PR TITLE
[IMP] pos_self_order: hide `self_order` field on product form when not necessary

### DIFF
--- a/addons/pos_self_order/models/pos_category.py
+++ b/addons/pos_self_order/models/pos_category.py
@@ -11,6 +11,7 @@ class PosCategory(models.Model):
 
     hour_until = fields.Float(string='Availability Until', default=24.0, help="The product will be available until this hour.")
     hour_after = fields.Float(string='Availability After', default=0.0, help="The product will be available after this hour.")
+    pos_config_ids = fields.Many2many('pos.config', string='Linked PoS Configurations')
 
     @api.model
     def _load_pos_data_fields(self, config_id):

--- a/addons/pos_self_order/views/product_views.xml
+++ b/addons/pos_self_order/views/product_views.xml
@@ -23,7 +23,7 @@
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
             <group name="pos" position="inside">
-                <field name="self_order_available"/>
+                <field name="self_order_available" invisible="not self_order_visible"/>
             </group>
             <xpath expr="//group[@name='public_description']" position="attributes">
                 <attribute name="invisible">0</attribute>


### PR DESCRIPTION
Only show the field `self_order_available` inside a product form if self ordering is enabled in the settings (in any `pos_config` which is using any `pos_category` of the current product).

task-id: 4273866




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
