### PR TITLE
[FIX] website_sale: test_04_admin_website_sale_tour tour

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -132,11 +132,11 @@
     },
     {
         content: "Check selected delivery address is same as typed in previous step",
-        trigger: '#delivery_and_billing:contains(SO1 Delivery Street, 33):contains(SO1DeliveryCity):contains(Afghanistan)',
+        trigger: '#delivery_address_row:contains(SO1 Delivery Street, 33):contains(SO1DeliveryCity):contains(Afghanistan)',
     },
     {
         content: "Check selected billing address is same as typed in previous step",
-        trigger: '#delivery_and_billing:contains(17, SO1 Billing Road):contains(SO1BillingCity):contains(Afghanistan)',
+        trigger: '#billing_address_row:contains(17, SO1 Billing Road):contains(SO1BillingCity):contains(Afghanistan)',
     },
     {
         content: "Click for edit address",
@@ -179,7 +179,7 @@
         tourUtils.confirmOrder(),
     {
         content: "Check selected billing address is same as typed in previous step",
-        trigger: '#delivery_and_billing:contains(SO1 Billing Street Edited, 33):contains(SO1BillingCityEdited):contains(Afghanistan)',
+        trigger: '#billing_address_row:contains(SO1 Billing Street Edited, 33):contains(SO1BillingCityEdited):contains(Afghanistan)',
     },
     {
         content: "Select `Wire Transfer` payment method",


### PR DESCRIPTION
This tour has been disabled since October 15, 2024. In this commit, we make the necessary adaptations to reactivate the tour.

runbot_error_id~99080

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
