### PR TITLE
[IMP] mail: chat windows larger by default

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -8,7 +8,6 @@ import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { ChatBubble } from "./chat_bubble";
-import { _t } from "@web/core/l10n/translation";
 
 export class ChatHub extends Component {
     static components = { ChatBubble, ChatWindow, Dropdown };
@@ -52,10 +51,6 @@ export class ChatHub extends Component {
         this.chatHub.onRecompute();
     }
 
-    get chatSizeTransitionText() {
-        return this.chatHub.isBig ? _t("Make chats smaller") : _t("Make chats bigger");
-    }
-
     get compactCounter() {
         let counter = 0;
         const cws = this.chatHub.opened.concat(this.chatHub.folded);
@@ -63,10 +58,6 @@ export class ChatHub extends Component {
             counter += chatWindow.thread.importantCounter > 0 ? 1 : 0;
         }
         return counter;
-    }
-
-    toggleChatSize() {
-        this.chatHub.isBig = !this.chatHub.isBig;
     }
 
     get hiddenCounter() {

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -5,7 +5,7 @@
     <div class="o-mail-ChatHub" t-if="isShown or ui.isSmall">
         <t t-if="!store.chatHub.compact">
             <t t-foreach="chatHub.opened" t-as="cw" t-key="cw.localId">
-                <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.opened.length - cw_index - 1) * ((chatHub.isBig ? chatHub.WINDOW_LARGE : chatHub.WINDOW) + chatHub.WINDOW_INBETWEEN * 2))"/>
+                <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.opened.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2))"/>
             </t>
         </t>
         <div t-if="isShown" class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto' }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
@@ -17,7 +17,6 @@
                     <Dropdown t-if="(chatHub.opened.length + chatHub.folded.length) gt 0" state="options" position="'top-end'" menuClass="'o-mail-ChatHub-optionsMenu o-mail-ChatHub-menu d-flex flex-column bg-view shadow-sm m-0 p-0 mb-1'">
                         <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-view mt-1" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
                         <t t-set-slot="content">
