### PR TITLE
[FIX] mrp: hide backorder option on mrp operation type

### DIFF
--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -132,6 +132,9 @@
             <field name="show_operations" position="attributes">
                 <attribute name="attrs">{"invisible": [("code", "=", "mrp_operation")]}</attribute>
             </field>
+            <field name="create_backorder" position="attributes">
+                <attribute name="attrs">{"invisible": [("code", "=", "mrp_operation")]}</attribute>
+            </field>
             <xpath expr="//group[@name='stock_picking_type_lot']" position="after">
                 <group attrs='{"invisible": [("code", "!=", "mrp_operation")]}' string="Traceability" groups="stock.group_production_lot">
                     <field name="use_create_components_lots"/>


### PR DESCRIPTION
Commit [1] added the possibility to set up the backorders system on
the operation types. But the feature has been intended to work with
pickings only. Still, we display the option on the mrp one. It's
therefore confusing for users who think they can change the
backorder system of MO. This feature has been added on 17 thanks to [2]

[1] https://github.com/odoo/odoo/commit/047bfa753692887eddf9edddd3a8e78b882009fb
[2] https://github.com/odoo/odoo/commit/1e5c82fda8a5867eb66fba1587674ad00a31326b

OPW-4358342