### PR TITLE
[FIX] fields,models,mail: prevent error while uninstalling module

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -398,7 +398,7 @@ class MailThread(models.AbstractModel):
 
     def _compute_field_value(self, field):
         if not self._context.get('tracking_disable') and not self._context.get('mail_notrack'):
-            self._track_prepare(f.name for f in self.pool.field_computed[field] if f.store)
+            self._track_prepare(f.name for f in self.pool.field_computed.get(field, [field]) if f.store)
 
         return super()._compute_field_value(field)
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1376,7 +1376,7 @@ class Field(MetaField('DummyField', (object,), {})):
         env = records.env
         if self.compute_sudo:
             records = records.sudo()
-        fields = records.pool.field_computed[self]
+        fields = records.pool.field_computed.get(self, [self])
 
         # Just in case the compute method does not assign a value, we already
         # mark the computation as done. This is also necessary if the compute

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4242,7 +4242,7 @@ class BaseModel(metaclass=MetaModel):
 
         if field.store and any(self._ids):
             # check constraints of the fields that have been computed
-            fnames = [f.name for f in self.pool.field_computed[field]]
+            fnames = [f.name for f in self.pool.field_computed.get(field, [field])]
             self.filtered('id')._validate_fields(fnames)
 
     def _parent_store_create(self):


### PR DESCRIPTION
Currently, an error is generated when the user tries to uninstall `helpdesk_fsm` (same for `wbesite_helpdesk_livechat` after enabling 'Live Chat' in the helpdesk team).

error: `KeyError: 'helpdesk.team.fsm_project_id'`

This issue was generated because at line [1] it tries to reset the `use_fsm` field (set use_fsm as false), but since `use_fsm` depends on the compute field of `fsm_project_id` it tries recompute value while uninstalling `helpdesk_fsm` but field `fsm_project_id` not in registry.

This commit will fix the above issue by accessing fields to compute from pool by `.get` instead of direct field access; it will not throw a key error when a field is not available.

[1] - https://github.com/odoo/enterprise/blob/c3d867ec1f17b1024e36213942c099f2982efe26/helpdesk/models/ir_module.py#L13-L16

sentry-6015535085

