### PR TITLE
[FIX] base: fixed the issue with multiple quote detection mutilating html

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -37,6 +37,7 @@ __all__ = [
     "parse_contact_from_email",
     "plaintext2html",
     "single_email_re",
+    "tag_quote",
 ]
 
 _logger = logging.getLogger(__name__)
@@ -183,6 +184,9 @@ def tag_quote(el):
             child_node = new_node
             idx = item.end()
             node_idx = node_idx + 1
+
+    if el.get('data-o-mail-quote') or el.get('data-o-mail-quote-node'):
+        return
 
     el_class = el.get('class', '') or ''
     el_id = el.get('id', '') or ''


### PR DESCRIPTION
Some mail templates are having an issue where read more is getting redundant.
This happens when we either send the template as mail in chatter or in some
cases when an automatic mail is sent when a tracked field is changed.

Technical Info:

- Generally when a template is processed/added it is sanitized as xml (sanitize
mode as 'email_outgoing').
- The body(a HTML field) is being sanitized.
- Then when sending a message in chatter is again sanitized again into field
`body_html` in `mail.message.compose`.
- The `mail.message.compose` is further copied into `mail.message` where the
field is again sanitized.

Now that problem is that when we sanitized the template of `mail.template` we
dont sanitize any of the tags as at this step the targetted output is a xml
(beacause can contain any tags as opposed to as html). In this very step we do
a clean up of tags which is causing the problem (in method 'tag_quote') which
adds the read-more inducing tag called `data-o-mail-quote`.

When this template is again sanitized now the due to the [condition](https://github.com/odoo/odoo/blob/db3b2671efaf7cb84dce93eefd9c3f12c0e6a65c/odoo/tools/mail.py#L221)
here every other node is set to be having the tag  `data-o-mail-quote`.
When a break(`<br />`) tag has this tag it induces the `read more`.

Solution:

- The main culprit is quote detection causing all the issues. So a condition to
stop it mutilating the main content of html which keeps on adding unnecessary
css classes distorting the html displayed.

task-4331146