### PR TITLE
[IMP] im_livechat, *: show operator has joined as a notification

### DIFF
--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -75,7 +75,7 @@ class TestLivechatChatbotUI(TestLivechatCommon, ChatbotCase):
             ("How can I help you?", operator, self.step_dispatch_operator),
             ("I want to speak with an operator", False, False),
             ("I will transfer you to a human", operator, False),
-            (f"{self.operator.livechat_username} has joined", operator, False),
+            ("joined the channel", self.operator.partner_id, False), # human_operator has joined the channel
         ]
 
         self.assertEqual(len(conversation_messages), len(expected_messages))


### PR DESCRIPTION
\* website_livechat

Before this commit, when an operator joined a live chat conversation, the 
message 'operator has joined' was added as a comment inside the message 
bubble.

With this commit, that message is now displayed as a notification.

task-4354211
