### PR TITLE
[IMP] l10n_it{_edi*}: remove redundant law reference field

### DIFF
--- a/addons/l10n_it/data/template/account.tax-it.csv
+++ b/addons/l10n_it/data/template/account.tax-it.csv
@@ -1,4 +1,4 @@
-"id","description","invoice_label","name","sequence","amount","amount_type","type_tax_use","tax_group_id","active","tax_scope","repartition_line_ids/repartition_type","repartition_line_ids/document_type","repartition_line_ids/tag_ids","repartition_line_ids/account_id","repartition_line_ids/factor_percent","name@it","children_tax_ids","l10n_it_exempt_reason","l10n_it_law_reference","description@it","price_include_override"
+"id","description","invoice_label","name","sequence","amount","amount_type","type_tax_use","tax_group_id","active","tax_scope","repartition_line_ids/repartition_type","repartition_line_ids/document_type","repartition_line_ids/tag_ids","repartition_line_ids/account_id","repartition_line_ids/factor_percent","name@it","children_tax_ids","l10n_it_exempt_reason","invoice_legal_notes","description@it","price_include_override"
 "22v","","22%","22%","30","22.0","percent","sale","tax_group_iva_22","","","base","invoice","+02","","","22%","","","","",""
 "","","","","","","","","","","","tax","invoice","+4v","2601","","","","","","",""
 "","","","","","","","","","","","base","refund","-02","","","","","","","",""

--- a/addons/l10n_it/models/account_tax.py
+++ b/addons/l10n_it/models/account_tax.py
@@ -2,6 +2,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError, UserError
+from odoo.tools import html2plaintext
 
 
 class AccountTax(models.Model):
@@ -37,18 +38,17 @@ class AccountTax(models.Model):
         string="Exoneration",
         help="Exoneration type",
     )
-    l10n_it_law_reference = fields.Char(string="Law Reference", size=100)
 
     @api.constrains('l10n_it_exempt_reason',
-                    'l10n_it_law_reference',
+                    'invoice_legal_notes',
                     'amount',
                     'invoice_repartition_line_ids',
                     'refund_repartition_line_ids')
     def _l10n_it_edi_check_exoneration_with_no_tax(self):
         for tax in self:
             if tax.country_id.code == 'IT':
-                if tax.amount_type == 'percent' and tax.amount == 0 and not (tax.l10n_it_exempt_reason and tax.l10n_it_law_reference):
-                    raise ValidationError(_("If the tax amount is 0%, you must enter the exoneration code and the related law reference."))
+                if tax.amount_type == 'percent' and tax.amount == 0 and not (tax.l10n_it_exempt_reason and html2plaintext(tax.invoice_legal_notes)):
+                    raise ValidationError(_("If the tax amount is 0%, you must enter the exoneration code and the related legal notes."))
                 if tax.l10n_it_exempt_reason == 'N6' and tax._l10n_it_is_split_payment():
                     raise UserError(_("Split Payment is not compatible with exoneration of kind 'N6'"))
 

--- a/addons/l10n_it/views/account_tax_views.xml
+++ b/addons/l10n_it/views/account_tax_views.xml
@@ -12,7 +12,6 @@
                 <group invisible="country_code != 'IT'">
                     <group>
                         <field name="l10n_it_exempt_reason"/>
-                        <field name="l10n_it_law_reference"/>
                     </group>
                 </group>
             </xpath>

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -10,7 +10,7 @@ from odoo import _, api, Command, fields, models, modules
 from odoo.addons.base.models.ir_qweb_fields import Markup, nl2br, nl2br_enclose
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
 from odoo.exceptions import UserError
-from odoo.tools import float_repr, cleanup_xml_node, float_is_zero
+from odoo.tools import cleanup_xml_node, float_is_zero, float_repr, html2plaintext
 
 _logger = logging.getLogger(__name__)
 
@@ -368,7 +368,7 @@ class AccountMove(models.Model):
                 'imponibile_importo': values['base_amount'],
                 'imposta': values['tax_amount'],
                 'esigibilita_iva': grouping_key['tax_exigibility_code'],
-                'riferimento_normativo': grouping_key['l10n_it_law_reference'],
+                'riferimento_normativo': grouping_key['invoice_legal_notes'],
             })
         return tax_lines
 
