### PR TITLE
[IMP] account_check_printing: hide check print button if no layout

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -46,6 +46,12 @@ class AccountPayment(models.Model):
     payment_method_line_id = fields.Many2one(index=True)
     show_check_number = fields.Boolean(compute='_compute_show_check_number')
 
+    check_layout_available = fields.Boolean(
+        string='Has Check Layout',
+        store=False,
+        default=lambda self: len(self.env['res.company']._fields['account_check_printing_layout'].selection) > 1
+    )
+
     @api.depends('payment_method_line_id.code', 'check_number')
     def _compute_show_check_number(self):
         for payment in self:

--- a/addons/account_check_printing/views/account_payment_views.xml
+++ b/addons/account_check_printing/views/account_payment_views.xml
@@ -6,7 +6,8 @@
             <field name="inherit_id" ref="account.view_account_payment_form" />
             <field name="arch" type="xml">
                 <xpath expr="//button[@name='action_post']" position="before">
-                    <button name="print_checks" class="oe_highlight" invisible="payment_method_code != 'check_printing' or state != 'posted' or is_move_sent" string="Print Check" type="object" data-hotkey="g" />
+                    <field name="check_layout_available" invisible="1"/>
+                    <button name="print_checks" class="oe_highlight" invisible="payment_method_code != 'check_printing' or state != 'posted' or is_move_sent or not check_layout_available" string="Print Check" type="object" data-hotkey="g" />
                     <button name="action_unmark_sent" invisible="payment_method_code != 'check_printing' or not is_move_sent" string="Unmark Sent" type="object" data-hotkey="l" />
                     <button name="action_void_check" invisible="payment_method_code != 'check_printing' or state != 'posted' or not is_move_sent" string="Void Check" type="object" data-hotkey="o" />
                 </xpath>


### PR DESCRIPTION
When opening a vendor payment with a "Check" payment method, and the payment is posted, then the button "Print Check" should only be visible if some check layout are available. To have a Check Layout, a user needs to install the Check Layout module for that localization. However, many localizations are not supported which was making this feature unusable.

task-4292174



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
