### PR TITLE
[IMP] mail: chat window, thread, message slight style improvements

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -8,7 +8,6 @@ import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { ChatBubble } from "./chat_bubble";
-import { _t } from "@web/core/l10n/translation";
 
 export class ChatHub extends Component {
     static components = { ChatBubble, ChatWindow, Dropdown };
@@ -52,10 +51,6 @@ export class ChatHub extends Component {
         this.chatHub.onRecompute();
     }
 
-    get chatSizeTransitionText() {
-        return this.chatHub.isBig ? _t("Make chats smaller") : _t("Make chats bigger");
-    }
-
     get compactCounter() {
         let counter = 0;
         const cws = this.chatHub.opened.concat(this.chatHub.folded);
@@ -63,10 +58,6 @@ export class ChatHub extends Component {
             counter += chatWindow.thread.importantCounter > 0 ? 1 : 0;
         }
         return counter;
-    }
-
-    toggleChatSize() {
-        this.chatHub.isBig = !this.chatHub.isBig;
     }
 
     get hiddenCounter() {

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -5,7 +5,7 @@
     <div class="o-mail-ChatHub" t-if="isShown or ui.isSmall">
         <t t-if="!store.chatHub.compact">
             <t t-foreach="chatHub.opened" t-as="cw" t-key="cw.localId">
-                <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.opened.length - cw_index - 1) * ((chatHub.isBig ? chatHub.WINDOW_LARGE : chatHub.WINDOW) + chatHub.WINDOW_INBETWEEN * 2))"/>
+                <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.opened.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2))"/>
             </t>
         </t>
         <div t-if="isShown" class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto' }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
@@ -17,7 +17,6 @@
                     <Dropdown t-if="(chatHub.opened.length + chatHub.folded.length) gt 0" state="options" position="'top-end'" menuClass="'o-mail-ChatHub-optionsMenu o-mail-ChatHub-menu d-flex flex-column bg-view shadow-sm m-0 p-0 mb-1'">
                         <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-view mt-1" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
                         <t t-set-slot="content">
