### PR TITLE
[IMP] mrp: reactive workorder state

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -228,6 +228,7 @@ class MrpWorkorder(models.Model):
                 workorder.production_id.qty_producing = workorder.qty_producing
                 workorder.production_id._set_qty_producing()
 
+    @api.depends('state', 'production_state', 'qty_produced', 'qty_producing', 'qty_remaining', 'blocked_by_workorder_ids')
     def _compute_qty_ready(self):
         for workorder in self:
             if workorder.production_state not in ('confirmed', 'progress') or workorder.state in ('cancel', 'done'):


### PR DESCRIPTION
Based on changes provided by https://github.com/odoo/odoo/pull/185092 Reestablish depends on _compute_qty_ready to make workorder state computation reactive on partial production.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
