### PR TITLE
Master set focus on selectmenu search input msh

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -166,6 +166,13 @@ export class SelectMenu extends Component {
         this.filterOptions();
     }
 
+    onOpened() {
+        const inputEl = this.inputRef.el;
+        if (inputEl) {
+            inputEl.focus();
+        }
+    }
+
     onStateChanged(open) {
         this.isOpen = open;
         if (open) {
@@ -220,9 +227,9 @@ export class SelectMenu extends Component {
         // Combine previously selected choices + newly selected choice from
         // the searched choices and then filter the choices based on
         // props.value i.e. valueSet.
-        return [...(this.selectedChoice || []), ...choices].filter((c, index, self) =>
-            valueSet.has(c.value)
-            && self.findIndex((t) => t.value === c.value) === index
+        return [...(this.selectedChoice || []), ...choices].filter(
+            (c, index, self) =>
+                valueSet.has(c.value) && self.findIndex((t) => t.value === c.value) === index
         );
     }
 

--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -8,6 +8,7 @@
                 menuRef="this.menuRef"
                 position="'bottom-fit'"
                 beforeOpen.bind="onBeforeOpen"
+                onOpened.bind="onOpened"
                 onStateChanged.bind="onStateChanged"
                 navigationOptions="{ virtualFocus: this.props.searchable }"
             >


### PR DESCRIPTION
Before this commit:
When we open SelectMenu with multiselect, it has search input element
but it does not have focus set.

After this commit:
When we open SelectMenu and if it has search input element the focus
will set on that element on open of dropdown.

task-4188301




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
