### PR TITLE
[FIX] base: shell_file doesn't require default arg

### DIFF
--- a/odoo/cli/shell.py
+++ b/odoo/cli/shell.py
@@ -60,7 +60,7 @@ class Shell(Command):
 
         group = optparse.OptionGroup(config.parser, "Shell options")
         group.add_option(
-            '--shell-file', dest='shell_file', type='string', default='', my_default='',
+            '--shell-file', dest='shell_file', type='string', my_default='',
             help="Specify a python script to be run after the start of the shell. "
                  "Overrides the env variable PYTHONSTARTUP."
         )


### PR DESCRIPTION
The new `--shell-file` option has an extra `default` argument.
`my_default` is sufficient, `default` it's useless and gives out a warning.

See preceding PR: odoo/odoo#185075