### PR TITLE
[IMP] sale_timesheet: update performance query count

### DIFF
--- a/addons/sale_timesheet/tests/test_performance.py
+++ b/addons/sale_timesheet/tests/test_performance.py
@@ -19,7 +19,7 @@ class TestPerformanceTimesheet(TestSaleTimesheet):
         })
         self.assertFalse(project.task_ids.sale_line_id)
         self.env.invalidate_all()
-        with self.assertQueryCount(80):
+        with self.assertQueryCount(83):
             project.write({
                 'allow_billable': True,
                 'partner_id': self.partner_b.id,


### PR DESCRIPTION
Following odoo/enterprise#74571 where we make the project base folder configurable, there are 3 additional queries in the test "test_performance_billable_project_change_customer" because instead of getting the base folder in _create_missing_folders method of project (in documents_project application) as:
  self.env.ref('documents_project.document_project_folder').id
we get it from the company as:
  self.env.company.documents_project_folder_id.id
which requires 3 additional queries to apply record rules.

Task-4294237