### PR TITLE
[FIX] product: prevent deleting Saleable product category

### DIFF
--- a/addons/product/models/product_category.py
+++ b/addons/product/models/product_category.py
@@ -63,3 +63,6 @@ class ProductCategory(models.Model):
         expense_category = self.env.ref('product.cat_expense', raise_if_not_found=False)
         if expense_category and expense_category in self:
             raise UserError(_("You cannot delete the %s product category.", expense_category.name))
+        saleable_category = self.env.ref('product.product_category_1', raise_if_not_found=False)
+        if saleable_category and saleable_category in self:
+            raise UserError(_("You cannot delete the %s product category.", saleable_category.name))


### PR DESCRIPTION
Currently a parse error would arises if the user deletes the saleable product category and try to install POS

To reproduce this issue

1) Install Sale Management without a demo data
2) Delete the Saleable product category
3) Try to install POS

Error:-
```
ParseError: while parsing /home/odoo/src/odoo/18.0/addons/point_of_sale/data/point_of_sale_data.xml:21, somewhere inside
<record id="product_category_pos" model="product.category">
            <field name="parent_id" ref="product.product_category_1"/>
            <field name="name">PoS</field>
        </record>

```

This error is occurring because the user deleted the saleable product category, which leads to the above traceback as the saleable product category is referenced at multiple places to create master data.

https://github.com/odoo/odoo/blob/51296055790f8c6f01dfbbc82ca340756c54cdb3/addons/point_of_sale/data/point_of_sale_data.xml#L16

We can resolve this issue by preventing the user to delete the saleable product category.

sentry-6026143114

