### PR TITLE
[FIX] sale: inconsistent demo loading

### DIFF
--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '1.2',
     'category': 'Sales/Sales',
     'summary': 'Sales internal machinery',
+    'sequence': 5,
     'description': """
 This module contains all the common features of Sales Management and eCommerce.
     """,

--- a/addons/sale/data/sale_demo.xml
+++ b/addons/sale/data/sale_demo.xml
@@ -562,6 +562,7 @@
     </record>
 
     <!-- Confirm some Sales Orders-->
+    <!-- FIXME : When post-loading demo data with stock installed, following call takes all availables quantities which lead to problem further (e.g. Helpdesk)-->
     <function model="sale.order" name="action_confirm" eval="[[
         ref('sale_order_4'),
         ref('sale_order_6'),

--- a/odoo/modules/graph.py
+++ b/odoo/modules/graph.py
@@ -77,9 +77,12 @@ class Graph(dict):
         dependencies = dict([(p, info['depends']) for p, info in packages])
         current, later = set([p for p, info in packages]), set()
 
-        while packages and current > later:
+        while packages and current > later: #current is a superset of later
             package, info = packages[0]
             deps = info['depends']
+
+            # if 'demo' in force and package == 'stock' and 'sale' in module_list and sale not in ():
+                # self.add_module(cr, 'sale', force)
 
             # if all dependencies of 'package' are already in the graph, add 'package' in the graph
             if all(dep in self for dep in deps):

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -112,8 +112,15 @@ def force_demo(env):
         "SELECT name FROM ir_module_module WHERE state IN ('installed', 'to upgrade', 'to remove')"
     )
     module_list = [name for (name,) in env.cr.fetchall()]
+    # DEBUG
+    if 'stock' in module_list and 'sale' in module_list:
+        module_list.remove('stock')
+        graph.add_modules(env.cr, module_list, ['demo'])
+        module_list.append('stock')
     graph.add_modules(env.cr, module_list, ['demo'])
 
+    for key in ('account_edi_ubl_cii', 'account_invoice_extract', 'account_payment', 'sale'):
+        graph[key].depth = 7  # force sale to be loaded first (same-level as stock)
     for package in graph:
         load_demo(env, package, {}, 'init')
 


### PR DESCRIPTION
**Issue:**
Loading of demo data during installation or post installation has different output on the database.

**Steps to reproduce:**
- Install stock, helpdesk, repair WITHOUT demo data.
- In debug mode : Setting -> Load Demo Data
- Helpdesk -> "Customer Care" -> Settings
  - In "After-Sales" section : check Repairs and save

**Current Behavior :**
- Loading of helpdesk_stock demo data fail:
  - < 18.0, only seen in the logs
  - \>= 18.0, an exception happens
- [FURN_0269] Office Chair Black has:
  - 0 quantity on hand
  - a negative forecast

**Expected Behavior :**
- Loading of helpdesk_stock demo data happens without pain
- [FURN_0269] Office Chair Black has:
  - 9 quantity on hand
  - positive forecast

**Explanation:**
Sale demo data is loaded AFTER stock demo data.
When sale_demo.xml reaches line 565, we confirm a bunch of sale order.
Normally, there's no stock management at this point, such as there's no need for reservation, quants and moves... And everything goes fine. 
However, as stock demo data loading affected some of the product types used in these sale orders (stock_demo_pre.xml from line 39 to end), the confirmation of the sale orders in the sale demo data is inconsistent compared to when the demo data are loaded during the installation process.

[opw-4278289](https://www.odoo.com/odoo/project/49/tasks/4278289)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
