### PR TITLE
[FIX] hr_timesheet: use the right SQL alias in custom query

### DIFF
--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -102,7 +102,7 @@ class ProjectProject(models.Model):
                AND Task.parent_id IS NULL
                AND Task.state IN ('01_in_progress', '02_changes_requested', '03_approved', '04_waiting_normal')
           GROUP BY Project.id
-            HAVING ProjectProject.allocated_hours - SUM(Task.effective_hours) < 0
+            HAVING Project.allocated_hours - SUM(Task.effective_hours) < 0
         )""")
         if (operator == '=' and value is True) or (operator == '!=' and value is False):
             operator_new = 'in'


### PR DESCRIPTION
Before this commit, due to the renaming of the class to be able to automatically compute `_name` of the models, the alias used in the query to know if the project is in overtime or not has been renamed to fit with the class name which is wrong.

This commit fixes the query to correctly used the alias created inside that query.

runbot-103051
