### PR TITLE
[FIX] mail: non-deterministic scroll to unread notification test

### DIFF
--- a/addons/im_livechat/static/tests/embed/livechat_session.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_session.test.js
@@ -1,4 +1,4 @@
-import { waitNotifications, waitUntilSubscribe } from "@bus/../tests/bus_test_helpers";
+import { waitUntilSubscribe } from "@bus/../tests/bus_test_helpers";
 import {
     defineLivechatModels,
     loadDefaultEmbedConfig,
@@ -23,8 +23,8 @@ import {
 } from "@web/../tests/web_test_helpers";
 
 import { LivechatButton } from "@im_livechat/embed/common/livechat_button";
-import { rpc } from "@web/core/network/rpc";
 import { queryFirst } from "@odoo/hoot-dom";
+import { rpc } from "@web/core/network/rpc";
 
 describe.current.tags("desktop");
 defineLivechatModels();
@@ -82,7 +82,7 @@ test("Seen message is saved on the server", async () => {
     const pyEnv = await startServer();
     await loadDefaultEmbedConfig();
     const userId = serverState.userId;
-    const env = await start({ authenticateAs: false });
+    await start({ authenticateAs: false });
     await mountWithCleanup(LivechatButton);
     await click(".o-livechat-LivechatButton");
     await contains(".o-mail-Thread");
@@ -113,7 +113,6 @@ test("Seen message is saved on the server", async () => {
         ["guest_id", "=", guestId],
         ["channel_id", "=", getService("im_livechat.livechat").thread.id],
     ]);
-    await waitNotifications([env, "mail.record/insert"]);
     expect(initialSeenMessageId).not.toBe(member.seen_message_id[0]);
     expect(getService("im_livechat.livechat").thread.selfMember.seen_message_id.id).toBe(
         member.seen_message_id[0]

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
@@ -225,7 +225,6 @@ export class DiscussChannelMember extends models.ServerModel {
         if (!member) {
             return;
         }
-        DiscussChannelMember._set_new_message_separator([member.id], message_id + 1);
         DiscussChannelMember.write([member.id], {
             fetched_message_id: message_id,
             seen_message_id: message_id,

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -23,6 +23,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 import { rpc } from "@web/core/network/rpc";
 import { waitNotifications } from "@bus/../tests/bus_test_helpers";
+import { queryFirst } from "@odoo/hoot-dom";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -112,38 +113,36 @@ test("reset new message separator from unread messages banner", async () => {
     await contains("span", { text: "30 new messagesMark as Read", count: 0 });
 });
 
-test.skip("scroll to unread notification", async () => {
+test("scroll to unread notification", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
     const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob" });
     const bobUserId = pyEnv["res.users"].create({ name: "Bob", partner_id: bobPartnerId });
-    let lastMessageId;
     for (let i = 0; i < 60; ++i) {
-        lastMessageId = pyEnv["mail.message"].create({
+        pyEnv["mail.message"].create({
             author_id: serverState.partnerId,
             body: `message ${i}`,
             model: "discuss.channel",
             res_id: channelId,
         });
     }
-    const [memberId] = pyEnv["discuss.channel.member"].search([
-        ["partner_id", "=", serverState.partnerId],
-        ["channel_id", "=", channelId],
-    ]);
-    pyEnv["discuss.channel.member"].write([memberId], { new_message_separator: lastMessageId + 1 });
+    onRpc("/discuss/channel/mark_as_read", () => asyncStep("/discuss/channel/mark_as_read"));
     await start();
+    await openDiscuss(channelId);
+    await tick(); // wait for the scroll to first unread to complete
+    await waitForSteps(["/discuss/channel/mark_as_read"]);
+    await click("span", {
+        text: "Mark as Read",
+        parent: ["span", { text: "60 new messagesMark as Read" }],
+    });
+    await waitForSteps(["/discuss/channel/mark_as_read"]);
+    await contains("span", { count: 0, text: "60 new messagesMark as Read" });
+    queryFirst(".o-mail-Composer-input").blur(); // avoid automatic mark as read
     await withUser(bobUserId, () => {
         getService("orm").call("discuss.channel", "add_members", [[channelId]], {
             partner_ids: [bobPartnerId],
         });
     });
-    await openDiscuss(channelId);
-    await contains(".o-mail-Thread-newMessage ~ .o-mail-NotificationMessage", {
-        text: "Bob joined the channel",
-    });
-    await tick(); // wait for the scroll to first unread to complete
-    await contains(".o-mail-Thread", { scroll: "bottom" });
-    await scroll(".o-mail-Thread", 0);
     await click("span", {
         text: "1 new message",
         parent: ["span", { text: "1 new messageMark as Read" }],


### PR DESCRIPTION
Before this PR, the "scroll to unread notification" test was
occasionally failing. It was actually relying on a race condition and
shouldn't have passed: the thread opens at the bottom so the banner
disappears.

This commit rewrites the test to properly verify the intended
behavior:
- The channel opens at the top, and all messages are unread.
- Mark a thread as read, then receive a new notification message.
- Scroll to the new notification using the unread message banner.

This is the exact scenario that the test was meant to cover: the user
should be able to scroll to an unread notification.

runbot-108408