### PR TITLE
[FIX] account: notify rank increases

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -674,6 +674,7 @@ class ResPartner(models.Model):
                     """).format(field=sql.Identifier(field))
                     self.env.cr.execute(query, {'partner_ids': tuple(self.ids), 'n': n})
                     self.invalidate_recordset([field])
+                    self.modified([field])
             except DatabaseError as e:
                 # 55P03 LockNotAvailable
                 # 40001 SerializationFailure


### PR DESCRIPTION
Any computed fields that depend on `customer_rank` or `supplier_rank` were not being recomputed when the ranks changed.

This isn't noticeable on standard Odoo code, but downstream modules that use such feature wouldn't work.

@moduon MT-8208




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
