### PR TITLE
[IMP] website: Add a new scrolling mode to the carousel snippet

### DIFF
--- a/addons/website/static/src/interactions/carousel/carousel_slider.edit.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.edit.js
@@ -4,7 +4,10 @@ import { registry } from "@web/core/registry";
 const CarouselSliderEdit = I => class extends I {
     dynamicContent = {
         ...this.dynamicContent,
-        _root: { "t-on-content_changed": this.onContentChanged },
+        _root: {
+            ...this.dynamicContent._root,
+            "t-on-content_changed": this.onContentChanged,
+        },
     };
     // Pause carousel in edit mode.
     carouselOptions = { ride: false, pause: true };

--- a/addons/website/static/src/interactions/carousel/carousel_slider.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.js
@@ -4,6 +4,10 @@ import { registry } from "@web/core/registry";
 export class CarouselSlider extends Interaction {
     static selector = ".carousel";
     dynamicContent = {
+        _root: {
+            "t-on-slide.bs.carousel": this.onSlideCarousel,
+            "t-on-slid.bs.carousel": this.onSlidCarousel,
+        },
         "img": {
             "t-on-load": this.computeMaxHeight,
         },
@@ -27,6 +31,26 @@ export class CarouselSlider extends Interaction {
         this.updateContent();
         const carouselBS = window.Carousel.getOrCreateInstance(this.el, this.carouselOptions);
         this.registerCleanup(() => carouselBS.dispose());
+
+        this.carouselInnerEl = this.el.querySelector(".carousel-inner");
+
+        const itemWidth = getComputedStyle(this.el).getPropertyValue("--o-carousel-item-width-percentage");
+        const itemsPerSlide = itemWidth ? Math.round(100 / parseFloat(itemWidth)) : 1;
+        this.options = {
+            scrollMode: this.el.classList.contains('o_carousel_multi_items') ? 'single' : 'all',
+            itemsPerSlide: itemsPerSlide,
+        };
+
+        // Preload first items only when carousel is on screen
+        const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    this.loadItemsToAppear();
+                    observer.unobserve(this.el);
+                }
+            });
+        });
+        observer.observe(this.el);
     }
 
     computeMaxHeight() {
@@ -39,6 +63,113 @@ export class CarouselSlider extends Interaction {
                 this.maxHeight = height;
             }
             itemEl.classList.toggle("active", isActive);
+        }
+    }
+
+    /**
+     * Handles the 'slide' event of the carousel. Called *before* a slide
+     * transition.
+     *
+     * @param {Event} ev The Bootstrap Carousel slide event.
+     */
+    onSlideCarousel(ev) {
+        const imageEls = [...this.carouselInnerEl.querySelectorAll("img")];
+        const isLoading = imageEls.some(el => el.loading !== "lazy" && !el.complete);
+        if (isLoading) {
+            // If images are loading, prevent the slide transition. It will
+            // slide once the next images are loaded.
+            ev.preventDefault();
+            return;
+        }
+        if (this.options.scrollMode === "single") {
+            this.onSlideSingleScroll(ev);
+        }
+    }
+
+    /**
+     * Handles the 'slid' event of the carousel. Called *after* a slide
+     * transition.
+     *
+     * @param {Event} ev The Bootstrap Carousel slid event.
+     */
+    onSlidCarousel(ev) {
+        if (this.options.scrollMode === "single") {
+            this.onSlidSingleScroll(ev);
+        }
+        this.loadItemsToAppear(); // Preload future items after a slide
+    }
+
+    /**
+     * Manages multi-items single-scroll behavior during the 'slide' event.
+     * Prepares the DOM for smooth transitions by moving elements.
+     *
+     * @param {Event} ev The Bootstrap Carousel slide event.
+     */
+    onSlideSingleScroll(ev) {
+        // We need to keep the active element at the beginning of the carousel-items elements
+        // This allows to have a smooth transition when the carousel is sliding
+        if (ev.direction === "right") {
+            const carouselItemsEls = Array.from(this.carouselInnerEl.querySelectorAll(".carousel-item"));
+            this.carouselInnerEl.prepend(carouselItemsEls.pop());
+        }
+    }
+
+    /**
+     * Manages single-item scroll behavior during the 'slid' event.
+     * Completes the DOM manipulation started in `onSlideSingleScroll`.
+     *
+     * @param {Event} ev The Bootstrap Carousel slid event.
+     */
+    onSlidSingleScroll(ev) {
+        // As for the onSlideSingleScroll method, we need to keep the active
+        // element at the beginning of the carousel-items list in the DOM. So
+        // when animation is done, we move the first item (which is not active
+        // anymore) to the end.
+        if (ev.direction === "left") {
+            const carouselItemsEls = this.carouselInnerEl.querySelectorAll(".carousel-item");
+            this.carouselInnerEl.appendChild(carouselItemsEls[0]);
+        }
+    }
+
+    /**
+     * Loads images of the carousel-item necessary for both 'prev' and 'next'
+     * animations. Loads images for items that are about to become visible.
+     *
+     * @param {number} [nbItemsToLoad=1] The number of items to preload on each side.
+     */
+    loadItemsToAppear(nbItemsToLoad = 1) {
+        const itemEls = Array.from(this.carouselInnerEl.children);
+        const index = itemEls.findIndex(el => el.classList.contains("active"));
+        const activeItemIndex = index >= 0 ? index : 0;
+
+        // Load "Next" items: nbItemsToLoad items after the active element
+        const nbItemElsOnScreen = this.options.scrollMode === "single" ? this.options.itemsPerSlide + 1 : 1;
+        const nextEndIndex = Math.min(activeItemIndex + nbItemElsOnScreen + nbItemsToLoad + 1, itemEls.length);
+        const nextItemElsToLoad = itemEls.slice(activeItemIndex, nextEndIndex);
+
+        // load "Prev" items : nbItemsToLoad items before the active element (circular wrapping)
+        // if currentIndex is 0, then the nbItemsToLoad items are the last elements of the carousel
+        let prevItemElsToLoad = [];
+        if (activeItemIndex - nbItemsToLoad < 0) {
+            const wrapAmount = Math.abs(activeItemIndex - nbItemsToLoad);
+            prevItemElsToLoad = itemEls.slice(itemEls.length - wrapAmount, itemEls.length).reverse().concat(itemEls.slice(0, activeItemIndex).reverse());
+        } else {
+            prevItemElsToLoad = itemEls.slice(Math.max(0, activeItemIndex - nbItemsToLoad), activeItemIndex).reverse();
+        }
+
+        // Set the `loading` attribute of lazy-loaded images to `eager` for the
+        // given carousel items. This forces the browser to load the images
+        // immediately.
+        const itemsToLoad = nextItemElsToLoad.concat(prevItemElsToLoad);
+        for (let carouselItemEl of itemsToLoad) {
+            const imageEls = carouselItemEl.querySelectorAll("img[loading='lazy']");
+            for (const imageEl of imageEls) {
+                // Note that we remove the attribute with the goal of forcing it
+                // to the "eager" value. Removing the attribute is better so
+                // that the attribute is not saved as eager in edit mode (the
+                // lazy value is auto added on page rendering).
+                imageEl.removeAttribute("loading");
+            }
         }
     }
 }

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1260,7 +1260,6 @@ $-o-carousel-controllers-size: var(--CarouselControllers-size, #{map-get($spacer
     }
 }
 
