### PR TITLE
[FIX] web: fix autocomplete search

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -71,7 +71,9 @@ export class AutoComplete extends Component {
         }
         const [sourceIndex, optionIndex] = this.state.activeSourceOption;
         const source = this.sources[sourceIndex];
-        return `${this.props.id || "autocomplete"}_${sourceIndex}_${source.isLoading ? "loading" : optionIndex}`;
+        return `${this.props.id || "autocomplete"}_${sourceIndex}_${
+            source.isLoading ? "loading" : optionIndex
+        }`;
     }
 
     get isOpened() {
@@ -244,7 +246,7 @@ export class AutoComplete extends Component {
     }
     onInputClick() {
         if (!this.isOpened) {
-            this.open(this.inputRef.el.value.trim() !== this.props.value);
+            this.open(this.inputRef.el.value.trim() !== this.props.value.trim());
         } else {
             this.close();
         }

--- a/addons/web/static/tests/core/autocomplete_tests.js
+++ b/addons/web/static/tests/core/autocomplete_tests.js
@@ -68,8 +68,8 @@ QUnit.module("Components", (hooks) => {
                 "aria-selected": el.getAttribute("aria-selected"),
             })),
             [
-                {"id": "autocomplete_0_0", "role": "option", "aria-selected": "true"},
-                {"id": "autocomplete_0_1", "role": "option", "aria-selected": "false"},
+                { id: "autocomplete_0_0", role: "option", "aria-selected": "true" },
+                { id: "autocomplete_0_1", role: "option", "aria-selected": "false" },
             ]
         );
 
@@ -431,8 +431,8 @@ QUnit.module("Components", (hooks) => {
                 "aria-selected": el.getAttribute("aria-selected"),
             })),
             [
-                {"id": "autocomplete_0_0", "role": "option", "aria-selected": "true"},
-                {"id": "autocomplete_0_1", "role": "option", "aria-selected": "false"},
+                { id: "autocomplete_0_0", role: "option", "aria-selected": "true" },
+                { id: "autocomplete_0_1", role: "option", "aria-selected": "false" },
             ]
         );
         assert.strictEqual(input.getAttribute("aria-activedescendant"), optionItems[0].id);
@@ -444,8 +444,8 @@ QUnit.module("Components", (hooks) => {
                 "aria-selected": el.getAttribute("aria-selected"),
             })),
             [
-                {"id": "autocomplete_0_0", "role": "option", "aria-selected": "false"},
-                {"id": "autocomplete_0_1", "role": "option", "aria-selected": "true"},
+                { id: "autocomplete_0_0", role: "option", "aria-selected": "false" },
+                { id: "autocomplete_0_1", role: "option", "aria-selected": "true" },
             ]
         );
         assert.strictEqual(input.getAttribute("aria-activedescendant"), optionItems[1].id);
@@ -534,5 +534,39 @@ QUnit.module("Components", (hooks) => {
         assert.containsN(target, ".o-autocomplete--dropdown-item", 2);
         await triggerEvent(target, "", "pointerdown");
         assert.containsNone(target, ".o-autocomplete--dropdown-item");
+    });
+
+    QUnit.test("autocomplete trim spaces for search", async (assert) => {
+        class Parent extends Component {
+            setup() {
+                this.state = useState({
+                    value: " World",
+                });
+            }
+            get sources() {
+                return [
+                    {
+                        options(search) {
+                            return [{ label: "World" }, { label: "Hello" }].filter(({ label }) =>
+                                label.startsWith(search)
+                            );
+                        },
+                    },
+                ];
+            }
+        }
+        Parent.template = xml`
+            <AutoComplete value="state.value" sources="sources" onSelect="() => {}"/>
+        `;
+        Parent.props = ["*"];
+        Parent.components = { AutoComplete };
+        await mount(Parent, target, { env });
+        await click(target, `.o-autocomplete input`);
+        assert.deepEqual(
+            [...target.querySelectorAll(`.o-autocomplete--dropdown-item`)].map(
+                (el) => el.textContent
+            ),
+            ["World", "Hello"]
+        );
     });
 });


### PR DESCRIPTION
When we click on a many2one field we want to open the dropdown with or without a query input. The use of the query input is determined by a simple heuristic `savedValue !== inputValue`. The issue here is that we could have extra spaces either in the saved value or in the input value. These extra spaces can influence the search results so we need to trim them.

opw-4146031