### PR TITLE
[FIX] point_of_sale: assign default sequence in demo categories

### DIFF
--- a/addons/point_of_sale/data/scenarios/bakery_data.xml
+++ b/addons/point_of_sale/data/scenarios/bakery_data.xml
@@ -5,10 +5,12 @@
         <record id="pos_category_breads" model="pos.category">
 			<field name="name">Breads</field>
 			<field name="image_128" type="base64" file="point_of_sale/static/img/breads-icon.png" />
+			<field name="sequence">7</field>
 		</record>
         <record id="pos_category_pastries" model="pos.category">
 			<field name="name">Pastries</field>
 			<field name="image_128" type="base64" file="point_of_sale/static/img/pastries-icon.png" />
+			<field name="sequence">8</field>
 		</record>
 
 		<!-- Bakery products -->

--- a/addons/point_of_sale/data/scenarios/clothes_data.xml
+++ b/addons/point_of_sale/data/scenarios/clothes_data.xml
@@ -9,16 +9,19 @@
         <record id="pos_category_upper" model="pos.category">
             <field name="name">Upper body</field>
             <field name="image_128" type="base64" file="point_of_sale/static/img/clothes-icon.png" />
+            <field name="sequence">4</field>
         </record>
 
         <record id="pos_category_lower" model="pos.category">
             <field name="name">Lower body</field>
             <field name="image_128" type="base64" file="point_of_sale/static/img/lower-body-icon.png" />
+            <field name="sequence">5</field>
         </record>
 
         <record id="pos_category_others" model="pos.category">
             <field name="name">Others</field>
             <field name="image_128" type="base64" file="point_of_sale/static/img/others-icon.png" />
+            <field name="sequence">6</field>
         </record>
 
         <!-- Clothes products -->

--- a/addons/point_of_sale/data/scenarios/furniture_data.xml
+++ b/addons/point_of_sale/data/scenarios/furniture_data.xml
@@ -6,14 +6,17 @@
         <record id="pos_category_miscellaneous" model="pos.category">
           <field name="name">Misc</field>
           <field name="image_128" type="base64" file="point_of_sale/static/img/misc_category.png" />
+          <field name="sequence">1</field>
         </record>
         <record id="pos_category_desks" model="pos.category">
           <field name="name">Desks</field>
           <field name="image_128" type="base64" file="point_of_sale/static/img/desk_category.png" />
+          <field name="sequence">2</field>
         </record>
         <record id="pos_category_chairs" model="pos.category">
           <field name="name">Chairs</field>
           <field name="image_128" type="base64" file="point_of_sale/static/img/chair_category.png" />
+          <field name="sequence">3</field>
         </record>
 
         <!-- Products -->

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -373,28 +373,28 @@ registry.category("web_tour.tours").add("PosCategoriesOrder", {
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             {
-                trigger: '.category-button:eq(0) > span:contains("AAA")',
+                trigger: '.category-button > span:contains("AAA")',
             },
             {
-                trigger: '.category-button:eq(1) > span:contains("AAB")',
+                trigger: '.category-button > span:contains("AAB")',
             },
             {
-                trigger: '.category-button:eq(2) > span:contains("AAC")',
+                trigger: '.category-button > span:contains("AAC")',
             },
             {
-                trigger: '.category-button:eq(1) > span:contains("AAB")',
+                trigger: '.category-button > span:contains("AAB")',
                 run: "click",
             },
             ProductScreen.productIsDisplayed("Product in AAB and AAX", 0),
             {
-                trigger: '.category-button:eq(2) > span:contains("AAX")',
+                trigger: '.category-button > span:contains("AAX")',
             },
             {
-                trigger: '.category-button:eq(2) > span:contains("AAX")',
+                trigger: '.category-button > span:contains("AAX")',
                 run: "click",
             },
             {
-                trigger: '.category-button:eq(3) > span:contains("AAY")',
+                trigger: '.category-button > span:contains("AAY")',
             },
         ].flat(),
 });

--- a/addons/pos_restaurant/data/scenarios/bar_data.xml
+++ b/addons/pos_restaurant/data/scenarios/bar_data.xml
@@ -4,11 +4,13 @@
 		<record id="pos_category_cocktails" model="pos.category">
 			<field name="name">Cocktails</field>
 			<field name="image_128" type="base64" file="point_of_sale/static/img/cocktail-icon.png" />
+			<field name="sequence">11</field>
 		</record>
 
         <record id="pos_category_soft_drinks" model="pos.category">
 			<field name="name">Soft drinks</field>
 			<field name="image_128" type="base64" file="pos_restaurant/static/img/soft-drink-icon.png" />
+			<field name="sequence">12</field>
 		</record>
 
 		<!-- Cocktails products -->

--- a/addons/pos_restaurant/data/scenarios/restaurant_data.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_data.xml
@@ -9,11 +9,13 @@
         <record id="food" model="pos.category">
             <field name="name">Food</field>
             <field name="image_128" type="base64" file="pos_restaurant/static/img/food_category.png" />
+            <field name="sequence">9</field>
         </record>
 
         <record id="drinks" model="pos.category">
             <field name="name">Drinks</field>
             <field name="image_128" type="base64" file="pos_restaurant/static/img/drink_category.png" />
+            <field name="sequence">10</field>
         </record>
 
         <record id="product_category_pos_food" model="product.category">


### PR DESCRIPTION
In this commit:
===
- Ensured that the default sequence defined for POS categories is properly
reflected on the product screen in the POS interface.

task-4365434
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
