### PR TITLE
[IMP] im_livechat: auto-open chat window on new message

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -8,7 +8,9 @@ patch(Thread.prototype, {
         super.setup();
         this.operator = Record.one("Persona");
     },
-
+    get autoOpenChatWindowOnNewMessage() {
+        return this.channel_type === "livechat" || super.autoOpenChatWindowOnNewMessage;
+    },
     get typesAllowingCalls() {
         return super.typesAllowingCalls.concat(["livechat"]);
     },

--- a/addons/im_livechat/static/tests/embed/unread_messages.test.js
+++ b/addons/im_livechat/static/tests/embed/unread_messages.test.js
@@ -75,7 +75,7 @@ test("new message from operator displays unread counter", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-ChatBubble-counter", { text: "1" });
+    await contains(".o-mail-ChatWindow-counter", { text: "1" });
 });
 
 test.tags("focus required")("focus on unread livechat marks it as read", async () => {

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -49,13 +49,25 @@ patch(Thread.prototype, {
                             message.recipients?.includes(this.store.self)))))
         ) {
             if (this.model === "discuss.channel") {
-                const chatWindow = this.store.ChatWindow.get({ thread: this });
+                let chatWindow = this.store.ChatWindow.get({ thread: this });
                 if (!chatWindow) {
-                    this.store.ChatWindow.insert({ thread: this }).fold();
+                    chatWindow = this.store.ChatWindow.insert({ thread: this });
+                    if (
+                        this.autoOpenChatWindowOnNewMessage &&
+                        !this.store.discuss.isActive &&
+                        this.store.chatHub.opened.length < this.store.chatHub.maxOpened
+                    ) {
+                        chatWindow.open();
+                    } else {
+                        chatWindow.fold();
+                    }
                 }
             }
             this.store.env.services["mail.out_of_focus"].notify(message, this);
         }
+    },
+    get autoOpenChatWindowOnNewMessage() {
+        return false;
     },
     /** @param {boolean} pushState */
     setAsDiscussThread(pushState) {


### PR DESCRIPTION
Currently, when receiving a new message, it opens a new chat bubble, i.e. a chat window that is folded on the right.

This is the preferred behaviour for most users. For livechat operators, however, they want to reply to visitors questions as quickly as possible. Therefore having the chat window open automatically on receiving new messages is quite useful for them.

This PR adds automatically opening of chat window on receiving new messages for livechat conversations. All other conversations are still open as chat bubble, as this is the preferred showing for all other users that want to know there are new messages without being disturbed while using Odoo web client.

Task-4354021

https://github.com/odoo/enterprise/pull/74468