### PR TITLE
[IMP] website: set common controllers as readonly

### DIFF
--- a/addons/website/controllers/backend.py
+++ b/addons/website/controllers/backend.py
@@ -8,7 +8,7 @@ from odoo.http import request
 
 class WebsiteBackend(http.Controller):
 
-    @http.route('/website/fetch_dashboard_data', type="json", auth='user')
+    @http.route('/website/fetch_dashboard_data', type="json", auth='user', readonly=True)
     def fetch_dashboard_data(self, website_id):
         Website = request.env['website']
         has_group_system = request.env.user.has_group('base.group_system')
@@ -33,11 +33,11 @@ class WebsiteBackend(http.Controller):
             dashboard_data['dashboards']['plausible_share_url'] = current_website._get_plausible_share_url()
         return dashboard_data
 
-    @http.route('/website/iframefallback', type="http", auth='user', website=True)
+    @http.route('/website/iframefallback', type="http", auth='user', website=True, readonly=True)
     def get_iframe_fallback(self):
         return request.render('website.iframefallback')
 
-    @http.route('/website/check_new_content_access_rights', type="json", auth='user')
+    @http.route('/website/check_new_content_access_rights', type="json", auth='user', readonly=True)
     def check_create_access_rights(self, models):
         """
         TODO: In master, remove this route and method and find a better way
@@ -54,7 +54,7 @@ class WebsiteBackend(http.Controller):
             for model in models
         }
 
-    @http.route('/website/track_installing_modules', type='json', auth='user')
+    @http.route('/website/track_installing_modules', type='json', auth='user', readonly=True)
     def website_track_installing_modules(self, selected_features, total_features=None):
         """
         During the website configuration, this route allows to track the

--- a/addons/website/controllers/binary.py
+++ b/addons/website/controllers/binary.py
@@ -5,7 +5,7 @@ from odoo.addons.web.controllers.binary import Binary
 
 class WebsiteBinary(Binary):
     @http.route([
-        '/web/assets/<int:website_id>/<unique>/<string:filename>'], type='http', auth="public")
+        '/web/assets/<int:website_id>/<unique>/<string:filename>'], type='http', auth="public", readonly=True)
     def content_assets_website(self, website_id=None, **kwargs):
         if not request.env['website'].browse(website_id).exists():
             raise request.not_found()

--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -21,7 +21,7 @@ _lt = LazyTranslate(__name__)
 
 class WebsiteForm(http.Controller):
 
-    @http.route('/website/form', type='http', auth="public", methods=['POST'], multilang=False)
+    @http.route('/website/form', type='http', auth="public", methods=['POST'], multilang=False, readonly=True)
     def website_form_empty(self, **kwargs):
         # This is a workaround to don't add language prefix to <form action="/website/form/" ...>
         return ""

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -129,7 +129,7 @@ class Website(Home):
 
         raise request.not_found()
 
-    @http.route('/website/force/<int:website_id>', type='http', auth="user", website=True, sitemap=False, multilang=False)
+    @http.route('/website/force/<int:website_id>', type='http', auth="user", website=True, sitemap=False, multilang=False, readonly=True)
     def website_force(self, website_id, path='/', isredir=False, **kw):
         """ To switch from a website to another, we need to force the website in
         session, AFTER landing on that website domain (if set) as this will be a
@@ -158,7 +158,7 @@ class Website(Home):
         website._force()
         return request.redirect(path)
 
-    @http.route(['/@/', '/@/<path:path>'], type='http', auth='public', website=True, sitemap=False, multilang=False)
+    @http.route(['/@/', '/@/<path:path>'], type='http', auth='public', website=True, sitemap=False, multilang=False, readonly=True)
     def client_action_redirect(self, path='', **kw):
         """ Redirect internal users to the backend preview of the requested path
         URL (client action iframe).
@@ -200,7 +200,7 @@ class Website(Home):
     # Business
     # ------------------------------------------------------
 
