### PR TITLE
[IMP] point_of_sale: adjust default font size for POS receipts from 16px to 14px for consistency

### DIFF
--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -1793,7 +1793,7 @@ td {
     background-color: white;
     margin: 20px;
     padding: 15px;
-    font-size: 16px;
+    font-size: 14px;
     padding-bottom:30px;
     display: inline-block;
     border: solid 1px rgb(220,220,220);


### PR DESCRIPTION
This PR proposes reducing the default font size for POS receipts from 16px to 14px to align with the --body-font-size introduced in Odoo 18.0. The adjustment ensures a more consistent design, optimizes receipt layout, and saves paper when printing.

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/7e1feaa4-df5c-43aa-89c0-b6a2d8fcbbdf) | ![After](https://github.com/user-attachments/assets/c14eda15-6b59-458e-b7ca-323da2b44770) |





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

