### PR TITLE
[FIX] web_editor: UI stuck when image crop denied

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6677,15 +6677,17 @@ registry.ImageTools = ImageHandlerOption.extend({
             mimetype: this._getImageMimetype(img),
         });
 
-        await new Promise(resolve => {
-            this.$target.one('image_cropper_destroyed', async () => {
-                if (isGif(this._getImageMimetype(img))) {
-                    img.dataset[img.dataset.shape ? 'originalMimetype' : 'mimetype'] = 'image/png';
-                }
-                await this._reapplyCurrentShape();
-                resolve();
+        if (!imageCropWrapper.component._cropperClosed) {
+            await new Promise(resolve => {
+                this.$target.one('image_cropper_destroyed', async () => {
+                    if (isGif(this._getImageMimetype(img))) {
+                        img.dataset[img.dataset.shape ? 'originalMimetype' : 'mimetype'] = 'image/png';
+                    }
+                    await this._reapplyCurrentShape();
+                    resolve();
+                });
             });
-        });
+        }
         imageCropWrapperElement.remove();
         imageCropWrapper.destroy();
         this.trigger_up('enable_loading_effect');


### PR DESCRIPTION
Steps to produce:
- Drop 'Text - Image' block
- Replace image by illustration
- Try to crop image
- A notification is displayed
- Try saving

The issue is ImageCrop is still not opened and we are trying to wait for image_cropper_destroyed to trigger, so here we check if ImageCrop is not opened.

task-4246644

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
