### PR TITLE
Master plus btn handled moda

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -146,7 +146,7 @@ export class PaymentScreen extends Component {
             this._displayPopupErrorPaymentlinesRounding();
         }
         if (result) {
-            this.numberBuffer.reset();
+            this.numberBuffer.set(result.amount.toString());
             if (paymentMethod.use_payment_terminal) {
                 const newPaymentLine = this.paymentLines.at(-1);
                 this.sendPaymentRequest(newPaymentLine);

--- a/addons/point_of_sale/static/src/app/services/number_buffer_service.js
+++ b/addons/point_of_sale/static/src/app/services/number_buffer_service.js
@@ -79,6 +79,7 @@ class NumberBuffer extends EventBus {
      * @param {String} val
      */
     set(val) {
+        this.state.lastSet = val;
         this.state.buffer = !isNaN(parseFloat(val)) ? val : "";
         this.trigger("buffer-update", this.state.buffer);
     }
@@ -296,6 +297,10 @@ class NumberBuffer extends EventBus {
             if (this.state.toStartOver) {
                 // when we want to erase the current buffer for a new value
                 this.state.buffer = "";
+            }
+            if (this.state.buffer === this.state.lastSet) {
+                this.state.buffer = "";
+                this.state.lastSet = false;
             }
             if (isFirstInput) {
                 this.state.buffer = "" + input;

--- a/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
@@ -37,14 +37,14 @@ registry.category("web_tour.tours").add("PaymentScreenTour", {
             // Use +10 and +50 to increment the amount of the paymentline
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickNumpad("+10"),
-            PaymentScreen.fillPaymentLineAmountMobile("Cash", "10"),
-            PaymentScreen.remainingIs("42.8"),
-            PaymentScreen.validateButtonIsHighlighted(false),
-            PaymentScreen.clickNumpad("+50"),
-            PaymentScreen.fillPaymentLineAmountMobile("Cash", "60"),
-            PaymentScreen.changeIs("7.2"),
+            PaymentScreen.fillPaymentLineAmountMobile("Cash", "62.8"),
+            PaymentScreen.changeIs("10.0"),
             PaymentScreen.validateButtonIsHighlighted(true),
-            PaymentScreen.clickPaymentlineDelButton("Cash", "60.0"),
+            PaymentScreen.clickNumpad("+50"),
+            PaymentScreen.fillPaymentLineAmountMobile("Cash", "112.80"),
+            PaymentScreen.changeIs("60.0"),
+            PaymentScreen.validateButtonIsHighlighted(true),
+            PaymentScreen.clickPaymentlineDelButton("Cash", "112.80"),
 
             // Multiple paymentlines
             PaymentScreen.clickPaymentMethod("Cash"),

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -315,7 +315,7 @@ registry.category("web_tour.tours").add("OrderChange", {
             PaymentScreen.clickNumpad("+10"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.isShown(),
-            TicketScreen.receiptChangeIs("7.80"),
+            TicketScreen.receiptChangeIs("10"),
         ].flat(),
 });
 


### PR DESCRIPTION
Simply number popup and change numpad behavior. Before, when clicking on
a button with + like +50 it was replacing the number in the buffer with
the new number. Now the buffer take into account the previous number.

taskId: 4349322