### PR TITLE
[FIX] point_of_sale: correctly store data in IndexedDB

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -744,10 +744,11 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
                     }
 
                     if (field.type === "many2one") {
-                        result[name] = record[name]?.id || (!orm && record.raw[name]) || false;
+                        result[name] =
+                            record[name]?.id || (!orm && toRaw(record.raw[name])) || false;
                     } else if (X2MANY_TYPES.has(field.type)) {
                         const ids = [...record[name]].map((record) => record.id);
-                        result[name] = ids.length ? ids : (!orm && record.raw[name]) || [];
+                        result[name] = ids.length ? ids : (!orm && toRaw(record.raw[name])) || [];
                     } else if (typeof record[name] === "object") {
                         result[name] = JSON.stringify(record[name]);
                     } else {

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -12,6 +12,7 @@ import {
     inLeftSide,
     selectButton,
     scan_barcode,
+    refresh,
 } from "@point_of_sale/../tests/tours/utils/common";
 import * as ProductConfiguratorPopup from "@point_of_sale/../tests/tours/utils/product_configurator_util";
 
@@ -383,5 +384,18 @@ registry.category("web_tour.tours").add("PosCategoriesOrder", {
             {
                 trigger: '.category-button:eq(3) > span:contains("AAY")',
             },
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosSaveOrderlinesIndexedDB", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickDisplayedProduct("Test Product 1"),
+            ProductScreen.selectedOrderlineHas("Test Product 1", "1.0"),
+            refresh(),
+            ProductScreen.selectedOrderlineHas("Test Product 1", "1.0"),
+            Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1563,6 +1563,17 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosCategoriesOrder', login="pos_admin")
 
+    def test_pos_save_orderlines_IndexedDB(self):
+        """ Test that the orderlines are saved in the IndexedDB """
+        self.env['product.product'].create({
+            'name': 'Test Product 1',
+            'available_in_pos': True,
+            'list_price': 1,
+            'taxes_id': False,
+        })
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_pos_tour('PosSaveOrderlinesIndexedDB')
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Before this commit, data stored in IndexedDB could fail to serialize correctly due to Proxy-wrapped objects, resulting in errors when saving data.

opw-4367293

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
