### PR TITLE
[IMP] hr,hr_*: generic improvements

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -38,8 +38,11 @@
                         <filter name="group_manager" string="Manager" domain="[]" context="{'group_by': 'parent_id'}"/>
                         <filter name="group_department" string="Department" domain="[]" context="{'group_by': 'department_id'}"/>
                         <filter name="group_job" string="Job Position" domain="[]" context="{'group_by': 'job_id'}"/>
+                        <separator name="main_groupby_separator"/>
                         <filter name="group_birthday" domain="[]" context="{'group_by': 'birthday'}"/>
                         <filter name="group_start" string="Start Date" domain="[]" context="{'group_by': 'create_date'}"/>
+                        <separator name="secondary_groupby_separator"/>
+                        <separator name="managers_groupby_separator"/>
                         <filter name="group_category_ids" string="Tags" domain="[]" context="{'group_by': 'category_ids'}"/>
                     </group>
                 </search>
@@ -273,11 +276,11 @@
                     </header>
                     <field name="name" readonly="1"/>
                     <field name="work_phone" class="o_force_ltr" readonly="1" optional="show"/>
-                    <field name="work_email"/>
-                    <field name="activity_ids" widget="list_activity" optional="show"/>
+                    <field name="work_email" optional="hide"/>
+                    <field name="activity_ids" widget="list_activity" optional="hide"/>
                     <field name="activity_user_id" optional="hide" string="Activity by" widget="many2one_avatar_user"/>
-                    <field name="activity_date_deadline" widget="remaining_days" optional="show"/>
-                    <field name="company_id" groups="base.group_multi_company" readonly="1" optional="show"/>
+                    <field name="activity_date_deadline" widget="remaining_days" optional="hide"/>
+                    <field name="company_id" groups="base.group_multi_company" readonly="1" optional="hide"/>
                     <field name="department_id"/>
                     <field name="job_id" context="{'default_no_of_recruitment': 0, 'default_is_favorite': False}"/>
                     <field name="parent_id" widget="many2one_avatar_user" optional="show"/>

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -13,6 +13,7 @@ class HrEmployee(models.Model):
 
     attendance_manager_id = fields.Many2one(
         'res.users', store=True, readonly=False,
+        string="Attendance Approver",
         domain="[('share', '=', False), ('company_ids', 'in', company_id)]",
         groups="hr_attendance.group_hr_attendance_officer",
         help="The user set in Attendance will access the attendance of the employee through the dedicated app and will be able to edit them.")

--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
+
+    <record id="hr_employee_search_view" model="ir.ui.view">
+        <field name="name">hr.employee.search.view</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.view_employee_filter"/>
+        <field name="arch" type="xml">
+            <xpath expr="//separator[@name='managers_groupby_separator']" position="before">
+                <filter name="group_attendance_manager" string="Attendance Approver" context="{'group_by': 'attendance_manager_id'}" groups="hr_attendance.group_hr_attendance_manager"/>
+            </xpath>
+        </field>
+    </record>
+
     <record id="view_employee_form_inherit_hr_attendance" model="ir.ui.view">
         <field name="name">hr.employee</field>
         <field name="model">hr.employee</field>
@@ -159,7 +171,7 @@
         <field name="inherit_id" ref="hr.view_employee_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='work_location_id']" position="after">
-                <field name="attendance_manager_id" optional="hide" string="Attendance" widget="many2one_avatar_user" groups="hr_attendance.group_hr_attendance_manager"/>
+                <field name="attendance_manager_id" optional="hide" widget="many2one_avatar_user" groups="hr_attendance.group_hr_attendance_manager"/>
             </xpath>
         </field>
     </record>

--- a/addons/hr_expense/models/hr_employee.py
+++ b/addons/hr_expense/models/hr_employee.py
@@ -45,7 +45,7 @@ class HrEmployee(models.Model):
 
     expense_manager_id = fields.Many2one(
         comodel_name='res.users',
-        string='Expense',
+        string='Expense Approver',
         compute='_compute_expense_manager', store=True, readonly=False,
         domain=_group_hr_expense_user_domain,
         help='Select the user responsible for approving "Expenses" of this employee.\n'

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="hr.view_employee_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//group[@name='managers']" position="inside">
-                    <field name="expense_manager_id" context="{'default_company_id': company_id}" widget="many2one_avatar_user"/>
+                    <field name="expense_manager_id" string="Expense" context="{'default_company_id': company_id}" widget="many2one_avatar_user"/>
                 </xpath>
                  <xpath expr="//group[@name='managers']" position="attributes">
                     <attribute name="invisible">0</attribute>
@@ -21,7 +21,18 @@
             <field name="inherit_id" ref="hr.view_employee_tree"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='work_location_id']" position="after">
-                    <field name="expense_manager_id" optional="hide" string="Expense Approver" widget="many2one_avatar_user"/>
+                    <field name="expense_manager_id" optional="hide" widget="many2one_avatar_user"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="hr_employee_search_view" model="ir.ui.view">
+            <field name="name">hr.employee.search.view</field>
+            <field name="model">hr.employee</field>
+            <field name="inherit_id" ref="hr.view_employee_filter"/>
+            <field name="arch" type="xml">
+                <xpath expr="//separator[@name='managers_groupby_separator']" position="before">
+                    <filter name="group_expense_manager" string="Expense Approver" context="{'group_by': 'expense_manager_id'}"/>
                 </xpath>
             </field>
         </record>
