### PR TITLE
[FIX] mail: allow playing video on safari

### DIFF
--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, models, SUPERUSER_ID
 from odoo.exceptions import AccessError, MissingError, UserError
-from odoo.http import request
 from odoo.tools import consteq
 
 
@@ -71,7 +69,6 @@ class IrAttachment(models.Model):
         self.unlink()
 
     def _attachment_format(self, legacy=False):
-        safari = request and request.httprequest.user_agent and request.httprequest.user_agent.browser == 'safari'
         res_list = []
         for attachment in self:
             res = {
@@ -79,7 +76,7 @@ class IrAttachment(models.Model):
                 'id': attachment.id,
                 'filename': attachment.name,
                 'name': attachment.name,
-                'mimetype': 'application/octet-stream' if safari and attachment.mimetype and 'video' in attachment.mimetype else attachment.mimetype,
+                'mimetype': attachment.mimetype,
                 'type': attachment.type,
                 'url': attachment.url,
             }


### PR DESCRIPTION
Revert the following fix:
https://github.com/odoo/odoo/commit/5e3b471f4a67553d6f7525595b15dc3d7b4efb3f

Which is no longer necessary since we have streams: https://github.com/odoo/odoo/commit/da8def8e410de68256ba4ab09ebf7a8b699355ac

In particular, media must be returned with code 206 and a range, which is now the case.
