### PR TITLE
[REF] base,stock,web: remove action flags

### DIFF
--- a/addons/stock/models/stock_package_level.py
+++ b/addons/stock/models/stock_package_level.py
@@ -210,5 +210,4 @@ class StockPackage_Level(models.Model):
             'view_id': view.id,
             'target': 'new',
             'res_id': self.id,
-            'flags': {'mode': 'readonly'},
         }

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -450,7 +450,6 @@ export class ListRenderer extends Component {
             res_id: resId,
             type: "ir.actions.act_window",
             views: [[false, "form"]],
-            flags: { mode: "edit" },
         });
     }
 

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -34,7 +34,6 @@ viewRegistry.addValidation({
 /** @typedef {Object} Config
  *  @property {integer|false} actionId
  *  @property {string|false} actionType
- *  @property {Object} actionFlags
  *  @property {() => []} breadcrumbs
  *  @property {() => string} getDisplayName
  *  @property {(string) => void} setDisplayName
@@ -57,7 +56,6 @@ export function getDefaultConfig() {
         embeddedActions: [],
         currentEmbeddedActionId: false,
         parentActionId: false,
-        actionFlags: {},
         breadcrumbs: reactive([
             {
                 get name() {

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -565,7 +565,6 @@ export function makeActionManager(env, router = _router) {
             config: {
                 actionId: action.id,
                 actionType: "ir.actions.client",
-                actionFlags: action.flags,
             },
             displayName: action.display_name || action.name || "",
         };
@@ -660,9 +659,6 @@ export function makeActionManager(env, router = _router) {
                     };
                 }
             }
-            if (action.flags && "mode" in action.flags) {
-                viewProps.mode = action.flags.mode;
-            }
         }
 
         const specialKeys = ["help", "useSampleModel", "limit", "count"];
@@ -718,7 +714,6 @@ export function makeActionManager(env, router = _router) {
                 embeddedActions,
                 parentActionId,
                 currentEmbeddedActionId,
-                actionFlags: action.flags,
                 views: action.views,
                 viewSwitcherEntries,
             },

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -6832,7 +6832,6 @@ test(`groupby node with edit button`, async () => {
                 res_model: "res.currency",
                 type: "ir.actions.act_window",
                 views: [[false, "form"]],
-                flags: { mode: "edit" },
             });
         },
     });

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -1636,60 +1636,6 @@ test.tags("desktop")("execute action with unknown view type", async () => {
     );
 });
 
-test("flags field of ir.actions.act_window is used", async () => {
-    // more info about flags field : https://github.com/odoo/odoo/commit/c9b133813b250e89f1f61816b0eabfb9bee2009d
-    defineActions([
-        {
-            id: 43,
-            name: "Partners",
-            res_id: 1,
-            res_model: "partner",
-            type: "ir.actions.act_window",
-            flags: {
-                mode: "edit",
-            },
-            views: [[false, "form"]],
-        },
-        {
-            id: 44,
-            name: "Partners",
-            res_id: 1,
-            res_model: "partner",
-            type: "ir.actions.act_window",
-            flags: {
-                mode: "readonly",
-            },
-            views: [[false, "form"]],
-        },
-    ]);
-
-    stepAllNetworkCalls();
-
-    await mountWithCleanup(WebClient);
-
-    // action 43 -> form in edit mode
-    await getService("action").doAction(43);
-    expect(".o_form_view .o_form_editable").toHaveCount(1, {
-        message: "should display the form view in edit mode",
-    });
-
-    // action 44 -> form in readonly mode
-    await getService("action").doAction(44);
-    expect(".o_form_view .o_form_readonly").toHaveCount(1, {
-        message: "should display the form view in readonly mode",
-    });
-    expect.verifySteps([
-        "/web/webclient/translations",
-        "/web/webclient/load_menus",
-        "/web/action/load",
-        "get_views",
-        "web_read",
-        "/web/action/load",
-        "get_views",
-        "web_read",
-    ]);
-});
-
 test.tags("desktop")("save current search", async () => {
     expect.assertions(4);
 

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -378,9 +378,6 @@ class IrActionsAct_Window(models.Model):
         return super()._get_readable_fields() | {
             "context", "mobile_view_mode", "domain", "filter", "groups_id", "limit",
             "res_id", "res_model", "search_view_id", "target", "view_id", "view_mode", "views", "embedded_action_ids",
-            # `flags` is not a real field of ir.actions.act_window but is used
-            # to give the parameters to generate the action
-            "flags",
             # this is used by frontend, with the document layout wizard before send and print
             "close_on_report_download",
         }


### PR DESCRIPTION
This commit removes the action flags parameter because its current usecases have no point: the stock_package_level form view has edit="false" and the list usecase is pointless since the view ends up in edit mode by default. Since flags.mode was the only remaining flag, we remove the feature.

task-4365034