### PR TITLE
[IMP] hw_posbox_homepage: better device list

### DIFF
--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -152,7 +152,8 @@ class IotBoxOwlHomePage(Home):
         iot_device = []
         for device in iot_devices:
             iot_device.append({
-                'name': iot_devices[device].device_name + ' : ' + str(iot_devices[device].data['value']),
+                'name': iot_devices[device].device_name,
+                'value': str(iot_devices[device].data['value']),
                 'type': iot_devices[device].device_type.replace('_', ' '),
                 'identifier': iot_devices[device].device_identifier,
             })

--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -29,8 +29,7 @@ export class Homepage extends Component {
 
     setup() {
         this.store = useStore();
-        this.state = useState({ loading: true, waitRestart: false });
-        this.data = useState({});
+        this.state = useState({ data: {}, loading: true, waitRestart: false });
         this.store.advanced = localStorage.getItem("showAdvanced") === "true";
 
         onWillStart(async () => {
@@ -52,7 +51,7 @@ export class Homepage extends Component {
                 this.store.isLinux = true;
             }
 
-            this.data = data;
+            this.state.data = data;
             this.store.base = data;
             this.state.loading = false;
             this.store.update = new Date().getTime();
@@ -92,41 +91,41 @@ export class Homepage extends Component {
                 <IconButton onClick.bind="restartOdooService" icon="'fa-power-off'" />
             </div>
             <div class="d-flex mb-4 flex-column align-items-center justify-content-center">
-                <h4 class="text-center m-0">IoT Box - <t t-esc="this.data.hostname" /></h4>
+                <h4 class="text-center m-0">IoT Box - <t t-esc="state.data.hostname" /></h4>
             </div>
             <div t-if="this.store.advanced" class="alert alert-warning" role="alert">
                 <p class="m-0 fw-bold">HTTPS certificate</p>
-                <small>Error code: <t t-esc="this.data.certificate_details" /></small>
+                <small>Error code: <t t-esc="state.data.certificate_details" /></small>
             </div>
-            <SingleData name="'Name'" value="this.data.hostname" icon="'fa-id-card'">
+            <SingleData name="'Name'" value="state.data.hostname" icon="'fa-id-card'">
 				<t t-set-slot="button">
 					<ServerDialog t-if="this.store.isLinux" />
 				</t>
 			</SingleData>
-            <SingleData t-if="this.store.advanced" name="'Version'" value="this.data.version" icon="'fa-microchip'">
+            <SingleData t-if="this.store.advanced" name="'Version'" value="state.data.version" icon="'fa-microchip'">
                 <t t-set-slot="button">
                     <UpdateDialog t-if="this.store.isLinux" />
                 </t>
             </SingleData>
-            <SingleData t-if="this.store.advanced" name="'IP address'" value="this.data.ip" icon="'fa-globe'" />
-            <SingleData t-if="this.store.advanced" name="'MAC address'" value="this.data.mac.toUpperCase()" icon="'fa-address-card'" />
-            <SingleData t-if="this.store.isLinux" name="'Internet Status'" value="this.data.network_status"  icon="'fa-wifi'">
+            <SingleData t-if="this.store.advanced" name="'IP address'" value="state.data.ip" icon="'fa-globe'" />
+            <SingleData t-if="this.store.advanced" name="'MAC address'" value="state.data.mac.toUpperCase()" icon="'fa-address-card'" />
+            <SingleData t-if="this.store.isLinux" name="'Internet Status'" value="state.data.network_status"  icon="'fa-wifi'">
                 <t t-set-slot="button">
                     <WifiDialog />
                 </t>
             </SingleData>
-            <SingleData name="'Odoo database connected'" value="this.data.server_status" icon="'fa-link'">
+            <SingleData name="'Odoo database connected'" value="state.data.server_status" icon="'fa-link'">
 				<t t-set-slot="button">
 					<ServerDialog />
 				</t>
 			</SingleData>
-            <SingleData t-if="this.data.pairing_code" name="'Pairing Code'" value="this.data.pairing_code" icon="'fa-code'"/>
-            <SingleData  t-if="this.store.advanced" name="'Six terminal'" value="this.data.six_terminal" icon="'fa-money'">
+            <SingleData t-if="state.data.pairing_code" name="'Pairing Code'" value="state.data.pairing_code" icon="'fa-code'"/>
+            <SingleData  t-if="this.store.advanced" name="'Six terminal'" value="state.data.six_terminal" icon="'fa-money'">
                 <t t-set-slot="button">
                     <SixDialog />
                 </t>
             </SingleData>
-            <SingleData name="'Devices'" value="this.data.iot_device_status.length + ' devices'" icon="'fa-plug'">
+            <SingleData name="'Devices'" value="state.data.iot_device_status.length + ' devices'" icon="'fa-plug'">
                 <t t-set-slot="button">
                     <DeviceDialog />
                 </t>

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/BootstrapDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/BootstrapDialog.js
@@ -7,6 +7,7 @@ export class BootstrapDialog extends Component {
         identifier: String,
         slots: Object,
         btnName: { type: String, optional: true },
+        isLarge: { type: Boolean, optional: true },
         onOpen: { type: Function, optional: true },
         onClose: { type: Function, optional: true },
     };
@@ -39,7 +40,7 @@ export class BootstrapDialog extends Component {
 
     static template = xml`
         <button type="button" class="btn btn-primary btn-sm" data-bs-toggle="modal" t-att-data-bs-target="'#'+this.props.identifier" t-esc="this.props.btnName" />
-        <div t-ref="dialog" t-att-id="this.props.identifier" class="modal modal-dialog-scrollable fade" tabindex="-1" aria-hidden="true">
+        <div t-ref="dialog" t-att-id="this.props.identifier" class="modal modal-dialog-scrollable fade" t-att-class="{'modal-lg': props.isLarge}" tabindex="-1" aria-hidden="true">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/DeviceDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/DeviceDialog.js
@@ -1,47 +1,76 @@
 /* global owl */
 
 import useStore from "../../hooks/useStore.js";
-import { SingleData } from "../SingleData.js";
 import { BootstrapDialog } from "./BootstrapDialog.js";
 
-const { Component, xml, useState } = owl;
+const { Component, xml } = owl;
+
+const DEVICE_ICONS = {
+    camera: "fa-camera",
+    device: "fa-plug",
+    display: "fa-desktop",
+    fiscal_data_module: "fa-dollar",
+    keyboard: "fa-keyboard-o",
+    payment: "fa-credit-card",
+    printer: "fa-print",
+    scale: "fa-balance-scale",
+    scanner: "fa-barcode",
+};
 
 export class DeviceDialog extends Component {
     static props = {};
-    static components = { BootstrapDialog, SingleData };
+    static components = { BootstrapDialog };
 
     setup() {
         this.store = useStore();
-        this.state = useState({
-            loading: false,
-        });
+        this.icons = DEVICE_ICONS;
     }
 
-    onClose() {
-        this.state.initialization = [];
-        this.state.handlerData = {};
+    formatDeviceType(deviceType, numDevices) {
+        const formattedDeviceType =
+            deviceType[0].toUpperCase() + deviceType.replaceAll("_", " ").slice(1);
+        return numDevices === 1 ? formattedDeviceType : `${formattedDeviceType}s`;
     }
 
-    get devices() {
-        // Put blackbox first in the list
-        return this.store.base.iot_device_status.sort((a, b) =>
-            a.type === "fiscal data module" ? -1 : 1
-        );
+    get groupedDevices() {
+        const devices = this.store.base.iot_device_status;
+        return devices.reduce((groupedDevices, nextDevice) => {
+            groupedDevices[nextDevice.type] ??= [];
+            groupedDevices[nextDevice.type].push(nextDevice);
+            return groupedDevices;
+        }, {});
     }
 
     static template = xml`
-        <BootstrapDialog identifier="'device-list'" btnName="'Show'">
+        <BootstrapDialog identifier="'device-list'" btnName="'Show'" isLarge="true">
             <t t-set-slot="header">
                 Devices list
             </t>
             <t t-set-slot="body">
-                <div t-if="this.store.base.iot_device_status.length === 0" class="alert alert-warning fs-6" role="alert">
+                <div t-if="Object.keys(groupedDevices).length === 0" class="alert alert-warning fs-6" role="alert">
                     No devices found.
                 </div>
-                <div>
-                    <t t-foreach="devices" t-as="device" t-key="device.identifier">
-                        <SingleData name="'Device: ' + device.name.slice(0, 40) +  device.name.length > 40 ? '...' : ''" value="device.type + ' - ' + device.identifier.slice(0, 50) + '...'" style="'secondary'" />
-                    </t>
+                <div class="accordion">
+                    <div t-foreach="Object.keys(groupedDevices)" t-as="deviceType" t-key="deviceType" class="accordion-item">
+                        <h2 class="accordion-header" t-att-id="'heading-' + deviceType">
+                            <button class="accordion-button px-3 d-flex gap-3 collapsed" type="button" data-bs-toggle="collapse" t-att-data-bs-target="'#collapse-' + deviceType" t-att-aria-controls="'collapse-' + deviceType">
+                                <span t-att-class="'color-primary fa fa-fw fa-2x ' + icons[deviceType]"/>
+                                <span class="fs-5 fw-bold" t-out="groupedDevices[deviceType].length"/>
+                                <span class="fs-5" t-out="formatDeviceType(deviceType, groupedDevices[deviceType].length)"/>
+                            </button>
+                        </h2>
+                        <div t-att-id="'collapse-' + deviceType" class="accordion-collapse collapse" t-att-aria-labelledby="'heading-' + deviceType">
+                            <div class="d-flex flex-column p-1 gap-2">
+                                <div t-foreach="groupedDevices[deviceType]" t-as="device" t-key="device.identifier" class="d-flex flex-column bg-light rounded p-2 gap-1">
+                                    <span t-out="device.name" class="one-line"/>
+                                    <span t-out="device.identifier" class="text-secondary one-line"/>
+                                    <div t-if="device.value" class="text-secondary one-line">
+                                        <i>Last sent value was <t t-out="device.value"/></i>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </t>
             <t t-set-slot="footer">

--- a/addons/hw_posbox_homepage/static/src/app/css/override.css
+++ b/addons/hw_posbox_homepage/static/src/app/css/override.css
@@ -1,6 +1,14 @@
+:root {
+    --odoo-purple: #714B67
+} 
+
+.color-primary {
+    color: var(--odoo-purple);
+}
+
 .btn.btn-primary {
-    background-color: #714B67 !important;
-    border-color: #714B67 !important;
+    background-color: var(--odoo-purple) !important;
+    border-color: var(--odoo-purple) !important;
 }
 
 .alert.alert-secondary {
@@ -10,8 +18,8 @@
 }
 
 .odoo-bg-primary, .bg-primary, .form-check-input:checked, .nav-pills .nav-link.active {
-    background-color: #714B67 !important;
-    border-color: #714B67 !important;
+    background-color: var(--odoo-purple) !important;
+    border-color: var(--odoo-purple) !important;
 }
 
 .odoo-bg-secondary, .bg-secondary {
@@ -29,6 +37,6 @@
 }
 
 .link-primary {
-    color: #714B67 !important;
+    color: var(--odoo-purple) !important;
     font-size: 12px;
 }

--- a/addons/hw_posbox_homepage/static/src/app/main.js
+++ b/addons/hw_posbox_homepage/static/src/app/main.js
@@ -13,4 +13,5 @@ mount(Homepage, document.body, {
     env: {
         store: createStore(),
     },
+    dev: new URLSearchParams(window.location.search).has("debug"),
 });


### PR DESCRIPTION
Before this PR, the device list only showed
the identifiers of each device, which aren't
very readable.

After this PR, the devices are grouped by
device type, with each device type having an icon.
Each device then shows it's name and identifier,
as well as the last sent value if applicable.

This PR also contains some small fixes (see commit messages).

task-4364479

![image](https://github.com/user-attachments/assets/5146199f-9a31-47aa-84c7-403260e73b7a)


![image](https://github.com/user-attachments/assets/7d58219e-349c-44ed-ab0c-f2d4cb90c521)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
