### PR TITLE
[FIX] web,sale_pdf_quote_builder: prevent uploading non-supported files

### DIFF
--- a/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
+++ b/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
@@ -14,13 +14,13 @@
                             <field
                                 name="sale_header"
                                 filename="sale_header_name"
-                                options="{'accepted_file_extensions': '.pdf'}"
+                                options="{'accepted_file_extensions': '.pdf', 'allowed_mime_type' : 'application/pdf'}"
                             />
                             <field name="sale_footer_name" invisible="1"/>
                             <field
                                 name="sale_footer"
                                 filename="sale_footer_name"
-                                options="{'accepted_file_extensions': '.pdf'}"
+                                options="{'accepted_file_extensions': '.pdf', 'allowed_mime_type' : 'application/pdf'}"
                             />
                         </group>
                         <group>

--- a/addons/sale_pdf_quote_builder/wizards/res_config_settings_views.xml
+++ b/addons/sale_pdf_quote_builder/wizards/res_config_settings_views.xml
@@ -20,7 +20,7 @@
                         <field
                             name="sale_header"
                             filename="sale_header_name"
-                            options="{'accepted_file_extensions': '.pdf'}"
+                            options="{'accepted_file_extensions': '.pdf', 'allowed_mime_type' : 'application/pdf'}"
                         />
                     </div>
                     <div>
@@ -29,7 +29,7 @@
                         <field
                             name="sale_footer"
                             filename="sale_footer_name"
-                            options="{'accepted_file_extensions': '.pdf'}"
+                            options="{'accepted_file_extensions': '.pdf', 'allowed_mime_type' : 'application/pdf'}"
                         />
                     </div>
                     <widget

--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -963,6 +963,12 @@ msgstr ""
 
 #. module: web
 #. odoo-javascript
+#: code:addons/web/static/src/views/fields/binary/binary_field.js:0
+msgid "Allowed file mimetype"
+msgstr ""
+
+#. module: web
+#. odoo-javascript
 #: code:addons/web/static/src/core/colorlist/colorlist.js:0
 msgid "Almond"
 msgstr ""
@@ -4653,6 +4659,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/web/static/src/core/debug/debug_menu_items.xml:0
 msgid "Only you"
+msgstr ""
+
+#. module: web
+#. odoo-javascript
+#: code:addons/web/static/src/views/fields/file_handler.js:0
+msgid "Oops! '%(fileName)s' didn’t upload since its format isn’t allowed."
 msgstr ""
 
 #. module: web

--- a/addons/web/static/src/views/fields/binary/binary_field.js
+++ b/addons/web/static/src/views/fields/binary/binary_field.js
@@ -18,6 +18,8 @@ export class BinaryField extends Component {
     static props = {
         ...standardFieldProps,
         acceptedFileExtensions: { type: String, optional: true },
+        // See https://www.iana.org/assignments/media-types/media-types.xhtml
+        allowedMIMETypes: { type: String, optional: true },
         fileNameField: { type: String, optional: true },
     };
     static defaultProps = {
@@ -80,10 +82,16 @@ export const binaryField = {
             name: "accepted_file_extensions",
             type: "string",
         },
+        {
+            label: _t("Allowed file mimetype"),
+            name: "allowed_mime_type",
+            type: "string",
+        },
     ],
     supportedTypes: ["binary"],
     extractProps: ({ attrs, options }) => ({
         acceptedFileExtensions: options.accepted_file_extensions,
+        allowedMIMETypes: options.allowed_mime_type,
         fileNameField: attrs.filename,
     }),
 };

--- a/addons/web/static/src/views/fields/binary/binary_field.xml
+++ b/addons/web/static/src/views/fields/binary/binary_field.xml
@@ -7,6 +7,7 @@
                 <div class="w-100 d-inline-flex gap-1">
                     <FileUploader
                         acceptedFileExtensions="props.acceptedFileExtensions"
+                        allowedMIMETypes="props.allowedMIMETypes"
                         onUploaded.bind="update"
                     >
                         <t name="download" t-if="props.record.resId and !props.record.dirty">

--- a/addons/web/static/src/views/fields/file_handler.js
+++ b/addons/web/static/src/views/fields/file_handler.js
@@ -18,6 +18,8 @@ export class FileUploader extends Component {
         acceptedFileExtensions: { type: String, optional: true },
         slots: { type: Object, optional: true },
         showUploadingText: { type: Boolean, optional: true },
+        // See https://www.iana.org/assignments/media-types/media-types.xhtml
+        allowedMIMETypes: { type: String, optional: true },
     };
     static defaultProps = {
         checkSize: true,
@@ -36,11 +38,13 @@ export class FileUploader extends Component {
      * @param {Event} ev
      */
     async onFileChange(ev) {
-        if (!ev.target.files.length) {
+        const files = [...ev.target.files].filter(file => this.validFileType(file));
+        const { target } = ev;
+        if (!files) {
             return;
         }
-        const { target } = ev;
-        for (const file of ev.target.files) {
+
+        for (const file of files) {
             if (this.props.checkSize && !checkFileSize(file.size, this.notification)) {
                 return null;
             }
@@ -68,6 +72,29 @@ export class FileUploader extends Component {
         if (this.props.multiUpload && this.props.onUploadComplete) {
             this.props.onUploadComplete({});
         }
+    }
+
+    /**
+     * The `allowedMIMETypes` props can restrict the file types users are guided to select. However,
+     * the `accept` attribute doesn't enforce strict validation; it only suggests file types for
+     * browsers.
+     *
+     * @param {File} file
+     * @returns Whether the upload file's type is in the whitelist (`allowedMIMETypes`).
+     */
+    validFileType(file) {
+        if (this.props.allowedMIMETypes && !this.props.allowedMIMETypes.includes(file.type)) {
+            this.notification.add(
+                _t(`Oops! '%(fileName)s' didn’t upload since its format isn’t allowed.`, {
+                    fileName: file.name,
+                }),
+                {
+                    type: "danger",
+                }
+            );
+            return false;
+        }
+        return true;
     }
 
     async onSelectFileButtonClick(ev) {


### PR DESCRIPTION
Currently an exception is arising when user upload a image or none pdf file
in 'Header or Footer pages'.

Steps to produce an error:
- Install `sale_management` and go to Sales
- Click Configuration > Quotation Templates > open or create quotation template
- Click on `PDF Quote Builder` tab
- Upload none pdf file on `Header or Footer pages` > Save Record

Error:  `PyPDF2.errors.PdfReadError: EOF marker not found`

This commit will fix the above issue by preventing uploading non-supported
files that were uploaded by users.

sentry-5962839786