@@ -406,7 +406,7 @@ class AccountMove(models.Model):
         return {
             'tax_amount_field': -23.0 if tax.amount == -11.5 else tax.amount,
             'l10n_it_exempt_reason': tax.l10n_it_exempt_reason,
-            'l10n_it_law_reference': tax.l10n_it_law_reference,
+            'invoice_legal_notes': html2plaintext(tax.invoice_legal_notes),
             'tax_exigibility_code': tax_exigibility_code,
             'tax_amount_type_field': tax.amount_type,
             'skip': tax_data['is_reverse_charge'] or self._l10n_it_edi_is_neg_split_payment(tax_data),

--- a/addons/l10n_it_edi/tests/test_edi_export.py
+++ b/addons/l10n_it_edi/tests/test_edi_export.py
@@ -403,7 +403,7 @@ class TestItEdiExport(TestItEdi):
             'amount': 0.0,
             'amount_type': 'percent',
             'l10n_it_exempt_reason': 'N3.1',
-            'l10n_it_law_reference': 'Art. 8, c.1, lett.a - D.P.R. 633/1972',
+            'invoice_legal_notes': 'Art. 8, c.1, lett.a - D.P.R. 633/1972',
         })
 
         american_partner_b = self.env['res.partner'].create({

--- a/addons/l10n_it_edi/tests/test_edi_reverse_charge.py
+++ b/addons/l10n_it_edi/tests/test_edi_reverse_charge.py
@@ -103,7 +103,7 @@ class TestItEdiReverseCharge(TestItEdi):
             'amount': 0.0,
             'amount_type': 'percent',
             'l10n_it_exempt_reason': 'N1',
-            'l10n_it_law_reference': 'test',
+            'invoice_legal_notes': 'test',
         })
 
         # Export tax 0% Internal Reverse Charge
@@ -114,7 +114,7 @@ class TestItEdiReverseCharge(TestItEdi):
             'amount': 0.0,
             'amount_type': 'percent',
             'l10n_it_exempt_reason': 'N6.3',
-            'l10n_it_law_reference': 'test',
+            'invoice_legal_notes': 'test',
         })
 
     def test_invoice_external_reverse_charge(self):

--- a/addons/l10n_it_edi_doi/data/template/account.tax-it.csv
+++ b/addons/l10n_it_edi_doi/data/template/account.tax-it.csv
@@ -1,4 +1,4 @@
-"id","description","invoice_label","name","sequence","amount","amount_type","type_tax_use","tax_group_id","active","tax_scope","repartition_line_ids/repartition_type","repartition_line_ids/document_type","repartition_line_ids/tag_ids","repartition_line_ids/account_id","repartition_line_ids/factor_percent","name@it","children_tax_ids","l10n_it_exempt_reason","l10n_it_law_reference","description@it"
+"id","description","invoice_label","name","sequence","amount","amount_type","type_tax_use","tax_group_id","active","tax_scope","repartition_line_ids/repartition_type","repartition_line_ids/document_type","repartition_line_ids/tag_ids","repartition_line_ids/account_id","repartition_line_ids/factor_percent","name@it","children_tax_ids","l10n_it_exempt_reason","invoice_legal_notes","description@it"
 "00di","Declaration of Intent","0%","0% E","950","0.0","percent","sale","tax_group_fuori","","","base","invoice","+02","","","","","N3.5","art. 8, c. 1, lett. c) D.P.R. 633/1972",""
 "","","","","","","","","","","","tax","invoice","","","","","","","",""
 "","","","","","","","","","","","base","refund","-02","","","","","","",""

--- a/addons/l10n_it_edi_withholding/tests/test_withholding.py
+++ b/addons/l10n_it_edi_withholding/tests/test_withholding.py
@@ -35,7 +35,7 @@ class TestWithholdingAndPensionFundTaxes(TestItEdi):
             'amount': 0.0,
             'amount_type': 'percent',
             'l10n_it_exempt_reason': 'N2.2',
-            'l10n_it_law_reference': 'Fatture emesse o ricevute da contribuenti forfettari o minimi',
+            'invoice_legal_notes': 'Fatture emesse o ricevute da contribuenti forfettari o minimi',
         })
 
         cls.withholding_sale_line = {


### PR DESCRIPTION
This commit removes the `l10n_it_law_reference` field from italian `account.tax`, and replaces all of its usage with the general tax field "Legal Notes" (`invoice_legal_notes`) HTML field.

By accident, we didn't take into account that both of these fields are saving the same data. Instead of having 2 redundant fields, we remove the italian field and uses the general Legal Notes when populating the RiferimentoNormativo node in the FatturaPA XML file.

Because it's a HTML field (saved as a Markup object), we need to extract its text content whenever we want to use it in the XML.

related upgrade PR: https://github.com/odoo/upgrade/pull/6833
task-id: 4284148