### PR TITLE
[IMP] core: read-only Environment

### DIFF
--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -99,10 +99,10 @@ class TestPeppolParticipant(TransactionCase):
 
     @contextmanager
     def _set_context(self, other_context):
-        previous_context = self.env.context
-        self.env.context = dict(previous_context, **other_context)
-        yield self
-        self.env.context = previous_context
+        cls = self.__class__
+        env = cls.env(context=dict(cls.env.context, **other_context))
+        with patch.object(cls, "env", env):
+            yield
 
     def test_create_participant_missing_data(self):
         # creating a participant without eas/endpoint/document should not be possible
@@ -155,8 +155,8 @@ class TestPeppolParticipant(TransactionCase):
         # if we reject the participant
         company = self.env.company
         wizard = self.env['peppol.registration'].create(self._get_participant_vals())
-
         with self._set_context({'participant_state': 'rejected'}):
+            wizard = wizard.with_env(self.env)
             wizard.button_register_peppol_participant()
             company.account_peppol_proxy_state = 'smp_registration'
             self.env['account_edi_proxy_client.user']._cron_peppol_get_participant_status()

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -287,17 +287,12 @@ class HrLeaveType(models.Model):
 
         return [('id', 'in', valid_leave_types.ids)]
 
-    @api.depends_context('employee_id', 'default_employee_id', 'default_date_from')
+    @api.depends_context('employee_id', 'default_employee_id', 'leave_date_from', 'default_date_from')
     def _compute_leaves(self):
         employee = self.env['hr.employee']._get_contextual_employee()
         # This is a workaround to save the date value in context for next triggers
         # when context gets cleaned and 'default_' context keys gets removed
-        target_date = self.env.context.get('default_date_from')
-        if target_date:
-            # TODO remove this hack, do not depend on "default_*" context keys
-            vars(self.env)['context'] = self.with_context(leave_date_from=target_date).env.context
-        else:
-            target_date = self.env.context.get('leave_date_from')
+        target_date = self.env.context.get('leave_date_from') or self.env.context.get('default_date_from')
         data_days = self.get_allocation_data(employee, target_date)[employee]
         for holiday_status in self:
             result = [item for item in data_days if item[0] == holiday_status.name]

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -320,8 +320,12 @@ class TestAllocations(TestHrHolidaysCommon):
             'date_to': date(2024, 12, 31)
         })
         second_allocation.action_approve()
+
+        # _compute_leaves depends on the context that is getting cleared
+        self.env['hr.leave.type'].invalidate_model(['max_leaves', 'leaves_taken', 'virtual_remaining_leaves'])
         result = self.env['hr.leave.type'].with_context(
             employee_id=self.employee.id,
+            leave_date_from='2024-08-18 06:00:00',  # for _compute_leaves
             default_date_from='2024-08-18 06:00:00',
             default_date_to='2024-08-18 15:00:00'
         ).name_search(domain=[['id', '=', leave_type.id]])

--- a/addons/hr_holidays/tests/test_dashboard.py
+++ b/addons/hr_holidays/tests/test_dashboard.py
@@ -5,7 +5,7 @@ from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
 
 class TestDashboard(TestHrHolidaysCommon):
     def test_dashboard_special_days(self):
