### PR TITLE
[FIX] mail: discuss sidebar last public channel icon cropped

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -65,8 +65,8 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
 
 .o-mail-DiscussSidebarChannel-threadIcon {
     font-size: xx-small;
-    width: 13px;
-    height: 13px;
+    width: 14px;
+    height: 14px;
 }
 
 .o-mail-DiscussSidebarChannel-indicatorCompact {


### PR DESCRIPTION
**Current behavior before PR:**

In the discuss sidebar, the last public channel icon appears cropped due to insufficient width and height.

**Desired behavior after PR is merged:**

The issue is resolved by little adjusted height and width of the icons, this ensures the last public channel icon displays correctly without cropping.

Before / after
![image](https://github.com/user-attachments/assets/f71da110-caf0-42c9-b371-6ef96bb4283b)  ![image](https://github.com/user-attachments/assets/e04eabf4-68b7-40fd-a8df-4473d38daabc)


task-4354447

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
