### PR TITLE
[FIX] account: display invoice in company currency with 0% tax

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -370,7 +370,7 @@
         </template>
 
         <template id="document_tax_totals_company_currency_template">
-            <t t-set="show_company_taxes" t-value="o.company_id.currency_id != o.currency_id and o.amount_tax != 0 and o.move_type in ['out_invoice', 'out_refund']"/>
+            <t t-set="show_company_taxes" t-value="o.company_id.currency_id != o.currency_id and o.move_type in ['out_invoice', 'out_refund']"/>
             <div t-if="not show_company_taxes" class="oe_structure"></div>
             <div class="mb-2 mt-3 border p-2 avoid-page-break-inside totals_taxes_company_currency"
                  t-else="">


### PR DESCRIPTION
When creating an invoice in foreign currency with only 0% tax, we still want to display the company currency table on the invoice pdf.

task-4367088



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
