### PR TITLE
[IMP] website: get header mobile breakpoint from the navbar

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -37,11 +37,16 @@ const BaseAnimatedHeader = animations.Animation.extend({
         this.$main = this.$el.next('main');
         this.isOverlayHeader = !!this.$el.closest('.o_header_overlay, .o_header_overlay_theme').length;
         this.hiddenOnScrollEl = this.el.querySelector(".o_header_hide_on_scroll");
+        const navbarEl = this.el.querySelector(".navbar");
+        const navBreakpoint = Object.keys(SIZES).find((size) =>
+            navbarEl.classList.contains(`navbar-expand-${size.toLowerCase()}`)
+        );
+        this.breakpointSize = SIZES[navBreakpoint || "LG"];
 
         // While scrolling through navbar menus on medium devices, body should
         // not be scrolled with it.
         const disableScroll = function () {
-            if (uiUtils.getSize() < SIZES.LG) {
+            if (uiUtils.getSize() < this.breakpointSize) {
                 $(document.body).addClass('overflow-hidden');
             }
         };
@@ -263,8 +268,10 @@ const BaseAnimatedHeader = animations.Animation.extend({
      */
     _updateHeaderOnResize: function () {
         this._adaptFixedHeaderPosition();
-        if (document.body.classList.contains('overflow-hidden')
-                && uiUtils.getSize() >= SIZES.LG) {
+        if (
+            document.body.classList.contains("overflow-hidden") &&
+            uiUtils.getSize() >= this.breakpointSize
+        ) {
             this.el.querySelectorAll(".offcanvas.show").forEach(offcanvasEl => {
                 Offcanvas.getOrCreateInstance(offcanvasEl).hide();
             });
@@ -671,7 +678,7 @@ publicWidget.registry.hoverableDropdown = animations.Animation.extend({
      */
     _dropdownHover: function () {
         this.$dropdownMenus.attr('data-bs-popper', 'none');
-        if (uiUtils.getSize() >= SIZES.LG) {
+        if (uiUtils.getSize() >= this.breakpointSize) {
             this.$dropdownMenus.css('margin-top', '0');
             this.$dropdownMenus.css('top', 'unset');
         } else {
@@ -685,7 +692,7 @@ publicWidget.registry.hoverableDropdown = animations.Animation.extend({
      * @param {boolean} [doShow=true] true to show, false to hide
      */
     _updateDropdownVisibility(ev, doShow = true) {
-        if (uiUtils.getSize() < SIZES.LG) {
+        if (uiUtils.getSize() < this.breakpointSize) {
             return;
         }
         if (ev.currentTarget.closest('.o_extra_menu_items')) {


### PR DESCRIPTION
The code from [1] fixed the inconsistencies caused by using the `SM` size
as header breakpoint (by setting it to a fixed value = `LG`).

The goal of this commit is to simply improve this fix by extracting the
breakpoint size from the `navbar-expand-xx` class of the navbar (using
`LG` as a fallback), allowing to also handle header customizations.

[1]: https://github.com/odoo/odoo/commit/9d0f6c6aa9a21d1690e687ac2b4b2028e9378370

linked to task-3086316