### PR TITLE
[IMP] mail: rename mail template to invite users

### DIFF
--- a/addons/auth_signup/data/mail_template_data.xml
+++ b/addons/auth_signup/data/mail_template_data.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <!-- Email template for new users -->
         <record id="set_password_email" model="mail.template">
-            <field name="name">Settings: New Portal Signup</field>
+            <field name="name">Settings: New User Invite</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">{{ object.create_uid.name }} from {{ object.company_id.name }} invites you to connect to Odoo</field>
             <field name="email_from">{{ (object.company_id.email_formatted or user.email_formatted) }}</field>

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -53,7 +53,10 @@
                                 <field name="body_html" widget="html_mail" class="oe-bordered-editor"
                                     options="{'codeview': true, 'dynamic_placeholder': true}"
                                     readonly="not can_write and id"/>
-                                <field name="attachment_ids" widget="many2many_binary"/>
+                                <div class="d-flex align-items-center gap-3">
+                                    <field name="attachment_ids" widget="many2many_binary" class="m-0"/>
+                                    <div class="text-muted">Write /field to insert dynamic content</div>
+                                </div>
                             </page>
                             <page string="Email Configuration" name="email_configuration">
                                 <group>


### PR DESCRIPTION
The mail template "Settings: New Portal Signup" has been renamed to "Settings: New User Invite" to reduce confusion. The previous name implied the creation of a new portal user account, which was misleading since the template is intended for creating new internal user accounts. Its new name should now better reflect its purpose.

Additionally, this commit adds a small placeholder beneath the mail template editor. This placeholder serves as a helpful reminder for users to insert dynamic values into emails using the `/field` command.

task-4273520

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
