### PR TITLE
[FIX] product,*: Change product.product order

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -625,7 +625,7 @@
             <field name="model">product.product</field>
             <field eval="50" name="priority"/>
             <field name="arch" type="xml">
-                <tree string="Product Variants">
+                <tree string="Product Variants" default_order="priority desc, default_code, name, id">
                     <field name="default_code"/>
                     <field name="name"/>
                     <field name="product_template_attribute_value_ids" widget="many2many_tags"
@@ -641,7 +641,7 @@
             <field name="name">product.product.expense.categories.tree.view</field>
             <field name="model">product.product</field>
             <field name="arch" type="xml">
-                <tree class="o_expense_categories">
+                <tree class="o_expense_categories" default_order="priority desc, default_code, name, id">
                     <field name="name" readonly="1"/>
                     <field name="default_code" optional="show" readonly="1"/>
                     <field name="description" widget="html" string="Internal Note" optional="show" readonly="1"/>

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -17,7 +17,7 @@ class ProductProduct(models.Model):
     _description = "Product Variant"
     _inherits = {'product.template': 'product_tmpl_id'}
     _inherit = ['mail.thread', 'mail.activity.mixin']
-    _order = 'priority desc, default_code, name, id'
+    _order = 'default_code, name, id'
     _check_company_domain = models.check_company_domain_parent_of
 
     # price_extra: catalog extra value only, sum of variant extra attributes

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -343,7 +343,7 @@
             <field name="model">product.product</field>
             <field eval="7" name="priority"/>
             <field name="arch" type="xml">
-                <tree string="Product Variants" multi_edit="1" duplicate="false" sample="1">
+                <tree string="Product Variants" multi_edit="1" duplicate="false" sample="1" default_order="priority desc, default_code, name, id">
                 <header>
                     <button string="Print Labels" type="object" name="action_open_label_layout"/>
                 </header>
@@ -382,7 +382,7 @@
             <field name="name">product.product.view.tree.tag</field>
             <field name="model">product.product</field>
             <field name="arch" type="xml">
-                <tree string="Product Variants" editable="bottom">
+                <tree string="Product Variants" editable="bottom" default_order="priority desc, default_code, name, id">
                     <field name="name" readonly="1"/>
                     <field name="default_code" readonly="1" optional="show"/>
                     <field name="product_template_variant_value_ids"
@@ -446,7 +446,7 @@
             <field name="name">Product Kanban</field>
             <field name="model">product.product</field>
             <field name="arch" type="xml">
-                <kanban sample="1">
+                <kanban sample="1" default_order="priority desc, default_code, name, id">
                     <field name="id"/>
                     <field name="lst_price"/>
                     <field name="activity_state"/>
@@ -546,7 +546,7 @@ action = {
         <field name="name">product.view.kanban.catalog</field>
         <field name="model">product.product</field>
         <field name="arch" type="xml">
-            <kanban records_draggable="0" js_class="product_kanban_catalog">
+            <kanban records_draggable="0" js_class="product_kanban_catalog" default_order="priority desc, default_code, name, id">
                 <field name="id" invisible="1"/>
                 <field name="default_code" invisible="1"/>
                 <templates>

--- a/addons/product_margin/views/product_product_views.xml
+++ b/addons/product_margin/views/product_product_views.xml
@@ -63,7 +63,7 @@
             <field name="model">product.product</field>
             <field name="priority" eval="50"/>
             <field name="arch" type="xml">
-                <tree string="Product Margins">
+                <tree string="Product Margins" default_order="priority desc, default_code, name, id">
                     <field name="name"/>
                     <field name="default_code"/>
                     <field name="sale_avg_price"/>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -513,7 +513,7 @@
             <field name="model">product.product</field>
             <field name="priority" eval="100"/>
             <field name="arch" type="xml">
-                <tree sample="1" js_class="stock_report_list_view" duplicate="0">
+                <tree sample="1" js_class="stock_report_list_view" duplicate="0" default_order="priority desc, default_code, name, id">
                     <field name="id" column_invisible="True"/>
                     <field name="display_name" string="Product"/>
                     <field name="categ_id" optional="hide"/>


### PR DESCRIPTION
For performance reasons, the priority field is moved from the model's _order
to the related tree & kanban views

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
