### PR TITLE
[FIX] web: restore ability to use grayscale classes on badges

### DIFF
--- a/addons/web/static/src/scss/bs_mixins_overrides.scss
+++ b/addons/web/static/src/scss/bs_mixins_overrides.scss
@@ -51,6 +51,12 @@ $o-color-extras-nesting-selector: '&' !default;
         $-yiq-threshold-met: alpha($color) > $yiq-min-opacity-threshold;
 
         $-yiq-color: if($text-color, $text-color, if($-yiq-threshold-met, color-contrast($color, $main-background: $background), null));
+
+        // Generate a pair of CSS variables for bg-* classes to then use them
+        // within the .badge design definition (see website.scss)
+        --bg-light: #{$color};
+        --color-light: #{$-yiq-color};
+
         background-color: $color#{if($important, ' !important', '')};
         color: $-yiq-color; // not important so that text utilities still work
 


### PR DESCRIPTION
Since the new front-end badge design[^1], we introduced a new way of handling their generation, aiming to provide a new sleek and clean design. To do so, we tweak the colors that are available with badges, aka `.o_color_*` and status one.

While this works fine, we also had to use some `!important` statements to enforce this design instead of the default BS one[^2]. Unfortunately, these `!important` introduced a side-effect, it prevents the badges to accept any other utility that we wouldn't loop through in this definition. This is what happened with the grayscale colors, meaning these badges were visually broken.

To fix this issue, we simply need to add the CSS variables in use for
the badge design within the grays utilities generation mixin.

Responsible Commit: b4a5bf03cd81ece2a7fd21a3c5a058ee2d3336fe

task-4361645

[^1]: https://github.com/odoo/odoo/pull/162935
[^2]: https://github.com/odoo/odoo/pull/162935/files#diff-f338780f594d6b1f46eda5d3fb9fed86f3c3c8f65522fb93e639534e9d92cdb2R611

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
