### PR TITLE
[IMP] web: list view: select all records on mobile

### DIFF
--- a/addons/web/static/src/core/pager/pager_indicator.scss
+++ b/addons/web/static/src/core/pager/pager_indicator.scss
@@ -1,6 +1,15 @@
 .o_pager_indicator {
     z-index: $zindex-modal + 1;
     transition: opacity 0.4s;
+
+    > .o_pager_indicator_inner {
+        min-width: 13ch;
+        padding: $o-touch-btn-padding;
+        border: var(--border-width) solid $o-gray-200;
+        border-radius: var(--border-radius);
+        background-color: $o-gray-200;
+    }
+
     &.o-fade-leave, &.o-fade-enter {
         opacity: 0;
     }

--- a/addons/web/static/src/core/pager/pager_indicator.xml
+++ b/addons/web/static/src/core/pager/pager_indicator.xml
@@ -3,8 +3,8 @@
 
     <t t-name="web.PagerIndicator">
         <Transition visible="state.show" name="'o-fade'" t-slot-scope="transition" leaveDuration="400">
-            <div class="o_pager_indicator position-fixed top-0 w-100 mt-2 d-flex justify-content-center" t-att-class="transition.className">
-                <span class="o_pager_indicator_inner px-3 py-1 text-bg-primary shadow rounded-4 fs-4">
+            <div class="o_pager_indicator position-fixed top-0 end-0 m-1 d-flex" t-att-class="transition.className">
+                <span class="o_pager_indicator_inner m-1 px-1 text-center shadow">
                     <span class="o_pager_value" t-esc="state.value" />
                     <span> / </span>
                     <span class="o_pager_limit" t-esc="state.total"/>

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -62,7 +62,7 @@
                     </CogMenu>
                 </t>
                 <t t-set-slot="control-panel-selection-actions">
-                    <div t-if="hasSelectedRecords" class="o_list_selection_container d-flex gap-1 w-100 w-md-auto">
+                    <div t-if="hasSelectedRecords" class="o_list_selection_container m-1 m-md-0 d-flex gap-1">
                         <t t-call="web.ListView.Selection"/>
                         <t t-if="!env.isSmall">
                             <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
@@ -116,7 +116,7 @@
     </t>
 
     <t t-name="web.ListView.Selection">
-        <div class="o_list_selection_box list-group flex-row w-auto" t-att-class="{'mt-1 gap-1': env.isSmall}" role="alert">
+        <div class="o_list_selection_box list-group flex-row w-auto" t-att-class="{'m-1 gap-1': env.isSmall}" role="alert">
             <span class="list-group-item active d-flex align-items-center pe-0 py-0 rounded-1 gap-1 flex-grow-1" t-att-class="{'shadow': env.isSmall}">
                 <span t-if="isDomainSelected">All <b t-esc="nbTotal"/> selected</span>
                 <t t-else="">
@@ -129,7 +129,7 @@
                         Select all <span t-if="model.root.isRecordCountTrustable" t-esc="nbTotal"/>
                     </button>
                 </t>
-                <button title="Unselect All" class="o_list_unselect_all" t-att-class="env.isSmall ? 'btn btn-primary ms-auto' : 'btn btn-link ms-auto border-0'" t-on-click="onUnselectAll">
+                <button title="Unselect All" class="o_list_unselect_all btn btn-link ms-auto border-0" t-on-click="onUnselectAll">
                     <i class="oi oi-close"/>
                 </button>
             </span>

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -133,7 +133,7 @@
                     <i class="oi oi-close"/>
                 </button>
             </span>
-            <button t-if="env.isSmall and !isDomainSelected and isPageSelected and (!model.root.isRecordCountTrustable or nbTotal > nbSelected)"
+            <button t-if="env.isSmall and !isDomainSelected and (!model.root.isRecordCountTrustable or nbTotal > nbSelected)"
                 class="o_list_select_domain btn btn-info shadow"
                 title="Select all records matching the search"
                 t-on-click="onSelectDomain">

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -574,15 +574,7 @@
     .o_list_view .o_list_selection_container {
         position: fixed;
         top: 0;
-        right: 0;
         left: 0;
-        justify-content: center;
-
-        .o_list_selection_box {
-            --#{$variable-prefix}list-group-active-color: #{$white};
-            --#{$variable-prefix}list-group-active-border-color: RGB(var(--primary-rgb));
-            --#{$variable-prefix}list-group-active-bg: RGB(var(--primary-rgb));
-        }
     }
 }
 .modal-footer .o_list_selection_box {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -3648,8 +3648,8 @@ test("selection box is properly displayed (multi pages) on mobile", async () => 
     await animationFrame();
 
     expect(".o_list_selection_box").toHaveCount(1);
-    expect(".o_list_selection_box .o_list_select_domain").toHaveCount(0);
-    expect(".o_list_selection_box").toHaveText("1\nselected");
+    expect(".o_list_selection_box .o_list_select_domain").toHaveCount(1);
+    expect(".o_list_selection_box").toHaveText("1\nselected\nAll");
     expect(".o_list_selection_box").toHaveCount(1);
     expect("div.o_control_panel .o_cp_action_menus").toHaveCount(1);
 
@@ -17476,9 +17476,9 @@ test("selection is properly displayed (single page) on mobile", async () => {
     // select a record
     await contains(".o_data_row:nth-child(1)").drag();
     expect(".o_list_selection_box").toHaveCount(1);
-    expect(".o_list_selection_box .o_list_select_domain").toHaveCount(0);
+    expect(".o_list_selection_box .o_list_select_domain").toHaveCount(1);
     expect(".o_control_panel .o_cp_searchview").toHaveCount(0);
-    expect(queryFirst(".o_list_selection_box")).toHaveText("1\nselected");
+    expect(queryFirst(".o_list_selection_box")).toHaveText("1\nselected\nAll");
 
     // unselect a record
     await contains(".o_data_row:nth-child(1)").drag();
@@ -17487,7 +17487,7 @@ test("selection is properly displayed (single page) on mobile", async () => {
     // select 2 records
     await contains(".o_data_row:nth-child(1)").drag();
     await contains(".o_data_row:nth-child(2)").drag();
-    expect(queryFirst(".o_list_selection_box")).toHaveText("2\nselected");
+    expect(queryFirst(".o_list_selection_box")).toHaveText("2\nselected\nAll");
 
     expect("div.o_control_panel .o_cp_action_menus").toHaveCount(1);
 


### PR DESCRIPTION
After this commit, as soon as at least one record is selected, the "All" button is available to select all records of the domain.

Note that it will not only select the records of the current page but all records of all pages.

Task-ID: 4314183

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
