### PR TITLE
[DRAFT][FIX] hr: restrict access to 'HR Settings' & proper permissions in 'My Profile'

### DIFF
--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -172,7 +172,11 @@ class TestSelfAccessRights(TestHrCommon):
             if v.type == 'char' or v.type == 'text':
                 val = '0000' if f == 'pin' else 'dummy'
             if val is not None:
-                self.richard.with_user(self.richard).write({f: val})
+                if f in ['pin', 'employee_type', 'barcode']:
+                    with self.assertRaises(AccessError):
+                        self.richard.with_user(self.richard).write({f: val})
+                else:
+                    self.richard.with_user(self.richard).write({f: val})
 
     def testWriteSelfUserPreferencesEmployee(self):
         # self should always be able to update non hr.employee fields if


### PR DESCRIPTION
Steps:
- Go to 'My Profile'.
- Check the 'HR Settings' tab and other sections ('Resume', 'Work Information' and 'Private Information').

Issues:
- Users could edit 'HR Settings' without proper HR permissions.

Fix:
- Restricted HR Settings edits to users with HR manager rights.
- Ensured fields in 'Resume', 'Work Information' and 'Private Information' are editable only with hr_employee_self_edit enabled.

task-4319956

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
