### PR TITLE
[IMP] *: rename incoterm to incoterms

### DIFF
--- a/addons/account/data/account_incoterms_data.xml
+++ b/addons/account/data/account_incoterms_data.xml
@@ -1,47 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <record id="incoterm_EXW" model="account.incoterms">
+        <record id="incoterms_EXW" model="account.incoterms">
             <field name="code">EXW</field>
             <field name="name">EX WORKS</field>
         </record>
-        <record id="incoterm_FCA" model="account.incoterms">
+        <record id="incoterms_FCA" model="account.incoterms">
             <field name="code">FCA</field>
             <field name="name">FREE CARRIER</field>
         </record>
-        <record id="incoterm_FAS" model="account.incoterms">
+        <record id="incoterms_FAS" model="account.incoterms">
             <field name="code">FAS</field>
             <field name="name">FREE ALONGSIDE SHIP</field>
         </record>
-        <record id="incoterm_FOB" model="account.incoterms">
+        <record id="incoterms_FOB" model="account.incoterms">
             <field name="code">FOB</field>
             <field name="name">FREE ON BOARD</field>
         </record>
-        <record id="incoterm_CFR" model="account.incoterms">
+        <record id="incoterms_CFR" model="account.incoterms">
             <field name="code">CFR</field>
             <field name="name">COST AND FREIGHT</field>
         </record>
-        <record id="incoterm_CIF" model="account.incoterms">
+        <record id="incoterms_CIF" model="account.incoterms">
             <field name="code">CIF</field>
             <field name="name">COST, INSURANCE AND FREIGHT</field>
         </record>
-        <record id="incoterm_CPT" model="account.incoterms">
+        <record id="incoterms_CPT" model="account.incoterms">
             <field name="code">CPT</field>
             <field name="name">CARRIAGE PAID TO</field>
         </record>
-        <record id="incoterm_CIP" model="account.incoterms">
+        <record id="incoterms_CIP" model="account.incoterms">
             <field name="code">CIP</field>
             <field name="name">CARRIAGE AND INSURANCE PAID TO</field>
         </record>
-        <record id="incoterm_DPU" model="account.incoterms">
+        <record id="incoterms_DPU" model="account.incoterms">
             <field name="code">DPU</field>
             <field name="name">DELIVERED AT PLACE UNLOADED</field>
         </record>
-        <record id="incoterm_DAP" model="account.incoterms">
+        <record id="incoterms_DAP" model="account.incoterms">
             <field name="code">DAP</field>
             <field name="name">DELIVERED AT PLACE</field>
         </record>
-        <record id="incoterm_DDP" model="account.incoterms">
+        <record id="incoterms_DDP" model="account.incoterms">
             <field name="code">DDP</field>
             <field name="name">DELIVERED DUTY PAID</field>
         </record>

--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -1195,7 +1195,7 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
-msgid "<strong>Incoterm</strong>"
+msgid "<strong>Incoterms</strong>"
 msgstr ""
 
 #. module: account
@@ -3549,7 +3549,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,help:account.field_account_incoterms__active
 msgid ""
-"By unchecking the active field, you may hide an INCOTERM you will not use."
+"By unchecking the active field, you may hide INCOTERMS you will not use."
 msgstr ""
 
 #. module: account
@@ -3564,22 +3564,22 @@ msgid "CAMT Import"
 msgstr ""
 
 #. module: account
-#: model:account.incoterms,name:account.incoterm_CIP
+#: model:account.incoterms,name:account.incoterms_CIP
 msgid "CARRIAGE AND INSURANCE PAID TO"
 msgstr ""
 
 #. module: account
-#: model:account.incoterms,name:account.incoterm_CPT
+#: model:account.incoterms,name:account.incoterms_CPT
 msgid "CARRIAGE PAID TO"
 msgstr ""
 
 #. module: account
-#: model:account.incoterms,name:account.incoterm_CFR
+#: model:account.incoterms,name:account.incoterms_CFR
 msgid "COST AND FREIGHT"
 msgstr ""
 
 #. module: account
-#: model:account.incoterms,name:account.incoterm_CIF
+#: model:account.incoterms,name:account.incoterms_CIF
 msgid "COST, INSURANCE AND FREIGHT"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.action_incoterms_tree
-msgid "Create a new incoterm"
+msgid "Create new incoterms"
 msgstr ""
 
 #. module: account
@@ -5268,17 +5268,17 @@ msgid "Cut-off {label} {percent}%"
 msgstr ""
 
 #. module: account
-#: model:account.incoterms,name:account.incoterm_DAP
+#: model:account.incoterms,name:account.incoterms_DAP
 msgid "DELIVERED AT PLACE"
 msgstr ""
 
 #. module: account
-#: model:account.incoterms,name:account.incoterm_DPU
+#: model:account.incoterms,name:account.incoterms_DPU
 msgid "DELIVERED AT PLACE UNLOADED"
 msgstr ""
 
 #. module: account
-#: model:account.incoterms,name:account.incoterm_DDP
+#: model:account.incoterms,name:account.incoterms_DDP
 msgid "DELIVERED DUTY PAID"
 msgstr ""
 
@@ -5506,12 +5506,12 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
-msgid "Default Incoterm"
+msgid "Default Incoterms"
 msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
-msgid "Default Incoterm of your company"
+msgid "Default Incoterms of your company"
 msgstr ""
 
 #. module: account
@@ -5572,9 +5572,9 @@ msgid "Default Values"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_res_company__incoterm_id
-#: model:ir.model.fields,field_description:account.field_res_config_settings__incoterm_id
-msgid "Default incoterm"
+#: model:ir.model.fields,field_description:account.field_res_company__incoterms_id
+#: model:ir.model.fields,field_description:account.field_res_config_settings__incoterms_id
+msgid "Default incoterms"
 msgstr ""
 
 #. module: account
@@ -6336,7 +6336,7 @@ msgid "EU Intra-community Distance Selling"
 msgstr ""
 
 #. module: account
-#: model:account.incoterms,name:account.incoterm_EXW
+#: model:account.incoterms,name:account.incoterms_EXW
 msgid "EX WORKS"
 msgstr ""
 
@@ -6764,17 +6764,17 @@ msgid "Extra Edis"
 msgstr ""
 
 #. module: account
-#: model:account.incoterms,name:account.incoterm_FAS
+#: model:account.incoterms,name:account.incoterms_FAS
 msgid "FREE ALONGSIDE SHIP"
 msgstr ""
 
 #. module: account
-#: model:account.incoterms,name:account.incoterm_FCA
+#: model:account.incoterms,name:account.incoterms_FCA
 msgid "FREE CARRIER"
 msgstr ""
 
 #. module: account