-    @http.route('/website/get_languages', type='json', auth="user", website=True)
+    @http.route('/website/get_languages', type='json', auth="user", website=True, readonly=True)
     def website_languages(self, **kwargs):
         return [(py_to_js_locale(lg.code), lg.url_code, lg.name) for lg in request.website.language_ids]
 
@@ -218,7 +218,7 @@ class Website(Home):
         redirect.set_cookie('frontend_lang', lang_code)
         return redirect
 
-    @http.route(['/website/country_infos/<model("res.country"):country>'], type='json', auth="public", methods=['POST'], website=True)
+    @http.route(['/website/country_infos/<model("res.country"):country>'], type='json', auth="public", methods=['POST'], website=True, readonly=True)
     def country_infos(self, country, **kw):
         fields = country.get_address_fields()
         return dict(fields=fields, states=[(st.id, st.name, st.code) for st in country.state_ids], phone_code=country.phone_code)
@@ -306,7 +306,7 @@ class Website(Home):
 
     # if not icon provided in DOM, browser tries to access /favicon.ico, eg when
     # opening an order pdf
-    @http.route(['/favicon.ico'], type='http', auth='public', website=True, multilang=False, sitemap=False)
+    @http.route(['/favicon.ico'], type='http', auth='public', website=True, multilang=False, sitemap=False, readonly=True)
     def favicon(self, **kw):
         website = request.website
         response = request.redirect(website.image_url(website, 'favicon'), code=301)
@@ -325,7 +325,7 @@ class Website(Home):
         if not qs or qs.lower() in '/website/info':
             yield {'loc': '/website/info'}
 
-    @http.route('/website/info', type='http', auth="public", website=True, sitemap=sitemap_website_info)
+    @http.route('/website/info', type='http', auth="public", website=True, sitemap=sitemap_website_info, readonly=True)
     def website_info(self, **kwargs):
         Module = request.env['ir.module.module'].sudo()
         apps = Module.search([('state', '=', 'installed'), ('application', '=', True)])
@@ -357,7 +357,7 @@ class Website(Home):
             raise werkzeug.exceptions.NotFound()
         return request.redirect(url, local=False)
 
-    @http.route('/website/get_suggested_links', type='json', auth="user", website=True)
+    @http.route('/website/get_suggested_links', type='json', auth="user", website=True, readonly=True)
     def get_suggested_link(self, needle, limit=10):
         current_website = request.website
 
@@ -397,19 +397,19 @@ class Website(Home):
             ]
         }
 
-    @http.route('/website/save_session_layout_mode', type='json', auth='public', website=True)
+    @http.route('/website/save_session_layout_mode', type='json', auth='public', website=True, readonly=True)
     def save_session_layout_mode(self, layout_mode, view_id):
         assert layout_mode in ('grid', 'list'), "Invalid layout mode"
         request.session[f'website_{view_id}_layout_mode'] = layout_mode
 
-    @http.route('/website/snippet/filters', type='json', auth='public', website=True)
+    @http.route('/website/snippet/filters', type='json', auth='public', website=True, readonly=True)
     def get_dynamic_filter(self, filter_id, template_key, limit=None, search_domain=None, with_sample=False, **custom_template_data):
         dynamic_filter = request.env['website.snippet.filter'].sudo().search(
             [('id', '=', filter_id)] + request.website.website_domain()
         )
         return dynamic_filter and dynamic_filter._render(template_key, limit, search_domain, with_sample, **custom_template_data) or []
 
-    @http.route('/website/snippet/options_filters', type='json', auth='user', website=True)
+    @http.route('/website/snippet/options_filters', type='json', auth='user', website=True, readonly=True)
     def get_dynamic_snippet_filters(self, model_name=None, search_domain=None):
         if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise werkzeug.exceptions.NotFound()
@@ -427,7 +427,7 @@ class Website(Home):
         )
         return dynamic_filter
 
