### PR TITLE
[17.0][FIX] account: Apply sudo to avoid an access error when importing records (e.g. partners).

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -98,7 +98,7 @@ class AccountChartTemplate(models.AbstractModel):
         field = self.env['ir.module.module']._fields['account_templates']
         modules = (
             self.env.cache.get_records(self.env['ir.module.module'], field)
-            or self.env['ir.module.module'].search([])
+            or self.env['ir.module.module'].sudo().search([])
         )
 
         return {


### PR DESCRIPTION
Apply sudo to avoid an access error when importing records (e.g. partners).

Example use case:
- Uninstall `base_install_request`
- A user without the Administrator > Settings permission
- Go to Contacts and click on Import records
- When uploading the file the access error occurs

@Tecnativa TT51841

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
