### PR TITLE
[IMP] web: quick create by default in first unfolded column in kanban

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -258,7 +258,7 @@ export class KanbanController extends Component {
         const { onCreate } = this.props.archInfo;
         const { root } = this.model;
         if (this.canQuickCreate && onCreate === "quick_create") {
-            const firstGroup = root.groups[0];
+            const firstGroup = root.groups.find((group) => !group.isFolded) || root.groups[0];
             if (firstGroup.isFolded) {
                 await firstGroup.toggle();
             }

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -1269,6 +1269,7 @@ export class Model extends Array {
                     model._computes = { ...previous._computes };
                     model._fetch = previous._fetch;
                     model._fields = { ...previous._fields };
+                    model._fold_name = previous._fold_name;
                     model._inherit = previous._inherit;
                     model._name = previous._name;
                     model._onChanges = { ...previous._onChanges };
@@ -1325,6 +1326,13 @@ export class Model extends Array {
     }
     static set _filters(value) {
         this.definition._filters = value;
+    }
+
+    static get _fold_name() {
+        return this.definition._fold_name;
+    }
+    static set _fold_name(value) {
+        this.definition._fold_name = value;
     }
 
     static get _inherit() {
@@ -1410,6 +1418,8 @@ export class Model extends Array {
     _fields = {};
     /** @type {Record<string, any>[]} */
     _filters = [];
+    /** @type {string} */
+    _fold_name = "fold";
     /** @type {string | null} */
     _inherit = null;
     /** @type {string} */
@@ -1461,6 +1471,7 @@ export class Model extends Array {
             this._computes = modelInstance._computes;
             this._fetch = modelInstance._fetch;
             this._fields = modelInstance._fields;
+            this._fold_name = modelInstance._fold_name;
             this._inherit = modelInstance._inherit;
             this._name = modelInstance._name;
             this._onChanges = modelInstance._onChanges;
@@ -1966,6 +1977,10 @@ export class Model extends Array {
                     const relatedRecord = this.env[relation].find(({ id }) => id === value);
                     if (relatedRecord) {
                         group[gbField] = [value, relatedRecord.display_name];
+                        const _fold_name = this.env[relation]._fold_name;
+                        if (_fold_name in this.env[relation]._fields) {
+                            group.__fold = relatedRecord[_fold_name] || false;
+                        }
                     } else {
                         group[gbField] = false;
                     }

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -178,6 +178,7 @@ class Product extends models.Model {
     _name = "product";
 
     name = fields.Char();
+    fold = fields.Boolean({ default: false });
 
     _records = [
         { id: 3, name: "hello" },
@@ -4163,7 +4164,7 @@ test("close a column while quick creating a record", async () => {
 
     expect.verifySteps([]); // "get_views" should have already be done
     expect(".o_form_view").toHaveCount(1);
-    expect(".o_column_folded").toHaveCount(0);
+    expect(".o_column_folded").toHaveCount(1);
 });
 
 test("quick create record: open on a column while another column has already one", async () => {
@@ -5441,77 +5442,9 @@ test("auto fold group when reach the limit", async () => {
         Product._records.push({ id: 8 + i, name: `column ${i}` });
         Partner._records.push({ id: 20 + i, foo: "dumb entry", product_id: 8 + i });
     }
+    Product._records[2].fold = true;
+    Product._records[8].fold = true;
 
-    onRpc("web_read_group", function ({ parent }) {
-        const result = parent();
-        result.groups[2].__fold = true;
-        result.groups[8].__fold = true;
-        return result;
-    });
-    onRpc("web_search_read", ({ kwargs }) => {
-        expect.step(`web_search_read domain: ${kwargs.domain}`);
-    });
-
-    await mountView({
-        type: "kanban",
-        resModel: "partner",
-        arch: `
-            <kanban>
-                <templates>
-                    <t t-name="card">
-                        <field name="foo"/>
-                    </t>
-                </templates>
-            </kanban>`,
-        groupBy: ["product_id"],
-    });
-
-    // we look if column are folded/unfolded according to what is expected
-    expect(getKanbanColumn(1)).not.toHaveClass("o_column_folded");
-    expect(getKanbanColumn(3)).not.toHaveClass("o_column_folded");
-    expect(getKanbanColumn(9)).not.toHaveClass("o_column_folded");
-    expect(getKanbanColumn(2)).toHaveClass("o_column_folded");
-    expect(getKanbanColumn(8)).toHaveClass("o_column_folded");
-
-    // we look if columns are actually folded after we reached the limit
-    expect(getKanbanColumn(12)).toHaveClass("o_column_folded");
-    expect(getKanbanColumn(13)).toHaveClass("o_column_folded");
-
-    // we look if we have the right count of folded/unfolded column
-    expect(".o_kanban_group:not(.o_column_folded)").toHaveCount(10);
-    expect(".o_kanban_group.o_column_folded").toHaveCount(4);
-
-    expect.verifySteps([
-        "web_search_read domain: product_id,=,3",
-        "web_search_read domain: product_id,=,5",
-        "web_search_read domain: product_id,=,9",
-        "web_search_read domain: product_id,=,10",
-        "web_search_read domain: product_id,=,11",
-        "web_search_read domain: product_id,=,12",
-        "web_search_read domain: product_id,=,13",
-        "web_search_read domain: product_id,=,15",
-        "web_search_read domain: product_id,=,16",
-        "web_search_read domain: product_id,=,17",
-    ]);
-});
-
-test.tags("desktop");
-test("auto fold group when reach the limit (2)", async () => {
-    // this test is similar to the previous one, except that in this one,
-    // read_group sets the __fold key on each group, even those that are
-    // unfolded, which could make subtle differences in the code
-    for (let i = 0; i < 12; i++) {
-        Product._records.push({ id: 8 + i, name: `column ${i}` });
-        Partner._records.push({ id: 20 + i, foo: "dumb entry", product_id: 8 + i });
-    }
-
-    onRpc("web_read_group", function ({ parent }) {
-        const result = parent();
-        for (let i = 0; i < result.groups.length; i++) {
-            result.groups[i].__fold = i == 2 || i == 8;
-        }
-        return result;
-    });
     onRpc("web_search_read", ({ kwargs }) => {
         expect.step(`web_search_read domain: ${kwargs.domain}`);
     });
@@ -12270,11 +12203,7 @@ test("fold a column and drag record on it should not unfold it", async () => {
 
 test.tags("desktop");
 test("drag record on initially folded column should not unfold it", async () => {
-    onRpc("web_read_group", function ({ parent }) {
-        const result = parent();
-        result.groups[1].__fold = true;
-        return result;
-    });
+    Product._records[1].fold = true;
 
     await mountView({
         type: "kanban",
@@ -12426,12 +12355,8 @@ test("quick create record in grouped kanban in a form view dialog", async () => 
 
 test.tags("desktop");
 test("no sample data when all groups are folded then one is unfolded", async () => {
-    onRpc("web_read_group", function ({ parent }) {
-        const result = parent();
-        for (const group of result.groups) {
-            group.__fold = true;
-        }
-        return result;
+    Product._records.forEach((group) => {
+        group.fold = true;
     });
 
     await mountView({
@@ -12459,12 +12384,8 @@ test("no sample data when all groups are folded then one is unfolded", async () 
 
 test.tags("desktop");
 test("no content helper, all groups folded with (unloaded) records", async () => {
-    onRpc("web_read_group", function ({ parent }) {
-        const result = parent();
-        for (const group of result.groups) {
-            group.__fold = true;
-        }
-        return result;
+    Product._records.forEach((group) => {
+        group.fold = true;
     });
 
     await mountView({
@@ -12831,18 +12752,9 @@ test("sample server: _mockWebReadGroup API", async () => {
 
 test.tags("desktop");
 test("scroll on group unfold and progressbar click", async () => {
+    Product._records[1].fold = true;
     onRpc(function ({ method, parent }) {
         expect.step(method);
-        if (method === "web_read_group") {
-            const result = parent();
-            if (result.groups.length) {
-                result.groups[0].__fold = false;
-                if (result.groups[1]) {
-                    result.groups[1].__fold = true;
-                }
-            }
-            return result;
-        }
     });
 
     await mountView({
@@ -13503,11 +13415,7 @@ test("click on empty kanban must shake the NEW button", async () => {
 
 test.tags("mobile");
 test("Should load grouped kanban with folded column", async () => {
-    onRpc("web_read_group", ({ parent }) => {
-        const result = parent();
-        result.groups[1].__fold = true;
-        return result;
-    });
+    Product._records[1].fold = true;
     await mountView({
         type: "kanban",
         resModel: "partner",

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -3095,26 +3095,41 @@ test("quick create when first column is folded", async () => {
     });
 
     expect(".o_kanban_group:first-child").not.toHaveClass("o_column_folded");
+    expect(".o_kanban_group:nth-child(2)").not.toHaveClass("o_column_folded");
 
     // fold the first column
     let clickColumnAction = await toggleKanbanColumnActions(0);
     await clickColumnAction("Fold");
 
     expect(".o_kanban_group:first-child").toHaveClass("o_column_folded");
+    expect(".o_kanban_group:nth-child(2)").not.toHaveClass("o_column_folded");
 
-    // click on 'Create' to open the quick create in the first column
+    expect(".o_kanban_quick_create").toHaveCount(0);
+
+    // click on 'Create' to open the quick create in the first non-folded column (second column)
     await createKanbanRecord();
 
-    expect(".o_kanban_group:first-child").not.toHaveClass("o_column_folded");
+    expect(".o_kanban_group:first-child").toHaveClass("o_column_folded");
+    expect(".o_kanban_group:nth-child(2)").not.toHaveClass("o_column_folded");
 
-    expect(".o_kanban_group:first-child .o_kanban_quick_create").toHaveCount(1);
+    expect(".o_kanban_group:nth-child(2) .o_kanban_quick_create").toHaveCount(1);
 
-    // fold again the first column
-    clickColumnAction = await toggleKanbanColumnActions(0);
+    // fold again the second column
+    clickColumnAction = await toggleKanbanColumnActions(1);
     await clickColumnAction("Fold");
 
     expect(".o_kanban_group:first-child").toHaveClass("o_column_folded");
+    expect(".o_kanban_group:nth-child(2)").toHaveClass("o_column_folded");
+
     expect(".o_kanban_quick_create").toHaveCount(0);
+
+    // click on 'Create' to open the quick create in the first column since all columns are folded
+    await createKanbanRecord();
+
+    expect(".o_kanban_group:first-child").not.toHaveClass("o_column_folded");
+    expect(".o_kanban_group:nth-child(2)").toHaveClass("o_column_folded");
+
+    expect(".o_kanban_group:first-child .o_kanban_quick_create").toHaveCount(1);
 });
 
 test("quick create record: cancel when not dirty", async () => {


### PR DESCRIPTION
[IMP] web: quick create by default in first unfolded column in kanban
-------------------

Before this commit: when quick-creating a record from the kanban view,
the record was created in the first column of the kanban view, even if
this column was folded.

After this commit: the record is created in the first unfolded column of
the kanban view. If all columns are folded, the record is created in the
first column of the kanban view.


[ADD] web: mock backend behavior for fold feature in JS unitest
-------------------

Before this commit, the fold value was manually set when needed.

This commit mocks the backend behavior.


[FIX] web: update kanban view when editing the fold value of a group
-------------------

Steps to reproduce:

- Install `Project` module
- Create a new Project and add some Stages
- Edit a stage so it's folded by default
- Save and go back to Kanban view

Issue:

The group is not folded.

Cause:

If the group already exists in the view, some values are not updated,
including the `fold` value.

Solution:

Update fold value each time the group is updated.

task-4240805