### PR TITLE
[FIX] stock: fix replenishment creation

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -353,6 +353,8 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _get_qty_to_order(self, force_visibility_days=False, qty_in_progress_by_orderpoint={}):
         self.ensure_one()
+        if not self.product_id or not self.location_id:
+            return False
         visibility_days = self.visibility_days
         if force_visibility_days is not False:
             # Accepts falsy values such as 0.


### PR DESCRIPTION
Steps to reproduce:

Inventory → Operations → Replenishment → New → Traceback Error

Issue:

[Last changes](odoo/odoo@28d24a05ca94f0fbecf) in the file removed the condition ensuring product_id before getting its quantity which created the error.

fix:

Added the removed condtion.

opw-4352363


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
