### PR TITLE
[FIX] l10n_in: fix fiscal position for vendor bill and refunds

### DIFF
--- a/addons/l10n_in/__manifest__.py
+++ b/addons/l10n_in/__manifest__.py
@@ -34,6 +34,7 @@ Sheet, now only Vertical format has been permitted Which is Supported By Odoo.
         'data/l10n_in_chart_data.xml',
         'data/l10n_in.port.code.csv',
         'data/res_country_state_data.xml',
+        'data/res_country_group.xml',
         'data/uom_data.xml',
         'data/res_partner_industry.xml',
         'data/account_cash_rounding.xml',

--- a/addons/l10n_in/data/res_country_group.xml
+++ b/addons/l10n_in/data/res_country_group.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="inter_state_group" model="res.country.group">
+        <field name="name">India inter-state group</field>
+        <field name="country_ids" eval="[Command.set([ref('base.in')])]"/>
+        <field name="exclude_state_ids" eval="[Command.set([ref('l10n_in.state_in_oc')])]"/>
+    </record>
+</odoo>

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -71,23 +71,53 @@ class AccountMove(models.Model):
 
     @api.depends('l10n_in_state_id')
     def _compute_fiscal_position_id(self):
-        other_country = None
-        in_moves = self.filtered(lambda move: move.country_code == 'IN' and move.is_sale_document(include_receipts=True))
-        for move in in_moves:
-            state_id = move.l10n_in_state_id.id
-            country_id = move.l10n_in_state_id.country_id.id
-            if move.l10n_in_state_id.l10n_in_tin == '96':  # Foreign Country
-                other_country = other_country or self.env['res.country'].search([('code', '!=', 'IN')], limit=1)
-                country_id = other_country.id
-                state_id = False
-            virtual_partner = self.env['res.partner'].new({
-                'state_id': state_id,
-                'country_id': country_id,
-            })
-            move.fiscal_position_id = self.env['account.fiscal.position'].with_company(
-                move.company_id
-            )._get_fiscal_position(virtual_partner)
-        super(AccountMove, self - in_moves)._compute_fiscal_position_id()
+
+        def _get_fiscal_state(move):
+            """
+            Maps each move to its corresponding fiscal state based on its type,
+            fiscal conditions, and the state of the associated partner or company.
+            """
+
+            if (
+                move.country_code != 'IN'
+                or not move.is_invoice(include_receipts=True)
+                # Partner's FP takes precedence through super
+                or move.partner_shipping_id.property_account_position_id
+                or move.partner_id.property_account_position_id
+            ):
+                return False
+            elif move.l10n_in_gst_treatment == 'special_economic_zone':
+                # Special Economic Zone
+                return self.env.ref('l10n_in.state_in_oc')
+            elif move.is_sale_document(include_receipts=True):
+                # In Sales Documents: Compare place of supply with company state
+                return move.l10n_in_state_id
+            elif move.is_purchase_document(include_receipts=True) and move.partner_id.country_id.code == 'IN':
+                # In Purchases Documents: Compare place of supply with vendor state
+                pos_state_id = move.l10n_in_state_id
+                if pos_state_id.l10n_in_tin == '96':
+                    return pos_state_id
+                elif pos_state_id == move.partner_id.state_id:
+                    # Intra-State: Group by state matching the company's state.
+                    return move.company_id.state_id
+                elif pos_state_id != move.partner_id.state_id:
+                    # Inter-State: Group by state that doesn't match the company's state.
+                    return (
+                        pos_state_id == move.company_id.state_id
+                        and move.partner_id.state_id
+                        or pos_state_id
+                    )
+            return False
+
+        for state_id, moves in self.grouped(_get_fiscal_state).items():
+            if state_id:
+                virtual_partner = self.env['res.partner'].new({
+                    'state_id': state_id.id,
+                    'country_id': state_id.country_id.id,
+                })
+                moves.fiscal_position_id = self.env['account.fiscal.position']._get_fiscal_position(virtual_partner)
+            else:
+                super(AccountMove, moves)._compute_fiscal_position_id()
 
     @api.onchange('name')
     def _onchange_name_warning(self):

--- a/addons/l10n_in/models/template_in.py
+++ b/addons/l10n_in/models/template_in.py
@@ -67,7 +67,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'sequence': 2,
                 'auto_apply': True,
                 'tax_ids': self._get_l10n_in_fiscal_tax_vals(),
-                'country_id': self.env.ref('base.in').id
+                'country_group_id': 'l10n_in.inter_state_group',
             },
         }
         if company.parent_id:

