### PR TITLE
[FIX] account: prevent error when editing information in portal

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -257,7 +257,7 @@
                     You can choose how you want us to send your invoices, and with which electronic format.
                 </small>
             </div>
-            <div class="row m-0 p-0" t-if="len(invoice_sending_methods) > 1">
+            <div class="row m-0 p-0" t-if="invoice_sending_methods and len(invoice_sending_methods) > 1">
                 <div class="col-xl-6">
                     <label class="col-form-label" for="invoice_sending_method">Receive invoices</label>
                     <select name="invoice_sending_method" class="form-select">


### PR DESCRIPTION
When there is no invoice sending method and the user tries to edit information
in the portal, a traceback will appear.

Traceback:
```
QWebException: Error while render the template
TypeError: object of type 'NoneType' has no len()
Node: <div class="row m-0 p-0" t-if="len(invoice_sending_methods) > 1"/>
```

https://github.com/odoo/odoo/blob/14ddd49c52f0030f7dbad7d4889f4edf1b74ae39/addons/account/views/account_portal_templates.xml#L260
When there is no invoice sending method, ``invoice_sending_methods`` will be None.
So, It will lead to the above traceback.

sentry-6015474981

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
