### PR TITLE
[FIX] html_editor: link popover does not opens in firefox

### DIFF
--- a/addons/html_editor/static/src/main/link/link_selection.scss
+++ b/addons/html_editor/static/src/main/link/link_selection.scss
@@ -4,3 +4,8 @@
     border: 1px dashed #008f8c;
     margin: -1px;
 }
+
+.odoo-editor-editable .btn {
+    user-select: auto;
+    cursor: text !important;
+}


### PR DESCRIPTION
**Current behavior before PR:**

- In Firefox, the user-select: none style disabled text selection and prevented
  the cursor from being placed inside a button. This caused the button click to
  fail in opening the link popover.

**Desired behavior after PR is merged:**

- The user-select property for the btn class is changed from none to auto.
  This allows users to place the cursor inside the button-styled link, enabling
  editing and ensuring the link popover can be opened as expected.

task:4358091


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
