### PR TITLE
[IMP] website_event: recaptcha on new registrations form

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -278,6 +278,7 @@ class WebsiteEventController(http.Controller):
         :param form_details: posted data from frontend registration form, like
             {'1-name': 'r', '1-email': 'r@r.com', '1-phone': '', '1-event_ticket_id': '1'}
         """
+        form_details.pop("recaptcha_token_response", None)
         allowed_fields = request.env['event.registration']._get_website_registration_allowed_fields()
         registration_fields = {key: v for key, v in request.env['event.registration']._fields.items() if key in allowed_fields}
         for ticket_id in list(filter(lambda x: x is not None, [form_details[field] if 'event_ticket_id' in field else None for field in form_details.keys()])):
@@ -373,6 +374,8 @@ class WebsiteEventController(http.Controller):
             that we have enough seats for all selected tickets.
             If we don't, the user is instead redirected to page to register with a
             formatted error message. """
+        if not request.env['ir.http']._verify_request_recaptcha_token('website_event_registration'):
+            return request.redirect('/event/%s/register?registration_error_code=recaptcha_failed' % event.id)
         registrations_data = self._process_attendees_form(event, post)
         registration_tickets = Counter(registration['event_ticket_id'] for registration in registrations_data)
         event_tickets = request.env['event.event.ticket'].browse(list(registration_tickets.keys()))

--- a/addons/website_event/i18n/website_event.pot
+++ b/addons/website_event/i18n/website_event.pot
@@ -557,6 +557,12 @@ msgid "Download Tickets <i class=\"ms-1 fa fa-download\"/>"
 msgstr ""
 
 #. module: website_event
+#. odoo-javascript
+#: code:addons/website_event/static/src/js/website_event.js:0
+msgid "Error"
+msgstr ""
+
+#. module: website_event
 #: model:ir.model,name:website_event.model_event_event
 #: model:ir.model.fields,field_description:website_event.field_website_event_menu__event_id
 msgid "Event"
@@ -1096,6 +1102,11 @@ msgstr ""
 #. module: website_event
 #: model_terms:ir.ui.view,arch_db:website_event.registration_complete
 msgid "Registration confirmed!"
+msgstr ""
+
+#. module: website_event
+#: model_terms:ir.ui.view,arch_db:website_event.registration_template
+msgid "Registration failed! Suspicious activity detected by Google reCaptcha."
 msgstr ""
 
 #. module: website_event

--- a/addons/website_event/static/src/js/website_event.js
+++ b/addons/website_event/static/src/js/website_event.js
@@ -1,8 +1,27 @@
 import publicWidget from "@web/legacy/js/public/public_widget";
+import { _t } from "@web/core/l10n/translation";
+import { ReCaptcha } from "@google_recaptcha/js/recaptcha";
 import { rpc } from "@web/core/network/rpc";
 
 // Catch registration form event, because of JS for attendee details
 var EventRegistrationForm = publicWidget.Widget.extend({
+
+    /**
+     * @constructor
+     */
+    init: function () {
+        this._super(...arguments);
+        this._recaptcha = new ReCaptcha();
+        this.notification = this.bindService("notification");
+    },
+
+    /**
+     * @override
+     */
+    willStart: async function () {
+        this._recaptcha.loadLibs();
+        return this._super(...arguments);
+    },
 
     /**
      * @override
@@ -42,29 +61,47 @@ var EventRegistrationForm = publicWidget.Widget.extend({
      * @private
      * @param {Event} ev
      */
-    _onClick(ev) {
+    async _onClick(ev) {
         ev.preventDefault();
         ev.stopPropagation();
         const formEl = ev.currentTarget.closest("form");
         const buttonEl = ev.currentTarget.closest("[type='submit']");
         const post = this._getPost();
         buttonEl.disabled = true;
-        return rpc(formEl.action, post).then((modal) => {
-            const modalEl = new DOMParser().parseFromString(modal, "text/html").body.firstChild;
-            const _onClick = () => {
-                buttonEl.disabled = false;
-                modalEl.querySelector(".js_goto_event").removeEventListener("click", _onClick);
-                modalEl.querySelector(".btn-close").removeEventListener("click", _onClick);
-                modalEl.remove();
-            };
-            modalEl.querySelector(".js_goto_event").addEventListener("click", _onClick);
-            modalEl.querySelector(".btn-close").addEventListener("click", _onClick);
-            const formModal = Modal.getOrCreateInstance(modalEl, {
-                backdrop: "static",
-                keyboard: false,
+        const [modal, recaptchaToken] = await Promise.all([
+            rpc(formEl.action, post),
+            this._recaptcha.getToken("website_event_registration"),
+        ]);
+        if (recaptchaToken.error) {
+            this.notification.add(recaptchaToken.error, {
+                type: "danger",
+                title: _t("Error"),
+                sticky: true,
             });
-            formModal.show();
+            buttonEl.disabled = false;
+            return false;
+        }
+        const modalEl = new DOMParser().parseFromString(modal, "text/html").body.firstChild;
+        const _onClick = () => {
+            buttonEl.disabled = false;
+            modalEl.querySelector(".js_goto_event").removeEventListener("click", _onClick);
+            modalEl.querySelector(".btn-close").removeEventListener("click", _onClick);
+            modalEl.remove();
+        };
+        modalEl.querySelector(".js_goto_event").addEventListener("click", _onClick);
+        modalEl.querySelector(".btn-close").addEventListener("click", _onClick);
+        modalEl.querySelector("form").addEventListener("submit", (ev) => {
+            const tokenInput = document.createElement("input");
+            tokenInput.setAttribute("name", "recaptcha_token_response");
+            tokenInput.setAttribute("type", "hidden");
+            tokenInput.setAttribute("value", recaptchaToken.token);
+            ev.currentTarget.appendChild(tokenInput);
         });
+        const formModal = Modal.getOrCreateInstance(modalEl, {
+            backdrop: "static",
+            keyboard: false,
+        });
+        formModal.show();
     },
 });
 

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -156,6 +156,9 @@
     <div t-if="registration_error_code == 'insufficient_seats'" class="alert alert-danger my-3" role="alert">
         Registration failed! These tickets are not available anymore.
     </div>
+    <div t-if="registration_error_code == 'recaptcha_failed'" class="alert alert-danger my-3" role="alert">
+        Registration failed! Suspicious activity detected by Google reCaptcha.
+    </div>
     <t t-if="not event.event_registrations_open">
         <!-- Delayed registration time -->
         <div t-if="not event.event_registrations_started and not event.event_registrations_sold_out" class="alert alert-info mb-3 small" role="status">


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

To quote [the Odoo documentation](https://www.odoo.com/documentation/16.0/applications/websites/website/configuration/recaptcha.html?highlight=recaptcha):

> All pages using the Form, Newsletter Block, Newsletter Popup snippets, and the eCommerce Extra Step During Checkout form are now protected by reCAPTCHA.
    
However, it's still possible for a bot to register itself to free events, as it doesn't have to go through the checkout process.. and cause quite a mess.

This commits adds a recaptcha to the new registrations form.

---

Superseeds:
- https://github.com/odoo/odoo/pull/186991

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
