### PR TITLE
[IMP] web: new eslint rule for arrow functions

### DIFF
--- a/addons/point_of_sale/static/src/app/components/accordion_item/accordion_item.js
+++ b/addons/point_of_sale/static/src/app/components/accordion_item/accordion_item.js
@@ -37,9 +37,10 @@ export class AccordionItem extends Component {
 
     calculateFullHeight() {
         const children = Array.from(this.content.el.getElementsByClassName("accordion-content"));
-        const fullHeight = children.reduce((accumulator, child) => {
-            return accumulator + Math.min(this.getHiddenHeight(child), 100);
-        }, 0);
+        const fullHeight = children.reduce(
+            (accumulator, child) => accumulator + Math.min(this.getHiddenHeight(child), 100),
+            0
+        );
         return fullHeight;
     }
 

--- a/addons/point_of_sale/static/src/app/components/navbar/proxy_status/proxy_status.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/proxy_status/proxy_status.js
@@ -41,9 +41,10 @@ export class ProxyStatus extends Component {
                     enabled: iface_electronic_scale,
                 },
             ];
-            const disconnectedDevices = devices.filter(({ enabled, driver }) => {
-                return enabled && !["connected", "connecting"].includes(driver?.status);
-            });
+            const disconnectedDevices = devices.filter(
+                ({ enabled, driver }) =>
+                    enabled && !["connected", "connecting"].includes(driver?.status)
+            );
             if (disconnectedDevices.length) {
                 return `${disconnectedDevices.map((d) => d.name).join(" & ")} ${_t("Offline")}`;
             }

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -658,9 +658,7 @@ export class PosOrderline extends Base {
 
     // FIXME all below should be removed
     getValidLots() {
-        return this.pack_lot_ids.filter((item) => {
-            return item.lot_name;
-        });
+        return this.pack_lot_ids.filter((item) => item.lot_name);
     }
     // FIXME what is the use of this ?
     updateSavedQuantity() {

--- a/addons/point_of_sale/static/src/app/models/utils/currency.js
+++ b/addons/point_of_sale/static/src/app/models/utils/currency.js
@@ -1,13 +1,10 @@
 import { formatMonetary } from "@web/views/fields/formatters";
 import { roundDecimals } from "@web/core/utils/numbers";
 
-export const formatCurrency = (value, currency, hasSymbol = true) => {
-    return formatMonetary(value, {
+export const formatCurrency = (value, currency, hasSymbol = true) =>
+    formatMonetary(value, {
         currencyId: currency.id,
         noSymbol: !hasSymbol,
     });
-};
 
-export const roundCurrency = (value, currency) => {
-    return roundDecimals(value, currency.decimal_places);
-};
+export const roundCurrency = (value, currency) => roundDecimals(value, currency.decimal_places);

--- a/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
+++ b/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
@@ -56,9 +56,7 @@ export default class IndexedDB {
             });
         });
 
-        return Promise.allSettled(promises).then((results) => {
-            return results;
-        });
+        return Promise.allSettled(promises).then((results) => results);
     }
     getNewTransaction(dbStore) {
         try {
@@ -113,15 +111,15 @@ export default class IndexedDB {
                 })
         );
 
