### PR TITLE
[IMP] im_livechat: chatbot buttons outside of message bubble

### DIFF
--- a/addons/im_livechat/static/src/embed/common/message_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/message_patch.xml
@@ -7,7 +7,7 @@
             </div>
             <t t-else="">$0</t>
         </xpath>
-        <xpath expr="//*[@t-ref='body']" position="inside">
+        <xpath expr="//*[hasclass('o-mail-Message-textContent')]" position="inside">
             <ul class="p-0 m-0" t-if="props.message.chatbotStep?.answers and !props.message.chatbotStep.selectedAnswer">
                 <li
                     t-foreach="props.message.chatbotStep?.answers" t-as="answer" t-key="answer.id"


### PR DESCRIPTION
Moved chatbot answers buttons outside of the message bubble

![image](https://github.com/user-attachments/assets/413b4735-b0ab-4172-acbf-dd6d5eb0347c)


task-4354009
