### PR TITLE
[FIX] l10n_in_withholding: use record instead of recordset in compute

### DIFF
--- a/addons/l10n_in_withholding/models/account_move.py
+++ b/addons/l10n_in_withholding/models/account_move.py
@@ -90,9 +90,9 @@ class AccountMove(models.Model):
                 }
             if sections:
                 tds_tcs_applicable_lines = (
-                    self.move_type == 'out_invoice'
-                    and self._get_tcs_applicable_lines(self.invoice_line_ids)
-                    or self.invoice_line_ids
+                    move.move_type == 'out_invoice'
+                    and move._get_tcs_applicable_lines(move.invoice_line_ids)
+                    or move.invoice_line_ids
                 )
                 warnings['tds_tcs_threshold_alert'] = {
                     'message': sections._get_warning_message(),
@@ -104,8 +104,8 @@ class AccountMove(models.Model):
                         'domain': [('id', 'in', tds_tcs_applicable_lines.ids)],
                         'views': [(self.env.ref('l10n_in_withholding.view_move_line_list_l10n_in_withholding').id, 'list')],
                         'context': {
-                            'default_tax_type_use': self.invoice_filter_type_domain,
-                            'move_type': self.move_type == 'in_invoice'
+                            'default_tax_type_use': move.invoice_filter_type_domain,
+                            'move_type': move.move_type == 'in_invoice'
                         },
                     }
                 }


### PR DESCRIPTION
Issue introduced at https://github.com/odoo/odoo/commit/41b754db52feeb0ad7d50a0154cd381a30b49d8e accidently inside the compute we use the recordset i.e. `self` instead of the record

In this commit we resolve the issue

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
