### PR TITLE
[FIX] website_sale_stock : Remove import website_sale from variant_mixin file

### DIFF
--- a/addons/website_sale_stock/__manifest__.py
+++ b/addons/website_sale_stock/__manifest__.py
@@ -31,6 +31,7 @@ Then it can be made specific at the product level.
     'auto_install': True,
     'assets': {
         'web.assets_frontend': [
+            ('before', 'website_sale/static/src/js/website_sale.js', 'website_sale_stock/static/src/js/variant_mixin.js'),
             'website_sale_stock/static/src/js/**/*',
             'website_sale_stock/static/src/xml/**/*',
         ],

--- a/addons/website_sale_stock/static/src/js/variant_mixin.js
+++ b/addons/website_sale_stock/static/src/js/variant_mixin.js
@@ -1,11 +1,9 @@
 /** @odoo-module **/
 
 import VariantMixin from "@website_sale/js/sale_variant_mixin";
-import publicWidget from "@web/legacy/js/public/public_widget";
 import { renderToFragment } from "@web/core/utils/render";
 import { formatFloat } from "@web/core/utils/numbers";
 
-import "@website_sale/js/website_sale";
 
 import { markup } from "@odoo/owl";
 
@@ -85,27 +83,5 @@ VariantMixin._onChangeCombinationStock = function (ev, $parent, combination) {
         combination
     ));
 };
-
-publicWidget.registry.WebsiteSale.include({
-    /**
-     * Adds the stock checking to the regular _onChangeCombination method
-     * @override
-     */
-    _onChangeCombination: function () {
-        this._super.apply(this, arguments);
-        VariantMixin._onChangeCombinationStock.apply(this, arguments);
-    },
-    /**
-     * Recomputes the combination after adding a product to the cart
-     * @override
-     */
-    _onClickAdd(ev) {
-        return this._super.apply(this, arguments).then(() => {
-            if ($('div.availability_messages').length) {
-                this._getCombinationInfo(ev);
-            }
-        });
-    }
-});
 
 export default VariantMixin;

--- a/addons/website_sale_stock/static/src/js/website_sale.js
+++ b/addons/website_sale_stock/static/src/js/website_sale.js
@@ -3,6 +3,7 @@
 import { WebsiteSale } from '@website_sale/js/website_sale';
 import { rpc } from "@web/core/network/rpc";
 import { isEmail } from '@web/core/utils/strings';
+import VariantMixin from "@website_sale/js/sale_variant_mixin";
 
 WebsiteSale.include({
     events: Object.assign({}, WebsiteSale.prototype.events, {
@@ -55,6 +56,26 @@ WebsiteSale.include({
     _displayEmailIncorrectMessage(stockNotificationEl) {
         const incorrectIconEl = stockNotificationEl.querySelector('#stock_notification_input_incorrect');
         incorrectIconEl.classList.remove('d-none');
+    },
+
+    /**
+     * Adds the stock checking to the regular _onChangeCombination method
+     * @override
+     */
+    _onChangeCombination: function () {
+        this._super.apply(this, arguments);
+        VariantMixin._onChangeCombinationStock.apply(this, arguments);
+    },
+    /**
+     * Recomputes the combination after adding a product to the cart
+     * @override
+     */
+    _onClickAdd(ev) {
+        return this._super.apply(this, arguments).then(() => {
+            if ($('div.availability_messages').length) {
+                this._getCombinationInfo(ev);
+            }
+        });
     }
 });
 


### PR DESCRIPTION
### Current behavior before PR:
While working on this https://github.com/odoo/enterprise/pull/74813/commits/337ea18baebdf4c896bc3e503448207fd9095991 we were overriding a method in VariantMixin but it was shadowed and not executed this was happening because of the order JS is loading the files when importing website_sale.

### Desired behavior after PR is merged:
After discussing with XBO, we are removing the import of website_sale from variant_mixin.js and moving the overridden method to website_sale.js to avoid having this problem in the future.