-#: model:account.incoterms,name:account.incoterm_FOB
+#: model:account.incoterms,name:account.incoterms_FOB
 msgid "FREE ON BOARD"
 msgstr ""
 
@@ -8066,26 +8066,26 @@ msgid ""
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_bank_statement_line__invoice_incoterm_id
-#: model:ir.model.fields,field_description:account.field_account_move__invoice_incoterm_id
-msgid "Incoterm"
+#: model:ir.model.fields,field_description:account.field_account_bank_statement_line__invoice_incoterms_id
+#: model:ir.model.fields,field_description:account.field_account_move__invoice_incoterms_id
+msgid "Incoterms"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_bank_statement_line__incoterm_location
-#: model:ir.model.fields,field_description:account.field_account_move__incoterm_location
-msgid "Incoterm Location"
+#: model:ir.model.fields,field_description:account.field_account_bank_statement_line__incoterms_location
+#: model:ir.model.fields,field_description:account.field_account_move__incoterms_location
+msgid "Incoterms Location"
 msgstr ""
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_incoterms__code
-msgid "Incoterm Standard Code"
+msgid "Incoterms Standard Code"
 msgstr ""
 
 #. module: account
 #: model:ir.actions.act_window,name:account.action_incoterms_tree
 #: model:ir.model,name:account.model_account_incoterms
-#: model:ir.ui.menu,name:account.menu_action_incoterm_open
+#: model:ir.ui.menu,name:account.menu_action_incoterms_open
 #: model_terms:ir.ui.view,arch_db:account.account_incoterms_form
 #: model_terms:ir.ui.view,arch_db:account.account_incoterms_view_search
 #: model_terms:ir.ui.view,arch_db:account.view_incoterms_tree
@@ -8240,10 +8240,10 @@ msgid "Internal link"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,help:account.field_account_bank_statement_line__invoice_incoterm_id
-#: model:ir.model.fields,help:account.field_account_move__invoice_incoterm_id
-#: model:ir.model.fields,help:account.field_res_company__incoterm_id
-#: model:ir.model.fields,help:account.field_res_config_settings__incoterm_id
+#: model:ir.model.fields,help:account.field_account_bank_statement_line__invoice_incoterms_id
+#: model:ir.model.fields,help:account.field_account_move__invoice_incoterms_id
+#: model:ir.model.fields,help:account.field_res_company__incoterms_id
+#: model:ir.model.fields,help:account.field_res_config_settings__incoterms_id
 msgid ""
 "International Commercial Terms are a series of predefined commercial terms "
 "used in international transactions."

--- a/addons/account/models/account_incoterms.py
+++ b/addons/account/models/account_incoterms.py
@@ -13,12 +13,12 @@ class AccountIncoterms(models.Model):
         help="Incoterms are series of sales terms. They are used to divide transaction costs and responsibilities between buyer and seller and reflect state-of-the-art transportation practices.")
     code = fields.Char(
         'Code', size=3, required=True,
-        help="Incoterm Standard Code")
+        help="Incoterms Standard Code")
     active = fields.Boolean(
         'Active', default=True,
-        help="By unchecking the active field, you may hide an INCOTERM you will not use.")
+        help="By unchecking the active field, you may hide INCOTERMS you will not use.")
 
     @api.depends('code')
     def _compute_display_name(self):
-        for incoterm in self:
-            incoterm.display_name = '%s%s' % (incoterm.code and '[%s] ' % incoterm.code or '', incoterm.name)
+        for incoterms in self:
+            incoterms.display_name = '%s%s' % (incoterms.code and '[%s] ' % incoterms.code or '', incoterms.name)

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -617,16 +617,16 @@ class AccountMove(models.Model):
         tracking=True,
         help="The document(s) that generated the invoice.",
     )
