### PR TITLE
[FIX] pos_loyalty: fix program selection

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -16,8 +16,9 @@ const COUPON_CACHE_MAX_SIZE = 4096; // Maximum coupon cache size, prevents long 
 patch(PosStore.prototype, {
     async addProductFromUi(product, options) {
         const order = this.get_order();
-        const linkedPrograms =
-            this.models["loyalty.program"].getBy("trigger_product_ids", product.id) || [];
+        const linkedPrograms = (
+            this.models["loyalty.program"].getBy("trigger_product_ids", product.id) || []
+        ).filter((p) => ["gift_card", "ewallet"].includes(p.program_type));
         let selectedProgram = null;
         if (linkedPrograms.length > 1) {
             selectedProgram = await makeAwaitable(this.dialog, SelectionPopup, {


### PR DESCRIPTION
When clicking on a product that is linked to multiple loyalty programs you are prompted to select one of them everytime you add one item via the ui.

Steps to reproduce:
-------------------
* Create 2 loyalty programs activated when buying a certain product
* Open PoS and click on the product
> Observation: You will get a prompt everytime you click on the product

Why the fix:
------------
The variable `selected_program` is actually only usefull if the program selected is gift card or an eWallet program. So we filter it before and only prompt when the output will be usefull.

opw-4187037