### PR TITLE
[IMP] web, *: setup views as readonly

### DIFF
--- a/addons/crm/static/tests/crm_rainbowman_tests.js
+++ b/addons/crm/static/tests/crm_rainbowman_tests.js
@@ -120,7 +120,6 @@ QUnit.module('Crm Rainbowman Triggers', {
             ...this.testFormView,
             resId: 6,
             mockRPC: getMockRpc(assert),
-            mode: "readonly",
         });
 
         await click(target.querySelector(".o_statusbar_status button[data-value='3']"));
@@ -147,7 +146,6 @@ QUnit.module('Crm Rainbowman Triggers', {
             ...this.testFormView,
             resId: 2,
             mockRPC: getMockRpc(assert),
-            mode: "readonly",
         });
 
         await click(target.querySelector(".o_statusbar_status button[data-value='3']"));
@@ -161,7 +159,6 @@ QUnit.module('Crm Rainbowman Triggers', {
             ...this.testFormView,
             resId: 1,
             mockRPC: getMockRpc(assert),
-            mode: "readonly",
         });
 
         await click(target.querySelector(".o_statusbar_status button[data-value='3']"));
@@ -175,7 +172,6 @@ QUnit.module('Crm Rainbowman Triggers', {
             ...this.testFormView,
             resId: 8,
             mockRPC: getMockRpc(assert),
-            mode: "readonly",
         });
 
         await click(target.querySelector(".o_statusbar_status button[data-value='3']"));
@@ -189,7 +185,6 @@ QUnit.module('Crm Rainbowman Triggers', {
             ...this.testFormView,
             resId: 10,
             mockRPC: getMockRpc(assert),
-            mode: "readonly",
         });
 
         await click(target.querySelector(".o_statusbar_status button[data-value='3']"));
@@ -203,7 +198,6 @@ QUnit.module('Crm Rainbowman Triggers', {
             ...this.testFormView,
             resId: 1,
             mockRPC: getMockRpc(assert),
-            mode: "readonly",
         });
 
         await click(target.querySelector(".o_statusbar_status button[data-value='2']"));

--- a/addons/event/static/src/views/event_registration_kanban_controller.js
+++ b/addons/event/static/src/views/event_registration_kanban_controller.js
@@ -12,7 +12,7 @@ export class EventRegistrationKanbanController extends KanbanController {
         this.orm = useService("orm");
     }
 
-    async openRecord(record, mode) {
+    async openRecord(record) {
         if (this.props.context.is_registration_desk_view) {
             const barcode = record.data.barcode;
             const eventId = record.data.event_id[0];
@@ -30,7 +30,7 @@ export class EventRegistrationKanbanController extends KanbanController {
                 }
             );
         } else {
-            return super.openRecord(record, mode);
+            return super.openRecord(record);
         }
     }
 }

