### PR TITLE
[IMP] website_sale: add product information as subject in contactus

### DIFF
--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -28,11 +28,11 @@
                                 <t t-set="rating_count" t-value="record.rating_count"/>
                             </t>
                         </div>
-                        <div class="w-100 d-flex flex-wrap flex-md-column flex-lg-row align-items-center align-self-end justify-content-between mt-3">
+                        <div class="w-100 d-flex flex-wrap flex-md-column flex-lg-row align-items-center align-self-end justify-content-between">
                             <div class="py-2">
                                 <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
                             </div>
-                            <div class="o_dynamic_snippet_btn_wrapper" t-if="record._website_show_quick_add()">
+                            <div class="o_dynamic_snippet_btn_wrapper mt-3" t-if="record._website_show_quick_add()">
                                 <button
                                     type="button"
                                     role="button"
@@ -438,10 +438,7 @@
             </t>
         </template>
         <template id="price_dynamic_filter_template_product_product" name="Dynamic Product Filter Price">
-            <t t-if="data.get('prevent_zero_price_sale')">
-                <span t-field="website.prevent_zero_price_sale_text"/>
-            </t>
-            <t t-elif="not data.get('is_sample')">
+            <t t-if="not data.get('prevent_zero_price_sale') and not data.get('is_sample')">
                 <span t-esc="data['price']"
                       class="fw-bold"
                       name="product_price"

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -835,8 +835,7 @@ class ProductTemplate(models.Model):
 
     def _search_render_results_prices(self, mapping, combination_info):
         if combination_info.get('prevent_zero_price_sale'):