-    invoice_incoterm_id = fields.Many2one(
+    invoice_incoterms_id = fields.Many2one(
         comodel_name='account.incoterms',
-        string='Incoterm',
-        default=lambda self: self.env.company.incoterm_id,
+        string='Incoterms',
+        default=lambda self: self.env.company.incoterms_id,
         help='International Commercial Terms are a series of predefined commercial '
              'terms used in international transactions.',
     )
-    incoterm_location = fields.Char(
-        string='Incoterm Location',
-        compute='_compute_incoterm_location',
+    incoterms_location = fields.Char(
+        string='Incoterms Location',
+        compute='_compute_incoterms_location',
         readonly=False,
         store=True,
     )
@@ -1885,7 +1885,7 @@ class AccountMove(models.Model):
         for move in self:
             move[attachment_field] = move_vals.get(move._origin.id, False)
 
-    def _compute_incoterm_location(self):
+    def _compute_incoterms_location(self):
         pass
 
     @api.depends('partner_id', 'invoice_date', 'amount_total')

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -125,7 +125,7 @@ class ResCompany(models.Model):
                 ('account_type', '=', 'expense')]")
     anglo_saxon_accounting = fields.Boolean(string="Use anglo-saxon accounting")
     bank_journal_ids = fields.One2many('account.journal', 'company_id', domain=[('type', '=', 'bank')], string='Bank Journals')
-    incoterm_id = fields.Many2one('account.incoterms', string='Default incoterm',
+    incoterms_id = fields.Many2one('account.incoterms', string='Default incoterms',
         help='International Commercial Terms are a series of predefined commercial terms used in international transactions.')
 
     qr_code = fields.Boolean(string='Display QR-code on invoices')

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -124,7 +124,7 @@ class ResConfigSettings(models.TransientModel):
     account_fiscal_country_id = fields.Many2one(string="Fiscal Country Code", related="company_id.account_fiscal_country_id", readonly=False, store=False)
 
     qr_code = fields.Boolean(string='Display SEPA QR-code', related='company_id.qr_code', readonly=False)
-    incoterm_id = fields.Many2one('account.incoterms', string='Default incoterm', related='company_id.incoterm_id', help='International Commercial Terms are a series of predefined commercial terms used in international transactions.', readonly=False)
+    incoterms_id = fields.Many2one('account.incoterms', string='Default incoterms', related='company_id.incoterms_id', help='International Commercial Terms are a series of predefined commercial terms used in international transactions.', readonly=False)
     invoice_terms = fields.Html(related='company_id.invoice_terms', string="Terms & Conditions", readonly=False)
     invoice_terms_html = fields.Html(related='company_id.invoice_terms_html', string="Terms & Conditions as a Web page",
                                      readonly=False)

--- a/addons/account/views/account_incoterms_view.xml
+++ b/addons/account/views/account_incoterms_view.xml
@@ -49,7 +49,7 @@
             <field name="view_mode">list,form</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
-                Create a new incoterm
+                Create new incoterms
               </p><p>
                 Incoterms are used to divide transaction costs and responsibilities between buyer and seller.
               </p>

--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -40,7 +40,7 @@
             <menuitem id="menu_account_config" name="Settings" action="action_account_config" groups="base.group_system" sequence="0"/>
             <menuitem id="account_invoicing_menu" name="Invoicing" groups="account.group_account_invoice,account.group_account_readonly" sequence="1">
                 <menuitem id="menu_action_payment_term_form" action="action_payment_term_form" sequence="1"/>
-                <menuitem id="menu_action_incoterm_open" action="action_incoterms_tree" groups="base.group_no_one" sequence="3"/>
+                <menuitem id="menu_action_incoterms_open" action="action_incoterms_tree" groups="base.group_no_one" sequence="3"/>
             </menuitem>
             <menuitem id="account_banks_menu" name="Banks" groups="account.group_account_manager" sequence="2">
                 <menuitem id="menu_action_account_bank_journal_form" action="action_new_bank_setting" groups="account.group_account_manager" sequence="1"/>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1410,8 +1410,8 @@
                                            name="accounting_info_group"
                                            invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')">
                                         <field name="company_id" groups="base.group_multi_company"/>
-                                        <field name="invoice_incoterm_id"/>
-                                        <field name="incoterm_location"/>
+                                        <field name="invoice_incoterms_id"/>
+                                        <field name="incoterms_location"/>
                                         <field name="fiscal_position_id" readonly="state in ['cancel', 'posted']"/>
                                         <field name="secured" groups="account.group_account_secured,base.group_no_one"/>
                                         <field name="preferred_payment_method_line_id"

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -92,13 +92,13 @@
                                 <strong>Reference</strong>
                                 <div t-field="o.ref">INV/2023/00001</div>
                             </div>
-                            <div class="col" t-if="o.invoice_incoterm_id" name="incoterm_id">
-                                <strong>Incoterm</strong>
-                                <div t-if="o.incoterm_location">
-                                    <span t-field="o.invoice_incoterm_id.code"/> <br/>
-                                    <span t-field="o.incoterm_location"/>
+                            <div class="col" t-if="o.invoice_incoterms_id" name="incoterms_id">
+                                <strong>Incoterms</strong>
+                                <div t-if="o.incoterms_location">
+                                    <span t-field="o.invoice_incoterms_id.code"/> <br/>
+                                    <span t-field="o.incoterms_location"/>
                                 </div>
-                                <div t-else="" t-field="o.invoice_incoterm_id.code" class="m-0"/>
+                                <div t-else="" t-field="o.invoice_incoterms_id.code" class="m-0"/>
                             </div>
                         </div>
 

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -129,8 +129,8 @@
                                 documentation="/applications/finance/accounting/reporting/declarations/intrastat.html">
                                 <field name="module_account_intrastat" widget="upgrade_boolean"/>
                             </setting>
-                            <setting id="default_incoterm" string="Default Incoterm" help="Default Incoterm of your company">
-                                <field name="incoterm_id"/>
+                            <setting id="default_incoterms" string="Default Incoterms" help="Default Incoterms of your company">
+                                <field name="incoterms_id"/>
                             </setting>
                             <setting id="show_sale_receipts" help="Activate to create sale receipt">
                                 <field name="group_show_sale_receipts"/>

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -698,12 +698,12 @@ class AccountEdiXmlUbl_20(models.AbstractModel):
         invoice_values['narration'] = self._import_description(tree, xpaths=['./{*}Note', './{*}PaymentTerms/{*}Note'])
         invoice_values['payment_reference'] = tree.findtext('./{*}PaymentMeans/{*}PaymentID')
 
-        # ==== invoice_incoterm_id ====
-        incoterm_code = tree.findtext('./{*}TransportExecutionTerms/{*}DeliveryTerms/{*}ID')
-        if incoterm_code:
-            incoterm = self.env['account.incoterms'].search([('code', '=', incoterm_code)], limit=1)
-            if incoterm:
-                invoice_values['invoice_incoterm_id'] = incoterm.id
+        # ==== invoice_incoterms_id ====
+        incoterms_code = tree.findtext('./{*}TransportExecutionTerms/{*}DeliveryTerms/{*}ID')
+        if incoterms_code:
+            incoterms = self.env['account.incoterms'].search([('code', '=', incoterms_code)], limit=1)
+            if incoterms:
+                invoice_values['invoice_incoterms_id'] = incoterms.id
 
         # ==== Document level AllowanceCharge, Prepaid Amounts, Invoice Lines ====
         allowance_charges_line_vals, allowance_charges_logs = self._import_document_allowance_charges(tree, invoice, invoice.journal_id.type, qty_factor)

--- a/addons/l10n_ar/demo/account_customer_invoice_demo.xml
+++ b/addons/l10n_ar/demo/account_customer_invoice_demo.xml
@@ -80,7 +80,7 @@
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-03'"/>
-        <field name="invoice_incoterm_id" ref="account.incoterm_EXW"/>
+        <field name="invoice_incoterms_id" ref="account.incoterms_EXW"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
             (0, 0, {'product_id': ref('product_product_telefonia'), 'price_unit': 250.0, 'quantity': 1}),
@@ -99,7 +99,7 @@
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-03'"/>
-        <field name="invoice_incoterm_id" ref="account.incoterm_EXW"/>
+        <field name="invoice_incoterms_id" ref="account.incoterms_EXW"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
             (0, 0, {'product_id': ref('product_product_telefonia'), 'price_unit': 250.0, 'quantity': 1}),
@@ -196,7 +196,7 @@
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-20'"/>
-        <field name="invoice_incoterm_id" ref="account.incoterm_EXW"/>
+        <field name="invoice_incoterms_id" ref="account.incoterms_EXW"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
         ]"/>
@@ -210,7 +210,7 @@
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-20'"/>
-        <field name="invoice_incoterm_id" ref="account.incoterm_EXW"/>
+        <field name="invoice_incoterms_id" ref="account.incoterms_EXW"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product_product_telefonia'), 'price_unit': 250.0, 'quantity': 1}),
         ]"/>
@@ -225,7 +225,7 @@
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-22'"/>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-01'"/>
-        <field name="invoice_incoterm_id" ref="account.incoterm_EXW"/>
+        <field name="invoice_incoterms_id" ref="account.incoterms_EXW"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
         ]"/>

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -113,7 +113,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
 msgid ""
 "<br/>\n"
-"                        <strong>Incoterm:</strong>"
+"                        <strong>Incoterms:</strong>"
 msgstr ""
 
 #. module: l10n_ar

