### PR TITLE
[FIX] web_editor: adapts forced size in image_shape route

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -755,6 +755,15 @@ class Web_Editor(http.Controller):
         img = binary_to_image(image)
         width, height = tuple(str(size) for size in img.size)
         root = etree.fromstring(svg)
+
+        if root.attrib.get("data-forced-size"):
+            # Adjusts the SVG height to ensure the image fits properly within
+            # the SVG (e.g. for "devices" shapes).
+            svgHeight = float(root.attrib.get("height"))
+            svgWidth = float(root.attrib.get("width"))
+            svgAspectRatio = svgWidth / svgHeight
+            height = str(float(width) / svgAspectRatio)
+
         root.attrib.update({'width': width, 'height': height})
         # Update default color palette on shape SVG.
         svg, _ = self._update_svg_colors(kwargs, etree.tostring(root, pretty_print=True).decode('utf-8'))


### PR DESCRIPTION
In commit [1], we introduced a "data-forced-size" attribute on "image
shapes" SVGs to adjust SVGs height to ensure the image fits properly
within it (e.g. for "devices" shapes).

However, the "image_shape" route was not updated to match this change,
preventing the use of predefined building blocks containing an image
shape with a "forced-size" attribute.

This commit updates the "image_shape" route to support the
"data-forced-size" attribute.

[1]: https://github.com/odoo/odoo/commit/63cf8a693a5262600d465d70f0383229464d71e7

task-4094393