-        self.env.user = self.user_hrmanager
+        self.uid = self.user_hrmanager.id
         employee = self.env.user.employee_id
         other_calendar = self.env['resource.calendar'].create({
             'name': 'Other calendar',

--- a/addons/l10n_ro_edi_stock/tests/test_etransport_flows.py
+++ b/addons/l10n_ro_edi_stock/tests/test_etransport_flows.py
@@ -180,8 +180,7 @@ class TestETransportFlows(TestL10nRoEdiStockCommon):
 
         # Send amended changes to ANAF
         make_request.return_value = self.successful_upload_response
-        with patch.object(self.env, 'context', dict(self.env.context) | {'l10n_ro_edi_stock_send_type': 'amend'}):
-            self.delivery_picking.action_l10n_ro_edi_stock_send_etransport()
+        self.delivery_picking.with_context(test_send_and_amend_etransport='amend').action_l10n_ro_edi_stock_send_etransport()
 
         self._assert_picking_state(self.delivery_picking, 'stock_sent', 2, ('enable', 'enable_fetch', 'fields_readonly'))
         self._assert_etransport_document(self.delivery_picking._l10n_ro_edi_stock_get_last_document('stock_sent'), 'test_send_and_amend_etransport_2')

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -188,9 +188,7 @@ class ThreadController(http.Controller):
         if not thread:
             raise NotFound()
         if not self._get_thread_with_access(thread_model, thread_id, mode="write"):
-            thread.env.context = frozendict(
-                thread.env.context, mail_post_autofollow_author_skip=True, mail_post_autofollow=False
-            )
+            thread = thread.with_context(mail_post_autofollow_author_skip=True, mail_post_autofollow=False)
         post_data = {
                 key: value
                 for key, value in post_data.items()

--- a/addons/mail/models/ir_actions_server.py
+++ b/addons/mail/models/ir_actions_server.py
@@ -417,7 +417,6 @@ class IrActionsServer(models.Model):
         to the currently executed action will be set in the queue instead of
         sent directly. This will avoid possible break in transactions. """
         eval_context = super()._get_eval_context(action=action)
-        ctx = dict(eval_context['env'].context)
-        ctx['mail_notify_force_send'] = False
-        eval_context['env'].context = ctx
+        env = eval_context['env']
+        eval_context['env'] = env(context={**env.context, 'mail_notify_force_send': False})
         return eval_context

--- a/addons/mail/tests/discuss/test_discuss_attachment_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_attachment_controller.py
@@ -12,7 +12,7 @@ class TestDiscussAttachmentController(MailControllerAttachmentCommon):
             {"group_public_id": None, "name": "public channel"}
         )
         channel.add_members(guest_ids=[self.guest.id])
-        channel.env.context = {**channel.env.context, "guest": self.guest}
+        channel = channel.with_context(guest=self.guest)
         self._execute_subtests(
             channel,
             (

--- a/addons/mail/tests/discuss/test_discuss_message_update_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_message_update_controller.py
@@ -11,7 +11,7 @@ class TestDiscussMessageUpdateController(MailControllerUpdateCommon):
             {"group_public_id": None, "name": "public channel"}
         )
         channel.add_members(guest_ids=[self.guest.id])
-        channel.env.context = {**channel.env.context, "guest": self.guest}
+        channel = channel.with_context(guest=self.guest)
         message = channel.with_user(self.user_public).message_post(
             body=self.message_body,
             message_type="comment",

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -29,8 +29,8 @@ def add_guest_to_context(func):
                 guest._update_timezone(timezone)
         if guest:
             req.update_context(guest=guest)
-            if hasattr(self, "env"):
-                self.env.context = {**self.env.context, "guest": guest}
+            if isinstance(self, models.BaseModel):
+                self = self.with_context(guest=guest)
         return func(self, *args, **kwargs)
 
     return wrapper

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -253,8 +253,8 @@ class MrpBom(models.Model):
         parent_production_id = self.env.context.get('parent_production_id')
         if parent_production_id:  # In this case, assign the newly created BoM to the MO.
             # Clean context to avoid parasitic default values.
-            self.env.context = clean_context(self.env.context)
-            production = self.env['mrp.production'].browse(parent_production_id)
+            env = self.env(context=clean_context(self.env.context))
+            production = env['mrp.production'].browse(parent_production_id)
             production._link_bom(res[0])
         return res
 

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -170,8 +170,8 @@ class MrpUnbuild(models.Model):
     def action_unbuild(self):
         self.ensure_one()
         self._check_company()
-        # remove the default_* keys that was only needed in the unbuild wizard
-        self.env.context = dict(clean_context(self.env.context))
+        # remove the default_* keys that were only needed in the unbuild wizard
+        self = self.with_env(self.env(context=clean_context(self.env)))  # noqa: PLW0642
         if self.product_id.tracking != 'none' and not self.lot_id.id:
             raise UserError(_('You should provide a lot number for the final product.'))
 

--- a/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
@@ -425,7 +425,7 @@ class TestTimesheetGlobalTimeOff(common.TransactionCase):
         hr_leave_start_datetime = datetime(next_monday.year, next_monday.month, next_monday.day, 8, 0, 0) # monday next week
         hr_leave_end_datetime = hr_leave_start_datetime + timedelta(days=4, hours=9) # friday next week
 
-        self.env.company = self.test_company
+        self.env = self.env(context=dict(self.env.context, allowed_company_ids=self.test_company.ids))
 
         internal_project = self.test_company.internal_project_id
         internal_task_leaves = self.test_company.leave_timesheet_task_id

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -370,7 +370,7 @@ class TestSaleOrder(SaleCommon):
         company_2 = self.env['res.company'].create({
             'name': 'Company 2'
         })
-        self.env.companies = [self.env.company, company_2]
+        self.env = self.env(context=dict(self.env.context, allowed_company_ids=[self.env.company.id, company_2.id]))
         so_form = Form(self.env['sale.order'])
         with self.assertRaises(ValidationError):
             so_form.company_id = self.env['res.company']

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1770,7 +1770,7 @@ class StockPicking(models.Model):
 
     def _get_action(self, action_xmlid):
         action = self.env["ir.actions.actions"]._for_xml_id(action_xmlid)
-        context = self.env.context
+        context = dict(self.env.context)
         context.update(literal_eval(action['context']))
         action['context'] = context
 

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -4322,7 +4322,7 @@ class TestStockValuation(TestStockValuationBase):
             'parent_id': self.env.company.id,
         })
         # Create a move in the branch company
-        self.env.company = branch
+        self.patch(self, 'env', branch.with_company(branch).env)
         self.product1.with_company(branch).categ_id.property_cost_method = 'average'
         warehouse = self.env['stock.warehouse'].search([('company_id', '=', branch.id)], limit=1)
         self._make_in_move(self.product1, 1, unit_cost=30, location_dest_id=warehouse.lot_stock_id.id, picking_type_id=warehouse.in_type_id.id)

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -1097,7 +1097,7 @@ class IrActionsServer(models.Model):
                 for active_id in active_ids:
                     # run context dedicated to a particular active_id
                     run_self = action.with_context(active_ids=[active_id], active_id=active_id)
-                    eval_context["env"].context = run_self._context
+                    eval_context['env'] = eval_context['env'](context=run_self.env.context)
                     res = runner(run_self, eval_context=eval_context)
             else:
                 _logger.warning(

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -83,6 +83,12 @@ class Environment(Mapping[str, "BaseModel"]):
             transaction.default_env = self
         return self
 
+    def __setattr__(self, name: str, value: typing.Any) -> None:
+        # once initialized, attributes are read-only
+        if name in vars(self):
+            raise AttributeError(f"Attribute {name!r} is read-only, call `env()` instead")
+        return super().__setattr__(name, value)
+
     #
     # Mapping methods
     #

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -418,6 +418,7 @@ class BaseCase(case.TestCase):
     def with_user(self, login):
         """ Change user for a given test, like with self.with_user() ... """
         old_uid = self.uid
+        old_env = self.env
         try:
             user = self.env['res.users'].sudo().search([('login', '=', login)])
             assert user, "Login %s not found" % login
@@ -428,7 +429,7 @@ class BaseCase(case.TestCase):
         finally:
             # back
             self.uid = old_uid
-            self.env = self.env(user=self.uid)
+            self.env = old_env
 
     @contextmanager
     def debug_mode(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Make the environment read-only. Once an attribute is computed, it cannot be set anymore.

Current behavior before PR:
You can set variables on the `Environment` which is supposed to be immutable.

Desired behavior after PR is merged:
Prevent setting arbitrary values.
Deletion of attributes is still possible for lazy properties.

odoo/enterprise#74572
task-4201974

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