--- a/addons/l10n_ar/tests/common.py
+++ b/addons/l10n_ar/tests/common.py
@@ -320,7 +320,7 @@ class TestAr(AccountTestInvoicingCommon):
         """ Create in the unit tests the same invoices created in demo data """
         payment_term_id = self.env.ref("account.account_payment_term_end_following_month")
         invoice_user_id = self.env.user
-        incoterm = self.env.ref("account.incoterm_EXW")
+        incoterms = self.env.ref("account.incoterms_EXW")
 
         decimal_price = self.env.ref('product.decimal_price')
         decimal_price.digits = 4
@@ -398,7 +398,7 @@ class TestAr(AccountTestInvoicingCommon):
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-03",
                 "company_id": self.company_ri,
-                "invoice_incoterm_id": incoterm,
+                "invoice_incoterms_id": incoterms,
                 "invoice_line_ids": [
                     {'product_id': self.product_iva_105, 'price_unit': 642.0, 'quantity': 5},
                     {'product_id': self.service_iva_27, 'price_unit': 250.0, 'quantity': 1},
@@ -416,7 +416,7 @@ class TestAr(AccountTestInvoicingCommon):
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-03",
                 "company_id": self.company_ri,
-                "invoice_incoterm_id": incoterm,
+                "invoice_incoterms_id": incoterms,
                 "invoice_line_ids": [
                     {'product_id': self.product_iva_105, 'price_unit': 642.0, 'quantity': 5},
                     {'product_id': self.service_iva_27, 'price_unit': 250.0, 'quantity': 1},
@@ -503,7 +503,7 @@ class TestAr(AccountTestInvoicingCommon):
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-20",
                 "company_id": self.company_ri,
-                "invoice_incoterm_id": incoterm,
+                "invoice_incoterms_id": incoterms,
                 "invoice_line_ids": [
                     {'product_id': self.product_iva_105, 'price_unit': 642.0, 'quantity': 5},
                 ],
@@ -516,7 +516,7 @@ class TestAr(AccountTestInvoicingCommon):
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-20",
                 "company_id": self.company_ri,
-                "invoice_incoterm_id": incoterm,
+                "invoice_incoterms_id": incoterms,
                 "invoice_line_ids": [
                     {'product_id': self.service_iva_27, 'price_unit': 250.0, 'quantity': 1},
                 ],
@@ -529,7 +529,7 @@ class TestAr(AccountTestInvoicingCommon):
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-22",
                 "company_id": self.company_ri,
-                "invoice_incoterm_id": incoterm,
+                "invoice_incoterms_id": incoterms,
                 "invoice_line_ids": [
                     {'product_id': self.product_iva_105, 'price_unit': 642.0, 'quantity': 5},
                 ],
@@ -580,8 +580,8 @@ class TestAr(AccountTestInvoicingCommon):
                 invoice_form.invoice_payment_term_id = values['invoice_payment_term_id']
                 if not use_current_date:
                     invoice_form.invoice_date = values['invoice_date']
-                if values.get('invoice_incoterm_id'):
-                    invoice_form.invoice_incoterm_id = values['invoice_incoterm_id']
+                if values.get('invoice_incoterms_id'):
+                    invoice_form.invoice_incoterms_id = values['invoice_incoterms_id']
                 for line in values['invoice_line_ids']:
                     with invoice_form.invoice_line_ids.new() as line_form:
                         line_form.product_id = line.get('product_id')
@@ -634,8 +634,8 @@ class TestAr(AccountTestInvoicingCommon):
                 invoice_form.l10n_latam_document_type_id = data.get('document_type')
             if data.get('document_number'):
                 invoice_form.l10n_latam_document_number = data.get('document_number')
-            if data.get('incoterm'):
-                invoice_form.invoice_incoterm_id = data.get('incoterm')
+            if data.get('incoterms'):
+                invoice_form.invoice_incoterms_id = data.get('incoterms')
             if data.get('currency'):
                 invoice_form.currency_id = data.get('currency')
             for line in data.get('lines', [{}]):

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -218,14 +218,14 @@
                     <!-- (18) REMITOS -->
                     <!-- We do not have remitos implement yet. print here the remito number when we have it -->
 
-                    <t t-if="o.invoice_incoterm_id">
+                    <t t-if="o.invoice_incoterms_id">
                         <br/>
-                        <strong>Incoterm:</strong>
-                        <p t-if="o.incoterm_location">
-                            <span t-field="o.invoice_incoterm_id.code"/> <br/>
-                            <span t-field="o.incoterm_location"/>
+                        <strong>Incoterms:</strong>
+                        <p t-if="o.incoterms_location">
+                            <span t-field="o.invoice_incoterms_id.code"/> <br/>
+                            <span t-field="o.incoterms_location"/>
                         </p>
-                        <p t-else="" t-field="o.invoice_incoterm_id.name" class="m-0"/>
+                        <p t-else="" t-field="o.invoice_incoterms_id.name" class="m-0"/>
                     </t>
 
                 </div>

--- a/addons/l10n_cl/i18n/l10n_cl.pot
+++ b/addons/l10n_cl/i18n/l10n_cl.pot
@@ -71,7 +71,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_cl.informations
 msgid ""
 "<br/>\n"
-"                    <strong>Incoterm:</strong>"
+"                    <strong>Incoterms:</strong>"
 msgstr ""
 
 #. module: l10n_cl

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -104,10 +104,10 @@
                 <span t-out="o.invoice_date_due" t-options='{"widget": "date"}'/>
                 <br/>
 
-                <t t-if="o.invoice_incoterm_id">
+                <t t-if="o.invoice_incoterms_id">
                     <br/>
-                    <strong>Incoterm:</strong>
-                    <span t-field="o.invoice_incoterm_id.name"/>
+                    <strong>Incoterms:</strong>
+                    <span t-field="o.invoice_incoterms_id.name"/>
                 </t>
 
                 <t t-if="o.partner_shipping_id and o.partner_id not in o.partner_shipping_id" >

--- a/addons/l10n_din5008_purchase/i18n/l10n_din5008_purchase.pot
+++ b/addons/l10n_din5008_purchase/i18n/l10n_din5008_purchase.pot
@@ -36,7 +36,7 @@ msgstr ""
 #. module: l10n_din5008_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_purchaseorder_document
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_purchase.report_common_purchase_din5008_template
-msgid "Incoterm:"
+msgid "Incoterms:"
 msgstr ""
 
 #. module: l10n_din5008_purchase

--- a/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
+++ b/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
@@ -26,9 +26,9 @@
                         <td>Order Deadline:</td>
                         <td><t t-out="o.date_order" t-options="{'widget': 'date'}"/></td>
                     </tr>
-                    <tr t-if="o.incoterm_id">
-                        <td>Incoterm:</td>
-                        <td><t t-out="o.incoterm_id"/></td>
+                    <tr t-if="o.incoterms_id">
+                        <td>Incoterms:</td>
+                        <td><t t-out="o.incoterms_id"/></td>
                     </tr>
                 </table>
             </div>

--- a/addons/l10n_din5008_sale/i18n/l10n_din5008_sale.pot
+++ b/addons/l10n_din5008_sale/i18n/l10n_din5008_sale.pot
@@ -42,7 +42,7 @@ msgstr ""
 
 #. module: l10n_din5008_sale
 #: model_terms:ir.ui.view,arch_db:l10n_din5008_sale.report_saleorder_document
-msgid "Incoterm:"
+msgid "Incoterms:"
 msgstr ""
 
 #. module: l10n_din5008_sale

--- a/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
+++ b/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
@@ -37,9 +37,9 @@
                             <td>Salesperson:</td>
                             <td><div t-field="doc.user_id.name"/></td>
                         </tr>
-                        <tr t-if="'incoterm' in doc._fields and doc.incoterm">
-                            <td>Incoterm:</td>
-                            <td><div t-field="doc.incoterm.code"/></td>
+                        <tr t-if="'incoterms' in doc._fields and doc.incoterms">
+                            <td>Incoterms:</td>
+                            <td><div t-field="doc.incoterms.code"/></td>
                         </tr>
                     </table>
                 </div>

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -529,17 +529,17 @@
                     </div>
                 </p>
                 
-                <p name="incoterm" t-if="0"></p>
-                <div class="row" t-if="o.invoice_incoterm_id" name="incoterm">
+                <p name="incoterms" t-if="0"></p>
+                <div class="row" t-if="o.invoice_incoterms_id" name="incoterms">
                     <div class="col-2 offset-6">
-                        <strong>Incoterm:</strong>
+                        <strong>Incoterms:</strong>
                     </div>
                     <div class="col-2 text-nowrap">
-                        <span t-out="o.invoice_incoterm_id.code"/>
+                        <span t-out="o.invoice_incoterms_id.code"/>
                         -
-                        <span t-out="o.invoice_incoterm_id.name"/>
+                        <span t-out="o.invoice_incoterms_id.name"/>
                         -
-                        <span t-if="o.incoterm_location" t-out="o.incoterm_location"/>
+                        <span t-if="o.incoterms_location" t-out="o.incoterms_location"/>
                     </div>
                     <div class="col-2 text-end">
                         <strong>:شرط تجاري</strong>

--- a/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
+++ b/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
@@ -52,7 +52,7 @@
                                 </tr>
                                 <tr>
                                     <td>Carrier Condition</td>
-                                    <td><span t-field="o.sale_id.incoterm.name"/></td>
+                                    <td><span t-field="o.sale_id.incoterms.name"/></td>
                                 </tr>
                                 <tr>
                                     <td>Carrier</td>

--- a/addons/l10n_my_edi/data/my_ubl_templates.xml
+++ b/addons/l10n_my_edi/data/my_ubl_templates.xml
@@ -10,8 +10,8 @@
                     <cbc:SourceCurrencyCode t-out="vals.get('document_currency_code')"/>
                     <cbc:TargetCurrencyCode>MYR</cbc:TargetCurrencyCode>
                 </cac:TaxExchangeRate>
-                <cac:AdditionalDocumentReference t-if="vals.get('invoice_incoterm_code')">
-                    <cbc:ID t-out="vals['invoice_incoterm_code']"/>
+                <cac:AdditionalDocumentReference t-if="vals.get('invoice_incoterms_code')">
+                    <cbc:ID t-out="vals['invoice_incoterms_code']"/>
                 </cac:AdditionalDocumentReference>
                 <cac:AdditionalDocumentReference t-if="vals.get('custom_form_reference')">
                     <cbc:ID t-out="vals['custom_form_reference']"/>

--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -91,7 +91,7 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
             'issue_time': datetime.now(tz=UTC).strftime("%H:%M:%SZ"),
             # Exchange rate information must be provided if applicable
             'tax_exchange_rate': self._l10n_my_edi_get_tax_exchange_rate(invoice),
-            'invoice_incoterm_code': invoice.invoice_incoterm_id.code,
+            'invoice_incoterms_code': invoice.invoice_incoterms_id.code,
             'custom_form_reference': invoice.l10n_my_edi_custom_form_reference,
         })
 
