### PR TITLE
[FIX] stock: prioritize routes by sequence in extract_rule

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -573,7 +573,7 @@ class ProcurementGroup(models.Model):
 
         def extract_rule(rule_dict, route_ids, warehouse_id, location_dest_id):
             rule = self.env['stock.rule']
-            for route_id in route_ids:
+            for route_id in sorted(route_ids, key=lambda r: r.sequence):
                 sub_dict = rule_dict.get((location_dest_id.id, route_id.id))
                 if not sub_dict:
                     continue

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -132,6 +132,59 @@ class TestProcRule(TransactionCase):
         ])
         self.assertEqual(len(moves.ids), 1, "It should have created a picking from Stock to Output with the original picking as destination")
 
+    def test_get_rule_respects_sequence_order(self):
+        """Test that _get_rule selects the rule associated with the route of the lowest sequence."""
+
+        # Create a warehouse and a product
+        warehouse = self.env['stock.warehouse'].search([], limit=1)
+        product = self.env['product.product'].create({'name': 'Test Product', 'type': 'product'})
+
+        # Create routes with different sequences to simulate prioritization.
+        route_low_priority = self.env['stock.route'].create({'name': 'Route 1', 'sequence': 10})
+        rule_low_priority = self.env['stock.rule'].create({
+            'name': 'Rule for Route 1',
+            'route_id': route_low_priority.id,
+            'action': 'pull',
+            'location_src_id': warehouse.lot_stock_id.id,
+            'location_dest_id': warehouse.lot_stock_id.id,
+            'picking_type_id': warehouse.out_type_id.id,
+            'sequence': 20,
+        })
+
+        # Create a second route with higher priority (lower sequence).
+        route_high_priority = self.env['stock.route'].create({'name': 'Route 2', 'sequence': 5})
+        rule_high_priority = self.env['stock.rule'].create({
+            'name': 'Rule for Route 2',
+            'route_id': route_high_priority.id,
+            'action': 'pull',
+            'location_src_id': warehouse.lot_stock_id.id,
+            'location_dest_id': warehouse.lot_stock_id.id,
+            'picking_type_id': warehouse.out_type_id.id,
+            'sequence': 20,
+        })
+
+        # Assign both routes to the product. This order is set so that the method
+        # will be forced to sort the routes by their sequence.
+        product.write({'route_ids': [(4, route_low_priority.id), (4, route_high_priority.id)]})
+
+        # Create a procurement group for testing rule selection.
+        procurement_group = self.env['procurement.group'].create({'name': 'Test Procurement Group'})
+
+        # Call the _get_rule method to simulate rule selection.
+        rule = procurement_group._get_rule(
+            product_id=product,
+            location_id=warehouse.lot_stock_id,
+            values={
+                'warehouse_id': warehouse,
+                'route_ids': product.route_ids,
+            }
+        )
+
+        # Assert that the selected rule corresponds to the route with the lowest sequence.
+        self.assertEqual(rule, rule_high_priority,
+                         "The rule associated with the route having the lowest sequence "
+                         "(high_priority) should be selected.")
+
     def test_propagate_deadline_move(self):
         deadline = datetime.now()
         move_dest = self.env['stock.move'].create({

--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -22,3 +22,4 @@ Bernat Puig bernat.puig@forgeflow.com https://github.com/BernatPForgeFlow
 Joan Sisquella joan.sisquella@forgeflow.com https://github.com/JoanSForgeFlow
 Laura Cazorla laura.cazorla@forgeflow.com https://github.com/LauraCForgeFlow
 Arnau Cruz arnau.cruz@forgeflow.com https://github.com/ArnauCForgeFlow
+Ricard Calvo ricard.calvo@forgeflow.com https://github.com/RicardCForgeFlow


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
When a product is configured with both buy and manufacture routes, the manufacture route is always prioritized, regardless of the sequence defined in the routes.

### Current behavior before PR:
The method extract_rule stops evaluating routes once it finds a valid rule, even if other rules with a lower sequence exist. This leads to the manufacture route being prioritized over buy, which is not the intended behavior.

### Desired behavior after PR is merged:
The routes are now evaluated based on their sequence, ensuring that rules associated with routes of lower sequence are considered first.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
cc @ForgeFlow