### PR TITLE
[FIX] point_of_sale: link records cache to reactivity

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
@@ -8,7 +8,7 @@
             forceSmall="ui.isSmall and !env.inDialog"
         >
             <t t-set="order" t-value="scope.item" />
-            <div id="floating-order-container" class="position-relative">
+            <div class="floating-order-container position-relative">
                 <button t-esc="order.getName()"
                     t-att-class="{ 'active': pos.getOrder()?.id === order.id }"
                     class="btn btn-lg btn-secondary text-truncate mx-1"

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -3,7 +3,7 @@ import { useService } from "@web/core/utils/hooks";
 import { useBarcodeReader } from "@point_of_sale/app/hooks/barcode_reader_hook";
 import { _t } from "@web/core/l10n/translation";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
-import { Component, onMounted, useEffect, useState, reactive, onWillRender } from "@odoo/owl";
+import { Component, onMounted, useEffect, useState, onWillRender } from "@odoo/owl";
 import { CategorySelector } from "@point_of_sale/app/components/category_selector/category_selector";
 import { Input } from "@point_of_sale/app/components/inputs/input/input";
 import {
@@ -348,11 +348,11 @@ export class ProductScreen extends Component {
     }
 
     async addProductToOrder(product) {
-        await reactive(this.pos).addLineToCurrentOrder({ product_tmpl_id: product }, {});
+        await this.pos.addLineToCurrentOrder({ product_tmpl_id: product }, {});
     }
 
     async onProductInfoClick(productTemplate) {
-        const info = await reactive(this.pos).getProductInfo(productTemplate, 1);
+        const info = await this.pos.getProductInfo(productTemplate, 1);
         this.dialog.add(ProductInfoPopup, { info: info, productTemplate: productTemplate });
     }
 }

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -147,7 +147,7 @@ export class PosData extends Reactive {
 
         const preLoadData = await this.preLoadData(data);
         const missing = await this.missingRecursive(preLoadData);
-        const results = this.models.loadData(missing, [], true);
+        const results = this.models.loadData(this.models, missing, [], true);
         for (const data of Object.values(results)) {
             for (const record of data) {
                 if (record.raw.JSONuiState) {
@@ -243,8 +243,8 @@ export class PosData extends Reactive {
         delete data["pos.order"];
         delete data["pos.order.line"];
 
-        this.models.loadData(data, this.modelToLoad);
-        this.models.loadData({ "pos.order": order, "pos.order.line": orderlines });
+        this.models.loadData(this.models, data, this.modelToLoad);
+        this.models.loadData(this.models, { "pos.order": order, "pos.order.line": orderlines });
     }
 
     async loadFieldsAndRelations() {
@@ -451,7 +451,7 @@ export class PosData extends Reactive {
             if (this.models[model] && this.opts.autoLoadedOrmMethods.includes(type)) {
                 const data = await this.missingRecursive({ [model]: result });
                 this.synchronizeServerDataInIndexedDB(data);
-                const results = this.models.loadData(data);
+                const results = this.models.loadData(this.models, data);
                 result = results[model];
             } else if (type === "write") {
                 const baseData = Object.assign(this.baseData[model][ids[0]], values);
@@ -646,7 +646,7 @@ export class PosData extends Reactive {
 
     async callRelated(model, method, args = [], kwargs = {}, queue = true) {
         const data = await this.execute({ type: "call", model, method, args, kwargs, queue });
-        const results = this.models.loadData(data, [], true);
+        const results = this.models.loadData(this.models, data, [], true);
         return results;
     }
 

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1149,7 +1149,7 @@ export class PosStore extends WithLazyGetterTrap {
                 context,
             });
             const missingRecords = await this.data.missingRecursive(data);
-            const newData = this.models.loadData(missingRecords);
+            const newData = this.models.loadData(this.models, missingRecords);
 
             for (const line of newData["pos.order.line"]) {
                 const refundedOrderLine = line.refunded_orderline_id;

--- a/addons/point_of_sale/static/src/app/utils/debug/debug_widget.js
+++ b/addons/point_of_sale/static/src/app/utils/debug/debug_widget.js
@@ -178,7 +178,7 @@ export class DebugWidget extends Component {
             }
 
             const missing = await this.pos.data.missingRecursive(data);
-            this.pos.data.models.loadData(missing, [], true);
+            this.pos.data.models.loadData(this.models, missing, [], true);
             this.notification.add(_t("%s orders imported", data["pos.order"].length));
         }
     }

--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -110,6 +110,13 @@ registry.category("web_tour.tours").add("ChromeTour", {
             PaymentScreen.clickInvoiceButton(),
             PaymentScreen.clickValidate(),
             ReceiptScreen.isShown(),
+
+            // Cancelling a floating order should remove it from the floating orders list.
+            ReceiptScreen.clickNextOrder(),
+            Chrome.hasFloatingOrder("007"),
+            ProductScreen.clickReview(),
+            ProductScreen.clickControlButton("Cancel Order"),
+            Chrome.noFloatingOrder("007"),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -72,3 +72,39 @@ export function fillTextArea(target, value) {
 export function createFloatingOrder() {
     return { trigger: ".pos-leftheader .list-plus-btn", run: "click" };
 }
+
+function _hasFloatingOrder(name, yes) {
+    const negateIfNecessary = (trigger) => (yes ? trigger : negate(trigger));
+    return [
+        {
+            isActive: ["desktop"],
+            trigger: negateIfNecessary(
+                `.pos-topheader .floating-order-container:contains('${name}')`
+            ),
+        },
+        {
+            isActive: ["mobile"],
+            trigger: ".pos-leftheader button.fa-caret-down",
+            run: "click",
+        },
+        {
+            isActive: ["mobile"],
+            trigger: negateIfNecessary(
+                `.modal-header:contains(Choose an order) ~ .modal-body .floating-order-container:contains('${name}')`
+            ),
+        },
+        {
+            isActive: ["mobile"],
+            trigger: ".oi-arrow-left",
+            run: "click",
+        },
+    ];
+}
+
+export function hasFloatingOrder(name) {
+    return _hasFloatingOrder(name, true);
+}
+
+export function noFloatingOrder(name) {
+    return _hasFloatingOrder(name, false);
+}

--- a/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
@@ -7,7 +7,7 @@ patch(SelfOrder.prototype, {
         await super.setup(...args);
         this.onlinePaymentStatus = null;
         this.onNotified("ONLINE_PAYMENT_STATUS", ({ status, data }) => {
-            this.models.loadData(data, [], false);
+            this.models.loadData(this.models, data, [], false);
             this.onlinePaymentStatus = status;
             this.paymentError = status === "fail";
 

--- a/addons/pos_restaurant/static/src/app/components/order_tabs/order_tabs.xml
+++ b/addons/pos_restaurant/static/src/app/components/order_tabs/order_tabs.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.OrderTabs" t-inherit="point_of_sale.OrderTabs" t-inherit-mode="extension">
-       <xpath expr="//div[@id='floating-order-container']" position="before">
+       <xpath expr="//div[hasclass('floating-order-container')]" position="before">
             <t t-set="changes" t-value="this.pos.getOrderChanges(false, order)" />
         </xpath>
-        <xpath expr="//div[@id='floating-order-container']" position="inside">
+        <xpath expr="//div[hasclass('floating-order-container')]" position="inside">
             <div t-if="(changes.nbrOfChanges or changes.nbrOfSkipped) and this.pos.config.module_pos_restaurant"
                 class="position-absolute rounded-circle d-flex align-items-center justify-content-center"
                 style="top: -7px; right: -6px; width: 1.5rem; height: 1.5rem"
@@ -12,7 +12,7 @@
                 <span t-esc="changes.nbrOfChanges || changes.nbrOfSkipped" />
             </div>
         </xpath>
-        <xpath expr="//div[@id='floating-order-container']" position="attributes">
+        <xpath expr="//div[hasclass('floating-order-container')]" position="attributes">
             <attribute name="t-att-class">{'me-2': (changes.nbrOfChanges || changes.nbrOfSkipped) and this.pos.config.module_pos_restaurant}</attribute>
         </xpath>
     </t>

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -70,7 +70,7 @@ export class ConfirmationPage extends Component {
             access_token: this.selfOrder.access_token,
             order_access_tokens: [this.props.orderAccessToken],
         });
-        this.selfOrder.models.loadData(data);
+        this.selfOrder.models.loadData(this.selfOrder.models, data);
         const order = this.selfOrder.models["pos.order"].find(
             (o) => o.access_token === this.props.orderAccessToken
         );

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -76,7 +76,7 @@ export class SelfOrder extends Reactive {
 
         this.onNotified = getOnNotified(this.bus, this.access_token);
         this.onNotified("PRODUCT_CHANGED", (payload) => {
-            this.models.loadData(payload);
+            this.models.loadData(this.models, payload);
         });
         if (this.config.self_ordering_mode === "kiosk") {
             this.onNotified("STATUS", ({ status }) => {
@@ -91,7 +91,7 @@ export class SelfOrder extends Reactive {
             });
             this.onNotified("PAYMENT_STATUS", ({ payment_result, data }) => {
                 if (payment_result === "Success") {
-                    this.models.loadData(data);
+                    this.models.loadData(this.models, data);
                     const order = this.models["pos.order"].find(
                         (o) => o.access_token === data["pos.order"][0].access_token
                     );
@@ -148,7 +148,7 @@ export class SelfOrder extends Reactive {
 
         const handleMessage = (data) => {
             let message = "";
-            this.models.loadData(data);
+            this.models.loadData(this.models, data);
             const oUpdated = data["pos.order"].find((o) => o.uuid === this.selectedOrderUuid);
 
             if (["paid", "invoiced", "done"].includes(oUpdated?.state)) {
@@ -667,7 +667,7 @@ export class SelfOrder extends Reactive {
                     table_identifier: this.currentOrder?.table_id?.identifier || false,
                 }
             );
-            this.models.loadData(data);
+            this.models.loadData(this.models, data);
             for (const order of data["pos.order"]) {
                 this.subscribeToOrderChannel(order);
             }
@@ -701,7 +701,7 @@ export class SelfOrder extends Reactive {
                 access_token: this.access_token,
                 order_access_tokens: [...accessTokens, ...localAccessToken],
             });
-            this.models.loadData(data);
+            this.models.loadData(this.models, data);
             this.selectedOrderUuid = null;
         } catch (error) {
             this.handleErrorNotification(


### PR DESCRIPTION
The records cache (from `related_models` module) isn't properly linked to the
reactivity of `posmodel`. As a result, some expected rerenderings aren't
executed. An example of this is the `OrderTab`. When a new floating order is
created the `OrderTab` rerenders listing the new order. However, when that empty
order is deleted, the corresponding tab item isn't removed in the list. That is
because the `OrderTab`'s render method isn't properly subscribed to the changes
in `models['pos.order']`. The render subscription doesn't exist because
`models['pos.order'].readAll` isn't reading on the reactive version of the
`records` cache. That is because `get orderedRecords` is pointing to the
non-reactive version of `records`. `get records` exists in `models` and that's
what we should use to properly link it to the reactivity and that `OrderTab`
properly subscribes `models['pos.order']`.

In this PR we are making sure that the methods of `models` (return value of
`createCRUD`) is properly using the `reactive` version of the `records` cache.
We then pass that version to the CRUD methods to ensure continuity of reactivity
in the records.

We also need to make changes in the `OrderTab` template, converting
`floating-order-container` from `id` to `class` since it's being used for each
order. We should not have multiple instances of an id in the html.

TASK-ID: 4369054