### PR TITLE
[FIX] mail: text cropped in call settings

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/call_settings.xml
@@ -37,7 +37,7 @@
             </div>
             <div class="d-flex flex-column">
                 <t t-if="!store.settings.use_push_to_talk">
-                    <span class="me-2 my-1 text-truncate text-wrap">Voice detection sensitivity</span>
+                    <span class="me-2 my-1">Voice detection sensitivity</span>
                     <div class="d-flex align-items-center w-100 h-100">
                         <button class="btn btn-primary" t-on-click="microphoneVolume.toggle" t-att-disabled="!microphoneVolume.isReady">
                             <div class="position-relative">


### PR DESCRIPTION
Before this commit, the "Voice detection sensitivity" text in the call settings was cropped.

This happens because of the `text-truncate` class of the span. This commit fixes the issue by removing said class.

Also removed redundant `text-wrap` class as wrap is default value.

Before
![image](https://github.com/user-attachments/assets/7719155b-e9a5-42b8-9d17-dd456f4dba38)

After:
![image](https://github.com/user-attachments/assets/d04fa390-21f3-4169-84d5-b42d624726cc)

task-4354608
