### PR TITLE
[REM] html_editor: remove unused `split_unsplittable_handlers`

### DIFF
--- a/addons/html_editor/static/src/core/line_break_plugin.js
+++ b/addons/html_editor/static/src/core/line_break_plugin.js
@@ -17,7 +17,6 @@ export class LineBreakPlugin extends Plugin {
     static shared = ["insertLineBreak", "insertLineBreakNode", "insertLineBreakElement"];
     resources = {
         beforeinput_handlers: this.onBeforeInput.bind(this),
-        split_unsplittable_handlers: this.insertLineBreakElement.bind(this),
     };
 
     insertLineBreak() {


### PR DESCRIPTION
`split_unsplittable_handlers` was not removed in [1] by mistake.

[1]: https://github.com/odoo/odoo/commit/75f6f0a20cb7a860a703e73e80a4247e716ab620
