### PR TITLE
[IMP] base: get model attribute _fold_name from ir.model

### DIFF
--- a/addons/web/tests/test_ir_model.py
+++ b/addons/web/tests/test_ir_model.py
@@ -199,6 +199,14 @@ class TestIrModel(TransactionCase):
             bananas = self.env['x_bananas'].search([])
             self.assertEqual(bananas.mapped('x_name'), names, 'failed to order by %s' % order)
 
+    def test_model_fold_search(self):
+        """Check that custom orders are applied when querying a model."""
+        self.assertEqual(self.bananas_model.fold_name, False)
+        self.assertEqual(self.env['x_bananas']._fold_name, None)
+
+        self.bananas_model.fold_name = 'x_name'
+        self.assertEqual(self.env['x_bananas']._fold_name, 'x_name')
+
     def test_group_expansion(self):
         """Check that the basic custom group expansion works."""
         model = self.env['x_bananas'].with_context(read_group_expand=True)


### PR DESCRIPTION
The model attribute `_fold_name` is used in `_read_group_fill_results()` to know which variable determines whether a `group_by` is folded by default in the kanban/list view.  We extend `ir.model` to reflect and instantiate the attribute `_fold_name` in the field `fold_name`.
    
We also make Studio modify this attribute in https://github.com/odoo/enterprise/pull/74568
    
task-3978030