### PR TITLE
[FIX] account_peppol: Fix bad write override in case of multiple records

### DIFF
--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -195,6 +195,7 @@ class ResCompany(models.Model):
 
     @api.model
     def _sanitize_peppol_endpoint(self, vals, eas=False, endpoint=False):
+        # TODO: remove in master
         if not (peppol_eas := vals.get('peppol_eas', eas)) or not (peppol_endpoint := vals.get('peppol_endpoint', endpoint)):
             return vals
 
@@ -203,13 +204,23 @@ class ResCompany(models.Model):
 
         return vals
 
+    @api.model
+    def _sanitize_peppol_endpoint_in_values(self, values):
+        eas = values.get('peppol_eas')
+        endpoint = values.get('peppol_endpoint')
+        if not eas or not endpoint:
+            return
+        if sanitizer := PEPPOL_ENDPOINT_SANITIZERS.get(eas):
+            new_endpoint = sanitizer(endpoint)
+            if new_endpoint:
+                values['peppol_endpoint'] = new_endpoint
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
-            vals = self._sanitize_peppol_endpoint(vals)
+            self._sanitize_peppol_endpoint_in_values(vals)
         return super().create(vals_list)
 
     def write(self, vals):
-        for company in self:
-            vals = self._sanitize_peppol_endpoint(vals, company.peppol_eas, company.peppol_endpoint)
+        self._sanitize_peppol_endpoint_in_values(vals)
         return super().write(vals)


### PR DESCRIPTION
When the write is called with multiple companies (like the test TestAccountComposerPerformance), the values are updated with the values of the very first company. This will write a new peppol_endpoint on all companies. However, in this test, the very first company is a BE one but another is FR. Then, this write makes an inconsistency between the original FR EAS and the new BE endpoint.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
