### PR TITLE
[FIX] stock_account: fix accessing svls.company_id.anglo_saxon_accounting

### DIFF
--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -59,11 +59,11 @@ class StockValuationLayer(models.Model):
         if am_vals:
             account_moves = self.env['account.move'].sudo().create(am_vals)
             account_moves._post()
-        products_svl = groupby(self, lambda svl: svl.product_id)
-        for product, svls in products_svl:
+        products_svl = groupby(self, lambda svl: (svl.product_id, svl.company_id.anglo_saxon_accounting))
+        for (product, anglo_saxon_accounting), svls in products_svl:
             svls = self.browse(svl.id for svl in svls)
             moves = svls.stock_move_id
-            if svls.company_id.anglo_saxon_accounting:
+            if anglo_saxon_accounting:
                 moves._get_related_invoices()._stock_account_anglo_saxon_reconcile_valuation(product=product)
             moves = (moves | moves.origin_returned_move_id).with_prefetch(chain(moves._prefetch_ids, moves.origin_returned_move_id._prefetch_ids))
             for aml in moves._get_all_related_aml():


### PR DESCRIPTION
In https://github.com/odoo/odoo/commit/e862e3f7b52f322389dea16666d6e495e6f75aaf condition on svls.company_id.anglo_saxon_accounting was added which will crash if svls.company_id recotdset len > 1. Fix by addong groupby on svls.company_id.anglo_saxon_accounting