### PR TITLE
[FIX] web: black list "add a credit card account"

### DIFF
--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -17,7 +17,8 @@ const BLACKLISTED_MENUS = [
     "event.menu_event_registration_desk", // there's no way to come back from this menu (tablet mode)
     "hr_attendance.menu_hr_attendance_kiosk_no_user_mode", // same here (tablet mode)
     "mrp_workorder.menu_mrp_workorder_root", // same here (tablet mode)
-    "account.menu_action_account_bank_journal_form", // Modal in an iFrame
+    "account.menu_action_account_bank_journal_form", // Modal in an iFrame bank account
+    "account.menu_action_account_credit_card_journal_form", // Modal in an iFrame credit card account
     "pos_preparation_display.menu_point_kitchen_display_root", // conditional menu that may leads to frontend
 ];
 // If you change this selector, adapt Studio test "Studio icon matches the clickbot selector"


### PR DESCRIPTION
In this commit: https://github.com/odoo/odoo/commit/c9dc6edfa9326512ca16f6ca6a8b3f379638cad8 we added a menu item to add a credit card account that is opening an iframe just like the "add a bank account" menu. However, the "add a bank account" menu is blacklisted from the click all already and the new one should be too.

task: no task id




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
