### PR TITLE
[FIX] website: add static props to redirect_field

### DIFF
--- a/addons/website/static/src/components/fields/redirect_field.js
+++ b/addons/website/static/src/components/fields/redirect_field.js
@@ -4,8 +4,10 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { pick } from "@web/core/utils/objects";
 import { Component } from "@odoo/owl";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
 
 class RedirectField extends Component {
+    static props = {...standardFieldProps};
     get info() {
         return this.props.record.data[this.props.name] ? _t("Published") : _t("Unpublished");
     }


### PR DESCRIPTION
In 17.0 redirect_field does not have static props, which causes warning to pop. 
This commit adds static props to redirect_field. 

fixes [broken runbot builds](https://runbot.odoo.com/web#id=65725&menu_id=424&cids=1&action=573&model=runbot.build.error&view_type=form)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
