### PR TITLE
[FIX] tools: float_round

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6446,6 +6446,15 @@ class BaseModel(metaclass=MetaModel):
                         result[name] = []
                         continue
 
+                    if name == 'product_uom_qty':
+                        print("####### other.get({}) self[{}]".format(other.get(name), self[name]))
+                        print("###########################")
+                        '''
+                            The next line will compare two floats values using the '==' operator.
+                            Should we use float_expr instead? This results in a error, because the value
+                            stored in the database is "434.40" and the value computed by the "fetch" method is
+                            "434.4000000003".
+                        '''
                     if not force and other.get(name) == self[name]:
                         continue
                     if field.type not in ('one2many', 'many2many'):

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -260,6 +260,32 @@ if __name__ == "__main__":
             errors += 1
             print('###!!! Rounding error: got %s , expected %s' % (result, expected))
 
+    # Special case
+    def special_try_round():
+        amount = 14.48 * 30 # 434.40000000000003
+        expected_round = 434.40
+
+        global count, errors; count += 1
+        rounded = float_round(amount, precision_digits=2)
+        # expected: rounded = 434.40, got: rounded = 434.40000000000003. No rounding was applied
+        mantissa = rounded - expected_round
+
+        result = format(mantissa, "e")
+        expected = format(0.0, "e")
+
+        if result != expected:
+            errors += 1
+            print('###!!! Rounding error: got %s , expected %s' % (result, expected))
+
+        mantissa = rounded - amount
+        result = format(mantissa, "e")
+
+        if result == expected:
+            errors += 1
+            print('###!!! Rounding error: No rounding was applied. result(%s) == amount(%s).' % (result, expected))
+
+    special_try_round()
+
     # Extended float range test, inspired by Cloves Almeida's test on bug #882036.
     fractions = [.0, .015, .01499, .675, .67499, .4555, .4555, .45555]
     expecteds = ['.00', '.02', '.01', '.68', '.67', '.46', '.456', '.4556']


### PR DESCRIPTION
Steps to Reproduce

* Install sales and stock modules
* Enable product packaging in the settings tab
* Create a product with packaging
* Add a packaging line with a quantity of 14.48
* Go to the sales app
* Create a quotation and add the newly created product as an order line.
* Change the packaging quantity to 30
* Change the unit price to 2.0
* Save the quotation
* Go to the (other info) tab
* Change the delivery date and save it.

Current behavior

The unit price is unexpectedly changed.

Expected behavior

The unit price should not be changed

Reason

This is a rather complicated scenario. However, the core issue comes from the 43440 * 0.01 multiplication, which results in 434.400000000000003. This small difference affects the float_round method, causing incorrect rounding. If we change the packaging quantity to 20.0, for example, the issue would not occur. With this difference in value, the system detects a change and triggers the onchange method, cascading into other methods, resulting in the issue described above.

Testing

This commit is a test, should not be merged. Just to follow and trace the way from the issue starting until in how it is finished.

opw-4285889

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