-
 .carousel .container {
     .carousel-img img {
         max-height: 95%;
@@ -1325,6 +1324,52 @@ $-o-carousel-controllers-size: var(--CarouselControllers-size, #{map-get($spacer
         }
         > .carousel-image {
             display: none !important;
+        }
+    }
+}
+
+// Multiple visible items configuration for carousels
+.carousel.o_carousel_multi_items {
+    --o-carousel-item-width-percentage: 25%;
+
+    @include media-breakpoint-up(md) {
+        .carousel-inner {
+            // Display the carousel items in a row
+            display: flex;
+            flex-wrap: nowrap;
+
+            // Slide right animation
+            .carousel-item.active,
+            .carousel-item-end:not(.active),
+            .carousel-item-prev:not(.active) {
+                &, ~ .carousel-item {
+                    display: block;
+                    flex: 0 0 var(--o-carousel-item-width-percentage);
+                    margin-right: 0;
+                }
+            }
+            .active.carousel-item-end + .carousel-item-prev.carousel-item-end,
+            .carousel-item-prev.carousel-item-end ~ .carousel-item {
+                right: var(--o-carousel-item-width-percentage);
+                transform: translateX(100%);
+                display: block;
+                margin-right: 0;
+            }
+
+            // Slide left animation
+            .carousel-item-start.active,
+            .carousel-item-start:not(.active),
+            .carousel-item-start:not(.active) ~ .carousel-item {
+                transform: translateX(-100%);
+            }
+            .carousel-item.active:not(.carousel-item-start):not(.carousel-item-end),
+            .carousel-item.active:not(.carousel-item-start):not(.carousel-item-end) ~ .carousel-item {
+                transition: none;
+                margin-right: initial;
+            }
+            .carousel-item-next:not(.carousel-item-start) {
+                transform: translateX(0%);
+            }
         }
     }
 }

