### PR TITLE
[IMP] web: action_service: loadState can take a state as argument

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -158,8 +158,7 @@ export function makeActionManager(env, router = _router) {
      *
      * @returns {Promise<object[]>} an array of virtual controllers
      */
-    async function _controllersFromState() {
-        const state = router.current;
+    async function _controllersFromState(state) {
         if (!state?.actionStack?.length) {
             return [];
         }
@@ -1620,9 +1619,9 @@ export function makeActionManager(env, router = _router) {
      *
      * @returns {Promise<boolean>} true if doAction was performed
      */
-    async function loadState() {
-        const newStack = await _controllersFromState();
-        const actionParams = _getActionParams();
+    async function loadState(state = router.current, _options = {}) {
+        const newStack = await _controllersFromState(state);
+        const actionParams = _getActionParams(state);
         if (actionParams) {
             // Params valid => performs a "doAction"
             const { actionRequest, options } = actionParams;
@@ -1632,7 +1631,7 @@ export function makeActionManager(env, router = _router) {
             } else {
                 options.newStack = newStack;
             }
-            await doAction(actionRequest, options);
+            await doAction(actionRequest, { ...options, ..._options });
             return true;
         }
     }


### PR DESCRIPTION
Before this commit, the loadState function of the actionService did not take any argument. It made sense since generally the state from the router was taken.

This method proves very handy to load a complete action stack (that is, multiple actions "at once", the last one is the only one that will actually be instanciated). In studio, for the navigation between the upside-down and the backend this is very practical to improve the experience.

After this commit, loadState can take a routerState-like object, and options for the actual doAction.

part of task-4356704

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
