### PR TITLE
[FIX] stock: onchange lot on moves to reassign move lines

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -536,7 +536,7 @@ Please change the quantity done or the rounding precision of your unit of measur
                         }))
                         mls_without_lots -= move_line
                     else:  # No line without serial number, creates a new one.
-                        reserved_quants = self.env['stock.quant']._get_reserve_quantity(move.product_id, move.location_id, 1.0, lot)
+                        reserved_quants = self.env['stock.quant']._get_reserve_quantity(move.product_id, move.location_id, 1.0, lot_id=lot)
                         if reserved_quants:
                             move_line_vals = self._prepare_move_line_vals(quantity=0, reserved_quant=reserved_quants[0][0])
                         else:


### PR DESCRIPTION
### Steps to reproduce:
- Create a storable prodcut tracked by SN and put 4 units in stock: SN001, SN002, SN003 and SN004
- Create and confim a delivery order for 2 units of a tracked product
> SN001 and SN002 should be used on the move of the DO.
- Change the lots from the form view of the picking to be SN003, SN004
- Save the record
### > only SN003 remains.

### Cause of the issue:

Changing the `lot_ids` of the move and saving will trigger a call of the `_set_lot_ids` in order to adapat the `move_lines` accordingly. During this call and inorder to take sublocations into account, the `_get_reserve_quantity` method is called in order to generate the move lines from the adequate quant:
https://github.com/odoo/odoo/blob/8420efd0ae3b5b9aee13e9735bd57edf43e860a4/addons/stock/models/stock_move.py#L539-L548 However, the spec of this method uses the `product_packaging_id` as 4th argument and the lot as 6th:
https://github.com/odoo/odoo/blob/8420efd0ae3b5b9aee13e9735bd57edf43e860a4/addons/stock/models/stock_quant.py#L897
and the lot is used here as 4th argument:
https://github.com/odoo/odoo/blob/8420efd0ae3b5b9aee13e9735bd57edf43e860a4/addons/stock/models/stock_move.py#L539

opw-4358121, opw-4360592, opw-4360808
opw-4361219, opw-4363070, opw-4358080
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
