### PR TITLE
[IMP] account{,_peppol}: Add Peppol information in mail footer

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -28,11 +28,19 @@ MONTH_SELECTION = [
     ('12', 'December'),
 ]
 
-PEPPOL_LIST = [
-    'AD', 'AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
-    'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IS', 'IT', 'LI', 'LT', 'LU', 'LV', 'MC', 'ME',
-    'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK', 'SM', 'TR', 'VA',
+# List of countries where Peppol should be used by default.
+PEPPOL_DEFAULT_COUNTRIES = [
+    'AT', 'BE', 'CH', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
+    'FR', 'GR', 'IE', 'IS', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL',
+    'NO', 'PL', 'PT', 'RO', 'SE', 'SI',
 ]
+
+# List of countries where Peppol is accessible.
+PEPPOL_LIST = PEPPOL_DEFAULT_COUNTRIES + [
+    'AD', 'AL',  'BA', 'BG', 'GB', 'HR', 'HU', 'LI', 'MC', 'ME',
+    'MK', 'RS', 'SK', 'SM', 'TR', 'VA',
+]
+
 
 class ResCompany(models.Model):
     _name = "res.company"

--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -486,7 +486,7 @@ class AccountMoveSend(models.TransientModel):
                 message_type='comment',
                 **kwargs,
                 **{
-                    'email_layout_xmlid': 'mail.mail_notification_layout_with_responsible_signature',
+                    'email_layout_xmlid': self._get_mail_layout(),
                     'email_add_signature': not mail_template,
                     'mail_auto_delete': mail_template.auto_delete,
                     'mail_server_id': mail_template.mail_server_id.id,
@@ -502,6 +502,10 @@ class AccountMoveSend(models.TransientModel):
             'res_model': new_message._name,
             'res_id': new_message.id,
         })
+
+    @api.model
+    def _get_mail_layout(self):
+        return 'mail.mail_notification_layout_with_responsible_signature'
 
     @api.model
     def _get_mail_params(self, move, move_data):

