### PR TITLE
[FIX] web: editable grouped list: correctly leave edition

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -277,6 +277,13 @@ export class ListRenderer extends Component {
         }
     }
 
+    async addInGroup(group) {
+        const left = await this.props.list.leaveEditMode({ canAbandon: false });
+        if (left) {
+            group.addNewRecord({}, this.props.editable === "top");
+        }
+    }
+
     processAllColumn(allColumns, list) {
         return allColumns.flatMap((column) => {
             if (column.type === "field" && list.fields[column.name].type === "properties") {
@@ -1173,8 +1180,8 @@ export class ListRenderer extends Component {
     async onDeleteRecord(record, ev) {
         this.keepColumnWidths = true;
         if (this.editedRecord && this.editedRecord !== record) {
-            const leaved = await this.props.list.leaveEditMode();
-            if (!leaved) {
+            const left = await this.props.list.leaveEditMode();
+            if (!left) {
                 return;
             }
         }
@@ -1836,6 +1843,13 @@ export class ListRenderer extends Component {
             (hotkey === "tab" && index < focusableEls.length - 1) ||
             (hotkey === "shift+tab" && index > 0)
         );
+    }
+
+    async onGroupHeaderClicked(ev, group) {
+        const left = await this.props.list.leaveEditMode();
+        if (left) {
+            this.toggleGroup(group);
+        }
     }
 
     toggleGroup(group) {

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -155,7 +155,7 @@
                         >
                             <a href="#"
                                 role="button"
-                                t-on-click.stop.prevent="() => group.addNewRecord({}, props.editable === 'top')"
+                                t-on-click.stop.prevent="() => this.addInGroup(group)"
                                 t-on-keydown="(ev) => this.onCellKeydown(ev)"
                             >
                                 Add a line
@@ -169,7 +169,7 @@
 
     <t t-name="web.ListRenderer.GroupRow">
         <tr t-attf-class="{{group.count > 0 ? 'o_group_has_content' : ''}} o_group_header {{!group.isFolded ? 'o_group_open' : ''}} cursor-pointer"
-            t-on-click="() => this.toggleGroup(group)"
+            t-on-click="(ev) => this.onGroupHeaderClicked(ev, group)"
         >
             <th t-on-keydown="(ev) => this.onCellKeydown(ev, group)"
                 tabindex="-1"

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -16598,6 +16598,48 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 5);
     });
 
+    QUnit.test("editable grouped list: fold group with edited row", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: '<tree editable="top"><field name="foo"/></tree>',
+            groupBy: ["bar"],
+        });
+
+        await click(target.querySelector(".o_group_header"));
+        assert.strictEqual(target.querySelector(".o_data_row .o_data_cell").innerText, "blip");
+        await click(target.querySelector(".o_data_row .o_data_cell"));
+        await editInput(target, ".o_selected_row [name=foo] input", "some change");
+        await click(target.querySelector(".o_group_header"));
+        await click(target.querySelector(".o_group_header"));
+        assert.strictEqual(
+            target.querySelector(".o_data_row .o_data_cell").innerText,
+            "some change"
+        );
+    });
+
+    QUnit.test("editable grouped list: add row with edited row", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: '<tree editable="bottom"><field name="foo"/></tree>',
+            groupBy: ["bar"],
+        });
+
+        await click(target.querySelector(".o_group_header"));
+        assert.containsOnce(target, ".o_data_row");
+        await click(target.querySelector(".o_data_row .o_data_cell"));
+        await editInput(target, ".o_selected_row [name=foo] input", "some change");
+        await click(target.querySelector(".o_group_field_row_add a"));
+        assert.containsN(target, ".o_data_row", 2);
+        assert.strictEqual(
+            target.querySelector(".o_data_row .o_data_cell").innerText,
+            "some change"
+        );
+    });
+
     QUnit.test(
         "add and discard a line through keyboard navigation without crashing",
         async function (assert) {


### PR DESCRIPTION
This commit fixes two issues with the editable grouped list view. In a group, click on a row to switch it into edition and edit an input field (e.g. a char). Do not blur the input. From this state,
 - clicking on the group header to close the group, or
 - clicking on "Add a line" to add a new record would both lead to the change being lost.

This commit ensures the keep the change in those flows by correctly calling `leaveEditMode` before closing the group or adding the new record.

opw~4174315

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
