### PR TITLE
[FIX] hr_expense: typo expense state

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -445,7 +445,7 @@ class HrExpense(models.Model):
                 raise UserError(_('You cannot delete a posted or approved expense.'))
 
     def write(self, vals):
-        if 'state' in vals and (not self.user_has_groups('hr_expense.group_hr_expense_manager') and vals['state'] != 'submit' and
+        if 'state' in vals and (not self.user_has_groups('hr_expense.group_hr_expense_manager') and vals['state'] != 'reported' and
         any(expense.state == 'draft' for expense in self)):
             raise UserError(_("You don't have the rights to bypass the validation process of this expense."))
         expense_to_previous_sheet = {}


### PR DESCRIPTION
Steps to reproduce:
- Remove all Expenses access rights from the user "Marc Demo."
- Create a new expense and generate a report from it.
- Attempt to change the state to "reported" using an API, server action, or browser extension.

Issue:
You will be blocked to do so

Cause:
there must have been a confusion with the state available for `hr.expense` model https://github.com/odoo/odoo/blob/063e224c17c0e0194e5ade6acbe82ff38a669b54/addons/hr_expense/models/hr_expense.py#L90-L95

and the `hr.expense.sheet` model
https://github.com/odoo/odoo/blob/063e224c17c0e0194e5ade6acbe82ff38a669b54/addons/hr_expense/models/hr_expense.py#L973-L979

=> 'submit' does not exist in hr.expense -> it is reported

opw-4278187
