### PR TITLE
[FIX] base_import_module: allow upgrade for modules with cloc_exclude in manifest

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -140,12 +140,15 @@ class IrModule(models.Model):
                     elif ext == '.xml':
                         convert_xml_import(self.env, module, fp, idref, mode, noupdate)
                         if filename in exclude_list:
-                            self.env['ir.model.data'].create([{
-                                'name': f"cloc_exclude_{key}",
-                                'model': self.env['ir.model.data']._xmlid_lookup(f"{module}.{key}")[0],
-                                'module': "__cloc_exclude__",
-                                'res_id': value,
-                            } for key, value in idref.items()])
+                            for key, value in idref.items():
+                                vals = {
+                                    'module': '__cloc_exclude__',
+                                    'name': f"cloc_exclude_{key}",
+                                    'model': self.env['ir.model.data']._xmlid_lookup(f"{module}.{key}")[0],
+                                    'res_id': value
+                                }
+                                existing = self.env['ir.model.data'].search([('module', '=', vals['module']), ('name', '=', vals['name'])])
+                                existing.write(vals) if existing else self.env['ir.model.data'].create(vals)
 
         path_static = opj(path, 'static')
         IrAttachment = self.env['ir.attachment']

--- a/addons/base_import_module/tests/test_cloc.py
+++ b/addons/base_import_module/tests/test_cloc.py
@@ -252,6 +252,28 @@ class TestClocFields(test_cloc.TestClocCustomization):
         # Import test module
         self.env['ir.module.module']._import_zipfile(stream)
 
+        cl = cloc.Cloc()
+        cl.count_customization(self.env)
+        self.assertEqual(cl.code.get('test_imported_module', 0), 0)
+
+    def test_module_with_exclude_cloc_can_be_imported_twice(self):
+        manifest_content = json.dumps({
+            'name': 'test_imported_module',
+            'description': 'Test',
+            'data': ['data/test.xml'],
+            'cloc_exclude': ['data/test.xml'],
+            'license': 'LGPL-3',
+        })
+
+        stream = BytesIO()
+        with ZipFile(stream, 'w', compression=ZIP_DEFLATED) as archive:
+            archive.writestr('test_imported_module/__manifest__.py', manifest_content)
+            archive.writestr('test_imported_module/data/test.xml', VALID_XML_2)
+
+        # Import test module
+        self.env['ir.module.module']._import_zipfile(stream)
+        # Import test module again (during an upgrade for instance)
+        self.env['ir.module.module']._import_zipfile(stream)
 
         cl = cloc.Cloc()
         cl.count_customization(self.env)


### PR DESCRIPTION
When trying to upgrade a module having `cloc_exclude` in its manifest, through the main "Upgrade" button from the Apps list, the installation fails.

Steps to reproduce:
1. Install the 'construction' industry app
2. Go to Apps and search for 'construction'
3. Click on the main 'Upgrade' purple button
4. Confirm the upgrade popup

Reason:
The main 'Upgrade' button is internally calling `_import_zipfile`, this function creates new `ir.model.data` records for xml tags in `idref`. However, when upgrading, we're running this code again, and trying to recreate those records, which fails with a unique id constraint error.

Solution:
Before creating those records, we now check if they exist, and in that case, we just update their values instead of trying to recreate them.

opw-4339886
