### PR TITLE
[FIX] web: stop preventDefaulting the beforeinstallprompt event

### DIFF
--- a/addons/web/static/src/core/install_prompt/install_prompt_service.js
+++ b/addons/web/static/src/core/install_prompt/install_prompt_service.js
@@ -42,7 +42,6 @@ const installPromptService = {
             browser.addEventListener("beforeinstallprompt", (ev) => {
                 // This event is only triggered by the browser when the native prompt to install can be shown
                 // This excludes incognito tabs, as well as visiting the website while the app is installed
-                ev.preventDefault();
                 nativePrompt = ev;
                 if (installationState === "accepted") {
                     // If this event is triggered with the installationState stored, it means that the app has been


### PR DESCRIPTION
It is not necessary useful to prevent the event in our case, so we can just stop doing it while maintaining the same functionality.

Preventing the event writes a log in the console, and we prefer to avoid having a log if we can keep the service without it.
