### PR TITLE
[IMP] product: leverage related fields for single variant products

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -486,10 +486,7 @@ class ProductPricelistItem(models.Model):
             if is_product_template:
                 if self.applied_on == "1_product" and product.id != self.product_tmpl_id.id:
                     res = False
-                elif self.applied_on == "0_product_variant" and not (
-                    product.product_variant_count == 1
-                    and product.product_variant_id.id == self.product_id.id
-                ):
+                elif self.applied_on == "0_product_variant" and product.product_single_variant_id != self.product_id:
                     # product self acceptable on template if has only one variant
                     res = False
             else:

--- a/addons/product/report/product_pricelist_report.py
+++ b/addons/product/report/product_pricelist_report.py
@@ -54,7 +54,7 @@ class ReportProductReport_Pricelist(models.AbstractModel):
         for qty in quantities:
             data['price'][qty] = pricelist._get_product_price(product, qty)
 
-        if is_product_tmpl and product.product_variant_count > 1:
+        if is_product_tmpl and not product.product_single_variant_id:
             data['variants'] = [
                 self._get_product_data(False, variant, pricelist, quantities)
                 for variant in product.product_variant_ids

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -312,10 +312,8 @@ class TestVariants(ProductVariantsCommon):
         })
         self.assertEqual(len(template.product_variant_ids), 1)
         self.assertEqual(template.barcode, 'test')
-
         template.product_variant_ids.action_archive()
         self.assertFalse(template.active)
-        template.invalidate_model(['barcode'])
         self.assertEqual(template.barcode, 'test')
         template.product_variant_ids.action_unarchive()
         template.action_unarchive()
@@ -338,11 +336,9 @@ class TestVariants(ProductVariantsCommon):
         variant_2.barcode = 'v2_barcode'
 
         variant_1.action_archive()
-        template.invalidate_model(['barcode'])
         self.assertEqual(template.barcode, variant_2.barcode)  # 1 active variant --> barcode on template
 
         variant_1.action_unarchive()
-        template.invalidate_model(['barcode'])
         self.assertFalse(template.barcode)  # 2 active variants --> no barcode on template
 
     @mute_logger('odoo.models.unlink')

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -6,7 +6,7 @@
         <field name="priority">10</field>
         <field name="arch" type="xml">
             <list string="Product" multi_edit="1" sample="1">
-                <field name="product_variant_count" column_invisible="True"/>
+                <field name="product_single_variant_id" column_invisible="True"/>
                 <field name="sale_ok" column_invisible="True"/>
                 <field name="currency_id" column_invisible="True"/>
                 <field name="cost_currency_id" column_invisible="True"/>
@@ -14,7 +14,7 @@
                 <field name="name" string="Product Name"/>
                 <field name="default_code" optional="show"/>
                 <field name="product_tag_ids" widget="many2many_tags" optional="hide"/>
-                <field name="barcode" optional="hide" readonly="product_variant_count != 1"/>
+                <field name="barcode" optional="hide" readonly="not product_single_variant_id"/>
                 <field name="company_id" options="{'no_create': True}"
                     groups="base.group_multi_company" optional="hide"/>
                 <field name="list_price" string="Sales Price" widget='monetary' options="{'currency_field': 'currency_id'}" optional="show" decoration-muted="not sale_ok"/>

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -464,6 +464,12 @@ class Test_New_ApiRelated(models.Model):
     foo_bar_sudo_id = fields.Many2one(string='foo_bar_sudo_id', related='foo_id.bar_id', related_sudo=True)
     foo_bar_sudo_id_name = fields.Char('foo_bar_sudo_id_name', related='foo_bar_sudo_id.name', related_sudo=False)
 
+    foo_name_custom_search = fields.Char('foo_name_custom_search', related='foo_id.name', search='_search_foo_name_custom_search')
+
+    def _search_foo_name_custom_search(self, operator, value):
+        # Searches on self.name instead
+        return [('name', operator, value)]
+
 
 class Test_New_ApiRelated_Foo(models.Model):
     _name = 'test_new_api.related_foo'

--- a/odoo/addons/test_new_api/tests/test_search.py
+++ b/odoo/addons/test_new_api/tests/test_search.py
@@ -417,6 +417,20 @@ class TestSubqueries(TransactionCase):
         """]):
             model.search([('foo_name', '=', 'a')])
 
+    def test_related_custom_search(self):
+        model = self.env['test_new_api.related']
+
+        # warmup
+        model.search([('foo_name_custom_search', '=', 'a')])
+
+        with self.assertQueries(["""
+            SELECT "test_new_api_related"."id"
+            FROM "test_new_api_related"
+            WHERE "test_new_api_related"."name" = %s
+            ORDER BY "test_new_api_related"."id"
+        """]):
+            model.search([('foo_name_custom_search', '=', 'a')])
+
     def test_related_multi(self):
         model = self.env['test_new_api.related'].with_user(self.env.ref('base.user_admin'))
         self.env['ir.rule'].create({

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -577,7 +577,7 @@ class Field(typing.Generic[T]):
         self.compute = self._compute_related
         if self.inherited or not (self.readonly or field.readonly):
             self.inverse = self._inverse_related
-        if field._description_searchable:
+        if field._description_searchable and not self.search:
             # allow searching on self only if the related field is searchable
             self.search = self._search_related
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Related fields were recently upgraded, and it's now possible to group over them.

With that in mind, this commit refactors the way we handle template fields for single variant products, to leverage related fields instead of computed ones.

This reduces the need for boilerplate code.

How?

We compute and store a new field named `product_single_variant_id`.
This field is only set if the template has a single variant.

Then, single variant fields like `volume`, `weight`, `barcode`, etc.. can be declared as simple related fields, without any special compute/inverse/search methods.


Enterprise PR:
- https://github.com/odoo/enterprise/pull/74824

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
