### PR TITLE
[FIX] mail: inline style in technical menu

### DIFF
--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -40,9 +40,7 @@
                         </group>
                         <notebook>
                             <page string="Body" name="body">
-                            <field name="body_html" widget="html"
-                                   options="{'sandboxedPreview': true}"
-                                   attrs="{'readonly': [('state', 'not in', ['outgoing', 'exception'])]}"/>
+                                <field name="body_content"/>
                             </page>
                             <page string="Advanced" name="advanced" groups="base.group_no_one">
                                 <group>

--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -58,7 +58,7 @@ class SnailmailLetter(models.Model):
              "If the letter is correctly sent, the status goes in 'Sent',\n"
              "If not, it will got in state 'Error' and the error message will be displayed in the field 'Error Message'.")
     error_code = fields.Selection([(err_code, err_code) for err_code in ERROR_CODES], string="Error")
-    info_msg = fields.Char('Information')
+    info_msg = fields.Html('Information')
     display_name = fields.Char('Display Name', compute="_compute_display_name")
 
     reference = fields.Char(string='Related Record', compute='_compute_reference', readonly=True, store=False)


### PR DESCRIPTION
body_content is a better representation of what the email will actually
look like when sent.

task-4333657

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
