### PR TITLE
[IMP] base_vat: Issue with RUT validation (UY)

### DIFF
--- a/addons/base_vat/i18n/base_vat.pot
+++ b/addons/base_vat/i18n/base_vat.pot
@@ -207,6 +207,34 @@ msgstr ""
 
 #. module: base_vat
 #. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "The VAT must have exactly 12 characters."
+msgstr ""
+
+#. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "The VAT must contain only numbers."
+msgstr ""
+
+#. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "The VAT contains invalid or unknown components."
+msgstr ""
+
+#. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "The VAT check digit does not match."
+msgstr ""
+
+#. module: base_vat
+#. odoo-python
 #: code:addons/base_vat/models/account_fiscal_position.py:0
 #, python-format
 msgid ""

--- a/addons/base_vat/i18n/es.po
+++ b/addons/base_vat/i18n/es.po
@@ -209,6 +209,34 @@ msgstr "El número de IVA %s no pudo ser interpretado por el servidor VIES."
 
 #. module: base_vat
 #. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "The VAT must have exactly 12 characters."
+msgstr "El RUT debe tener exactamente 12 caracteres."
+
+#. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "The VAT must contain only numbers."
+msgstr "El RUT debe contener solo números."
+
+#. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "The VAT contains invalid or unknown components."
+msgstr "El RUT contiene componentes inválidos o desconocidos."
+
+#. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "The VAT check digit does not match."
+msgstr "El dígito de verificación del RUT no coincide."
+
+#. module: base_vat
+#. odoo-python
 #: code:addons/base_vat/models/account_fiscal_position.py:0
 #, python-format
 msgid ""

--- a/addons/base_vat/i18n/es_419.po
+++ b/addons/base_vat/i18n/es_419.po
@@ -212,6 +212,34 @@ msgstr "El número de IVA %s no pudo ser interpretado por el servidor VIES."
 
 #. module: base_vat
 #. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "The VAT must have exactly 12 characters."
+msgstr "El RUT debe tener exactamente 12 caracteres."
+
+#. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "The VAT must contain only numbers."
+msgstr "El RUT debe contener solo números."
+
+#. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "The VAT contains invalid or unknown components."
+msgstr "El RUT contiene componentes inválidos o desconocidos."
+
+#. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "The VAT check digit does not match."
+msgstr "El dígito de verificación del RUT no coincide."
+
+#. module: base_vat
+#. odoo-python
 #: code:addons/base_vat/models/account_fiscal_position.py:0
 #, python-format
 msgid ""

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -121,11 +121,9 @@ class TestStructure(TransactionCase):
         test_partner.write({"vat": "21-55217500-17"})
         test_partner.write({"vat": "21 55217500 17"})
         test_partner.write({"vat": "UY215521750017"})
-
-        # Test invalid VAT (should raise a ValidationError)
-        with self.assertRaisesRegex(ValidationError, "The VAT number.*does not seem to be valid."):
-            test_partner.write({"vat": "215521750018"})
-
+        # Test invalid VAT (should raise a ValidationError)        
+        with self.assertRaisesRegex(ValidationError, "The VAT check digit does not match.", msg=f"Invalid VAT: {'215521750018'}"):
+            test_partner.write({"vat": '215521750018'})
 
 @tagged('-standard', 'external')
 class TestStructureVIES(TestStructure):

--- a/addons/l10n_uy/tests/test_check_vat.py
+++ b/addons/l10n_uy/tests/test_check_vat.py
@@ -1,6 +1,5 @@
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
-
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
@@ -62,14 +61,19 @@ class CheckUyVat(AccountTestInvoicingCommon):
             self._create_partner("it_nie", "ABC 93:402. asas 010-1")
 
     def test_invalid_rut(self):
-        common_msg = "The RUT number.*does not seem to be valid."
+
+        common_msg = "The VAT check digit does not match."
         with self.assertRaisesRegex(ValidationError, common_msg, msg="invalid number"):
             self._create_partner("it_rut", "215521750018")
-        with self.assertRaisesRegex(ValidationError, common_msg, msg="do not accept dot ('.') character"):
-            self._create_partner("it_rut", "21.55217500.17")
-        with self.assertRaisesRegex(ValidationError, common_msg, msg="should not contain letters"):
-            self._create_partner("it_rut", "2155 ABC 21750017")
 
+        common_msg = "The VAT must contain only numbers."
+        with self.assertRaisesRegex(ValidationError, common_msg, msg="do not accept dot ('.') character"):
+            self._create_partner("it_rut", "21.557500.17")
+
+        with self.assertRaisesRegex(ValidationError, common_msg, msg="should not contain letters"):
+            self._create_partner("it_rut", "2155ABC21717")
+
+        common_msg = "The VAT check digit does not match."
         with self.assertRaisesRegex(ValidationError, common_msg, msg="Validation not working with generic VAT id type"):
             self.env["res.partner"].create({
                 "name": "Uruguayan Partner",


### PR DESCRIPTION
Task: 1292
adhoc-task-side: 45613

Description of the issue/feature this PR addresses:
Customers could not enter a VAT starting with '22'.

Current behavior before PR:
Now, in addition to allowing VAT numbers that start with '22', we have implemented the validation logic for Uruguayan VAT numbers.

Desired behavior after PR is merged:
Proper validation for Uruguayan VAT numbers.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
