### PR TITLE
[IMP] mrp: improve MO splitting process

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1424,7 +1424,10 @@ class MrpProduction(models.Model):
 
     def _prepare_stock_lot_values(self):
         self.ensure_one()
-        name = self.product_id.lot_sequence_id.next_by_id()
+        if self.product_id.lot_sequence_id:
+            name = self.product_id.lot_sequence_id.next_by_id()
+        else:
+            name = self.env['ir.sequence'].next_by_code('stock.lot.serial')
         exist_lot = not name or self.env['stock.lot'].search([
             ('product_id', '=', self.product_id.id),
             '|', ('company_id', '=', False), ('company_id', '=', self.company_id.id),

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -486,7 +486,7 @@ class TestMrpProductionBackorder(TestMrpCommon):
 
         action = mo.action_split()
         wizard = Form.from_action(self.env, action)
-        wizard.counter = 2
+        wizard.max_batch_size = 1
         wizard.save().action_split()
         self.assertEqual(len(mo.procurement_group_id.mrp_production_ids), 2)
 
@@ -503,7 +503,7 @@ class TestMrpProductionBackorder(TestMrpCommon):
         # Split in 3 parts
         action = mo.action_split()
         wizard = Form.from_action(self.env, action)
-        wizard.counter = 3
+        wizard.max_batch_size = 4
         action = wizard.save().action_split()
         # Should have 3 mos
         self.assertEqual(len(mo.procurement_group_id.mrp_production_ids), 3)
@@ -511,16 +511,16 @@ class TestMrpProductionBackorder(TestMrpCommon):
         mo2 = mo.procurement_group_id.mrp_production_ids[1]
         mo3 = mo.procurement_group_id.mrp_production_ids[2]
         # Check quantities
-        self.assertEqual(mo1.product_qty, 3)
-        self.assertEqual(mo2.product_qty, 3)
-        self.assertEqual(mo3.product_qty, 4)
+        self.assertEqual(mo1.product_qty, 4)
+        self.assertEqual(mo2.product_qty, 4)
+        self.assertEqual(mo3.product_qty, 2)
         # Check raw movew quantities
-        self.assertEqual(mo1.move_raw_ids.filtered(lambda m: m.product_id == p1).product_qty, 12)
-        self.assertEqual(mo2.move_raw_ids.filtered(lambda m: m.product_id == p1).product_qty, 12)
-        self.assertEqual(mo3.move_raw_ids.filtered(lambda m: m.product_id == p1).product_qty, 16)
-        self.assertEqual(mo1.move_raw_ids.filtered(lambda m: m.product_id == p2).product_qty, 3)
-        self.assertEqual(mo2.move_raw_ids.filtered(lambda m: m.product_id == p2).product_qty, 3)
-        self.assertEqual(mo3.move_raw_ids.filtered(lambda m: m.product_id == p2).product_qty, 4)
+        self.assertEqual(mo1.move_raw_ids.filtered(lambda m: m.product_id == p1).product_qty, 16)
+        self.assertEqual(mo2.move_raw_ids.filtered(lambda m: m.product_id == p1).product_qty, 16)
+        self.assertEqual(mo3.move_raw_ids.filtered(lambda m: m.product_id == p1).product_qty, 8)
+        self.assertEqual(mo1.move_raw_ids.filtered(lambda m: m.product_id == p2).product_qty, 4)
+        self.assertEqual(mo2.move_raw_ids.filtered(lambda m: m.product_id == p2).product_qty, 4)
+        self.assertEqual(mo3.move_raw_ids.filtered(lambda m: m.product_id == p2).product_qty, 2)
 
         # Merge them back
         expected_origin = ",".join([mo1.name, mo2.name, mo3.name])
@@ -619,7 +619,7 @@ class TestMrpProductionBackorder(TestMrpCommon):
         self.assertEqual(mo.state, 'draft')
         action = mo.action_split()
         wizard = Form.from_action(self.env, action)
-        wizard.counter = 10
+        wizard.max_batch_size = 1
         action = wizard.save().action_split()
         # check that the MO is split in 10 and the components are split accordingly
         self.assertEqual(len(mo.procurement_group_id.mrp_production_ids), 10)
@@ -642,7 +642,7 @@ class TestMrpProductionBackorder(TestMrpCommon):
         mo.action_assign()
         action = mo.action_split()
         wizard = Form.from_action(self.env, action)
-        wizard.counter = 10
+        wizard.max_batch_size = 1
         action = wizard.save().action_split()
         # check that the MO is split in 10 and exactly one of the components is not available
         self.assertEqual(len(mo.procurement_group_id.mrp_production_ids), 10)
@@ -992,5 +992,5 @@ class TestMrpWorkorderBackorder(TransactionCase):
         self.assertEqual(mo.state, 'draft')
         action = mo.action_split()
         wizard = Form(self.env[action['res_model']].with_context(action['context']))
-        wizard.counter = 10
+        wizard.max_batch_size = 1
         wizard.save().action_split()

--- a/addons/mrp/tests/test_manual_consumption.py
+++ b/addons/mrp/tests/test_manual_consumption.py
@@ -103,7 +103,7 @@ class TestManualConsumption(TestMrpCommon):
         # Split in 3 parts
         action = mo.action_split()
         wizard = Form.from_action(self.env, action)
-        wizard.counter = 3
+        wizard.max_batch_size = 4
         action = wizard.save().action_split()
         for production in mo.procurement_group_id.mrp_production_ids:
             self.assertTrue(production.move_raw_ids.filtered(lambda m: m.product_id == p1).manual_consumption)

--- a/addons/mrp/wizard/mrp_production_split.xml
+++ b/addons/mrp/wizard/mrp_production_split.xml
@@ -42,10 +42,15 @@
                             </div>
                         </group>
                         <group>
-                            <field name="counter"/>
+                            <label for="max_batch_size"/>
+                            <div class="d-flex">
+                                <field name="max_batch_size" class="w-50"/>
+                                <field name="product_uom_id" groups="uom.group_uom"/>
+                            </div>
+                            <field name="num_splits"/>
                         </group>
                     </group>
-                    <field name="production_detailed_vals_ids" invisible="counter == 0">
+                    <field name="production_detailed_vals_ids" invisible="max_batch_size &lt;= 0">
                         <list editable="top">
                             <field name="date"/>
                             <field name="user_id"/>
@@ -54,7 +59,7 @@
                     </field>
                     <field name="production_split_multi_id" invisible="1"/>
                     <field name="valid_details" invisible="1"/>
-                    <div class="alert alert-danger" role="alert" invisible="valid_details or counter == 0">
+                    <div class="alert alert-danger" role="alert" invisible="valid_details or max_batch_size &lt;= 0">
                         The total should be equal to the quantity to produce.
                     </div>
                     <footer>


### PR DESCRIPTION
Before this commit:
======================
When splitting a Manufacturing Order (MO), users were required to manually specify the number of splits, without an option to define the maximum batch size for each resulting MO. This approach was less flexible and did not align with more common practices for managing production volumes.

After this commit:
======================
Introduces a new feature that allows users to define the maximum batch size when splitting MOs. Users can now specify the maximum size for each split MO, and the system will automatically calculate the number of splits needed to meet the batch size requirement. This enhancement improves flexibility and streamlines the MO splitting process.

task-4274773