-        return Promise.allSettled(promises).then((results) => {
-            return results.reduce((acc, result) => {
+        return Promise.allSettled(promises).then((results) =>
+            results.reduce((acc, result) => {
                 if (result.status === "fulfilled") {
                     return { ...acc, ...result.value };
                 } else {
                     return acc;
                 }
-            }, {});
-        });
+            }, {})
+        );
     }
 
     delete(storeName, uuids) {

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -330,8 +330,8 @@ export class TicketScreen extends Component {
             orders = fuzzyLookup(this.state.search.searchTerm, orders, repr);
         }
 
-        const sortOrders = (orders, ascending = false) => {
-            return orders.sort((a, b) => {
+        const sortOrders = (orders, ascending = false) =>
+            orders.sort((a, b) => {
                 const dateA = parseUTCString(a.date_order, "yyyy-MM-dd HH:mm:ss");
                 const dateB = parseUTCString(b.date_order, "yyyy-MM-dd HH:mm:ss");
 
@@ -343,7 +343,6 @@ export class TicketScreen extends Component {
                     return ascending ? nameA - nameB : nameB - nameA;
                 }
             });
-        };
 
         if (this.state.filter === "SYNCED") {
             return sortOrders(orders).slice(

--- a/addons/point_of_sale/static/src/app/services/contextual_utils_service.js
+++ b/addons/point_of_sale/static/src/app/services/contextual_utils_service.js
@@ -33,30 +33,21 @@ export const contextualUtilsService = {
             floatRegex = new RegExp(`^-?(?:\\d+)?(?:${escapedDecimalPoint}\\d*)?$`);
         }
 
-        const formatProductQty = (qty) => {
-            return formatFloat(qty, { digits: [true, productUoMDecimals] });
-        };
+        const formatProductQty = (qty) => formatFloat(qty, { digits: [true, productUoMDecimals] });
 
-        const formatCurrency = (value, hasSymbol = true) => {
-            return webFormatCurrency(value, res_currency.id, {
+        const formatCurrency = (value, hasSymbol = true) =>
+            webFormatCurrency(value, res_currency.id, {
                 noSymbol: !hasSymbol,
             });
-        };
-        const floatIsZero = (value) => {
-            return genericFloatIsZero(value, res_currency.decimal_places);
-        };
+        const floatIsZero = (value) => genericFloatIsZero(value, res_currency.decimal_places);
 
-        const roundCurrency = (value) => {
-            return roundDecimals(value, res_currency.decimal_places);
-        };
+        const roundCurrency = (value) => roundDecimals(value, res_currency.decimal_places);
 
-        const isValidFloat = (inputValue) => {
-            return ![decimalPoint, "-"].includes(inputValue) && floatRegex.test(inputValue);
-        };
+        const isValidFloat = (inputValue) =>
+            ![decimalPoint, "-"].includes(inputValue) && floatRegex.test(inputValue);
 
-        const parseValidFloat = (inputValue) => {
-            return isValidFloat(inputValue) ? parseFloat(inputValue) : 0;
-        };
+        const parseValidFloat = (inputValue) =>
+            isValidFloat(inputValue) ? parseFloat(inputValue) : 0;
 
         env.utils = {
             formatCurrency,

--- a/addons/point_of_sale/static/src/app/services/number_buffer_service.js
+++ b/addons/point_of_sale/static/src/app/services/number_buffer_service.js
@@ -231,9 +231,7 @@ class NumberBuffer extends EventBus {
      * @param {String} input valid input
      */
     _updateBuffer(input) {
-        const isEmpty = (val) => {
-            return val === "" || val === null;
-        };
+        const isEmpty = (val) => val === "" || val === null;
         if (input === undefined || input === null) {
             return;
         }

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -653,16 +653,14 @@ export class PosStore extends WithLazyGetterTrap {
                         this.models["product.template.attribute.value"].get(id),
                     ]),
                     custom_attribute_value_ids: Object.entries(payload.attribute_custom_values).map(
-                        ([id, cus]) => {
-                            return [
-                                "create",
-                                {
-                                    custom_product_template_attribute_value_id:
-                                        this.models["product.template.attribute.value"].get(id),
-                                    custom_value: cus,
-                                },
-                            ];
-                        }
+                        ([id, cus]) => [
+                            "create",
+                            {
+                                custom_product_template_attribute_value_id:
+                                    this.models["product.template.attribute.value"].get(id),
+                                custom_value: cus,
+                            },
+                        ]
                     ),
                     price_extra: values.price_extra + payload.price_extra,
                     qty: payload.qty || values.qty,
@@ -724,16 +722,14 @@ export class PosStore extends WithLazyGetterTrap {
                     ]),
                     custom_attribute_value_ids: Object.entries(
                         comboItem.attribute_custom_values
-                    ).map(([id, cus]) => {
-                        return [
-                            "create",
-                            {
-                                custom_product_template_attribute_value_id:
-                                    this.data.models["product.template.attribute.value"].get(id),
-                                custom_value: cus,
-                            },
-                        ];
-                    }),
+                    ).map(([id, cus]) => [
+                        "create",
+                        {
+                            custom_product_template_attribute_value_id:
+                                this.data.models["product.template.attribute.value"].get(id),
+                            custom_value: cus,
+                        },
+                    ]),
                 },
             ]);
         }
@@ -953,9 +949,9 @@ export class PosStore extends WithLazyGetterTrap {
         return !this.config.restrict_price_control || this.getCashier()._role == "manager";
     }
     createNewOrder(data = {}) {
-        const fiscalPosition = this.models["account.fiscal.position"].find((fp) => {
-            return fp.id === this.config.default_fiscal_position_id?.id;
-        });
+        const fiscalPosition = this.models["account.fiscal.position"].find(
+            (fp) => fp.id === this.config.default_fiscal_position_id?.id
+        );
 
         const order = this.models["pos.order"].create({
             session_id: this.session,

--- a/addons/point_of_sale/static/src/app/services/render_service.js
+++ b/addons/point_of_sale/static/src/app/services/render_service.js
@@ -54,9 +54,8 @@ const renderService = {
             await new Promise((r) => (resolver = r));
             return elem;
         };
-        const toCanvas = async (component, props, options) => {
-            return htmlToCanvas(await toHtml(component, props), options);
-        };
+        const toCanvas = async (component, props, options) =>
+            htmlToCanvas(await toHtml(component, props), options);
         const toJpeg = async (component, props, options) => {
             const canvas = await toCanvas(component, props, options);
             return canvas.toDataURL("image/jpeg").replace("data:image/jpeg;base64,", "");
@@ -99,13 +98,12 @@ export const htmlToCanvas = async (el, options) => {
     return await applyWhenMounted({
         el,
         container: document.querySelector(".render-container"),
-        callback: async (el) => {
-            return toCanvas(el, {
+        callback: async (el) =>
+            toCanvas(el, {
                 backgroundColor: "#ffffff",
                 height: Math.ceil(el.clientHeight),
                 width: Math.ceil(el.clientWidth),
                 pixelRatio: 1,
-            });
-        },
+            }),
     });
 };

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
@@ -39,21 +39,22 @@ export class PosKanbanRenderer extends KanbanRenderer {
         this.orm = useService("orm");
         this.action = useService("action");
         this.posState = useState(this.props.initialPosState);
-        this.loadScenario = useTrackedAsync(async ({ functionName, isRestaurant }) => {
-            return await this.callWithViewUpdate(async () => {
-                let isInstalledWithDemo = false;
-                if (isRestaurant && !this.posState.is_restaurant_installed) {
-                    const result = await this.orm.call("pos.config", "install_pos_restaurant");
-                    isInstalledWithDemo = result.installed_with_demo;
-                }
-                if (
-                    !isInstalledWithDemo ||
-                    (isInstalledWithDemo && !this.posState.is_main_company)
-                ) {
-                    await this.orm.call("pos.config", functionName);
-                }
-            });
-        });
+        this.loadScenario = useTrackedAsync(
+            async ({ functionName, isRestaurant }) =>
+                await this.callWithViewUpdate(async () => {
+                    let isInstalledWithDemo = false;
+                    if (isRestaurant && !this.posState.is_restaurant_installed) {
+                        const result = await this.orm.call("pos.config", "install_pos_restaurant");
+                        isInstalledWithDemo = result.installed_with_demo;
+                    }
+                    if (
+                        !isInstalledWithDemo ||
+                        (isInstalledWithDemo && !this.posState.is_main_company)
+                    ) {
+                        await this.orm.call("pos.config", functionName);
+                    }
+                })
+        );
 
         onWillRender(() => this.checkDisplayedResult());
         onWillStart(async () => {

--- a/addons/point_of_sale/static/src/lazy_getter.js
+++ b/addons/point_of_sale/static/src/lazy_getter.js
@@ -30,12 +30,7 @@ function getGetters(Class) {
             if (name.startsWith("__") && name.endsWith("__")) {
                 continue;
             }
-            getters.set(name, [
-                `__lazy_${name}`,
-                (obj) => {
-                    return func.call(obj);
-                },
-            ]);
+            getters.set(name, [`__lazy_${name}`, (obj) => func.call(obj)]);
         }
         classGetters.set(Class, getters);
     }

--- a/addons/pos_adyen/static/src/app/utils/payment/payment_adyen.js
+++ b/addons/pos_adyen/static/src/app/utils/payment/payment_adyen.js
@@ -118,9 +118,7 @@ export class PaymentAdyen extends PaymentInterface {
         var data = this._adyenPayData();
         var line = order.payment_ids.find((paymentLine) => paymentLine.uuid === uuid);
         line.setTerminalServiceId(this.most_recent_service_id);
-        return this._callAdyen(data).then((data) => {
-            return this._adyenHandleResponse(data);
-        });
+        return this._callAdyen(data).then((data) => this._adyenHandleResponse(data));
     }
 
     _adyenCancel(ignore_error) {
@@ -260,9 +258,9 @@ export class PaymentAdyen extends PaymentInterface {
         const payment_response = notification.SaleToPOIResponse.PaymentResponse;
         const payment_result = payment_response.PaymentResult;
 
-        const cashier_receipt = payment_response.PaymentReceipt.find((receipt) => {
-            return receipt.DocumentQualifier == "CashierReceipt";
-        });
+        const cashier_receipt = payment_response.PaymentReceipt.find(
+            (receipt) => receipt.DocumentQualifier == "CashierReceipt"
+        );
 
         if (cashier_receipt) {
             line.setCashierReceipt(
@@ -270,9 +268,9 @@ export class PaymentAdyen extends PaymentInterface {
             );
         }
 
-        const customer_receipt = payment_response.PaymentReceipt.find((receipt) => {
-            return receipt.DocumentQualifier == "CustomerReceipt";
-        });
+        const customer_receipt = payment_response.PaymentReceipt.find(
+            (receipt) => receipt.DocumentQualifier == "CustomerReceipt"
+        );
 
         if (customer_receipt) {
             line.setReceiptInfo(

--- a/addons/pos_event/static/src/app/models/data_service_options.js
+++ b/addons/pos_event/static/src/app/models/data_service_options.js
@@ -7,20 +7,14 @@ patch(DataServiceOptions.prototype, {
             ...super.databaseTable,
             "event.registration": {
                 key: "id",
-                condition: (record) => {
-                    return (
-                        !record.pos_order_line_id || record.pos_order_line_id?.order_id?.finalized
-                    );
-                },
+                condition: (record) =>
+                    !record.pos_order_line_id || record.pos_order_line_id?.order_id?.finalized,
             },
             "event.registration.answer": {
                 key: "id",
-                condition: (record) => {
-                    return (
-                        !record.registration_id ||
-                        record.registration_id?.pos_order_line_id?.order_id?.finalized
-                    );
-                },
+                condition: (record) =>
+                    !record.registration_id ||
+                    record.registration_id?.pos_order_line_id?.order_id?.finalized,
             },
         };
     },

--- a/addons/pos_hr/static/src/app/utils/select_cashier_mixin.js
+++ b/addons/pos_hr/static/src/app/utils/select_cashier_mixin.js
@@ -65,16 +65,13 @@ export function useCashierSelector({ exclusive, onScan } = { onScan: () => {}, e
             return;
         }
 
-        const prepareList = (employees) => {
-            return employees.map((employee) => {
-                return {
-                    id: employee.id,
-                    item: employee,
-                    label: employee.name,
-                    isSelected: false,
-                };
-            });
-        };
+        const prepareList = (employees) =>
+            employees.map((employee) => ({
+                id: employee.id,
+                item: employee,
+                label: employee.name,
+                isSelected: false,
+            }));
 
         const wrongPinNotification = () => {
             notification.add(_t("PIN not found"), {

--- a/addons/pos_loyalty/static/src/app/models/data_service_options.js
+++ b/addons/pos_loyalty/static/src/app/models/data_service_options.js
@@ -7,11 +7,10 @@ patch(DataServiceOptions.prototype, {
             ...super.databaseTable,
             "loyalty.card": {
                 key: "id",
-                condition: (record) => {
-                    return record["<-pos.order.line.coupon_id"].find(
+                condition: (record) =>
+                    record["<-pos.order.line.coupon_id"].find(
                         (l) => l.order_id?.finalized && typeof l.order_id.id === "number"
-                    );
-                },
+                    ),
             },
         };
     },

--- a/addons/pos_loyalty/static/src/app/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order.js
@@ -600,9 +600,9 @@ patch(PosOrder.prototype, {
                     // In this case we count the points per rule
                     if (rule.reward_point_mode === "unit") {
                         splitPoints.push(
-                            ...Array.apply(null, Array(totalProductQty)).map((_) => {
-                                return { points: rule.reward_point_amount };
-                            })
+                            ...Array.apply(null, Array(totalProductQty)).map((_) => ({
+                                points: rule.reward_point_amount,
+                            }))
                         );
                     } else if (rule.reward_point_mode === "money") {
                         for (const line of orderLines) {
@@ -711,19 +711,15 @@ patch(PosOrder.prototype, {
 
         const allCouponPrograms = Object.values(this.uiState.couponPointChanges)
             .filter((pe) => !excludedCouponIds.includes(pe.coupon_id))
-            .map((pe) => {
-                return {
-                    program_id: pe.program_id,
-                    coupon_id: pe.coupon_id,
-                };
-            })
+            .map((pe) => ({
+                program_id: pe.program_id,
+                coupon_id: pe.coupon_id,
+            }))
             .concat(
-                this._code_activated_coupon_ids.map((coupon) => {
-                    return {
-                        program_id: coupon.program_id.id,
-                        coupon_id: coupon.id,
-                    };
-                })
+                this._code_activated_coupon_ids.map((coupon) => ({
+                    program_id: coupon.program_id.id,
+                    coupon_id: coupon.id,
+                }))
             );
         const result = [];
         const totalWithTax = this.getTotalWithTax();
@@ -1442,13 +1438,12 @@ patch(PosOrder.prototype, {
     removeOrderline(lineToRemove) {
         if (lineToRemove.is_reward_line) {
             // Remove any line that is part of that same reward aswell.
-            const linesToRemove = this.getOrderlines().filter((line) => {
-                return (
+            const linesToRemove = this.getOrderlines().filter(
+                (line) =>
                     line.reward_id === lineToRemove.reward_id &&
                     line.coupon_id === lineToRemove.coupon_id &&
                     line.reward_identifier_code === lineToRemove.reward_identifier_code
-                );
-            });
+            );
             for (const line of linesToRemove) {
                 line.delete();
             }

--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -81,8 +81,8 @@ patch(PosStore.prototype, {
         if (order.finalized) {
             return;
         }
-        updateRewardsMutex.exec(() => {
-            return this.orderUpdateLoyaltyPrograms().then(async () => {
+        updateRewardsMutex.exec(() =>
+            this.orderUpdateLoyaltyPrograms().then(async () => {
                 // Try auto claiming rewards
                 const claimableRewards = order.getClaimableRewards(false, false, true);
                 let changed = false;
@@ -102,8 +102,8 @@ patch(PosStore.prototype, {
                     await this.orderUpdateLoyaltyPrograms();
                 }
                 order._updateRewardLines();
-            });
-        });
+            })
+        );
     },
     async couponForProgram(program) {
         const order = this.getOrder();
@@ -171,9 +171,9 @@ patch(PosStore.prototype, {
             if (pointsAdded.length < oldChanges.length) {
                 const removedIds = oldChanges.map((pe) => pe.coupon_id);
                 order.uiState.couponPointChanges = Object.fromEntries(
-                    Object.entries(order.uiState.couponPointChanges).filter(([k, pe]) => {
-                        return !removedIds.includes(pe.coupon_id);
-                    })
+                    Object.entries(order.uiState.couponPointChanges).filter(
+                        ([k, pe]) => !removedIds.includes(pe.coupon_id)
+                    )
                 );
             } else if (pointsAdded.length > oldChanges.length) {
                 const pointsCount = pointsAdded.reduce((acc, pointObj) => {
@@ -239,9 +239,10 @@ patch(PosStore.prototype, {
     },
     async activateCode(code) {
         const order = this.getOrder();
-        const rule = this.models["loyalty.rule"].find((rule) => {
-            return rule.mode === "with_code" && (rule.promo_barcode === code || rule.code === code);
-        });
+        const rule = this.models["loyalty.rule"].find(
+            (rule) =>
+                rule.mode === "with_code" && (rule.promo_barcode === code || rule.code === code)
+        );
         let claimableRewards = null;
         let coupon = null;
         if (rule) {
@@ -469,19 +470,15 @@ patch(PosStore.prototype, {
     getPotentialFreeProductRewards() {
         const order = this.getOrder();
         const allCouponPrograms = Object.values(order.uiState.couponPointChanges)
-            .map((pe) => {
-                return {
-                    program_id: pe.program_id,
-                    coupon_id: pe.coupon_id,
-                };
-            })
+            .map((pe) => ({
+                program_id: pe.program_id,
+                coupon_id: pe.coupon_id,
+            }))
             .concat(
-                order._code_activated_coupon_ids.map((coupon) => {
-                    return {
-                        program_id: coupon.program_id.id,
-                        coupon_id: coupon.id,
-                    };
-                })
+                order._code_activated_coupon_ids.map((coupon) => ({
+                    program_id: coupon.program_id.id,
+                    coupon_id: coupon.id,
+                }))
             );
         const result = [];
         for (const couponProgram of allCouponPrograms) {

--- a/addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js
+++ b/addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js
@@ -105,9 +105,9 @@ export class PaymentRazorpay extends PaymentInterface {
             amount: line.amount,
             referenceId: localStorage.getItem("referenceId"),
         };
-        return this._callRazorpay(data, "razorpay_make_payment_request").then((data) => {
-            return this._razorpayHandleResponse(data);
-        });
+        return this._callRazorpay(data, "razorpay_make_payment_request").then((data) =>
+            this._razorpayHandleResponse(data)
+        );
     }
 
     /**

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
@@ -94,9 +94,7 @@ export class FloorScreen extends Component {
         this.floorScrollBox = useRef("floor-map-scroll");
         this.map = useRef("map");
         this.alert = useService("alert");
-        const getTableElem = (table) => {
-            return this.map.el.querySelector(`.tableId-${table.id}`);
-        };
+        const getTableElem = (table) => this.map.el.querySelector(`.tableId-${table.id}`);
         const findIntersectingTableElem = (tableElem) => {
             const table = this.getPosTable(tableElem);
             return [...tableElem.parentElement.getElementsByClassName("table")].find(
@@ -909,9 +907,7 @@ export class FloorScreen extends Component {
         // Since we wanted to disable the selected table after deletion, we should be
         //   setting the selectedTableId to null. However, we only do this if nothing
         //   else is selected during the rpc call.
-        const equalsCheck = (a, b) => {
-            return JSON.stringify(a) === JSON.stringify(b);
-        };
+        const equalsCheck = (a, b) => JSON.stringify(a) === JSON.stringify(b);
         if (equalsCheck(this.state.selectedTableIds, originalSelectedTableIds)) {
             this.state.selectedTableIds = [];
         }

--- a/addons/pos_sale/static/src/app/models/data_service_options.js
+++ b/addons/pos_sale/static/src/app/models/data_service_options.js
@@ -7,19 +7,17 @@ patch(DataServiceOptions.prototype, {
             ...super.databaseTable,
             "sale.order": {
                 key: "id",
-                condition: (record) => {
-                    return record.models["pos.order.line"].find(
+                condition: (record) =>
+                    record.models["pos.order.line"].find(
                         (l) => l.sale_order_origin_id?.id === record.id
-                    );
-                },
+                    ),
             },
             "sale.order.line": {
                 key: "id",
-                condition: (record) => {
-                    return record.models["pos.order.line"].find(
+                condition: (record) =>
+                    record.models["pos.order.line"].find(
                         (l) => l.sale_order_line_id?.id === record.id
-                    );
-                },
+                    ),
             },
         };
     },

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
@@ -19,9 +19,10 @@ export class ProductListPage extends Component {
         this.categoryList = useRef("categoryList");
         this.currentProductCard = useChildRef();
         this.categoryButton = Object.fromEntries(
-            this.selfOrder.productCategories.map((category) => {
-                return [category.id, useRef(`category_${category.id}`)];
-            })
+            this.selfOrder.productCategories.map((category) => [
+                category.id,
+                useRef(`category_${category.id}`),
+            ])
         );
 
         useEffect(

--- a/addons/pos_self_order/static/src/app/services/self_order_router_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_router_service.js
@@ -54,9 +54,10 @@ export class SelfOrderRouter extends Reactive {
         const { route } = this.registeredRoutes[routeName];
         const url = new URL(browser.location.href);
 
-        url.pathname = route.replace(/\{\w+:(\w+)\}/g, (match, paramName) => {
-            return routeParams[paramName];
-        });
+        url.pathname = route.replace(
+            /\{\w+:(\w+)\}/g,
+            (match, paramName) => routeParams[paramName]
+        );
 
         history.pushState({}, "", url);
         this.path = window.location.pathname;

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -188,9 +188,9 @@ export class SelfOrder extends Reactive {
             .sort((a, b) => a.sequence - b.sequence);
 
         this.categoryList = new Set(availableCategories);
-        this.availableCategories = availableCategories.filter((c) => {
-            return now > c.hour_after && now < c.hour_until;
-        });
+        this.availableCategories = availableCategories.filter(
+            (c) => now > c.hour_after && now < c.hour_until
+        );
         this.currentCategory = this.productCategories[0] || null;
     }
 
@@ -293,9 +293,7 @@ export class SelfOrder extends Reactive {
                     ]),
                     custom_attribute_value_ids: Object.entries(
                         comboItem.attribute_custom_values
-                    ).map(([id, cus]) => {
-                        return ["create", cus];
-                    }),
+                    ).map(([id, cus]) => ["create", cus]),
                 },
             ]);
         }
@@ -415,9 +413,9 @@ export class SelfOrder extends Reactive {
             return existingOrder;
         }
 
-        const fiscalPosition = this.models["account.fiscal.position"].find((fp) => {
-            return fp.id === this.config.default_fiscal_position_id?.id;
-        });
+        const fiscalPosition = this.models["account.fiscal.position"].find(
+            (fp) => fp.id === this.config.default_fiscal_position_id?.id
+        );
 
         const newOrder = this.models["pos.order"].create({
             company_id: this.company,

--- a/addons/pos_self_order/static/src/app/utils.js
+++ b/addons/pos_self_order/static/src/app/utils.js
@@ -41,8 +41,8 @@ export const attributeFormatter = (attrById, values, customValues = []) => {
     return Object.values(selectedValue);
 };
 
-export const attributeFlatter = (attribute) => {
-    return Object.values(attribute)
+export const attributeFlatter = (attribute) =>
+    Object.values(attribute)
         .map((v) => {
             if (v instanceof Object) {
                 return Object.entries(v)
@@ -54,4 +54,3 @@ export const attributeFlatter = (attribute) => {
         })
         .flat()
         .map((v) => parseInt(v));
-};

--- a/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
+++ b/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
@@ -90,9 +90,9 @@ export class PaymentVivaWallet extends PaymentInterface {
             maxInstalments: 0,
             tipAmount: 0,
         };
-        return this._call_viva_wallet(data, "viva_wallet_send_payment_request").then((data) => {
-            return this._viva_wallet_handle_response(data);
-        });
+        return this._call_viva_wallet(data, "viva_wallet_send_payment_request").then((data) =>
+            this._viva_wallet_handle_response(data)
+        );
     }
 
     async _viva_wallet_cancel(order, uuid) {

--- a/addons/web/tooling/_eslintrc.json
+++ b/addons/web/tooling/_eslintrc.json
@@ -34,7 +34,8 @@
     "prefer-const": ["error", {
       "destructuring": "all",
       "ignoreReadBeforeAssign": true
-    }]
+    }],
+    "arrow-body-style": ["error", "as-needed"]
   },
   "globals": {
     "odoo": "readonly",


### PR DESCRIPTION
In this commit we add the `"arrow-body-style": ["error", "as-needed"]` eslint rule to the `_eslintrc.json` file in order to enforce that lambda functions with a single return statement are written in a concise form
(i.e., without the curly braces and return keyword).

```js
//before
const myFunction = (myargs) => {
  return 3;
};
//after
const myFunction = (myargs) => 3;
```


https://github.com/odoo/enterprise/pull/74764


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
