### PR TITLE
[IMP] mail: enable video blur during call from call actions

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -1554,6 +1554,12 @@ msgstr ""
 
 #. module: mail
 #. odoo-javascript
+#: code:addons/mail/static/src/discuss/call/common/call_actions.js:0
+msgid "Blur Background"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
 #: code:addons/mail/static/src/discuss/call/common/call_settings.xml:0
 msgid "Blur video background"
 msgstr ""
@@ -7653,6 +7659,12 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_followers__partner_id
 msgid "Related Partner"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/discuss/call/common/call_actions.js:0
+msgid "Remove Blur"
 msgstr ""
 
 #. module: mail

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -1,5 +1,5 @@
 import { useComponent, useState } from "@odoo/owl";
-import { isMobileOS } from "@web/core/browser/feature_detection";
+import { isBrowserSafari, isMobileOS } from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
@@ -69,6 +69,18 @@ callActionsRegistry
         select: (component) => component.rtc.toggleVideo("screen"),
         sequence: 40,
     })
+    .add("blur-background", {
+        condition: (component) =>
+            !isBrowserSafari() && component.rtc && component.rtc.selfSession?.isCameraOn,
+        name: (component) =>
+            component.store.settings.useBlur ? _t("Remove Blur") : _t("Blur Background"),
+        isActive: (component) => component.store?.settings?.useBlur,
+        icon: "fa-photo",
+        select: (component) => {
+            component.store.settings.useBlur = !component.store.settings.useBlur;
+        },
+        sequence: 60,
+    })
     .add("fullscreen", {
         condition: (component) => component.props && component.props.fullscreen,
         name: (component) =>
@@ -83,7 +95,7 @@ callActionsRegistry
                 component.props.fullscreen.enter();
             }
         },
-        sequence: 60,
+        sequence: 70,
     });
 
 function transformAction(component, id, action) {

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -10,7 +10,7 @@ import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { debounce } from "@web/core/utils/timing";
-import { loadBundle } from "@web/core/assets";
+import { loadBundle, loadJS } from "@web/core/assets";
 import { memoize } from "@web/core/utils/functions";
 import { callActionsRegistry } from "./call_actions";
 
@@ -445,6 +445,7 @@ export class Rtc extends Record {
      * @param {boolean} [initialState.camera]
      */
     async toggleCall(channel, { audio = true, camera } = {}) {
+        await loadJS("/mail/static/lib/selfie_segmentation/selfie_segmentation.js");
         if (this.state.hasPendingRequest) {
             return;
         }

--- a/addons/web/static/src/core/browser/feature_detection.js
+++ b/addons/web/static/src/core/browser/feature_detection.js
@@ -21,7 +21,7 @@ export function isBrowserFirefox() {
  * @returns {boolean}
  */
 export function isBrowserSafari() {
-    return !isBrowserChrome() && browser.navigator.userAgent.includes("Safari");
+    return !isBrowserChrome() && browser.navigator.userAgent?.includes("Safari");
 }
 
 export function isAndroid() {


### PR DESCRIPTION
**Current behavior before PR:**

Blurring the background in video during a call was not possible directly from the call actions menu. Users had to navigate to the call and video settings to enable this feature.

**Desired behavior after PR is merged:**

New call actions have been introduced, allowing users to blur their video background directly during a call, making the feature more accessible.

**Task**-4354247

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
