### PR TITLE
[FIX] website: fix website_form_editor tour

### DIFF
--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -325,15 +325,14 @@
         ...wTourUtils.clickOnSave(),
         {
             content: "Check 'products' field is visible.",
-            trigger: `iframe .s_website_form:has(${triggerFieldByLabel("Products")}:visible)`,
-            isCheck: true,
+            trigger: `:iframe .s_website_form:has(${triggerFieldByLabel("Products")}:visible)`,
         }, {
             content: "choose the option 'Mitchell Admin' of partner.",
-            trigger: "iframe .checkbox:has(label:contains('Mitchell Admin')) input[type='checkbox']",
+            trigger: ":iframe .checkbox:has(label:contains('Mitchell Admin')) input[type='checkbox']",
+            run: "click",
         }, {
             content: "Check 'products' field is not visible.",
-            trigger: "iframe .s_website_form" +`:has(${triggerFieldByLabel("Products")}:not(:visible))`,
-            isCheck: true,
+            trigger: ":iframe .s_website_form" +`:has(${triggerFieldByLabel("Products")}:not(:visible))`,
         },
         ...wTourUtils.clickOnEditAndWaitEditMode(),
 


### PR DESCRIPTION
With this PR [1], unfortunately an extra parameter `isCheck` was introduced in the tour. This commit removes that unusual parameter.

[1]: https://github.com/odoo/odoo/pull/168474

runbot-107873


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
