### PR TITLE
[FIX] core: use the original constraint definition

### DIFF
--- a/odoo/addons/base/tests/test_sql.py
+++ b/odoo/addons/base/tests/test_sql.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import BaseCase
-from odoo.tools import SQL
+from psycopg2.errors import CheckViolation
+
+from odoo.tests.common import BaseCase, TransactionCase
+from odoo.tools import SQL, mute_logger, sql
 
 
 class TestSQL(BaseCase):
@@ -158,3 +160,18 @@ class TestSQL(BaseCase):
             repr(sql),
             """SQL('SELECT "id" FROM "table" WHERE "table"."foo"=%s AND "table"."bar"=%s', 1, 2)"""
         )
+
+class TestSqlTools(TransactionCase):
+
+    def test_add_constraint(self):
+        definition = "CHECK (name !~ '%')"
+        sql.add_constraint(self.env.cr, 'res_bank', 'test_constraint_dummy', definition)
+
+        # ensure the constraint with % works and it's in the DB
+        with self.assertRaises(CheckViolation), mute_logger('odoo.sql_db'):
+            self.env['res.bank'].create({'name': '10% bank'})
+
+        # ensure the definitions match
+        db_definition = sql.constraint_definition(self.env.cr, 'res_bank', 'test_constraint_dummy')
+        self.assertEqual(definition, db_definition)
+

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -405,8 +405,6 @@ def constraint_definition(cr, tablename, constraintname):
 
 def add_constraint(cr, tablename, constraintname, definition):
     """ Add a constraint on the given table. """
-    if "%" in definition:
-        definition = definition.replace("%", "%%")
     query1 = SQL(
         "ALTER TABLE %s ADD CONSTRAINT %s %s",
         SQL.identifier(tablename), SQL.identifier(constraintname), SQL(definition),


### PR DESCRIPTION
If we replace the original definition then the check between the existing definition and the original one will always fail, thus we are always removing and re-adding the same constraint. https://github.com/odoo/odoo/blob/5ba361ddffa757cf60968f37180c7fd1304b3fd4/odoo/models.py#L3209

Replacing `%` by `%%` works for `LIKE` operator because they are equivalent. Since they are sent as-is to the DB the constraint could actually be plainly wrong.

```sql
test_17=> SELECT coalesce(d.description, pg_get_constraintdef(c.oid))
   FROM pg_constraint c
   JOIN pg_class t
     ON t.oid = c.conrelid
   LEFT JOIN pg_description d
     ON c.oid = d.objoid
  WHERE t.relname = 'ir_model_fields'
    AND conname = 'ir_model_fields_name_manual_field'
+------------------------------------------------+
| coalesce                                       |
|------------------------------------------------|
| CHECK (state != 'manual' OR name LIKE 'x\_%%') |
+------------------------------------------------+
```

Example where the definition sent to the DB is wrong:
```py
class A(models.Model):
    _inherit = "res.users"

    _sql_constraints = [("test_constraint", "CHECK (login !~ '%')", "Cannot have % in login")]
```
```sql
test_17=> \d res_users
...
Check constraints:
    "res_users_test_constraint" CHECK (login::text !~ '%%'::text)
...
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
