### PR TITLE
[FIX] mail: traceback on welcome bot avatar card

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -30,7 +30,7 @@ export class ChannelMemberList extends Component {
         if (this.store.inPublicPage) {
             return false;
         }
-        if (member.persona.type === "guest") {
+        if (member.persona.type === "guest" || member.persona.is_bot) {
             return false;
         }
         return true;


### PR DESCRIPTION
Traceback: https://pastebin.com/UmtLxudu

Steps to reproduce:
- Open conversation with a visitor in chat window
- Using the thread actions, open the channel member list
- Click on the Welcome bot > leads to a traceback

The Welcome Bot partner does not have user_id hence when opening its avatar card leads to a traceback as the avatar card requires a user_id. This commit address this issue.
