### PR TITLE
[FIX] packaging: empty windows install path

### DIFF
--- a/setup/win32/setup.nsi
+++ b/setup/win32/setup.nsi
@@ -418,6 +418,8 @@ Function .onInit
     ${If} $previous_install_dir == ""
         StrCpy $INSTDIR "$PROGRAMFILES64\Odoo ${VERSION}"
         WriteRegStr HKLM "${REGISTRY_KEY}" "Install_dir" "$INSTDIR"
+    ${Else}
+        StrCpy $INSTDIR $previous_install_dir
     ${EndIf}
 
     Push $R0


### PR DESCRIPTION
Introduced in #57155 (commit da29586).

Steps to reproduce:
- Install Odoo on a Windows machine
  - The install path defaults to Program Files as expected
- Uninstall Odoo
- Try to install Odoo again
  - The install path defaults to the empty string, forcing the user to manually set one

Expected behaviour:
- The install path defaults to the previous install path

task-4104451

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
