### PR TITLE
[FIX] l10n_in_ewaybill: fix print report

### DIFF
--- a/addons/l10n_in_ewaybill/report/ewaybill_report.xml
+++ b/addons/l10n_in_ewaybill/report/ewaybill_report.xml
@@ -63,7 +63,7 @@
                                     </tr>
                                     <tr>
                                         <td style="white-space: normal; word-break: break-all;">
-                                            Type: <t t-out="doc.supply_type"/> - <t t-out="doc.type_id.sub_type"/>-<t t-out="doc.type_description"/>
+                                            Type: <t t-out="doc.supply_type"/> - <t t-out="doc.type_id.sub_type"/>
                                         </td>
                                         <td colspan="2">
                                             Document Details:<t t-out="doc.type_id.name"/> - <t t-out="doc.document_number"/> - <t t-out="doc.ewaybill_date"/>

--- a/addons/l10n_in_ewaybill_stock/report/ewaybill_report_inherit.xml
+++ b/addons/l10n_in_ewaybill_stock/report/ewaybill_report_inherit.xml
@@ -8,5 +8,10 @@
             </h4>
             <h4 t-else="" style="margin-top: 1rem;">e-Way Bill</h4>
         </xpath>
+        <xpath expr="//t[@t-out='doc.type_id.sub_type']" position="after">
+            <t t-if="doc.type_description">
+                - <t t-out="doc.type_description"/>
+            </t>
+        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Steps to reporduce:

1. Install `l10n_in_ewaybill`
2. Create an ewaybill for an invoice
3. Generate the ewaybill
4. Print the ewaybill

It gives us a traceback

In this commit we resolve the issue

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