-    @http.route('/website/snippet/filter_templates', type='json', auth='public', website=True)
+    @http.route('/website/snippet/filter_templates', type='json', auth='public', website=True, readonly=True)
     def get_dynamic_snippet_templates(self, filter_name=False):
         domain = [['key', 'ilike', '.dynamic_filter_template_'], ['type', '=', 'qweb']]
         if filter_name:
@@ -447,7 +447,7 @@ class Website(Home):
             t['thumb'] = attribs.get('data-thumb')
         return templates
 
-    @http.route('/website/get_current_currency', type='json', auth="public", website=True)
+    @http.route('/website/get_current_currency', type='json', auth="public", website=True, readonly=True)
     def get_current_currency(self, **kwargs):
         return {
             'id': request.website.company_id.currency_id.id,
@@ -465,7 +465,7 @@ class Website(Home):
         order = order or 'name ASC'
         return 'is_published desc, %s, id desc' % order
 
-    @http.route('/website/snippet/autocomplete', type='json', auth='public', website=True)
+    @http.route('/website/snippet/autocomplete', type='json', auth='public', website=True, readonly=True)
     def autocomplete(self, search_type=None, term=None, order=None, limit=5, max_nb_chars=999, options=None):
         """
         Returns list of results according to the term and options
@@ -560,7 +560,7 @@ class Website(Home):
             'allowFuzzy': not post.get('noFuzzy'),
         }
 
-    @http.route(['/pages', '/pages/page/<int:page>'], type='http', auth="public", website=True, sitemap=False)
+    @http.route(['/pages', '/pages/page/<int:page>'], type='http', auth="public", website=True, sitemap=False, readonly=True)
     def pages_list(self, page=1, search='', **kw):
         options = self._get_page_search_options(**kw)
         step = 50
@@ -603,7 +603,7 @@ class Website(Home):
         '/website/search/page/<int:page>',
         '/website/search/<string:search_type>',
         '/website/search/<string:search_type>/page/<int:page>',
-    ], type='http', auth="public", website=True, sitemap=False)
+    ], type='http', auth="public", website=True, sitemap=False, readonly=True)
     def hybrid_list(self, page=1, search='', search_type='all', **kw):
         if not search:
             return request.render("website.list_hybrid")
@@ -676,7 +676,7 @@ class Website(Home):
             return json.dumps({'view_id': page.get('view_id')})
         return json.dumps({'url': url})
 
-    @http.route('/website/get_new_page_templates', type='json', auth='user', website=True)
+    @http.route('/website/get_new_page_templates', type='json', auth='user', website=True, readonly=True)
     def get_new_page_templates(self, **kw):
         View = request.env['ir.ui.view']
         result = []
@@ -733,7 +733,7 @@ class Website(Home):
                 result.append(group)
         return result
 
-    @http.route("/website/get_switchable_related_views", type="json", auth="user", website=True)
+    @http.route("/website/get_switchable_related_views", type="json", auth="user", website=True, readonly=True)
     def get_switchable_related_views(self, key):
         views = request.env["ir.ui.view"].get_related_views(key, bundles=False).filtered(lambda v: v.customize_show)
         views = views.sorted(key=lambda v: (v.inherit_id.id, v.name))
@@ -752,7 +752,7 @@ class Website(Home):
         view.with_context(website_id=None).reset_arch(mode)
         return True
 
-    @http.route(['/website/seo_suggest'], type='json', auth="user", website=True)
+    @http.route(['/website/seo_suggest'], type='json', auth="user", website=True, readonly=True)
     def seo_suggest(self, keywords=None, lang=None):
         """
         Suggests search keywords based on a given input using Google's
@@ -797,7 +797,7 @@ class Website(Home):
         xmlroot = ET.fromstring(response)
         return json.dumps([sugg[0].attrib['data'] for sugg in xmlroot if len(sugg) and sugg[0].attrib['data']])
 
-    @http.route(['/website/get_seo_data'], type='json', auth="user", website=True)
+    @http.route(['/website/get_seo_data'], type='json', auth="user", website=True, readonly=True)
     def get_seo_data(self, res_id, res_model):
         if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise werkzeug.exceptions.Forbidden()
@@ -823,7 +823,7 @@ class Website(Home):
 
         return res
 
-    @http.route(['/website/check_can_modify_any'], type='json', auth="user", website=True)
+    @http.route(['/website/check_can_modify_any'], type='json', auth="user", website=True, readonly=True)
     def check_can_modify_any(self, records):
         if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise werkzeug.exceptions.Forbidden()
@@ -839,7 +839,7 @@ class Website(Home):
                 continue
         raise first_error
 
-    @http.route(['/google<string(length=16):key>.html'], type='http', auth="public", website=True, sitemap=False)
+    @http.route(['/google<string(length=16):key>.html'], type='http', auth="public", website=True, sitemap=False, readonly=True)
     def google_console_search(self, key, **kwargs):
         if not request.website.google_search_console:
             logger.warning('Google Search Console not enable')
@@ -856,7 +856,7 @@ class Website(Home):
 
         return request.make_response("google-site-verification: %s" % request.website.google_search_console)
 
-    @http.route('/website/google_maps_api_key', type='json', auth='public', website=True)
+    @http.route('/website/google_maps_api_key', type='json', auth='public', website=True, readonly=True)
     def google_maps_api_key(self):
         return json.dumps({
             'google_maps_api_key': request.website.google_maps_api_key or ''
@@ -900,7 +900,7 @@ class Website(Home):
         domain = expression.AND([[("key", "in", keys)], request.website.website_domain()])
         return Model.search(domain).filter_duplicate()
 
-    @http.route(['/website/theme_customize_data_get'], type='json', auth='user', website=True)
+    @http.route(['/website/theme_customize_data_get'], type='json', auth='user', website=True, readonly=True)
     def theme_customize_data_get(self, keys, is_view_data):
         records = self._get_customize_data(keys, is_view_data)
         return records.filtered('active').mapped('key')
@@ -925,7 +925,7 @@ class Website(Home):
             records = self._get_customize_data(enable, is_view_data)
             records.filtered(lambda x: not x.active).write({'active': True})
 
-    @http.route(['/website/theme_customize_bundle_reload'], type='json', auth='user', website=True)
+    @http.route(['/website/theme_customize_bundle_reload'], type='json', auth='user', website=True, readonly=True)
     def theme_customize_bundle_reload(self):
         """
         Reloads asset bundles and returns their unique URLs.
@@ -1066,7 +1066,7 @@ class WebsiteBinary(Binary):
         '/website/image/<xmlid>/<field>/<int:width>x<int:height>',
         '/website/image/<model>/<id>/<field>',
         '/website/image/<model>/<id>/<field>/<int:width>x<int:height>'
-    ], type='http', auth="public", website=False, multilang=False)
+    ], type='http', auth="public", website=False, multilang=False, readonly=True)
     def website_content_image(self, id=None, max_width=0, max_height=0, **kw):  # noqa: A002
         if max_width:
             kw['width'] = max_width

--- a/addons/website/controllers/model_page.py
+++ b/addons/website/controllers/model_page.py
@@ -13,7 +13,7 @@ class ModelPageController(Controller):
         "/model/<string:page_name_slugified>",
         "/model/<string:page_name_slugified>/page/<int:page_number>",
         "/model/<string:page_name_slugified>/<string:record_slug>",
-    ], website=True, auth="public")
+    ], website=True, auth="public", readonly=True)
     def generic_model(self, page_name_slugified=None, page_number=1, record_slug=None, **searches):
         if not page_name_slugified:
             raise werkzeug.exceptions.NotFound()


### PR DESCRIPTION
Since [1], the readonly parameter was added to ensure that these endpoints open a cursor on the read-only replica instead of the primary read/write database, enhancing performance and scalability for read-intensive operations.

This commit adds 'readonly=True' to routes handling non-modifying requests.

task-4357885

[1] https://github.com/odoo/odoo/commit/584a172274caefb23e5d91b609fc893160535416