### PR TITLE
[FIX] web: stop preventDefaulting the beforeinstallprompt event

### DIFF
--- a/addons/web/static/src/core/pwa/pwa_service.js
+++ b/addons/web/static/src/core/pwa/pwa_service.js
@@ -24,7 +24,6 @@ let REGISTER_BEFOREINSTALLPROMPT_EVENT;
 browser.addEventListener("beforeinstallprompt", (ev) => {
     // This event is only triggered by the browser when the native prompt to install can be shown
     // This excludes incognito tabs, as well as visiting the website while the app is installed
-    ev.preventDefault();
     if (REGISTER_BEFOREINSTALLPROMPT_EVENT) {
         // service has been started before the event was triggered, update the service
         return REGISTER_BEFOREINSTALLPROMPT_EVENT(ev);


### PR DESCRIPTION
It is not necessary useful to prevent the event in our case, so we can just stop doing it while maintaining the same functionality.

Preventing the event writes a log in the console, and we prefer to avoid having a log if we can keep the service without it.

->Will be fw-ported from 17.0
