### PR TITLE
[FIX] base: merge partner with ir.property w/o company

### DIFF
--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -312,6 +312,32 @@ class TestPartner(TransactionCaseWithUserDemo):
             "'Destination Contact' name should contain db ID in brackets"
         )
 
+    def test_partner_merge_null_company_property(self):
+        """ Check that partner with null company ir.property can be merged """
+        partners = self.env['res.partner'].create([
+            {'name': 'no barcode partner'},
+            {'name': 'partner1', 'barcode': 'partner1'},
+            {'name': 'partner2', 'barcode': 'partner2'},
+        ])
+        with self.assertLogs(level='ERROR'):
+            partner_merge_wizard = self.env['base.partner.merge.automatic.wizard']._merge(
+                partners.ids,
+                partners[0],
+            )
+            self.assertFalse(partners[0].barcode)
+
+        partners = self.env['res.partner'].create([
+            {'name': 'partner1', 'barcode': 'partner1'},
+            {'name': 'partner2', 'barcode': 'partner2'},
+        ])
+        self.env['ir.property'].search([
+            ('res_id', 'in', ["res.partner,{}".format(p.id) for p in partners])
+        ]).company_id = None
+        partner_merge_wizard = self.env['base.partner.merge.automatic.wizard']._merge(
+            partners.ids,
+            partners[0],
+        )
+
     def test_read_group(self):
         title_sir = self.env['res.partner.title'].create({'name': 'Sir...'})
         title_lady = self.env['res.partner.title'].create({'name': 'Lady...'})

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -214,22 +214,25 @@ class MergePartnerAutomatic(models.TransientModel):
         self.env.flush_all()
 
         # Company-dependent fields
-        with self._cr.savepoint():
-            params = {
-                'destination_id': f'res.partner,{dst_partner.id}',
-                'source_ids': tuple(f'res.partner,{src}' for src in src_partners.ids),
-            }
-            self._cr.execute("""
-        UPDATE ir_property AS _ip1
-        SET res_id = %(destination_id)s
-        WHERE res_id IN %(source_ids)s
-        AND NOT EXISTS (
-             SELECT
-             FROM ir_property AS _ip2
-             WHERE _ip2.res_id = %(destination_id)s
-             AND _ip2.fields_id = _ip1.fields_id
-             AND _ip2.company_id = _ip1.company_id
-        )""", params)
+        try:
+            with self._cr.savepoint():
+                params = {
+                    'destination_id': f'res.partner,{dst_partner.id}',
+                    'source_ids': tuple(f'res.partner,{src}' for src in src_partners.ids),
+                }
+                self._cr.execute("""
+            UPDATE ir_property AS _ip1
+            SET res_id = %(destination_id)s
+            WHERE res_id IN %(source_ids)s
+            AND NOT EXISTS (
+                 SELECT
+                 FROM ir_property AS _ip2
+                 WHERE _ip2.res_id = %(destination_id)s
+                 AND _ip2.fields_id = _ip1.fields_id
+                 AND _ip2.company_id IS NOT DISTINCT FROM _ip1.company_id
+            )""", params)
+        except psycopg2.Error:
+            _logger.info(f'Could not move ir.property from partners: {src_partners.ids} to partner: {dst_partner.id}')
 
     def _get_summable_fields(self):
         """ Returns the list of fields that should be summed when merging partners


### PR DESCRIPTION
Scenario:

- have two res.partner with ir.property with res_id and without company_id (eg. by editing the ir.property and removing it)
- merge these partners => UniqueViolation error because of unicity of (fields_id, company_id, res_id) constraint of ir_property table

Why:

The query merging property doesn't take NULL into account for company_id when checking if the destination partner already has this property.

Also a savepoint was used, without ignoring the error so the import could not be done if an error happened.

Fix:

Take the case where both records have NULL company_id into account.

Also ignore error and log a warning when a legitimate error happens because of duplicate ir.property in source records.

Note:

This issue should only happen when:

- modifying ir.property directly
- after a migration with a res.partner field becoming company_dependent field, the partners without company would get an ir.property without company_id

Without the fix, the added test would fail because of an error at each _merge call.

opw-4300572
opw-4030442
