### PR TITLE
[IMP] mail: move share screen action out of more menu

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_action_list.xml
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.xml
@@ -5,7 +5,7 @@
         <div class="o-discuss-CallActionList d-flex flex-column justify-content-center" t-attf-class="{{ className }}" t-ref="root">
             <div class="d-flex align-items-center flex-wrap justify-content-between" t-att-class="{ 'w-100 ps-2 pe-2': isSmall }">
                 <t t-if="isOfActiveCall and rtc.selfSession">
-                    <t t-foreach="callActions.actions.slice(0, 3)" t-as="action" t-key="action_index">
+                    <t t-foreach="callActions.actions.slice(0, isMobileOS ? 3 : 4)" t-as="action" t-key="action_index">
                         <t t-call="discuss.CallActionList.actionButton" />
                     </t>
                     <Dropdown position="'top-end'" menuClass="'d-flex flex-column py-0'">
@@ -15,7 +15,7 @@
                             </div>
                         </button>
                         <t t-set-slot="content">
-                            <DropdownItem t-foreach="callActions.actions.slice(3)" t-as="action" t-key="action_index" class="'btn rounded-0 d-flex align-items-center px-2 py-2 m-0 opacity-75 opacity-100-hover'" attrs="{ title: action.name }" onSelected="action.select">
+                            <DropdownItem t-foreach="callActions.actions.slice(isMobileOS ? 3 : 4)" t-as="action" t-key="action_index" class="'btn rounded-0 d-flex align-items-center px-2 py-2 m-0 opacity-75 opacity-100-hover'" attrs="{ title: action.name }" onSelected="action.select">
                                 <i class="fa fa-fw" t-att-class="{
                                     [action.inactiveIcon]: !action.isActive,
                                     [action.icon]: action.isActive or !action.inactiveIcon,

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -55,7 +55,7 @@ callActionsRegistry
         isActive: (component) => component.rtc.selfSession?.raisingHand,
         icon: "fa-hand-paper-o",
         select: (component) => component.rtc.raiseHand(!component.rtc.selfSession.raisingHand),
-        sequence: 40,
+        sequence: 50,
     })
     .add("share-screen", {
         condition: (component) => component.rtc && !isMobileOS(),
@@ -66,7 +66,7 @@ callActionsRegistry
         isActive: (component) => component.rtc.selfSession?.isScreenSharingOn,
         icon: "fa-desktop",
         select: (component) => component.rtc.toggleVideo("screen"),
-        sequence: 50,
+        sequence: 40,
     })
     .add("fullscreen", {
         condition: (component) => component.props && component.props.fullscreen,

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -42,15 +42,15 @@ test("basic rendering", async () => {
     await contains(".o-discuss-CallParticipantCard[aria-label='Mitchell Admin']");
     await contains(".o-discuss-CallActionList");
     await contains(".o-discuss-CallMenu-buttonContent");
-    await contains(".o-discuss-CallActionList button", { count: 5 });
+    await contains(".o-discuss-CallActionList button", { count: 6 });
     await contains("button[aria-label='Unmute'], button[aria-label='Mute']"); // FIXME depends on current browser permission
     await contains(".o-discuss-CallActionList button[aria-label='Deafen']");
     await contains(".o-discuss-CallActionList button[aria-label='Turn camera on']");
+    await contains(".o-discuss-CallActionList button[aria-label='Share Screen']");
     await contains("[title='More']");
     await contains(".o-discuss-CallActionList button[aria-label='Disconnect']");
     await click("[title='More']");
     await contains("[title='Raise Hand']");
-    await contains("[title='Share Screen']");
     await contains("[title='Enter Full Screen']");
     // screen sharing not available in mobile OS
     mockUserAgent("Chrome/0.0.0 Android (OdooMobile; Linux; Android 13; Odoo TestSuite)");


### PR DESCRIPTION
**Current behavior before PR:**

The 'Share Screen' action was located within the 'More' button, making it less accessible during a video call.

**Desired behavior after PR is merged:**

The 'Share Screen' action has been moved outside the 'More' menu and is now always visible during a video call.

**Task**-4354220

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
