### PR TITLE
[FIX] product: ensure markup equals negative discount

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -131,8 +131,10 @@ class PricelistItem(models.Model):
 
     price_markup = fields.Float(
         string="Markup",
-        default=0,
         digits=(16, 2),
+        compute='_compute_price_markup',
+        inverse='_inverse_price_markup',
+        store=True,
         help="You can apply a mark-up on the cost")
 
     price_min_margin = fields.Float(
@@ -158,7 +160,7 @@ class PricelistItem(models.Model):
     #=== COMPUTE METHODS ===#
 
     @api.depends('applied_on', 'categ_id', 'product_tmpl_id', 'product_id', 'compute_price', 'fixed_price', \
-        'pricelist_id', 'percent_price', 'price_discount', 'price_surcharge')
+        'pricelist_id', 'percent_price', 'price_discount', 'price_surcharge', 'price_markup')
     def _compute_name_and_price(self):
         for item in self:
             if item.categ_id and item.applied_on == '2_product_category':
@@ -194,8 +196,19 @@ class PricelistItem(models.Model):
                         discount_type=discount_type,
                     )
 
+    @api.depends('price_discount')
+    def _compute_price_markup(self):
+        for item in self:
+            item.price_markup = -item.price_discount
+
+    def _inverse_price_markup(self):
+        for item in self:
+            item.price_discount = -item.price_markup
+
     @api.depends_context('lang')
-    @api.depends('compute_price', 'price_discount', 'price_surcharge', 'base', 'price_round')
+    @api.depends(
+        'base', 'compute_price', 'price_discount', 'price_markup', 'price_round', 'price_surcharge',
+    )
     def _compute_rule_tip(self):
         base_selection_vals = {elem[0]: elem[1] for elem in self._fields['base']._description_selection(self.env)}
         self.rule_tip = False
@@ -203,7 +216,8 @@ class PricelistItem(models.Model):
             if item.compute_price != 'formula':
                 continue
             base_amount = 100
-            discount_factor = (100 - item.price_discount) / 100
+            discount = item.price_discount if item.base != 'standard_price' else -item.price_markup
+            discount_factor = (100 - discount) / 100
             discounted_price = base_amount * discount_factor
             if item.price_round:
                 discounted_price = tools.float_round(discounted_price, precision_rounding=item.price_round)
@@ -321,8 +335,7 @@ class PricelistItem(models.Model):
 
     @api.onchange('price_markup')
     def _onchange_price_markup(self):
-        for item in self:
-            item.price_discount = -item.price_markup
+        pass  # TODO: remove in master
 
     @api.onchange('product_id')
     def _onchange_product_id(self):
@@ -487,7 +500,8 @@ class PricelistItem(models.Model):
             base_price = self._compute_base_price(product, quantity, uom, date, currency)
             # complete formula
             price_limit = base_price
-            price = (base_price - (base_price * (self.price_discount / 100))) or 0.0
+            discount = self.price_discount if self.base != 'standard_price' else -self.price_markup
+            price = base_price - (base_price * (discount / 100))
             if self.price_round:
                 price = tools.float_round(price, precision_rounding=self.price_round)
 

--- a/addons/product/tests/test_pricelist.py
+++ b/addons/product/tests/test_pricelist.py
@@ -34,6 +34,12 @@ class TestPricelist(ProductCommon):
                     'product_id': cls.datacard.id,
                     'applied_on': '0_product_variant',
                 }),
+                Command.create({
+                    'compute_price': 'formula',
+                    'base': 'standard_price',  # based on cost
+                    'price_markup': 99.99,
+                    'applied_on': '3_global',
+                }),
             ],
         })
         # Enable pricelist feature
@@ -59,6 +65,19 @@ class TestPricelist(ProductCommon):
         self.assertAlmostEqual(
             self.sale_pricelist_id._get_product_price(self.datacard, 1.0, uom=self.uom_unit)*12,
             self.sale_pricelist_id._get_product_price(self.datacard, 1.0, uom=self.uom_dozen))
+
+    def test_11_markup(self):
+        """Ensure `price_markup` always equals negative `price_discount`."""
+        # Check create values
+        for item in self.sale_pricelist_id.item_ids:
+            self.assertEqual(item.price_markup, -item.price_discount)
+
+        # Overwrite create values, and check again
+        self.sale_pricelist_id.item_ids[0].price_discount = 0
+        self.sale_pricelist_id.item_ids[1].price_discount = -20.02
+        self.sale_pricelist_id.item_ids[2].price_markup = -0.5
+        for item in self.sale_pricelist_id.item_ids:
+            self.assertEqual(item.price_markup, -item.price_discount)
 
     def test_20_pricelist_uom(self):
         # Verify that the pricelist rules are correctly using the product's default UoM


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Create a pricelist;
2. add a rule using a cost-based formula;
3. add a 50% markup;
4. export pricelist, then delete or archive it;
5. import pricelist;
6. use pricelist on a quotation.

Issue
-----
The markup isn't applied.

Cause
-----
Commit 06d0053763cd added the `price_markup` field to `product.pricelist.item`. Whenever the markup is set/changed, the `price_discount` field is supposed to get set to its negative value. Currently this only happens in an `onchange` method, which does not get called during import: https://github.com/odoo/odoo/blob/9905de54a55b6d77f67772dde7b2d0ea21adaff1/addons/product/models/product_pricelist_item.py#L322-L325

The value of `price_discount` is what eventual price calculations are based on, so if this isn't updated along with `price_markup`, any price mark-up gets ignored.


Solution
--------
Ensure `price_markup` & `price_discount` are consistent with each other on using `_compute_price_markup` and `_inverse_price_markup`.

opw-4282087