### PR TITLE
[FIX] l10n_in_withholding: populate journal in TDS wizard

### DIFF
--- a/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.xml
+++ b/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.xml
@@ -21,6 +21,8 @@
                 <sheet>
                     <group>
                         <group id="header_left_group">
+                            <field name="related_move_id" invisible="1"/> <!-- used to compute the company_id -->
+                            <field name="related_payment_id" invisible="1"/> <!-- used to compute the company_id -->
                             <field name="date"/>
                             <field name="journal_id" domain="[('type', '=', 'general')]"/>
                         </group>


### PR DESCRIPTION
Before This Commit:
- The TDS journal is set in the settings, but when opening the withhold wizard, the journal is not populated in the wizard.

After This Commit:
- The TDS journal now correctly populates in the withhold wizard.

Reason:
- The compute method `_compute_journal` depends on `company_id`. The compute method of `company_id` depends on `related_move_id` and `related_payment_id`, but these two fields are not defined in the view. As a result, `company_id` is not computed. Since `company_id` is not set, `_compute_journal` cannot retrieve the journal from the settings.
- The fields `related_move_id` and `related_payment_id` were mistakenly removed in this PR: https://github.com/odoo/odoo/pull/178572

Task-4366374
