### PR TITLE
[IMP] website: adds new field type "Inline Checkbox" for website form

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -221,7 +221,7 @@ const FormEditor = options.Class.extend({
         if (["url", "email", "tel"].includes(field.type)) {
             params.field.inputType = field.type;
         }
-        if (["boolean", "selection", "binary"].includes(field.type)) {
+        if (["boolean", "selection", "binary", "inlinebool"].includes(field.type)) {
             params.field.isCheck = true;
         }
         if (field.type === "one2many" && field.relation !== "ir.attachment") {
@@ -342,6 +342,9 @@ const FieldEditor = FormEditor.extend({
      */
     _getLabelPosition: function () {
         const label = this.$target[0].querySelector('.s_website_form_label');
+        if (label.style.visibility === "hidden") {
+            return "none";
+        }
         if (this.$target[0].querySelector('.row:not(.s_website_form_multiple)')) {
             return label.classList.contains('text-end') ? 'right' : 'left';
         } else {

--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -106,6 +106,54 @@
         </t>
     </t>
 
+    <!-- Inline Boolean Field -->
+    <t t-name="website.form_field_inlinebool">
+        <div t-attf-class="s_website_form_field mb-3 #{field.formatInfo.col or 'col-12'} #{field.custom and 's_website_form_custom' or ''} #{(field.required and 's_website_form_required' or '') or (field.modelRequired and 's_website_form_model_required' or '')} #{field.hidden and 's_website_form_field_hidden' or ''} #{field.dnone and 's_website_form_dnone' or ''}"
+            t-att-data-type="field.type"
+            data-name="Field">
+            <div t-if="field.formatInfo.labelPosition != 'top'" class="row s_col_no_resize s_col_no_bgcolor">
+                <label t-attf-class="#{!field.isCheck and 'col-form-label' or ''} col-sm-auto s_website_form_label #{field.formatInfo.labelPosition == 'right' and 'text-end' or ''}" t-attf-style="width: #{field.formatInfo.labelWidth or '200px'}; #{field.formatInfo.labelPosition == 'none' and 'visibility: hidden' or ''}" t-att-for="field.id">
+                     <t t-call="website.form_label_content"/>
+                </label>
+                <div class="col-sm">
+                     <div class="form-check">
+                        <input
+                            type="checkbox"
+                            value="Yes"
+                            class="s_website_form_input form-check-input"
+                            t-att-name="field.name"
+                            t-att="{checked: field.value and 'checked' or None}"
+                            t-att-required="field.required || field.modelRequired || None"
+                            t-att-id="field.id"
+                        />
+                        <span t-if="default_description" class="s_website_form_field_description small form-text text-muted" contenteditable="true">
+                            <t t-esc="default_description"/>
+                        </span>
+                    </div>
+                </div>
+            </div>
+            <t t-else="">
+                <label t-attf-class="s_website_form_label" t-attf-style="width: #{field.formatInfo.labelWidth or '200px'}" t-att-for="field.id">
+                     <t t-call="website.form_label_content"/>
+                </label>
+                <div class="form-check">
+                    <input
+                        type="checkbox"
+                        value="Yes"
+                        class="s_website_form_input form-check-input"
+                        t-att-name="field.name"
+                        t-att="{checked: field.value and 'checked' or None}"
+                        t-att-required="field.required || field.modelRequired || None"
+                        t-att-id="field.id"
+                    />
+                    <span t-if="default_description" class="s_website_form_field_description small form-text text-muted" contenteditable="true">
+                        <t t-esc="default_description"/>
+                    </span>
+                </div>
+            </t>
+        </div>
+    </t>
+
     <!-- Email Field -->
     <t t-name="website.form_field_email">
         <t t-call="website.form_field_char"/>

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -153,6 +153,7 @@
             <we-select data-name="type_opt" string="Type" data-no-preview="true">
                 <we-title>Custom Field</we-title>
                 <we-button data-custom-field="char">Text</we-button>
+                <we-button data-custom-field="inlinebool">Inline Checkbox</we-button>
                 <we-button data-custom-field="text">Long Text</we-button>
                 <we-button data-custom-field="email">Email</we-button>
                 <we-button data-custom-field="tel">Telephone</we-button>


### PR DESCRIPTION
Specification:

- Introduce a new field type: ```Inline Checkbox```.
- Allow the field label to be optional, enabling users to
leave the label field blank maintaining alignment with
rest of the fields.
- Provide the option to add a description displayed next to
the <input type="checkbox" /> field.

After this PR:

- Added new field type "Inline Checkbox".
- On hiding label of the field checkbox maintains
alignment with rest of the field.
- Whenever we add description to this new "Inline Checkbox" field
description will be next to checkbox.


task-3922625

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
