### PR TITLE
[FIX] website_project: don't track partner_phone field in task

### DIFF
--- a/addons/website_project/models/project_task.py
+++ b/addons/website_project/models/project_task.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields
+from odoo import api, models, fields
 
 
 class ProjectTask(models.Model):
@@ -10,5 +10,20 @@ class ProjectTask(models.Model):
     email_from = fields.Char('Email From')
     # Used to submit tasks from a contact form
     partner_name = fields.Char(string='Customer Name', related="partner_id.name", store=True, readonly=False, tracking=False)
-    partner_phone = fields.Char(string='Customer Phone', related="partner_id.phone", store=True, readonly=False)
-    partner_company_name = fields.Char(string='Company Name', related="partner_id.company_name", store=True, readonly=False)
+    partner_phone = fields.Char(
+        compute='_compute_partner_phone', inverse='_inverse_partner_phone',
+        string="Contact Number", readonly=False, store=True, copy=False)
+    partner_company_name = fields.Char(string='Company Name', related="partner_id.company_name", store=True, readonly=False, tracking=False)
+
+    @api.depends('partner_id.phone', 'partner_id.mobile')
+    def _compute_partner_phone(self):
+        for task in self:
+            task.partner_phone = task.partner_id.mobile or task.partner_id.phone or False
+
+    def _inverse_partner_phone(self):
+        for task in self:
+            if task.partner_id:
+                if task.partner_id.mobile or not task.partner_id.phone:
+                    task.partner_id.mobile = task.partner_phone
+                else:
+                    task.partner_id.phone = task.partner_phone


### PR DESCRIPTION
Before this commit, the partner_phone field in `project.task` model is tracked because it is a related field linked to `partner_id.phone` and `phone` is tracked. Moreover, that field is also defined in `industry_fsm` module but its definition is different which could lead to unexpected behavior depending on the installation order.

This commit duplicates the definition of that field from industry_fsm to website_project to make sure to not have a different behavior depending on the installation order of those modules. It also removes the tracking on `partner_company_name` since it is not really useful in task if one day `company_name` in `res.partner` model is tracked.