-                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center rounded-0 fw-normal" t-on-click="() => this.toggleChatSize()"><div class="form-check form-switch m-0 smaller" style="min-height: auto;"><input class="form-check-input" type="checkbox" role="switch" t-att-checked="this.chatHub.isBig ? 'checked' : ''" t-att-title="chatSizeTransitionText"/></div> <span>Large windows</span></button>
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash ms-1"></i>Hide all conversations</button>
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close ms-1"></i>Close all conversations</button>
                         </t>

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -9,7 +9,6 @@ export class ChatHub extends Record {
     WINDOW_GAP = 10; // for a single end, multiply by 2 for left and right together.
     WINDOW_INBETWEEN = 5;
     WINDOW = 360; // same value as $o-mail-ChatWindow-width
-    WINDOW_LARGE = 510; // same value as $o-mail-ChatWindow-widthLarge
 
     /** @returns {import("models").ChatHub} */
     static get(data) {
@@ -19,22 +18,6 @@ export class ChatHub extends Record {
     static insert(data) {
         return super.insert(...arguments);
     }
-    isBig = Record.attr(false, {
-        compute() {
-            return browser.localStorage.getItem("mail.user_setting.chat_window_big") === "true";
-        },
-        onUpdate() {
-            /** @this {import("models").ChatHub} */
-            if (this.isBig) {
-                browser.localStorage.setItem(
-                    "mail.user_setting.chat_window_big",
-                    this.isBig.toString()
-                );
-            } else {
-                browser.localStorage.removeItem("mail.user_setting.chat_window_big");
-            }
-        },
-    });
     compact = false;
     /** From left to right. Right-most will actually be folded */
     opened = Record.many("ChatWindow", {
@@ -79,9 +62,7 @@ export class ChatHub extends Record {
         const available = browser.innerWidth - startGap - endGap - chatBubblesWidth;
         const maxAmountWithoutHidden = Math.max(
             1,
-            Math.floor(
-                available / ((this.isBig ? this.WINDOW_LARGE : this.WINDOW) + this.WINDOW_INBETWEEN)
-            )
+            Math.floor(available / (this.WINDOW + this.WINDOW_INBETWEEN))
         );
         return maxAmountWithoutHidden;
     }

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -1,11 +1,6 @@
 .o-mail-ChatWindow {
-    height: 480px;
     width: $o-mail-ChatWindow-width;
-
-    &.o-large {
-        height: 680px;
-        width: $o-mail-ChatWindow-widthLarge;
-    }
+    aspect-ratio: 9 / 16;
 
     z-index: 999; // messaging menu is dropdown (1000)
     &.o-mobile {

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -8,7 +8,6 @@
         t-att-class="{
             'w-100 h-100 o-mobile': ui.isSmall,
             'rounded-top-3 border border-bottom-0 border-dark': !ui.isSmall,
-            'o-large': store.chatHub.isBig,
         }"
         t-on-keydown="onKeydown"
         tabindex="1"

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -93,11 +93,6 @@
 
     .o-mail-Composer.o-chatWindow & {
         @media (min-height: 325px) {
-            max-height: Min(350px, 70vh);
-        }
-    }
-    .o-mail-Composer.o-chatWindowBig & {
-        @media (min-height: 325px) {
             max-height: Min(550px, 70vh);
         }
     }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -16,7 +16,6 @@
                     'o-focused': props.composer.isFocused,
                     'o-editing': props.composer.message,
                     'o-chatWindow': env.inChatWindow,
-                    'o-chatWindowBig': store.chatHub.isBig,
                     'o-discussApp': env.inDiscussApp,
                 }" t-attf-class="{{ props.className }}">
             <div class="o-mail-Composer-sidebarMain flex-shrink-0" t-if="showComposerAvatar">

--- a/addons/mail/static/src/core/common/primary_variables.scss
+++ b/addons/mail/static/src/core/common/primary_variables.scss
@@ -1,7 +1,6 @@
 $o-mail-Avatar-size: 36px !default;
 $o-mail-Avatar-sizeSmall: 28px !default;
 $o-mail-ChatWindow-width: 360px !default; // same value as WINDOW
-$o-mail-ChatWindow-widthLarge: 510px !default; // same value as WINDOW_LARGE
 $o-mail-ChatHub-bubblesWidth: 56px !default; // same value as BUBBLE
 $o-mail-ChatHub-bubblesMargin: 10px !default; // same value as BUBBLE_OUTER
 $o-mail-ChatHub-bubblesStart: 15px !default; // same value as BUBBLE_START

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -5,7 +5,6 @@ import {
     contains,
     defineMailModels,
     focus,
-    hover,
     inputFiles,
     insertText,
     onRpcBefore,
@@ -20,7 +19,6 @@ import {
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
-import { queryFirst } from "@odoo/hoot-dom";
 import { mockDate, tick } from "@odoo/hoot-mock";
 import { EventBus } from "@odoo/owl";
 import {
@@ -1046,42 +1044,6 @@ test("Notification settings rendering in chatwindow", async () => {
     await contains("button", { text: "For 8 hours" });
     await contains("button", { text: "For 24 hours" });
     await contains("button", { text: "Until I turn it back on" });
-});
-
-test("Can make chat windows bigger", async () => {
-    const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "general", channel_type: "channel" });
-    await start();
-    await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
-    await click(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow");
-    const normalWidth = queryFirst(".o-mail-ChatWindow").getBoundingClientRect().width;
-    await hover(".o-mail-ChatHub-bubbles");
-    await click("button[title='Chat Options']");
-    await contains("button:contains(Large windows)");
-    await contains("button:contains(Large windows) input");
-    await contains("button:contains(Large windows) input:not(:checked)");
-    await click("button:contains(Large windows)");
-    await contains("button:contains(Large windows) input:checked");
-    await contains(".o-mail-ChatWindow.o-large");
-    const largeWidth = queryFirst(".o-mail-ChatWindow").getBoundingClientRect().width;
-    expect(largeWidth).toBeGreaterThan(normalWidth);
-});
-
-test("Bigger chat windows is locally persistent (saved in local storage)", async () => {
-    const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "general", channel_type: "channel" });
-    browser.localStorage.setItem("mail.user_setting.chat_window_big", true);
-    await start();
-    await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
-    await click(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow.o-large");
-    expect(browser.localStorage.getItem("mail.user_setting.chat_window_big")).toBe("true");
-    await hover(".o-mail-ChatHub-bubbles");
-    await click("button[title='Chat Options']");
-    await click("button:contains(Large windows)");
-    await contains(".o-mail-ChatWindow.o-large");
-    expect(browser.localStorage.getItem("mail.user_setting.chat_window_big")).toBe(null);
 });
 
 test("open channel in chat window from push notification", async () => {


### PR DESCRIPTION
Chat window could have toggleable size change from the "..." menu above chat bubbles. Its purpose was to incite users that didn't like using chat windows because to appreciate using chat windows thanks to their optional bigger size.

This bigger size was appreciated, so this commit now puts it as the default sizing and removes the option to change the size.

Chat windows had a ratio of 3 / 4, which is too squared, resulting in chat windows being either too small in height or too large in width. This commit puts a 9 / 16 ratio instead. The actual size of chat windows after this commit has the same width as a small chat window with the height of large chat windows.

Task-4354014

<img width="1554" alt="Screenshot 2024-11-25 at 15 00 13" src="https://github.com/user-attachments/assets/1f08a632-a7f1-45cf-9adf-5dc08bdade4c">
