### PR TITLE
[FIX] mrp: Fix batch pause feature for work order

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -672,7 +672,7 @@ class MrpWorkorder(models.Model):
         return self.end_previous(doall=True)
 
     def button_pending(self):
-        self.end_previous()
+        self.end_all()
         return True
 
     def button_unblock(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- In the work order list view, when selecting multiple lines and attempting to pause them, only one work order is successfully paused.

Current behavior before PR:

https://github.com/user-attachments/assets/ecca2e91-fca4-4ecb-999d-619635aee907

Desired behavior after PR is merged:

https://github.com/user-attachments/assets/8ba9cacb-37e4-494d-95ab-7d8c80d9e67d


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