-                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center rounded-0 fw-normal" t-on-click="() => this.toggleChatSize()"><div class="form-check form-switch m-0 smaller" style="min-height: auto;"><input class="form-check-input" type="checkbox" role="switch" t-att-checked="this.chatHub.isBig ? 'checked' : ''" t-att-title="chatSizeTransitionText"/></div> <span>Large windows</span></button>
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash ms-1"></i>Hide all conversations</button>
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close ms-1"></i>Close all conversations</button>
                         </t>

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -8,8 +8,7 @@ export class ChatHub extends Record {
     BUBBLE_OUTER = 10; // same value as $o-mail-ChatHub-bubblesMargin
     WINDOW_GAP = 10; // for a single end, multiply by 2 for left and right together.
     WINDOW_INBETWEEN = 5;
-    WINDOW = 360; // same value as $o-mail-ChatWindow-width
-    WINDOW_LARGE = 510; // same value as $o-mail-ChatWindow-widthLarge
+    WINDOW = 380; // same value as $o-mail-ChatWindow-width
 
     /** @returns {import("models").ChatHub} */
     static get(data) {
@@ -19,22 +18,6 @@ export class ChatHub extends Record {
     static insert(data) {
         return super.insert(...arguments);
     }
-    isBig = Record.attr(false, {
-        compute() {
-            return browser.localStorage.getItem("mail.user_setting.chat_window_big") === "true";
-        },
-        onUpdate() {
-            /** @this {import("models").ChatHub} */
-            if (this.isBig) {
-                browser.localStorage.setItem(
-                    "mail.user_setting.chat_window_big",
-                    this.isBig.toString()
-                );
-            } else {
-                browser.localStorage.removeItem("mail.user_setting.chat_window_big");
-            }
-        },
-    });
     compact = false;
     /** From left to right. Right-most will actually be folded */
     opened = Record.many("ChatWindow", {
@@ -79,9 +62,7 @@ export class ChatHub extends Record {
         const available = browser.innerWidth - startGap - endGap - chatBubblesWidth;
         const maxAmountWithoutHidden = Math.max(
             1,
-            Math.floor(
-                available / ((this.isBig ? this.WINDOW_LARGE : this.WINDOW) + this.WINDOW_INBETWEEN)
-            )
+            Math.floor(available / (this.WINDOW + this.WINDOW_INBETWEEN))
         );
         return maxAmountWithoutHidden;
     }

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -1,11 +1,6 @@
 .o-mail-ChatWindow {
-    height: 480px;
     width: $o-mail-ChatWindow-width;
-
-    &.o-large {
-        height: 680px;
-        width: $o-mail-ChatWindow-widthLarge;
-    }
+    aspect-ratio: 9 / 15;
 
     z-index: 999; // messaging menu is dropdown (1000)
     &.o-mobile {
@@ -19,11 +14,15 @@
 
 .o-mail-ChatWindow-command {
     color: inherit !important;
+    &:not(.o-actionsMenu) {
+        padding: map-get($spacers, 1) / 2;
+    }
     &:hover:not(.o-actionsMenu), &.o-active, &.o-hover {
         background-color: var(--mail-ChatWindow-commandHoverBg, mix($gray-100, $gray-200));
+        border-color: transparent !important;
     }
     &:not(.o-active):not(.o-hover) .fa-caret-down {
-        opacity: 50%;
+        opacity: 25%;
     }
 }
 
@@ -33,6 +32,7 @@
 
 .o-mail-ChatWindow-counter {
     padding: 3px 6px;
+    margin-bottom: map-get($spacers, 1) / 2;
 }
 
 .o-mail-ChatWindow-country {
@@ -42,6 +42,10 @@
 .o-mail-ChatWindow-header .o-mail-ChatWindow-threadAvatar img {
     height: $o-mail-Avatar-sizeSmall;
     width: $o-mail-Avatar-sizeSmall;
+}
+
+.o-mail-ChatWindow-quickActions {
+    gap: map-get($spacers, 1) / 2;
 }
 
 .o-mail-ChatWindow-typing {

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -7,19 +7,18 @@
         t-att-style="style"
         t-att-class="{
             'w-100 h-100 o-mobile': ui.isSmall,
-            'rounded-top-3 border border-bottom-0 border-dark': !ui.isSmall,
-            'o-large': store.chatHub.isBig,
+            'rounded-4 border border-dark mb-2': !ui.isSmall,
         }"
         t-on-keydown="onKeydown"
         tabindex="1"
     >
-        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall and thread and !state.actionsDisabled, 'pt-2': !thread }">
+        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1 shadow-sm" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall and thread and !state.actionsDisabled, 'pt-2': !thread }">
             <t t-if="hasActionsMenu">
                 <div class="d-flex text-truncate">
                     <Dropdown position="'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="'d-flex flex-column py-0'">
                         <button
-                            class="o-mail-ChatWindow-command o-actionsMenu btn rounded-0 d-flex align-items-center px-1 py-1 m-0 w-100 rounded-end-0"
-                            t-att-class="{ 'ps-2 pe-1 rounded-top-3': !ui.isSmall, 'o-active': state.actionsMenuOpened, 'o-hover': actionsMenuButtonHover.isHover and !parentChannelHover.isHover }"
+                            class="o-mail-ChatWindow-command o-actionsMenu btn rounded-0 d-flex align-items-center p-1 mx-1 my-0 w-100 rounded-end-0"
+                            t-att-class="{ 'rounded-top-3': !ui.isSmall, 'o-active': state.actionsMenuOpened, 'o-hover': actionsMenuButtonHover.isHover and !parentChannelHover.isHover }"
                             t-att-disabled="state.editingName or state.actionsDisabled"
                             t-att-title="actionsMenuTitleText"
                             t-ref="actionsMenuButton"
@@ -76,12 +75,14 @@
                 <t t-call="mail.ChatWindow.headerContent"/>
             </t>
             <div class="flex-grow-1"/>
-            <div t-if="thread and thread.importantCounter > 0" class="o-mail-ChatWindow-counter mx-1 my-0 badge rounded-pill fw-bold o-discuss-badge" t-ref="needactionCounter">
+            <div t-if="thread and thread.importantCounter > 0" class="o-mail-ChatWindow-counter mx-1 badge rounded-pill fw-bold o-discuss-badge" t-ref="needactionCounter">
                 <t t-out="thread.importantCounter"/>
             </div>
-            <t t-foreach="partitionedActions.quick.slice(0, ui.isSmall ? 2 : 3).reverse()" t-as="action" t-key="action.id" t-call="mail.ChatWindow.quickAction">
-                <t t-if="action_last" t-set="itemClass" t-value="ui.isSmall ? 'mx-2' : 'me-1'"/>
-            </t>
+            <div class="o-mail-ChatWindow-quickActions d-flex flex-shrink-0 me-2">
+                <t t-foreach="partitionedActions.quick.slice(0, ui.isSmall ? 2 : 3).reverse()" t-as="action" t-key="action.id" t-call="mail.ChatWindow.quickAction">
+                    <t t-if="action_last" t-set="itemClass" t-value="ui.isSmall ? 'mx-2' : ''"/>
+                </t>
+            </div>
             <t t-if="this.store.inPublicPage and this.store.self.type === 'guest'">
                 <button class="btn ps-1" t-if="!state.editingGuestName">
                     <img class="o-mail-Discuss-selfAvatar rounded-circle o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="store.self.avatarUrl" t-on-click="() => state.editingGuestName = true"/>
@@ -115,11 +116,11 @@
 </t>
 
 <t t-name="mail.ChatWindow.quickAction">
-    <button class="o-mail-ChatWindow-command btn d-flex p-2 opacity-75 opacity-100-hover" t-att-class="ui.isSmall ? 'border' : ''" t-attf-class="{{ itemClass }}" t-att-title="action.name" t-att-disabled="state.actionsDisabled" t-on-click.stop="() => action.onSelect()"><i t-att-class="ui.isSmall ? 'fa-lg' : ''" t-attf-class="{{ action.icon }}"/></button>
+    <button class="o-mail-ChatWindow-command btn d-flex opacity-100-hover align-items-center" style="aspect-ratio: 1;" t-att-class="{ 'border o-small': ui.isSmall, 'opacity-25': !ui.isSmall }" t-attf-class="{{ itemClass }}" t-att-title="action.name" t-att-disabled="state.actionsDisabled" t-on-click.stop="() => action.onSelect()"><i t-att-class="ui.isSmall ? 'fa-lg' : ''" t-attf-class="{{ action.icon }}"/></button>
 </t>
 
 <t t-name="mail.ChatWindow.dropdownAction">
-    <DropdownItem class="'o-mail-ChatWindow-command btn rounded-0 d-flex align-items-center px-2 py-2 m-0'" onSelected="() => action.onSelect()">
+    <DropdownItem class="'o-mail-ChatWindow-command btn rounded-0 d-flex align-items-center p-2 m-0'" onSelected="() => action.onSelect()">
         <i t-att-class="action.icon"/>
         <span class="mx-2" t-out="action.name"/>
     </DropdownItem>

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -93,11 +93,6 @@
 
     .o-mail-Composer.o-chatWindow & {
         @media (min-height: 325px) {
-            max-height: Min(350px, 70vh);
-        }
-    }
-    .o-mail-Composer.o-chatWindowBig & {
-        @media (min-height: 325px) {
             max-height: Min(550px, 70vh);
         }
     }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -15,8 +15,7 @@
                     'o-hasSelfAvatar': !env.inChatWindow and thread,
                     'o-focused': props.composer.isFocused,
                     'o-editing': props.composer.message,
-                    'o-chatWindow': env.inChatWindow,
-                    'o-chatWindowBig': store.chatHub.isBig,
+                    'o-chatWindow mx-2 mb-3': env.inChatWindow,
                     'o-discussApp': env.inDiscussApp,
                 }" t-attf-class="{{ props.className }}">
             <div class="o-mail-Composer-sidebarMain flex-shrink-0" t-if="showComposerAvatar">
@@ -32,11 +31,10 @@
                 <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => props.messageToReplyTo.cancel()"/>
             </div>
             <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : extended }">
-                <div class="d-flex o-mail-Composer-bg flex-grow-1 border border-secondary"
+                <div class="d-flex o-mail-Composer-bg flex-grow-1 border border-secondary rounded-3"
                     t-att-class="{
                         'o-mail-Composer-compactContainer m-1 shadow-sm': compact and !props.composer.message,
                         'o-iosPwa': isIosPwa,
-                        'rounded-3' : normal or isMobileOS or extended,
                         'align-self-stretch' : extended,
                     }"
                     t-ref="input-container"

--- a/addons/mail/static/src/core/common/date_section.xml
+++ b/addons/mail/static/src/core/common/date_section.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.DateSection">
     <div class="o-mail-DateSection d-flex align-items-center w-100 fw-bold z-1" t-attf-class="{{ props.className }}">
         <hr class="o-discuss-separator flex-grow-1"/>
-        <span class="px-2 smaller text-muted opacity-50" t-att-class="{ 'user-select-none': isMobileOS }"><t t-esc="props.date"/></span>
+        <span class="px-2 smaller text-muted opacity-75" t-att-class="{ 'user-select-none': isMobileOS }"><t t-esc="props.date"/></span>
         <hr class="o-discuss-separator flex-grow-1"/>
     </div>
 </t>

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -19,7 +19,7 @@
 }
 
 .o-mail-Message-date {
-    opacity: 75%;
+    opacity: 50%;
 }
 
 .o-mail-Message-edited {
@@ -39,10 +39,6 @@
     &.o-inChatWindow {
         flex-basis: $o-mail-Message-sidebarSmallWidth;
         max-width: $o-mail-Message-sidebarSmallWidth;
-    }
-
-    .o-mail-Message-date {
-        font-size: 0.75rem;
     }
 }
 
@@ -144,8 +140,12 @@
         z-index: $o-mail-NavigableList-zIndex - 2;
     }
 
-    button:hover, .focus {
-        background-color: mix($o-gray-100, $o-gray-200) !important;
+    button {
+        opacity: 50%;
+
+        &:hover, &.focus, &.show {
+            opacity: 100%;
+        }
     }
 }
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.Message">
-        <div t-if="message.isNotification" class="o-mail-NotificationMessage text-break mx-auto text-500 px-3 text-center smaller" t-on-click="onClickNotificationMessage"  t-att-class="props.className" t-ref="root">
+        <div t-if="message.isNotification" class="o-mail-NotificationMessage text-break mx-auto text-muted opacity-75 px-3 text-center smaller" t-on-click="onClickNotificationMessage"  t-att-class="props.className" t-ref="root">
             <i t-if="message.notificationIcon" t-attf-class="{{ message.notificationIcon }} me-1"/>
             <span class="o-mail-NotificationMessage-author d-inline" t-if="message.author and !message.body.includes(escape(message.author.name))" t-esc="message.author.name"/> <t t-out="message.body"/>
         </div>
@@ -24,7 +24,7 @@
                         </div>
                         <t t-elif="message.isPending" t-call="mail.Message.pendingStatus"/>
                         <t t-elif="!message.is_transient">
-                            <small t-if="isActive and props.showDates" class="o-mail-Message-date text-muted smaller mt-2">
+                            <small t-if="isActive and props.showDates" class="o-mail-Message-date o-xsmaller mt-2" t-att-title="message.datetimeShort">
                                 <t t-esc="message.dateSimple"/>
                             </small>
                         </t>
@@ -35,10 +35,9 @@
                                 <strong class="me-1" t-esc="authorName"/>
                             </span>
                             <t t-if="!isAlignedRight" t-call="mail.Message.notification"/>
-                            <small t-if="!message.is_transient" class="o-mail-Message-date text-muted smaller" t-att-title="message.datetimeShort">
-                                <t t-if="shouldDisplayAuthorName">- </t>
+                            <small t-if="!message.is_transient" class="o-mail-Message-date o-xsmaller" t-att-title="message.datetimeShort">
                                 <t t-if="message.isPending" t-call="mail.Message.pendingStatus"/>
-                                <RelativeTime t-else="" datetime="message.datetime"/>
+                                <t t-else="" t-out="message.dateSimple"/>
                             </small>
                             <small t-if="isPersistentMessageFromAnotherThread" t-on-click.prevent="openRecord" class="ms-1 text-500">
                                 <t t-if="message.thread.model !== 'discuss.channel'">
@@ -154,7 +153,7 @@
                         'rounded-start-1': isStart,
                         'rounded-end-1': isEnd,
                     }"/>
-                    <button t-else="" class="btn px-1 py-0 rounded-0" t-att-title="action.title" t-att-name="action.id" t-on-click.stop="action.onClick" t-att-class="{
+                    <button t-else="" class="btn border-0 px-1 py-0 rounded-0" t-att-title="action.title" t-att-name="action.id" t-on-click.stop="action.onClick" t-att-class="{
                         'rounded-start-1': isStart,
                         'rounded-end-1': isEnd,
                     }">