--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.scss
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.scss
@@ -9,3 +9,7 @@
     }
   }
 }
+
+.s_dynamic_snippet_title_aside + .s_dynamic_snippet_content {
+    width: 75%;
+}

--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.xml
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.xml
@@ -10,27 +10,28 @@
             <span class="visually-hidden">Next</span>
         </a>
     </t>
-    <t t-name="website.s_dynamic_snippet.carousel">
-        <div t-att-id="unique_id" class="carousel slide" t-att-data-bs-interval="interval" data-bs-ride="carousel">
+    <t t-name="website.s_dynamic_snippet.carousel.base">
+        <div t-att-id="unique_id" t-attf-class="carousel slide #{extraCarouselClass || ''}"
+             t-att-style="extraCarouselStyle"
+             t-att-data-bs-interval="interval" data-bs-ride="carousel">
             <!-- Content -->
-            <t t-set="rowSize" t-value="chunkSize" />
             <t t-set="slideSize" t-value="rowSize * rowPerSlide" />
-            <t t-set="colClass" t-value="'d-flex flex-grow-0 flex-shrink-0 col-' + Math.trunc(12 / rowSize).toString()"/>
             <t t-set="slideIndexGenerator" t-value="Array.from(Array(Math.ceil(data.length/slideSize)).keys())"/>
             <t t-set="rowIndexGenerator" t-value="Array.from(Array(rowPerSlide).keys())"/>
             <t t-set="colIndexGenerator" t-value="Array.from(Array(rowSize).keys())"/>
-            <div class="carousel-inner row w-100 mx-auto" role="listbox" aria-label="Carousel">
+            <div t-attf-class="carousel-inner w-100 mx-auto #{extraInnerClass || ''}" role="listbox"
+                 aria-label="Carousel">
                 <t t-foreach="slideIndexGenerator" t-as="slideIndex" t-key="slideIndex_index">
                     <t t-set="slideOffset" t-value="slideIndex * slideSize"/>
-                    <div t-attf-class="carousel-item #{extraClasses} #{slideIndex_first ? 'active' : ''}" role="option">
+                    <div t-attf-class="carousel-item #{extraClasses || ''} #{slideIndex_first ? 'active' : ''}" role="option">
                         <t t-foreach="rowIndexGenerator" t-as="rowIndex" t-key="rowIndex_index">
                             <t t-set="rowOffset" t-value="slideOffset + (rowIndex * rowSize)"/>
                             <t t-if="rowOffset &lt; data.length">
-                                <div class="s_dynamic_snippet_row row g-3">
+                                <div t-attf-class="s_dynamic_snippet_row row g-3 #{extraRowClass || ''}">
                                     <t t-foreach="colIndexGenerator" t-as="colIndex" t-key="colIndex_index">
                                         <t t-set="itemIndex" t-value="rowOffset + colIndex"/>
                                         <t t-if="itemIndex &lt; data.length">
-                                            <div t-attf-class="#{colClass}">
+                                            <div t-attf-class="#{colClass || ''}">
                                                 <t t-out="data[itemIndex]"/>
                                             </div>
                                         </t>
@@ -42,7 +43,7 @@
                 </t>
             </div>
             <!-- Controls -->
