### PR TITLE
[FIX] bus: fix timezone mismatch in outdated page watcher

### DIFF
--- a/addons/bus/static/src/outdated_page_watcher_service.js
+++ b/addons/bus/static/src/outdated_page_watcher_service.js
@@ -21,15 +21,12 @@ export class OutdatedPageWatcherService {
         this.nextAutovacuumDt = vacuumInfo ? deserializeDateTime(vacuumInfo.nextcall) : null;
         this.lastDisconnectDt = null;
         this.closeNotificationFn;
-        bus_service.addEventListener(
-            "disconnect",
-            () => (this.lastDisconnectDt = DateTime.now().toUTC())
-        );
+        bus_service.addEventListener("disconnect", () => (this.lastDisconnectDt = DateTime.now()));
         bus_service.addEventListener("reconnect", async () => {
             if (!multi_tab.isOnMainTab() || !this.lastDisconnectDt) {
                 return;
             }
-            if (!this.lastAutovacuumDt || DateTime.now().toUTC() >= this.nextAutovacuumDt) {
+            if (!this.lastAutovacuumDt || DateTime.now() >= this.nextAutovacuumDt) {
                 const { lastcall, nextcall } = await rpc("/bus/get_autovacuum_info", {
                     silent: true,
                 });


### PR DESCRIPTION
The outdated page watcher detects when the page is outdated i.e. when the autovacuum ran while the websocket was disconnected.

To do so, it compares the last disconnection datetime with the last autovacuum datetime received from the server. However, last disconnected datetime is saved in UTC while value coming from the server is parsed using the default timezone.

This PR fixes the issue by handling both datetime with the default timezone.
