### PR TITLE
[FIX] stock: set production_id on scrap stock move

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -462,6 +462,7 @@ class StockMove(models.Model):
         # we go further with the list of ids potentially changed by action_explode
         return super(StockMove, moves)._action_confirm(merge=merge, merge_into=merge_into)
 
+
     def action_explode(self):
         """ Explodes pickings """
         # in order to explode a move, we must have a picking_type_id on that move because otherwise the move

--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -133,6 +133,7 @@ class StockScrap(models.Model):
                 'lot_id': self.lot_id.id,
             })],
             # 'restrict_partner_id': self.owner_id.id,
+            'production_id': self.production_id.id,
             'picked': True,
             'picking_id': self.picking_id.id
         }


### PR DESCRIPTION
**Issue:**
    In 17.0 and saas-17.2, The Cost of Scrap section does not appear in the the Cost Analysis Report despite having scrapped some components during manufacturing.

**Steps to reproduce:**
    1. Create a product with a BoM
    2. Manufacture the product
    3. Scrap some components during manufacturing
    4. print the Cost Analysis Report
    5. Notice the cost of scrap section does not appear in the report.

**Solution:**
- In v17.0, the Cost Analysis Report fails to include scrap costs because `production_id` is not assigned to scrap stock moves.
- This issue was introduced by changes in PR #176186,which cleared the context, preventing `production_id` from being set. 
- The fix involves reverting these changes in v17.0 and replacing them with the solution implemented in https://github.com/odoo/odoo/pull/176417 where `production_id` is correctly assigned, ensuring scrap costs are included  the report.

opw-4183097

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
