### PR TITLE
[IMP] repair: auto-link source document in sales orders

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -450,6 +450,7 @@ class RepairOrder(models.Model):
                 "partner_id": self.partner_id.id,
                 "warehouse_id": self.picking_type_id.warehouse_id.id,
                 "repair_order_ids": [Command.link(repair.id)],
+                "origin": repair.name,
             })
         self.env['sale.order'].create(sale_order_values_list)
         # Add Sale Order Lines for 'add' move_ids


### PR DESCRIPTION
Before Commit:
-----------------------------------------
Repair orders generating sales orders did not link the repair order in the 'Source Document', causing traceability issues.

After Commit:
-----------------------------------------
The 'Source Document' in sales orders now automatically references the repair order, improving traceability and meeting user feedback.

task-4276531
