### PR TITLE
[IMP] project: avoid displaying private tasks in portal

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -480,12 +480,12 @@ class ProjectCustomerPortal(CustomerPortal):
 
         # extends filterby criteria with project (criteria name is the project id)
         # Note: portal users can't view projects they don't follow
-        project_groups = request.env['project.task']._read_group(AND([[('project_id', 'not in', projects.ids)], task_domain or []]),
-                                                                ['project_id'])
+        project_groups = request.env['project.task']._read_group(
+            AND([[('project_id', 'not in', projects.ids), ('project_id', '!=', False)], task_domain or []]),
+            ['project_id'])
         for [project] in project_groups:
-            proj_name = project.sudo().display_name if project else _('Others')
             searchbar_filters.update({
-                str(project.id): {'label': proj_name, 'domain': [('project_id', '=', project.id)]}
+                str(project.id): {'label': project.sudo().display_name, 'domain': [('project_id', '=', project.id)]}
             })
         return searchbar_filters
 


### PR DESCRIPTION
**Before this PR:**
- Private tasks were being displayed in the portal.
- These tasks were visible in the portal views, potentially causing confusion as users might assume those private tasks were accessible to public or other users.

**After this PR:**
- We avoid displaying private tasks in portal view.
- Private tasks or tasks that the user does not have permission to view will no longer appear in the portal.

task-4317051


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
