### PR TITLE
[16.0][IMP] website_slides: send invitation email considering the course website domain

### DIFF
--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -163,6 +163,15 @@ class ChannelUsersRelation(models.Model):
         if mail_mail_values:
             self.env['mail.mail'].sudo().create(mail_mail_values)
 
+    def get_base_url(self):
+        if not self:
+            return super().get_base_url()
+        self.ensure_one()
+
+        if 'channel_website_id' in self and self.sudo().channel_website_id.domain:
+            return self.sudo().channel_website_id.domain
+
+        return super().get_base_url()
 
 class Channel(models.Model):
     """ A channel is a container of slides. """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When sending an invitation email the website associated to the slide.channel is ignored, and thus you may be sending an email to invite a course from website 1 with domain mywebsite1.com and the actual invitation link is sent containing domain mycompany.com.

@rdeodoo Do you agree?


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
