### PR TITLE
[FIX] im_livechat: chatbot answer buttons outside bubble

### DIFF
--- a/addons/im_livechat/static/src/embed/common/message_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/message_patch.xml
@@ -7,7 +7,7 @@
             </div>
             <t t-else="">$0</t>
         </xpath>
-        <xpath expr="//*[hasclass('o-mail-Message-textContent')]" position="inside">
+        <xpath expr="//*[hasclass('o-mail-Message-textContent')]" position="after">
             <ul class="p-0 m-0" t-if="props.message.chatbotStep?.answers and !props.message.chatbotStep.selectedAnswer">
                 <li
                     t-foreach="props.message.chatbotStep?.answers" t-as="answer" t-key="answer.id"


### PR DESCRIPTION
Before this commit, chatbot answers buttons appear inside the message bubble.

This happens because the new xpath target introduced in https://github.com/odoo/odoo/pull/188407 had the wrong position argument. This commit fixes the issue by changing the position to `after`.

Before:
![image](https://github.com/user-attachments/assets/e1d6ebf8-c02e-4dc4-aff4-47b959322bd3)

After:
![389491233-413b4735-b0ab-4172-acbf-dd6d5eb0347c](https://github.com/user-attachments/assets/fe2cbe25-d8e6-4af8-8f10-039a4a1da94f)
