### PR TITLE
[FIX] mail: Incoming call pop-ups shouldn't be transparent

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_invitation.scss
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.scss
@@ -1,3 +1,8 @@
+.o-discuss-CallInvitation {
+    background-color: #000;
+    color: #fff;
+}
+
 .o-discuss-CallInvitation-correspondent {
     width: 130px;
 }

--- a/addons/mail/static/src/discuss/call/common/call_invitation.xml
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallInvitation">
-        <div class="o-discuss-CallInvitation d-flex flex-column m-2 p-5 border border-dark rounded-1 text-bg-900" t-attf-class="{{ className }}" t-ref="root">
+        <div class="o-discuss-CallInvitation d-flex flex-column m-2 p-5 rounded-1 border" t-attf-class="{{ className }}" t-ref="root">
             <div t-if="props.thread.rtcInvitingSession" class="o-discuss-CallInvitation-correspondent d-flex flex-column justify-content-around align-items-center text-nowrap">
                 <img class="o-discuss-CallInvitation-avatar mb-2 rounded-circle cursor-pointer o_object_fit_cover"
                     t-att-src="props.thread.rtcInvitingSession.channelMember.persona.avatarUrl"


### PR DESCRIPTION
Call invitation was transparent because text-bg-900 is a backend-specific classname style. As a result, the pop-up had no bg-color.

Also the background color and text looks good in white theme: black background with white text. This matches the colors in the call view. In dark theme the colors were inverted: white background and black text. This is unintentional, because this doesn't match call view color that is black color and white text in dark theme too. Also the main advantage of dark theme is to put less eye strain and the inverted colors in dark theme were actually more eye-straining than white theme.

This commit fixes the issue by putting specific color in CSS. These colors should not change with theme: dark theme should keep dark background and white text.

task-4354214
