### PR TITLE
[IMP] spreadsheet: add boolean global filter

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/boolean_multi_selector/boolean_multi_selector.js
+++ b/addons/spreadsheet/static/src/global_filters/components/boolean_multi_selector/boolean_multi_selector.js
@@ -1,0 +1,55 @@
+import { Component } from "@odoo/owl";
+import { TagsList } from "@web/core/tags_list/tags_list";
+import { AutoComplete } from "@web/core/autocomplete/autocomplete";
+import { _t } from "@web/core/l10n/translation";
+
+function toBoolean(value) {
+    return value === "true";
+}
+
+const OPTIONS = [
+    { value: "true", label: _t("Is set") },
+    { value: "false", label: _t("Is not set") },
+];
+
+export class BooleanMultiSelector extends Component {
+    static template = "spreadsheet.BooleanMultiSelector";
+    static components = {
+        TagsList,
+        AutoComplete,
+    };
+
+    static props = {
+        selectedValues: Array,
+        update: Function,
+        placeholder: { type: String, optional: true },
+    };
+
+    onSelect({ value }) {
+        this.props.update([...this.props.selectedValues, toBoolean(value)]);
+    }
+
+    get placeholder() {
+        return this.props.selectedValues.length ? "" : this.props.placeholder;
+    }
+
+    get tags() {
+        return this.props.selectedValues.map((value) => ({
+            id: `${value}`,
+            text: OPTIONS.find((option) => option.value === `${value}`).label,
+            onDelete: () => {
+                this.props.update(this.props.selectedValues.filter((v) => v !== value));
+            },
+        }));
+    }
+
+    get sources() {
+        return [
+            {
+                options: OPTIONS.filter(
+                    (option) => !this.props.selectedValues.includes(toBoolean(option.value))
+                ),
+            },
+        ];
+    }
+}

--- a/addons/spreadsheet/static/src/global_filters/components/boolean_multi_selector/boolean_multi_selector.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/boolean_multi_selector/boolean_multi_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <t t-name="spreadsheet.BooleanMultiSelector">
+        <div class="o_input d-flex flex-wrap gap-1">
+            <TagsList tags="tags"/>
+            <AutoComplete sources="sources" placeholder="placeholder" onSelect.bind="onSelect" />
+        </div>
+    </t>
+</templates>

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
@@ -13,6 +13,7 @@ import { Domain } from "@web/core/domain";
 import { user } from "@web/core/user";
 import { TextFilterValue } from "../filter_text_value/filter_text_value";
 import { getFields, ModelNotFoundError } from "@spreadsheet/data_sources/data_source";
+import { BooleanMultiSelector } from "../boolean_multi_selector/boolean_multi_selector";
 
 const { ValidationMessages } = components;
 
