### PR TITLE
[FIX] core: don't --save the demo option

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -659,7 +659,7 @@ class configmanager(object):
         for opt in sorted(self.options):
             if keys is not None and opt not in keys:
                 continue
-            if opt in ('version', 'language', 'translate_out', 'translate_in', 'overwrite_existing_translations', 'init', 'update'):
+            if opt in ('version', 'language', 'translate_out', 'translate_in', 'overwrite_existing_translations', 'init', 'update', 'demo'):
                 continue
             if opt in self.blacklist_for_save:
                 continue


### PR DESCRIPTION
config['demo'] is always set at runtime, there is no point in saving it as it is basically ignored from the config file.

