### PR TITLE
[FIX] mrp_account_enterprise: display quantity produced of byproducts

### DIFF
--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -131,7 +131,7 @@ class ReportMoOverview(models.AbstractModel):
             if bp_move.state == 'cancel' or float_is_zero(bp_move.cost_share, precision_digits=2):
                 continue
             # As UoMs can vary, we use the default UoM of each product
-            quantities_by_product[bp_move.product_id] += bp_move.product_qty
+            quantities_by_product[bp_move.product_id] += bp_move.product_uom._compute_quantity(bp_move.quantity, bp_move.product_id.uom_id, rounding_method='HALF-UP')
             cost_share = bp_move.cost_share / 100
             total_cost_by_product[bp_move.product_id] += extras['total_real_cost'] * cost_share
             component_cost_by_product[bp_move.product_id] += extras['total_real_cost_components'] * cost_share


### PR DESCRIPTION
**Steps to reproduce the bug:**

- Create a storable product:
   - "Finished Product" with the following BoM:
     - Component: 1 unit of "C1"
     - Byproducts:
       - 1 unit of "By-product 1"
       - 1 unit of "By-product 2"

- Create a manufacturing order to produce 5 units of the finished product.
- Confirm the MO.
- Set the quantity produced to 5 units.
- Set the quantity of byproducts to:
   - By-product 1: 4 units
   - By-product 2: 3 units

- Validate the MO.
- Print the cost analysis.

**Problem:**
The reported quantity does not show the actual quantity produced but
instead shows the "to produce" quantity.

opw-4312292