### PR TITLE
[IMP] stock: removal strategy hidden if no route

### DIFF
--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -51,7 +51,7 @@
                             <field name="last_inventory_date"/>
                             <field name="next_inventory_date" invisible="not active"/>
                         </group>
-                        <group string="Logistics" groups="stock.group_adv_location">
+                        <group string="Logistics">
                             <field name="removal_strategy_id" widget="radio" options="{'no_create': True}" invisible="usage in ('supplier', 'customer', 'inventory', 'production') or scrap_location or usage == 'transit' and not company_id"/>
                         </group>
                     </group>


### PR DESCRIPTION
Removal strategy is a global inventory feature and could be used without
using advanced route.

Task-id: 4361744