### PR TITLE
[IMP] im_livechat: remove format_for_frontend from chatbot.script.step

### DIFF
--- a/addons/im_livechat/models/chatbot_script.py
+++ b/addons/im_livechat/models/chatbot_script.py
@@ -186,15 +186,13 @@ class ChatbotScript(models.Model):
 
     def _to_store(self, store: Store, /, *, fields=None, **kwargs):
         if fields is None:
-            fields = ["title", "operator_partner_id", "welcome_steps"]
+            fields = ["title", "operator_partner_id"]
         for script in self:
             data = script._read_format(
-                [f for f in fields if f not in {"operator_partner_id", "welcome_steps"}], load=False
+                [f for f in fields if f not in {"operator_partner_id"}], load=False
             )[0]
             if "operator_partner_id" in fields:
                 data["operator_partner_id"] = Store.one(script.operator_partner_id, fields=["name"])
-            if "welcome_steps" in fields:
-                data["welcome_steps"] = Store.many(script._get_welcome_steps())
             store.add(script, data)
 
     def _validate_email(self, email_address, discuss_channel):

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -384,23 +384,3 @@ class ChatbotScriptStep(models.Model):
             if "is_last" in fields:
                 data["isLast"] = step._is_last_step()
             store.add("chatbot.script.step", data)
-
-    # --------------------------
-    # Tooling / Misc
-    # --------------------------
-
-    def _format_for_frontend(self):
-        """ Small utility method that formats the step into a dict usable by the frontend code. """
-        self.ensure_one()
-
-        return {
-            'id': self.id,
-            'answers': [{
-                'id': answer.id,
-                "name": answer.name,
-                "redirect_link": answer.redirect_link,
-            } for answer in self.answer_ids],
-            'message': plaintext2html(self.message) if not is_html_empty(self.message) else False,
-            'isLast': self._is_last_step(),
-            'type': self.step_type
-        }

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -54,7 +54,7 @@ class DiscussChannel(models.Model):
                     and m.mail_message_id.author_id == chatbot_script.operator_partner_id
                 ), None) if channel.chatbot_current_step_id.sudo().step_type != 'forward_operator' else None
                 current_step = {
-                    'scriptStep': current_step_sudo._format_for_frontend(),
+                    'scriptStep': current_step_sudo.id,
                     "message": Store.one_id(step_message),
                     'operatorFound': current_step_sudo.step_type == 'forward_operator' and len(channel.channel_member_ids) > 2,
                 }
@@ -63,6 +63,7 @@ class DiscussChannel(models.Model):
                     'steps': [current_step],
                     'currentStep': current_step,
                 }
+                store.add(current_step_sudo)
                 store.add(chatbot_script)
             channel_info['anonymous_name'] = channel.anonymous_name
             channel_info['anonymous_country'] = {

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_script_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_script_model.js
@@ -10,6 +10,5 @@ export class ChatbotScript extends Record {
     title;
     isLivechatTourRunning = false;
     operator_partner_id = Record.one("Persona");
-    welcome_steps = Record.many("chatbot.script.step");
 }
 ChatbotScript.register();


### PR DESCRIPTION
This commit removes the `_format_for_frontend` method from the `chatbot.script.step` model, replacing its use cases with `_to_store` for a more streamlined approach.

Additionally, the obsolete `welcome_steps` field has been removed as part of the cleanup.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
