### PR TITLE
[FIX] stock_account: run test without demo data

### DIFF
--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -4404,8 +4404,10 @@ class TestStockValuation(TestStockValuationBase):
         self.product1.categ_id.property_cost_method = 'fifo'
         other_categ = self.product1.categ_id.copy({
             'property_cost_method': 'average',
-            'property_stock_account_output_categ_id': self.product1.categ_id.property_stock_account_output_categ_id.id,
-            'property_stock_valuation_account_id': self.product1.categ_id.property_stock_valuation_account_id.id,
+            'property_stock_account_output_categ_id': self.stock_output_account.id,
+            'property_stock_valuation_account_id': self.stock_valuation_account.id,
+            'property_stock_account_input_categ_id': self.stock_input_account.id,
+            'property_stock_journal': self.stock_journal.id,
         })
         move1 = self.env['stock.move'].create({
             'name': 'IN 10 units @ 7.20 per unit',


### PR DESCRIPTION
This commit makes sure the test can be launched without demo data installed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
