### PR TITLE
[REF] mail: remove partner_id from follower store

### DIFF
--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -526,7 +526,6 @@ GROUP BY fol.id%s%s""" % (
                 "email": True,
                 "is_active": True,
                 "name": True,
-                "partner_id": True,
                 "partner": None,
                 "thread": [],
             }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_followers.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_followers.js
@@ -20,7 +20,6 @@ export class MailFollowers extends models.ServerModel {
                 email: true,
                 is_active: true,
                 name: true,
-                partner_id: true,
                 partner: null,
                 thread: [],
             };


### PR DESCRIPTION
This field is never used. Also free the name space in order to later rename `partner` to `partner_id`, which will be done separately as it requires more work on partner/persona.