### PR TITLE
[FIX] account: Keep account codes in sync between branches and root

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -387,6 +387,12 @@ class AccountAccount(models.Model):
             # Need to set record.code with `company = self.env.company`, not `self.env.company.root_id`
             record_root.code_store = record.code
 
+        # Changing the code for one company should also change it for all the companies which share the same root_id.
+        # The simplest way of achieving this is invalidating it for all companies here.
+        # We re-compute it right away for the active company, as it is used by constraints while `code` is still protected.
+        self.invalidate_recordset(fnames=['code'], flush=False)
+        self._compute_code()
+
     @api.depends_context('company')
     @api.depends('code')
     def _compute_placeholder_code(self):

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -98,6 +98,25 @@ class TestAccountAccount(TestAccountMergeCommon):
         account_copy_3.write({'code_mapping_ids': [Command.create({'company_id': company_3.id, 'code': '180026'})]})
         self.assertRecordValues(account_copy_3.with_company(company_3), [{'code': '180026'}])
 
+    def test_write_on_code_from_branch(self):
+        """ Ensure that when writing on account.code from a company, the old code isn't erroneously kept
+        on other companies that share the same root_id """
+        branch = self.env['res.company'].create([{
+            'name': "My Test Branch",
+            'parent_id': self.company_data['company'].id,
+        }])
+
+        account = self.env['account.account'].create([{
+            'name': 'My Test Account',
+            'code': '180001',
+        }])
+
+        # Change the code from the branch
+        account.with_company(branch).code = '180002'
+
+        # Ensure it's changed from the perspective of the root company
+        self.assertRecordValues(account, [{'code': '180002'}])
+
     def test_ensure_code_unique(self):
         ''' Test the `_ensure_code_unique` check method.
 


### PR DESCRIPTION
When we implemented shared accounts, a design decision was that all the branches of a root company should have the same code for an account. However, updating the code for a company doesn't update it for the other companies with the same root.

#### Steps to reproduce:
- Create a company and a branch.
- With both companies active, try to modify the code of an account.
- Notice the ValidationError that pops up.

#### Analysis:
When writing on `code`, `_inverse_code` writes on `code_store`, which is a dependency of `code`. However, because `code` is protected at that point, it isn't invalidated + recomputed for the other companies. As a result, the old, incorrect value persists in cache.

#### Solution:
I don't think there is a nice neat solution to this. Ideally, we would like to remove the cache values for all the companies other than the active company. However, there isn't a cache function for doing that on context-dependent fields. We try to simulate that by first invalidating, then eagerly recomputing the code again just for the active company.

task-none
