### PR TITLE
[FIX] stock: prevent IndexError in _get_rule

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -553,6 +553,8 @@ class ProcurementGroup(models.Model):
         locations if it could not be found.
         """
         result = self.env['stock.rule']
+        if not location_id:
+            return result
         locations = location_id
         # Get the location hierarchy, starting from location_id up to its root location.
         while locations[-1].location_id:


### PR DESCRIPTION
When `location_id` is None in `_get_rule` the line `while locations[-1].location_id` raises an IndexError. This commit fixes that by returning early with an empty recordset of stock.rule in case location_id is None.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
