### PR TITLE
[FIX] html_editor: properly handle `ctrl+click` and link preview in editor

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -189,6 +189,9 @@ export class LinkPlugin extends Plugin {
         this.overlay = this.dependencies.overlay.createOverlay(LinkPopover, {}, { sequence: 50 });
         this.addDomListener(this.editable, "click", (ev) => {
             if (ev.target.tagName === "A" && ev.target.isContentEditable) {
+                if (ev.ctrlKey || ev.metaKey) {
+                    window.open(ev.target.href, "_blank");
+                }
                 ev.preventDefault();
                 this.toggleLinkTools({ link: ev.target });
             }

--- a/addons/html_editor/tests/test_controller.py
+++ b/addons/html_editor/tests/test_controller.py
@@ -205,3 +205,30 @@ class TestController(HttpCase):
         )
         self.assertEqual(200, response_not_record.status_code)
         self.assertTrue('other_error_msg' in response_not_record.text)
+
+        # Attempt to retrieve metadata for path format `odoo/<model>/<record_id>`
+        response_model_record = self.url_open(
+            '/html_editor/link_preview_internal',
+            data=json_safe.dumps({
+                "params": {
+                    "preview_url": f"/odoo/res.users/{self.portal_user.id}",
+                }
+            }),
+            headers=self.headers
+        )
+        self.assertEqual(200, response_model_record.status_code)
+        self.assertTrue('display_name' in response_model_record.text)
+        self.assertIn(self.portal_user.display_name, response_model_record.text)
+
+        # Attempt to retrieve metadata for an abstract model
+        response_abstract_model = self.url_open(
+            '/html_editor/link_preview_internal',
+            data=json_safe.dumps({
+                "params": {
+                    "preview_url": "/odoo/mail.thread/1",
+                }
+            }),
+            headers=self.headers
+        )
+        self.assertEqual(200, response_abstract_model.status_code)
+        self.assertTrue('error_msg' in response_abstract_model.text)


### PR DESCRIPTION
**Problem**:
1. `Ctrl+click` on a link in the editor does not open the link in a new tab.
2. Internal links with the format `odoo/<model>/<record_id>` do not display a proper preview. Instead, a warning toaster appears: _"Action `<model>` not found, link preview is not available. Please check your URL is correct."_

**Solution**:
1. Implement the same code as version 17.0 to handle `ctrl+click` for opening links in a new tab: https://github.com/odoo/odoo/commit/981290ee9c88ea00440268d2a7b829d3a601a2d2
2. For internal links (`odoo/<model>/<record_id>`), validate the `action_name` as a model name. If valid, treat `action_name` as the model name for the link preview.

**Steps to reproduce**:
1. Open the editor.
2. Add a link with the path `odoo/project.task/59`.
3. Try `Ctrl+click`:
   - **Issue**: The link does not open in a new tab.
4. Observe the warning toaster: _"Action project.task not found, link preview is not available. Please check your URL is correct."_

opw-4353235

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
