### PR TITLE
[REF] Purchase: allow overriding vendor bill line sequence.

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -648,7 +648,7 @@ class PurchaseOrder(models.Model):
 
         # 1) Prepare invoice vals and clean-up the section lines
         invoice_vals_list = []
-        sequence = 10
+        sequence = 0
         for order in self:
             if order.invoice_status != 'to invoice':
                 continue
@@ -664,13 +664,11 @@ class PurchaseOrder(models.Model):
                     continue
                 if not float_is_zero(line.qty_to_invoice, precision_digits=precision):
                     if pending_section:
-                        line_vals = pending_section._prepare_account_move_line()
-                        line_vals.update({'sequence': sequence})
+                        line_vals = pending_section._prepare_account_move_line(sequence=sequence)
                         invoice_vals['invoice_line_ids'].append((0, 0, line_vals))
                         sequence += 1
                         pending_section = None
-                    line_vals = line._prepare_account_move_line()
-                    line_vals.update({'sequence': sequence})
+                    line_vals = line._prepare_account_move_line(sequence=sequence)
                     invoice_vals['invoice_line_ids'].append((0, 0, line_vals))
                     sequence += 1
             invoice_vals_list.append(invoice_vals)

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -548,13 +548,20 @@ class PurchaseOrderLine(models.Model):
 
         return name
 
-    def _prepare_account_move_line(self, move=False):
+    def _prepare_account_move_line(self, move=False, **optional_values):
+        """Prepare the values to create the new invoice line for a purchase order line.
+
+        :param move: the invoice for this line
+        :param optional_values: any parameter that should be added to the returned invoice line
+        :rtype: dict
+        """
         self.ensure_one()
         aml_currency = move and move.currency_id or self.currency_id
         date = move and move.date or fields.Date.today()
 
         res = {
             'display_type': self.display_type or 'product',
+            'sequence': self.sequence,
             'name': self.env['account.move.line']._get_journal_items_full_name(self.name, self.product_id.display_name),
             'product_id': self.product_id.id,
             'product_uom_id': self.product_uom.id,
@@ -567,6 +574,8 @@ class PurchaseOrderLine(models.Model):
         }
         if self.analytic_distribution and not self.display_type:
             res['analytic_distribution'] = self.analytic_distribution
+        if optional_values:
+            res.update(optional_values)
         return res
 
     @api.model


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The `purcahse.order.action_create_invoice` method calls `purchase.order.line._prepare_account_move_line`, but updates the returned result's `sequence` field (starting with value `10`) immediately afterward. To allow any overriding methods to preseve modification to `sequence` field, pass it as part of optional parameters, just as how `sale.order.line._create_invoices` does when calling the method `sale.oder.line._prepare_invoice_line`.

Current behavior before PR:
Vendor invoice line sequences are starting with 10, set by any overriding inherited method.

Desired behavior after PR is merged:
Vendor invoice lines can be overridden by inherited methods easily.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
