### PR TITLE
[FIX] web_editor: UI stuck when image crop denied

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6602,6 +6602,18 @@ registry.ImageTools = ImageHandlerOption.extend({
         const document = this.$el[0].ownerDocument;
         const imageCropWrapperElement = document.createElement('div');
         document.body.append(imageCropWrapperElement);
+
+        // Attach the event listener before attaching the component
+        const cropperPromise = new Promise(resolve => {
+            this.$target.one("image_cropper_destroyed", async () => {
+                if (isGif(this._getImageMimetype(img))) {
+                    img.dataset[img.dataset.shape ? "originalMimetype" : "mimetype"] = "image/png";
+                }
+                await this._reapplyCurrentShape();
+                resolve();
+            });
+        });
+
         const imageCropWrapper = await attachComponent(this, imageCropWrapperElement, ImageCrop, {
             rpc: this.rpc,
             activeOnStart: true,
@@ -6609,15 +6621,8 @@ registry.ImageTools = ImageHandlerOption.extend({
             mimetype: this._getImageMimetype(img),
         });
 
-        await new Promise(resolve => {
-            this.$target.one('image_cropper_destroyed', async () => {
-                if (isGif(this._getImageMimetype(img))) {
-                    img.dataset[img.dataset.shape ? 'originalMimetype' : 'mimetype'] = 'image/png';
-                }
-                await this._reapplyCurrentShape();
-                resolve();
-            });
-        });
+        await cropperPromise;
+
         imageCropWrapperElement.remove();
         imageCropWrapper.destroy();
         this.trigger_up('enable_loading_effect');

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -74,6 +74,24 @@ wTourUtils.registerWebsitePreviewTour("website_media_dialog_external_library", {
             }
         },
     },
+    {
+        content: "Click on the first illustration image",
+        trigger: ".o_select_media_dialog .o_we_attachment_highlight",
+    },
+    {
+        content: "Select the image",
+        trigger: "iframe .s_text_image img",
+    },
+    {
+        content: "Try to crop the image",
+        trigger: "#oe_snippets .o_we_customize_panel .o_we_user_value_widget[data-crop='true']",
+    },
+    {
+        content: "Observe the crop is denied for illustration image",
+        trigger: ".o_notification_manager .o_notification",
+        run: () => {}, // it's a check
+    },
+    ...wTourUtils.clickOnSave(),
 ]);
 
 wTourUtils.registerWebsitePreviewTour('website_media_dialog_icons', {


### PR DESCRIPTION
Steps to produce:
- Drop 'Text - Image' block
- Replace image by illustration
- Try to crop image
- A notification is displayed
- Try saving

The issue is ImageCrop is still not opened and we are trying to wait for image_cropper_destroyed to trigger,
so here we check if ImageCrop is not opened.

task-4246644

