### PR TITLE
[FIX] web: correct tooltip display for descriptions

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.js
@@ -36,6 +36,11 @@ export class CalendarCommonPopover extends Component {
         } else {
             format = formattersRegistry.get(field.type);
         }
+        if (field.type === "html") {
+            const snippetsDocument = new DOMParser().parseFromString(record.data[fieldName], 'text/html');
+            const rawText = snippetsDocument.body.textContent;
+            return format(rawText);
+        }
         return format(record.data[fieldName]);
     }
 


### PR DESCRIPTION
Version:
- 16.0

steps to reproduce:
- Create a calendar event with a description.
- Hover over the description field in the calendar view.

Issue:
- The tooltip displays raw HTML instead of the actual description.

Cause:
- HTML content is not being rendered correctly in the tooltip.

solution:
- Ensure the HTML field data is displayed in the correct format.

opw-4356581
