### PR TITLE
[FIX] web: compute editedRecord when needed

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -116,18 +116,20 @@ export class DynamicList extends DataPoint {
     }
 
     async leaveEditMode({ discard } = {}) {
-        const editedRecord = this.editedRecord;
+        let editedRecord = this.editedRecord;
         if (editedRecord) {
             let canProceed = true;
             if (discard) {
                 await editedRecord.discard();
+                editedRecord = this.editedRecord;
                 if (editedRecord && editedRecord.isNew) {
                     this._removeRecords([editedRecord.id]);
                 }
             } else {
                 if (!this.model._urgentSave) {
                     await editedRecord.checkValidity();
-                    if (!this.editedRecord) {
+                    editedRecord = this.editedRecord;
+                    if (!editedRecord) {
                         return true;
                     }
                 }
@@ -138,6 +140,7 @@ export class DynamicList extends DataPoint {
                 }
             }
 
+            editedRecord = this.editedRecord;
             if (canProceed && editedRecord) {
                 this.model._updateConfig(
                     editedRecord.config,


### PR DESCRIPTION
In a previous commit [1], we reduced the number of call to the getter `editedRecord` which does a heavy operation.
In `DynamicList.leaveEditMode` we saved the edited record but it could become outdated so we need to compute at some point.

[1]: b1191a7b99d5e374f92b62c541ac058cff26d4d7