### PR TITLE
[FIX] web: clickbot: blacklist menu opening iframe

### DIFF
--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -18,6 +18,7 @@ const BLACKLISTED_MENUS = [
     "hr_attendance.menu_hr_attendance_kiosk_no_user_mode", // same here (tablet mode)
     "mrp_workorder.menu_mrp_workorder_root", // same here (tablet mode)
     "account.menu_action_account_bank_journal_form", // Modal in an iFrame
+    "account.menu_action_account_credit_card_journal_form", // Modal in an iFrame
     "pos_preparation_display.menu_point_kitchen_display_root", // conditional menu that may leads to frontend
 ];
 // If you change this selector, adapt Studio test "Studio icon matches the clickbot selector"


### PR DESCRIPTION
Before this commit, the clickbot failed in the Accounting module (timeout), because it opened an action that opens a dialog inside an iframe, which isn't supported. There was already another menu doing the same, which was blacklisted. This commit thus also blacklists the problematic menu.

Runbot error~108444

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
