### PR TITLE
[FIX] hr_holidays: fix search by name in the overview section

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -121,3 +121,7 @@ class LeaveReportCalendar(models.Model):
 
     def action_refuse(self):
         self.leave_id.action_refuse()
+
+    @api.model
+    def _search_name(self, operator, value):
+        return ['|', '|', ('employee_id', operator, value), ('leave_id.holiday_status_id', operator, value), ('leave_id.duration_display', operator, value)]


### PR DESCRIPTION
Steps:
- Install the time-off app.
- Navigate to the Overview section.
- Searching by name is not working.

Cause of the issue:
- The name field is non-stored.

Fix:
- Added a search method for the name.

task-4348198

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
