### PR TITLE
[IMP] control button : remove 'merge' from tranfer / merge button

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -28,7 +28,7 @@
                     <i class="fa fa-files-o me-1"/>Split
                 </button>
                 <button class="btn btn-secondary btn-lg py-5" t-on-click.stop="() => this.clickTransferOrder()">
-                    <i class="oi oi-arrow-right me-1" />Transfer / Merge
+                    <i class="oi oi-arrow-right me-1" />Transfer
                 </button>
                 <button t-if="!pos.getOrder()?.table_id" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.editFloatingOrderName(this.pos.getOrder())">
                     <i class="fa fa-pencil-square-o me-1" />Edit Order Name


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Control button "transfer / merge" leads to misunderstanding towards users. 
A lot of them expect the tables to be visually merged together on the floor plan instead of just the order lines. 

Current behavior before PR:



Desired behavior after PR is merged:

Remove the 'merge' from the control button name. Keeping only 'Transfer' makes it clearer for users that you transfer the order to another table. 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
