### PR TITLE
[FIX] account_report: options on composite report creation

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -150,9 +150,13 @@ class AccountReport(models.Model):
         for report in self.sorted(lambda x: not x.section_report_ids):
             # Reports are sorted in order to first treat the composite reports, in case they need to compute their filters a the same time
             # as their sections
+            is_accessible = self.env['ir.actions.client'].search_count([('context', 'ilike', f"'report_id': {report.id}"), ('tag', '=', 'account_report')])
+            is_variant = bool(report.root_report_id)
+            if (is_accessible or is_variant) and report.section_main_report_ids:
+                continue  # prevent updating the filters of a report when being added as a section of a report
             if report.root_report_id:
                 report[field_name] = report.root_report_id[field_name]
-            elif len(report.section_main_report_ids) == 1 and not self.env['ir.actions.client'].search_count([('context', 'ilike', f"'report_id': {report.id}"), ('tag', '=', 'account_report')]):
+            elif len(report.section_main_report_ids) == 1 and not is_accessible:
                 report[field_name] = report.section_main_report_ids[field_name]
             else:
                 report[field_name] = default_value


### PR DESCRIPTION
Steps to reproduce:

initial state: The accounting report "General Ledger" has the filter "unfold all" option activated and this filter can be selected on the report.

 - Create a new accounting report
 - Select "Composite Report"
 - Add the General Ledger as a section
 - Save

 -> When navigating to the General Ledger, it no longer has the "unfold all" option selected.

 Solution provided:
 If the report is accessible, should not change its fields when being added to a composite report.

 task-4317649


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
