### PR TITLE
[FIX] web_editor: ensure validity of the tel protocol

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
@@ -122,7 +122,7 @@ export function deduceURLfromText(text, link) {
    // Check for telephone url.
    match = label.match(PHONE_REGEX);
    if (match) {
-       return match[1] ? match[0] : 'tel://' + match[0];
+        return (match[1] ? match[0] : "tel://" + match[0]).replace(/\s+/g, "");
    }
    return null;
 }


### PR DESCRIPTION
Since [1], the `tel://` protocol was adopted instead of `tel:`. However, URIs cannot contain space characters, which can lead to invalid URIs in certain cases.

Steps to reproduce:

- Open the website editor.
- Attempt to edit the phone number in the header.
- The URI becomes invalid due to the presence of a space character.

This commit resolves the issue by removing space characters from the URI, ensuring it remains valid.

[1]:
    https://github.com/odoo/odoo/commit/6d4a3b3ab5c0f3361d1d681d05b974e295dcbabe

opw-4354614
