### PR TITLE
[FIX] web: keep datepicker value when picking time

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.js
+++ b/addons/web/static/src/core/datetime/datetime_picker.js
@@ -38,7 +38,7 @@ const { DateTime, Info } = luxon;
  * @property {PrecisionLevel} [maxPrecision="decades"]
  * @property {DateLimit} [minDate]
  * @property {PrecisionLevel} [minPrecision="days"]
- * @property {(value: DateTime) => any} [onSelect]
+ * @property {(value: DateTime | DateRange, unit: "date" | "time") => any} [onSelect]
  * @property {boolean} [range]
  * @property {number} [rounding=5] the rounding in minutes, pass 0 to show seconds, pass 1 to avoid
  *  rounding minutes without displaying seconds.
@@ -629,14 +629,15 @@ export class DateTimePicker extends Component {
      */
     selectTime(valueIndex) {
         const value = this.values[valueIndex] || today();
-        this.validateAndSelect(value, valueIndex);
+        this.validateAndSelect(value, valueIndex, "time");
     }
 
     /**
      * @param {DateTime} value
      * @param {number} valueIndex
+     * @param {"date" | "time"} unit
      */
-    validateAndSelect(value, valueIndex) {
+    validateAndSelect(value, valueIndex, unit) {
         if (!this.props.onSelect) {
             // No onSelect handler
             return false;
@@ -654,7 +655,7 @@ export class DateTimePicker extends Component {
             // Date is outside range defined by min and max dates
             return false;
         }
-        this.props.onSelect(result.length === 2 ? result : result[0]);
+        this.props.onSelect(result.length === 2 ? result : result[0], unit);
         return true;
     }
 
@@ -701,7 +702,7 @@ export class DateTimePicker extends Component {
         }
         const [value] = dateItem.range;
         const valueIndex = this.props.focusedDateIndex;
-        const isValid = this.validateAndSelect(value, valueIndex);
+        const isValid = this.validateAndSelect(value, valueIndex, "date");
         this.shouldAdjustFocusDate = isValid && !this.props.range;
     }
 }

--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -346,9 +346,10 @@ export const datetimePickerService = {
 
                 /**
                  * @param {DateTimePickerProps["value"]} value
+                 * @param {"date" | "time"} unit
                  * @param {"input" | "picker"} source
                  */
-                const updateValue = (value, source) => {
+                const updateValue = (value, unit, source) => {
                     const previousValue = pickerProps.value;
                     pickerProps.value = value;
 
@@ -356,27 +357,29 @@ export const datetimePickerService = {
                         return;
                     }
 
-                    if (pickerProps.range && source === "picker") {
-                        if (
-                            pickerProps.focusedDateIndex === 0 ||
-                            (value[0] && value[1] && value[1] < value[0])
-                        ) {
-                            // If selecting either:
-                            // - the first value
-                            // - OR a second value before the first:
-                            // Then:
-                            // - Set the DATE (year + month + day) of all values
-                            // to the one that has been selected.
-                            const { year, month, day } = value[pickerProps.focusedDateIndex];
-                            for (let i = 0; i < value.length; i++) {
-                                value[i] = value[i] && value[i].set({ year, month, day });
+                    if (unit !== "time") {
+                        if (pickerProps.range && source === "picker") {
+                            if (
+                                pickerProps.focusedDateIndex === 0 ||
+                                (value[0] && value[1] && value[1] < value[0])
+                            ) {
+                                // If selecting either:
+                                // - the first value
+                                // - OR a second value before the first:
+                                // Then:
+                                // - Set the DATE (year + month + day) of all values
+                                // to the one that has been selected.
+                                const { year, month, day } = value[pickerProps.focusedDateIndex];
+                                for (let i = 0; i < value.length; i++) {
+                                    value[i] = value[i] && value[i].set({ year, month, day });
+                                }
+                                pickerProps.focusedDateIndex = 1;
+                            } else {
+                                // If selecting the second value after the first:
+                                // - simply toggle the focus index
+                                pickerProps.focusedDateIndex =
+                                    pickerProps.focusedDateIndex === 1 ? 0 : 1;
                             }
-                            pickerProps.focusedDateIndex = 1;
-                        } else {
-                            // If selecting the second value after the first:
-                            // - simply toggle the focus index
-                            pickerProps.focusedDateIndex =
-                                pickerProps.focusedDateIndex === 1 ? 0 : 1;
                         }
                     }
 
@@ -400,7 +403,7 @@ export const datetimePickerService = {
                             }
                         }
                     );
-                    updateValue(values.length === 2 ? values : values[0], "input");
+                    updateValue(values.length === 2 ? values : values[0], "date", "input");
                 };
 
                 // Hook variables
@@ -408,9 +411,9 @@ export const datetimePickerService = {
                 /** @type {DateTimePickerProps} */
                 const rawPickerProps = {
                     ...DateTimePicker.defaultProps,
-                    onSelect: (value) => {
+                    onSelect: (value, unit) => {
                         value &&= markRaw(value);
-                        updateValue(value, "picker");
+                        updateValue(value, unit, "picker");
                         if (!pickerProps.range && pickerProps.type === "date") {
                             saveAndClose();
                         }


### PR DESCRIPTION
Before this commit, selecting a 'time' in a daterange for the value that is _not_ focused would erase the other date with the current one.

This is what the datepicker is meant to do when the date is selected, but it doesn't make sense to do that for time selection, as it is agnostic of the focused date with the help of distinct `select` elements.

This commit sends the information whether the 'time' part has been changed to bypass the overwrite system in such cases.

Task [4354382](https://www.odoo.com/odoo/project/133/tasks/4354382?debug=1)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
