### PR TITLE
[IMP] mail: speed up test contains with focus or value

### DIFF
--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -184,6 +184,8 @@ test("chat window: basic rendering", async () => {
     await contains("[title='Fold']");
     await contains("[title*='Close Chat Window']");
     await contains(".o-mail-ChatWindow .o-mail-Thread", { text: "The conversation is empty." });
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await contains(".o-mail-ChatWindow-command", { count: 14 });
     await contains(".o-dropdown-item", { text: "Attachments" });
@@ -433,6 +435,8 @@ test("Close active thread action in chatwindow on ESCAPE", async () => {
     });
     await start();
     await contains(".o-mail-ChatWindow");
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains(".o-mail-ChatWindow-command", { text: "General" });
     await click(".o-mail-ChatWindow-command", { text: "General" });
     await click(".o-dropdown-item", { text: "Invite People" });
     await contains(".o-discuss-ChannelInvitation");
@@ -450,6 +454,8 @@ test("ESC cancels thread rename", async () => {
         ],
     });
     await start();
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains(".o-mail-ChatWindow-command", { text: "General" });
     await click(".o-mail-ChatWindow-command", { text: "General" });
     await click(".o-dropdown-item", { text: "Rename Thread" });
     await contains(".o-mail-AutoresizeInput.o-focused[title='General']");
@@ -864,6 +870,8 @@ test("folded chat window should hide member-list and settings buttons", async ()
     // Open Thread
     await click("button i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await contains(".o-dropdown-item", { text: "Members" });
     await contains(".o-dropdown-item", { text: "Call Settings" });
@@ -876,6 +884,8 @@ test("folded chat window should hide member-list and settings buttons", async ()
     await contains(".o-dropdown-item", { text: "Call Settings", count: 0 });
     // Unfold chat window
     await click(".o-mail-ChatBubble");
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await contains(".o-dropdown-item", { text: "Members" });
     await contains(".o-dropdown-item", { text: "Call Settings" });
@@ -919,6 +929,7 @@ test("chat window of channels should not have 'Open in Discuss' (mobile)", async
     patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss(channelId);
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await contains(".o-dropdown-item", { text: "Open in Discuss", count: 0 });
@@ -1034,11 +1045,15 @@ test("Notification settings rendering in chatwindow", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem", { text: "general" });
     await contains(".o-mail-ChatWindow", { count: 1 });
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Notification Settings" });
     await contains("button", { text: "All Messages" });
     await contains("button", { text: "Mentions Only", count: 2 }); // the extra is in the Use Default as subtitle
     await contains("button", { text: "Nothing" });
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("button", { text: "Mute Conversation" });
     await click("button", { text: "Mute Conversation" });
     await contains("button", { text: "For 15 minutes" });
     await contains("button", { text: "For 1 hour" });

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -232,8 +232,11 @@ test("keep emoji picker scroll value when re-opening it", async () => {
     await start();
     await openDiscuss(channelId);
     await click("button[title='Add Emojis']");
+    // requires an extra delay (give time for auto scroll before setting new value)
+    await contains(".o-EmojiPicker-content", { scroll: 0 });
     await scroll(".o-EmojiPicker-content", 150);
     await click("button[title='Add Emojis']");
+    await contains(".o-EmojiPicker-content", { count: 0 });
     await click("button[title='Add Emojis']");
     await contains(".o-EmojiPicker-content", { scroll: 150 });
 });
@@ -244,6 +247,8 @@ test("reset emoji picker scroll value after an emoji is picked", async () => {
     await start();
     await openDiscuss(channelId);
     await click("button[title='Add Emojis']");
+    // requires an extra delay (give time for auto scroll before setting new value)
+    await contains(".o-EmojiPicker-content", { scroll: 0 });
     await scroll(".o-EmojiPicker-content", 150);
     await click(".o-Emoji", { text: "😎" });
     await click("button[title='Add Emojis']");
@@ -266,6 +271,8 @@ test("keep emoji picker scroll value independent if two or more different emoji 
     await click("button[title='Add Emojis']", {
         parent: [".o-mail-ChatWindow", { text: "Sales" }],
     });
+    // requires an extra delay (give time for auto scroll before setting new value)
+    await contains(".o-EmojiPicker-content", { scroll: 0 });
     await scroll(".o-EmojiPicker-content", 200);
     await contains(".o-EmojiPicker-content", { scroll: 200 });
     await click("button[title='Add Emojis']", {
@@ -275,6 +282,8 @@ test("keep emoji picker scroll value independent if two or more different emoji 
     await click("button[title='Add Emojis']", {
         parent: [".o-mail-ChatWindow", { text: "roblox-jaywalking" }],
     });
+    // requires an extra delay (give time for auto scroll before setting new value)
+    await contains(".o-EmojiPicker-content", { scroll: 0 });
     await scroll(".o-EmojiPicker-content", 150);
     await contains(".o-EmojiPicker-content", { scroll: 150 });
     await click("button[title='Add Emojis']", {

--- a/addons/mail/static/tests/core/new_message_separator.test.js
+++ b/addons/mail/static/tests/core/new_message_separator.test.js
@@ -181,6 +181,8 @@ test("keep new message separator when switching between chat window and discuss 
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Mark as Unread']");
     await contains(".o-mail-Thread-newMessage");
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Open in Discuss" });
     await contains(".o-mail-Discuss-threadName", { value: "General" });

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -319,6 +319,8 @@ test("'Start a meeting' in mobile", async () => {
     await click(".o-discuss-ChannelInvitation-selectable", { text: "Partner 2" });
     await click("button:not([disabled])", { text: "Invite to Group Chat" });
     await contains(".o-discuss-Call");
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Members" });
     await contains(".o-discuss-ChannelMember", { text: "Partner 2" });

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -41,6 +41,8 @@ test("Renders the call settings", async () => {
     patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss(channelId);
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });
     await contains(".o-discuss-CallSettings");
@@ -61,6 +63,8 @@ test("activate push to talk", async () => {
     patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss(channelId);
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });
     await click("button", { text: "Push to Talk" });
@@ -75,6 +79,8 @@ test("activate blur", async () => {
     patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss(channelId);
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });
     await click("input[title='Blur video background']");
@@ -101,6 +107,8 @@ test("local storage for call settings", async () => {
     await start();
     await openDiscuss(channelId);
     // testing load from local storage
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });
     await contains("input[title='Show video participants only']:checked");

--- a/addons/mail/static/tests/discuss/call/ptt_ad_banner.test.js
+++ b/addons/mail/static/tests/discuss/call/ptt_ad_banner.test.js
@@ -27,6 +27,8 @@ test("display banner when ptt extension is not enabled", async () => {
     patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss(channelId);
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });
     await click("button", { text: "Push to Talk" });
@@ -34,6 +36,8 @@ test("display banner when ptt extension is not enabled", async () => {
     await click("button", { text: "Start a meeting" });
     await click("button[title='Close panel']"); // invitation panel automatically open
     await contains(".o-discuss-PttAdBanner");
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });
     await click("button", { text: "Voice Detection" });

--- a/addons/mail/static/tests/discuss/call/web/call.test.js
+++ b/addons/mail/static/tests/discuss/call/web/call.test.js
@@ -64,9 +64,13 @@ test.tags("mobile")("show Push-to-Talk button on mobile", async () => {
     await start();
     await openDiscuss(channelId);
     await click("[title='Start a Call']");
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });
     await click("button", { text: "Push to Talk" });
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Call Settings" });
     await contains("button", { text: "Push to talk" });

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -49,6 +49,8 @@ test("can invite users in channel from chat window", async () => {
         channel_type: "channel",
     });
     await start();
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Invite People" });
     await contains(".o-discuss-ChannelInvitation");

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2038,6 +2038,8 @@ test("Correct breadcrumb when open discuss from chat window then see settings", 
     await start();
     await click(".o_main_navbar i[aria-label='Messages']");
     await click(".o-mail-NotificationItem", { text: "General" });
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Open in Discuss" });
     await click("[title='Channel settings']", {
@@ -2097,6 +2099,8 @@ test("Notification settings: basic rendering", async () => {
     await contains("button", { text: "All Messages" });
     await contains("button", { text: "Mentions Only", count: 2 }); // the extra is in the Use Default as subtitle
     await contains("button", { text: "Nothing" });
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("button", { text: "Mute Conversation" });
     await click("button", { text: "Mute Conversation" });
     await contains("button", { text: "For 15 minutes" });
     await contains("button", { text: "For 1 hour" });
@@ -2120,6 +2124,8 @@ test("Notification settings: mute conversation will change the style of sidebar"
         count: 0,
     });
     await click("[title='Notification Settings']");
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("button", { text: "Mute Conversation" });
     await click("button", { text: "Mute Conversation" });
     await click("button", { text: "For 15 minutes" });
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario Party" });
@@ -2140,11 +2146,15 @@ test("Notification settings: change the mute duration of the conversation", asyn
         count: 0,
     });
     await click("[title='Notification Settings']");
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("button", { text: "Mute Conversation" });
     await click("button", { text: "Mute Conversation" });
     await click("button", { text: "For 15 minutes" });
     await click("[title='Notification Settings']");
     await click(".o-discuss-NotificationSettings span", { text: "Unmute Conversation" });
     await click("[title='Notification Settings']");
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("button", { text: "Mute Conversation" });
     await click("button", { text: "Mute Conversation" });
     await click("button", { text: "For 1 hour" });
 });
@@ -2158,6 +2168,8 @@ test("Notification settings: mute/unmute conversation works correctly", async ()
     await start();
     await openDiscuss(channelId);
     await click("[title='Notification Settings']");
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("button", { text: "Mute Conversation" });
     await click("button", { text: "Mute Conversation" });
     await click("button", { text: "For 15 minutes" });
     await click("[title='Notification Settings']");

--- a/addons/mail/static/tests/emoji/emoji.test.js
+++ b/addons/mail/static/tests/emoji/emoji.test.js
@@ -6,6 +6,7 @@ import {
     defineMailModels,
     insertText,
     openDiscuss,
+    scroll,
     start,
     startServer,
     triggerHotkey,

--- a/addons/mail/static/tests/gif_picker/gif_picker.test.js
+++ b/addons/mail/static/tests/gif_picker/gif_picker.test.js
@@ -272,6 +272,8 @@ test("Scrolling at the bottom should trigger the search to load more gif, even a
     await start();
     await openDiscuss(channelId);
     await click("button[title='Add GIFs']");
+    // gif picker quires extra delay before click (to give time to load initial state)
+    await contains(".o-discuss-GifPicker");
     await click(".o-discuss-GifPicker div[aria-label='list-item']", { text: "Favorites" });
     await click("i[aria-label='back']");
     await click("img[data-src='https://media.tenor.com/6uIlQAHIkNoAAAAM/cry.gif']");

--- a/addons/mail/static/tests/mail_test_helpers_contains.js
+++ b/addons/mail/static/tests/mail_test_helpers_contains.js
@@ -611,6 +611,9 @@ class Contains {
         this.done = false;
         this.def = new Deferred();
         this.scrollListeners = new Set();
+        this.onBlur = () => this.runOnce("after blur");
+        this.onChange = () => this.runOnce("after change");
+        this.onFocus = () => this.runOnce("after focus");
         this.onScroll = () => this.runOnce("after scroll");
         if (!this.runOnce("immediately")) {
             this.timer = setTimeout(
@@ -629,6 +632,9 @@ class Contains {
                 childList: true,
                 subtree: true,
             });
+            document.body.addEventListener("blur", this.onBlur, { capture: true });
+            document.body.addEventListener("change", this.onChange, { capture: true });
+            document.body.addEventListener("focus", this.onFocus, { capture: true });
             after(() => {
                 if (!this.done) {
                     this.runOnce("Test ended", { crashOnFail: true });
@@ -659,6 +665,9 @@ class Contains {
             for (const el of this.scrollListeners ?? []) {
                 el.removeEventListener("scroll", this.onScroll);
             }
+            document.body.removeEventListener("blur", this.onBlur, { capture: true });
+            document.body.removeEventListener("change", this.onChange, { capture: true });
+            document.body.removeEventListener("focus", this.onFocus, { capture: true });
             this.done = true;
         }
         if ((res?.length ?? 0) === this.options.count) {

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -862,6 +862,8 @@ test("click on expand from chat window should close the chat window and open the
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem", { text: "Frodo Baggins" });
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await click(".o-dropdown-item", { text: "Open Form View" });
     await contains(".o-mail-ChatWindow", { count: 0 });

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -59,6 +59,8 @@ test("can leave channel in mobile", async () => {
     patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss(channelId);
+    // dropdown requires an extra delay before click (because handler is registered in useEffect)
+    await contains(".o-mail-ChatWindow-command", { text: "General" });
     await click(".o-mail-ChatWindow-command", { text: "General" });
     await contains(".o-dropdown-item", { text: "Leave" });
 });


### PR DESCRIPTION
:focus and :value do not trigger DOM mutations and are therefore not observed for changes.

Tests that rely on them currently either immediately resolve (by luck) or pass due to the fallback timeout after 3s.

With this PR, they resolve as soon as the focus or value changes.


The tests are now so fast that Dropdown requires an extra step, because for some reason the click handler is registered in useEffect, so the click is not caught when doing it too early.

Some other tests also need extra delay, as commented in files.

https://github.com/odoo/enterprise/pull/74605