### PR TITLE
[FIX] account: access error with branch

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.exceptions import UserError
-from odoo.tests import tagged, Form
+from odoo.tests import tagged, Form, users
 from odoo import fields, Command
 
 from dateutil.relativedelta import relativedelta
@@ -156,6 +156,19 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'invoice_line_ids': [Command.create({'product_id': cls.product_a.id, 'price_unit': 10.0, 'tax_ids': []})],
         })
         (cls.in_refund_1 + cls.in_refund_2).action_post()
+
+        cls.branch = cls.setup_company_data("Branch", parent_id=cls.env.company.id)['company']
+        cls.user_branch = cls.env['res.users'].create({
+            'name': 'Branch User',
+            'login': 'user_branch',
+            'groups_id': [
+                Command.link(cls.env.ref('base.group_user').id),
+                Command.link(cls.env.ref('account.group_account_user').id),
+                Command.link(cls.env.ref('account.group_account_manager').id),
+            ],
+            'company_id': cls.branch.id,
+            'company_ids': [Command.set(cls.branch.ids)],
+        })
 
     def test_register_payment_single_batch_grouped_keep_open_lower_amount(self):
         ''' Pay 800.0 with 'open' as payment difference handling on two customer invoices (1000 + 2000). '''
@@ -1566,3 +1579,26 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         ])
         # When user select 2+ branches and parent company allow to create payment on the parent journal
         self.assertEqual(available_journals.company_id, self.env.company)
+
+    @users('user_branch')
+    def test_branch_user_register_payment(self):
+        bill = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'invoice_date': '2024-05-01',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [Command.create({
+                'name': 'line',
+                'price_unit': 1000,
+                'quantity': 1,
+            })]
+        })
+        bill.action_post()
+
+        wizard = self.env['account.payment.register'].with_context(allowed_company_ids=self.env.company.ids, active_model='account.move', active_ids=bill.ids).create({
+            'amount': bill.amount_total,
+            'currency_id': bill.currency_id.id,
+            'payment_method_line_id': self.inbound_payment_method_line.id,
+        })
+        self.env.company.parent_ids.invalidate_recordset()
+        payment = wizard._create_payments()
+        self.assertTrue(payment)

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -219,7 +219,7 @@ class AccountPaymentRegister(models.TransientModel):
             # Receiving money on a bank account linked to the journal.
             return journal.bank_account_id
         else:
-            company = min(batch_result['lines'].company_id, key=lambda c: len(c.parent_ids))
+            company = min(batch_result['lines'].company_id, key=lambda c: len(c.sudo().parent_ids))
             # Sending money to a bank account owned by a partner.
             return batch_result['lines'].partner_id.bank_ids.filtered(lambda x: x.company_id.id in (False, company.id))._origin
 


### PR DESCRIPTION
We get an access error when trying to register
a vendor payment with a user having access only to a branch
company.

Steps:

- Create a branch B
- Create a user U with company_id and company_ids being B
- Log as user U
- Create and confirm a vendor bill
- Open the 'Register payment' wizard and try to create a payment
-> Access Error on company id

opw-4317289