--- a/addons/hr_holidays/static/tests/leave_stats.test.js
+++ b/addons/hr_holidays/static/tests/leave_stats.test.js
@@ -124,7 +124,6 @@ test("leave stats reload when employee/department changes", async () => {
     await mountView({
         type: "form",
         resModel: "hr.leave",
-        mode: "edit",
         arch: `
             <form string="Leave">
                 <field name="employee_id"/>

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -188,7 +188,7 @@
                                                     initially
                                                 </t>
                                             </div>
-                                            <t t-if="!read_only_mode">
+                                            <t t-if="widget.editable">
                                                 <a type="open" t-attf-class="oe_kanban_action text-black">
                                                     <t t-call="level_content"/>
                                                 </a>

--- a/addons/mail/static/src/views/web/activity/activity_controller.js
+++ b/addons/mail/static/src/views/web/activity/activity_controller.js
@@ -127,9 +127,9 @@ export class ActivityController extends Component {
         this.model.orm.call(this.props.resModel, "activity_send_mail", [resIds, templateID], {});
     }
 
-    async openRecord(record, { mode, newWindow }) {
+    async openRecord(record, { newWindow }) {
         const activeIds = this.model.root.records.map((datapoint) => datapoint.resId);
-        this.props.selectRecord(record.resId, { activeIds, mode, newWindow });
+        this.props.selectRecord(record.resId, { activeIds, newWindow });
     }
 
     get rendererProps() {

--- a/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
+++ b/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
@@ -22,7 +22,7 @@ defineMailModels();
 
 test("base rendering not editable", async () => {
     await start();
-    await openFormView("res.partner", undefined, { mode: "edit" });
+    await openFormView("res.partner", undefined, {});
     await contains(".o-mail-Followers");
     await contains(".o-mail-Followers-button:disabled");
     await contains(".o-mail-Followers-dropdown", { count: 0 });

--- a/addons/mail/static/tests/web/fields/many2many_tags_email.test.js
+++ b/addons/mail/static/tests/web/fields/many2many_tags_email.test.js
@@ -50,7 +50,6 @@ test("fieldmany2many tags email (edition)", async () => {
                 <field name="partner_ids" widget="many2many_tags_email"/>
             </form>
         `,
-        mode: "edit",
     });
     await waitForSteps([]);
     await contains('.o_field_many2many_tags_email[name="partner_ids"] .badge.o_tag_color_0');

--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.xml
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.xml
@@ -8,7 +8,6 @@
             <attribute name="t-attf-class">{{ stateIcon(currentValue) }} {{ statusColor(currentValue) }}</attribute>
         </xpath>
         <xpath expr="//t[@t-if='props.readonly']/button" position="attributes">
-            <attribute name="style">cursor: default;</attribute>
             <attribute name="t-att-title">label</attribute>
         </xpath>
         <!-- Waiting state button -->

--- a/addons/sale/static/src/js/sale_progressbar_field.js
+++ b/addons/sale/static/src/js/sale_progressbar_field.js
@@ -34,7 +34,7 @@ export class SaleProgressBarField extends KanbanProgressBarField {
     async defineInvoicingTarget() {
         const { resId, resModel } = this.props.record;
         const action = await this.orm.call(resModel, "get_formview_action", [[resId]]);
-        this.actionService.doAction(action, { props: { mode: "edit" } });
+        this.actionService.doAction(action);
     }
 }
 

--- a/addons/sms/static/tests/web/sms_button.test.js
+++ b/addons/sms/static/tests/web/sms_button.test.js
@@ -28,7 +28,7 @@ test("Sms button in form view", async () => {
         type: "form",
         resModel: "visitor",
         resId: visitorId,
-        mode: "readonly",
+        readonly: true,
         arch:
             `<form>
                 <sheet>
@@ -46,7 +46,7 @@ test("Sms button with option enable_sms set as False", async () => {
         type: "form",
         resModel: "visitor",
         resId: visitorId,
-        mode: "readonly",
+        readonly: true,
         arch:
             `<form>
                 <sheet>

--- a/addons/survey/static/tests/components/question_page_one2many_field_tests.js
+++ b/addons/survey/static/tests/components/question_page_one2many_field_tests.js
@@ -106,7 +106,7 @@ QUnit.module("QuestionPageOneToManyField", (hooks) => {
                     </field>
                 </form>
             `,
-            mode: "readonly",
+            readonly: true,
         });
 
         await click(target.querySelector(".o_data_cell"));

--- a/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.xml
+++ b/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.BooleanFavoriteField">
-        <div class="o_favorite" t-on-click.prevent.stop="update">
+        <div class="o_favorite" t-att-class="{'o_disabled': props.readonly}" t-on-click.prevent.stop="update">
             <a href="#" t-att-class="{'pe-none' : props.readonly}">
                 <i t-att-class="iconClass" role="img" t-att-title="label" t-att-aria-label="label"/>
                 <t t-if="!props.readonly and !props.noLabel" t-esc="label"/>

--- a/addons/web/static/src/views/fields/handle/handle_field.js
+++ b/addons/web/static/src/views/fields/handle/handle_field.js
@@ -17,6 +17,11 @@ export const handleField = {
     supportedTypes: ["integer"],
     isEmpty: () => false,
     listViewWidth: 20,
+    extractProps(_, dynamicInfo) {
+        return {
+            readonly: dynamicInfo.readonly,
+        };
+    },
 };
 
 registry.category("fields").add("handle", handleField);

--- a/addons/web/static/src/views/fields/handle/handle_field.xml
+++ b/addons/web/static/src/views/fields/handle/handle_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.HandleField">
-        <span class="o_row_handle oi oi-draggable ui-sortable-handle" t-on-click.stop="" />
+        <span class="o_row_handle oi oi-draggable ui-sortable-handle" t-att-class="{ 'o_disabled': props.readonly }" t-on-click.stop="" />
     </t>
 
 </templates>

--- a/addons/web/static/src/views/fields/priority/priority_field.xml
+++ b/addons/web/static/src/views/fields/priority/priority_field.xml
@@ -7,7 +7,7 @@
                 <t t-if="!value_first">
                     <t t-if="props.readonly">
                         <span
-                            class="o_priority_star fa"
+                            class="o_priority_star fa o_disabled"
                             role="radio"
                             t-att-class="value_index lte index ? 'fa-star' : 'fa-star-o'"
                             t-att-tabindex="value_index === state.index ? 0 : -1"

--- a/addons/web/static/src/views/fields/relational_utils.xml
+++ b/addons/web/static/src/views/fields/relational_utils.xml
@@ -3,10 +3,10 @@
 
 <t t-name="web.X2ManyFieldDialog">
     <Dialog t-props="dialogProps">
-        <FormRenderer record="record" archInfo="archInfo"/>
+        <FormRenderer readonly="readonly" record="record" archInfo="archInfo"/>
         <t t-set-slot="footer">
             <t t-if="footerArchInfo">
-                <FormRenderer record="record" archInfo="footerArchInfo">
+                <FormRenderer readonly="readonly" record="record" archInfo="footerArchInfo">
                     <t t-set-slot="default_buttons">
                         <t t-call="web.X2ManyFieldDialogDefaultButtons"/>
                     </t>

--- a/addons/web/static/src/views/fields/state_selection/state_selection_field.xml
+++ b/addons/web/static/src/views/fields/state_selection/state_selection_field.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.StateSelectionField">
         <t t-if="props.readonly">
-            <button class="d-flex align-items-center btn fw-normal p-0">
+            <button class="d-flex align-items-center btn fw-normal p-0 o_disabled">
                 <span t-attf-class="o_status {{ statusColor(currentValue) }} "/>
                 <span t-if="props.showLabel" class="o_status_label ms-1" t-esc="label"/>
             </button>

--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -70,12 +70,10 @@ export class X2ManyField extends Component {
             }),
             fieldType: this.isMany2Many ? "many2many" : "one2many",
             subViewActiveActions,
-            getEvalParams: (props) => {
-                return {
-                    evalContext: props.record.evalContext,
-                    readonly: props.readonly,
-                };
-            },
+            getEvalParams: (props) => ({
+                evalContext: props.record.evalContext,
+                readonly: props.readonly,
+            }),
         });
 
         this.addInLine = useAddInlineRecord({
@@ -193,12 +191,12 @@ export class X2ManyField extends Component {
             archInfo,
             list: this.list,
             openRecord: this.openRecord.bind(this),
+            readonly: this.props.readonly,
         };
 
         if (this.props.viewMode === "kanban") {
             const recordsDraggable = !this.props.readonly && archInfo.recordsDraggable;
             props.archInfo = { ...archInfo, recordsDraggable };
-            props.readonly = this.props.readonly;
             // TODO: apply same logic in the list case
             props.deleteRecord = (record) => {
                 if (this.isMany2Many) {
@@ -273,7 +271,7 @@ export class X2ManyField extends Component {
             return this._openRecord({
                 record,
                 context: this.props.context,
-                mode: this.props.readonly ? "readonly" : "edit",
+                readonly: this.props.readonly,
             });
         }
     }

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -140,10 +140,7 @@ export class FormController extends Component {
     static props = {
         ...standardViewProps,
         discardRecord: { type: Function, optional: true },
-        mode: {
-            optional: true,
-            validate: (m) => ["edit", "readonly"].includes(m),
-        },
+        readonly: { type: Boolean, optional: true },
         saveRecord: { type: Function, optional: true },
         removeRecord: { type: Function, optional: true },
         Model: Function,
@@ -354,10 +351,6 @@ export class FormController extends Component {
     }
 
     get modelParams() {
-        let mode = this.props.mode || "edit";
-        if (!this.canEdit && this.props.resId) {
-            mode = "readonly";
-        }
         return {
             config: {
                 resModel: this.props.resModel,
@@ -366,7 +359,7 @@ export class FormController extends Component {
                 fields: this.props.fields,
                 activeFields: {}, // will be generated after loading sub views (see willStart)
                 isMonoRecord: true,
-                mode,
+                mode: this.props.readonly ? "readonly" : "edit",
                 context: this.props.context,
             },
             state: this.props.state?.modelState,

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -684,7 +684,7 @@
         .o_field_translate:not(.o_field_input_buttons):not(.btn) {
             display: none;
         }
-        
+
         .o_field_translate.btn {
             // hide language button for current language
             visibility: hidden !important;
@@ -942,12 +942,6 @@
             padding: 3px;
             color: $o-main-text-color;
         }
-    }
-    .o_form_readonly .o_field_widget .o_list_renderer .o_row_handle {
-        display: none;  // Hide the handler in non-edit mode
-    }
-    .o_field_widget.o_readonly_modifier .o_list_renderer .o_row_handle {
-        display: none;  // Hide the handler on readonly fields
     }
 
     &.oe_form_configuration .o_form_renderer {

--- a/addons/web/static/src/views/form/form_controller.xml
+++ b/addons/web/static/src/views/form/form_controller.xml
@@ -53,7 +53,7 @@
                             <button type="button" class="btn btn-outline-primary o_form_button_create" data-hotkey="c" t-on-click.stop="create">New</button>
                         </t>
                     </t>
-                    <t t-component="props.Renderer" record="model.root" Compiler="props.Compiler" archInfo="archInfo" translateAlert="translateAlert" onNotebookPageChange.bind="onNotebookPageChange" activeNotebookPages="props.state and props.state.activeNotebookPages"/>
+                    <t t-component="props.Renderer" record="model.root" Compiler="props.Compiler" readonly="props.readonly" archInfo="archInfo" translateAlert="translateAlert" onNotebookPageChange.bind="onNotebookPageChange" activeNotebookPages="props.state and props.state.activeNotebookPages"/>
                 </Layout>
             </div>
         </div>

--- a/addons/web/static/src/views/form/form_renderer.js
+++ b/addons/web/static/src/views/form/form_renderer.js
@@ -50,6 +50,7 @@ export class FormRenderer extends Component {
         translateAlert: { type: [Object, { value: null }], optional: true },
         onNotebookPageChange: { type: Function, optional: true },
         activeNotebookPages: { type: Object, optional: true },
+        readonly: { type: Boolean, optional: true },
         saveRecord: { type: Function, optional: true },
         setFieldAsDirty: { type: Function, optional: true },
         slots: { type: Object, optional: true },

--- a/addons/web/static/src/views/form/form_view.js
+++ b/addons/web/static/src/views/form/form_view.js
@@ -22,6 +22,9 @@ export const formView = {
 
         return {
             ...genericProps,
+            readonly:
+                genericProps.readonly ||
+                (archInfo.activeActions?.edit === false && genericProps.resId !== false),
             Model: view.Model,
             Renderer: view.Renderer,
             buttonTemplate: genericProps.buttonTemplate || view.buttonTemplate,

--- a/addons/web/static/src/views/kanban/kanban_compiler.js
+++ b/addons/web/static/src/views/kanban/kanban_compiler.js
@@ -29,7 +29,6 @@ const SPECIAL_TYPES = [
 
 export class KanbanCompiler extends ViewCompiler {
     setup() {
-        this.ctx.readonly = "read_only_mode";
         this.compilers.push(
             { selector: "t[t-call]", fn: this.compileTCall },
             { selector: "img", fn: this.compileImage }

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -34,6 +34,7 @@ export class KanbanController extends Component {
         editable: { type: Boolean, optional: true },
         forceGlobalClick: { type: Boolean, optional: true },
         onSelectionChanged: { type: Function, optional: true },
+        readonly: { type: Boolean, optional: true },
         showButtons: { type: Boolean, optional: true },
         Compiler: { type: Function, optional: true }, // optional in stable for backward compatibility
         Model: Function,
@@ -249,9 +250,9 @@ export class KanbanController extends Component {
         return evaluateBooleanExpr(modifier, { context: this.props.context });
     }
 
-    async openRecord(record, { mode, newWindow } = {}) {
+    async openRecord(record, { newWindow } = {}) {
         const activeIds = this.model.root.records.map((datapoint) => datapoint.resId);
-        this.props.selectRecord(record.resId, { activeIds, mode, newWindow });
+        this.props.selectRecord(record.resId, { activeIds, newWindow });
     }
 
     async createRecord() {

--- a/addons/web/static/src/views/kanban/kanban_controller.xml
+++ b/addons/web/static/src/views/kanban/kanban_controller.xml
@@ -43,7 +43,7 @@
                     list="model.root"
                     archInfo="props.archInfo"
                     Compiler="props.Compiler"
-                    readonly="true"
+                    readonly="props.readonly"
                     forceGlobalClick="props.forceGlobalClick"
                     deleteRecord.bind="deleteRecord"
                     openRecord.bind="openRecord"

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -233,8 +233,10 @@ export class KanbanRecord extends Component {
         const { activeActions } = archInfo;
         // Widget
         const deletable =
-            activeActions.delete && (!groupByField || groupByField.type !== "many2many");
-        const editable = activeActions.edit;
+            activeActions.delete &&
+            (!groupByField || groupByField.type !== "many2many") &&
+            !props.readonly;
+        const editable = activeActions.edit && !props.readonly;
         this.dataState.widget = {
             deletable,
             editable,
@@ -305,7 +307,7 @@ export class KanbanRecord extends Component {
         const { type } = params;
         switch (type) {
             case "open": {
-                return openRecord(record, { mode: "edit" });
+                return openRecord(record);
             }
             case "archive": {
                 return archiveRecord(record, true);
@@ -358,7 +360,6 @@ export class KanbanRecord extends Component {
             context: this.props.record.context,
             JSON,
             luxon,
-            read_only_mode: this.props.readonly,
             record: this.dataState.record,
             selection_mode: this.props.forceGlobalClick,
             widget: this.dataState.widget,

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -50,7 +50,7 @@ export class KanbanRenderer extends Component {
         "list",
         "deleteRecord",
         "openRecord",
-        "readonly",
+        "readonly?",
         "forceGlobalClick?",
         "noContentHelp?",
         "scrollTop?",
@@ -401,7 +401,7 @@ export class KanbanRenderer extends Component {
             withProgressBars: true,
         });
         if (mode === "edit") {
-            await this.props.openRecord(record, { mode: "edit" });
+            await this.props.openRecord(record);
         } else {
             this.props.progressBarState?.updateCounts(group);
         }

--- a/addons/web/static/src/views/kanban/kanban_view.js
+++ b/addons/web/static/src/views/kanban/kanban_view.js
@@ -23,6 +23,7 @@ export const kanbanView = {
 
         return {
             ...genericProps,
+            readonly: genericProps.readonly || !archInfo.activeActions?.edit,
             // Compiler: view.Compiler, // don't pass it automatically in stable, for backward compat
             Model: view.Model,
             Renderer: view.Renderer,

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -57,8 +57,8 @@ export class ListController extends Component {
     static props = {
         ...standardViewProps,
         allowSelectors: { type: Boolean, optional: true },
-        editable: { type: Boolean, optional: true },
         onSelectionChanged: { type: Function, optional: true },
+        readonly: { type: Boolean, optional: true },
         showButtons: { type: Boolean, optional: true },
         Model: Function,
         Renderer: Function,
@@ -68,7 +68,6 @@ export class ListController extends Component {
     static defaultProps = {
         allowSelectors: true,
         createRecord: () => {},
-        editable: true,
         selectRecord: () => {},
         showButtons: true,
     };
@@ -80,9 +79,8 @@ export class ListController extends Component {
 
         this.archInfo = this.props.archInfo;
         this.activeActions = this.archInfo.activeActions;
-        this.editable =
-            this.activeActions.edit && this.props.editable ? this.archInfo.editable : false;
         this.onOpenFormView = this.openRecord.bind(this);
+        this.editable = (!this.props.readonly && this.archInfo.editable) || false;
         this.hasOpenFormViewButton = this.editable ? this.archInfo.openFormView : false;
         this.model = useState(useModelWithSampleData(this.props.Model, this.modelParams));
 
@@ -130,9 +128,7 @@ export class ListController extends Component {
         });
         useSetupAction({
             rootRef: this.rootRef,
-            beforeLeave: async () => {
-                return this.model.root.leaveEditMode();
-            },
+            beforeLeave: async () => this.model.root.leaveEditMode(),
             beforeUnload: async (ev) => {
                 if (this.editedRecord) {
                     const isValid = await this.editedRecord.urgentSave();
@@ -152,9 +148,7 @@ export class ListController extends Component {
                     },
                 };
             },
-            getOrderBy: () => {
-                return this.model.root.orderBy;
-            },
+            getOrderBy: () => this.model.root.orderBy,
         });
 
         usePager(() => {

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -97,6 +97,7 @@
                     noContentHelp="props.info.noContentHelp"
                     onAdd.bind="createRecord"
                     optionalActiveFields="optionalActiveFields"
+                    readonly="props.readonly"
                 />
             </Layout>
         </div>

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -84,6 +84,7 @@ export class ListRenderer extends Component {
         "noContentHelp?",
         "nestedKeyOptionalFieldsData?",
         "optionalActiveFields?",
+        "readonly?",
     ];
 
     setup() {
@@ -331,7 +332,10 @@ export class ListRenderer extends Component {
 
     getFieldProps(record, column) {
         return {
-            readonly: this.isCellReadonly(column, record) || this.isRecordReadonly(record),
+            readonly:
+                this.props.readonly ||
+                this.isCellReadonly(column, record) ||
+                this.isRecordReadonly(record),
         };
     }
 
@@ -340,7 +344,7 @@ export class ListRenderer extends Component {
     }
 
     get canResequenceRows() {
-        if (!this.props.list.canResequence()) {
+        if (!this.props.list.canResequence() || this.props.readonly) {
             return false;
         }
         const { handleField, orderBy } = this.props.list;

--- a/addons/web/static/src/views/list/list_view.js
+++ b/addons/web/static/src/views/list/list_view.js
@@ -22,6 +22,7 @@ export const listView = {
         const archInfo = new ArchParser().parse(arch, relatedModels, resModel);
         return {
             ...genericProps,
+            readonly: genericProps.readonly || !archInfo.activeActions?.edit,
             Model: view.Model,
             Renderer: view.Renderer,
             buttonTemplate: view.buttonTemplate,

--- a/addons/web/static/src/views/view_compiler.js
+++ b/addons/web/static/src/views/view_compiler.js
@@ -374,10 +374,7 @@ export class ViewCompiler {
         field.setAttribute("name", `'${fieldName}'`);
         field.setAttribute("record", recordExpr);
         field.setAttribute("fieldInfo", `__comp__.props.archInfo.fieldNodes['${fieldId}']`);
-        field.setAttribute(
-            "readonly",
-            `__comp__.props.archInfo.activeActions?.edit === false and !${recordExpr}.isNew`
-        );
+        field.setAttribute("readonly", `__comp__.props.readonly`);
 
         if (el.hasAttribute("widget")) {
             field.setAttribute("type", `'${el.getAttribute("widget")}'`);

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.js
@@ -14,10 +14,7 @@ export class FormViewDialog extends Component {
 
         context: { type: Object, optional: true },
         nextRecordsContext: { type: Object, optional: true },
-        mode: {
-            optional: true,
-            validate: (m) => ["edit", "readonly"].includes(m),
-        },
+        readonly: { type: Boolean, optional: true },
         onRecordSaved: { type: Function, optional: true },
         onRecordDiscarded: { type: Function, optional: true },
         removeRecord: { type: Function, optional: true },
@@ -55,7 +52,7 @@ export class FormViewDialog extends Component {
 
             context: this.props.context || {},
             display: { controlPanel: false },
-            mode: this.props.mode || "edit",
+            readonly: this.props.readonly,
             resId: this.props.resId || false,
             resModel: this.props.resModel,
             viewId: this.props.viewId || false,

--- a/addons/web/static/src/views/view_dialogs/select_create_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/select_create_dialog.js
@@ -50,7 +50,6 @@ export class SelectCreateDialog extends Component {
         this.busy = false; // flag used to ensure we only call once the onSelected/onUnselect props
         this.baseViewProps = {
             display: { searchPanel: false },
-            editable: false, // readonly
             noBreadcrumbs: true,
             noContentHelp,
             showButtons: false,
@@ -69,6 +68,7 @@ export class SelectCreateDialog extends Component {
             context: this.props.context,
             domain: this.props.domain,
             dynamicFilters: this.props.dynamicFilters,
+            readonly: true,
             resModel: this.props.resModel,
             searchViewId: this.props.searchViewId,
             type,

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -644,10 +644,14 @@ export function makeActionManager(env, router = _router) {
         if (typeof groupBy === "string") {
             groupBy = [groupBy];
         }
-        const openFormView = (resId, { activeIds, mode, force, newWindow } = {}) => {
+        const openFormView = (resId, { activeIds, readonly, force, newWindow } = {}) => {
             if (target !== "new") {
                 if (_getView("form")) {
-                    return switchView("form", { mode, resId, resIds: activeIds }, { newWindow });
+                    return switchView(
+                        "form",
+                        { readonly, resId, resIds: activeIds },
+                        { newWindow }
+                    );
                 } else if (force || !resId) {
                     return doAction(
                         {
@@ -655,7 +659,7 @@ export function makeActionManager(env, router = _router) {
                             res_model: action.res_model,
                             views: [[false, "form"]],
                         },
-                        { newWindow, props: { mode, resId, resIds: activeIds } }
+                        { newWindow, props: { readonly, resId, resIds: activeIds } }
                     );
                 }
             }
@@ -674,7 +678,7 @@ export function makeActionManager(env, router = _router) {
         });
         if (view.type === "form") {
             if (target === "new") {
-                viewProps.mode = "edit";
+                viewProps.readonly = false;
                 if (!viewProps.onSave) {
                     viewProps.onSave = (record, params) => {
                         if (params && params.closable) {

--- a/addons/web/static/tests/views/fields/boolean_favorite_field.test.js
+++ b/addons/web/static/tests/views/fields/boolean_favorite_field.test.js
@@ -242,6 +242,7 @@ test("FavoriteField in kanban view with readonly attribute", async () => {
         message: "should be favorite",
     });
     expect(`.o_kanban_record .o_field_widget .o_favorite > a`).toHaveClass("pe-none");
+    expect(`.o_kanban_record .o_field_widget .o_favorite`).toHaveClass("o_disabled");
     expect(`.o_kanban_record .o_field_widget`).toHaveText("");
 
     // click on favorite

--- a/addons/web/static/tests/views/fields/handle_field.test.js
+++ b/addons/web/static/tests/views/fields/handle_field.test.js
@@ -100,10 +100,7 @@ test("HandleField in a readonly one2many", async () => {
         resId: 1,
     });
 
-    expect(".o_row_handle").toHaveCount(3, {
-        message: "there should be 3 handles, one for each row",
-    });
-    expect(queryFirst("td span.o_row_handle")).not.toBeVisible({
-        message: "handle should be invisible",
+    expect(".o_row_handle.o_disabled").toHaveCount(3, {
+        message: "there should be 3 handles but they should be disabled from readonly",
     });
 });

--- a/addons/web/static/tests/views/fields/many2many_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_field.test.js
@@ -248,7 +248,6 @@ test("many2many kanban: edition", async () => {
                             <t t-name="card">
                                 <div>
                                     <a
-                                        t-if="!read_only_mode"
                                         type="delete"
                                         class="fa fa-times float-end delete_icon"
                                     />
@@ -416,7 +415,7 @@ test("many2many kanban: create action disabled", async () => {
                         <templates>
                             <t t-name="card">
                                 <div>
-                                    <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
+                                    <a type="delete" class="fa fa-times float-end delete_icon"/>
                                     <field name="name"/>
                                 </div>
                             </t>

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -343,9 +343,7 @@ test("editing a many2one (with form view opened with external button)", async ()
             </form>`,
     };
 
-    onRpc("get_formview_id", () => {
-        return false;
-    });
+    onRpc("get_formview_id", () => false);
     onRpc("web_save", () => {
         expect.step("web_save");
     });
@@ -2155,9 +2153,7 @@ test("list in form: call button in sub view", async () => {
             });
         },
     });
-    onRpc("get_formview_id", () => {
-        return false;
-    });
+    onRpc("get_formview_id", () => false);
 
     await mountViewInDialog({
         type: "form",
@@ -2249,9 +2245,7 @@ test("X2Many sequence list in modal", async () => {
             </list>`,
     };
 
-    onRpc("partner.type", "get_formview_id", () => {
-        return false;
-    });
+    onRpc("partner.type", "get_formview_id", () => false);
     onRpc("partner.type", "web_save", () => {
         expect.step("partner.type web_save");
     });
@@ -2711,9 +2705,7 @@ test("can_create and can_write option on a many2one", async () => {
             </form>`,
     };
 
-    onRpc("product", "get_formview_id", () => {
-        return false;
-    });
+    onRpc("product", "get_formview_id", () => false);
 
     await mountViewInDialog({
         type: "form",
@@ -2799,9 +2791,7 @@ test("propagate can_create onto the search popup", async () => {
                 <field name="name"/>
             </search>`,
     };
-    onRpc("get_formview_id", () => {
-        return false;
-    });
+    onRpc("get_formview_id", () => false);
 
     await mountView({
         type: "form",
@@ -3404,7 +3394,7 @@ test("updating a many2one from a many2many", async () => {
     expect(".o_dialog:not(.o_inactive_modal) div[name=turtle_trululu] input").toHaveValue("test");
 });
 
-test("search more in many2one: resequence inside dialog", async () => {
+test("search more in many2one: cannot resequence inside dialog", async () => {
     // when the user clicks on 'Search More...' in a many2one dropdown, resequencing inside
     // the dialog works
     Partner._fields.sequence = fields.Integer();
@@ -3441,11 +3431,7 @@ test("search more in many2one: resequence inside dialog", async () => {
     await contains(`.o_field_widget[name="trululu"] .o_m2o_dropdown_option_search_more`).click();
 
     expect(".modal").toHaveCount(1);
-    expect(".modal .ui-sortable-handle").toHaveCount(11);
-    await contains(".modal .o_data_row:nth-child(2) .ui-sortable-handle").dragAndDrop(
-        ".modal tbody tr"
-    );
-    await animationFrame();
+    expect(".modal .o_row_handle.o_disabled").toHaveCount(11);
 
     expect.verifySteps([
         "get_views",
@@ -3454,8 +3440,6 @@ test("search more in many2one: resequence inside dialog", async () => {
         "get_views", // list view in dialog
         "web_search_read", // to display results in the dialog
         "has_group",
-        "/web/dataset/resequence", // resequencing lines
-        "read",
     ]);
 });
 
@@ -3551,9 +3535,7 @@ test("focus when closing many2one modal in many2one modal", async () => {
         form: '<form><field name="trululu"/></form>',
     };
 
-    onRpc("get_formview_id", () => {
-        return false;
-    });
+    onRpc("get_formview_id", () => false);
 
     await mountViewInDialog({
         type: "form",
@@ -3770,17 +3752,15 @@ test("external_button opens a new tab when middle clicked or ctrl+click", async 
         form: '<form><field name="trululu"/></form>',
         search: "<search></search>",
     };
-    onRpc("get_formview_action", () => {
-        return {
-            type: "ir.actions.act_window",
-            res_model: "partner",
-            view_type: "form",
-            view_mode: "form",
-            views: [[false, "form"]],
-            target: "current",
-            res_id: false,
-        };
-    });
+    onRpc("get_formview_action", () => ({
+        type: "ir.actions.act_window",
+        res_model: "partner",
+        view_type: "form",
+        view_mode: "form",
+        views: [[false, "form"]],
+        target: "current",
+        res_id: false,
+    }));
     await mountWithCleanup(WebClient);
     await getService("action").doAction({
         name: "Partner",
@@ -3802,9 +3782,7 @@ test("keep changes when editing related record in a dialog", async () => {
     Partner._views = {
         [["form", 98]]: '<form><field name="int_field"/></form>',
     };
-    onRpc("get_formview_id", () => {
-        return 98;
-    });
+    onRpc("get_formview_id", () => 98);
     onRpc("web_save", () => {
         expect.step("web_save");
     });
@@ -3838,9 +3816,7 @@ test("create and edit, save and then discard", async () => {
     Partner.views = {
         [[98, "form"]]: '<form><field name="name"/></form>',
     };
-    onRpc("get_formview_id", () => {
-        return 98;
-    });
+    onRpc("get_formview_id", () => 98);
     await mountView({
         type: "form",
         resModel: "partner",
@@ -3904,9 +3880,7 @@ test("many2one field with false as name", async () => {
 });
 
 test("many2one search with false as name", async () => {
-    onRpc("name_search", () => {
-        return [[1, false]];
-    });
+    onRpc("name_search", () => [[1, false]]);
     await mountView({
         type: "form",
         resModel: "partner",

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -2456,7 +2456,7 @@ test("edition of one2many field with pager", async () => {
                         <templates>
                             <t t-name="card">
                                 <div>
-                                    <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
+                                    <a type="delete" class="fa fa-times float-end delete_icon"/>
                                     <field name="name"/>
                                 </div>
                             </t>
@@ -2592,7 +2592,7 @@ test("edition of one2many field with pager on desktop", async () => {
                         <templates>
                             <t t-name="card">
                                 <div>
-                                    <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
+                                    <a type="delete" class="fa fa-times float-end delete_icon"/>
                                     <field name="name"/>
                                 </div>
                             </t>
@@ -3429,7 +3429,7 @@ test("one2many kanban: edition", async () => {
                         <templates>
                             <t t-name="card">
                                 <div>
-                                    <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
+                                    <a type="delete" class="fa fa-times float-end delete_icon"/>
                                     <field name="name"/>
                                     <field name="color"/>
                                 </div>
@@ -3531,7 +3531,7 @@ test("one2many kanban: create action disabled", async () => {
                         <templates>
                             <t t-name="card">
                                 <div>
-                                    <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
+                                    <a type="delete" class="fa fa-times float-end delete_icon"/>
                                     <field name="name"/>
                                 </div>
                             </t>
@@ -4086,7 +4086,6 @@ test("save a record with not new, dirty and invalid subrecord", async () => {
                 </field>
             </form>`,
         resId: 1,
-        mode: "edit",
     });
 
     expect(".o_form_editable").toHaveCount(1);
@@ -11974,7 +11973,6 @@ test("nested one2manys, multi page, onchange", async () => {
                 </field>
             </form>`,
         resId: 1,
-        mode: "edit",
     });
 
     await contains(".o_field_widget[name=int_field] input").edit("5", { confirm: "blur" });
@@ -12106,7 +12104,6 @@ test("active actions are passed to o2m field", async () => {
                 </field>
             </form>`,
         resId: 1,
-        mode: "edit",
     });
 
     expect(".o_data_row").toHaveCount(3);

--- a/addons/web/static/tests/views/fields/phone_field.test.js
+++ b/addons/web/static/tests/views/fields/phone_field.test.js
@@ -24,7 +24,7 @@ test("PhoneField in form view on normal screens (readonly)", async () => {
     await mountView({
         type: "form",
         resModel: "partner",
-        mode: "readonly",
+        readonly: true,
         arch: /* xml */ `
             <form>
                 <sheet>
@@ -159,7 +159,7 @@ test("href is correctly formatted", async () => {
     await mountView({
         type: "form",
         resModel: "partner",
-        mode: "readonly",
+        readonly: true,
         arch: /* xml */ `
             <form>
                 <sheet>

--- a/addons/web/static/tests/views/fields/priority_field.test.js
+++ b/addons/web/static/tests/views/fields/priority_field.test.js
@@ -371,7 +371,7 @@ test("PriorityField with readonly attribute", async () => {
         arch: '<form><field name="selection" widget="priority" readonly="1"/></form>',
     });
 
-    expect("span.o_priority_star.fa.fa-star-o").toHaveCount(2, {
+    expect("span.o_priority_star.fa.fa-star-o.o_disabled").toHaveCount(2, {
         message: "stars of priority widget should rendered with span tag if readonly",
     });
     await hover(".o_priority_star.fa-star-o:last");
@@ -383,7 +383,7 @@ test("PriorityField with readonly attribute", async () => {
     await click(".o_priority_star.fa-star-o:last");
     await animationFrame();
     expect.step("click");
-    expect("span.o_priority_star.fa.fa-star-o").toHaveCount(2, {
+    expect("span.o_priority_star.fa.fa-star-o.o_disabled").toHaveCount(2, {
         message: "should still have two stars",
     });
     expect.verifySteps(["hover", "click"]);

--- a/addons/web/static/tests/views/fields/state_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/state_selection_field.test.js
@@ -162,6 +162,7 @@ test("StateSelectionField with readonly modifier", async () => {
     });
 
     expect(".o_field_state_selection").toHaveClass("o_readonly_modifier");
+    expect(".o_field_state_selection button").toHaveClass("o_disabled");
     expect(".dropdown-menu").not.toBeVisible();
     await click(".o_field_state_selection span.o_status");
     await animationFrame();

--- a/addons/web/static/tests/views/form/form_compiler.test.js
+++ b/addons/web/static/tests/views/form/form_compiler.test.js
@@ -30,7 +30,7 @@ test("label with empty string compiles to FormLabel with empty string", () => {
     const expected = /*xml*/ `
         <t t-translation="off">
             <div class="o_form_renderer o_form_nosheet" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-block {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
-                <Field id="'test'" name="'test'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['test']" readonly="__comp__.props.archInfo.activeActions?.edit === false and !__comp__.props.record.isNew"/>
+                <Field id="'test'" name="'test'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['test']" readonly="__comp__.props.readonly"/>
                 <FormLabel id="'test'" fieldName="'test'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['test']" className="&quot;&quot;" string="\`\`" />
             </div>
         </t>
@@ -45,7 +45,7 @@ test("properly compile simple div with field", () => {
             <div class="o_form_renderer o_form_nosheet" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-block {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
                 <div class="someClass">
                     lol
-                    <Field id="'display_name'" name="'display_name'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['display_name']" readonly="__comp__.props.archInfo.activeActions?.edit === false and !__comp__.props.record.isNew"/>
+                    <Field id="'display_name'" name="'display_name'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['display_name']" readonly="__comp__.props.readonly"/>
                 </div>
             </div>
         </t>
@@ -69,14 +69,14 @@ test("properly compile inner groups", () => {
                     <t t-set-slot="item_0" type="'item'" sequence="0" t-slot-scope="scope" isVisible="true" itemSpan="1">
                         <InnerGroup class="scope &amp;&amp; scope.className">
                             <t t-set-slot="item_0" type="'item'" sequence="0" t-slot-scope="scope" props="{id:'display_name',fieldName:'display_name',record:__comp__.props.record,string:__comp__.props.record.fields.display_name.string,fieldInfo:__comp__.props.archInfo.fieldNodes['display_name']}" Component="__comp__.constructor.components.FormLabel" subType="'item_component'" isVisible="true" itemSpan="2">
-                                <Field id="'display_name'" name="'display_name'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['display_name']" readonly="__comp__.props.archInfo.activeActions?.edit === false and !__comp__.props.record.isNew" class="scope &amp;&amp; scope.className"/>
+                                <Field id="'display_name'" name="'display_name'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['display_name']" readonly="__comp__.props.readonly" class="scope &amp;&amp; scope.className"/>
                             </t>
                         </InnerGroup>
                     </t>
                     <t t-set-slot="item_1" type="'item'" sequence="1" t-slot-scope="scope" isVisible="true" itemSpan="1">
                         <InnerGroup class="scope &amp;&amp; scope.className">
                             <t t-set-slot="item_0" type="'item'" sequence="0" t-slot-scope="scope" props="{id:'charfield',fieldName:'charfield',record:__comp__.props.record,string:__comp__.props.record.fields.charfield.string,fieldInfo:__comp__.props.archInfo.fieldNodes['charfield']}" Component="__comp__.constructor.components.FormLabel" subType="'item_component'" isVisible="true" itemSpan="2">
-                                <Field id="'charfield'" name="'charfield'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['charfield']" readonly="__comp__.props.archInfo.activeActions?.edit === false and !__comp__.props.record.isNew" class="scope &amp;&amp; scope.className"/>
+                                <Field id="'charfield'" name="'charfield'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['charfield']" readonly="__comp__.props.readonly" class="scope &amp;&amp; scope.className"/>
                             </t>
                         </InnerGroup>
                     </t>
@@ -109,7 +109,7 @@ test("properly compile attributes with nested forms", () => {
                         <InnerGroup class="scope &amp;&amp; scope.className">
                             <t t-set-slot="item_0" type="'item'" sequence="0" t-slot-scope="scope" isVisible="true" itemSpan="1">
                                 <div class="o_form_renderer o_form_nosheet" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-block {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }} {{scope &amp;&amp; scope.className || &quot;&quot; }}">
-                                    <div><Field id="'test'" name="'test'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['test']" readonly="__comp__.props.archInfo.activeActions?.edit === false and !__comp__.props.record.isNew"/></div>
+                                    <div><Field id="'test'" name="'test'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['test']" readonly="__comp__.props.readonly"/></div>
                                 </div>
                             </t>
                         </InnerGroup>
@@ -135,10 +135,10 @@ test("properly compile notebook", () => {
             <div class="o_form_renderer o_form_nosheet" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-block {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
                 <Notebook defaultPage="__comp__.props.record.isNew ? undefined : __comp__.props.activeNotebookPages[0]" onPageUpdate="(page) =&gt; __comp__.props.onNotebookPageChange(0, page)">
                     <t t-set-slot="page_1" title="\`Page1\`" name="\`p1\`" isVisible="true">
-                        <Field id="'charfield'" name="'charfield'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['charfield']" readonly="__comp__.props.archInfo.activeActions?.edit === false and !__comp__.props.record.isNew"/>
+                        <Field id="'charfield'" name="'charfield'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['charfield']" readonly="__comp__.props.readonly"/>
                     </t>
                     <t t-set-slot="page_2" title="\`Page2\`" name="\`p2\`" isVisible="true">
-                        <Field id="'display_name'" name="'display_name'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['display_name']" readonly="__comp__.props.archInfo.activeActions?.edit === false and !__comp__.props.record.isNew"/>
+                        <Field id="'display_name'" name="'display_name'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['display_name']" readonly="__comp__.props.readonly"/>
                     </t>
                 </Notebook>
             </div>
@@ -156,7 +156,7 @@ test("properly compile field without placeholder", () => {
     const expected = /*xml*/ `
         <t t-translation="off">
             <div class="o_form_renderer o_form_nosheet" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-block {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
-                <Field id="'display_name'" name="'display_name'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['display_name']" readonly="__comp__.props.archInfo.activeActions?.edit === false and !__comp__.props.record.isNew"/>
+                <Field id="'display_name'" name="'display_name'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['display_name']" readonly="__comp__.props.readonly"/>
             </div>
         </t>
     `;
@@ -352,7 +352,7 @@ test("properly compile settings", () => {
                             name="'bar'"
                             record="__comp__.props.record"
                             fieldInfo="__comp__.props.archInfo.fieldNodes['bar']"
-                            readonly="__comp__.props.archInfo.activeActions?.edit === false and !__comp__.props.record.isNew"/>
+                            readonly="__comp__.props.readonly"/>
                     </t>
                     <label>label with content</label>
                 </Setting>
@@ -429,7 +429,7 @@ test("keep nosheet style if a sheet is part of a nested form", (assert) => {
                 name="'move_line_ids'"
                 record="__comp__.props.record"
                 fieldInfo="__comp__.props.archInfo.fieldNodes['move_line_ids']"
-                readonly="__comp__.props.archInfo.activeActions?.edit === false and !__comp__.props.record.isNew"
+                readonly="__comp__.props.readonly"
             />
         </div>
     </t>`;

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -9081,47 +9081,6 @@ test(`form view is not broken if save operation fails`, async () => {
     expect.verifySteps(["web_save"]); // write on save (it works)
 });
 
-test(`form view is not broken if save failed in readonly mode on field changed`, async () => {
-    expect.errors(1);
-
-    let failFlag = false;
-    onRpc("web_save", () => {
-        expect.step("web_save");
-        if (failFlag) {
-            throw makeServerError();
-        }
-    });
-    onRpc("web_read", () => expect.step("web_read"));
-
-    await mountView({
-        resModel: "partner",
-        type: "form",
-        arch: `
-            <form>
-                <header>
-                    <field name="parent_id" widget="statusbar" options="{'clickable': '1'}"/>
-                </header>
-            </form>
-        `,
-        mode: "readonly",
-        resId: 1,
-    });
-    expect.verifySteps(["web_read"]);
-    expect(`button[data-value="4"]`).toHaveClass("o_arrow_button_current");
-    expect(`button[data-value="4"]`).not.toBeEnabled();
-
-    failFlag = true;
-    await contains(`button[data-value="1"]`).click();
-    expect(`button[data-value="4"]`).toHaveClass("o_arrow_button_current");
-    expect.verifyErrors(["RPC_ERROR: Odoo Server Error"]);
-    expect.verifySteps(["web_save", "web_read"]); // must reload when saving fails
-
-    failFlag = false;
-    await contains(`button[data-value="1"]`).click();
-    expect(`button[data-value="4"]`).toHaveClass("o_arrow_button_current");
-    expect.verifySteps(["web_save"]);
-});
-
 test.tags("desktop");
 test(`context is correctly passed after save & new in FormViewDialog`, async () => {
     Product._views = {

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -5265,9 +5265,8 @@ test("clicking on a link triggers correct event", async () => {
                     </t>
                 </templates>
             </kanban>`,
-        selectRecord: (resId, { mode }) => {
+        selectRecord: (resId) => {
             expect(resId).toBe(1);
-            expect(mode).toBe("edit");
         },
     });
     await contains("a", { root: getKanbanRecord({ index: 0 }) }).click();
@@ -10258,9 +10257,9 @@ test("set cover image", async () => {
     });
 
     mockService("action", {
-        switchView(_viewType, { mode, resModel, res_id, view_type }) {
-            expect({ mode, resModel, res_id, view_type }).toBe({
-                mode: "readonly",
+        switchView(_viewType, { readonly, resModel, res_id, view_type }) {
+            expect({ readonly, resModel, res_id, view_type }).toBe({
+                readonly: true,
                 resModel: "partner",
                 res_id: 1,
                 view_type: "form",

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -1183,7 +1183,6 @@ test(`freeze widths: x2many, edit a record`, async () => {
                 </field>
             </form>`,
         resId: 1,
-        mode: "edit",
     });
 
     const initialWidths = getColumnWidths();
@@ -1214,7 +1213,6 @@ test(`freeze widths: x2many, remove last record`, async () => {
                 </field>
             </form>`,
         resId: 1,
-        mode: "edit",
     });
 
     const initialWidths = getColumnWidths();
@@ -1527,7 +1525,6 @@ test(`resize: unnamed columns cannot be resized`, async () => {
             </form>
         `,
         resId: 1,
-        mode: "edit",
     });
     expect(Math.floor(queryRect(`.o_field_one2many th:eq(0)`).right)).toBe(
         Math.floor(queryRect(`.o_field_one2many th:eq(0) .o_resize`).right),

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -9165,7 +9165,6 @@ test(`navigation with tab on a one2many list with create="0"`, async () => {
             </form>
         `,
         resId: 1,
-        mode: "edit",
     });
     expect(`.o_field_widget[name=o2m] .o_data_row`).toHaveCount(2);
 
@@ -17293,7 +17292,6 @@ test(`list: remove a record from sorted recordlist`, async () => {
             </form>
         `,
         resId: 1,
-        mode: "edit",
     });
     // 3 th (1 for delete button, 2 for columns)
     expect(`th`).toHaveCount(3, { message: "should have 2 columns and delete buttons" });

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
@@ -337,9 +337,11 @@ test("SelectCreateDialog correctly evaluates domains", async () => {
 });
 
 test.tags("desktop");
-test("SelectCreateDialog list view in readonly", async () => {
+test("SelectCreateDialog list view is readonly", async () => {
+    Partner._fields.sequence = fields.Integer();
     Partner._views["list"] = /* xml */ `
         <list string="Partner" editable="bottom">
+            <field name="sequence" widget="handle"/>
             <field name="name"/>
             <field name="foo"/>
         </list>
@@ -358,6 +360,10 @@ test("SelectCreateDialog list view in readonly", async () => {
 
     expect(".o_list_view tbody tr td .o_field_char input").toHaveCount(0, {
         message: "list view should not be editable in a SelectCreateDialog",
+    });
+    expect(".o_handle_cell").toHaveCount(4);
+    expect(".o_row_handle.o_disabled").toHaveCount(3, {
+        message: "handles should be disabled in readonly",
     });
 });
 

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
@@ -1883,7 +1883,7 @@ test("standalone field labels with string inside a settings page", async () => {
                 <SettingsApp key="\`crm\`" string="\`CRM\`" imgurl="\`${MOCK_IMAGE}\`" selectedTab="settings.selectedTab">
                     <SearchableSetting title="\`\`"  help="\`\`" companyDependent="false" documentation="\`\`" record="__comp__.props.record" id="\`setting_id\`" string="\`\`" addLabel="true">
                         <FormLabel id="'display_name_0'" fieldName="'display_name'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['display_name_0']" className="&quot;highhopes&quot;" string="\`My&quot; little '  Label\`"/>
-                        <Field id="'display_name_0'" name="'display_name'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['display_name_0']" readonly="__comp__.props.archInfo.activeActions?.edit === false and !__comp__.props.record.isNew"/>
+                        <Field id="'display_name_0'" name="'display_name'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['display_name_0']" readonly="__comp__.props.readonly"/>
                     </SearchableSetting>
                 </SettingsApp>
             </SettingsPage>`;
@@ -1922,7 +1922,7 @@ test("highlight Element with inner html/fields", async () => {
     );
     const expectedCompiled = /* xml */ `
             <HighlightText originalText="\`this is Baz value: \`"/>
-            <Field id="'baz_0'" name="'baz'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['baz_0']" readonly="__comp__.props.archInfo.activeActions?.edit === false and !__comp__.props.record.isNew"/>
+            <Field id="'baz_0'" name="'baz'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['baz_0']" readonly="__comp__.props.readonly"/>
             <HighlightText originalText="\` and this is the after text\`"/>`;
     expect(queryFirst("SearchableSetting div.text-muted", { root: compiled })).toHaveInnerHTML(
         expectedCompiled

--- a/addons/web_hierarchy/static/src/hierarchy_controller.js
+++ b/addons/web_hierarchy/static/src/hierarchy_controller.js
@@ -71,9 +71,9 @@ export class HierarchyController extends Component {
         return this.model.resIds.length === 0;
     }
 
-    async openRecord(node, mode) {
+    async openRecord(node) {
         const activeIds = this.model.root.resIds;
-        this.props.selectRecord(node.resId, { activeIds, mode });
+        this.props.selectRecord(node.resId, { activeIds });
     }
 
     async beforeExecuteActionButton(clickParams) {}

--- a/addons/website_slides/static/tests/legacy/slide_category_one2many_field_tests.js
+++ b/addons/website_slides/static/tests/legacy/slide_category_one2many_field_tests.js
@@ -80,7 +80,6 @@ QUnit.test("click on section behaves as usual in readonly mode", async (assert) 
         resModel: "partner",
         resId: 1,
         serverData,
-        mode: "readonly",
         arch: `
             <form>
                 <field name="lines" widget="slide_category_one2many">
@@ -91,6 +90,7 @@ QUnit.test("click on section behaves as usual in readonly mode", async (assert) 
                     </list>
                 </field>
             </form>`,
+        readonly: true,
     });
     await click($(".o_data_cell")[0]);
     assert.containsNone($, ".o_selected_row");


### PR DESCRIPTION
This commit changes how readonly mode works for views and fields: it allows to setup certain views as readonly (like the select_create_dialog) and unifies the way readonly is passed to fields inside kanban, list and form view. It results in clearer code in the view_compiler and removes read_only_mode from the kanban_record rendering context. Usage of mode
(edit or readonly) for view is removed and completly replaced by the new readonly which allows to have completly readonly views (where even priority field, etc are readonly). We also adapt several field widgets to have the disabled style when in readonly.

task-4344188
