### PR TITLE
[FIX] maintenance: hide smart button for serial number

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -160,7 +160,7 @@ class MaintenanceEquipment(models.Model):
 
     @api.depends('serial_no')
     def _compute_match_serial(self):
-        if 'stock.lot' not in self.env:
+        if 'stock.lot' not in self.env or not self.env['stock.lot'].has_access('read'):
             self.match_serial = False
             return
         matched_serial_data = self.env['stock.lot']._read_group(

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -373,7 +373,7 @@
                         <button type="object"
                             name="action_open_matched_serial"
                             icon="fa-bars" class="oe_stat_button"
-                            invisible="not match_serial"> <!-- The button must stay invisible without stock module -->
+                            invisible="not match_serial"> <!-- The button must stay invisible without any access to `stock.lot` -->
                             <field string="Serial Number" name="serial_no" widget="statinfo"/>
                         </button>
                         <button name="%(hr_equipment_request_action_from_equipment)d"


### PR DESCRIPTION
To reproduce the issue:
(Need stock. Enable demo data)
1. In Settings, edit user "Marc Demo":
   - Inventory: Nothing
2. Log in as Marc Demo
3. Maintenance > Equipment, click on an equipment

Error: an Access Error is displayed because a forbidden read
operation on `stock.lot`

Because of a condition on a smart button of the form view
https://github.com/odoo/odoo/blob/f1e217c5cb4934de4cb52d46136d89500d84d904/addons/maintenance/views/maintenance_views.xml#L373-L378
We execute the compute method of `match_serial`, which leads to
https://github.com/odoo/odoo/blob/61e586556028aff2f989f5bb90a94afffbd1ac96/addons/maintenance/models/maintenance.py#L166-L170
But the user does not have any access to `stock.lot` (cf step 1).

The current diff is not the most elegant one, but:
- Adding a `sudo` in the compute method would let the smart button
  displayed, which would result in a bad UX (when clicking on the
  button, the user would have another access error)
- Adding a `groups` attribute on the button would require a bridge
  module and would not affect any existing database

The above ideas will be applied on master

Indirectly related to sentry-5964505411
(cf discussion on PR of https://github.com/odoo-dev/odoo/commit/f1e217c5cb4934de4cb52d46136d89500d84d904)