### PR TITLE
[FIX] sale: allow salesman without accounting group to send invoice

### DIFF
--- a/addons/sale/security/ir.model.access.csv
+++ b/addons/sale/security/ir.model.access.csv
@@ -2,7 +2,8 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_account_account_salesman,account_account salesman,account.model_account_account,sales_team.group_sale_salesman,1,0,0,0
 access_account_analytic_account_salesman,account_analytic_account salesman,analytic.model_account_analytic_account,sales_team.group_sale_salesman,1,1,1,0
 access_account_account_tag_sale_salesman,account.account.tag.sale.salesman,account.model_account_account_tag,sales_team.group_sale_salesman,1,0,0,0
-access_account_move_send_salesman,access.account.move.send.salesman,account.model_account_move_send,sales_team.group_sale_salesman,1,1,1,0
+access_account_move_send_wizard_salesman,access.account.move.send.wizard.salesman,account.model_account_move_send_wizard,sales_team.group_sale_salesman,1,1,1,0
+access_account_move_send_batch_wizard_salesman,access.account.move.send.batch.wizard.salesman,account.model_account_move_send_batch_wizard,sales_team.group_sale_salesman,1,1,1,0
 access_sale_account_journal,account.journal sale order.user,account.model_account_journal,sales_team.group_sale_salesman,1,0,0,0
 access_account_move_salesman,account_move salesman,account.model_account_move,sales_team.group_sale_salesman,1,0,0,0
 access_account_move_line_salesman,account_move_line salesman,account.model_account_move_line,sales_team.group_sale_salesman,1,0,0,0


### PR DESCRIPTION
To reproduce:
- Create a user with `Sales / User: Own Documents Only` and no `Accounting` rights

- Log-in with that user

- Create a Sale Order, add some product and confirm it

- Create an invoice for that order, post it and then try to send it

=> An AccessError is raised:

`You are not allowed to access 'Account Move Send Wizard' records.`

Salesman record rules where adapted in odoo/odoo@9e769e1b11f2 after the introduction of new 'Send & Print' wizard but not the access rights, which this commit does.

opw-4351500

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
