### PR TITLE
[FIX] hr_expense: Revert Use bank account defined on employee form

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -4,7 +4,7 @@ import re
 from markupsafe import Markup
 from odoo import api, fields, Command, models, _
 from odoo.tools import float_round
-from odoo.exceptions import UserError, ValidationError, RedirectWarning
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools import email_split, float_is_zero, float_repr, float_compare, is_html_empty
 from odoo.tools.misc import clean_context, format_date
 
@@ -1342,7 +1342,6 @@ class HrExpenseSheet(models.Model):
             'partner_id': self.employee_id.sudo().address_home_id.commercial_partner_id.id,
             'currency_id': self.currency_id.id,
             'line_ids':[Command.create(expense._prepare_move_line_vals()) for expense in self.expense_line_ids],
-            'partner_bank_id': self.employee_id.sudo().bank_account_id.id,
         }
 
     def _prepare_move_vals(self):
@@ -1427,7 +1426,7 @@ class HrExpenseSheet(models.Model):
 
     def approve_expense_sheets(self):
         self._check_can_approve()
-        self._check_bank_account()
+
         self._validate_analytic_distribution()
         duplicates = self.expense_line_ids.duplicate_expense_ids.filtered(lambda exp: exp.state in ['approved', 'done'])
         if duplicates:
@@ -1435,28 +1434,6 @@ class HrExpenseSheet(models.Model):
             action['context'] = {'default_sheet_ids': self.ids, 'default_expense_ids': duplicates.ids}
             return action
         self._do_approve()
-
-    def _check_bank_account(self):
-        no_bank_employees = self.filtered(lambda sheet: sheet.payment_mode == 'own_account' and not sheet.employee_id.sudo().bank_account_id).mapped('employee_id')
-        if no_bank_employees:
-            if (len(no_bank_employees.ids) == 1):
-                kwargs = {
-                    'views': [(False, 'form')],
-                    'res_id': no_bank_employees.id,
-                }
-            else:
-                kwargs = {
-                    'views': [(False, 'list'), (False, 'form')],
-                    'domain': [('id', 'in', no_bank_employees.ids)],
-                }
-            action = {
-                    'res_model': 'hr.employee',
-                    'type': 'ir.actions.act_window',
-                    'target': 'current',
-                    'name': _("Employee(s)"),
-                    **kwargs
-                }
-            raise RedirectWarning(_("Employee(s) should have a bank account set."), action, _("Go to Employee(s)"))
 
     def _validate_analytic_distribution(self):
         for line in self.expense_line_ids:
@@ -1563,7 +1540,6 @@ class HrExpenseSheet(models.Model):
         The default_partner_bank_id is set only if there is one available, if more than one the field is left empty.
         :return: An action opening the account.payment.register wizard.
         '''
-        self._check_bank_account()
         return {
             'name': _('Register Payment'),
             'res_model': 'account.payment.register',
@@ -1571,7 +1547,7 @@ class HrExpenseSheet(models.Model):
             'context': {
                 'active_model': 'account.move',
                 'active_ids': self.account_move_id.ids,
-                'default_partner_bank_id': self.employee_id.sudo().bank_account_id.id,
+                'default_partner_bank_id': self.employee_id.sudo().bank_account_id.id if len(self.employee_id.sudo().bank_account_id.ids) <= 1 else None,
             },
             'target': 'new',
             'type': 'ir.actions.act_window',

--- a/addons/hr_expense/tests/common.py
+++ b/addons/hr_expense/tests/common.py
@@ -24,11 +24,6 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
             groups='base.group_user',
             company_ids=[(6, 0, cls.env.companies.ids)],
         )
-        cls.employee_bank_account = cls.env['res.partner.bank'].create({
-            'acc_number': "0123456789",
-            'partner_id': cls.expense_user_employee.partner_id.id,
-            'acc_type': 'bank',
-        })
         cls.expense_user_manager = mail_new_test_user(
             cls.env,
             name='Expense manager',
@@ -53,7 +48,6 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
             'user_id': cls.expense_user_employee.id,
             'address_home_id': cls.expense_user_employee.partner_id.id,
             'address_id': cls.expense_user_employee.partner_id.id,
-            'bank_account_id': cls.employee_bank_account.id,
         })
 
         cls.product_zero_cost = cls.env['product.product'].create({


### PR DESCRIPTION
This revert commit 063e224c17c0e0194e5ade6acbe82ff38a669b54

Many customers don’t use the bank account field on the employee form, and the change was blocking for them.

Enterprise: https://github.com/odoo/enterprise/pull/74769

task-4206895


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
