### PR TITLE
[FIX] pos_loyalty: correctly save loyalty.card in IndexedDB

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/data_service_options.js
+++ b/addons/pos_loyalty/static/src/overrides/models/data_service_options.js
@@ -9,7 +9,7 @@ patch(DataServiceOptions.prototype, {
             key: "id",
             condition: (record) => {
                 return record["<-pos.order.line.coupon_id"].find(
-                    (l) => l.order_id?.finalized && typeof l.order_id.id === "number"
+                    (l) => !(l.order_id?.finalized && typeof l.order_id.id === "number")
                 );
             },
         });


### PR DESCRIPTION
Before this commit, the condition to check the loyalty card to be saved in IndexedDB only kept the loyalty cards related to the finalized orders that were synced. It should keep the items that are not synced or finalized.

opw-4257389

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
