### PR TITLE
[FIX] point_of_sale: prevent error when updating quantity

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -27,6 +27,7 @@ export class PosOrderline extends Base {
         this.uiState = {
             hasChange: true,
         };
+        this.saved_quantity = 0;
     }
 
     set_full_product_name() {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -180,7 +180,6 @@ export class OrderSummary extends Component {
         selectedLine.set_quantity(newQuantity);
         if (newQuantity == 0) {
             selectedLine.delete();
-            this.currentOrder._unlinkOrderline(selectedLine);
         }
         return decreaseQuantity;
     }
@@ -205,7 +204,6 @@ export class OrderSummary extends Component {
                 selectedLine.set_quantity(newQuantity, true);
             } else {
                 newLine.set_quantity(-decreasedQuantity, true);
-                this.pos.addLineToCurrentOrder(newLine.serialize());
             }
         }
         if (newLine !== selectedLine && selectedLine.saved_quantity != 0) {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1392,11 +1392,12 @@ export class PosStore extends Reactive {
         const uuid = o.uuid;
         this.addPendingOrder([o.id]);
         await this.syncAllOrders({ cancel_table_notification: true });
-
-        const order = this.models["pos.order"].find((order) => order.uuid === uuid);
+        const getOrder = (uuid) => this.models["pos.order"].getBy("uuid", uuid);
+        const order = getOrder(uuid);
         await this.sendOrderInPreparation(order, cancelled);
         order.updateLastOrderChange();
         await this.syncAllOrders();
+        getOrder(uuid).updateSavedQuantity();
     }
     closeScreen() {
         this.addOrderIfEmpty();


### PR DESCRIPTION
Before this commit, updating the quantity in localizations with disallowLineQuantityChange, such as Germany, would result in an error.

opw-4367694

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
