### PR TITLE
[FIX] product: fixed ValueError to ensure 'uom_id' is passed

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -225,7 +225,7 @@ class ProductProduct(models.Model):
 
         for product in self:
             if to_uom:
-                list_price = product.uom_id._compute_price(product.list_price, to_uom)
+                list_price = (product.uom_id or to_uom)._compute_price(product.list_price, to_uom)
             else:
                 list_price = product.list_price
             product.lst_price = list_price + product.price_extra


### PR DESCRIPTION
Currently a `ValueError` is arising when user changes the 'Sales Price' of newly created product when 'Unit of Measure' is empty.

To reproduce this error:
- Go to "Settings" from the "Configuration" menu and check the 'Unit of Measure'
- Now create a quotation and enable 'Product Variant'.
- Create a new 'UoM' and then create a new 'Product Variant'
- The wizard opens to create new product variant, empty the 'Unit of Measure' and edit the 'Sales Price'
- The error arises in the logs.

Error:  `'ValueError': Expected singleton: uom.uom()`

To fix this issue, added the 'to_uom', to make sure uom_id is passed.

sentry-6084541202
