### PR TITLE
[FIX] mail: fix mark as read when server is already up to date

### DIFF
--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -272,6 +272,12 @@ const threadPatch = {
         return super.importantCounter;
     },
     /** @override */
+    isDisplayedOnUpdate() {
+        super.isDisplayedOnUpdate(...arguments);
+        if (this.selfMember && !this.isDisplayed) {
+            this.selfMember.syncUnread = true;
+        }
+    },
     get isUnread() {
         return this.selfMember?.message_unread_counter > 0 || super.isUnread;
     },
@@ -294,6 +300,8 @@ const threadPatch = {
             this.selfMember.seen_message_id?.id >= newestPersistentMessage.id &&
             this.selfMember.new_message_separator > newestPersistentMessage.id;
         if (alreadyReadBySelf) {
+            // Server is up to date, but local state must be updated as well.
+            this.selfMember.syncUnread = sync ?? this.selfMember.syncUnread;
             return;
         }
         rpc("/discuss/channel/mark_as_read", {

--- a/addons/mail/static/src/discuss/core/common/thread_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_patch.js
@@ -66,13 +66,6 @@ const threadPatch = {
             super.fetchMessages();
         }
     },
-    /** @override */
-    isDisplayedOnUpdate() {
-        super.isDisplayedOnUpdate(...arguments);
-        if (this.selfMember && !this.isDisplayed) {
-            this.selfMember.syncUnread = true;
-        }
-    },
     get newMessageBannerText() {
         if (this.props.thread.selfMember?.totalUnreadMessageCounter > 1) {
             return _t("%s new messages", this.props.thread.selfMember.totalUnreadMessageCounter);

--- a/addons/mail/static/tests/core/new_message_separator.test.js
+++ b/addons/mail/static/tests/core/new_message_separator.test.js
@@ -114,6 +114,7 @@ test("keep new message separator until user goes back to the thread", async () =
     await contains(".o-mail-Discuss-threadName", { value: "History" });
     await click(".o-mail-DiscussSidebar-item", { text: "test" });
     await contains(".o-mail-Discuss-threadName", { value: "test" });
+    await contains(".o-mail-Message", { text: "hello" });
     await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New" });
 });
 


### PR DESCRIPTION
A new message banner is displayed on discuss channels to help user
keep track of their messages. Clicking on the "mark as read" button
sometimes does not remove the banner.

This happens since [1] because the value is kept locally and not updated
anymore when clicking on the "mark as read" button. This PR fixes this
issue.

At the same time, this PR restores the `isDisplayedOnUpdate` patch that
was incorrectly put on the thread component patch instead of the model.

[1]: https://github.com/odoo/odoo/pull/188127