### PR TITLE
[FIX] html_editor: ctrl + click not working on link

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -16,6 +16,7 @@ from odoo.tools.mimetypes import guess_mimetype
 from odoo.tools.misc import file_open
 from odoo.addons.iap.tools import iap_tools
 from odoo.addons.mail.tools import link_preview
+from lxml import html
 
 from ..models.ir_attachment import SUPPORTED_IMAGE_MIMETYPES
 
@@ -559,7 +560,10 @@ class HTML_Editor(http.Controller):
 
     @http.route('/html_editor/link_preview_external', type="json", auth="public", methods=['POST'])
     def link_preview_metadata(self, preview_url):
-        return link_preview.get_link_preview_from_url(preview_url)
+        link_preview_data = link_preview.get_link_preview_from_url(preview_url)
+        if link_preview_data['og_description']:
+            link_preview_data['og_description'] = html.fromstring(link_preview_data['og_description']).text_content()
+        return link_preview_data
 
     @http.route('/html_editor/link_preview_internal', type="json", auth="user", methods=['POST'])
     def link_preview_metadata_internal(self, preview_url):
@@ -589,7 +593,7 @@ class HTML_Editor(http.Controller):
 
             result = {}
             if 'description' in record:
-                result['description'] = record.description
+                result['description'] = html.fromstring(record.description).text_content() if record.description else ""
 
             if 'link_preview_name' in record:
                 result['link_preview_name'] = record.link_preview_name

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -220,7 +220,6 @@ export class LinkPopover extends Component {
                 this.state.urlTitle = this.state.label;
             }
         } else {
-            const html_parser = new window.DOMParser();
             // Set state based on cached link meta data
             // for record missing errors, we push a warning that the url is likely invalid
             // for other errors, we log them to not block the ui
@@ -243,10 +242,7 @@ export class LinkPopover extends Component {
                     internalMetadata.link_preview_name ||
                     internalMetadata.display_name ||
                     internalMetadata.name;
-                this.state.urlDescription = internalMetadata.description
-                    ? html_parser.parseFromString(internalMetadata.description, "text/html").body
-                          .textContent
-                    : "";
+                this.state.urlDescription = internalMetadata?.description || "";
                 this.state.urlTitle = this.state.linkPreviewName
                     ? this.state.linkPreviewName
                     : this.state.url;

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -632,7 +632,7 @@ describe("link preview", () => {
     test("test internal link preview", async () => {
         onRpc("/html_editor/link_preview_internal", () => {
             return {
-                description: markup("<p>Test description</p>"),
+                description: markup("Test description"),
                 link_preview_name: "Task name | Project name",
             };
         });


### PR DESCRIPTION
**Current behavior before PR:**

In some url, opening link preview displays special characters as string instead of parsed characters inside description of
link preview popover.

**Desired behavior after PR is merged:**

Now special characters are getting parsed before displaying on popover.

task-4345237



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
