### PR TITLE
[FIX] mail: active icon on screen share

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -65,6 +65,7 @@ callActionsRegistry
                 : _t("Share Screen"),
         isActive: (component) => component.rtc.selfSession?.isScreenSharingOn,
         icon: "fa-desktop",
+        activeClass: "text-success",
         select: (component) => component.rtc.toggleVideo("screen"),
         sequence: 40,
     })


### PR DESCRIPTION
Current behavior before PR:
The screen share icon did not reflect any change when screen sharing was active

Desired behavior after PR is merged:
The screen share icon now turns green to indicate that screen sharing is active

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
