### PR TITLE
[IMP] mail: mark as read the messages around a message when jumping to it

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -59,7 +59,7 @@ class ChannelController(http.Controller):
         ]
         res = request.env["mail.message"]._message_fetch(domain, **(fetch_params or {}))
         messages = res.pop("messages")
-        if not request.env.user._is_public() and not (fetch_params or {}).get("around"):
+        if not request.env.user._is_public():
             messages.set_message_done()
         return {
             **res,


### PR DESCRIPTION
When the user jumps to a particular message in a channel, the messages around that message are fetched. In this case, although the fetched messages around that message are visible, we don't mark them as read. The main idea behind this setting was that we don't want to affect the unread messages when we fetch around a particular message in a channel. But it makes sense if some messages are visible regardless how they are fetched, then mark them as read. This commit does so.

