### PR TITLE
[FIX] stock: remove non deterministic part

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -328,7 +328,9 @@ class StockLocation(models.Model):
         putaway_rules = putaway_rules.sorted(lambda rule: (rule.package_type_ids,
                                                            rule.product_id,
                                                            rule.category_id == categs[:1],  # same categ, not a parent
-                                                           rule.category_id),
+                                                           rule.category_id,
+                                                           rule.sequence,
+                                                           rule.id),
                                              reverse=True)
 
         putaway_location = None


### PR DESCRIPTION
The sorted part doesn't have a fallback on sequence and id. So in some cases, if the rules share the same selection data, it could be not deterministic

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
