### PR TITLE
[FIX] account: memo in payment wizard

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -179,7 +179,7 @@ class AccountPaymentRegister(models.TransientModel):
         '''
         if len(lines.move_id) == 1:
             move = lines.move_id
-            label = (len(lines) == 1 and lines.name) or move.ref or move.name
+            label = move.payment_reference or move.ref or move.name
         else:
             label = self.company_id.get_next_batch_payment_communication()
         return label


### PR DESCRIPTION
With those commits:
https://github.com/odoo/odoo/commit/a6cbb7c2d3538d57dc8498f0dacf4566ea1492e7 https://github.com/odoo/odoo/commit/67e2270d56a81d385db3ca27d29fa3945501fca8

The communication field in the payment register wizard has been changed, when there was only one line we took the line.name. But the line name was in some condition the payment ref and move ref separated with a "-". The communication should only be the move reference or the name of the move.

task: 4366478



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
