### PR TITLE
[FIX] hr_holidays: allow search on name

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -4,6 +4,7 @@ from odoo import api, fields, models, tools, SUPERUSER_ID
 
 from odoo.addons.base.models.res_partner import _tz_get
 
+from odoo.osv import expression
 
 class LeaveReportCalendar(models.Model):
     _name = "hr.leave.report.calendar"
@@ -11,7 +12,7 @@ class LeaveReportCalendar(models.Model):
     _auto = False
     _order = "start_datetime DESC, employee_id"
 
-    name = fields.Char(string='Name', readonly=True, compute="_compute_name")
+    name = fields.Char(string='Name', readonly=True, compute="_compute_name", search="_search_name")
     start_datetime = fields.Datetime(string='From', readonly=True)
     stop_datetime = fields.Datetime(string='To', readonly=True)
     tz = fields.Selection(_tz_get, string="Timezone", readonly=True)
@@ -94,12 +95,19 @@ class LeaveReportCalendar(models.Model):
     def _compute_name(self):
         for leave in self:
             leave.name = leave.employee_id.name
-            if self.env.user.has_group('hr_holidays.group_hr_holidays_manager') or self.env.user.has_group('hr_holidays.group_hr_holidays_user'):
+            if self.env.user.has_group('hr_holidays.group_hr_holidays_user'):
                 # Include the time off type name
                 leave.name += f" {leave.leave_id.holiday_status_id.name}"
             # Include the time off duration.
             leave.name += f": {leave.sudo().leave_id.duration_display}"
 
+    def _search_name(self, operator, value):
+        query = self.env['hr.leave'].sudo()._search([('duration_display', operator, value)])
+        domain = ['|', ('employee_id.name', operator, value), ('leave_id', 'in', query)]
+        if self.env.user.has_group('hr_holidays.group_hr_holidays_user'):
+            domain = expression.OR([domain , [('leave_id.holiday_status_id.name', operator, value)]])
+        return domain
+    
     @api.depends('leave_manager_id')
     def _compute_is_manager(self):
         for leave in self:

--- a/addons/hr_holidays/tests/test_holidays_calendar.py
+++ b/addons/hr_holidays/tests/test_holidays_calendar.py
@@ -40,3 +40,47 @@ class TestHolidaysCalendar(HttpCase, TestHrHolidaysCommon):
         self.assertEqual(last_leave.date_from.weekday(), 3, "It should be Thursday")
         self.assertEqual(last_leave.date_from.hour, expected_leave_start, "Wrong start of the day")
         self.assertEqual(last_leave.date_to.hour, expected_leave_end, "Wrong end of the day")
+
+    def test_search_holidays_calendar(self):
+        """
+        Test the search functionality of the holidays calendar.
+
+        Verifies that the search results match expected outcomes for different
+        search terms and user roles, considering user access rights.
+        """
+        david = self.employee_emp
+        holiday_status_sick = self.env.ref('hr_holidays.holiday_status_sl')
+        holiday_status_3_days = self.env.ref('hr_holidays.holiday_status_cl')
+
+        self.env['hr.leave'].create({
+            'name': '3 days Off',
+            'employee_id': david.id,
+            'holiday_status_id': holiday_status_3_days.id,
+            'request_date_from': date.today(),
+            'request_date_to': date.today() + timedelta(days=2),
+        })
+        self.env['hr.leave'].create({
+            'name': 'Sick Ronnie',
+            'employee_id': david.id,
+            'holiday_status_id': holiday_status_sick.id,
+            'request_date_from': date.today() + timedelta(days=3),
+            'request_date_to': date.today() + timedelta(days=5),
+        })
+
+        search_cases = [
+            ('3 days', [True, True, True]),
+            ('Sick', [False, True, True]),
+            ('David', [True, True, True]),
+        ]
+        users = [self.user_employee, self.user_hrmanager, self.user_hruser]
+
+        for term, expected_results in search_cases:
+            for user, expected in zip(users, expected_results):
+                records = self.env['hr.leave.report.calendar'].search(
+                    self.env['hr.leave.report.calendar'].with_user(user)._search_name('ilike', term)
+                )
+                self.assertEqual(
+                    bool(records), 
+                    expected, 
+                    f"Failed for term '{term}' with user {user.login}. Expected {expected}, got {bool(records)}."
+                )


### PR DESCRIPTION
Steps to reproduce:

 - Go in time off app -> overview
 - Search on name

Issue:

When searching on name, the search does not work. This is due to the
name being computed and not stored. Directly related to the [recent
changes](https://github.com/odoo/odoo/commit/7a65a1b6ac34f214)

Fix

The field has now a search method on the different component of the name
separetly.

opw-4351362

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
