### PR TITLE
[FIX] point_of_sale: self-service invoicing when customer not selected

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -222,6 +222,7 @@ class PosController(PortalAccount):
             'invoice_required_fields': additional_invoice_fields,
             'partner_required_fields': additional_partner_fields,
             'access_token': access_token,
+            'invoice_sending_methods': {'email': _('by Email')},
             **form_values,
         })
 


### PR DESCRIPTION
Steps to reproduce:
=====
- Enable Self-Service Invoicing and select any method for print (i.e. QR Code or URL)
- Place an order without selecting a customer and invoice.
- On the receipt screen, a receipt with a QR or portal URL is visible.
- Scan the QR code or open the portal URL, and enter the necessary details from the receipt.
- Click on the Request Invoice button.
- 500 Internal Server Error!

Cause:
=====
- In the account module, the `portal_my_details_fields` template will check the length of a `invoice_sending_method` which is not passed in `ticket_validation_screen`.

Fix:
=====
- `invoice_sending_method` is passed while rendering the `point_of_sale.ticket_validation_screen`.

task: 4360753


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
