### PR TITLE
[FIX] web: DomainSelector: shorten descriptions of long lists

### DIFF
--- a/addons/web/static/src/core/tree_editor/utils.js
+++ b/addons/web/static/src/core/tree_editor/utils.js
@@ -90,9 +90,9 @@ export function leafToString(tree, fieldDef, displayNames) {
     }
 
     const dis = disambiguate(value, displayNames);
-    const values = (Array.isArray(value) ? value : [value]).map((val) =>
-        formatValue(val, dis, fieldDef, displayNames)
-    );
+    const values = (Array.isArray(value) ? value : [value])
+        .slice(0, 21)
+        .map((val, index) => (index < 20 ? formatValue(val, dis, fieldDef, displayNames) : "..."));
     let join;
     let addParenthesis = Array.isArray(value);
     switch (operator) {

--- a/addons/web/static/tests/core/domain_selector_tests.js
+++ b/addons/web/static/tests/core/domain_selector_tests.js
@@ -2239,4 +2239,16 @@ QUnit.module("Components", (hooks) => {
             `Dateis between03|11|2023 and 13|11|2023`
         );
     });
+
+    QUnit.test("shorten descriptions of long lists", async (assert) => {
+        const values = new Array(500).fill(42525245);
+        await makeDomainSelector({
+            domain: `[("id", "in", [${values}])]`,
+            readonly: true,
+        });
+        assert.strictEqual(
+            target.querySelector(".o_tree_editor_condition").textContent,
+            `IDis in( ${values.slice(0, 20).join(" , ")} , ... )`
+        );
+    });
 });


### PR DESCRIPTION
When adding a custom filter, we can produce a domain of the form

["id", "in", [
    1415T215,
    1545481,
    ...
]]

with a very long list of ids. In this commit we make the domain description contain only the 20 first ids of the list. If we don't do that we obtain a (unscrollable) search bar facet that is not fully visible when confirming the domain.