### PR TITLE
[FIX] website, website_sale, sale: add to cart + checkout mobile fixes

### DIFF
--- a/addons/sale/static/src/js/product/product.scss
+++ b/addons/sale/static/src/js/product/product.scss
@@ -17,18 +17,20 @@
     }
 }
 
-.o_sale_product_configurator_qty {
-    width: 64px;
-
-    @include media-breakpoint-up(md) {
+@include media-breakpoint-up(md) {
+    .o_sale_product_configurator_qty,
+    .o_sale_product_configurator_price {
         width: 160px;
     }
 }
 
-.o_sale_product_configurator_price {
-    width: 100px;
+.product_name_description {
+    max-width: 8rem;
+}
 
-    @include media-breakpoint-up(md) {
-        width: 160px;
+@include media-breakpoint-down(lg) {
+    .impossible_combination_alert {
+        margin-left: -3rem;
+        margin-right: -9rem;
     }
 }

--- a/addons/sale/static/src/js/product/product.xml
+++ b/addons/sale/static/src/js/product/product.xml
@@ -8,17 +8,14 @@
                 alt="Product Image"
             />
         </td>
-        <td class="p-3" t-att-colspan="this.props.optional ? 2:false">
-            <div class="mb-4 text-break" name="o_sale_product_configurator_name">
+        <td class="p-3 product_name_description">
+            <div class="mb-4 text-break text-truncate" name="o_sale_product_configurator_name">
                 <span class="h5" t-out="this.props.display_name"/>
                 <div
                     t-if="this.props.description_sale"
                     t-out="this.props.description_sale"
-                    class="text-muted small"
+                    class="text-muted small text-truncate"
                 />
-                <div t-if="!this.env.isPossibleCombination(this.props)" class="alert alert-warning mt-3">
-                    <span>This option or combination of options is not available</span>
-                </div>
             </div>
             <t t-foreach="this.props.attribute_lines" t-as="ptal" t-key="ptal.id">
                 <PTAL
@@ -27,49 +24,58 @@
                     productTmplId="this.props.product_tmpl_id"
                 />
             </t>
+            <div t-if="!this.env.isPossibleCombination(this.props)" class="alert alert-warning impossible_combination_alert mt-3">
+                <span>This option or combination of options is not available</span>
+            </div>
         </td>
-        <td
-            t-if="env.showQuantityAndPrice"
-            class="o_sale_product_configurator_qty py-3 px-0 text-end"
-        >
+        <t t-if="env.showQuantityAndPrice">
             <t t-if="!this.props.optional">
-                <QuantityButtons
-                    quantity="this.props.quantity"
-                    setQuantity="quantity => this.env.setQuantity(this.props.product_tmpl_id, quantity)"
-                    isMinusButtonDisabled="this.props.quantity === 1 &amp;&amp; isMainProduct"
-                />
-            </t>
-            <t t-else="">
-                <t t-call="sale.product_price" name="sale_product_configurator_optional_price"/>
-            </t>
-            <a
-                class="d-block mt-2"
-                role="button"
-                t-if="!this.props.optional &amp;&amp; !isMainProduct"
-                t-on-click="() => this.env.removeProduct(this.props.product_tmpl_id)">
-                Remove
-            </a>
-        </td>
-        <td
-            t-if="env.showQuantityAndPrice"
-            class="o_sale_product_configurator_price py-3 px-0 text-end"
-            name="price"
-        >
-            <t t-if="!this.props.optional">
-                <t t-call="sale.product_price" name="sale_product_configurator_price"/>
-            </t>
-            <t t-else="">
-                <button
-                    name="sale_product_configurator_add_button"
-                    class="btn btn-secondary"
-                    t-att-class="{'disabled': !this.env.isPossibleCombination(this.props)}"
-                    t-on-click="() => this.env.addProduct(this.props.product_tmpl_id)"
+                <td
+                    class="o_sale_product_configurator_price py-3 px-0 text-end text-md-center d-block d-md-table-cell"
+                    name="price"
                 >
-                    <i class="fa fa-plus" role="img"/>
-                    <span class="ms-2 d-none d-md-inline">Add</span>
-                </button>
+                    <t t-call="sale.product_price" name="sale_product_configurator_price"/>
+                </td>
+                <td
+                    class="o_sale_product_configurator_qty py-3 px-0 text-end text-md-center d-block d-md-table-cell"
+                >
+                    <QuantityButtons
+                        quantity="this.props.quantity"
+                        setQuantity="quantity => this.env.setQuantity(this.props.product_tmpl_id, quantity)"
+                        isMinusButtonDisabled="this.props.quantity === 1 &amp;&amp; isMainProduct"
+                    />
+                    <a
+                        class="d-block mt-2 text-end"
+                        role="button"
+                        t-if="!isMainProduct"
+                        t-on-click="() => this.env.removeProduct(this.props.product_tmpl_id)"
+                    >
+                        Remove
+                    </a>
+                </td>
             </t>
-        </td>
+            <t t-else="">
+                <td
+                    class="o_sale_product_configurator_qty py-3 px-0 text-end text-md-center"
+                >
+                    <t t-call="sale.product_price" name="sale_product_configurator_optional_price"/>
+                </td>
+                <td
+                    class="o_sale_product_configurator_price py-3 px-0 text-end text-md-center"
+                    name="price"
+                >
+                    <button
+                        name="sale_product_configurator_add_button"
+                        class="btn btn-secondary"
+                        t-att-class="{'disabled': !this.env.isPossibleCombination(this.props)}"
+                        t-on-click="() => this.env.addProduct(this.props.product_tmpl_id)"
+                    >
+                        <i class="fa fa-plus" role="img"/>
+                        <span class="ms-2 d-none d-md-inline">Add</span>
+                    </button>
+                </td>
+            </t>
+        </t>
     </t>
 
     <t t-name="sale.product_price">

--- a/addons/sale/static/src/js/product_list/product_list.scss
+++ b/addons/sale/static/src/js/product_list/product_list.scss
@@ -1,0 +1,13 @@
+table.o_sale_product_configurator_table > tbody > tr > td {
+    min-width: 50px;
+}
+
+@include media-breakpoint-down(md) {
+    .non_optional_product_row_borders {
+        border-bottom-width: 1px;
+    
+        & > td {
+            border-bottom-width: 0;
+        }
+    }
+}

--- a/addons/sale/static/src/js/product_list/product_list.xml
+++ b/addons/sale/static/src/js/product_list/product_list.xml
@@ -12,12 +12,12 @@
             <thead t-if="!this.props.areProductsOptional &amp;&amp; env.showQuantityAndPrice">
                 <tr>
                     <th class="px-0 border-bottom-0" colspan="2">Product</th>
-                    <th class="px-0 text-center border-bottom-0">Quantity</th>
-                    <th class="px-0 text-end border-bottom-0">Price</th>
+                    <th class="px-0 text-center d-none d-md-table-cell border-bottom-0">Price</th>
+                    <th class="px-0 text-center d-none d-md-table-cell border-bottom-0">Quantity</th>
                 </tr>
             </thead>
             <tbody class="border-top-0">
-                <tr t-foreach="this.props.products" t-as="product" t-key="product.product_tmpl_id">
+                <tr t-foreach="this.props.products" t-as="product" t-key="product.product_tmpl_id" t-att-class="{'non_optional_product_row_borders': !this.props.areProductsOptional}">
                     <Product t-props="product" optional="this.props.areProductsOptional"/>
                 </tr>
                 <tr t-if="!this.props.areProductsOptional &amp;&amp; env.showQuantityAndPrice">

--- a/addons/sale/static/src/js/quantity_buttons/quantity_buttons.scss
+++ b/addons/sale/static/src/js/quantity_buttons/quantity_buttons.scss
@@ -1,5 +1,14 @@
 input[name="sale_quantity"] {
-    max-width: 4rem;
+    padding: 0;
+
+    @include media-breakpoint-down(md) {
+        max-width: 3rem;
+    }
+
+    @include media-breakpoint-up(md) {
+        max-width: 4rem;
+    }
+    
     // removing input field=number arrows as their size might
     // change depending on browser default styling and shift input's position
     &::-webkit-outer-spin-button,

--- a/addons/sale/static/src/js/quantity_buttons/quantity_buttons.xml
+++ b/addons/sale/static/src/js/quantity_buttons/quantity_buttons.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.QuantityButtons">
-        <div name="quantity_buttons_wrapper" class="input-group justify-content-center">
+        <div name="quantity_buttons_wrapper" class="input-group justify-content-end justify-content-md-center">
             <button
-                t-attf-class="btn btn-secondary {{ props.btnClasses or 'd-none d-md-inline-block' }}"
+                t-attf-class="px-2 px-md-3 btn btn-secondary {{ props.btnClasses or 'd-md-inline-block' }}"
                 name="sale_quantity_button_minus"
                 aria-label="Remove one"
                 t-att-disabled="props.isMinusButtonDisabled"
@@ -17,7 +17,7 @@
                 t-att-value="props.quantity"
                 t-on-change="setQuantity"/>
             <button
-                t-attf-class="btn btn-secondary {{ props.btnClasses or 'd-none d-md-inline-block' }}"
+                t-attf-class="px-2 px-md-3 btn btn-secondary {{ props.btnClasses or 'd-md-inline-block' }}"
                 name="sale_quantity_button_plus"
                 aria-label="Add one"
                 t-att-disabled="props.isPlusButtonDisabled"

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
@@ -40,16 +40,16 @@ registry.category("web_tour.tours").add('sale_product_configurator_pricelist_tou
         ...tourUtils.addProduct("Customizable Desk (TEST)"),
         {
             content: "check price is correct (USD)",
-            trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(4) span:contains("750.00")',
+            trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(3) span:contains("750.00")',
         },
         {
             content: "add one more",
-            trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(3)>div>button:has(i.fa-plus)',
+            trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(4)>div>button:has(i.fa-plus)',
             run: "click",
         },
         {
             content: "check price for 2",
-            trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(4) span:contains("600.00")',
+            trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(3) span:contains("600.00")',
         },
         configuratorTourUtils.addOptionalProduct("Conference Chair"),
         configuratorTourUtils.increaseProductQuantity("Conference Chair"),

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -993,8 +993,16 @@ a.no-decoration {
     display: none;
 }
 
-.text-overflow-ellipsis {
+.overflow-hidden {
     overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+}
+
+@include media-breakpoint-down(md) {
+    .css_quantity > a {
+        --btn-padding-x: 0.6rem;
+    }
+}
+
+body.modal-open:has(.js_sale.o_wsale_product_page) {
+    overflow: hidden;
 }

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1870,7 +1870,7 @@
         <t t-set="description_lines" t-value="line.get_description_following_lines()"/>
         <div t-if="description_lines" t-attf-class="text-muted small">
             <t t-foreach="description_lines" t-as="name_line">
-                <span t-if="name_line" class="d-block" t-out="name_line"/>
+                <span t-if="name_line" class="d-block text-truncate" t-out="name_line"/>
             </t>
         </div>
     </template>
@@ -1901,25 +1901,27 @@
                             always shown for unsellable lines, we use the raw image data as src
                             (which doesn't require access, unlike the image URL).
                         -->
-                        <img
-                            t-if="line._is_not_sellable_line() and line.product_id.image_128"
-                            t-att-src="image_data_uri(line.product_id.image_128)"
-                            class="o_image_64_max img rounded"
-                            t-att-alt="line.name_short"
-                        />
-                        <div
-                            t-elif="line.product_id.image_128"
-                            t-field="line.product_id.image_128"
-                            t-options="{
-                                'widget': 'image',
-                                'qweb_img_responsive': False,
-                                'class': 'o_image_64_max rounded',
-                            }"
-                        />
-                    </div>
-                    <div class="flex-grow-1 text-overflow-ellipsis">
                         <t t-call="website_sale.cart_line_product_link">
-                            <h6 t-field="line.name_short" class="d-inline align-top h6 fw-bold"/>
+                            <img
+                                t-if="line._is_not_sellable_line() and line.product_id.image_128"
+                                t-att-src="image_data_uri(line.product_id.image_128)"
+                                class="o_image_64_max img rounded"
+                                t-att-alt="line.name_short"
+                            />
+                            <div
+                                t-elif="line.product_id.image_128"
+                                t-field="line.product_id.image_128"
+                                t-options="{
+                                    'widget': 'image',
+                                    'qweb_img_responsive': False,
+                                    'class': 'o_image_64_max rounded',
+                                }"
+                            />
+                        </t>
+                    </div>
+                    <div class="flex-grow-1 overflow-hidden">
+                        <t t-call="website_sale.cart_line_product_link">
+                            <h6 t-field="line.name_short" class="d-block align-top h6 fw-bold text-truncate"/>
                         </t>
                         <t t-call="website_sale.cart_line_description_following_lines"/>
                         <div name="o_wsale_cart_line_button_container">


### PR DESCRIPTION
Before the change, in the mobile version of the eCommerce cart and
add to cart page, if a product had a name that was too long or the
font size was too big it would push the elements to its right
offscreen.
After the change, the overflow of a product name that is too long or
too big gets replaced with ellipsis, keeping the elements to its right
from beign pushed offscreen.

The add to cart mobile page has also been refactored to be more
similar to the checkout page.

Furthermore, a bug with the alert message that caused it to be
squished in the "add to cart" page and a bug in the same page with
the background scrollbar still beign visible when the dialog is open
have been fixed.

task-4260720
opw-4253880

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
