### PR TITLE
[FIX] website: fix `s_numbers_charts` title styling

### DIFF
--- a/addons/website/views/snippets/s_numbers_charts.xml
+++ b/addons/website/views/snippets/s_numbers_charts.xml
@@ -42,7 +42,7 @@
                     </svg>
                     <!-- End of placeholder -->
                     <p><br/></p>
-                    <p class="display-1" style="text-align: center;">75%</p>
+                    <p class="display-1-fs" style="text-align: center;">75%</p>
                     <p class="o_small text-600" style="text-align: center;">75% of clients use the service for over a decade consistently.<br/>This showcases remarkable loyalty and satisfaction with the quality provided.</p>
                 </div>
             </div>


### PR DESCRIPTION
This commit fixes an implementation issue that was not reproducible with the editor (`<p class="display-1">`).

task-4223179
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
