### PR TITLE
[FIX] l10n_be_pos_sale: activate default invoice only with intracom taxes

### DIFF
--- a/addons/l10n_be_pos_sale/static/src/js/ProductScreen.js
+++ b/addons/l10n_be_pos_sale/static/src/js/ProductScreen.js
@@ -6,8 +6,20 @@ import Registries from 'point_of_sale.Registries';
 export const PoSSaleBeProductScreen = (ProductScreen) =>
     class extends ProductScreen {
         async _onClickPay() {
-            const has_origin_order = this.currentOrder.get_orderlines().some(line => line.sale_order_origin_id);
-            if (this.env.pos.company.country && this.env.pos.company.country.code === "BE" && has_origin_order) {
+            const orderLines = this.currentOrder.get_orderlines();
+            const has_origin_order = orderLines.some(line => line.sale_order_origin_id);
+            const has_intracom_taxes = orderLines.some(
+                (line) =>
+                    line.tax_ids &&
+                    this.env.pos.intracom_tax_ids &&
+                    line.tax_ids.some((tax) => this.env.pos.intracom_tax_ids.includes(tax))
+            );
+            if (
+                this.env.pos.company.country &&
+                this.env.pos.company.country.code === "BE" &&
+                has_origin_order &&
+                has_intracom_taxes
+            ) {
                 this.currentOrder.to_invoice = true;
             }
             return super._onClickPay(...arguments);

--- a/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
+++ b/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
@@ -4,6 +4,7 @@ odoo.define('l10n_be_pos_sale.tour', function (require) {
     const { ErrorPopup } = require('point_of_sale.tour.ErrorPopupTourMethods');
     const { PaymentScreen } = require('point_of_sale.tour.PaymentScreenTourMethods');
     const { ProductScreen } = require('pos_sale.tour.ProductScreenTourMethods');
+    const { ReceiptScreen } = require('pos_sale.tour.ReceiptScreenTourMethods');
     const { getSteps, startSteps } = require('point_of_sale.tour.utils');
     const Tour = require('web_tour.tour');
 
@@ -13,12 +14,22 @@ odoo.define('l10n_be_pos_sale.tour', function (require) {
 
     ProductScreen.do.confirmOpeningPopup();
     ProductScreen.do.clickQuotationButton();
-    ProductScreen.do.selectFirstOrder();
+    ProductScreen.do.selectNthOrder(2);
     ProductScreen.do.clickPayButton();
     PaymentScreen.check.isInvoiceButtonChecked();
     PaymentScreen.do.clickInvoiceButton();
     PaymentScreen.check.isInvoiceButtonChecked();
     ErrorPopup.do.clickConfirm();
+    PaymentScreen.do.clickPaymentMethod("Cash");
+    PaymentScreen.do.clickValidate();
+    ReceiptScreen.do.clickNextOrder();
+
+    ProductScreen.do.clickQuotationButton();
+    ProductScreen.do.selectFirstOrder();
+    ProductScreen.do.clickPayButton();
+    PaymentScreen.check.isInvoiceButtonNotChecked();
+    PaymentScreen.do.clickInvoiceButton();
+    PaymentScreen.check.isInvoiceButtonChecked();
 
     Tour.register('PosSettleOrderIsInvoice', { test: true, url: '/pos/ui' }, getSteps());
 });

--- a/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
+++ b/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
@@ -58,5 +58,17 @@ class TestPoSSaleL10NBe(TestPointOfSaleHttpCommon):
         })
 
         sale_order.action_confirm()
+
+        sale_order2 = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': self.product_a.id,
+                'product_uom_qty': 20,
+                'product_uom': self.product_a.uom_id.id,
+                'price_unit': 20,
+                'tax_id': False,
+            })],
+        })
+        sale_order2.action_confirm()
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrderIsInvoice', login="accountman")

--- a/addons/point_of_sale/static/tests/tours/helpers/PaymentScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/PaymentScreenTourMethods.js
@@ -223,6 +223,15 @@ odoo.define('point_of_sale.tour.PaymentScreenTourMethods', function (require) {
                 }
             ]
         }
+        isInvoiceButtonNotChecked() {
+            return [
+                {
+                    content: "check invoice button is checked",
+                    trigger: ".js_invoice:not(.highlight)",
+                    run: () => {},
+                },
+            ];
+        }
     }
 
     class Execute {


### PR DESCRIPTION
Previously, settling a sale.order from the POS of a Belgian company
would auto check the invoice option before paying.

Steps to reproduce:
-------------------
* Install `l10n_be_pos_cert`
* Switch to the Beligian company
* Crete a quotation in **Sale** app
* Add any partner and any product, remove all taxes for the product line
* Save
* Open pos shop
* Settle the order
* Go to the payment screen
> Observation: The invoice button is already selected.

Why the fix:
------------
This invoice option was auto selected since this commit: https://github.com/odoo/odoo/commit/c760fbb1bd2e7725b5e759198684a07060612033

The following commit https://github.com/odoo/odoo/commit/3a5e22218708b4b6c9aedfa965d9f3c279edbd46
updates the previous one as the invoice enforcement is only needed when we have
intracom taxes on the SO. Thus when no intracom taxes apply we can still 
decide wether or not to invoice. We fallback on the default behavior which 
is to have the invoice button un-selected.

opw-4334095
