### PR TITLE
[FIX] hr_holidays: exclude hidden leave types from remaining leaves

### DIFF
--- a/addons/hr_holidays/models/hr_employee_base.py
+++ b/addons/hr_holidays/models/hr_employee_base.py
@@ -111,7 +111,7 @@ class HrEmployeeBase(models.AbstractModel):
             employee_remaining_leaves = 0
             employee_max_leaves = 0
             for leave_type in leaves_taken[employee]:
-                if leave_type.requires_allocation == 'no':
+                if leave_type.requires_allocation == 'no' or not leave_type.show_on_dashboard:
                     continue
                 for allocation in leaves_taken[employee][leave_type]:
                     if allocation and allocation.date_from <= current_date\


### PR DESCRIPTION
This commit excludes the time off types which are hidden from dashbaord in the count of employee's remaining leaves.

task-4268945


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
