### PR TITLE
[FIX] account: fixed filters when navigating through invoice pages

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -111,7 +111,7 @@ class PortalAccount(CustomerPortal):
             'page_name': 'invoice',
             'pager': {  # vals to define the pager.
                 "url": url,
-                "url_args": {'date_begin': date_begin, 'date_end': date_end, 'sortby': sortby},
+                "url_args": {'date_begin': date_begin, 'date_end': date_end, 'sortby': sortby, 'filterby': filterby},
                 "total": AccountInvoice.search_count(domain) if AccountInvoice.check_access_rights('read', raise_exception=False) else 0,
                 "page": page,
                 "step": self._items_per_page,


### PR DESCRIPTION
before this commit, when users applied a filter Invoice or Other in the My Invoices portal and then changed the page number, the selected filter was removed, resetting to the default view.

This commit resolves the issue by ensuring the  filterby parameter is preserved in the pager's url_args, allowing the selected filter to persist across pagination.

opw-4367525