@@ -24,6 +25,7 @@ export class FilterValue extends Component {
         MultiRecordSelector,
         TextFilterValue,
         ValidationMessages,
+        BooleanMultiSelector,
     };
     static props = {
         filter: Object,
@@ -90,6 +92,10 @@ export class FilterValue extends Component {
     }
 
     onTextInput(id, value) {
+        this.props.model.dispatch("SET_GLOBAL_FILTER_VALUE", { id, value });
+    }
+
+    onBooleanInput(id, value) {
         this.props.model.dispatch("SET_GLOBAL_FILTER_VALUE", { id, value });
     }
 

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
@@ -2,6 +2,13 @@
 <templates>
     <t t-name="spreadsheet.FilterValue">
         <div class="o-filter-value d-flex align-items-start w-100" t-att-title="props.showTitle and filter.label">
+            <div t-if="filter.type === 'boolean'" class="w-100">
+                <BooleanMultiSelector
+                    placeholder="' ' + translate(filter.label)"
+                    selectedValues="filterValue || []"
+                    update="(value) => this.onBooleanInput(filter.id, value)"
+                />
+            </div>
             <div t-if="filter.type === 'text'" class="w-100">
                 <TextFilterValue
                     value="filterValue"

--- a/addons/spreadsheet/static/tests/global_filters/boolean_multi_selector.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/boolean_multi_selector.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, test, getFixture } from "@odoo/hoot";
+import { makeMockEnv, contains, mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
+import { getTemplate } from "@web/core/templates";
+import { BooleanMultiSelector } from "@spreadsheet/global_filters/components/boolean_multi_selector/boolean_multi_selector";
+
+describe.current.tags("desktop");
+defineSpreadsheetModels();
+
+/**
+ *
+ * @param {{ model: Model, filter: object}} props
+ */
+async function mountBooleanMultiSelector(env, props) {
+    await mountWithCleanup(BooleanMultiSelector, { props, env, getTemplate });
+}
+
+test("basic boolean multi selector", async function () {
+    const env = await makeMockEnv();
+    await mountBooleanMultiSelector(env, {
+        selectedValues: [],
+        update: (values) => {
+            expect(values).toEqual([true]);
+            expect.step("update");
+        },
+    });
+    expect.verifySteps([]);
+    await contains("input").click();
+    await contains("a:first").click();
+    expect.verifySteps(["update"]);
+});
+
+test("Autocomplete only provide values that are not selected", async function () {
+    const env = await makeMockEnv();
+    await mountBooleanMultiSelector(env, {
+        selectedValues: [true],
+        update: () => {},
+    });
+    await contains("input").click();
+    const options = getFixture().querySelectorAll(".o-autocomplete a");
+    expect(options.length).toBe(1);
+    expect(options[0].textContent).toBe("Is not set");
+});
+
+test("Can click on delete", async function () {
+    const env = await makeMockEnv();
+    await mountBooleanMultiSelector(env, {
+        selectedValues: [true, false],
+        update: (values) => {
+            expect(values).toEqual([false]);
+            expect.step("update");
+        },
+    });
+    expect.verifySteps([]);
+    await contains(".o_badge:first .o_delete").click();
+    expect.verifySteps(["update"]);
+});

--- a/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
@@ -108,3 +108,17 @@ test("relational filter with a contextual domain", async function () {
     await animationFrame();
     expect.verifySteps(["name_search"]);
 });
+
+test("boolean filter", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "boolean",
+        label: "Boolean Filter",
+    });
+    await mountFilterValueComponent({ model, filter: model.getters.getGlobalFilter("42") });
+    await contains("input").click();
+    await contains("a:first").click();
+    expect(model.getters.getGlobalFilterValue("42")).toEqual([true], { message: "value is set" });
+});

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -5,9 +5,9 @@ import { animationFrame, mockDate, mockTimeZone } from "@odoo/hoot-mock";
 import { DispatchResult, Model, helpers, tokenize } from "@odoo/o-spreadsheet";
 import { Domain } from "@web/core/domain";
 import {
-  defineSpreadsheetModels,
-  getBasicPivotArch,
-  getBasicServerData,
+    defineSpreadsheetModels,
+    getBasicPivotArch,
+    getBasicServerData,
 } from "@spreadsheet/../tests/helpers/data";
 import {
     createModelWithDataSource,
@@ -1980,10 +1980,12 @@ test("Can set a value to a date filter from the SET_MANY_GLOBAL_FILTER_VALUE com
 test("getFiltersMatchingPivot return correctly matching filter according to cell formula", async function () {
     mockDate("2022-07-14 00:00:00");
     const serverData = getBasicServerData();
-    serverData.models.partner.records = [{
-      id: 10000,
-      product_id: false,
-    }];
+    serverData.models.partner.records = [
+        {
+            id: 10000,
+            product_id: false,
+        },
+    ];
     const { model } = await createSpreadsheetWithPivot({
         serverData,
         arch: /*xml*/ `
@@ -2021,7 +2023,10 @@ test("getFiltersMatchingPivot return correctly matching filter according to cell
     expect(relationalFilters1).toEqual([{ filterId: "42", value: [37] }]);
     const relationalFilters2 = getFiltersMatchingPivot(model, '=PIVOT.HEADER(1,"product_id","41")');
     expect(relationalFilters2).toEqual([{ filterId: "42", value: [41] }]);
-    const relationalFiltersWithNoneValue = getFiltersMatchingPivot(model, '=PIVOT.HEADER(1,"#product_id",1)');
+    const relationalFiltersWithNoneValue = getFiltersMatchingPivot(
+        model,
+        '=PIVOT.HEADER(1,"#product_id",1)'
+    );
     expect(relationalFiltersWithNoneValue).toEqual([{ filterId: "42", value: undefined }]);
     const dateFilters1 = getFiltersMatchingPivot(model, '=PIVOT.HEADER(1,"date:month","08/2016")');
     expect(dateFilters1).toEqual([{ filterId: "43", value: { yearOffset: -6, period: "august" } }]);
@@ -2573,5 +2578,69 @@ test("Updating the list domain should keep the global filter domain", async () =
     computedDomain = new Domain(model.getters.getListComputedDomain("1"));
     expect(computedDomain.toString()).toBe(
         `["&", ("date", ">=", "2022-01-01"), ("date", "<=", "2022-12-31")]`
+    );
+});
+
+test("Can add a boolean filter", async () => {
+    const model = new Model();
+    const filter = {
+        id: "42",
+        label: "test",
+        type: "boolean",
+        defaultValue: [],
+    };
+    model.dispatch("ADD_GLOBAL_FILTER", { filter });
+    model.dispatch("SET_GLOBAL_FILTER_VALUE", { id: "42", value: [true] });
+    expect(model.getters.getGlobalFilterValue("42")).toEqual([true]);
+});
+
+test("Add a boolean filter with a default value", async () => {
+    const model = new Model();
+    const filter = {
+        id: "42",
+        label: "test",
+        type: "boolean",
+        defaultValue: [true],
+    };
+    model.dispatch("ADD_GLOBAL_FILTER", { filter });
+    expect(model.getters.getGlobalFilterValue("42")).toEqual([true]);
+});
+
+test("Can set a boolean filter with both true and false", async () => {
+    const model = new Model();
+    const filter = {
+        id: "42",
+        label: "test",
+        type: "boolean",
+        defaultValue: [],
+    };
+    model.dispatch("ADD_GLOBAL_FILTER", { filter });
+    model.dispatch("SET_GLOBAL_FILTER_VALUE", { id: "42", value: [true, false] });
+    expect(model.getters.getGlobalFilterValue("42")).toEqual([true, false]);
+});
+
+test("Check boolean filter domain", async () => {
+    const model = new Model();
+    const filter = {
+        id: "42",
+        label: "test",
+        type: "boolean",
+        defaultValue: [],
+    };
+    model.dispatch("ADD_GLOBAL_FILTER", { filter });
+    model.dispatch("SET_GLOBAL_FILTER_VALUE", { id: "42", value: [] });
+    const fieldMatching = { chain: "active", type: "boolean" };
+    expect(model.getters.getGlobalFilterDomain("42", fieldMatching).toString()).toEqual("[]");
+    model.dispatch("SET_GLOBAL_FILTER_VALUE", { id: "42", value: [true] });
+    expect(model.getters.getGlobalFilterDomain("42", fieldMatching).toString()).toEqual(
+        `[("active", "=", True)]`
+    );
+    model.dispatch("SET_GLOBAL_FILTER_VALUE", { id: "42", value: [false] });
+    expect(model.getters.getGlobalFilterDomain("42", fieldMatching).toString()).toEqual(
+        `[("active", "=", False)]`
+    );
+    model.dispatch("SET_GLOBAL_FILTER_VALUE", { id: "42", value: [true, false] });
+    expect(model.getters.getGlobalFilterDomain("42", fieldMatching).toString()).toEqual(
+        `[("active", "in", [True, False])]`
     );
 });


### PR DESCRIPTION
This commit adds the boolean global filter to the spreadsheet data sources. The boolean global filter is a multi-select filter that allows the user to select multiple boolean values (True/False) to filter the data. (can be empty, true, false, or both).

It will be useful to filter the data based on boolean values, for example to filter the data based on the field `active`.

On a technical level, this commit adds a new component `BooleanMultiSelector` This component is a TagList with only two values that can be selected: True and False.

Task: 4361196

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
