### PR TITLE
[FIX] mrp: prevent an error when split a backorder of MO's

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1843,7 +1843,7 @@ class MrpProduction(models.Model):
             # Adapt quantities produced
             for workorder in production.workorder_ids:
                 initial_workorder_remaining_qty.append(max(initial_qty - workorder.qty_reported_from_previous_wo - workorder.qty_produced, 0))
-                if workorder.production_id.id not in self.env.context.get('mo_ids_to_backorder', []):
+                if workorder.production_id.id not in (self.env.context.get('mo_ids_to_backorder') or []):
                     workorder.qty_produced = min(workorder.qty_produced, workorder.qty_production)
             workorders_len = len(production.workorder_ids)
             for index, workorder in enumerate(bo.workorder_ids):


### PR DESCRIPTION
Currently, an error occurs when splitting a backorder of MO's.

Step to produce:

- Install the 'mrp' module.
- Enable work orders in the settings.
- Create a BOM for a product P with an operation: - OP1: Assembly line 1, duration 10 minutes.
- Create and confirm an MO for 5 units of P.
- Add a Work Center and Operation in the work order line.
- Set a producing quantity of 2.
- Validate the MO and create a backorder.
- Open a backorder of MO, Select a backorder that is in a confirmed state.
- Click on the 'Action' button to split a backorder into two productions.

See Traceback:

```
TypeError: argument of type 'NoneType' is not iterable
  File "odoo/http.py", line 2363, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1891, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1954, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1921, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2168, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 329, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 727, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 40, in call_button
    action = call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 517, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/mrp/wizard/mrp_batch_produce.py", line 59, in action_done
    return self._production_text_to_object(mark_done=True)
  File "addons/mrp/wizard/mrp_batch_produce.py", line 90, in _production_text_to_object
    productions = self.production_id._split_productions({self.production_id: productions_amount})
  File "home/odoo/src/enterprise/18.0/mrp_workorder/models/mrp_production.py", line 87, in _split_productions
    productions = super()._split_productions(amounts=amounts, cancel_remaining_qty=cancel_remaining_qty, set_consumed_qty=set_consumed_qty)
  File "addons/mrp/models/mrp_production.py", line 1996, in _split_productions
    if workorder.production_id.id not in self.env.context.get('mo_ids_to_backorder', []):

```

An error occurs because the system retrieves a None value for 'mo_ids_to_backorder' from the context at [1], which is not iterable. This causes issues as an iterable value is expected.

Link [1]: https://github.com/odoo/odoo/blob/99e2b13416256a0a23a1a619b92873bcfe15b8a9/addons/mrp/models/mrp_production.py#L1846

To resolve this issue, provide an empty list
for 'mo_ids_to_backorder' if the retrieved value is None instead of an iterable.

Sentry-6080156727

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
