### PR TITLE
[FIX] web: properly align fields in calendar popover

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.scss
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.scss
@@ -6,14 +6,6 @@ $o-cw-popup-avatar-size: 16px;
     max-width: 328px;
     font-size: $font-size-base;
 
-    .role-container span {
-        display: block;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        max-width: 100%;
-    }
-
     .card-header,
     .card-header .popover-header {
         font-size: 1.05em;
@@ -47,6 +39,10 @@ $o-cw-popup-avatar-size: 16px;
     .list-group-item {
         padding: 0.5rem 1rem;
         border: none;
+    }
+
+    .o_cw_popover_field .o_field_widget {
+        @include o-text-overflow(block);
     }
 
     .o_cw_popover_fields_secondary {

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
@@ -59,8 +59,8 @@
                                     <t t-esc="fieldInfo.string" />:
                                 </t>
                             </strong>
-                            <div class="role-container text-truncate">
-                                <Field name="fieldName" class="'w-100'" record="slot.record" fieldInfo="fieldInfo" type="fieldInfo.widget" />
+                            <div class="o_cw_popover_field overflow-hidden">
+                                <Field name="fieldName" record="slot.record" fieldInfo="fieldInfo" type="fieldInfo.widget" />
                             </div>
                         </li>
                     </t>


### PR DESCRIPTION
Previously, the fields in the calendar popover were misaligned. 

This fix ensures proper alignment of the fields.

Task-4315829

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
