### PR TITLE
[FIX] html_editor: disable table position update on resize

### DIFF
--- a/addons/html_editor/static/src/core/overlay.js
+++ b/addons/html_editor/static/src/core/overlay.js
@@ -52,18 +52,21 @@ export class EditorOverlay extends Component {
         }
 
         const rootRef = useRef("root");
-        const resizeObserver = new ResizeObserver(() => {
-            position.unlock();
-        });
-        useEffect(
-            (root) => {
-                resizeObserver.observe(root);
-                return () => {
-                    resizeObserver.unobserve(root);
-                };
-            },
-            () => [rootRef.el]
-        );
+
+        if (this.props.positionOptions?.updatePositionOnResize ?? true) {
+            const resizeObserver = new ResizeObserver(() => {
+                position.unlock();
+            });
+            useEffect(
+                (root) => {
+                    resizeObserver.observe(root);
+                    return () => {
+                        resizeObserver.unobserve(root);
+                    };
+                },
+                () => [rootRef.el]
+            );
+        }
 
         if (this.props.closeOnPointerdown) {
             const editableDocument = this.props.editable.ownerDocument;

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -35,6 +35,7 @@ export class TableUIPlugin extends Plugin {
         /** @type {import("@html_editor/core/overlay_plugin").Overlay} */
         this.picker = this.dependencies.overlay.createOverlay(TablePicker, {
             positionOptions: {
+                updatePositionOnResize: false,
                 onPositioned: (picker, position) => {
                     const popperRect = picker.getBoundingClientRect();
                     const { left } = position;


### PR DESCRIPTION
**Problem**:
When creating a table and expanding its size, its position shifts upon reaching the window border due to the following code:
https://github.com/odoo/odoo/blob/1f4a85386eb258b08a3a6f43f1f3910598f005c4/addons/html_editor/static/src/core/overlay.js#L55-L57

The resize mechanism keeps the bottom of the table picker aligned with the top of the target element. When hovering over the gray square to add rows, the table expands upward (due to the position change), triggering a hover event again. This results in rapid row additions, causing the picker to jump back and forth, creating a poor user experience.

**Solution**:
Allow dynamic enabling or disabling of position changes during resizing, to match the fixed overlay positioning as prior versions (approved by the Product Owner).

**Steps to reproduce**:
1. Open the editor and insert a table.
2. Start adding rows by hovering over the table's resize picker.
3. As the picker moves above the target element, try to hover to add more rows.
4. Observe that rows are rapidly added during mouse movement, and the picker jumps back to the bottom, causing chaotic behavior.

opw-4351695

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
