### PR TITLE
[IMP] pos_hr: restore discard button on the opening control popup

### DIFF
--- a/addons/pos_hr/static/src/app/components/popups/opening_control_popup/opening_control_popup.xml
+++ b/addons/pos_hr/static/src/app/components/popups/opening_control_popup/opening_control_popup.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<templates id="template" xml:space="preserve">
-    <t t-name="pos_hr.OpeningControlPopup" t-inherit="point_of_sale.OpeningControlPopup" t-inherit-mode="extension">
-        <xpath expr="//button[hasclass('backend-button')]" position="attributes">
-            <attribute name="t-if">!this.pos.config.module_pos_hr</attribute>
-        </xpath>
-    </t>
-</templates>


### PR DESCRIPTION
Following this commit :
- This commit restores the Discard button in the Opening Control popup. The restoration is necessary due to the upcoming implementation of minimal access rights functionality. Under this new functionality, users without admin access will no longer be able to open the register directly.

- By reintroducing the Discard button, users can return to the splash screen instead of being stuck in the flow, improving the user experience and maintaining smooth navigation.

task- 4360713
