### PR TITLE
[FIX] purchase_stock,stock_landed_costs: link landed cost on bill

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -82,6 +82,7 @@ class StockMove(models.Model):
                 total_invoiced_value += invoice_line.currency_id._convert(
                         invoice_line_value, order.currency_id, order.company_id, invoice_line.move_id.invoice_date, round=False)
                 invoiced_qty += invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_id.uom_id)
+            total_invoiced_value += self.company_id.currency_id._convert(self._additional_invoice_value(move_layer), order.currency_id, order.company_id, self.date, round=False)
             # TODO currency check
             remaining_value = total_invoiced_value - receipt_value
             # TODO qty_received in product uom
@@ -109,6 +110,10 @@ class StockMove(models.Model):
         if self.product_id.lot_valuated:
             return dict.fromkeys(self.lot_ids, price_unit)
         return {self.env['stock.lot']: price_unit}
+
+    def _additional_invoice_value(self, layers):
+        """ override to add invoice value not linked to the purchase order line. i.e landed costs"""
+        return 0
 
     def _generate_valuation_lines_data(self, partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, svl_id, description):
         """ Overridden from stock_account to support amount_currency on valuation lines generated from po

--- a/addons/stock_landed_costs/models/stock_move.py
+++ b/addons/stock_landed_costs/models/stock_move.py
@@ -7,3 +7,12 @@ class StockMove(models.Model):
     def _get_stock_valuation_layer_ids(self):
         self.ensure_one()
         return self.stock_valuation_layer_ids
+
+    def _additional_invoice_value(self, layers):
+        """ If a landed cost have an own invoice line, the additional value will not be added to the
+        product invoice line. We need to get the value from the landed cost layer."""
+        value = super()._additional_invoice_value(layers)
+        for layer in layers:
+            if layer.stock_landed_cost_id and layer.stock_landed_cost_id.vendor_bill_id:
+                value += layer.value
+        return value

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -8,6 +8,7 @@ from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounti
 from odoo import fields
 from odoo.fields import Command, Date
 from odoo.tests import tagged, Form
+from odoo import Command, fields
 
 
 @tagged('post_install', '-at_install')
@@ -492,6 +493,64 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         for move in receipt2.move_ids:
             move.quantity = move.product_qty
             move.picked = True
+        receipt2.button_validate()
+        self.assertEqual(self.product1.standard_price, 1.5)
+        self.assertEqual(product2.standard_price, 3.5)
+
+    def test_lc_with_avco_ordered_qty_backorder(self):
+        """ Make sure the landed cost added in invoices are taken into account to compute product
+        cost even in 'Ordered Quantity' invoice policy. """
+        self.env.company.anglo_saxon_accounting = True
+        self.landed_cost.split_method_landed_cost = 'by_quantity'
+        self.product1.purchase_method = 'purchase'
+        self.product1.categ_id.write({
+            'property_stock_account_input_categ_id': self.company_data['default_account_stock_in'].id,
+            'property_stock_account_output_categ_id': self.company_data['default_account_stock_out'].id,
+            'property_stock_valuation_account_id': self.company_data['default_account_stock_valuation'].id,
+            'property_valuation': 'real_time',
+            'property_cost_method': 'average',
+        })
+        product2 = self.product1.with_context(create_product_product=True).copy({"name": "product2"})
+
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': self.product1.id,
+                'product_qty': 100000,
+                'price_unit': 1,
+            }), Command.create({
+                'product_id': product2.id,
+                'product_qty': 50000,
+                'price_unit': 3,
+            })],
+        })
+        purchase_order.button_confirm()
+        purchase_order.action_create_invoice()
+        bill = purchase_order.invoice_ids[0]
+        receipt = purchase_order.picking_ids[0]
+        receipt.picking_type_id.create_backorder = 'always'
+        receipt.move_ids[0].quantity = 50000
+        receipt.move_ids[1].quantity = 25000
+        receipt.button_validate()
+        self.assertEqual(self.product1.standard_price, 1)
+        self.assertEqual(product2.standard_price, 3)
+
+        bill.invoice_date = fields.Date.today()
+        with Form(bill) as bill_form:
+            with bill_form.invoice_line_ids.new() as inv_line:
+                inv_line.product_id = self.landed_cost
+                inv_line.price_unit = 75000
+                inv_line.is_landed_costs_line = True
+        bill.action_post()
+        action = bill.button_create_landed_costs()
+        lc_form = Form(self.env[action['res_model']].browse(action['res_id']))
+        lc_form.picking_ids.add(receipt)
+        lc = lc_form.save()
+        lc.button_validate()
+        self.assertEqual(self.product1.standard_price, 2)
+        self.assertEqual(product2.standard_price, 4)
+
+        receipt2 = purchase_order.picking_ids.filtered(lambda p: p.state == 'assigned')
         receipt2.button_validate()
         self.assertEqual(self.product1.standard_price, 1.5)
         self.assertEqual(product2.standard_price, 3.5)


### PR DESCRIPTION
Steps to reproduce

1. Create a product invoiced on ordered quantities
2. Create a PO and a bill for it, post the bill
3. Receipt half the quantity
4. Add a landed cost product on the PO, create a second bill for this landed cost product. Create and validate the landed cost
5. Receipt the second half quantity.

Issue

The valuation of the second transfer is too low

Explanation

To get the price unit for "on ordered qty" policy, We compute the ratio of already receipt value on already invoiced value

https://github.com/odoo/odoo/blob/4f6353ec8a7306fbf63e95e8e02248d72f413aa3/addons/purchase_stock/models/stock_move.py#L84

The issue is the receipt value is increase by the landed costs value because the receipt valuation layer is linked to the landed cost valuation layer. But the product invoice line is not linked to the landed costs invoice line. Resulting in a invoice value under valuated.

This commit will increase the `total_invoice_value` by the same value of the landed costs value *if* the landed cost has it's own invoice line. In case the landed cost is created manually and it's value is already added into the Purchase order line price unit, we don't want to artificially increase the invoice value.

Task : 4354498

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
