### PR TITLE
[IMP] point_of_sale: improve coin bill screen

### DIFF
--- a/addons/l10n_in_pos/data/pos_bill_data.xml
+++ b/addons/l10n_in_pos/data/pos_bill_data.xml
@@ -4,25 +4,5 @@
             <field name="name">500.00</field>
             <field name="value">500.00</field>
         </record>
-
-        <record model="pos.bill" id="point_of_sale.0_05" forcecreate="0">
-            <field name="for_all_config">False</field>
-        </record>
-
-        <record model="pos.bill" id="point_of_sale.0_10" forcecreate="0">
-            <field name="for_all_config">False</field>
-        </record>
-
-        <record model="pos.bill" id="point_of_sale.0_20" forcecreate="0">
-            <field name="for_all_config">False</field>
-        </record>
-
-        <record model="pos.bill" id="point_of_sale.0_25" forcecreate="0">
-            <field name="for_all_config">False</field>
-        </record>
-
-        <record model="pos.bill" id="point_of_sale.0_50" forcecreate="0">
-            <field name="for_all_config">False</field>
-        </record>
     </data>
 </odoo>

--- a/addons/l10n_in_pos/models/__init__.py
+++ b/addons/l10n_in_pos/models/__init__.py
@@ -6,3 +6,4 @@ from . import pos_order_line
 from . import product_template
 from . import account_move
 from . import account_tax
+from . import pos_bill

--- a/addons/l10n_in_pos/models/pos_bill.py
+++ b/addons/l10n_in_pos/models/pos_bill.py
@@ -1,0 +1,15 @@
+from odoo import api, models
+from odoo.osv import expression
+from odoo.osv.expression import AND
+
+class PosBill(models.Model):
+    _inherit = "pos.bill"
+
+    @api.model
+    def _load_pos_data_domain(self, data):
+        domain = super()._load_pos_data_domain(data)
+
+        if self.env.company.country_code == 'IN':
+            domain = expression.AND([domain, [('value', '>=', 1.0), ('value', '<=', 2000.0)]])
+
+        return domain

--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -78,6 +78,7 @@
             'point_of_sale/static/src/backend/pos_payment_provider_cards/*',
             'point_of_sale/static/src/app/hooks/hooks.js',
             'point_of_sale/static/src/backend/many2one_with_placeholder_field/*',
+            'point_of_sale/static/src/backend/many2many_placeholder_list_view/*',
         ],
         'web.assets_tests': [
             'barcodes/static/tests/legacy/helpers.js',

--- a/addons/point_of_sale/models/pos_bill.py
+++ b/addons/point_of_sale/models/pos_bill.py
@@ -10,8 +10,7 @@ class PosBill(models.Model):
     _inherit = ["pos.load.mixin"]
 
     name = fields.Char("Name")
-    value = fields.Float("Coin/Bill Value", required=True, digits=(16, 4))
-    for_all_config = fields.Boolean("For All PoS", default=True, help="If checked, this coin/bill will be available in all PoS.")
+    value = fields.Float("Value", required=True, digits=(16, 2))
     pos_config_ids = fields.Many2many("pos.config", string="Point of Sales")
 
     @api.model
@@ -25,10 +24,7 @@ class PosBill(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data):
-        return OR([
-            [('id', 'in', data['pos.config'][0]['default_bill_ids']), ('for_all_config', '=', False)],
-            [('for_all_config', '=', True)]
-        ])
+        return ['|', ('id', 'in', data['pos.config'][0]['default_bill_ids']), ('pos_config_ids', '=', False)]
 
     @api.model
     def _load_pos_data_fields(self, config_id):

--- a/addons/point_of_sale/static/src/backend/many2many_placeholder_list_view/many2many_placeholder_list_view.js
+++ b/addons/point_of_sale/static/src/backend/many2many_placeholder_list_view/many2many_placeholder_list_view.js
@@ -1,0 +1,19 @@
+import { registry } from "@web/core/registry";
+import {
+    Many2ManyTagsField,
+    many2ManyTagsField,
+} from "@web/views/fields/many2many_tags/many2many_tags_field";
+
+export class Many2ManyPlaceholderListView extends Many2ManyTagsField {
+    static template = "point_of_sale.Many2ManyPlaceholderListView";
+}
+
+export const many2ManyPlaceholderListView = {
+    ...many2ManyTagsField,
+    component: Many2ManyPlaceholderListView,
+    additionalClasses: ["o_field_many2many_tags"],
+};
+
+registry
+    .category("fields")
+    .add("many2many_tags_placeholder_list_view", many2ManyPlaceholderListView);

--- a/addons/point_of_sale/static/src/backend/many2many_placeholder_list_view/many2many_placeholder_list_view.xml
+++ b/addons/point_of_sale/static/src/backend/many2many_placeholder_list_view/many2many_placeholder_list_view.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="point_of_sale.Many2ManyPlaceholderListView" t-inherit="web.Many2ManyTagsField" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('o_field_tags')]" position="inside">
+            <span t-elif="!tags.length" class="opacity-50" t-esc="props.placeholder"/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/point_of_sale/views/pos_bill_view.xml
+++ b/addons/point_of_sale/views/pos_bill_view.xml
@@ -23,8 +23,7 @@
             <list string="Bills" create="1" delete="1" editable="bottom">
                 <field name="name" />
                 <field name="value" />
-                <field name="for_all_config" />
-                <field name="pos_config_ids" widget="many2many_tags" readonly="for_all_config" />
+                <field name="pos_config_ids" widget="many2many_tags_placeholder_list_view" placeholder="For all point of sale."/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
Before this commit:
====================
The `for_all_config` field controlled coin availability across POS config.

After this commit:
===================
- The `for_all_config` field is removed. Coins are now available in all POS
  configs by default if the `pos_config_ids` field is empty. If `pos_config_ids`
  is populated, coins will only be available in the selected POS configurations.
- The `value` field precision is reduced to 2 decimal places (from 4).
- A placeholder is added to the `pos_config_ids` field in the list view to
  inform users that coins are available in all configs if this field is
  left empty

Task- 4351738

Related upgrade PR: https://github.com/odoo/upgrade/pull/6819