### PR TITLE
[IMP] html_editor, website_sale: first breadcrumb is editable in product pages

### DIFF
--- a/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
@@ -34,6 +34,21 @@ class ProductPageOptionPlugin extends Plugin {
             ProductRemoveAllExtraImagesAction,
         },
         clean_for_save_handlers: ({ root: el }) => {
+            // TODO the content of this clean_for_save_handlers should probably
+            // be a generic thing for the whole editor.
+
+            // Make sure that if the user removes the whole text of the
+            // breadcrumb, it is restored to the default value.
+            if (
+                // TODO the "placeholder" feature should be reviewed, this is
+                // not a valid HTML attribute.
+                el.getAttribute("placeholder")
+                && el.hasAttribute("data-oe-zws-empty-inline")
+                && /^[\s\u200b]*$/.test(el.textContent)
+            ) {
+                el.textContent = el.getAttribute("placeholder");
+            }
+
             const mainEl = el.querySelector(productPageSelector);
             if (!mainEl) {
                 return;

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1895,8 +1895,10 @@
                     <div class="d-flex flex-wrap align-items-center">
                         <div class="d-flex align-items-center flex-grow-1 mb-4 m-lg-0">
                             <ol class="o_wsale_breadcrumb breadcrumb m-0 p-0">
-                                <li class="o_not_editable breadcrumb-item d-none d-lg-inline-block">
-                                    <a t-att-href="keep(shop_path)">All Products</a>
+                                <li class="breadcrumb-item d-none d-lg-inline-block">
+                                    <a t-att-href="keep(shop_path)">
+                                        <t t-call="website_sale.all_products_link_name"/>
+                                    </a>
                                 </li>
                                 <t t-foreach="category.parents_and_self" t-as="cat">
                                     <li
@@ -1920,7 +1922,9 @@
                                 </li>
                                 <li class="breadcrumb-item d-lg-none">
                                     <a t-att-href="category and keep('%s/category/%s' % (shop_path, slug(cat))) or keep(shop_path)">
-                                        <i class="oi oi-chevron-left me-2" role="img"/><t t-out="category.name or 'All Products'"/>
+                                        <i class="oi oi-chevron-left me-2" role="img"/>
+                                        <t t-if="category.name" t-out="category.name"/>
+                                        <t t-else="" t-call="website_sale.all_products_link_name"/>
                                     </a>
                                 </li>
                             </ol>
@@ -2290,6 +2294,10 @@
         <xpath expr="//a[contains(@t-attf-class, 'o_wsale_product_search_mobile_btn')]" position="attributes">
             <attribute name="t-attf-class" add="d-md-none" remove="d-none" separator=" "/>
         </xpath>
+    </template>
+
+    <template id="all_products_link_name" name="All Products name">
+        <span placeholder="All products">All products</span>
     </template>
 
     <template id="product_accordion" name="Accordion On Product Page">


### PR DESCRIPTION
Before the change in the product and blog pages the first breadcrumb
was an hardcoded "All products" string that could not be edited by users.
After the change the first breadcrumb can be renamed freely and the
new name shows up on every product page.

task-4351506
