### PR TITLE
[IMP] pos_{, self_order}: public description in PoS terminal

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -50,7 +50,7 @@ class ProductTemplate(models.Model):
         return [
             'id', 'display_name', 'standard_price', 'categ_id', 'pos_categ_ids', 'taxes_id', 'barcode', 'name', 'list_price', 'is_favorite',
             'default_code', 'to_weight', 'uom_id', 'description_sale', 'description', 'tracking', 'type', 'service_tracking', 'is_storable',
-            'write_date', 'available_in_pos', 'attribute_line_ids', 'active', 'image_128', 'combo_ids', 'product_variant_ids',
+            'write_date', 'available_in_pos', 'attribute_line_ids', 'active', 'image_128', 'combo_ids', 'product_variant_ids', 'public_description'
         ]
 
     def _load_pos_data(self, data):

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
@@ -3,6 +3,12 @@
     <t t-name="point_of_sale.ProductInfoPopup">
         <Dialog title.translate="Product information">
             <ProductInfoBanner productTemplate="props.productTemplate" info="props.info"/>
+            <div class="section-public-description mt-3 mb-4 pb-4 border-bottom text-start" t-if="props.productTemplate.productDescriptionMarkup">
+                <h3 class="section-title">
+                    Description
+                </h3>
+                <t t-out="props.productTemplate.productDescriptionMarkup" />
+            </div>
             <div class="section-inventory mt-3 mb-4 pb-4 border-bottom text-start" t-if="props.info?.productInfo?.warehouses?.length > 0">
                 <h3 class="section-title">
                     Inventory

--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -3,6 +3,7 @@ import { Base } from "./related_models";
 import { _t } from "@web/core/l10n/translation";
 import { roundPrecision } from "@web/core/utils/numbers";
 import { getTaxesAfterFiscalPosition, getTaxesValues } from "./utils/tax_utils";
+import { markup } from "@odoo/owl";
 
 /**
  * ProductProduct, shadow of product.product in python.
@@ -271,6 +272,10 @@ export class ProductTemplate extends Base {
             });
         });
         return isCombinationArchived;
+    }
+
+    get productDescriptionMarkup() {
+        return this.public_description ? markup(this.public_description) : "";
     }
 }
 registry.category("pos_available_models").add(ProductTemplate.pythonModel, ProductTemplate);

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -73,7 +73,7 @@
                                    string="Category"
                                    options="{'color_field': 'color'}"/>
                         </group>
-                        <group string="Public Description" name="public_description" invisible="1">
+                        <group string="Description" name="public_description">
                             <field name="public_description"
                                 placeholder="Information about your product."
                                 nolabel="1"

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -44,12 +44,6 @@ class ProductTemplate(models.Model):
                 product['_archived_combinations'].append(product_product.product_template_attribute_value_ids.ids)
 
     @api.model
-    def _load_pos_self_data_fields(self, config_id):
-        params = super()._load_pos_self_data_fields(config_id)
-        params += ['public_description']
-        return params
-
-    @api.model
     def _load_pos_data_fields(self, config_id):
         params = super()._load_pos_data_fields(config_id)
         params += ['self_order_available']

--- a/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.xml
@@ -9,7 +9,7 @@
                             <h1 class="modal-title fw-bolder" t-esc="props.productTemplate.name"/>
                             <button type="button" class="btn-close" t-on-click.stop="() => this.props.close()"></button>
                         </div>
-                        <span class="modal-body o_self_order_main_desc fs-3 p-4 ps-5 overflow-auto" t-out="props.productTemplate.public_description" />
+                        <span class="modal-body o_self_order_main_desc fs-3 p-4 ps-5 overflow-auto" t-out="props.productTemplate.productDescriptionMarkup" />
                         <div class="modal-footer d-flex flex-row-reverse justify-content-between align-items-center">
                             <button type="button" class="btn btn-primary" t-on-click.stop="() => this.addToCartAndClose()">Add to Cart</button>
                             <div t-if="!props.productTemplate.isCombo() and !props.productTemplate.isConfigurable()" class="o_self_order_incr_button btn-group " role="group" aria-label="Quantity select" >

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
@@ -27,7 +27,7 @@
                         <h2 t-esc="productTemplate.name"/>
                         <small t-if="productTemplate.public_description"
                             class="o_self_order_main_desc d-block mb-3 text-muted"
-                            t-out="productTemplate.public_description"
+                            t-out="productTemplate.productDescriptionMarkup"
                         />
                         <span class="fs-3" t-esc="selfOrder.formatMonetary(selfOrder.getProductDisplayPrice(productTemplate))"/>
                     </div>

--- a/addons/pos_self_order/views/product_views.xml
+++ b/addons/pos_self_order/views/product_views.xml
@@ -25,9 +25,6 @@
             <group name="pos" position="inside">
                 <field name="self_order_available"/>
             </group>
-            <xpath expr="//group[@name='public_description']" position="attributes">
-                <attribute name="invisible">0</attribute>
-            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Before this commit:
=========
- The public description field is only visible in the product form after the `pos_self_order` or `pos_urban_piper` modules have been installed.
- We are not providing a public description in the product information popup for the PoS terminal.

After this commit:
=========
- The public description field is visible after the `point_of_sale` module is installed in the product form view.
- Public description is available in the product information popup for the PoS terminal.

task- 4337758

Related: https://github.com/odoo/enterprise/pull/74868
