### PR TITLE
[FIX] product_expiry: set expiration date when generating or importing lot/sn

### DIFF
--- a/addons/product_expiry/__manifest__.py
+++ b/addons/product_expiry/__manifest__.py
@@ -29,6 +29,11 @@ Also implements the removal strategy First Expiry First Out (FEFO) widely used, 
              'data/product_expiry_data.xml',
             ],
     'post_init_hook': '_enable_tracking_numbers',
+    'assets': {
+        'web.assets_tests': [
+            'product_expiry/static/tests/tours/*.js',
+        ],
+    },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/addons/product_expiry/static/tests/tours/stock_picking_tour.js
+++ b/addons/product_expiry/static/tests/tours/stock_picking_tour.js
@@ -1,0 +1,45 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add('test_generate_serial_with_expiration', {
+    steps: () => [
+        {
+            trigger: "button:contains('Details')",
+            run: "click",
+        },
+        {
+            trigger: '.o_widget_generate_serials > button',
+            run: "click",
+        },
+        {
+            trigger: ".modal .btn-primary:contains('New')",
+            run: "click",
+        },
+        {
+            trigger: ".modal .btn-primary:contains('Generate')",
+            run: "click",
+        },
+        // Check that the expiration date is now set after generating Serials/Lots.
+        {
+            trigger: "td.o_field_cell[name=expiration_date]",
+            run: () => {
+                const exp_dates = document.querySelectorAll("td.o_field_cell[name=expiration_date]");
+                for (const exp_date of exp_dates) {
+                    if (exp_date.innerText.trim() !== "06/03/2025 00:00") {
+                        throw new Error("Expiration date should be 06/03/2025.");
+                    }
+                }
+            }
+        },
+        {
+            trigger: ".modal button:contains(save)",
+            run: "click",
+        },
+        {
+            trigger: "button.o_form_button_save",
+            run: "click",
+        },
+        {
+            trigger: ".o_form_saved",
+        },
+    ],
+});


### PR DESCRIPTION
Issue:
------------------------------------------
In receipt operation, when user open detailed operations wizard and generate or
import lot/sn, the expiration-date is missing in move line.

How to reproduce:
------------------------------------------
1.Install product_expiry.
2.Create product with inventory tracking by lot/sn and also set
  the expiration time.
3.Create reciept for that product.
4.Generate or Import lot/sn in detailed operations wizard.
5.Now you can see that the expiration-date is not set for the generated or
  imported lot/sn.

Cause of the issue:
------------------------------------------
In `action_generate_lot_line_vals` method the `expiration_date` is not passed even
if product has `use_expiration_date` set.

Solution:
------------------------------------------
In `action_generate_lot_line_vals` method now the `expiration_date` is correctly
passed if product has `use_expiration_date` set.
So the expiration-date is now correctly displayed in the generated move lines.

Task ID: [4281345](https://www.odoo.com/odoo/project/966/tasks/4281345)