### PR TITLE
[FIX] account: prevent home menu redirection on outstanding click

### DIFF
--- a/addons/account/static/src/components/account_move_form/account_move_form.js
+++ b/addons/account/static/src/components/account_move_form/account_move_form.js
@@ -23,6 +23,13 @@ export class AccountMoveController extends FormController {
 };
 
 export class AccountMoveFormNotebook extends Notebook {
+    onAnchorClicked(ev) {
+        if (ev.detail.detail.id === "#outstanding") {
+            ev.preventDefault();
+            ev.detail.detail.originalEv.preventDefault();
+        }
+    }
+
     async changeTabTo(page_id) {
         if (this.props.onBeforeTabSwitch) {
             await this.props.onBeforeTabSwitch(page_id);


### PR DESCRIPTION
Steps to reproduce
==================

- Click on an invoice
- Register a payment where the amount exceeds the invoice amount
- Switch to another invoice with the same customer
- Switch the active notebook to "Journal Items"
- Click on "Outstanding credits"

=> You are redirected to the homepage

Cause of the issue
==================

Before 16.0, it used to be possible to click on a link where the target is inside another notebook.
In that case, the notebook was switched before scrolling to the anchor. With owl, it is no longer possible to query where the target is as the DOM inside other notebooks is not yet rendered before switching to them.

Solution
========

If the anchor is visible, the link will work as intended, otherwise, the redirection to the homepage will be prevented

opw-4344125