### PR TITLE
[FIX] calendar: fix issue with start and stop date

### DIFF
--- a/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
@@ -45,6 +45,16 @@ export class CalendarQuickCreateFormController extends CalendarFormController {
 
     goToFullEvent() {
         const context = getDefaultValuesFromRecord(this.model.root.data)
+        if (!context.default_start_date) {
+            context.default_start_date = this.model.root.data.start
+                ? serializeDate(this.model.root.data.start)
+                : false;
+        }
+        if (!context.default_stop_date) {
+            context.default_stop_date = this.model.root.data.stop
+                ? serializeDate(this.model.root.data.stop)
+                : false;
+        }
         this.props.goToFullEvent(context);
     }
 }


### PR DESCRIPTION
Before this commit, opening the dialog from the calendar view and clicking on the More Options button sometimes resulted in start_date and stop_date being false in the default context, causing an error.

This commit ensures that start_date and stop_date are properly set in the default context to prevent traceback.

