### PR TITLE
[FIX] account_peppol: Make text translation friendly

### DIFF
--- a/addons/account_peppol/data/mail_templates_email_layouts.xml
+++ b/addons/account_peppol/data/mail_templates_email_layouts.xml
@@ -16,8 +16,10 @@
                         <p style="min-width: 590px;">
                             PS: <b style="color: $o-enterprise-action-color;">We did not send your invoice on Peppol.</b>
                             <t t-if="peppol_info['peppol_country'] == 'BE'">
-                                In Belgium, electronic invoicing will be
-                                <a target="_blank" href="https://finance.belgium.be/en/enterprises/vat/e-invoicing/mandatory-use-structured-electronic-invoices-2026">mandatory as of January 2026</a>.
+                                In Belgium, electronic invoicing will be <u>mandatory as of January 2026</u>.
+                                <a target="_blank" href="https://finance.belgium.be/en/enterprises/vat/e-invoicing/mandatory-use-structured-electronic-invoices-2026" style="text-decoration: none;">
+                                    &#x1F517;
+                                </a>
                             </t>
                             <br/>
                             If you need a Peppol compliant software, we recommend <a target="_blank" href="https://www.odoo.com/app/invoicing?utm_source=db&amp;utm_medium=email&amp;utm_campaign=einvoicing" style="color: $o-enterprise-color;">Odoo</a>.

--- a/addons/account_peppol/i18n/account_peppol.pot
+++ b/addons/account_peppol/i18n/account_peppol.pot
@@ -294,7 +294,9 @@ msgstr ""
 
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
-msgid "In Belgium, electronic invoicing will be"
+msgid ""
+"In Belgium, electronic invoicing will be <u>mandatory as of January "
+"2026</u>."
 msgstr ""
 
 #. module: account_peppol
@@ -448,7 +450,7 @@ msgstr ""
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
 msgid ""
-"PS: <b style=\"color: $o-enterprise-action-color;\">We could not send your "
+"PS: <b style=\"color: $o-enterprise-action-color;\">We did not send your "
 "invoice on Peppol.</b>"
 msgstr ""
 
@@ -948,9 +950,4 @@ msgstr ""
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.res_config_settings_view_form
 msgid "Your registration should be activated within a day."
-msgstr ""
-
-#. module: account_peppol
-#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
-msgid "mandatory as of January 2026"
 msgstr ""


### PR DESCRIPTION
In previous commit [1] we added text at the bottom of email sent when sending invoices, this doesn't work well for translation to have <a> tags in the middle of sentences, in particular in Dutch and German. We move the cliquable URL at the end of the sentence in an icon.

[1]: https://github.com/odoo/odoo/commit/42cc1ea713aa977794231897b2f04758e30d8e19

task-no
![image](https://github.com/user-attachments/assets/550d5c3c-6c02-4c6a-bc16-f76a96a0a588)
