### PR TITLE
[FIX] website: test_04_website_navbar_menu tour

### DIFF
--- a/addons/website/static/tests/tours/website_navbar_menu.js
+++ b/addons/website/static/tests/tours/website_navbar_menu.js
@@ -6,13 +6,23 @@ registry.category("web_tour.tours").add("website_navbar_menu", {
     test: true,
     url: "/",
     steps: () => [
-    {
-        content: "Ensure menus are in DOM",
-        trigger: '.top_menu .nav-item a:contains("Test Tour Menu")',
-        run: function () {}, // it's a check
-    }, {
-        content: "Ensure menus loading is done (so they are actually visible)",
-        trigger: 'body:not(:has(.o_menu_loading))',
-        run: function () {}, // it's a check
-    }
-]});
+        {
+            content: "Ensure menus are in DOM",
+            trigger: '.top_menu .nav-item a:contains("Test Tour Menu")',
+            run: function () {}, // it's a check
+        },
+        {
+            content: "Ensure menus loading is done (so they are actually visible)",
+            trigger: "body:not(:has(.o_menu_loading))",
+            run: function () {}, // it's a check
+        },
+        {
+            trigger: `.o_main_nav a[role="menuitem"]:contains(test tour menu)`,
+            run: "click",
+        },
+        {
+            trigger: `main:contains(We couldn't find the page you're looking for!)`,
+            run: function () {}, // it's a check
+        },
+    ],
+});


### PR DESCRIPTION
In this commit, we fix the Uncaught (in promise)Event error in this tour by adding few additionnal steps to ensure every Promise is resumed before to close browser.

runbot_error_id~70404

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
