### PR TITLE
[PERF] stock: skip merging quants upon opening the inventory adjustment view

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -410,7 +410,8 @@ class StockQuant(models.Model):
     def action_view_inventory(self):
         """ Similar to _get_quants_action except specific for inventory adjustments (i.e. inventory counts). """
         self = self._set_view_context()
-        self._quant_tasks()
+        if not self.env['ir.config_parameter'].sudo().get_param('stock.skip_quant_tasks'):
+            self._quant_tasks()
 
         ctx = dict(self.env.context or {})
         ctx['no_at_date'] = True


### PR DESCRIPTION
Originally, the inventory adjustment view will attempt to merge quants eventhough this merging is done in the scheduler. In this PR we allow a way to skip the function _quant_tasks which performs merging. This is done through a system parameter.

Merging quants has been seen to cause deadlocks in cases where multiple users are visiting the same view at the same time. Skipping this process will make sure to only merge quants through the scheduler. This will speedup opening the quants views and could also be helpful in debugging.

opw-4226821






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
