### PR TITLE
[IMP] mail: log the redacted to headers

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -587,7 +587,13 @@ class MailMail(models.Model):
                             raise
                 if res:  # mail has been sent at least once, no major exception occurred
                     mail.write({'state': 'sent', 'message_id': res, 'failure_reason': False})
-                    _logger.info('Mail with ID %r and Message-Id %r successfully sent', mail.id, mail.message_id)
+                    _logger.info(
+                        "Mail with ID %r and Message-Id %r from %r to (redacted) %r successfully sent",
+                        mail.id,
+                        mail.message_id,
+                        tools.email_normalize(msg['from']),
+                        tools.mail.email_anonymize(tools.email_normalize(msg['to']))
+                    )
                     # /!\ can't use mail.state here, as mail.refresh() will cause an error
                     # see revid:odo@openerp.com-20120622152536-42b2s28lvdv3odyr in 6.1
                 mail._postprocess_sent_message(success_pids=success_pids, failure_type=failure_type)

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -14,7 +14,7 @@ from odoo.tests import tagged
 from odoo.tools import (
     is_html_empty, html_to_inner_content, html_sanitize, append_content_to_html, plaintext2html,
     email_domain_normalize, email_normalize, email_split, email_split_and_format, html2plaintext,
-    misc, formataddr,
+    misc, formataddr, email_anonymize,
     prepend_html_content,
     config,
 )
@@ -680,6 +680,34 @@ class TestEmailTools(BaseCase):
         for source, expected in cases:
             with self.subTest(source=source):
                 self.assertEqual(extract_rfc2822_addresses(source), expected)
+
+    def test_email_anonymize(self):
+        cases = [
+            # examples
+            ('admin@example.com', 'a****@example.com', 'a****@e******.com'),  # short
+            ('portal@example.com', 'p***al@example.com', 'p***al@e******.com'),  # long
+
+            # edge cases
+            ('a@example.com', 'a@example.com', 'a@e******.com'),  # single letter
+            ('joé@example.com', 'j**@example.com', 'j**@e******.com'),  # hidden unicode
+            ('élise@example.com', 'é****@example.com', 'é****@e******.com'),  # visible unicode
+            ('admin@[127.0.0.1]', 'a****@[127.0.0.1]', 'a****@[127.0.0.1]'),  # IPv4
+            ('admin@[IPv6:::1]', 'a****@[IPv6:::1]', 'a****@[IPv6:::1]'),  # IPv6
+
+            # bad cases, to show how the system behave
+            ('', '', ''),  # empty string
+            ('@example.com', '@example.com', '@e******.com'),  # missing local part
+            ('john', 'j***', 'j***'),  # missing domain
+            ('Jo <j@example.com>', 'J****@example.com>', 'J****@e******.com>'),  # non-normalized
+            ('admin@com', 'a****@com', 'a****@com'),  # dotless domain, prohibited by icann
+        ]
+        for source, expected, expected_redacted_domain in cases:
+            with self.subTest(source=source):
+                self.assertEqual(email_anonymize(source), expected)
+                self.assertEqual(
+                    email_anonymize(source, redact_domain=True),
+                    expected_redacted_domain,
+                )
 
 
 class EmailConfigCase(TransactionCase):

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -696,6 +696,38 @@ def _normalize_email(email):
         local_part = local_part.lower()
     return local_part + at + domain.lower()
 
+def email_anonymize(normalized_email, *, redact_domain=False):
+    """
+    Replace most charaters in the local part of the email address with
+    '*' to hide the recipient, but keep enough characters for debugging
+    purpose.
+
+    The email address must be normalized already.
+
+    >>> email_anonymize('admin@example.com')
+    'a****@example.com'
+    >>> email_anonymize('portal@example.com')
+    'p***al@example.com'
+    >>> email_anonymize('portal@example.com', redact_domain=True)
+    'p***al@e******.com'
+    """
+    if not normalized_email:
+        return normalized_email
+
+    local, at, domain = normalized_email.partition('@')
+    if len(local) <= 5:
+        anon_local = local[:1] + '*' * (len(local) - 1)
+    else:
+        anon_local = local[:1] + '*' * (len(local) - 3) + local[-2:]
+
+    host, dot, tld = domain.rpartition('.')
+    if redact_domain and not domain.startswith('[') and all((host, dot, tld)):
+        anon_host = host[0] + '*' * (len(host) - 1)
+    else:
+        anon_host = host
+
+    return f'{anon_local}{at}{anon_host}{dot}{tld}'
+
 def email_domain_extract(email):
     """ Extract the company domain to be used by IAP services notably. Domain
     is extracted from email information e.g:


### PR DESCRIPTION
Debugging outgoing emails is fastidious. Only the mail record id and Message-Id are logged, but most of the time the mail record is removed once the mail is sent, making it impossible to find back who the recipients were.

In this work we also log the (redacted) From and To headers. We decided to redact the headers out of excessive caution regarding the GDPR.

The new `email_anonymize` function must balance disambiguation and redaction. Disambiguation so it is easy to tell two different email addresses appart (for debugging). Redaction so it hard to find the original email address back (for privacy). It must also be simple.

We conducted several experiments using a dataset of 600ish email address (95% of which have a local part that is at least 6 characters long) to determine a nice function. The final function keep the first character for shorter inputs (length of local part < 6) and the first plus two lasts chars for longer inputs (>=6). Using that function we achieve a 99% disambiguation of emails in the dataset (with or without redacting the domain) while retaining minimal info (3 chars at most).

Redacting the domain isn't that useful as most addresses use gmail, hotmail, outlook, yahoo.

Task-4361561

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
