### PR TITLE
[FIX] analytic: enhance message for base analytic plan

### DIFF
--- a/addons/analytic/i18n/analytic.pot
+++ b/addons/analytic/i18n/analytic.pot
@@ -884,6 +884,13 @@ msgstr ""
 
 #. module: analytic
 #. odoo-python
+#: code:addons/analytic/models/analytic_plan.py:0
+#, python-format
+msgid "You cannot add a parent to the base plan '%s'"
+msgstr ""
+
+#. module: analytic
+#. odoo-python
 #: code:addons/analytic/models/analytic_distribution_model.py:0
 #, python-format
 msgid ""

--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -174,6 +174,12 @@ class AccountAnalyticPlan(models.Model):
         for plan in self:
             plan.children_count = len(plan.children_ids)
 
+    @api.onchange('parent_id')
+    def _onchange_parent_id(self):
+        project_plan, __ = self._get_all_plans()
+        if self._origin.id == project_plan.id:
+            raise UserError(_("You cannot add a parent to the base plan '%s'", project_plan.name))
+
     def action_view_analytical_accounts(self):
         result = {
             "type": "ir.actions.act_window",


### PR DESCRIPTION
Steps to reproduce:
- Try to add a parent to the base plan "Projects"

Issue:
Unclear error message

Cause:
This is a master data and the constraint raised an unclear message
"Invalid Operation
This column contains module data and cannot be removed!"

https://github.com/odoo/odoo/blob/1621f12e90b5903d1132875db7b0d94fa68bc642/odoo/addons/base/models/ir_model.py#L857-L859

Solution:
We specify a more user-friendly message during the onchange

opw-4327913