### PR TITLE
[IMP] web: x2many: support `invisible` attr on custom controls

### DIFF
--- a/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_list_renderer.xml
+++ b/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_list_renderer.xml
@@ -9,7 +9,7 @@
             </t>
         </xpath>
 
-        <xpath expr="//t[@t-foreach='creates']" position="after">
+        <xpath expr="//t[@t-foreach='controls']" position="after">
             <a t-if="ShowX2MRecords" role="button" class="ml16 o_toggle_closed_task_button" href="#" t-on-click="() => this.toggleHideClosed()">
                 <t t-esc="toggleListHideLabel"/>
             </a>

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -3,6 +3,7 @@ import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 import { makeContext } from "@web/core/context";
 import { Dialog } from "@web/core/dialog/dialog";
 import { Domain } from "@web/core/domain";
+import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { RPCError } from "@web/core/network/rpc";
 import { Cache } from "@web/core/utils/cache";
 import {
@@ -546,6 +547,10 @@ export class X2ManyFieldDialog extends Component {
         delete: { optional: true },
         deleteButtonLabel: { optional: true },
         config: Object,
+        controls: { type: Array, optional: true },
+    };
+    static defaultProps = {
+        controls: [],
     };
     setup() {
         this.actionService = useService("action");
@@ -625,6 +630,13 @@ export class X2ManyFieldDialog extends Component {
             };
         }
         return props;
+    }
+
+    get displayDeleteButton() {
+        const deleteControl = this.props.controls.find((control) => control.type === "delete");
+        return (
+            !deleteControl || !evaluateBooleanExpr(deleteControl.invisible, this.record.evalContext)
+        );
     }
 
     async beforeExecuteActionButton(clickParams) {
@@ -739,7 +751,7 @@ export function useOpenX2ManyRecord({
     const addDialog = useOwnedDialogs();
     const viewMode = activeField.viewMode;
 
-    async function openRecord({ record, mode, context, title, onClose }) {
+    async function openRecord({ record, mode, context, title, controls, onClose }) {
         if (!title) {
             title = record
                 ? _t("Open: %s", activeField.string)
@@ -785,6 +797,7 @@ export function useOpenX2ManyRecord({
                 config: env.config,
                 archInfo,
                 record,
+                controls,
                 addNew: () => {
                     return getList().extendRecord(params);
                 },

--- a/addons/web/static/src/views/fields/relational_utils.xml
+++ b/addons/web/static/src/views/fields/relational_utils.xml
@@ -69,7 +69,7 @@
         </t>
         <button class="btn btn-secondary o_form_button_cancel" t-on-click="discard" data-hotkey="j">Discard</button>
 
-        <t t-if="props.delete">
+        <t t-if="props.delete and displayDeleteButton">
             <button class="btn btn-secondary o_btn_remove" t-on-click="remove" data-hotkey="k">
                 <t t-if="props.deleteButtonLabel" t-out="props.deleteButtonLabel"/>
                 <t t-else="">Remove</t>

--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -50,10 +50,10 @@ export class X2ManyField extends Component {
             : ["o_field_x2many"];
         this.className = computeViewClassName(this.props.viewMode, this.archInfo.xmlDoc, classes);
 
-        const { activeActions, creates } = this.archInfo;
+        const { activeActions, controls } = this.archInfo;
         if (this.props.viewMode === "kanban") {
-            this.creates = creates.length
-                ? creates
+            this.controls = controls.length
+                ? controls
                 : [
                       {
                           type: "create",
@@ -95,6 +95,7 @@ export class X2ManyField extends Component {
             const activeElement = document.activeElement;
             openRecord({
                 ...params,
+                controls: this.controls,
                 onClose: () => {
                     if (activeElement) {
                         activeElement.focus();

--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -1,6 +1,7 @@
 import { makeContext } from "@web/core/context";
 import { _t } from "@web/core/l10n/translation";
 import { Pager } from "@web/core/pager/pager";
+import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { getFieldDomain } from "@web/model/relational_model/utils";
@@ -221,6 +222,10 @@ export class X2ManyField extends Component {
         props.onOpenFormView = this.switchToForm.bind(this);
         props.hasOpenFormViewButton = archInfo.editable ? archInfo.openFormView : false;
         return props;
+    }
+
+    evalInvisible(invisible) {
+        return evaluateBooleanExpr(invisible, this.list.evalContext);
     }
 
     async switchToForm(record) {

--- a/addons/web/static/src/views/fields/x2many/x2many_field.xml
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.xml
@@ -6,24 +6,24 @@
             <div class="o_x2m_control_panel d-empty-none mt-1 mb-4">
                 <t t-if="displayControlPanelButtons">
                     <div class="o_cp_buttons gap-1" role="toolbar" aria-label="Control panel buttons" t-ref="buttons">
-                        <t t-foreach="creates" t-as="create" t-key="create_index">
+                        <t t-foreach="controls" t-as="control" t-key="control_index">
                             <button
-                                t-if="create.type === 'create' and !evalInvisible(create.invisible)"
+                                t-if="control.type === 'create' and !evalInvisible(control.invisible)"
                                 type="button"
                                 class="btn btn-secondary"
-                                t-att-class="create.class"
-                                t-on-click.stop.prevent="() => this.onAdd({ context: create.context })"
+                                t-att-class="control.class"
+                                t-on-click.stop.prevent="() => this.onAdd({ context: control.context })"
                             >
-                                <t t-esc="create.string"/>
+                                <t t-esc="control.string"/>
                             </button>
                             <ViewButton
-                                t-if="create.type === 'button' and !evalInvisible(create.invisible)"
-                                className="`${create.className}`"
-                                clickParams="create.clickParams"
-                                icon="create.icon"
+                                t-if="control.type === 'button' and !evalInvisible(control.invisible)"
+                                className="`${control.className}`"
+                                clickParams="control.clickParams"
+                                icon="control.icon"
                                 record="props.record.data[props.name]"
-                                string="create.string"
-                                title="create.title"
+                                string="control.string"
+                                title="control.title"
                             />
                         </t>
                     </div>

--- a/addons/web/static/src/views/fields/x2many/x2many_field.xml
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.xml
@@ -8,7 +8,7 @@
                     <div class="o_cp_buttons gap-1" role="toolbar" aria-label="Control panel buttons" t-ref="buttons">
                         <t t-foreach="creates" t-as="create" t-key="create_index">
                             <button
-                                t-if="create.type === 'create'"
+                                t-if="create.type === 'create' and !evalInvisible(create.invisible)"
                                 type="button"
                                 class="btn btn-secondary"
                                 t-att-class="create.class"
@@ -17,7 +17,7 @@
                                 <t t-esc="create.string"/>
                             </button>
                             <ViewButton
-                                t-if="create.type === 'button'"
+                                t-if="create.type === 'button' and !evalInvisible(create.invisible)"
                                 className="`${create.className}`"
                                 clickParams="create.clickParams"
                                 icon="create.icon"

--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -39,7 +39,7 @@ export class KanbanArchParser {
         const openAction = action && type ? { action, type } : null;
         const templateDocs = {};
         let headerButtons = [];
-        const creates = [];
+        const controls = [];
         let button_id = 0;
         // Root level of the template
         visitXML(xmlDoc, (node) => {
@@ -60,15 +60,20 @@ export class KanbanArchParser {
             } else if (node.tagName === "control") {
                 for (const childNode of node.children) {
                     if (childNode.tagName === "button") {
-                        creates.push({
+                        controls.push({
                             type: "button",
                             ...processButton(childNode),
                         });
                     } else if (childNode.tagName === "create") {
-                        creates.push({
+                        controls.push({
                             type: "create",
                             context: childNode.getAttribute("context"),
                             string: childNode.getAttribute("string"),
+                            invisible: childNode.getAttribute("invisible"),
+                        });
+                    } else if (childNode.tagName === "delete") {
+                        controls.push({
+                            type: "delete",
                             invisible: childNode.getAttribute("invisible"),
                         });
                     }
@@ -144,7 +149,7 @@ export class KanbanArchParser {
             cardClassName,
             cardColorField: xmlDoc.getAttribute("highlight_color"),
             className,
-            creates,
+            controls,
             fieldNodes,
             widgetNodes,
             handleField,

--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -69,6 +69,7 @@ export class KanbanArchParser {
                             type: "create",
                             context: childNode.getAttribute("context"),
                             string: childNode.getAttribute("string"),
+                            invisible: childNode.getAttribute("invisible"),
                         });
                     }
                 }

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -60,7 +60,7 @@ export class ListArchParser {
             fields: {},
         };
         let headerButtons = [];
-        const creates = [];
+        const controls = [];
         const groupListArchParser = new GroupListArchParser();
         let buttonGroup;
         let handleField = null;
@@ -168,15 +168,20 @@ export class ListArchParser {
             } else if (node.tagName === "control") {
                 for (const childNode of node.children) {
                     if (childNode.tagName === "button") {
-                        creates.push({
+                        controls.push({
                             type: "button",
                             ...processButton(childNode),
                         });
                     } else if (childNode.tagName === "create") {
-                        creates.push({
+                        controls.push({
                             type: "create",
                             context: childNode.getAttribute("context"),
                             string: childNode.getAttribute("string"),
+                            invisible: childNode.getAttribute("invisible"),
+                        });
+                    } else if (childNode.tagName === "delete") {
+                        controls.push({
+                            type: "delete",
                             invisible: childNode.getAttribute("invisible"),
                         });
                     }
@@ -229,7 +234,7 @@ export class ListArchParser {
         }
 
         return {
-            creates,
+            controls,
             headerButtons,
             fieldNodes,
             widgetNodes,

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -177,6 +177,7 @@ export class ListArchParser {
                             type: "create",
                             context: childNode.getAttribute("context"),
                             string: childNode.getAttribute("string"),
+                            invisible: childNode.getAttribute("invisible"),
                         });
                     }
                 }

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -111,9 +111,10 @@ export class ListRenderer extends Component {
          */
         this.preventReorder = false;
 
-        this.creates = this.props.archInfo.creates.length
-            ? this.props.archInfo.creates
+        this.controls = this.props.archInfo.controls.length
+            ? this.props.archInfo.controls
             : [{ type: "create", string: _t("Add a line") }];
+        this.deleteControl = this.controls.find((control) => control.type === "delete") || {};
 
         this.cellToFocus = null;
         this.activeRowId = null;
@@ -875,6 +876,10 @@ export class ListRenderer extends Component {
         return this.isX2Many && this.canCreate;
     }
 
+    displayDeleteIcon(record) {
+        return !evaluateBooleanExpr(this.deleteControl.invisible, record.evalContext);
+    }
+
     // Group headers logic:
     // if there are aggregates, the first th spans until the first
     // aggregate column then all cells between aggregates are rendered
@@ -1383,7 +1388,7 @@ export class ListRenderer extends Component {
                             return false;
                         }
                         // add a line
-                        const { context } = this.creates[0];
+                        const { context } = this.controls[0];
                         this.add({ context });
                     } else if (
                         this.canCreate &&

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -120,26 +120,26 @@
                     class="o_field_x2many_list_row_add"
                     t-on-keydown="(ev) => this.onCellKeydown(ev, null)"
                 >
-                    <t t-foreach="creates" t-as="create" t-key="create_index">
+                    <t t-foreach="controls" t-as="control" t-key="control_index">
                         <a
-                            t-if="create.type === 'create' and !evalColumnInvisible(create.invisible)"
+                            t-if="control.type === 'create' and !evalColumnInvisible(control.invisible)"
                             href="#"
                             role="button"
-                            t-att-class="create_index !== 0 ? 'ml16' : ''"
-                            t-att-tabindex="editedRecord ? '-1' : '0'"
-                            t-on-click.stop.prevent="() => this.add({ context: create.context })"
+                            t-att-class="control_index !== 0 ? 'ml16' : ''"
+                            t-att-tabindex="props.list.editedRecord ? '-1' : '0'"
+                            t-on-click.stop.prevent="() => this.add({ context: control.context })"
                         >
-                            <t t-esc="create.string"/>
+                            <t t-esc="control.string"/>
                         </a>
                         <ViewButton
-                            t-if="create.type === 'button' and !evalColumnInvisible(create.invisible)"
-                            className="`${create.className} ${create_index !== 0 ? 'ml16' : ''}`"
-                            clickParams="create.clickParams"
-                            icon="create.icon"
+                            t-if="control.type === 'button' and !evalColumnInvisible(control.invisible)"
+                            className="`${control.className} ${control_index !== 0 ? 'ml16' : ''}`"
+                            clickParams="control.clickParams"
+                            icon="control.icon"
                             record="props.list"
-                            string="create.string"
-                            title="create.title"
-                            tabindex="editedRecord ? '-1' : '0'"
+                            string="control.string"
+                            title="control.title"
+                            tabindex="props.list.editedRecord ? '-1' : '0'"
                         />
                     </t>
                 </td>
@@ -308,6 +308,7 @@
                         tabindex="-1"
                     >
                         <button class="fa d-print-none"
+                            t-if="this.displayDeleteIcon(record)"
                             t-att-class="{
                                 'fa-trash-o': !useUnlink and activeActions.delete,
                                 'fa-times': useUnlink and activeActions.unlink,

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -122,7 +122,7 @@
                 >
                     <t t-foreach="creates" t-as="create" t-key="create_index">
                         <a
-                            t-if="create.type === 'create'"
+                            t-if="create.type === 'create' and !evalColumnInvisible(create.invisible)"
                             href="#"
                             role="button"
                             t-att-class="create_index !== 0 ? 'ml16' : ''"
@@ -132,7 +132,7 @@
                             <t t-esc="create.string"/>
                         </a>
                         <ViewButton
-                            t-if="create.type === 'button'"
+                            t-if="create.type === 'button' and !evalColumnInvisible(create.invisible)"
                             className="`${create.className} ${create_index !== 0 ? 'ml16' : ''}`"
                             clickParams="create.clickParams"
                             icon="create.icon"

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -9001,6 +9001,83 @@ test("one2many kanban with custom control with invisible modifier using context"
     expect(".o_cp_buttons button:contains(D)").toHaveCount(1);
 });
 
+test("one2many list with delete control with invisible modifier", async () => {
+    Partner._records[1].p = [1, 2];
+    Partner._records[0].bar = false;
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 2,
+        arch: `
+            <form>
+                <field name="bar"/>
+                <field class="first" name="p">
+                    <list>
+                        <control>
+                            <delete invisible="parent.bar and bar"/>
+                        </control>
+                        <field name="name"/>
+                        <field name="bar"/>
+                    </list>
+                </field>
+                <field class="second" name="p">
+                    <list>
+                        <control>
+                            <delete invisible="not parent.bar"/>
+                        </control>
+                        <field name="name"/>
+                        <field name="bar"/>
+                    </list>
+                </field>
+            </form>`,
+    });
+
+    expect(".first .o_data_row").toHaveCount(2);
+    expect(".first .o_data_row:eq(0) .o_list_record_remove button").toHaveCount(1);
+    expect(".first .o_data_row:eq(1) .o_list_record_remove button").toHaveCount(0);
+    expect(".second .o_data_row").toHaveCount(2);
+    expect(".second .o_data_row .o_list_record_remove button").toHaveCount(2);
+});
+
+test("one2many kanban with delete control with invisible modifier", async () => {
+    Partner._records[1].p = [1, 2];
+    Partner._records[0].bar = false;
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 2,
+        arch: `
+            <form>
+                <field name="bar"/>
+                <field name="p">
+                    <kanban>
+                        <control>
+                            <delete invisible="parent.bar and bar"/>
+                        </control>
+                        <templates>
+                            <t t-name="card">
+                                <field name="name"/>
+                                <field name="bar"/>
+                            </t>
+                        </templates>
+                    </kanban>
+                </field>
+            </form>`,
+    });
+
+    await contains(".o_kanban_record:eq(0)").click();
+    expect(".o_dialog .o_form_view").toHaveCount(1);
+    expect(".o_dialog footer .o_btn_remove").toHaveCount(1);
+
+    await contains(".o_dialog footer .o_form_button_cancel").click();
+    await contains(".o_kanban_record:eq(1)").click();
+    expect(".o_dialog .o_form_view").toHaveCount(1);
+    expect(".o_dialog footer .o_btn_remove").toHaveCount(0);
+
+    await contains(".o_dialog .o_form_view .o_field_widget[name=bar] input").click();
+    expect(".o_dialog footer .o_btn_remove").toHaveCount(1);
+});
+
 test("o2m button with parent in context", async () => {
     onRpc("test_button", (args) => {
         expect.step("test_button");

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -8879,6 +8879,128 @@ test("o2m add an action button control", async () => {
     expect.verifySteps(["do_something"]);
 });
 
+test("one2many list with custom control with invisible modifier", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 2,
+        arch: `
+            <form>
+                <field name="bar"/>
+                <field name="p">
+                    <list>
+                        <control>
+                            <create string="A" invisible="parent.bar"/>
+                            <create string="B" invisible="not parent.bar"/>
+                            <button string="C" name="do_something" type="object" invisible="parent.bar"/>
+                            <button string="D" name="do_something" type="object" invisible="not parent.bar"/>
+                        </control>
+                        <field name="name"/>
+                    </list>
+                </field>
+            </form>`,
+    });
+
+    expect(".o_field_x2many_list_row_add a:contains(A)").toHaveCount(0);
+    expect(".o_field_x2many_list_row_add a:contains(B)").toHaveCount(1);
+    expect(".o_field_x2many_list_row_add button:contains(C)").toHaveCount(0);
+    expect(".o_field_x2many_list_row_add button:contains(D)").toHaveCount(1);
+});
+
+test("one2many list with custom control with invisible modifier using context", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 2,
+        arch: `
+            <form>
+                <field name="bar"/>
+                <field name="p">
+                    <list>
+                        <control>
+                            <create string="A" invisible="context.get('someKey')"/>
+                            <create string="B" invisible="not context.get('someKey')"/>
+                            <button string="C" name="do_something" type="object" invisible="context.get('someKey')"/>
+                            <button string="D" name="do_something" type="object" invisible="not context.get('someKey')"/>
+                        </control>
+                        <field name="name"/>
+                    </list>
+                </field>
+            </form>`,
+        context: { someKey: true },
+    });
+
+    expect(".o_field_x2many_list_row_add a:contains(A)").toHaveCount(0);
+    expect(".o_field_x2many_list_row_add a:contains(B)").toHaveCount(1);
+    expect(".o_field_x2many_list_row_add button:contains(C)").toHaveCount(0);
+    expect(".o_field_x2many_list_row_add button:contains(D)").toHaveCount(1);
+});
+
+test("one2many kanban with custom control with invisible modifier", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 2,
+        arch: `
+            <form>
+                <field name="bar"/>
+                <field name="p">
+                    <kanban>
+                        <control>
+                            <create string="A" invisible="parent.bar"/>
+                            <create string="B" invisible="not parent.bar"/>
+                            <button string="C" name="do_something" type="object" invisible="parent.bar"/>
+                            <button string="D" name="do_something" type="object" invisible="not parent.bar"/>
+                        </control>
+                        <templates>
+                            <t t-name="card">
+                                <field name="name"/>
+                            </t>
+                        </templates>
+                    </kanban>
+                </field>
+            </form>`,
+    });
+
+    expect(".o_cp_buttons button:contains(A)").toHaveCount(0);
+    expect(".o_cp_buttons button:contains(B)").toHaveCount(1);
+    expect(".o_cp_buttons button:contains(C)").toHaveCount(0);
+    expect(".o_cp_buttons button:contains(D)").toHaveCount(1);
+});
+
+test("one2many kanban with custom control with invisible modifier using context", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 2,
+        arch: `
+            <form>
+                <field name="bar"/>
+                <field name="p">
+                    <kanban>
+                        <control>
+                            <create string="A" invisible="context.get('someKey')"/>
+                            <create string="B" invisible="not context.get('someKey')"/>
+                            <button string="C" name="do_something" type="object" invisible="context.get('someKey')"/>
+                            <button string="D" name="do_something" type="object" invisible="not context.get('someKey')"/>
+                        </control>
+                        <templates>
+                            <t t-name="card">
+                                <field name="name"/>
+                            </t>
+                        </templates>
+                    </kanban>
+                </field>
+            </form>`,
+        context: { someKey: true },
+    });
+
+    expect(".o_cp_buttons button:contains(A)").toHaveCount(0);
+    expect(".o_cp_buttons button:contains(B)").toHaveCount(1);
+    expect(".o_cp_buttons button:contains(C)").toHaveCount(0);
+    expect(".o_cp_buttons button:contains(D)").toHaveCount(1);
+});
+
 test("o2m button with parent in context", async () => {
     onRpc("test_button", (args) => {
         expect.step("test_button");


### PR DESCRIPTION
This PR adds the support for the invisible modifier on custom controls (create and button) in list view archs. The given expression can use the context (`context.get("...")`) and the parent record (`parent.some_field`) in the case of a list inside an x2many field.

It also defines a new type of control: `<delete/>`. This control supports a single attribute `invisible`, which allows to conditionally enable the delete/remove feature. The attribute's value is a python expression that can use the context, the parent record and fields of the record itself (i.e. the feature can be disabled at a record level).

request for task~4063960


