### PR TITLE
[FIX] stock_account: fix company_id singleton error in _validate_accounting_entries

### DIFF
--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -59,11 +59,11 @@ class StockValuationLayer(models.Model):
         if am_vals:
             account_moves = self.env['account.move'].sudo().create(am_vals)
             account_moves._post()
-        products_svl = groupby(self, lambda svl: svl.product_id)
-        for product, svls in products_svl:
+        products_svl = groupby(self, lambda svl: (svl.product_id, svl.company_id.anglo_saxon_accounting))
+        for (product, anglo_saxon_accounting), svls in products_svl:
             svls = self.browse(svl.id for svl in svls)
             moves = svls.stock_move_id
-            if svls.company_id.anglo_saxon_accounting:
+            if anglo_saxon_accounting:
                 moves._get_related_invoices()._stock_account_anglo_saxon_reconcile_valuation(product=product)
             moves = (moves | moves.origin_returned_move_id).with_prefetch(chain(moves._prefetch_ids, moves.origin_returned_move_id._prefetch_ids))
             for aml in moves._get_all_related_aml():


### PR DESCRIPTION
This commit fixes a bug introduced in the PR ( https://github.com/odoo/odoo/pull/186434 ). This PR aims to batch operations on svls by grouping based on products. However, it didn't take into account the possibility where svls could belong to different companies. This would lead to a singleton error upon referencing the field "anglo_saxon_accounting".

To fix the problem, grouping svls must be done based on a composite key based on product and value of "anglo_saxon_accounting".


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
