### PR TITLE
[FIX] web: prevent overflow in button box

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -36,7 +36,7 @@
                     <span class="d-none d-xl-block me-auto"/> <!-- Spacer -->
                 </div>
 
-                <div class="o_control_panel_actions d-empty-none d-flex align-items-center justify-content-start justify-content-lg-around order-2 order-lg-1 w-100 w-lg-auto">
+                <div class="o_control_panel_actions d-empty-none d-flex align-items-center justify-content-start justify-content-lg-around order-2 order-lg-1 w-100 mw-100 w-lg-auto">
                     <t t-if="display.layoutActions" t-slot="layout-actions"/>
                     <t t-slot="control-panel-selection-actions"/>
                 </div>

--- a/addons/web/static/src/views/form/button_box/button_box.scss
+++ b/addons/web/static/src/views/form/button_box/button_box.scss
@@ -43,6 +43,11 @@
         padding-top: 0;
         padding-bottom: 0;
         height: $-stat-button-height;
+        min-width: 0;
+
+        &:not(.dropdown) {
+            overflow: hidden;
+        }
 
         @include media-breakpoint-up(md) {
             min-width: 7.5em; // Arbitrary


### PR DESCRIPTION
Steps to reproduce
==================

- Create a product with many variants
- Go to the form view
- Switch to the french language so that the text is long enough or edit the button label with studio

=> The button box goes outside the main view

Solution
========

- Set a max width on the control panel
- Set a min-width on stat buttons so they can reduce their size
- Hide the overflow as when a text is truncated, it goes outside

opw-4056439