### PR TITLE
[REV] stock_account: remove CoGS analytic_distribution

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -162,6 +162,7 @@ class AccountMove(models.Model):
                     'price_unit': -price_unit,
                     'amount_currency': amount_currency,
                     'account_id': credit_expense_account.id,
+                    'analytic_distribution': line.analytic_distribution,
                     'display_type': 'cogs',
                     'tax_ids': [],
                 })

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -4,7 +4,7 @@
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
 from odoo.tests.common import tagged, Form
-from odoo import fields
+from odoo import fields, Command
 
 class TestAccountMoveStockCommon(AccountTestInvoicingCommon):
     @classmethod
@@ -294,3 +294,28 @@ class TestAccountMove(TestAccountMoveStockCommon):
             [stock_valuation_line, output_line],
             [expected_valuation_line, expected_output_line]
         )
+
+    def test_cogs_analytic_accounting(self):
+        """Check analytic distribution is correctly propagated to COGS lines"""
+        self.env.company.anglo_saxon_accounting = True
+        default_plan = self.env['account.analytic.plan'].create({'name': 'Default', 'company_id': False})
+        analytic_account = self.env['account.analytic.account'].create({'name': 'Account 1', 'plan_id': default_plan.id})
+
+        move = self.env['account.move'].create({
+            'move_type': 'out_refund',
+            'invoice_date': fields.Date.from_string('2019-01-01'),
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_A.id,
+                    'analytic_distribution': {
+                        analytic_account.id: 100,
+                    },
+                }),
+            ]
+        })
+        move.action_post()
+
+        cogs_line = move.line_ids.filtered(lambda l: l.account_id == self.product_A.property_account_expense_id)
+        self.assertEqual(cogs_line.analytic_distribution, {str(analytic_account.id): 100})


### PR DESCRIPTION
Users rely on analytical accounting for accurate sales reporting.
In operations involving automated inventory valuation, when an account
move is confirmed, cogs entries are created with the same analytic
account as the product line.
However, due to a recent commit this is no longer the case.

Steps to reproduce:
- Enable Analytic Accounting and Anglo-Saxon Accounting in the settings
- Create a storable product
   - Set inventory valuation to Automated on the product's category
   - Add a cost to the product
- Create an invoice with the product and add an analytic distribution
- When the invoice is confirmed, COGS line are created

Issue: Analytic distribution is not applied to COGS line

This reverts commit https://github.com/odoo/odoo/commit/2a5463eb013aecc1d24041928974a9bbff5fb23a.

opw-4347110
opw-4351323
opw-4351111
opw-4350640
opw-4350188
...