### PR TITLE
[FIX] sale_edi_ubl: fix different uom issue

### DIFF
--- a/addons/sale_edi_ubl/models/sale_edi_common.py
+++ b/addons/sale_edi_ubl/models/sale_edi_common.py
@@ -34,10 +34,13 @@ class SaleEdiCommon(models.AbstractModel):
                     Markup().join(Markup("<li>%s</li>") % l for l in logs)
             order.message_post(body=body)
 
-        lines_with_products = order.order_line.filtered('product_id')
+        # Only re-compute lines with product having same uom
+        lines_to_recompute = order.order_line.filtered(
+            lambda line: line.product_id and line.product_uom_id == line.product_id.uom_id
+        )
         # Recompute product price and discount according to sale price
-        lines_with_products._compute_price_unit()
-        lines_with_products._compute_discount()
+        lines_to_recompute._compute_price_unit()
+        lines_to_recompute._compute_discount()
 
         return True
 


### PR DESCRIPTION
Steps:
- Install sale.
- Import purchase order file with dozen uom which exist in seller database with unit uom.

Issue:
- Computed price on sale order is not same as purchase order.

Cause:
- Having product with unit uom and line with dozen uom will re-compute wrong sale price for line as it'll take uom from product instead of line.

Fix:
- Avoid re-computing price if matching product does not have same uom set on line

Alternative: we can pass uom and quantity in context to properly recompute price same as we pass context in view of SOL.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
