### PR TITLE
[FIX] l10n_gcc_invoice: correct wrong access to Arabic language

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -283,7 +283,7 @@
                                     <td name="account_invoice_line_name">
                                         <t t-if="line.product_id">
                                             <t t-set="english_name" t-value="line.with_context(lang='en_US').product_id.display_name"/>
-                                            <t t-set="arabic_name" t-value="line.with_context(lang='ar_001').product_id.display_name"/>
+                                            <t t-set="arabic_name" t-value="line.with_context(lang=o.env['res.lang']._get_code('ar_001')).product_id.display_name"/>
 
                                             <span t-out="arabic_name + '\n'" t-if="arabic_name not in line.name" t-options="{'widget': 'text'}" dir="rtl"/>
                                             <span t-out="english_name + '\n'" t-if="(english_name != arabic_name) and (english_name not in line.name)" t-options="{'widget': 'text'}"/>


### PR DESCRIPTION
### Steps to reproduce:
- Install 'l10n_sa' and switch to a Saudi company
- Do not have the Arabic language installed
- try to generate a Customer Invoice
- An error pops up

### Cause:
The way the language is retrieved changed in saas-17.2 from `lang='ar_001'` to `lang=o.env['res.lang']._get_code('ar_001')` The forward port of this [commit](https://github.com/odoo/odoo/commit/f1fa69f6a924a68bad4b10e6854f8caae89b43c3) from 16.0 does not adapt to the way the language is retrieved.

### Solution:
Use the new way to retrieve the language.

opw-4303367