### PR TITLE
[FIX] mass_mailing: unnecessary validations for reply_to and email_from

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -86,7 +86,7 @@ class MassMailing(models.Model):
              'Keep it empty if you prefer the first characters of your email content to appear instead.')
     email_from = fields.Char(
         string='Send From',
-        compute='_compute_email_from', readonly=False, required=True, store=True,
+        compute='_compute_email_from', readonly=False, store=True,
         precompute=True)
     favorite = fields.Boolean('Favorite', copy=False, tracking=True)
     favorite_date = fields.Datetime(
@@ -227,6 +227,11 @@ class MassMailing(models.Model):
         'percentage_valid',
         'CHECK(ab_testing_pc >= 0 AND ab_testing_pc <= 100)',
         'The A/B Testing Percentage needs to be between 0 and 100%'
+    ),
+    (
+        'email_from',
+        "CHECK(email_from IS NOT NULL OR mailing_type != 'mail')",
+        "email from is required for mailing"
     )]
 
     @api.constrains('mailing_model_id', 'mailing_filter_id')

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -151,6 +151,9 @@
             <xpath expr="//label[@for='reply_to']" position="attributes">
                 <attribute name="attrs">{'invisible': [('mailing_type', '!=', 'mail')]}</attribute>
             </xpath>
+            <xpath expr="//field[@name='reply_to']" position="attributes">
+                <attribute name="attrs">{'required': [('mailing_type', '==', 'mail')]}</attribute>
+            </xpath>
             <xpath expr="//div[@name='reply_to_details']" position="attributes">
                 <attribute name="attrs">{'invisible': [('mailing_type', '!=', 'mail')]}</attribute>
             </xpath>


### PR DESCRIPTION
- Fixed issue where reply_to was required when sending SMS. This field is not applicable for SMS and is now excluded from validation.
- Updated validation logic to ensure email_from is not required for SMS, preventing errors when this field is empty.
(removed required=true from email_from and added a constraint for making email_from not null for mail only 
as it is not required for sms mailing type) 

Task-3996903