### PR TITLE
[FIX] mail: escape closes chatwindow instead of reaction menu

### DIFF
--- a/addons/mail/static/src/core/common/message_reaction_list.js
+++ b/addons/mail/static/src/core/common/message_reaction_list.js
@@ -17,9 +17,11 @@ export class MessageReactionList extends Component {
         this.loadEmoji = loadEmoji;
         this.store = useState(useService("mail.store"));
         this.ui = useService("ui");
+        this.preview = useDropdownState();
         this.hover = useHover(["reactionButton", "reactionList*"], {
             onHover: () => (this.preview.isOpen = true),
             onAway: () => (this.preview.isOpen = false),
+            stateObserver: () => [this.preview?.isOpen],
         });
         this.state = useState({ emojiLoaded: Boolean(loader.loaded) });
         if (!loader.loaded) {
@@ -27,15 +29,12 @@ export class MessageReactionList extends Component {
         }
         onMounted(() => void this.state.emojiLoaded);
         onPatched(() => void this.state.emojiLoaded);
-        this.preview = useDropdownState();
     }
 
     /** @param {import("models").MessageReactions} reaction */
     previewText(reaction) {
         const { count, content: emoji } = reaction;
-        const personNames = reaction.personas
-              .slice(0, 3)
-              .map(persona => persona.name);
+        const personNames = reaction.personas.slice(0, 3).map((persona) => persona.name);
         const shortcode = loader.loaded?.emojiValueToShortcode?.[emoji] ?? "?";
         switch (count) {
             case 1:
@@ -97,5 +96,10 @@ export class MessageReactionList extends Component {
             ev.preventDefault();
             this.props.openReactionMenu();
         }
+    }
+
+    onClickReactionList(reaction) {
+        this.preview.isOpen = false; // closes dropdown immediately as to not recover focus after dropdown closes
+        this.props.openReactionMenu(reaction);
     }
 }

--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -22,7 +22,7 @@
     </t>
     
     <t t-name="mail.MessageReactionList.preview">
-        <div class="o-mail-MessageReactionList-preview px-0 py-1 border cursor-pointer d-flex" t-on-click="(ev) => this.props.openReactionMenu(props.reaction)" t-ref="reactionList">
+        <div class="o-mail-MessageReactionList-preview px-0 py-1 border cursor-pointer d-flex" t-on-click="(ev) => this.onClickReactionList(props.reaction)" t-ref="reactionList">
             <div class="d-flex align-items-center mx-2 gap-2">
                 <span class="fs-1" t-esc="props.reaction.content"/>
                 <span class="o-mail-MessageReactionList-previewText small me-1" t-esc="previewText(props.reaction)"/>


### PR DESCRIPTION
Before this commit, when opening message reaction menu in a chat window, clicking on ESC was closing the chat window.

Steps to reproduce:
- as Mitchell Admin, open a chat window of channel General from click on messaging menu in systray
- add an emoji reaction to the last message
- click on composer to have focus on it
- mouse hover the reaction then click on emoji reaction tooltip
- press ESC when the message reaction menu is open

=> it closes the chat window instead of message reaction menu.

This happens because when opening the message reaction menu, the dialog is mounted. It detects dropdown is closed after a delay, and when closing the dropdown it recovers the focus before the opening of dropdown, which could be the composer of chat window. In the case when the focus was on composer, pressing ESC on message reaction menu will close the chat window due to composer being focused.

This commit fixes the issue by immediately setting the dropdown state to close when clicking to open message reaction menu, so that it won't recover the old focused element such as the composer.

---------

This commit also fixes a related minor bug when closing the message reaction menu then hovering the reaction was not showing the dropdown/tooltip of reaction. This happens because the `useHover()` hook was not aware the click on dropdown content closes the hovered ref, thus it kept internally thinking the item is hovered so it wasn't updating UI to open dropdown or reaction.

This is fixed by adding a parameter `stateObserver` to help the `useHover()` hook to re-check whether the targets are present on UI. Thanks to this, it can detect whether the currently hovered target has been removed, thus invoking the behaviour to mark is as no longer hovered.

task-4351992

Before
![before](https://github.com/user-attachments/assets/de6c8dc2-6c96-4399-8ec0-81d81cbd2dd7)

After
![after](https://github.com/user-attachments/assets/26607676-1210-4e1e-9968-ab7274c83159)
