### PR TITLE
[FIX] portal: no need to raise when init chatter

### DIFF
--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -43,10 +43,8 @@ class PortalChatter(http.Controller):
     def portal_chatter_init(self, thread_model, thread_id, **kwargs):
         store = Store()
         thread = request.env[thread_model]._get_thread_with_access(thread_id, **kwargs)
-        if not thread:
-            raise NotFound()
         partner = request.env.user.partner_id
-        if request.env.user._is_public():
+        if thread and request.env.user._is_public():
             if portal_partner := get_portal_partner(
                 thread, kwargs.get("hash"), kwargs.get("pid"), kwargs.get("token")
             ):


### PR DESCRIPTION
Since the `chatter_init` route is only responsible for checking the valid partner in the case of a public user, there is no need to raise `NotFound` if there is no access to the thread. Checking for access to the thread and raise if
 it's needed is done when fetching the messages.

reported on [this build error](https://runbot.odoo.com/web/#id=99087&menu_id=405&cids=1&model=runbot.build.error&view_type=form)