### PR TITLE
[FIX] stock: fix traceback when user creates a new replenishment record

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -353,6 +353,8 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _get_qty_to_order(self, force_visibility_days=False, qty_in_progress_by_orderpoint={}):
         self.ensure_one()
+        if not self.product_id or not self.location_id:
+            return False
         visibility_days = self.visibility_days
         if force_visibility_days is not False:
             # Accepts falsy values such as 0.


### PR DESCRIPTION
Currently, a traceback occurs when the user tries to create a new stock replenishment record.

To reproduce this issue:

1) Install `stock`
2) Create a new record from `operation/replenishment`

Error:- 
```
AssertionError: precision_rounding must be positive, got 0.0
```

This error is occurring because of the recent refactoring from the below commit.
https://github.com/odoo/odoo/pull/183833/commits/17d9af14cad0bace48edf2d1b072cc4d12532875

Initially, there was a condition that if there is no product or location, the `_get_qty_to_order` method simply returns False.

But because the condition was removed from the above mentioned commit, we get the rounding value as 0.0 as there is no uom when initially creating a new record.

This leads to the above traceback when the below line executes with rounding as 0.0

https://github.com/odoo/odoo/blob/74d4503a45c9d4ca741d349c3fce673358d2cc42/addons/stock/models/stock_orderpoint.py#L361-L364

We can resolve either by returning False if there is no product/uom or 
just add an extra check of rounding.

sentry-6088943207
