### PR TITLE
[IMP] stock: Use quant recordset to delete it if zero

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1854,6 +1854,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         backorder_moves.with_context(bypass_entire_pack=True)._action_confirm(merge=False)
         if cancel_backorder:
             backorder_moves.with_context(moves_todo=moves_todo)._action_cancel()
+        package_quants = moves_todo.mapped('move_line_ids.package_id.quant_ids')
         moves_todo.mapped('move_line_ids').sorted()._action_done()
         # Check the consistency of the result packages; there should be an unique location across
         # the contained quants.
@@ -1863,7 +1864,7 @@ Please change the quantity done or the rounding precision of your unit of measur
             if len(result_package.quant_ids.filtered(lambda q: not float_is_zero(abs(q.quantity) + abs(q.reserved_quantity), precision_rounding=q.product_uom_id.rounding)).mapped('location_id')) > 1:
                 raise UserError(_('You cannot move the same package content more than once in the same transfer or split the same package into two location.'))
         if any(ml.package_id and ml.package_id == ml.result_package_id for ml in moves_todo.move_line_ids):
-            self.env['stock.quant']._unlink_zero_quants()
+            package_quants._unlink_zero_quants()
         picking = moves_todo.mapped('picking_id')
         moves_todo.write({'state': 'done', 'date': fields.Datetime.now()})
 

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -919,14 +919,24 @@ class StockQuant(models.Model):
         the cache. We defer the calls to unlink in this method.
         """
         precision_digits = max(6, self.sudo().env.ref('product.decimal_product_uom').digits * 2)
-        # Use a select instead of ORM search for UoM robustness.
-        query = """SELECT id FROM stock_quant WHERE (round(quantity::numeric, %s) = 0 OR quantity IS NULL)
-                                                     AND round(reserved_quantity::numeric, %s) = 0
-                                                     AND (round(inventory_quantity::numeric, %s) = 0 OR inventory_quantity IS NULL)
-                                                     AND user_id IS NULL;"""
-        params = (precision_digits, precision_digits, precision_digits)
-        self.env.cr.execute(query, params)
-        quant_ids = self.env['stock.quant'].browse([quant['id'] for quant in self.env.cr.dictfetchall()])
+        if self._ids:
+            # If quants are defined, don't search for all of them for performances reasons.
+            # Uses exists() as quant could have been already deleted during quant_tasks() in
+            # unpack().
+            quant_ids = self.exists().filtered(
+                lambda quant: float_is_zero(quant.quantity, precision_digits=precision_digits)
+                and float_is_zero(quant.reserved_quantity, precision_digits=precision_digits)
+                and float_is_zero(quant.inventory_quantity, precision_digits=precision_digits)
+                and not quant.user_id)
+        else:
+            # Use a select instead of ORM search for UoM robustness.
+            query = """SELECT id FROM stock_quant WHERE (round(quantity::numeric, %s) = 0 OR quantity IS NULL)
+                                                        AND round(reserved_quantity::numeric, %s) = 0
+                                                        AND (round(inventory_quantity::numeric, %s) = 0 OR inventory_quantity IS NULL)
+                                                        AND user_id IS NULL;"""
+            params = (precision_digits, precision_digits, precision_digits)
+            self.env.cr.execute(query, params)
+            quant_ids = self.env['stock.quant'].browse([quant['id'] for quant in self.env.cr.dictfetchall()])
         quant_ids.sudo().unlink()
 
     @api.model


### PR DESCRIPTION
For performance reasons on a big database (+ 5M records), use the quant to be deleted instead of a query


In the same spirit of what has been done there: https://github.com/odoo/odoo/commit/c261eb3820e7cbfc98de9c1bd0a79375e6f5d4f4


This test covers the use case: https://github.com/odoo/odoo/blob/18.0/addons/stock/tests/test_quant.py#L1529


opw-4369549



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
