### PR TITLE
[FIX] sale_pdf_quote_builder: allow users access to header/footers

### DIFF
--- a/addons/sale_pdf_quote_builder/models/quotation_document.py
+++ b/addons/sale_pdf_quote_builder/models/quotation_document.py
@@ -87,3 +87,12 @@ class QuotationDocument(models.Model):
             },
             'target': 'current',
         }
+
+    # === CRUD METHODS ===#
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        docs = super().create(vals_list)
+        for doc in docs:
+            doc.write({'res_model': 'quotation.document', 'res_id': doc.id})
+        return docs


### PR DESCRIPTION
Problem: When users with no Settings/Admin rights attempt to access the header/footers of the quote builder, an access error is thrown because they have no access to the private attachments.

Purpose: Users with access to Sales should have access to the headers/footers to use the quote builder. To resolve the bug, the header/footer attachments needs to have both res_model and res_id of the quotation documents.

Steps to Reproduce on Runbot:
1. Install Sales
2. Log in as admin and create a quotation template with a header attached in the quote builder
3. Log in as a demo user with no setting rights but is a sales admin
4. Navigate to a quotation template with headers attached --> access error

opw-4318572


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
