### PR TITLE
[FIX] spreadsheet: Remove data validation in production

### DIFF
--- a/addons/spreadsheet/models/spreadsheet_mixin.py
+++ b/addons/spreadsheet/models/spreadsheet_mixin.py
@@ -8,7 +8,7 @@ import re
 
 from collections import defaultdict
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, _, tools
 from odoo.exceptions import ValidationError, MissingError
 
 from odoo.addons.spreadsheet.utils.validate_data import fields_in_spreadsheet, menus_xml_ids_in_spreadsheet
@@ -28,6 +28,8 @@ class SpreadsheetMixin(models.AbstractModel):
 
     @api.constrains("spreadsheet_binary_data")
     def _check_spreadsheet_data(self):
+        if not(tools.config['test_enable'] or tools.config['test_file']):
+            return None
         for spreadsheet in self.filtered("spreadsheet_binary_data"):
             try:
                 data = json.loads(base64.b64decode(spreadsheet.spreadsheet_binary_data).decode())


### PR DESCRIPTION
Following #184846, the data validation is no longer necessary in a production context.
Moreover, it currently limits some capacities for the user to user the history of the spreadsheets.
Eg:

- Create a new field with studio
- Add a datasouce in a spreadsheet which relies on that field
- make a bunch of revision
- Delete the field you created
- Go back to the spreadsheet
- Open the version history and try to "make a copy" of some recent revision

=> it will throw as you try to create a spreadsheet with invalid fields

However, the data validation still make sense to alert developpers to adapts dashboards
when they change the schema of some tables. This revision deactivates the data validation
on production which ensures that the last point is still respected while developping
(will be detected by runbot tests).

Task: 4363803

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