--- a/addons/account_peppol/__manifest__.py
+++ b/addons/account_peppol/__manifest__.py
@@ -16,6 +16,7 @@
     ],
     'data': [
         'data/cron.xml',
+        'data/mail_templates_email_layouts.xml',
         'views/account_journal_dashboard_views.xml',
         'views/account_move_views.xml',
         'views/res_partner_views.xml',

--- a/addons/account_peppol/data/mail_templates_email_layouts.xml
+++ b/addons/account_peppol/data/mail_templates_email_layouts.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="mail_notification_layout_with_responsible_signature_and_peppol"
+                  name="Mail: mail notification layout with responsible signature (user_id of the record) and Peppol advertisement"
+                  inherit_id="mail.mail_notification_layout_with_responsible_signature"
+                  primary="True">
+            <xpath expr="//t[hasclass('o_signature')]" position="after">
+                <div id="peppol_advertisement" t-if="peppol_info" style="font-size: 13px;">
+                    <t t-if="peppol_info['is_peppol_sent']">
+                        <p style="min-width: 590px;">
+                            PS: This invoice has also been <b style="color: $o-enterprise-action-color">sent on Peppol</b>.
+                        </p>
+                    </t>
+                    <t t-if="not peppol_info['is_peppol_sent']">
+                        <p style="min-width: 590px;">
+                            PS: <b style="color: $o-enterprise-action-color;">We did not send your invoice on Peppol.</b>
+                            <t t-if="peppol_info['peppol_country'] == 'BE'">
+                                In Belgium, electronic invoicing will be
+                                <a target="_blank" href="https://finance.belgium.be/en/enterprises/vat/e-invoicing/mandatory-use-structured-electronic-invoices-2026">mandatory as of January 2026</a>.
+                            </t>
+                            <br/>
+                            If you need a Peppol compliant software, we recommend <a target="_blank" href="https://www.odoo.com/app/invoicing?utm_source=db&amp;utm_medium=email&amp;utm_campaign=einvoicing" style="color: $o-enterprise-color;">Odoo</a>.
+                        </p>
+                    </t>
+                </div>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/addons/account_peppol/i18n/account_peppol.pot
+++ b/addons/account_peppol/i18n/account_peppol.pot
@@ -16,6 +16,13 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
+msgid ""
+"<br/>\n"
+"                            If you need a Peppol compliant software, we recommend"
+msgstr ""
+
+#. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.account_peppol_view_move_form
 msgid ""
 "<span class=\"mx-1\" invisible=\"not peppol_is_demo_uuid\"> (Demo)</span>\n"
@@ -286,6 +293,11 @@ msgid "Fetch from Peppol"
 msgstr ""
 
 #. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
+msgid "In Belgium, electronic invoicing will be"
+msgstr ""
+
+#. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.res_config_settings_view_form
 msgid ""
 "In demo mode sending and receiving invoices is simulated. There will be no "
@@ -375,6 +387,11 @@ msgid "Not verified yet"
 msgstr ""
 
 #. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
+msgid "Odoo"
+msgstr ""
+
+#. module: account_peppol
 #: model:ir.model.fields.selection,name:account_peppol.selection__account_edi_proxy_client_user__proxy_type__peppol
 msgid "PEPPOL"
 msgstr ""
@@ -426,6 +443,20 @@ msgstr ""
 #. module: account_peppol
 #: model:ir.actions.server,name:account_peppol.ir_cron_peppol_get_participant_status_ir_actions_server
 msgid "PEPPOL: update participant status"
+msgstr ""
+
+#. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
+msgid ""
+"PS: <b style=\"color: $o-enterprise-action-color;\">We could not send your "
+"invoice on Peppol.</b>"
+msgstr ""
+
+#. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
+msgid ""
+"PS: This invoice has also been <b style=\"color: $o-enterprise-action-"
+"color\">sent on Peppol</b>."
 msgstr ""
 
 #. module: account_peppol
@@ -917,4 +948,9 @@ msgstr ""
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.res_config_settings_view_form
 msgid "Your registration should be activated within a day."
+msgstr ""
+
+#. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
+msgid "mandatory as of January 2026"
 msgstr ""

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from odoo.addons.account.models.company import PEPPOL_DEFAULT_COUNTRIES
 
 
 class AccountMove(models.Model):
@@ -70,3 +71,14 @@ class AccountMove(models.Model):
                 move.peppol_move_state = False
             else:
                 move.peppol_move_state = move.peppol_move_state
+
+    def _notify_by_email_prepare_rendering_context(self, message, **kwargs):
+        render_context = super()._notify_by_email_prepare_rendering_context(message, **kwargs)
+        invoice = render_context['record']
+        invoice_country = invoice.commercial_partner_id.country_code
+        if invoice_country in PEPPOL_DEFAULT_COUNTRIES:
+            render_context['peppol_info'] = {
+                'peppol_country': invoice_country,
+                'is_peppol_sent': invoice.peppol_move_state in ('processing', 'done'),
+            }
+        return render_context

--- a/addons/account_peppol/wizard/account_move_send.py
+++ b/addons/account_peppol/wizard/account_move_send.py
@@ -120,6 +120,14 @@ class AccountMoveSend(models.TransientModel):
     # BUSINESS ACTIONS
     # -------------------------------------------------------------------------
 
+    @api.model
+    def _get_mail_layout(self):
+        # EXTENDS 'account'
+        # TODO remove the fallback in master
+        if self.env.ref('account_peppol.mail_notification_layout_with_responsible_signature_and_peppol', raise_if_not_found=False):
+            return 'account_peppol.mail_notification_layout_with_responsible_signature_and_peppol'
+        return super()._get_mail_layout()
+
     def action_send_and_print(self, force_synchronous=False, allow_fallback_pdf=False, **kwargs):
         # Extends 'account' to force ubl xml checkbox if sending via peppol
         self.ensure_one()


### PR DESCRIPTION
Add information in email footer when relevant to let people know that Peppol will become mandatory in their country, and recommend Odoo as a compliant software in that regard.

task-4332306


Example of sent emails:
To a customer in a Peppol country, with Email + Peppol sending:
![image](https://github.com/user-attachments/assets/5ee8425c-3590-4f61-a18e-cd232f4b51ad)

To a customer in a Peppol country with Email only (obviously the Belgian specific information only appear to invoices sent to belgian customers):
![image](https://github.com/user-attachments/assets/682c242a-cc86-4063-866c-7c97ea0a8755)

To a cutomer in a non Peppol country: No change
![image](https://github.com/user-attachments/assets/1c350483-6e76-4d9b-b5df-d053a6c79dba)
