### PR TITLE
[IMP] im_livechat: limit the number of livechat session

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -30,6 +30,8 @@ class DiscussChannel(models.Model):
         'Livechat Operator ID is required for a channel of type livechat.',
     )
 
+    _livechat_active_idx = models.Index("(livechat_active) WHERE livechat_active IS TRUE")
+
     @api.depends('message_ids')
     def _compute_duration(self):
         for record in self:

--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -21,6 +21,7 @@ class ResUsers(models.Model):
         help="When forwarding live chat conversations, the chatbot will prioritize users with matching expertise.",
     )
     has_access_livechat = fields.Boolean(compute='_compute_has_access_livechat', string='Has access to Livechat', store=False, readonly=True)
+    is_in_call = fields.Boolean("Is in call", compute="_compute_is_in_call")
 
     @property
     def SELF_READABLE_FIELDS(self):
@@ -73,6 +74,14 @@ class ResUsers(models.Model):
     def _compute_has_access_livechat(self):
         for user in self.sudo():
             user.has_access_livechat = user.has_group('im_livechat.im_livechat_group_user')
+
+    @api.depends("partner_id.channel_member_ids.rtc_session_ids")
+    def _compute_is_in_call(self):
+        rtc_sessions = self.env["discuss.channel.rtc.session"].search(
+            [("partner_id", "in", self.partner_id.ids)]
+        )
+        for user in self:
+            user.is_in_call = user.partner_id in rtc_sessions.partner_id
 
     def _init_store_data(self, store: Store):
         super()._init_store_data(store)

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -139,6 +139,12 @@
                                         </div>
                                     </group>
                                 </group>
+                                <group>
+                                    <group>
+                                        <field name="max_sessions_mode" widget="radio" options="{'horizontal': true}"/>
+                                        <field name="max_sessions" invisible="max_sessions_mode != 'limited'"/>
+                                    </group>
+                                </group>
                             </page>
                             <page string="Channel Rules" name="channel_rules">
                                 <field name="rule_ids" colspan="2"/>

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -17,6 +17,7 @@ class ResPartner(models.Model):
         string="Channels",
         copy=False,
     )
+    channel_member_ids = fields.One2many("discuss.channel.member", "partner_id")
 
     @api.readonly
     @api.model


### PR DESCRIPTION
This PR introduces the ability to limit the number of livechat sessions by operator to a specific number.

This PR also excludes "in call" operator from the available operator list.

Task-4354256