### PR TITLE
[FIX] website_(sale,payment): Load currency from frontend session

### DIFF
--- a/addons/website_payment/models/__init__.py
+++ b/addons/website_payment/models/__init__.py
@@ -5,3 +5,5 @@ from . import account_payment
 from . import payment_provider
 from . import payment_transaction
 from . import res_config_settings
+from . import ir_http
+from . import website

--- a/addons/website_payment/models/ir_http.py
+++ b/addons/website_payment/models/ir_http.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, api
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @api.model
+    def get_frontend_session_info(self):
+        session_info = super().get_frontend_session_info()
+        website_sudo = self.env['website'].sudo().get_current_website()
+        if website_sudo:
+            session_info['website_currency_id'] = website_sudo.get_website_currency().id
+        return session_info

--- a/addons/website_payment/models/website.py
+++ b/addons/website_payment/models/website.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class Website(models.Model):
+    _inherit = 'website'
+
+    def get_website_currency(self):
+        return self.company_id.currency_id

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -154,6 +154,7 @@ class Website(models.Model):
         string="Default Currency",
         comodel_name='res.currency',
         compute='_compute_currency_id',
+        store=True,
     )
     pricelist_ids = fields.One2many(
         string="Price list available for this Ecommerce/Website",
@@ -186,7 +187,7 @@ class Website(models.Model):
         for website in self:
             website.fiscal_position_id = website._get_current_fiscal_position()
 
-    @api.depends('all_pricelist_ids', 'pricelist_id', 'company_id')
+    @api.depends('all_pricelist_ids', 'pricelist_id', 'pricelist_id.currency_id', 'company_id')
     def _compute_currency_id(self):
         for website in self:
             website.currency_id = website.pricelist_id.currency_id or website.company_id.currency_id
@@ -270,6 +271,9 @@ class Website(models.Model):
         # sudo is needed to ensure no records rules are applied during the sorted call,
         # we only want to reorder the records on hand, not filter them.
         return pricelists.sudo().sorted().ids
+
+    def get_website_currency(self):
+        return self.currency_id
 
     def get_pricelist_available(self, show_visible=False):
         """ Return the list of pricelists that can be used on website for the current user.


### PR DESCRIPTION
Prior this commit
    - The currency for donation snippet was set using rpc call

Post this commit
    - The currency_id is loaded into frontend assets and then
      set using web session on js

task-4129347

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