@@ -376,10 +376,10 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
     def _import_fill_invoice_form(self, invoice, tree, qty_factor):
         # EXTENDS 'account_edi_ubl_cii'
         logs = super()._import_fill_invoice_form(invoice, tree, qty_factor)
-        # We get the incoterm
-        incoterm_code = self._find_value('./cac:AdditionalDocumentReference[not(descendant::cbc:DocumentType)]/cbc:ID', tree)
-        if incoterm_code is not None:
-            invoice.invoice_incoterm_id = self.env['account.incoterms'].search([('code', '=', incoterm_code)], limit=1)
+        # We get the incoterms
+        incoterms_code = self._find_value('./cac:AdditionalDocumentReference[not(descendant::cbc:DocumentType)]/cbc:ID', tree)
+        if incoterms_code is not None:
+            invoice.invoice_incoterms_id = self.env['account.incoterms'].search([('code', '=', incoterms_code)], limit=1)
         custom_form_ref = self._find_value('./cac:AdditionalDocumentReference[descendant::cbc:DocumentType[text()="CustomsImportForm"]]/cbc:ID', tree)
         invoice.l10n_my_edi_custom_form_reference = custom_form_ref
 

--- a/addons/l10n_my_edi/tests/test_file_generation.py
+++ b/addons/l10n_my_edi/tests/test_file_generation.py
@@ -172,7 +172,7 @@ class L10nMyEDITestSubmission(AccountTestInvoicingCommon):
             'out_invoice', amounts=[100], currency=self.other_currency
         )
         basic_invoice.write({
-            'invoice_incoterm_id': self.env.ref('account.incoterm_CFR').id,
+            'invoice_incoterms_id': self.env.ref('account.incoterms_CFR').id,
             'l10n_my_edi_custom_form_reference': 'E12345678912',
         })
 
@@ -188,11 +188,11 @@ class L10nMyEDITestSubmission(AccountTestInvoicingCommon):
         root = etree.fromstring(file)
 
         # We test a few values that are optional, yet mandatory in some cases (we leave it up to the user)
