### PR TITLE
[FIX] certificate: Fix wrong method call

### DIFF
--- a/addons/certificate/models/certificate.py
+++ b/addons/certificate/models/certificate.py
@@ -291,7 +291,7 @@ class Certificate(models.Model):
             return (self.public_key_id or self.private_key_id)._get_public_key_numbers_bytes(formatting=formatting)
 
         # When no keys are set to the certificate, use the self-contained public key from the content
-        return self.env['certificate.key']._get_public_key_numbers_bytes_with_key(
+        return self.env['certificate.key']._numbers_public_key_bytes_with_key(
             self._get_public_key_bytes(encoding='pem'),
             formatting=formatting,
         )


### PR DESCRIPTION
`[certificate.certificate]._get_public_key_numbers_bytes` currently calls `[certificate.key]._get_public_key_numbers_bytes_with_key` if no keys are set in the certificate object.
However, this method does not actually exists and is actually named `[certificate.key]._numbers_public_key_bytes_with_key`.

This commit simply, renames the call correctly.

opw-4355675

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
