### PR TITLE
[FIX] project: restrict access to task in shared project for portal user

### DIFF
--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -168,7 +168,7 @@
         <field name="domain_force">[
             '&amp;',
                 ('privacy_visibility', '=', 'portal'),
-                ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
+                ('message_partner_ids', 'child_of', [user.partner_id.id]),
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
@@ -190,7 +190,7 @@
             ('project_id.privacy_visibility', '=', 'portal'),
             ('active', '=', True),
             '|',
-                ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
+                ('message_partner_ids', 'child_of', [user.partner_id.id]),
                 ('project_id.collaborator_ids', 'any', [
                     ('partner_id', '=', user.partner_id.id),
                     ('limited_access', '=', False),
@@ -210,8 +210,9 @@
         <field name="domain_force">[
             ('project_id.privacy_visibility', '=', 'portal'),
             ('active', '=', True),
+            ('project_id.collaborator_ids.partner_id', '=', user.partner_id.id),
             '|',
-                ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
+                ('message_partner_ids', 'child_of', [user.partner_id.id]),
                 ('project_id.collaborator_ids', 'any', [
                     ('partner_id', '=', user.partner_id.id),
                     ('limited_access', '=', False),


### PR DESCRIPTION
Steps to reproduce:
-------------------

- Install `Project` module
- Create a contact as company (e.g. 'Test Company')
- Create 2 contacts under the above company (e.g. 'test1' and 'test2')
- Grant portal access to these 2 contacts
- Create a project and share it with the above 2 portal users
- Give 'edit' access to first portal user (test1)
- Give 'edit-limited' access to second portal user (test2)
- Create a task and add only first user (test1) as follower
- Login as second user (test2) and go to Projects (under 'My account')

Issue:
------

User 'test2' can see/edit the task, but should not.

Cause:
------

By using the `commercial_partner_id` in record rule, we give the rights to all user having the same `commercial_partner_id`.

Solution:
---------

Instead of `user.partner_id.commercial_partner_id`, use the `user.partner_id` in the record rule.

opw-4140453