### PR TITLE
[IMP] pos_restaurant: introduce pay and transfer options on split bill screen

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -45,24 +45,7 @@ patch(ControlButtons.prototype, {
     },
     clickTransferOrder() {
         this.dialog.closeAll();
-        this.pos.isOrderTransferMode = true;
-        const orderUuid = this.pos.getOrder().uuid;
-        this.pos.getOrder().setBooked(true);
-        this.pos.showScreen("FloorScreen");
-        document.addEventListener(
-            "click",
-            async (ev) => {
-                this.pos.isOrderTransferMode = false;
-                const tableElement = ev.target.closest(".table");
-                if (!tableElement) {
-                    return;
-                }
-                const table = this.pos.getTableFromElement(tableElement);
-                await this.pos.transferOrder(orderUuid, table);
-                this.pos.setTableFromUi(table);
-            },
-            { once: true }
-        );
+        this.pos.startTransferOrder();
     },
 });
 patch(ControlButtons, {

--- a/addons/pos_restaurant/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -18,7 +18,8 @@ patch(ReceiptScreen.prototype, {
         this.currentOrder.uiState.screen_data.value = "";
         this.currentOrder.uiState.locked = true;
         this.pos.selectedOrderUuid = originalOrderUuid;
-        this.pos.showScreen("ProductScreen");
+        const nextOrderScreen = this.pos.getOrder().getCurrentScreenData().name;
+        this.pos.showScreen(nextOrderScreen || "ProductScreen");
     },
     isContinueSplitting() {
         if (

--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
@@ -92,6 +92,23 @@ export class SplitBillScreen extends Component {
         return `${latestOrderName.slice(0, -1)}${nextChar}`;
     }
 
+    async paySplittedOrder() {
+        if (this.getNumberOfProducts() > 0) {
+            const originalOrder = this.currentOrder;
+            await this.createSplittedOrder();
+            originalOrder.setScreenData({ name: "SplitBillScreen" });
+        }
+        this.pos.pay();
+    }
+    async transferSplittedOrder(event) {
+        // Prevents triggering the 'startTransferOrder' event listener
+        event.stopPropagation();
+        if (this.getNumberOfProducts() > 0) {
+            await this.createSplittedOrder();
+        }
+        this.pos.startTransferOrder();
+    }
+
     async createSplittedOrder() {
         const curOrderUuid = this.currentOrder.uuid;
         const originalOrder = this.pos.models["pos.order"].find((o) => o.uuid === curOrderUuid);

--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.xml
@@ -5,8 +5,8 @@
         <div class="splitbill-screen screen h-100 bg-200">
             <div class="contents d-flex flex-column flex-nowrap h-100 my-0 mx-auto">
                 <div class="top-content d-flex align-items-center p-2 border-bottom text-center bg-view">
-                    <button  t-if="!this.ui.isSmall" class="button back back-button btn btn-secondary lh-lg" t-on-click="back">
-                        <i class="oi oi-chevron-left fa-fw"/> Back
+                    <button class="button back back-button btn btn-secondary lh-lg" t-on-click="back">
+                        <i class="oi oi-chevron-left fa-fw"/><t t-if="!this.ui.isSmall" t-esc="' Back'"/>
                     </button>
                     <div class="top-content-center flex-grow-1" t-att-class="{'pe-5':!this.ui.isSmall}">
                         <h4 class="mb-0">Bill Splitting</h4>
@@ -39,14 +39,22 @@
                         </div>
 
                         <div class="pay-button" t-att-class="{'d-flex flex-row bg-white p-2 gap-2 rounded-3':this.ui.isSmall}">
-                            <button class="button btn btn-lg btn-primary py-3 py-lg-5 w-100"
+                            <button class="button btn btn-lg btn-primary py-3 py-lg-5"
+                                t-att-class="(this.ui.isSmall ? 'w-50' : 'w-100')"
                                 t-att-disabled="!this.getNumberOfProducts()"
                                 t-on-click="createSplittedOrder">
-                                <span>Split Order</span>
+                                Split Order
                             </button>
-                            <button t-if="this.ui.isSmall" class="button back back-button btn btn-secondary btn-lg lh-lg w-100" t-on-click="back">
-                                <span>Back</span>
-                            </button>
+                            <div class="d-flex gap-2 w-100">
+                                <button class="btn btn-lg py-3 py-lg-5 w-100" t-att-class="(this.ui.isSmall ? 'btn-secondary' : 'mt-2 btn-light')"
+                                    t-on-click="paySplittedOrder">
+                                    Pay
+                                </button>
+                                <button class="btn btn-lg py-3 py-lg-5 w-100" t-att-class="(this.ui.isSmall ? 'btn-secondary' : 'mt-2 btn-light')"
+                                    t-on-click="transferSplittedOrder">
+                                    Transfer
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -515,6 +515,26 @@ patch(PosStore.prototype, {
             [...el.classList].find((c) => c.includes("tableId")).split("-")[1]
         );
     },
+    startTransferOrder() {
+        this.isOrderTransferMode = true;
+        const orderUuid = this.getOrder().uuid;
+        this.getOrder().setBooked(true);
+        this.showScreen("FloorScreen");
+        document.addEventListener(
+            "click",
+            async (ev) => {
+                this.isOrderTransferMode = false;
+                const tableElement = ev.target.closest(".table");
+                if (!tableElement) {
+                    return;
+                }
+                const table = this.getTableFromElement(tableElement);
+                await this.transferOrder(orderUuid, table);
+                this.setTableFromUi(table);
+            },
+            { once: true }
+        );
+    },
     prepareOrderTransfer(order, destinationTable) {
         const originalTable = order.table_id;
         this.loadingOrderState = false;

--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -42,7 +42,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour", {
             SplitBillScreen.subtotalIs("8.0"),
 
             // click pay to split, go back to check the lines
-            SplitBillScreen.clickPay(),
+            SplitBillScreen.clickButton("Split"),
             ProductScreen.clickOrderline("Water", "3"),
             ProductScreen.clickOrderline("Coca-Cola", "1"),
 
@@ -66,7 +66,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour", {
             SplitBillScreen.orderlineHas("Minute Maid", "3", "1"),
             SplitBillScreen.subtotalIs("4.0"),
 
-            SplitBillScreen.clickPay(),
+            SplitBillScreen.clickButton("Split"),
 
             // go back to the original order and see if the order is changed
             Chrome.clickOrders(),
@@ -95,7 +95,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour2", {
             SplitBillScreen.orderlineHas("Water", "1", "1"),
             SplitBillScreen.clickOrderline("Coca-Cola"),
             SplitBillScreen.orderlineHas("Coca-Cola", "1", "1"),
-            SplitBillScreen.clickPay(),
+            SplitBillScreen.clickButton("Split"),
             Chrome.clickOrders(),
             TicketScreen.selectOrder("002"),
             TicketScreen.loadSelectedOrder(),
@@ -128,7 +128,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour3", {
             SplitBillScreen.subtotalIs("2.0"),
 
             // click pay to split, and pay
-            SplitBillScreen.clickPay(),
+            SplitBillScreen.clickButton("Split"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
@@ -184,7 +184,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour4ProductCombo", {
             SplitBillScreen.orderlineHas("Combo Product 7", "1", "0"),
 
             ...SplitBillScreen.subtotalIs("53.80"),
-            ...SplitBillScreen.clickPay(),
+            ...SplitBillScreen.clickButton("Split"),
             ProductScreen.clickPayButton(),
             ...PaymentScreen.clickPaymentMethod("Bank"),
             ...PaymentScreen.clickValidate(),
@@ -199,5 +199,76 @@ registry.category("web_tour.tours").add("SplitBillScreenTour4ProductCombo", {
             ...ProductScreen.orderLineHas("Combo Product 4", "1"),
             ...ProductScreen.orderLineHas("Combo Product 7", "1"),
             ...ProductScreen.totalAmountIs("45.53"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("SplitBillScreenTour5Actions", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("2"),
+            ProductScreen.addOrderline("Water", "2", "2", "4.00"),
+            ProductScreen.addOrderline("Minute Maid", "1", "3", "3.00"),
+            ProductScreen.clickControlButton("Split"),
+
+            SplitBillScreen.orderlineHas("Water", "2", "0"),
+            SplitBillScreen.clickOrderline("Water"),
+            SplitBillScreen.clickOrderline("Minute Maid"),
+            SplitBillScreen.subtotalIs("5.0"),
+
+            // click transfer button to split and transfer
+            SplitBillScreen.clickButton("Transfer"),
+            FloorScreen.isShown(),
+            FloorScreen.clickTable("5"),
+
+            // check table 5 order and pay
+            ProductScreen.orderLineHas("Water", "1"),
+            ProductScreen.orderLineHas("Minute Maid", "1"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            {
+                ...Dialog.confirm(),
+                content:
+                    "acknowledge printing error ( because we don't have printer in the test. )",
+            },
+            ReceiptScreen.clickNextOrder(),
+
+            // Add products in order
+            FloorScreen.clickTable("2"),
+            ProductScreen.orderLineHas("Water", "1"),
+            ProductScreen.addOrderline("Minute Maid", "2", "3", "6.00"),
+            ProductScreen.clickControlButton("Split"),
+
+            SplitBillScreen.clickOrderline("Minute Maid"),
+            SplitBillScreen.clickOrderline("water"),
+            SplitBillScreen.subtotalIs("5.0"),
+
+            // click pay to split, and pay
+            SplitBillScreen.clickButton("Pay"),
+            PaymentScreen.isShown(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            {
+                ...Dialog.confirm(),
+                content:
+                    "acknowledge printing error ( because we don't have printer in the test. )",
+            },
+            ReceiptScreen.clickContinueOrder(),
+
+            // Check if redirect to split bill screen of original order
+            SplitBillScreen.orderlineHas("Minute Maid", "1", "0"),
+            SplitBillScreen.clickButton("Pay"),
+            PaymentScreen.isShown(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            // Check if there is no more order to continue
+            {
+                ...Dialog.confirm(),
+                content:
+                    "acknowledge printing error ( because we don't have printer in the test. )",
+            },
+            ReceiptScreen.clickNextOrder(),
         ].flat(),
 });

--- a/addons/pos_restaurant/static/tests/tours/utils/split_bill_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/split_bill_screen_util.js
@@ -12,11 +12,11 @@ export function clickBack() {
         },
     ];
 }
-export function clickPay() {
+export function clickButton(name) {
     return [
         {
-            content: "click pay button",
-            trigger: `.splitbill-screen .pay-button .button`,
+            content: `click '${name}' button`,
+            trigger: `.splitbill-screen .pay-button button:contains("${name}")`,
             run: "click",
         },
     ];

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -336,3 +336,7 @@ class TestFrontend(TestFrontendCommon):
         assert_payment(1, 4.4)
         self.start_pos_tour('PoSPaymentSyncTour3')
         assert_payment(2, 6.6)
+
+    def test_15_split_bill_screen_actions(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('SplitBillScreenTour5Actions')


### PR DESCRIPTION
In this commit:
==========

Two new actions are added to the Split Bill screen:

- **Pay**: Redirects to the payment screen for the selected split order.
- **Transfer**: Navigate to the Floor screen in transfer/merge mode, 
  allowing the user to transfer the split order to a selected table.

It also fixes the traceback when transferring floating order to the table.

Task-4358352