--- a/addons/l10n_in/tests/test_l10n_in_fiscal_position.py
+++ b/addons/l10n_in/tests/test_l10n_in_fiscal_position.py
@@ -26,9 +26,9 @@ class TestFiscal(L10nInTestInvoicingCommon):
                 }]
             )
 
-    def _assert_invoice_fiscal_position(self, fiscal_position_ref, partner, taxes, post=True):
+    def _assert_invoice_fiscal_position(self, fiscal_position_ref, partner, taxes=None, move_type='out_invoice', post=True):
         test_invoice = self.init_invoice(
-            move_type="out_invoice",
+            move_type=move_type,
             partner=partner,
             post=post,
             amounts=[110, 500],
@@ -132,3 +132,86 @@ class TestFiscal(L10nInTestInvoicingCommon):
             out_invoice.fiscal_position_id,
             self.env['account.chart.template'].ref('fiscal_position_in_export_sez_in')
         )
+
+    def test_l10n_in_fiscal_in_vendor_bills(self):
+        '''
+        In Purchase Document: Compare place of supply with vendor state
+        '''
+
+        self.env.company = self.default_company
+        template = self.env['account.chart.template']
+        company_state = self.env.company.state_id
+        other_state = self.env['res.country.state'].search([
+            ('id', '!=', company_state.id),
+            ('country_id', '=', company_state.country_id.id)
+        ], limit=1)
+
+        # Sub-test: Intra-State
+        with self.subTest(scenario="Intra-State"):
+            self.partner_a.write({'state_id': company_state.id})
+            vendor_bill = self._assert_invoice_fiscal_position(
+                fiscal_position_ref='fiscal_position_in_intra_state',
+                partner=self.partner_a,
+                move_type='in_invoice',
+                post=False,
+            )
+            self.partner_a.write({'state_id': other_state.id})
+            vendor_bill.write({'l10n_in_state_id': other_state.id})
+            self.assertEqual(
+                vendor_bill.fiscal_position_id,
+                template.ref('fiscal_position_in_intra_state')
+            )
+
+        # Sub-test: Inter-State
+        with self.subTest(scenario="Inter-State"):
+            self.partner_a.write({'state_id': other_state.id})
+            vendor_bill = self._assert_invoice_fiscal_position(
+                fiscal_position_ref='fiscal_position_in_inter_state',
+                partner=self.partner_a,
+                move_type='in_invoice',
+                post=False,
+            )
+            self.partner_a.write({'state_id': company_state.id})
+            vendor_bill.write({'l10n_in_state_id': other_state.id})
+            self.assertEqual(
+                vendor_bill.fiscal_position_id,
+                template.ref('fiscal_position_in_inter_state')
+            )
+
+        # Sub-test: Export/SEZ (Outside India)
+        with self.subTest(scenario="Export/SEZ"):
+            vendor_bill = self._assert_invoice_fiscal_position(
+                fiscal_position_ref='fiscal_position_in_export_sez_in',
+                partner=self.partner_foreign,
+                move_type='in_invoice',
+                post=False,
+            )
+            vendor_bill.write({'l10n_in_state_id': self.env.ref('l10n_in.state_in_oc').id})  # Other Country State
+            self.assertEqual(
+                vendor_bill.fiscal_position_id,
+                template.ref('fiscal_position_in_export_sez_in')
+            )
+            # Here fpos should Inter-State. But due to `l10n_in_gst_treatment` it will be Export/SEZ
+            self.partner_a.write({'state_id': other_state.id})
+            vendor_bill.write({
+                'partner_id': self.partner_a.id,  # Inter-State Partner
+                'l10n_in_state_id': company_state.id,  # Company State
+                'l10n_in_gst_treatment': 'special_economic_zone',
+            })
+            self.assertEqual(
+                vendor_bill.fiscal_position_id,
+                template.ref('fiscal_position_in_export_sez_in')
+            )
+
+        # Sub-test: Manual Partner Fiscal Check
+        with self.subTest(scenario="Manual Partner Fiscal Check"):
+            # Here fpos should Inter-State. But due to `property_account_position_id` it will be Export/SEZ
+            self.partner_a.write({
+                'state_id': company_state.id,  # Intra-State Partner
+                'property_account_position_id': template.ref('fiscal_position_in_export_sez_in').id
+            })
+            vendor_bill_4 = self._assert_invoice_fiscal_position(
+                fiscal_position_ref='fiscal_position_in_export_sez_in',
+                partner=self.partner_a,
+                move_type='in_invoice',
+            )


### PR DESCRIPTION
### Before this commit:
Fiscal position computation was limited to `Invoices` and `Credit Notes`. `Vendor Bills` and `Refunds` were not included.

### After this commit:
Fiscal position computation now includes `Vendor Bills` and `Refunds` as well.


> Task: 4357473