### PR TITLE
[FIX] sms: wrong message error

### DIFF
--- a/addons/sms/i18n/sms.pot
+++ b/addons/sms/i18n/sms.pot
@@ -1065,7 +1065,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/sms/models/ir_actions_server.py:0
 #, python-format
-msgid "Sending SMS can only be done on a mail.thread or a transient model"
+msgid "Sending SMS can only be done on a not transient mail.thread model"
 msgstr ""
 
 #. module: sms

--- a/addons/sms/models/ir_actions_server.py
+++ b/addons/sms/models/ir_actions_server.py
@@ -49,7 +49,7 @@ class ServerActions(models.Model):
         super()._check_model_coherency()
         for action in self:
             if action.state == 'sms' and (action.model_id.transient or not action.model_id.is_mail_thread):
-                raise ValidationError(_("Sending SMS can only be done on a mail.thread or a transient model"))
+                raise ValidationError(_("Sending SMS can only be done on a not transient mail.thread model"))
 
     def _run_action_sms_multi(self, eval_context=None):
         # TDE CLEANME: when going to new api with server action, remove action


### PR DESCRIPTION
* When checking model coherency for sms, if choose transient model -> raise ValidationError message but the message seem not follow with the code so much

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
