### PR TITLE
[PERF] point_of_sale: load needed product tags fields

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1835,7 +1835,7 @@ class PosSession(models.Model):
         return self.env['product.tag'].search_read(**params['search_params'])
 
     def _loader_params_product_tag(self):
-        return {'search_params': {'domain': [], 'fields': []}}
+        return {'search_params': {'domain': [], 'fields': ['name']}}
 
     def _loader_params_account_tax(self):
         return {


### PR DESCRIPTION
Before this commit, all fields of product tags were loaded into PoS, which was unnecessary. For example, product templates field and product variants field, which contain all products with that tag, were loaded. This caused performance issues when there were a high number of products using tags. This commit fixes the issue by only loading the name field, which is needed in PoS.

opw-4343131

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
