### PR TITLE
[FIX] website_crm_partner_assign: duplicated sitemap partners

### DIFF
--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -182,9 +182,7 @@ class WebsiteAccount(CustomerPortal):
             })
 
 
-class WebsiteCrmPartnerAssign(WebsitePartnerPage, GoogleMap):
-    _references_per_page = 40
-
+class WebsiteGMapDomains(GoogleMap):
     def _get_gmap_domains(self, **kw):
         if kw.get('dom', '') != "website_crm_partner_assign.partners":
             return super()._get_gmap_domains(**kw)
@@ -202,6 +200,10 @@ class WebsiteCrmPartnerAssign(WebsitePartnerPage, GoogleMap):
             domain += [('grade_id', '=', int(current_grade))]
 
         return domain
+
+
+class WebsiteCrmPartnerAssign(WebsitePartnerPage):
+    _references_per_page = 40
 
     def sitemap_partners(env, rule, qs):
         if not qs or qs.lower() in '/partners':


### PR DESCRIPTION
Before this PR, since the 17.2 version, when the `GoogleMap` class has been introduced
as parent class of the `WebsiteCrmPartnerAssign` class, the sitemap duplicates the urls 
of the partners.

This PR aims to fix this issue introducing a new `WebsiteGMapDomains` class that is 
responsible to handle the overriding of the `_get_gmap_domains` function.

When you enable the `website_crm_assign_module` you'll end up with a
duplicated partners sitemap. The issue appears since the  `GoogleMap` class has been 
added as a parent class to the `WebsiteCrmPartnerAssign` class.

This lead to a strange issue, that maybe needs more investigation,
when you add 2 parent classes to a controller it will duplicate the
sitemap.

So, since the parent `GoogleMap` class do not have any real impact on
the child  ` WebsiteCrmPartnerAssign` class I moved it to an independent
class.

task-4074719

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
