### PR TITLE
[FIX] web_editor: traceback when copying selection near table

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3656,15 +3656,16 @@ export class OdooEditor extends EventTarget {
             // just its rows.
             rangeContent = tableClone;
         }
-        const table = closestElement(range.startContainer, 'table');
-        if (rangeContent.firstChild.nodeName === 'TABLE' && table) {
+        const startTable = closestElement(range.startContainer, 'table');
+        if (rangeContent.firstChild.nodeName === 'TABLE' && startTable) {
             // Make sure the full leading table is copied.
-            rangeContent.firstChild.after(table.cloneNode(true));
+            rangeContent.firstChild.after(startTable.cloneNode(true));
             rangeContent.firstChild.remove();
         }
-        if (rangeContent.lastChild.nodeName === 'TABLE') {
+        const endTable = closestElement(range.endContainer, 'table');
+        if (rangeContent.lastChild.nodeName === 'TABLE' && endTable) {
             // Make sure the full trailing table is copied.
-            rangeContent.lastChild.before(closestElement(range.endContainer, 'table').cloneNode(true));
+            rangeContent.lastChild.before(endTable.cloneNode(true));
             rangeContent.lastChild.remove();
         }
 

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -69,6 +69,23 @@ describe('Copy', () => {
                     window.chai.expect(clipboardData.getData('text/odoo-editor')).to.be.equal('<table><tbody><tr><td><ul><li>a</li><li>b</li><li>c</li></ul></td><td><br></td></tr></tbody></table>');
                 },
             });
+            await testEditor(BasicEditor, {
+                contentBefore: `<p>[abcd</p><table><tbody><tr><td><br></td><td><br></td></tr></tbody></table>]`,
+                stepFunction: async (editor) => {
+                  const clipboardData = new DataTransfer();
+                  await triggerEvent(editor.editable, "copy", { clipboardData });
+                  window.chai
+                    .expect(clipboardData.getData("text/html"))
+                    .to.be.equal(
+                      `<p>abcd</p><table class="o_selected_table"><tbody><tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr></tbody></table>`
+                    );
+                  window.chai
+                    .expect(clipboardData.getData("text/odoo-editor"))
+                    .to.be.equal(
+                      `<p>abcd</p><table class="o_selected_table"><tbody><tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr></tbody></table>`
+                    );
+                },
+            });
         });
         it('should wrap the selected text with clones of ancestors up to a block element to keep styles', async () => {
             await testEditor(BasicEditor, {


### PR DESCRIPTION
Steps to reproduce:

- Open the Notes App.
- Type some content in the document.
- On a new line, insert a table.
- Resize the table so there is blank space on its right side.
- Select some content and the entire table, ensuring the mouse pointer
ends up in the blank space on the right side of the table.
- Press `Ctrl + C`
- A traceback error occurs.

Description of the issue/feature this PR addresses:

When selecting content with mouse and ending pointer in empty space to right of a table, pressing Ctrl+C triggers `_onClipboardCopy`. It tries to clone the closest element of endContainer as a table, but if `closestElement` is not a table, it causes a traceback.

Desired behavior after PR is merged:

The traceback no longer occurs when copying a selection near a table.

task-4357182