### PR TITLE
[FIX] mail: fix race condition in scroll to unread test

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -383,6 +383,7 @@ export class Thread extends Component {
             } else if (snapshot && messagesAtBottom) {
                 setScroll(snapshot.scrollTop);
             } else if (
+                !this.scrollingToHighlight &&
                 !this.env.messageHighlight?.highlightedMessageId &&
                 thread.scrollTop !== undefined
             ) {
@@ -494,6 +495,7 @@ export class Thread extends Component {
         this.props.thread.loadNewer = false;
         this.props.thread.scrollTop = "bottom";
         this.state.showJumpPresent = false;
+        this.scrollingToHighlight = false;
     }
 
     /**

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -216,13 +216,6 @@ export function useVisible(refName, cb, { ready = true } = {}) {
     return state;
 }
 
-/**
- * @typedef {Object} MessageHighlight
- * @property {function} clearHighlight
- * @property {function} highlightMessage
- * @property {number|null} highlightedMessageId
- * @returns {MessageHighlight}
- */
 export function useMessageHighlight(duration = 2000) {
     let timeout;
     const state = useState({

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -91,18 +91,18 @@ test("scroll to the first unread message (slow ref registration)", async () => {
         async registerMessageRef() {
             if (slowRegisterMessageRef) {
                 // Ensure scroll is made even when messages are mounted later.
-                await new Promise((res) => setTimeout(res, 500));
+                await new Promise((res) => setTimeout(res, 250));
             }
             super.registerMessageRef(...arguments);
         },
     });
     await start();
     await openDiscuss(channelId);
+    await tick(); // wait for the scroll to first unread to complete
     await click(".o-mail-Thread-banner", {
         text: "You're viewing older messagesJump to Present",
     });
-    await scroll(".o-mail-Thread", "bottom");
-    await contains(".o-mail-Thread", { scroll: "bottom" });
+    await isInViewportOf(".o-mail-Message:contains(message 200)", ".o-mail-Thread");
     slowRegisterMessageRef = true;
     await click("span", {
         text: "101 new messages",


### PR DESCRIPTION
This PR resolves an issue with the `scroll to the first unread message` test, which occasionally failed due to race conditions.

Several issues were identified with this test:
- We do not wait for the initial scroll to complete, which can lead to race conditions.
- Under high CPU load, the message highlight can be shorter than the scroll. We should wait for the scroll to complete before allowing adjustments to be made.

runbot-103421

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
