### PR TITLE
[FIX] bus: resolve non-deterministic rate limit test

### DIFF
--- a/addons/bus/tests/test_websocket_rate_limiting.py
+++ b/addons/bus/tests/test_websocket_rate_limiting.py
@@ -22,8 +22,10 @@ class TestWebsocketRateLimiting(WebsocketCase):
         time.sleep(Websocket.RL_DELAY)
 
         for _ in range(Websocket.RL_BURST + 1):
-            ws.send(json.dumps({'event_name': 'test_rate_limiting'}))
-            time.sleep(Websocket.RL_DELAY)
+            ws.send(json.dumps({"event_name": "test_rate_limiting"}))
+            time.sleep(Websocket.RL_DELAY * 1.25)
+
+        self.assertTrue(ws.connected)
 
     def test_rate_limiting_base_ko(self):
         def check_base_ko():


### PR DESCRIPTION
The `test_rate_limiting_base_ok` ensures that rate limiting does not activate when requests are made within the accepted delay.

However, the test only waits for the exact delay duration, whereas the rate limiter expects the delay to be strictly greater than the threshold.

This PR introduces a small additional wait time before each request to ensure it falls within the accepted range. It also verifies that the WebSocket (WS) remains connected at the end of the test.

runbot-73027