### PR TITLE
[IMP] website: skip theme wizard when configuring website from scratch

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -516,7 +516,9 @@ class Website(models.Model):
     @api.model
     def configurator_skip(self):
         website = self.get_current_website()
+        theme = self.env["ir.module.module"].search([("name", "=", "theme_default")])
         website.configurator_done = True
+        return theme.button_choose_theme()
 
     @api.model
     def configurator_missing_industry(self, unknown_industry):

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -717,6 +717,7 @@ export class Configurator extends Component {
     setup() {
         this.orm = useService('orm');
         this.action = useService('action');
+        this.website = useService("website");
 
         // Using the back button must update the router state.
         useExternalListener(window, "popstate", (ev) => {
@@ -871,11 +872,13 @@ export class Configurator extends Component {
     }
 
     async skipConfigurator() {
-        await this.orm.call('website', 'configurator_skip');
+        this.website.showLoader({ showTips: true });
+        const redirectUrl = await this.orm.call("website", "configurator_skip");
         this.clearStorage();
-        this.action.doAction('website.theme_install_kanban_action', {
-            clearBreadcrumbs: true,
-        });
+        // Here the website service goToWebsite method is not used because
+        // the web client needs to be reloaded after the new modules have
+        // been installed.
+        await this.action.doAction(redirectUrl);
     }
 }
 

--- a/addons/website/static/src/components/website_loader/website_loader.xml
+++ b/addons/website/static/src/components/website_loader/website_loader.xml
@@ -15,7 +15,7 @@
 
             <div t-if="state.showWaitingMessages" t-out="currentWaitingMessage.title" class="h4-fs text-muted mb-3"/>
             <div t-elif="state.title" t-out="state.title"/>
-            <div t-elif="state.showTips">Building your website...</div>
+            <div t-else="">Building your website...</div>
             <div class="mt-3"/>
             <div t-if="['text', 'images', 'generic'].includes(currentWaitingMessage.flag)" class="o_website_loader_tip d-flex gap-2 h3-fs mb-2">
                 <div><i class="o_website_loader_check fa fa-check fa-fw text-success" role="presentation"/></div>

--- a/addons/website/static/tests/tours/skip_website_configurator.js
+++ b/addons/website/static/tests/tours/skip_website_configurator.js
@@ -26,14 +26,6 @@ registry.category("web_tour.tours").add('skip_website_configurator', {
         run: "click",
     },
     {
-        content: "Install a theme",
-        trigger: ".o_theme_preview_top",
-        run: "hover && click button[name=button_choose_theme]",
-    },
-    {
-        trigger: ".o_menu_systray .o_user_menu",
-    },
-    {
         content: "Check that the homepage is loaded",
         trigger: ".o_website_preview[data-view-xmlid='website.homepage']",
         timeout: 30000,


### PR DESCRIPTION
This commit speed up the website configuration process by removing the unnecessary theme selection step when opting to start from scratch.

Before this commit:
When users clicked "Skip and start from scratch" in the website wizard, they were redirected to the theme selection window.

After this commit:
Clicking "Skip and start from scratch" will automatically apply the default theme and load a new, fresh website.

task-3915905

