### PR TITLE
[FIX] account: 'parent' use in payment method line field domain

### DIFF
--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -113,11 +113,14 @@ class AccountPaymentMethodLine(models.Model):
         copy=False,
         ondelete='restrict',
         domain="[('deprecated', '=', False), "
-                "'|', ('account_type', 'in', ('asset_current', 'liability_current')), ('id', '=', parent.default_account_id)]"
+                "'|', ('account_type', 'in', ('asset_current', 'liability_current')), ('id', '=', default_account_id)]"
     )
     journal_id = fields.Many2one(
         comodel_name='account.journal',
         check_company=True,
+    )
+    default_account_id = fields.Many2one(
+        related='journal_id.default_account_id'
     )
 
     # == Display purpose fields ==


### PR DESCRIPTION
Users in debug mode can click on a 'View' button in the list renderer
and open the specific record form view. However this may crash if the
model was not intended to be opened in a stand alone form view

Steps to reproduce:
- Go to debug mode
- Go to Accounting Dashboard
- Open Bank Journal settings
- Switch to Outgoing Payments tab
- in List menu options activate 'View Button'
- Click 'View' button
- Try to modify the 'Payment Account' field

Issue: Tracbeack will raise
```
    Error: Name 'parent' is not defined
    EvalError: Can not evaluate python expression: ((company_id and [('company_ids', 'parent_of', [company_id])] or [('company_ids', 'parent_of', '')]) + ([('deprecated', '=', False), '|', ('account_type', 'in', ('asset_current', 'liability_current')), ('id', '=', parent.default_account_id)]))
    Error: Name 'parent' is not defined
```

opw-4233216