-        # AdditionalDocumentReference => incoterm and customs
+        # AdditionalDocumentReference => incoterms and customs
         self._assert_node_values(
             root,
             'cac:AdditionalDocumentReference[not(descendant::*[local-name() = "DocumentType"])]/cbc:ID',
-            basic_invoice.invoice_incoterm_id.code,
+            basic_invoice.invoice_incoterms_id.code,
         )
         self._assert_node_values(
             root,

--- a/addons/purchase/i18n/purchase.pot
+++ b/addons/purchase/i18n/purchase.pot
@@ -1433,8 +1433,8 @@ msgid "In the Order"
 msgstr ""
 
 #. module: purchase
-#: model:ir.model.fields,field_description:purchase.field_purchase_order__incoterm_id
-msgid "Incoterm"
+#: model:ir.model.fields,field_description:purchase.field_purchase_order__incoterms_id
+msgid "Incoterms"
 msgstr ""
 
 #. module: purchase
@@ -1444,7 +1444,7 @@ msgid "Indicate the product quantity you want to order."
 msgstr ""
 
 #. module: purchase
-#: model:ir.model.fields,help:purchase.field_purchase_order__incoterm_id
+#: model:ir.model.fields,help:purchase.field_purchase_order__incoterms_id
 msgid ""
 "International Commercial Terms are a series of predefined commercial terms "
 "used in international transactions."

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -132,7 +132,7 @@ class PurchaseOrder(models.Model):
         related='company_id.tax_calculation_rounding_method',
         string='Tax calculation rounding method', readonly=True)
     payment_term_id = fields.Many2one('account.payment.term', 'Payment Terms', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
-    incoterm_id = fields.Many2one('account.incoterms', 'Incoterm', help="International Commercial Terms are a series of predefined commercial terms used in international transactions.")
+    incoterms_id = fields.Many2one('account.incoterms', 'Incoterms', help="International Commercial Terms are a series of predefined commercial terms used in international transactions.")
 
     product_id = fields.Many2one('product.product', related='order_line.product_id', string='Product')
     user_id = fields.Many2one(

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -855,8 +855,8 @@ class TestPurchase(AccountTestInvoicingCommon):
         user_2 = self.env['res.users'].search([])[1]
         payment_term_id_1 = self.env['account.payment.term'].search([])[0]
         payment_term_id_2 = self.env['account.payment.term'].search([])[1]
-        incoterm_id_1 = self.env['account.incoterms'].search([])[0]
-        incoterm_id_2 = self.env['account.incoterms'].search([])[1]
+        incoterms_id_1 = self.env['account.incoterms'].search([])[0]
+        incoterms_id_2 = self.env['account.incoterms'].search([])[1]
 
         po_1 = Form(PurchaseOrder)
         po_1.partner_id = self.partner_a
@@ -869,7 +869,7 @@ class TestPurchase(AccountTestInvoicingCommon):
             po_line.product_qty = 1
             po_line.price_unit = 100
         po_1 = po_1.save()
-        po_1.incoterm_id = incoterm_id_1
+        po_1.incoterms_id = incoterms_id_1
 
         po_2 = Form(PurchaseOrder)
         po_2.partner_id = self.partner_a
@@ -887,7 +887,7 @@ class TestPurchase(AccountTestInvoicingCommon):
             po_line_2.product_qty = 5
             po_line_2.price_unit = 500
         po_2 = po_2.save()
-        po_2.incoterm_id = incoterm_id_2
+        po_2.incoterms_id = incoterms_id_2
 
         with self.assertRaises(UserError) as context:
             PurchaseOrder.browse([po_1.id]).action_merge()
@@ -901,4 +901,4 @@ class TestPurchase(AccountTestInvoicingCommon):
         self.assertEqual(po_1.origin, "s0003, s0004")
         self.assertEqual(po_1.user_id, user_1)
         self.assertEqual(po_1.payment_term_id, payment_term_id_1)
-        self.assertEqual(po_1.incoterm_id, incoterm_id_1)
+        self.assertEqual(po_1.incoterms_id, incoterms_id_1)

--- a/addons/purchase_stock/i18n/purchase_stock.pot
+++ b/addons/purchase_stock/i18n/purchase_stock.pot
@@ -59,7 +59,7 @@ msgstr ""
 #. module: purchase_stock
 #: model_terms:ir.ui.view,arch_db:purchase_stock.report_purchaseorder_document
 #: model_terms:ir.ui.view,arch_db:purchase_stock.report_purchasequotation_document
-msgid "<strong>Incoterm:</strong>"
+msgid "<strong>Incoterms:</strong>"
 msgstr ""
 
 #. module: purchase_stock
@@ -284,8 +284,8 @@ msgid "Incoming Shipments"
 msgstr ""
 
 #. module: purchase_stock
-#: model:ir.model.fields,field_description:purchase_stock.field_purchase_order__incoterm_location
-msgid "Incoterm Location"
+#: model:ir.model.fields,field_description:purchase_stock.field_purchase_order__incoterms_location
+msgid "Incoterms Location"
 msgstr ""
 
 #. module: purchase_stock

--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -166,11 +166,11 @@ class AccountMove(models.Model):
         return rslt
 
     @api.depends('purchase_id')
-    def _compute_incoterm_location(self):
-        super()._compute_incoterm_location()
+    def _compute_incoterms_location(self):
+        super()._compute_incoterms_location()
         for move in self:
-            purchase_locations = move.line_ids.purchase_line_id.order_id.mapped('incoterm_location')
-            incoterm_res = next((incoterm for incoterm in purchase_locations if incoterm), False)
-            # if multiple purchase order we take an incoterm that is not false
-            if incoterm_res:
-                move.incoterm_location = incoterm_res
+            purchase_locations = move.line_ids.purchase_line_id.order_id.mapped('incoterms_location')
+            incoterms_res = next((incoterms for incoterms in purchase_locations if incoterms), False)
+            # if multiple purchase order we take incoterms that is not false
+            if incoterms_res:
+                move.incoterms_location = incoterms_res

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -16,7 +16,7 @@ class PurchaseOrder(models.Model):
     def _default_picking_type(self):
         return self._get_picking_type(self.env.context.get('company_id') or self.env.company.id)
 
-    incoterm_location = fields.Char(string='Incoterm Location')
+    incoterms_location = fields.Char(string='Incoterms Location')
     incoming_picking_count = fields.Integer("Incoming Shipment count", compute='_compute_incoming_picking_count')
     picking_ids = fields.Many2many('stock.picking', compute='_compute_picking_ids', string='Receptions', copy=False, store=True)
     dest_address_id = fields.Many2one('res.partner', compute='_compute_dest_address_id', store=True, readonly=False)
@@ -198,7 +198,7 @@ class PurchaseOrder(models.Model):
 
     def _prepare_invoice(self):
         invoice_vals = super()._prepare_invoice()
-        invoice_vals['invoice_incoterm_id'] = self.incoterm_id.id
+        invoice_vals['invoice_incoterms_id'] = self.incoterms_id.id
         return invoice_vals
 
     # --------------------------------------------------

--- a/addons/purchase_stock/report/purchase_report_templates.xml
+++ b/addons/purchase_stock/report/purchase_report_templates.xml
@@ -14,13 +14,13 @@
             </t>
         </xpath>
         <xpath expr="//div[@t-if='o.date_planned']" position="after">
-            <div t-if="o.incoterm_id" class="col-2 bm-2">
-                <strong>Incoterm:</strong>
-                <p t-if="o.incoterm_location">
-                    <span t-field="o.incoterm_id.code"/> <br/>
-                    <span t-field="o.incoterm_location"/>
+            <div t-if="o.incoterms_id" class="col-2 bm-2">
+                <strong>Incoterms:</strong>
+                <p t-if="o.incoterms_location">
+                    <span t-field="o.incoterms_id.code"/> <br/>
+                    <span t-field="o.incoterms_location"/>
                 </p>
-                <p t-else="" t-field="o.incoterm_id.code" class="m-0"/>
+                <p t-else="" t-field="o.incoterms_id.code" class="m-0"/>
             </div>
         </xpath>
     </template>
@@ -39,13 +39,13 @@
         </xpath>
         <xpath expr="//span[@t-field='o.name']/.." position="after">
             <div id="informations" class="row mt16 mb16">
-                <div t-if="o.incoterm_id" class="col-3 bm-2">
-                    <strong>Incoterm:</strong>
-                    <p t-if="o.incoterm_location">
-                        <span t-field="o.incoterm_id.code"/> <br/>
-                        <span t-field="o.incoterm_location"/>
+                <div t-if="o.incoterms_id" class="col-3 bm-2">
+                    <strong>Incoterms:</strong>
+                    <p t-if="o.incoterms_location">
+                        <span t-field="o.incoterms_id.code"/> <br/>
+                        <span t-field="o.incoterms_location"/>
                     </p>
-                    <p t-else="" t-field="o.incoterm_id.code" class="m-0"/>
+                    <p t-else="" t-field="o.incoterms_id.code" class="m-0"/>
                 </div>
             </div>
         </xpath>

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -67,8 +67,8 @@
             </xpath>
             <xpath expr="//page[@name='purchase_delivery_invoice']/group/group" position="inside">
                 <field name="default_location_dest_id_usage" invisible="1"/>
-                <field name="incoterm_id" readonly="state == 'done'"/>
-                <field name="incoterm_location"  readonly="state == 'done'"/>
+                <field name="incoterms_id" readonly="state == 'done'"/>
+                <field name="incoterms_location"  readonly="state == 'done'"/>
             </xpath>
             <xpath expr="//div[@name='reminder']" position="after">
                 <field name="picking_type_id" domain="[('code','=','incoming'), '|', ('warehouse_id', '=', False), ('warehouse_id.company_id', '=', company_id)]" options="{'no_create': True}" groups="stock.group_stock_multi_locations" readonly="state in ['cancel', 'done', 'purchase']"/>

--- a/addons/sale_stock/i18n/sale_stock.pot
+++ b/addons/sale_stock/i18n/sale_stock.pot
@@ -76,7 +76,7 @@ msgstr ""
 #. module: sale_stock
 #: model_terms:ir.ui.view,arch_db:sale_stock.report_delivery_document_inherit_sale_stock
 #: model_terms:ir.ui.view,arch_db:sale_stock.report_saleorder_document_inherit_sale_stock
-msgid "<strong>Incoterm</strong>"
+msgid "<strong>Incoterms</strong>"
 msgstr ""
 
 #. module: sale_stock
@@ -290,22 +290,22 @@ msgstr ""
 
 #. module: sale_stock
 #: model:ir.model.fields,field_description:sale_stock.field_sale_order__incoterm
-msgid "Incoterm"
+msgid "Incoterms"
 msgstr ""
 
 #. module: sale_stock
-#: model:ir.model.fields,field_description:sale_stock.field_sale_order__incoterm_location
-msgid "Incoterm Location"
+#: model:ir.model.fields,field_description:sale_stock.field_sale_order__incoterms_location
+msgid "Incoterms Location"
 msgstr ""
 
 #. module: sale_stock
 #: model_terms:ir.ui.view,arch_db:sale_stock.report_delivery_document_inherit_sale_stock
-msgid "Incoterm details"
+msgid "Incoterms details"
 msgstr ""
 
 #. module: sale_stock
 #: model_terms:ir.ui.view,arch_db:sale_stock.sale_order_portal_content_inherit_sale_stock
-msgid "Incoterm:"
+msgid "Incoterms:"
 msgstr ""
 
 #. module: sale_stock

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -124,14 +124,14 @@ class AccountMove(models.Model):
                 move.delivery_date = effective_date_res
 
     @api.depends('line_ids.sale_line_ids.order_id')
-    def _compute_incoterm_location(self):
-        super()._compute_incoterm_location()
+    def _compute_incoterms_location(self):
+        super()._compute_incoterms_location()
         for move in self:
-            sale_locations = move.line_ids.sale_line_ids.order_id.mapped('incoterm_location')
-            incoterm_res = next((incoterm for incoterm in sale_locations if incoterm), False)
-            # if multiple purchase order we take an incoterm that is not false
-            if incoterm_res:
-                move.incoterm_location = incoterm_res
+            sale_locations = move.line_ids.sale_line_ids.order_id.mapped('incoterms_location')
+            incoterms_res = next((incoterms for incoterms in sale_locations if incoterms), False)
+            # if multiple purchase order we take incoterms that is not false
+            if incoterms_res:
+                move.incoterms_location = incoterms_res
 
     def _get_anglo_saxon_price_ctx(self):
         ctx = super()._get_anglo_saxon_price_ctx()

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -14,10 +14,10 @@ _logger = logging.getLogger(__name__)
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    incoterm = fields.Many2one(
-        'account.incoterms', 'Incoterm',
+    incoterms = fields.Many2one(
+        'account.incoterms', 'Incoterms',
         help="International Commercial Terms are a series of predefined commercial terms used in international transactions.")
-    incoterm_location = fields.Char(string='Incoterm Location')
+    incoterms_location = fields.Char(string='Incoterms Location')
     picking_policy = fields.Selection([
         ('direct', 'As soon as possible'),
         ('one', 'When all products are ready')],
@@ -262,7 +262,7 @@ class SaleOrder(models.Model):
 
     def _prepare_invoice(self):
         invoice_vals = super(SaleOrder, self)._prepare_invoice()
-        invoice_vals['invoice_incoterm_id'] = self.incoterm.id
+        invoice_vals['invoice_incoterms_id'] = self.incoterms.id
         return invoice_vals
 
     def _log_decrease_ordered_quantity(self, documents, cancel=False):

--- a/addons/sale_stock/report/sale_order_report_templates.xml
+++ b/addons/sale_stock/report/sale_order_report_templates.xml
@@ -2,13 +2,13 @@
 <odoo>
     <template id="report_saleorder_document_inherit_sale_stock" inherit_id="sale.report_saleorder_document">
         <xpath expr="//div[@name='expiration_date']" position="after">
-            <div class="col" t-if="doc.incoterm">
-                <strong>Incoterm</strong>
-                <div t-if="doc.incoterm_location">
-                    <span t-field="doc.incoterm.code"/> <br/>
-                    <span t-field="doc.incoterm_location"/>
+            <div class="col" t-if="doc.incoterms">
+                <strong>Incoterms</strong>
+                <div t-if="doc.incoterms_location">
+                    <span t-field="doc.incoterms.code"/> <br/>
+                    <span t-field="doc.incoterms_location"/>
                 </div>
-                <div t-else="" t-field="doc.incoterm.code"/>
+                <div t-else="" t-field="doc.incoterms.code"/>
             </div>
         </xpath>
     </template>

--- a/addons/sale_stock/report/stock_report_deliveryslip.xml
+++ b/addons/sale_stock/report/stock_report_deliveryslip.xml
@@ -6,10 +6,10 @@
                 <strong>Customer Reference</strong>
                 <div t-field="o.sudo().sale_id.client_order_ref" class="m-0">Customer reference</div>
             </div>
-            <div class="col col-3" t-if="o.sudo().sale_id.incoterm">
-                <strong>Incoterm</strong>
-                <div t-if="o.sudo().sale_id.incoterm_location" t-out="'%s %s' % (o.sudo().sale_id.incoterm.code, o.sudo().sale_id.incoterm_location)">Incoterm details</div>
-                <div t-else="" t-field="o.sudo().sale_id.incoterm.display_name">Incoterm details</div>
+            <div class="col col-3" t-if="o.sudo().sale_id.incoterms">
+                <strong>Incoterms</strong>
+                <div t-if="o.sudo().sale_id.incoterms_location" t-out="'%s %s' % (o.sudo().sale_id.incoterms.code, o.sudo().sale_id.incoterms_location)">Incoterms details</div>
+                <div t-else="" t-field="o.sudo().sale_id.incoterms.display_name">Incoterms details</div>
             </div>
         </xpath>
     </template>

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1451,17 +1451,17 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
             {'location_id': out_location.id, 'location_dest_id': customer_location.id, 'product_uom_qty': 6.0, 'quantity': 6.0, 'state': 'done'},
         ])
 
-    def test_incoterm_in_advance_payment(self):
-        """When generating a advance payment invoice from a SO, this invoice incoterm should be the same as the SO"""
+    def test_incoterms_in_advance_payment(self):
+        """When generating a advance payment invoice from a SO, this invoice incoterms should be the same as the SO"""
 
-        incoterm = self.env['account.incoterms'].create({
-            'name': 'Test Incoterm',
+        incoterms = self.env['account.incoterms'].create({
+            'name': 'Test Incoterms',
             'code': 'TEST',
         })
 
         so = self.env['sale.order'].create({
             'partner_id': self.partner_a.id,
-            'incoterm': incoterm.id,
+            'incoterms': incoterms.id,
             'order_line': [(0, 0, {
                 'name': self.product_a.name,
                 'product_id': self.product_a.id,
@@ -1479,7 +1479,7 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         act = adv_wiz.with_context(open_invoices=True).create_invoices()
         invoice = self.env['account.move'].browse(act['res_id'])
 
-        self.assertEqual(invoice.invoice_incoterm_id.id, incoterm.id)
+        self.assertEqual(invoice.invoice_incoterms_id.id, incoterms.id)
 
     def test_exception_delivery_partial_multi(self):
         """

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -22,8 +22,8 @@
                 <xpath expr="//label[@for='commitment_date']" position="before">
                     <field name="warehouse_id" invisible="1" readonly="state == 'sale'"/>  <!-- needed for js logic -->
                     <field name="warehouse_id" options="{'no_create': True}" force_save="1" readonly="state == 'sale'"/>
-                    <field name="incoterm" options="{'no_open': True, 'no_create': True}"/>
-                    <field name="incoterm_location"/>
+                    <field name="incoterms" options="{'no_open': True, 'no_create': True}"/>
+                    <field name="incoterms_location"/>
                     <field name="picking_policy" required="True" readonly="state not in ['draft', 'sent']"/>
                 </xpath>
                 <xpath expr="//span[@name='expected_date_span']" position="attributes">

--- a/addons/sale_stock/views/sale_stock_portal_template.xml
+++ b/addons/sale_stock/views/sale_stock_portal_template.xml
@@ -5,14 +5,14 @@
         name="Orders Shipping Followup"
         inherit_id="sale.sale_order_portal_content">
         <tbody id="sale_info_table" position="inside">
-            <tr t-if="sale_order.incoterm">
-                <th class="pb-0">Incoterm:</th>
+            <tr t-if="sale_order.incoterms">
+                <th class="pb-0">Incoterms:</th>
                 <td class="w-100 pb-0 text-wrap">
-                    <p t-if="sale_order.incoterm_location">
-                        <span t-field="sale_order.incoterm.code"/> <br/>
-                        <span t-field="sale_order.incoterm_location"/>
+                    <p t-if="sale_order.incoterms_location">
+                        <span t-field="sale_order.incoterms.code"/> <br/>
+                        <span t-field="sale_order.incoterms_location"/>
                     </p>
-                    <p t-else="" t-field="sale_order.incoterm.code" class="m-0"/>
+                    <p t-else="" t-field="sale_order.incoterms.code" class="m-0"/>
                 </td>
             </tr>
         </tbody>


### PR DESCRIPTION
According to international standards, the abbreviation of 'International Commercial Terms' is INCOTERMS. However, the use of INCOTERM is prevalent in our codebase. This commit fixes it, rewording all references to the correct one. This commit also updates the name of the fields in the models to avoid future confusion about the correct abbreviation.

task: 3995145

ENT-PR: https://github.com/odoo/enterprise/pull/74812
UPG-PR: https://github.com/odoo/upgrade/pull/6847

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
