### PR TITLE
[FIX] mail: no border around logged note

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -69,7 +69,7 @@
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="false"/>
                                         <t t-else="">
                                             <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
-                                                <div class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
+                                                <div t-if="message.bubbleColor" class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
                                                     'o-blue': message.bubbleColor === 'blue',
                                                     'o-green': message.bubbleColor === 'green',
                                                     'o-orange': message.bubbleColor === 'orange',

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -101,14 +101,14 @@ test("Message post in chat window of chatter should log a note", async () => {
     await contains(".o-mail-ChatWindow");
     await contains(".o-mail-Message", {
         text: "A needaction message to have it in messaging menu",
-        contains: [".o-mail-Message-bubble.o-blue"], // colored bubble = "Send message" mode
+        contains: [".o-mail-Message-bubble"], // bubble = "Send message" mode
     });
     await contains(".o-mail-Composer [placeholder='Log an internal note…']");
     await insertText(".o-mail-ChatWindow .o-mail-Composer-input", "Test");
     triggerHotkey("control+Enter");
     await contains(".o-mail-Message", {
         text: "Test",
-        contains: [".o-mail-Message-bubble:not(.o-blue)"], // non-colored bubble = "Log note" mode
+        contains: [".o-mail-Message-bubble", { count: 0 }], // no bubble = "Log note" mode
     });
 });
 


### PR DESCRIPTION
Before / After
<img width="254" alt="Screenshot 2024-11-25 at 14 23 16" src="https://github.com/user-attachments/assets/0ea6235e-ad18-4001-8c6c-31860e5d0371"> <img width="268" alt="Screenshot 2024-11-25 at 14 23 00" src="https://github.com/user-attachments/assets/efb3a21b-ce6c-4999-9aea-e67e52332011">
