### PR TITLE
[IMP] account: put default taxes on demo products

### DIFF
--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -17,9 +17,8 @@ class AccountChartTemplate(models.AbstractModel):
     @api.model
     def _get_demo_data(self, company=False):
         """Generate the demo data related to accounting."""
-        # This is a generator because data created here might be referenced by xml_id to data
-        # created later but defined in this same function.
         return {
+            **self._get_demo_data_products(company),
             'account.move': self._get_demo_data_move(company),
             'account.bank.statement': self._get_demo_data_statement(company),
             'account.bank.statement.line': self._get_demo_data_transactions(company),
@@ -27,6 +26,40 @@ class AccountChartTemplate(models.AbstractModel):
             'ir.attachment': self._get_demo_data_attachment(company),
             'mail.message': self._get_demo_data_mail_message(company),
             'mail.activity': self._get_demo_data_mail_activity(company),
+        }
+
+    def _get_demo_exception_product_template_xml_ids(self):
+        """ Return demo product template xml ids to not put taxes on"""
+        return []
+
+    def _get_demo_exception_product_variant_xml_ids(self):
+        """ Return demo product variant xml ids to not put taxes on"""
+        return ['product.office_combo']
+
+    def _get_demo_data_products(self, company):
+        # Only needed for the first company
+        if company != self.env.ref('base.main_company', raise_if_not_found=False):
+            return {}
+
+        taxes = {}
+        if company.account_sale_tax_id:
+            taxes.update({'taxes_id': [Command.link(company.account_sale_tax_id.id)]})
+        if company.account_purchase_tax_id:
+            taxes.update({'supplier_taxes_id': [Command.link(company.account_purchase_tax_id.id)]})
+        if not taxes:
+            return {}
+        IMD = self.env['ir.model.data'].sudo()
+        product_templates = sorted(
+            set(IMD.search([('model', '=', 'product.template')]).mapped('complete_name'))
+            - set(self._get_demo_exception_product_template_xml_ids())
+        )
+        product_variants = sorted(
+            set(IMD.search([('model', '=', 'product.product')]).mapped('complete_name'))
+            - set(self._get_demo_exception_product_variant_xml_ids())
+        )
+        return {
+            'product.template': {d: taxes for d in product_templates},
+            'product.product': {d: taxes for d in product_variants},
         }
 
     def _post_load_demo_data(self, company=False):


### PR DESCRIPTION
Right now, when a demo company is created, the demo products do not get taxes in that company.  (even in the main company)

It is because of https://github.com/odoo/odoo/pull/173803 It is treating however an exception case with tips that if a product does not have taxes in the initial company, we won't give it taxes in the new company.

But this means that all demo data won't have taxes unless we put them explicitly at least in one company.  That is why we explicitly put the taxes on demo data, but provide some hooks for exception cases like tips (and combo products).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
