### PR TITLE
[FIX] point_of_sale: do not kill ngrok on odoo restart

### DIFF
--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -298,7 +298,7 @@ class IotBoxOwlHomePage(Home):
     @http.route('/hw_posbox_homepage/enable_ngrok', auth="none", type="json", methods=['POST'], cors='*')
     def enable_remote_connection(self, auth_token):
         if subprocess.call(['pgrep', 'ngrok']) == 1:
-            subprocess.Popen(['ngrok', 'tcp', '--authtoken', auth_token, '--log', '/tmp/ngrok.log', '22'])
+            subprocess.Popen(['sudo', 'systemd-run', 'ngrok', 'tcp', '--authtoken', auth_token, '--log', '/tmp/ngrok.log', '22'])
 
         return {
             'status': 'success',


### PR DESCRIPTION
In IoT image 24.10, the Odoo service was changed
to a systemd service (rather than init). A side
effect of this change is that all subprocesses
are killed when the service is stopped. This
causes the `ngrok` to be killed while remote
debugging if you restart the Odoo service.

This PR changes `ngrok` to run as a service, which
is then started by Odoo. This means it now keeps
running when Odoo is stopped.

task-4363825

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
