### PR TITLE
[FIX] project: wrong context format for stat buttons in project's right side panel

### DIFF
--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.js
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.js
@@ -183,7 +183,7 @@ export class ProjectRightSidePanel extends Component {
     _getStatButtonRecordParams() {
         return {
             resId: this.projectId,
-            context: JSON.stringify(this.context),
+            context: this.context,
             resModel: 'project.project',
         };
     }


### PR DESCRIPTION
The stringified context is hardly readable and error-prone. After this commit, we keep it like it is given, as a regular JSON object.

version-18.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
