### PR TITLE
[IMP] mrp: add final product as a component on MO

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -315,7 +315,7 @@
                                     readonly="state != 'draft'"/>
                                 <button name="action_generate_bom" type="object" icon="fa-plus"
                                     title="Generate a new BoM from this Manufacturing Order" groups="mrp.group_mrp_manager"
-                                    invisible="bom_id or not product_id or (not move_raw_ids and not workorder_ids)">
+                                    invisible="not show_generate_bom">
                                     <span>Generate BOM</span>
                                 </button>
                                 <button name="action_update_bom" string="Update BoM" type="object"
@@ -407,7 +407,7 @@
                                         <create string="Add a line"/>
                                         <button name="action_add_from_catalog_raw" string="Catalog" type="object" class="px-4 btn-link" context="{'order_id': parent.id}"/>
                                     </control>
-                                    <field name="product_id" force_save="1" context="{'default_is_storable': True}" required="1" readonly="move_lines_count &gt; 0 or state == 'cancel' or (state != 'draft' and not additional)" domain="['&amp;', ('type', '=', 'consu'), ('id', '!=', parent.product_id)]"/>
+                                    <field name="product_id" force_save="1" context="{'default_is_storable': True}" required="1" readonly="move_lines_count &gt; 0 or state == 'cancel' or (state != 'draft' and not additional)" domain="[('type', '=', 'consu')]"/>
                                     <field name="forecast_availability" column_invisible="parent.state in ['done', 'cancel']" string="" widget="forecast_widget"/>
                                     <field name="location_id" string="From" readonly="1" force_save="1" groups="stock.group_stock_multi_locations" optional="hide"/>
                                     <!-- test_immediate_validate_uom_2, test_product_produce_different_uom -->


### PR DESCRIPTION
It will be possible, when a MO is created, to add the same final
product as a component. Previously, we had a constraint that
prevented this. It will be interesting to perform a similar operation
to what we do in the repair module. Let's manufacture a smartphone, for
example.

A smartphone has a serial number, let's suppose SN000. We have already
produced that product, but we notice that something is missing or we
want to upgrade it by adding some tools. We can reproduce it, adding
the same product as a component and setting its serial number one a move
line and in the final product. After making the MO as done, no warnings
or errors will appear.

task: 3894176