### PR TITLE
[FIX] l10n_jo_edi: Override move _post instead of action_post

### DIFF
--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -88,11 +88,11 @@ class AccountMove(models.Model):
         )
         return super().button_draft()
 
-    def action_post(self):
+    def _post(self, soft=True):
         # EXTENDS 'account'
         for invoice in self.filtered('l10n_jo_edi_is_needed'):
             invoice.l10n_jo_edi_state = 'to_send'
-        return super().action_post()
+        return super()._post(soft)
 
     def _get_name_invoice_report(self):
         # EXTENDS account


### PR DESCRIPTION
This commit makes changing the `l10n_jo_edi_state` to `to_send` take effect inside _post instead of action_post.

Repro steps of the problem before this commit:
1. Create an invoice in draft state.
2. Attempt to post the invoice from list view (Actions -> Confirm Entries)
3. This calls the _post method but not the action_post method, leaving the invoice with no value for `l10n_jo_edi_state`

task-3895493



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
