### PR TITLE
[IMP] mail: no arrow on quick reaction's popover

### DIFF
--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -31,6 +31,7 @@ export class QuickReactionMenu extends Component {
             position: "bottom-end",
             popoverClass: "o-mail-QuickReactionMenu-pickerPopover shadow-none",
             animation: false,
+            arrow: false,
             onPositioned: (el, { direction, variant }) =>
                 el.classList.add(`o-popover--${direction[0]}${variant[0]}`),
         });


### PR DESCRIPTION
Dialogs show arrow next to the button by default. It was not intended for quick reaction menu. This PR removes it.

Before:
![image](https://github.com/user-attachments/assets/a4da4b35-fc19-4053-a901-748481b10b8b)

After:
![image](https://github.com/user-attachments/assets/732b783d-4807-4ffc-99df-e6fa9d4c48a8)
