### PR TITLE
[IMP] payment_paypal: add idempotency key for paypal requests

### DIFF
--- a/addons/payment_paypal/controllers/main.py
+++ b/addons/payment_paypal/controllers/main.py
@@ -10,6 +10,7 @@ from odoo import _, http
 from odoo.exceptions import ValidationError
 from odoo.http import request
 
+from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment_paypal import const
 
 
@@ -21,15 +22,26 @@ class PaypalController(http.Controller):
     _webhook_url = '/payment/paypal/webhook/'
 
     @http.route(_complete_url, type='json', auth='public', methods=['POST'])
-    def paypal_complete_order(self, provider_id, order_id):
+    def paypal_complete_order(self, provider_id, order_id, reference=None):
         """ Make a capture request and handle the notification data.
 
         :param int provider_id: The provider handling the transaction, as a `payment.provider` id.
         :param string order_id: The order id provided by PayPal to identify the order.
+        :param str reference: The reference of the transaction used to generate idempotency key.
         :return: None
         """
         provider_sudo = request.env['payment.provider'].browse(provider_id).sudo()
-        response = provider_sudo._paypal_make_request(f'/v2/checkout/orders/{order_id}/capture')
+        idempotency_key = None
+        if reference:
+            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
+                'paypal', {'reference_id': reference}
+            )
+            idempotency_key = payment_utils.generate_idempotency_key(
+                tx_sudo, scope='payment_request_controller'
+            )
+        response = provider_sudo._paypal_make_request(
+            f'/v2/checkout/orders/{order_id}/capture', idempotency_key=idempotency_key
+        )
         normalized_response = self._normalize_paypal_data(response)
         tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
             'paypal', normalized_response

--- a/addons/payment_paypal/models/payment_provider.py
+++ b/addons/payment_paypal/models/payment_provider.py
@@ -70,7 +70,8 @@ class PaymentProvider(models.Model):
     #=== BUSINESS METHODS ===#
 
     def _paypal_make_request(
-        self, endpoint, data=None, json_payload=None, auth=None, is_refresh_token_request=False
+        self, endpoint, data=None, json_payload=None, auth=None, is_refresh_token_request=False,
+        idempotency_key=None,
     ):
         """ Make a request to Paypal API at the specified endpoint.
 
@@ -82,12 +83,15 @@ class PaymentProvider(models.Model):
         :param tuple auth: The authentication data.
         :param bool is_refresh_token_request: Whether the request is for refreshing the access
                                               token.
+        :param str idempotency_key: The idempotency key to pass in the request.
         :return: The JSON-formatted content of the response.
         :rtype: dict
         :raise ValidationError: If an HTTP error occurs.
         """
         url = self._paypal_get_api_url() + endpoint
         headers = {'Content-Type': 'application/json'}  # PayPal always wants JSON content-type.
+        if idempotency_key:
+            headers['PayPal-Request-Id'] = idempotency_key
         if not is_refresh_token_request:
             headers['Authorization'] = f'Bearer {self._paypal_fetch_access_token()}'
         try:

--- a/addons/payment_paypal/models/payment_transaction.py
+++ b/addons/payment_paypal/models/payment_transaction.py
@@ -78,8 +78,11 @@ class PaymentTransaction(models.Model):
             "Sending '/checkout/orders' request for transaction with reference %s:\n%s",
             self.reference, pprint.pformat(payload)
         )
+        idempotency_key = payment_utils.generate_idempotency_key(
+            self, scope='payment_request_order'
+        )
         order_data = self.provider_id._paypal_make_request(
-            '/v2/checkout/orders', json_payload=payload
+            '/v2/checkout/orders', json_payload=payload, idempotency_key=idempotency_key
         )
         _logger.info(
             "Response of '/checkout/orders' request for transaction with reference %s:\n%s",

--- a/addons/payment_paypal/static/src/js/payment_form.js
+++ b/addons/payment_paypal/static/src/js/payment_form.js
@@ -118,6 +118,7 @@ paymentForm.include({
             return;
         }
         this.paypalData[paymentOptionId].paypalOrderId = processingValues['order_id'];
+        this.paypalData[paymentOptionId].paypalTxRef = processingValues['reference'];
     },
 
     /**
@@ -134,6 +135,7 @@ paymentForm.include({
         await rpc('/payment/paypal/complete_order', {
             'provider_id': provider_id,
             'order_id': orderID,
+            'reference': this.paypalData[this.selectedOptionId].paypalTxRef,
         }).then(() => {
             // Close the PayPal buttons that were rendered
             this.paypalData[this.selectedOptionId]['paypalButton'].close();


### PR DESCRIPTION
An idempotency key was added to avoid processing a payment request twice. If the payment attempt fails and result wasn't received, sending the same request again will return the result of the first executed request. If User decides to retry, another request is made with the same parameters but a different idempotent id, thus resulting in a new request.

task-2894752

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
