### PR TITLE
[IMP] base_import: show preview error on loading another sheet

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -512,7 +512,7 @@ class Base_ImportImport(models.TransientModel):
         for rowx, row in enumerate(sheet.rows, 1):
             values = []
             for colx, cell in enumerate(row, 1):
-                if cell.data_type is types.TYPE_ERROR:
+                if cell.data_type == types.TYPE_ERROR:
                     raise ValueError(
                         _("Invalid cell value at row %(row)s, column %(col)s: %(cell_value)s", row=rowx, col=colx, cell_value=cell.value)
                     )

--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -151,6 +151,9 @@ export class ImportAction extends Component {
             const { res, error } = result;
             if (!error && res.num_rows) {
                 this.state.numRows = res.num_rows;
+                this.state.previewError = undefined;
+            } else {
+                this.state.previewError = error;
             }
         }
         this.model.unblock();


### PR DESCRIPTION
Previously when we try to import a file with some '#NA' inside the second 
sheet of the file, It was not showing '#NA' preview error and leaves 
everything blank.

After this commit we will also get preview error on loading another sheet.

Task-4024315

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
