### PR TITLE
[FIX] website: fix media dialog insert media tour

### DIFF
--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -169,17 +169,16 @@ wTourUtils.registerWebsitePreviewTour("website_media_dialog_insert_media", {
         trigger: ".oe-toolbar #media-insert",
     },
     {
-        content: "Search for an illustration/image",
-        trigger: ".o_select_media_dialog .o_we_search",
-        run: "text a",
+        content: "Click on the 'Icons' tab",
+        trigger: ".o_select_media_dialog a.nav-link:contains('Icons')",
     },
     {
-        content: "Click on the first illustration/image",
-        trigger: ".o_select_media_dialog img.o_we_attachment_highlight",
+        content: "Click on the first icon",
+        trigger: ".o_select_media_dialog .font-icons-icon",
     },
     {
-        content: "Verify that the illustration/image was inserted",
-        trigger: "iframe .s_text_block p > img",
+        content: "Verify that the icon was inserted",
+        trigger: "iframe .s_text_block p > span.fa",
         run: () => {}, //it's a check
     },
 ]);


### PR DESCRIPTION
Since this commit [1], where the "media dialog insert media" was added, the runbot sometimes fails because the tour contacts the "media-api.odoo.com" API, which is not allowed in a tour.

This commit fixes the issue by inserting an icon instead of an image, as the icon does not require any API call.

[1]: https://github.com/odoo/odoo/commit/2231148db55cfc6fa3f3f5b2b5c5250b74f2feac

runbot-107920