### PR TITLE
[FIX] website_forum: ensure forum order on website

### DIFF
--- a/addons/website_forum/views/forum_forum_templates_forum_all.xml
+++ b/addons/website_forum/views/forum_forum_templates_forum_all.xml
@@ -29,7 +29,7 @@
 <template id="forum_all_all_entries">
     <!-- Check if at least one forum without description exist -->
     <t t-set="no_description_exist" t-value="bool(_forums.filtered(lambda f: not f.description))"/>
-    <t t-set="sorted_forums" t-value="_forums.sorted(lambda f: (not f.description, f.sequence, f.id))"/>
+    <t t-set="sorted_forums" t-value="_forums.sorted(lambda f: (f.sequence, not f.description, f.id))"/>
 
     <!-- First, list all forums (those with descriptions first) -->
     <t t-foreach="sorted_forums" t-as="forum">


### PR DESCRIPTION
Steps to reproduce:

 - Go to the forum list (configuration -> forum -> forums)
 - Change the order of the forum
 - Go to the website forum

Issue:

The display of the forum in the website does not follow the order of the sequence defined in the list view of the forum.

Fix:

Moved the condition for the empty description after the sequence, and added the sequence in the liste view as invisible column.

opw-4305843

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
