### PR TITLE
[FIX] account: adapt Many2OneField to new URL format

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -30,7 +30,7 @@
                         <a t-if="(columnIsProductAndLabel.value and value) or (!columnIsProductAndLabel.value and (productName or (!productName and !label)))"
                             class="d-flex align-items-center justify-content-between"
                             t-attf-class="o_form_uri #{classFromDecoration}"
-                            t-att-href="value ? `#id=${value[0]}&amp;model=${relation}` : '#'"
+                            t-att-href="value ? `/odoo/${urlRelation}/${value[0]}` : '/'"
                             t-on-click.prevent="onClick"
                         >
                             <span t-ref="productNodeRef" class="w-100">


### PR DESCRIPTION
The links created with the product_label_section_and_note_field widget won't work correctly.

This commit, will change the link to the new format.

This commit is a followup of odoo/odoo@98f7486