@@ -32,7 +43,7 @@
             <field name="inherit_id" ref="hr.res_users_view_form_profile" />
             <field name="arch" type="xml">
                 <xpath expr="//group[@name='managers']" position="inside">
-                    <field name="expense_manager_id" readonly="not can_edit" context="{'default_company_id': company_id}"/>
+                    <field name="expense_manager_id" string="Expense" readonly="not can_edit" context="{'default_company_id': company_id}"/>
                 </xpath>
                  <xpath expr="//group[@name='managers']" position="attributes">
                     <attribute name="invisible">0</attribute>

--- a/addons/hr_holidays/models/hr_employee_base.py
+++ b/addons/hr_holidays/models/hr_employee_base.py
@@ -14,7 +14,7 @@ class HrEmployeeBase(models.AbstractModel):
     _inherit = "hr.employee.base"
 
     leave_manager_id = fields.Many2one(
-        'res.users', string='Time Off',
+        'res.users', string='Time Off Approver',
         compute='_compute_leave_manager', store=True, readonly=False,
         domain="[('share', '=', False), ('company_ids', 'in', company_id)]",
         help='Select the user responsible for approving "Time Off" of this employee.\n'

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -75,6 +75,9 @@
                 <filter name="on_timeoff" string="On Time Off" domain="[('is_absent', '=', True)]"/>
                 <separator/>
             </xpath>
+            <xpath expr="//separator[@name='secondary_groupby_separator']" position="after">
+                <filter name="group_leave_manager" string="Time Off Approver" context="{'group_by': 'leave_manager_id'}"/>
+            </xpath>
         </field>
     </record>
 
@@ -116,7 +119,7 @@
         <field name = "priority" eval="20" />
         <field name="arch" type="xml">
             <xpath expr="//group[@name='managers']" position="inside">
-                <field name="leave_manager_id" widget="many2one_avatar_user"/>
+                <field name="leave_manager_id" string="Time Off" widget="many2one_avatar_user"/>
             </xpath>
             <xpath expr="//group[@name='managers']" position="attributes">
                 <attribute name="invisible">0</attribute>
@@ -217,7 +220,7 @@
         <field name="inherit_id" ref="hr.view_employee_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='work_location_id']" position="after">
-                <field name="leave_manager_id" optional="hide" string="Time Off Approver" widget="many2one_avatar_user"/>
+                <field name="leave_manager_id" optional="hide" widget="many2one_avatar_user"/>
             </xpath>
         </field>
     </record>
@@ -229,7 +232,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='coach_id']" position="after">
                 <field name="company_id" invisible="1"/>
-                <field name="leave_manager_id" widget="many2one_avatar_user"/>
+                <field name="leave_manager_id" string="Time Off" widget="many2one_avatar_user"/>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <field name="show_leaves" invisible="1"/>
@@ -270,7 +273,7 @@
                 class="btn btn-primary"/>
             </xpath>
             <xpath expr="//group[@name='managers']" position="inside">
-                <field name="leave_manager_id" readonly="not can_edit"/>
+                <field name="leave_manager_id" string="Time Off" readonly="not can_edit"/>
             </xpath>
             <xpath expr="//group[@name='managers']" position="attributes">
                 <attribute name="invisible">0</attribute>

--- a/addons/hr_homeworking/views/hr_employee_views.xml
+++ b/addons/hr_homeworking/views/hr_employee_views.xml
@@ -5,8 +5,7 @@
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_filter"/>
         <field name="arch" type="xml">
-            <xpath expr="//filter[@name='group_department']" position="after">
-                <separator/>
+            <xpath expr="//separator[@name='main_groupby_separator']" position="after">
                 <filter name="_search_today_location" string="Work location" domain="[]" context="{'group_by':'today_location_name'}"/>
             </xpath>
         </field>

--- a/addons/hr_presence/views/hr_employee_views.xml
+++ b/addons/hr_presence/views/hr_employee_views.xml
@@ -9,7 +9,7 @@
                 <filter name="absent" string="Absent" domain="[('hr_presence_state_display', '=', 'absent')]"/>
                 <filter name="out_of_working_hours" string="Out of Working Hours" domain="[('hr_presence_state_display', '=', 'out_of_working_hour')]"/>
             </filter>
-            <filter name="group_start" position="before">
+            <filter name="group_birthday" position="before">
                 <filter name="group_hr_presence_state" string="Presence/Absence" domain="[]" context="{'group_by':'hr_presence_state_display'}" groups="hr.group_hr_manager"/>
             </filter>
         </field>
@@ -21,7 +21,7 @@
         <field name="inherit_id" ref="hr.view_employee_tree"/>
         <field name="arch" type="xml">
             <field name="work_email" position="after">
-                <field name="hr_presence_state_display" string="Presence" optional="show"/>
+                <field name="hr_presence_state_display" string="Presence" optional="hide"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
This commit adds group by to allow the user to easily group by with
manager fields in employee views (such timesheet approver,
attendance approver, leave approver and expense manager).
This commit also renames the label of manager fields inside their
definition to show in the tooltip of custom filter/group by those
fields represent the Approver and not a time off, attendance or
what ever.

task-4313650