### PR TITLE
[FIX] l10n_kz: Expense Account on Product Category

### DIFF
--- a/addons/l10n_kz/models/template_kz.py
+++ b/addons/l10n_kz/models/template_kz.py
@@ -12,7 +12,7 @@ class AccountChartTemplate(models.AbstractModel):
             'property_account_receivable_id': 'kz1210',
             'property_account_payable_id': 'kz3310',
             'property_account_income_categ_id': 'kz6010',
-            'property_account_expense_categ_id': 'kz1330',
+            'property_account_expense_categ_id': 'kz7010',
             'code_digits': '4',
         }
 


### PR DESCRIPTION
Before this commit the account that was set was a current assets but this prevents its impact on the P/L.

task: 4369691




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
