### PR TITLE
[FIX] l10n_latam_check: existing third party check outgoing payment method.

### DIFF
--- a/addons/l10n_latam_check/models/account_journal.py
+++ b/addons/l10n_latam_check/models/account_journal.py
@@ -10,8 +10,6 @@ class AccountJournal(models.Model):
             return res
         if self._is_payment_method_available('own_checks'):
             res |= self.env.ref('l10n_latam_check.account_payment_method_own_checks')
-        if self._is_payment_method_available('out_third_party_checks'):
-            res |= self.env.ref('l10n_latam_check.account_payment_method_out_third_party_checks')
         if self._is_payment_method_available('return_third_party_checks'):
             res |= self.env.ref('l10n_latam_check.account_payment_method_return_third_party_checks')
         return res

--- a/addons/l10n_latam_check/models/account_payment_method.py
+++ b/addons/l10n_latam_check/models/account_payment_method.py
@@ -9,7 +9,6 @@ class AccountPaymentMethod(models.Model):
         res = super()._get_payment_method_information()
         res['new_third_party_checks'] = {'mode': 'multi', 'type': ('cash',)}
         res['in_third_party_checks'] = {'mode': 'multi', 'type': ('cash',)}
-        res['out_third_party_checks'] = {'mode': 'multi', 'type': ('cash',)}
         res['return_third_party_checks'] = {'mode': 'multi', 'type': ('bank',)}
         res['own_checks'] = {'mode': 'multi', 'type': ('bank',)}
         return res


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:
It is necessay not to set "Existing Third Party Checks" outgoing payment method in all argentinean cash journals. It is only needed to be set on "Third Party Checks" and "Rejected Third Party Checks" Argentinean journals that are created when the module is installed or a new argentinean company is created.

**Current behavior before PR**:
"Existing Third Party Checks" outgoing payment method is set in all argentinean cash journals.

**Desired behavior after PR is merged**:
"Existing Third Party Checks" outgoing payment method is set only in "Third Party Checks" and "Rejected Third Party Checks" argentinean journals.

_Ticket Adhoc side_: 83443
_Task Latam side_: 1293

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
