### PR TITLE
[FIX] account,l10n_cz,l10n_hu_edi: fix currency rate computations

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -690,11 +690,12 @@ class AccountMoveLine(models.Model):
                     from_currency=line.company_currency_id,
                     to_currency=line.currency_id,
                     company=line.company_id,
-                    date=line._get_rate_date(),
+                    date=line.move_id.invoice_date or line.move_id.date or fields.Date.context_today(line),
                 )
             else:
                 line.currency_rate = 1
 
+    # TODO: remove in master
     def _get_rate_date(self):
         self.ensure_one()
         return self.move_id.invoice_date or self.move_id.date or fields.Date.context_today(self)

--- a/addons/l10n_cz/models/account_move.py
+++ b/addons/l10n_cz/models/account_move.py
@@ -13,3 +13,14 @@ class AccountMove(models.Model):
         for move in self:
             if move.country_code == 'CZ' and move.taxable_supply_date and move.state == 'draft':
                 move.date = move.taxable_supply_date
+
+    @api.depends('taxable_supply_date')
+    def _compute_invoice_currency_rate(self):
+        # In the Czech Republic, the currency rate should be based on the taxable supply date.
+        super()._compute_invoice_currency_rate()
+
+    def _get_invoice_currency_rate_date(self):
+        self.ensure_one()
+        if self.country_code == 'CZ' and self.taxable_supply_date:
+            return self.taxable_supply_date
+        return super()._get_invoice_currency_rate_date()

--- a/addons/l10n_cz/models/account_move_line.py
+++ b/addons/l10n_cz/models/account_move_line.py
@@ -5,17 +5,7 @@ from odoo import models, fields
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    def _compute_currency_rate(self):
-        super()._compute_currency_rate()
-        for line in self:
-            if line.move_id.country_code == 'CZ':
-                line.currency_rate = self.env['res.currency']._get_conversion_rate(
-                    from_currency=line.company_currency_id,
-                    to_currency=line.currency_id,
-                    company=line.company_id,
-                    date=line._get_rate_date(),
-                )
-
+    # TODO: remove in master
     def _get_rate_date(self):
         # EXTENDS 'account'
         self.ensure_one()

--- a/addons/l10n_cz/tests/test_moves.py
+++ b/addons/l10n_cz/tests/test_moves.py
@@ -27,6 +27,7 @@ class TestAccountCZ(AccountTestInvoicingCommon):
     def test_cz_out_invoice_onchange_accounting_date(self):
         self.invoice_a.taxable_supply_date = '2024-03-31'
         self.assertEqual(self.invoice_a.date, fields.Date.to_date('2024-03-31'))
+        self.assertEqual(self.invoice_a.invoice_currency_rate, 1.0)
         self.assertEqual(self.invoice_a.invoice_line_ids[0].currency_rate, 1.0)
 
         self.env['res.currency.rate'].create({
@@ -37,4 +38,5 @@ class TestAccountCZ(AccountTestInvoicingCommon):
 
         self.invoice_a.taxable_supply_date = '2024-05-31'
         self.assertEqual(self.invoice_a.date, fields.Date.to_date('2024-05-31'))
+        self.assertEqual(self.invoice_a.invoice_currency_rate, 0.042799058421)
         self.assertEqual(self.invoice_a.invoice_line_ids[0].currency_rate, 0.042799058421)

--- a/addons/l10n_cz/views/account_move_views.xml
+++ b/addons/l10n_cz/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='due_date']" position="after">
-                <field name="taxable_supply_date" invisible="country_code != 'CZ'" readonly="state != 'draft'"/>
+                <field name="taxable_supply_date" invisible="country_code != 'CZ' or move_type == 'entry'" readonly="state != 'draft'"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -124,6 +124,16 @@ class AccountMove(models.Model):
                 raise ValidationError(_('Cannot reset to draft or cancel invoice %s because an electronic document was already sent to NAV!', move.name))
 
     # === Computes === #
+    @api.depends('delivery_date')
+    def _compute_invoice_currency_rate(self):
+        # In Hungary, the currency rate should be based on the delivery date.
+        super()._compute_invoice_currency_rate()
+
+    def _get_invoice_currency_rate_date(self):
+        self.ensure_one()
+        if self.country_code == 'HU' and self.delivery_date:
+            return self.delivery_date
+        return super()._get_invoice_currency_rate_date()
 
     @api.depends('l10n_hu_edi_messages')
     def _compute_message_html(self):
@@ -1044,19 +1054,3 @@ class AccountMove(models.Model):
         )
 
         return tax_totals
-
-
-class AccountInvoiceLine(models.Model):
-    _inherit = 'account.move.line'
-
-    @api.depends('move_id.delivery_date')
-    def _compute_currency_rate(self):
-        super()._compute_currency_rate()
-        # In Hungary, the currency rate should be based on the delivery date.
-        for line in self.filtered(lambda l: l.move_id.country_code == 'HU' and l.currency_id):
-            line.currency_rate = self.env['res.currency']._get_conversion_rate(
-                from_currency=line.company_currency_id,
-                to_currency=line.currency_id,
-                company=line.company_id,
-                date=line.move_id.delivery_date or line.move_id.invoice_date or line.move_id.date or fields.Date.context_today(line),
-            )


### PR DESCRIPTION
In modules l10n_cz and l10n_hu_edi the currency rate computation on
the invoice lines was changed. Instead of using the standard date
(i.e. Invoice Date) for the currency conversion we use the
Taxable Supply Date (for l10n_cz / CZ) or Delivery Date
(for l10n_hu_edi / HU).

The way this was done conflicts with a change in 17.3:
Since then we store and display the currency rate on invoices
(See commit bedffa80beb61c134e8f476ef2ca71f2bd66f554 for more details).
The rate for each line should then just be taken from the rate stored on the move.
Currently the rate on the invoice is still computed with the standard date (invoice date)
in any case.

So e.g. with l10n_cz installed it can happen happen that the lines of a CZ invoice
- compute the currency rate individually "themselves" instead of taking it from the invoice
  (which is one of the things the change in 17.3 wanted to prevent)
- use a different different date for the currency rate conversion than the invoice
  (in case the Taxable Supply Date is set)
I.e. the rate stored and displayed on the invoice may have nothing to do with the rate
that was actually used for the conversion.

Example that goes wrong currently for l10n_cz on runbot
  1. Install l10n_cz
  2. Select CZ Company
  3. Ensure the USD currency is as follows:
     - Starting on 2024-12-01 there is 10 units per CZK rate
     - There is no other currency rate defined
  4. Create an invoice
     - in USD
     - with invoice date 2024-11-01
     - Taxable Supply Date 2024-12-01
     - a single invoice line with price 100 and no taxes
  5. The invoice displays:
     - "1 CZK = 1.000000 USD" (Since we ignore the Taxable Supply Date)
     - total: 100 USD
  6. The "Journal Items" tab displays only 10 CZK total.
     (Since we use the Taxable Supply Date for the actual conversion)

Related commits: The currency rate computations for move lines were overridden
in commits e3bac6461500d34425697eed5a263c605f6f9de5 (l10n_cz) and
b1e07d27da27aad86049c8eae42e1803cf24bd3f (l10n_hu_edi) respectively.

This commit fixes the currency rate computation for these localizations:
We revert the changes to the currency rate computation on the lines and
adapt the date used for the currency rate computation on the invoice.
The invoice then displays the correct rate and the lines just take the (correct)
rate from the invoice.

Further for l10n_cz the taxable supply date is hidden on non-invoices and
ignored for currency computations on non-invoices.

task-4367605


related upgrade PR: https://github.com/odoo/upgrade/pull/6853