### PR TITLE
[IMP] point_of_sale: prevent cancel of scheduled orders during close session

### DIFF
--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -176,7 +176,7 @@
                                 invisible="not session_move_id or state == 'invoiced'">
                                 <field name="session_move_id" readonly="1" />
                             </group>
-                            <group string="Other Information">
+                            <group string="Other Information" name="other_information">
                                 <field name="pos_reference"/>
                                 <field name="tracking_number"/>
                                 <field name="country_code" invisible="1"/>


### PR DESCRIPTION
In this commit:
===
- Added the `get_session_orders` method to handle session orders.
- Updated session closure logic to exclude scheduled orders from being canceled, ensuring better management of such orders.

task-4361079

Related: https://github.com/odoo/enterprise/pull/74555

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
