### PR TITLE
[FIX] pos_self_order: prevent loading products not available

### DIFF
--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 from typing import List, Dict
 from odoo import api, models, fields
+from odoo.osv.expression import AND
 
 
 class ProductTemplate(models.Model):
@@ -49,6 +50,11 @@ class ProductProduct(models.Model):
         params = super()._load_pos_self_data_fields(config_id)
         params += ['description_self_order']
         return params
+    
+    @api.model
+    def _load_pos_self_data_domain(self, data):
+        domain = super()._load_pos_self_data_domain(data)
+        return AND([domain, [('self_order_available', '=', True)]])
 
     def _load_pos_self_data(self, data):
         domain = self._load_pos_self_data_domain(data)


### PR DESCRIPTION
Before this commit, if you made a product available in PoS but set it to not be available in self order, it would still appear in the kiosk or mobile menu with an "out of stock" tag, which is confusing and not the expected behavior.

opw-4200540

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
