### PR TITLE
[IMP] l10n_ar: Dynamic label for partner type in invoice report

### DIFF
--- a/addons/l10n_ar/i18n/es.po
+++ b/addons/l10n_ar/i18n/es.po
@@ -202,6 +202,11 @@ msgstr "<strong>Cliente: </strong>"
 
 #. module: l10n_ar
 #: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
+msgid "<strong>Supplier: </strong>"
+msgstr "<strong>Proveedor: </strong>"
+
+#. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
 msgid "<strong>Due Date: </strong>"
 msgstr "<strong>Fecha de vencimiento: </strong>"
 

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -182,6 +182,11 @@ msgstr ""
 
 #. module: l10n_ar
 #: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
+msgid "<strong>Supplier: </strong>"
+msgstr ""
+
+#. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
 msgid "<strong>Due Date: </strong>"
 msgstr ""
 

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -185,7 +185,9 @@
                     <!-- IDENTIFICACION (ADQUIRIENTE-LOCATARIO-PRESTARIO) -->
 
                     <!-- (14) Apellido uy Nombre: Denominicacion o Razon Soclial -->
-                    <strong>Customer: </strong><span t-field="o.partner_id.commercial_partner_id.name"/>
+                    <t t-if="o.is_sale_document(include_receipts=True)"><strong>Customer: </strong></t>
+                    <t t-else=""><strong>Supplier: </strong></t>
+                    <span t-field="o.partner_id.commercial_partner_id.name"/>
 
                     <!-- (15) Domicilio Comercial -->
                     <br/>


### PR DESCRIPTION
This change improves the invoice report by making the partner type label dynamic.
It ensures that the label adapts correctly, enhancing flexibility and accuracy.

**Description of the issue/feature this PR addresses:**
The partner type label in the invoice report was previously static, which caused inconsistencies in cases where the label needed to reflect different partner types dynamically.

**Current behavior before PR:**
The partner type label in the invoice report is hardcoded, which does not adapt to specific partner configurations or custom scenarios.

**Desired behavior after PR is merged:**
The partner type label in the invoice report is dynamically computed based on the partner's type, ensuring it reflects the appropriate value for each invoice context.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
