### PR TITLE
[FIX] l10n_cl: cannot create credit note (code 61)

### DIFF
--- a/addons/l10n_cl/models/l10n_latam_document_type.py
+++ b/addons/l10n_cl/models/l10n_latam_document_type.py
@@ -35,7 +35,7 @@ class L10nLatamDocumentType(models.Model):
         return document_number.zfill(6)
 
     def _is_doc_type_vendor(self):
-        return self.code == '46'
+        return self.country_id.code == 'CL' and self.code in ('46', '61')
 
     def _is_doc_type_export(self):
         return self.code in ['110', '111', '112'] and self.country_id.code == 'CL'


### PR DESCRIPTION
Chilean users cannot succesfully create the credit note (with document type 61) of a Vendori bill (type 46) because of a conflict on the document number input method

- Open Vendor Bills journal and enable 'Use Documents?'
- Create a Bill with document type '(46) Factura de Compra Electrónica'
- Create the credit note
- In the Wizard: select 'Full Refund', Document Type 61, Confirm

Issue: The system blocks the action because the new move is missing the document number

opw-4268371
