### PR TITLE
[FIX] web: Allow PDF printing on mobile

### DIFF
--- a/addons/web/static/lib/pdfjs/web/viewer.js
+++ b/addons/web/static/lib/pdfjs/web/viewer.js
@@ -18255,7 +18255,8 @@ window.print = function () {
       return activeServiceOnEntry.performPrint();
     }).catch(function () {}).then(function () {
       if (activeServiceOnEntry.active) {
-        abort();
+        // ODOO Patch: https://github.com/mozilla/pdf.js/issues/10630#issuecomment-855754913
+        setTimeout(abort, 1000);
       }
     });
   }


### PR DESCRIPTION
This commit fixes the blank page when we print documents with PDF.js.
It seems that pdf.js lib won't fix it because it's platform specific.

We first try to fix this issue by hiding the "Download" and "Print" buttons
as you can see in [1] but in this case, it's the only way to be able to
dowload or print the document.

So we patched the lib with the fix given inside the thread issue [2].

Steps to reproduce:

- Open Odoo on the Android mobile App
- Go to "Shop Floor"
- Click on 'WH/MO/00003' > 'Assembly 1' > 'Worksheet'
- Click the print button on pdf.js toolbar
=> blank screen

opw-4190135

[1]: https://github.com/odoo/odoo/commit/8a755d58330218b550efc0fea2f98800151c09a5
[2]: https://github.com/mozilla/pdf.js/issues/10630#issuecomment-855754913

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