-            website = self.env['website'].get_current_website()
-            return website.prevent_zero_price_sale_text, None
+            return None, None
 
         monetary_options = {'display_currency': mapping['detail']['display_currency']}
         price = self.env['ir.qweb.field.monetary'].value_to_html(

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -147,11 +147,6 @@ class Website(models.Model):
     product_page_grid_columns = fields.Integer(default=2)
 
     prevent_zero_price_sale = fields.Boolean(string="Hide 'Add To Cart' when price = 0")
-    prevent_zero_price_sale_text = fields.Char(
-        string="Text to show instead of price",
-        translate=True,
-        default="Not Available For Sale",
-    )
 
     enabled_gmc_src = fields.Boolean(string="Google Merchant Center Data Source")
 

--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -395,6 +395,8 @@ var VariantMixin = {
             contactUsButton.removeClass('d-flex').addClass('d-none');
             product_unavailable.removeClass('d-flex').addClass('d-none');
         }
+        const url = contactUsButton.find('a').attr('data-url');
+        contactUsButton.find('a').attr('href', `${url}?subject=${combination.display_name}`);
 
         const self = this;
         const $price = $parent.find(".oe_price:first .oe_currency_value");

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -271,8 +271,6 @@
                               t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale"
                               t-out="template_price_vals['price_reduce']"
                               t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
-                        <span class="h6 mb-0" t-elif="any(ptav.price_extra for ptav in product.attribute_line_ids.product_template_value_ids)">&amp;nbsp;</span>
-                        <span class="h6 mb-0" t-else="" t-field="website.prevent_zero_price_sale_text"/>
                         <t
                             t-if="'base_price' in template_price_vals and (template_price_vals['base_price'] &gt; template_price_vals['price_reduce']) and (template_price_vals['price_reduce'] or not website.prevent_zero_price_sale)"
                             name="product_base_price"
@@ -1639,6 +1637,26 @@
                                                 Add to cart
                                             </a>
                                         </div>
+                                        <div
+                                            id="contact_us_wrapper"
+                                            t-attf-class="{{'d-flex' if combination_info['prevent_zero_price_sale'] else 'd-none'}} oe_structure oe_structure_solo mb-2 #{_div_classes}"
+                                        >
+                                            <section
+                                                class="s_text_block"
+                                                data-snippet="s_text_block"
+                                                data-name="Text"
+                                            >
+                                                <div class="container">
+                                                    <a
+                                                        t-att-href="website.contact_us_button_url"
+                                                        t-att-data-url="website.contact_us_button_url"
+                                                        class="btn btn-primary btn_cta"
+                                                    >
+                                                        Contact Us
+                                                    </a>
+                                                </div>
+                                            </section>
+                                        </div>
                                         <div id="product_option_block" class="d-flex flex-wrap w-100"/>
                                     </div>
                                     <t
@@ -1659,25 +1677,6 @@
                                 This product has no valid combination.
                             </p>
                             <t t-call="website_sale.product_accordion"/>
-                            <div
-                                id="contact_us_wrapper"
-                                t-attf-class="{{'d-flex' if combination_info['prevent_zero_price_sale'] else 'd-none'}} oe_structure oe_structure_solo mb-1 #{_div_classes}"
-                            >
-                                <section
-                                    class="s_text_block"
-                                    data-snippet="s_text_block"
-                                    data-name="Text"
-                                >
-                                    <div class="container">
-                                        <a
-                                            t-att-href="website.contact_us_button_url"
-                                            class="btn btn-primary btn_cta"
-                                        >
-                                            Contact Us
-                                        </a>
-                                    </div>
-                                </section>
-                            </div>
                             <div
                                 t-if="not is_view_active('website_sale_comparison.accordion_specs_item')"
                                 id="product_attributes_simple"
@@ -2024,7 +2023,7 @@
             </small>
         </div>
         <div id="product_unavailable" t-attf-class="{{'d-flex' if combination_info['prevent_zero_price_sale'] else 'd-none'}}">
-            <h3 class="fst-italic" t-field="website.prevent_zero_price_sale_text"/>
+            <br/>
         </div>
     </template>
 

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -174,17 +174,13 @@
                                 </tr>
                                 <tr>
                                     <td t-if="len(attrib_categories)" class='td-top-left border-top-0'/>
-                                    <td t-foreach="products" t-as="product" class="border-top-0">
+                                    <td t-foreach="products" t-as="product" class="border-top-0 align-top">
                                         <t t-set="combination_info" t-value="product._get_combination_info_variant()"/>
                                         <div class='product_summary'>
                                             <a class="o_product_comparison_table" t-att-href="product.website_url">
                                                 <span t-esc="combination_info['display_name']"></span><br/>
                                             </a>
-
-                                            <span class="o_comparison_price" t-if="combination_info['prevent_zero_price_sale']">
-                                                <strong t-field="website.prevent_zero_price_sale_text"/>
-                                            </span>
-                                            <span class="o_comparison_price" t-else="">
+                                            <span class="o_comparison_price" t-if="not combination_info['prevent_zero_price_sale']">
                                                 <strong>Price:</strong>
                                                 <span t-out="combination_info['price']"
                                                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
@@ -218,7 +214,7 @@
                                                     t-att-value="product.id"
                                                 />
                                                 <a t-if="combination_info['prevent_zero_price_sale']"
-                                                   t-att-href="website.contact_us_button_url"
+                                                   t-att-href="website.contact_us_button_url + '?subject=' + combination_info['display_name']"
                                                    class="btn btn-primary btn_cta">
                                                    Contact Us
                                                 </a>
@@ -296,7 +292,6 @@
                              t-esc="combination_info['list_price']"
                              t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
                     </div>
-                    <div t-attf-class="{{'' if combination_info['prevent_zero_price_sale'] else 'd-none'}}" t-field="website.prevent_zero_price_sale_text"/>
                 </h6>
             </div>
             <div class="col-1 text-end">

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -260,7 +260,7 @@
                                             <button type="button" class="btn btn-link o_wish_rm no-decoration"><small><i class='fa fa-trash-o'></i> Remove</small></button>
                                         </td>
                                         <td class="align-middle" t-if="combination_info['prevent_zero_price_sale']">
-                                            <span t-field="website.prevent_zero_price_sale_text"/>
+                                            <br/>
                                         </td>
                                         <td class="align-middle o_wish_price" t-else="">
                                             <t t-out="combination_info['price']"
@@ -293,7 +293,7 @@
                                             />
                                             <a
                                                 t-if="combination_info['prevent_zero_price_sale']"
-                                                t-att-href="website.contact_us_button_url"
+                                                t-att-href="website.contact_us_button_url + '?subject=' + combination_info['display_name']"
                                                 class="btn btn-primary btn_cta"
                                             >
                                                 Contact Us


### PR DESCRIPTION
Use the contactus url defined in the settings and add a subject
parameter containing the information of the product such as the
name and the variants chosen.
The form in the contact page is then pre-filled with product info
for the recipient of the email.

task-4331152
