### PR TITLE
[FIX] web: Correct domain initialization

### DIFF
--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -529,7 +529,7 @@ export class ListController extends Component {
     }
 
     async getExportedFields(model, import_compat, parentParams) {
-        let domain = this.model.root.domain;
+        let domain =  model === this.model.root.resModel ? this.model.root.domain : [];
         if (!this.isDomainSelected) {
             const resIds = await this.getSelectedResIds();
             const ids = resIds.length > 0 && resIds;


### PR DESCRIPTION
The domain was incorrectly initialized in the `getExportedFields` method after this commit https://github.com/odoo/odoo/pull/174366/files#diff-a3a01eded3e54743e243ef83e4c7dc682ddc91630015fa1f986e20346e7b84caR521-R530.
The domain now defaults to an empty array (`[]`) when `parentParams` is undefined, preventing unexpected errors during export operations.
This ensures consistent handling of record selection and domain construction.

Steps to reproduce 
Go to  Inventory / Reporting / Stock
Change the number of records displayed to be less than the total
When you try to select all in the list view it shows the select all button. Click it.
Actions / Export / Stock Quant
Open this
there is a video that explain in the [ticket](https://www.odoo.com/odoo/project.task/4333244)

opw-4333244

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
