### PR TITLE
[FIX] account: properly check the company name is already in the alias when generating it

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -692,7 +692,7 @@ class AccountJournal(models.Model):
             ), False
         )
         if company != self.env.ref('base.main_company'):
-            company_identifier = company.name if self.env['mail.alias']._is_encodable(company.name) else company.id
+            company_identifier = self.env['mail.alias']._sanitize_alias_name(company.name) if self.env['mail.alias']._is_encodable(company.name) else company.id
             if f'-{company_identifier}' not in alias_name:
                 alias_name = f"{alias_name}-{company_identifier}"
         return self.env['mail.alias']._sanitize_alias_name(alias_name)


### PR DESCRIPTION
When generating the mail alias for a journal, we check whether the name of the company is already in it, and add it if it's not. The problem is before this commit, we didn't sanitize the name of the company to do that check, so a company name with spaces or accents would never be detected as part of the alias, and could end up being in it twice.

This caused issues in the Winbooks import of one customer, who ended up with duplicate aliases because of that, since the journal code was not properly added to the generated alias while it should, and a duplicate of the company name was put instead.

opw-4196597
