### PR TITLE
[FIX] website: revert fixed parallax that was disabled on small devices

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1289,14 +1289,8 @@ $-o-carousel-controllers-size: map-get($spacers, 5);
     > .s_parallax_bg {
         @extend %o-we-background-layer;
     }
-    @include media-breakpoint-up(xl) {
-        // Fixed backgrounds are disabled when using a mobile/tablet device,
-        // which is not a big deal but, on some of them (iOS...), defining the
-        // background as fixed breaks the background-size/position props.
-        // So we enable this only for >= XL devices.
-        &.s_parallax_is_fixed > .s_parallax_bg {
-            background-attachment: fixed;
-        }
+    &.s_parallax_is_fixed > .s_parallax_bg {
+        background-attachment: fixed;
     }
 }
 // Keeps parallax snippet element selectable when Height = auto.


### PR DESCRIPTION
Since the fixed parallax seems to be finally supported by browsers on small devices, we can re-enable the fixed parallax on mobile.

Before this commit, the fixed parallax was disabled on small devices (phones and tablets).

After this commit, it will be re-enabled, making it possible to have a fixed parallax on mobile and tablet."

task-3487850


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