-            <t t-if='slideIndexGenerator.length > 1'>
+            <t t-if='slideIndexGenerator.length > minControlValue'>
                 <t t-if="arrowPosition === 'bottom'">
                     <div class="s_dynamic_snippet_arrow_bottom px-3 px-md-0 pt-2 d-flex justify-content-between">
                         <t t-call="website.s_dynamic_snippet.carousel.arrows">
@@ -57,5 +58,30 @@
                 </t>
             </t>
         </div>
+    </t>
+    <t t-name="website.s_dynamic_snippet.carousel.page_scroll">
+        <t t-call="website.s_dynamic_snippet.carousel.base">
+            <t t-set="rowSize" t-value="chunkSize"/>
+            <t t-set="extraInnerClass" t-value="'row'"/>
+            <t t-set="colClass"
+               t-value="'d-flex flex-grow-0 flex-shrink-0 col-' + Math.trunc(12 / rowSize).toString()"/>
+            <t t-set="minControlValue" t-value="1"/>
+        </t>
+    </t>
+    <t t-name="website.s_dynamic_snippet.carousel.single_scroll">
+        <t t-call="website.s_dynamic_snippet.carousel.base">
+            <t t-set="rowSize" t-value="1"/>
+            <t t-set="extraCarouselClass" t-value="'o_carousel_multi_items'"/>
+            <t t-set="extraCarouselStyle"
+               t-value="'--o-carousel-item-width-percentage: ' + (100.0 / chunkSize).toFixed(2) + '%;'"/>
+            <t t-set="extraRowClass" t-value="'mx-0'"/>
+            <t t-set="colClass" t-value="'d-flex flex-grow-1 flex-shrink-0'"/>
+            <t t-set="minControlValue" t-value="chunkSize"/>
+        </t>
+    </t>
+    <t t-name="website.s_dynamic_snippet.carousel">
+        <t t-if="scrollMode === 'single'"
+           t-call="website.s_dynamic_snippet.carousel.single_scroll"/>
+        <t t-else="" t-call="website.s_dynamic_snippet.carousel.page_scroll"/>
     </t>
 </templates>

--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/dynamic_snippet_carousel.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/dynamic_snippet_carousel.js
@@ -12,12 +12,14 @@ export class DynamicSnippetCarousel extends DynamicSnippet {
     }
 
     getQWebRenderOptions() {
+        const scrollMode = this.el.classList.contains('o_carousel_multi_items') ? 'single' : 'all';
         return Object.assign(
             super.getQWebRenderOptions(...arguments),
             {
                 interval: parseInt(this.el.dataset.carouselInterval),
                 rowPerSlide: parseInt(uiUtils.isSmall() ? 1 : this.el.dataset.rowPerSlide || 1),
                 arrowPosition: this.el.dataset.arrowPosition || "",
+                scrollMode: scrollMode,
             },
         );
     }

--- a/addons/website/views/snippets/s_dynamic_snippet_carousel.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet_carousel.xml
@@ -13,6 +13,10 @@
                   data-select-data-attribute="1s" data-name="speed_opt" data-attribute-name="carouselInterval" data-no-preview="true"
                   data-unit="s" data-save-unit="ms" data-step="0.1"/>
             <t t-out="0"/>
+            <we-button-group string="Scrolling Mode" data-no-preview="true">
+                <we-button data-select-class="">All</we-button>
+                <we-button data-select-class="o_carousel_multi_items">Single</we-button>
+            </we-button-group>
         </t>
     </template>
     <template id="s_dynamic_snippet_carousel_options" inherit_id="website.snippet_options">


### PR DESCRIPTION
This PR aims at adding a new scrolling mode to the product carousel. It's done by creating a new custom class that alters the default Bootstrap carousel to enable a single-item scroll, rather than the default
multi-item (page) scroll.
While there are other potential ways to achieve a single scroll carousel, we opted to stick with the original Bootstrap carousel structure and modify its behavior minimally just by adding a custom class (inevitably the templates also had to be modified to fit with a single item per slide design, for single scroll).
By doing this, we ensure compatibility with the default `.carousel` class and maintain consistency with Bootstrap's built-in design patterns.

Also it adds a new option for the cycle of the carousel, meaning that the carousel should come back to the first slide after reaching the last one or prevent the next scroll allowing only to come to previous items. 

task-4309599
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
