### PR TITLE
[FIX] web: prevent error when exporting file in xlsx format

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -228,7 +228,7 @@ class ExportXlsxWriter:
                 # fails note that you can't export
                 cell_value = cell_value.decode()
             except UnicodeDecodeError:
-                raise UserError(request.env._("Binary fields can not be exported to Excel unless their content is base64-encoded. That does not seem to be the case for %s.", self.field_names)[column]) from None
+                raise UserError(request.env._("Binary fields can not be exported to Excel unless their content is base64-encoded. That does not seem to be the case for %s.", self.columns_headers[column])) from None
         elif isinstance(cell_value, (list, tuple, dict)):
             cell_value = str(cell_value)
 


### PR DESCRIPTION
When the user tries to export a file of attachment in xlsx format,
A traceback will appear.

Steps to reproduce the error:
- Open attachments > Upload a file that does not contain base64-encoded content
- Select that file > Actions > Export > Export Format: XLSX >
  Add File content(raw) field > Export

Traceback:
```
AttributeError: 'ExportXlsxWriter' object has no attribute 'field_names'
```

In this commit: https://github.com/odoo/odoo/commit/a4e04518a437f09d6a10e25a35900c4adfe11dc6 ``field_names`` is renamed to ``fields``.

https://github.com/odoo/odoo/blob/0e98b684834cf9e1d646e55599e7bc00aa5997f0/addons/web/controllers/export.py#L231 Here, ``field_names`` is still used.
So, it will lead to the above traceback.

sentry-6096581800

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
