### PR TITLE
[REF] website_project,project: move partner_phone in project module

### DIFF
--- a/addons/website_project/models/project_task.py
+++ b/addons/website_project/models/project_task.py
@@ -10,20 +10,4 @@ class ProjectTask(models.Model):
     email_from = fields.Char('Email From')
     # Used to submit tasks from a contact form
     partner_name = fields.Char(string='Customer Name', related="partner_id.name", store=True, readonly=False, tracking=False)
-    partner_phone = fields.Char(
-        compute='_compute_partner_phone', inverse='_inverse_partner_phone',
-        string="Contact Number", readonly=False, store=True, copy=False)
     partner_company_name = fields.Char(string='Company Name', related="partner_id.company_name", store=True, readonly=False, tracking=False)
-
-    @api.depends('partner_id.phone', 'partner_id.mobile')
-    def _compute_partner_phone(self):
-        for task in self:
-            task.partner_phone = task.partner_id.mobile or task.partner_id.phone or False
-
-    def _inverse_partner_phone(self):
-        for task in self:
-            if task.partner_id:
-                if task.partner_id.mobile or not task.partner_id.phone:
-                    task.partner_id.mobile = task.partner_phone
-                else:
-                    task.partner_id.phone = task.partner_phone


### PR DESCRIPTION
Since the deployment of task-3635784, partner_phone field is defined in 2 different modules for the same model (project.task model), the problem is the definition of that field is different and could alter the expected behavior. 
The goal of this PR is to make sure to define that field in project.task model only in one place to improve the maintainability.

task-4357466

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
