### PR TITLE
[IMP] stock_account: remove absurd demo data and improve its relevance

### DIFF
--- a/addons/stock_account/data/stock_account_demo.xml
+++ b/addons/stock_account/data/stock_account_demo.xml
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <record id="product_category_avco" model="product.category">
-            <field name="property_valuation">manual_periodic</field>
+        <record id="product.product_category_furniture" model="product.category">
             <field name="property_cost_method">average</field>
-            <field name="name">AVCO</field>
         </record>
-        <record id="product_category_fifo" model="product.category">
-            <field name="property_valuation">manual_periodic</field>
+        <record id="product.product_category_construction" model="product.category">
             <field name="property_cost_method">fifo</field>
-            <field name="name">FIFO</field>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
Before Commit:
------------------------------------------
The demo data included insignificant product categories named AVCO and FIFO, which lacked meaningful business relevance. These categories were solely used to demonstrate costing methods and did not align with realistic use cases.

After Commit:
------------------------------------------
The AVCO and FIFO categories have been removed(from demo data). Instead, they are used in existing product categories Furniture and Home Construction.

The demo data's business relevance is improved by this modification.

task-4354578
