### PR TITLE
[FIX] website_sale, delivery: make delivery dialog fully translatable.

### DIFF
--- a/addons/delivery/i18n/delivery.pot
+++ b/addons/delivery/i18n/delivery.pot
@@ -177,14 +177,14 @@ msgstr ""
 
 #. module: delivery
 #. odoo-javascript
-#: code:addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml:0
+#: code:addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js:0
 #: code:addons/delivery/static/src/js/location_selector/map_container/map_container.xml:0
 msgid "Choose this location"
 msgstr ""
 
 #. module: delivery
 #. odoo-javascript
-#: code:addons/delivery/static/src/js/location_selector/location_schedule/location_schedule.xml:0
+#: code:addons/delivery/static/src/js/location_selector/location_schedule/location_schedule.js:0
 msgid "Closed"
 msgstr ""
 

--- a/addons/delivery/static/src/js/location_selector/location_schedule/location_schedule.js
+++ b/addons/delivery/static/src/js/location_selector/location_schedule/location_schedule.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { Component } from '@odoo/owl';
+import { _t } from '@web/core/l10n/translation';
 
 export class LocationSchedule extends Component {
     static template = 'delivery.locationSelector.schedule';
@@ -24,5 +25,9 @@ export class LocationSchedule extends Component {
      */
     getWeekDay(weekday) {
         return luxon.Info.weekdays()[weekday]
+    }
+
+    get closedLabel() {
+        return _t("Closed");
     }
 }

--- a/addons/delivery/static/src/js/location_selector/location_schedule/location_schedule.xml
+++ b/addons/delivery/static/src/js/location_selector/location_schedule/location_schedule.xml
@@ -21,7 +21,7 @@
                     </t>
                 </t>
                 <t t-else="">
-                    <small class="text-danger">Closed</small>
+                    <small class="text-danger" t-out="closedLabel"/>
                 </t>
             </span>
         </span>

--- a/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
+++ b/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
@@ -24,7 +24,6 @@ export class LocationSelectorDialog extends Component {
     };
 
     setup() {
-        this.title = _t("Choose a pick-up point");
         this.state = useState({
             locations: [],
             error: false,
@@ -145,6 +144,14 @@ export class LocationSelectorDialog extends Component {
     get mobileComponent() {
         if (this.state.viewMode === 'map') return MapContainer;
         return LocationList;
+    }
+
+    get title() {
+        return _t("Choose a pick-up point");
+    }
+
+    get validationButtonLabel() {
+        return _t("Choose this location");
     }
 
     /**

--- a/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml
+++ b/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml
@@ -98,9 +98,8 @@
                         class="btn btn-primary w-100"
                         t-att-disabled="!this.state.selectedLocationId"
                         t-on-click="validateSelection"
-                    >
-                        Choose this location
-                    </button>
+                        t-out="validationButtonLabel"
+                    />
                 </div>
             </t>
         </Dialog>

--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -1040,6 +1040,18 @@ msgid "Choose a delivery method"
 msgstr ""
 
 #. module: website_sale
+#. odoo-javascript
+#: code:addons/website_sale/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js:0
+msgid "Choose a pick-up point"
+msgstr ""
+
+#. module: website_sale
+#. odoo-javascript
+#: code:addons/website_sale/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js:0
+msgid "Choose this location"
+msgstr ""
+
+#. module: website_sale
 #: model:product.pricelist,name:website_sale.list_christmas
 msgid "Christmas"
 msgstr ""
@@ -1088,6 +1100,12 @@ msgstr ""
 #: code:addons/website_sale/static/src/js/notification/cart_notification/cart_notification.xml:0
 #: model_terms:ir.ui.view,arch_db:website_sale.o_wsale_offcanvas
 msgid "Close"
+msgstr ""
+
+#. module: website_sale
+#. odoo-javascript
+#: code:addons/website_sale/static/src/js/location_selector/location_schedule/location_schedule.js:0
+msgid "Closed"
 msgstr ""
 
 #. module: website_sale

--- a/addons/website_sale/static/src/js/location_selector/location_schedule/location_schedule.js
+++ b/addons/website_sale/static/src/js/location_selector/location_schedule/location_schedule.js
@@ -1,0 +1,12 @@
+import {
+    LocationSchedule
+} from '@delivery/js/location_selector/location_schedule/location_schedule';
+import { patch } from '@web/core/utils/patch';
+import { _t } from '@web/core/l10n/translation';
+
+patch(LocationSchedule.prototype, {
+    get closedLabel() {
+        // The original definition of this getter is in `delivery` module which is not a frontend module. This problem happens in the context of the website. So, it should be repeated here as translations are only fetched in the context of a frontend module, which is `website_sale` in this case.
+        return _t("Closed");
+    },
+});

--- a/addons/website_sale/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
+++ b/addons/website_sale/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
@@ -4,6 +4,7 @@ import {
     LocationSelectorDialog
 } from '@delivery/js/location_selector/location_selector_dialog/location_selector_dialog';
 import { patch } from '@web/core/utils/patch';
+import { _t } from '@web/core/l10n/translation';
 
 patch(LocationSelectorDialog, {
     props: {
@@ -20,5 +21,15 @@ patch(LocationSelectorDialog.prototype, {
         if (this.props.isFrontend) {
             this.getLocationUrl = '/website_sale/get_pickup_locations';
         }
+    },
+
+    get title() {
+        // The original definition of this getter is in `delivery` module which is not a frontend module. This problem happens in the context of the website. So, it should be repeated here as translations are only fetched in the context of a frontend module, which is `website_sale` in this case.
+        return _t("Choose a pick-up point");
+    },
+
+    get validationButtonLabel() {
+        // The original definition of this getter is in `delivery` module which is not a frontend module. This problem happens in the context of the website. So, it should be repeated here as translations are only fetched in the context of a frontend module, which is `website_sale` in this case.
+        return _t("Choose this location");
     },
 });


### PR DESCRIPTION
When you try to ship your products to a pick-up point on the website, you encounter a dialog to choose the exact location of the pick-up point that has the following strings untranslated: "Choose a pick-up point", "Choose this location", and "Closed" (if the pick-up location is closed on someday). This happens because these strings are defined in `delivery` module, which is not a frontend module. This commit redefines those strings in `website_sale` module, which is a fronend module.

Task-4328208
OPW-4326840