@@ -181,12 +180,11 @@
 
 
 <t t-name="mail.Message.expandAction">
-    <button class="btn rounded-0" t-att-title="expandText" t-on-click="openMobileActions" t-att-class="{
+    <button class="btn border-0 rounded-0" t-att-title="expandText" t-on-click="openMobileActions" t-att-class="{
         'o-mail-Message-openActionMobile opacity-25 p-2 mt-n2 rounded-circle user-select-none': isMobileOS and !mobileExpanded,
         'me-n2': isMobileOS and !mobileExpanded and isAlignedRight,
         'ms-n2': isMobileOS and !mobileExpanded and !isAlignedRight,
         'px-2 py-0': !isMobileOS,
-        'bg-200': optionsDropdown.isOpen,
         'rounded-start-1': !isMobileOS and isReverse,
         'rounded-end-1': !isMobileOS and !isReverse,
     }">

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -213,8 +213,8 @@ export class Message extends Record {
     }
 
     get dateDay() {
-        let dateDay = this.datetime.toLocaleString(DateTime.DATE_FULL);
-        if (dateDay === DateTime.now().toLocaleString(DateTime.DATE_FULL)) {
+        let dateDay = this.datetime.toLocaleString(DateTime.DATE_MED);
+        if (dateDay === DateTime.now().toLocaleString(DateTime.DATE_MED)) {
             dateDay = _t("Today");
         }
         return dateDay;

--- a/addons/mail/static/src/core/common/message_reaction_button.xml
+++ b/addons/mail/static/src/core/common/message_reaction_button.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.MessageReactionButton">
-        <button class="btn px-1 py-0 lh-1 rounded-0" t-att-class="props.classNames" tabindex="1" t-att-title="props.action.title" aria-label="props.action.title" t-ref="emoji-picker"><i class="fa-lg" t-att-class="props.action.icon"/></button>
+        <button class="btn px-1 py-0 lh-1 rounded-0 border-0" t-att-class="props.classNames" tabindex="1" t-att-title="props.action.title" aria-label="props.action.title" t-ref="emoji-picker"><i class="fa-lg" t-att-class="props.action.icon"/></button>
     </t>
 
 </templates>

--- a/addons/mail/static/src/core/common/primary_variables.scss
+++ b/addons/mail/static/src/core/common/primary_variables.scss
@@ -1,7 +1,6 @@
 $o-mail-Avatar-size: 36px !default;
 $o-mail-Avatar-sizeSmall: 28px !default;
-$o-mail-ChatWindow-width: 360px !default; // same value as WINDOW
-$o-mail-ChatWindow-widthLarge: 510px !default; // same value as WINDOW_LARGE
+$o-mail-ChatWindow-width: 380px !default; // same value as WINDOW
 $o-mail-ChatHub-bubblesWidth: 56px !default; // same value as BUBBLE
 $o-mail-ChatHub-bubblesMargin: 10px !default; // same value as BUBBLE_OUTER
 $o-mail-ChatHub-bubblesStart: 15px !default; // same value as BUBBLE_START

--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -4,6 +4,7 @@
 
 .o-mail-Thread-jumpPresent {
     z-index: $o-mail-NavigableList-zIndex - 1;
+    --border-opacity: .5;
 }
 
 .o-mail-Thread-newMessage {
@@ -34,6 +35,7 @@
 
 .o-mail-Thread-banner {
     z-index: $o-mail-NavigableList-zIndex - 1;
+    --border-opacity: 0.25;
 }
 
 .o-mail-Thread-bannerHover:hover {

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -17,10 +17,10 @@
                 <t t-if="state.mountedAndLoaded" t-foreach="messages" t-as="msg" t-key="msg.id">
                     <t t-set="prevMsg" t-value="messages[msg_index -1]"/>
                     <t t-if="msg.dateDay !== currentDay and props.showDates">
-                        <DateSection date="msg.dateDay" className="'pt-2'"/>
+                        <DateSection date="msg.dateDay" className="'pt-2 px-2'"/>
                         <t t-set="currentDay" t-value="msg.dateDay"/>
                     </t>
-                    <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-1">
+                    <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-1 px-2">
                         <hr class="flex-grow-1 border-danger opacity-100"/><span class="ps-2 pe-1 bg-danger o-text-white rounded text-uppercase">New</span>
                     </div>
                     <Message
@@ -62,12 +62,12 @@
 </t>
 
 <t t-name="mail.Thread.jumpPresent">
-    <button t-if="props.showJumpPresent and state.showJumpPresent" class="o-mail-Thread-jumpPresent position-fixed p-2 rounded-circle lh-1 m-n3 user-select-none btn btn-light border" t-ref="jump-present" t-on-click="() => this.jumpToPresent()" title="Jump to Present"><i class="oi" t-att-class="{ 'oi-chevron-down': props.order === 'asc', 'oi-chevron-up': props.order !== 'asc' }"/></button>
+    <button t-if="props.showJumpPresent and state.showJumpPresent" class="o-mail-Thread-jumpPresent position-fixed p-2 rounded-circle lh-1 m-n3 user-select-none btn btn-light shadow-sm border border-secondary" t-ref="jump-present" t-on-click="() => this.jumpToPresent()" title="Jump to Present"><i class="oi text-muted" t-att-class="{ 'oi-chevron-down': props.order === 'asc', 'oi-chevron-up': props.order !== 'asc' }"/></button>
 </t>
 
 <t t-name="mail.Thread.jumpUnread">
-    <span t-if="props.thread.showUnreadBanner" class="o-mail-Thread-banner d-flex cursor-pointer shadow-sm small fw-bold">
-        <t t-set="alertClass" t-value="'alert alert-info m-0 border-start-0 o-mail-Thread-bannerHover rounded-0 py-1'"/>
+    <span t-if="props.thread.showUnreadBanner" class="o-mail-Thread-banner d-flex cursor-pointer border-bottom border-warning smaller fw-bolder">
+        <t t-set="alertClass" t-value="'alert alert-warning m-0 border-start-0 o-mail-Thread-bannerHover rounded-0 px-2 py-1 smaller'"/>
         <span t-attf-class="{{ alertClass }} flex-grow-1" t-on-click="onClickUnreadMessagesBanner" t-esc="newMessageBannerText"/>
         <span t-attf-class="{{ alertClass }}" t-on-click="() => props.thread.markAsRead({ sync: true })">Mark as Read<i class="ms-2 fa fa-check-square"/></span>
     </span>

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -23,17 +23,17 @@
 
     <t t-name="mail.Mailbox.main">
         <button
-            class="o-mail-DiscussSidebar-item o-mail-Mailbox btn d-flex align-items-center px-0 mx-2 border-0 rounded-2 fw-normal text-reset"
+            class="o-mail-DiscussSidebar-item o-mail-Mailbox btn d-flex align-items-center px-0 border-0 rounded-2 fw-normal text-reset"
             t-att-class="{
                 'bg-inherit': mailbox.notEq(store.discuss.thread),
                 'o-active': mailbox.eq(store.discuss.thread),
-                'justify-content-center position-relative': store.discuss.isSidebarCompact,
-                'py-0': !store.discuss.isSidebarCompact,
+                'mx-2 justify-content-center position-relative': store.discuss.isSidebarCompact,
+                'mx-3 py-0': !store.discuss.isSidebarCompact,
             }"
             t-on-click="(ev) => this.openThread(ev)"
             t-ref="root"
         >
-            <ThreadIcon className="'bg-inherit ' + (store.discuss.isSidebarCompact ? '' : 'ms-3 me-2')" thread="mailbox"/>
+            <ThreadIcon className="'bg-inherit ' + (store.discuss.isSidebarCompact ? '' : 'mx-2')" thread="mailbox"/>
             <t t-if="!store.discuss.isSidebarCompact">
                 <div class="me-2 text-truncate small" style="line-height: 1.65;" t-esc="mailbox.name"/>
                 <div t-attf-class="flex-grow-1 {{ mailbox.counter === 0 ? 'me-3': '' }}"/>

--- a/addons/mail/static/src/scss/variables/primary_variables.scss
+++ b/addons/mail/static/src/scss/variables/primary_variables.scss
@@ -1,5 +1,5 @@
 $o-mail-Avatar-size: 42px !default;
-$o-mail-ChatWindow-width: 360px !default; // same value as WINDOW
+$o-mail-ChatWindow-width: 380px !default; // same value as WINDOW
 $o-mail-Discuss-inspector: 300px !default;
 $o-mail-Avatar-sizeSmall: 28px !default;
 // Needed because $border-radius variations are all set to 0 in enterprise.

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -5,7 +5,6 @@ import {
     contains,
     defineMailModels,
     focus,
-    hover,
     inputFiles,
     insertText,
     onRpcBefore,
@@ -20,7 +19,6 @@ import {
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
-import { queryFirst } from "@odoo/hoot-dom";
 import { mockDate, tick } from "@odoo/hoot-mock";
 import { EventBus } from "@odoo/owl";
 import {
@@ -1046,42 +1044,6 @@ test("Notification settings rendering in chatwindow", async () => {
     await contains("button", { text: "For 8 hours" });
     await contains("button", { text: "For 24 hours" });
     await contains("button", { text: "Until I turn it back on" });
-});
-
-test("Can make chat windows bigger", async () => {
-    const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "general", channel_type: "channel" });
-    await start();
-    await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
-    await click(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow");
-    const normalWidth = queryFirst(".o-mail-ChatWindow").getBoundingClientRect().width;
-    await hover(".o-mail-ChatHub-bubbles");
-    await click("button[title='Chat Options']");
-    await contains("button:contains(Large windows)");
-    await contains("button:contains(Large windows) input");
-    await contains("button:contains(Large windows) input:not(:checked)");
-    await click("button:contains(Large windows)");
-    await contains("button:contains(Large windows) input:checked");
-    await contains(".o-mail-ChatWindow.o-large");
-    const largeWidth = queryFirst(".o-mail-ChatWindow").getBoundingClientRect().width;
-    expect(largeWidth).toBeGreaterThan(normalWidth);
-});
-
-test("Bigger chat windows is locally persistent (saved in local storage)", async () => {
-    const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "general", channel_type: "channel" });
-    browser.localStorage.setItem("mail.user_setting.chat_window_big", true);
-    await start();
-    await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
-    await click(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow.o-large");
-    expect(browser.localStorage.getItem("mail.user_setting.chat_window_big")).toBe("true");
-    await hover(".o-mail-ChatHub-bubbles");
-    await click("button[title='Chat Options']");
-    await click("button:contains(Large windows)");
-    await contains(".o-mail-ChatWindow.o-large");
-    expect(browser.localStorage.getItem("mail.user_setting.chat_window_big")).toBe(null);
 });
 
 test("open channel in chat window from push notification", async () => {

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -336,7 +336,7 @@ test("show date separator above mesages of similar date", async () => {
     await openDiscuss(channelId);
     await contains(".o-mail-Message", {
         count: 29,
-        after: [".o-mail-DateSection", { text: "April 20, 2019" }],
+        after: [".o-mail-DateSection", { text: "Apr 20, 2019" }],
     });
 });
 


### PR DESCRIPTION
- chat windows are larger, removed option to resize chat windows
- chat window header commands: compacter, less visible
- message actions: less visible when not hovered, no border on click
- new message banner slightly smaller and warning style, text bolder
- HH:mm on non-squashed message for datetime
- slightly smaller and less visible datetime on message
- horizontal padding on date section and new message separator
- date section has shorter month name
- chat window is rounder, bottom is rounded too
- jump to present button reduced border opacity + shadow-sm added

Backport of https://github.com/odoo/odoo/pull/187654

Before
![Screenshot 2024-11-26 at 15 51 50](https://github.com/user-attachments/assets/339989d5-d7f0-44ff-8b16-8a1428ee7767)
After
![Screenshot 2024-11-26 at 15 51 35](https://github.com/user-attachments/assets/528a2423-6d60-4286-b25a-4c6d5eaf78e3)
