### PR TITLE
[FIX] web: clear embedded actions context keys

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -567,15 +567,18 @@ export class ControlPanel extends Component {
             parent_action_embedded_actions: this.state.embeddedInfos.embeddedActions,
             parent_action_id: action.parent_action_id[0] || action.parent_action_id,
         };
-        this.actionService.doActionButton({
-            type: action.python_method ? "object" : "action",
-            resId: this.env.searchModel?.globalContext.active_id,
-            name: action.python_method || action.action_id[0] || action.action_id,
-            resModel: action.parent_res_model,
-            context,
-            stackPosition: this.env.config.parentActionId ? "replaceCurrentAction" : "",
-            viewType: action.default_view_mode,
-        });
+        this.actionService.doActionButton(
+            {
+                type: action.python_method ? "object" : "action",
+                resId: this.env.searchModel?.globalContext.active_id,
+                name: action.python_method || action.action_id[0] || action.action_id,
+                resModel: action.parent_res_model,
+                context,
+                stackPosition: this.env.config.parentActionId ? "replaceCurrentAction" : "",
+                viewType: action.default_view_mode,
+            },
+            { isEmbeddedAction: true }
+        );
     }
 
     /**

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -122,6 +122,13 @@ export class InvalidButtonParamsError extends Error {}
 // regex that matches context keys not to forward from an action to another
 const CTX_KEY_REGEX =
     /^(?:(?:default_|search_default_|show_).+|.+_view_ref|group_by|active_id|active_ids|orderedBy)$/;
+// keys added to the context for the embedded actions feature
+const EMBEDDED_ACTIONS_CTX_KEYS = [
+    "current_embedded_action_id",
+    "parent_action_embedded_actions",
+    "parent_action_id",
+    "from_embedded_action",
+];
 
 // only register this template once for all dynamic classes ControllerComponent
 const ControllerComponentTemplate = xml`<t t-component="Component" t-props="componentProps"/>`;
@@ -1394,11 +1401,20 @@ export function makeActionManager(env, router = _router) {
      * 'ir.actions.act_window_close' is executed.
      *
      * @param {DoActionButtonParams} params
+     * @params {Object} [options={}]
+     * @params {boolean} [options.isEmbeddedAction] set to true if the action request is an
+     *  embedded action. This allows to do the necessary context cleanup and avoid infinite
+     *  recursion.
      * @returns {Promise<void>}
      */
-    async function doActionButton(params) {
+    async function doActionButton(params, { isEmbeddedAction } = {}) {
         // determine the action to execute according to the params
         let action;
+        if (!isEmbeddedAction) {
+            for (const key of EMBEDDED_ACTIONS_CTX_KEYS) {
+                delete params.context?.[key];
+            }
+        }
         const context = makeContext([params.context, params.buttonContext]);
         const blockUi = exprToBoolean(params["block-ui"]);
         if (blockUi) {
@@ -1477,17 +1493,20 @@ export function makeActionManager(env, router = _router) {
                     parent_action_embedded_actions: embeddedActions,
                     parent_action_id: action.id,
                 };
-                await this.doActionButton({
-                    name:
-                        embeddedAction.python_method ||
-                        embeddedAction.action_id[0] ||
-                        embeddedAction.action_id,
-                    resId: params.resId,
-                    context,
-                    type: embeddedAction.python_method ? "object" : "action",
-                    resModel: embeddedAction.parent_res_model,
-                    viewType: embeddedAction.default_view_mode,
-                });
+                await this.doActionButton(
+                    {
+                        name:
+                            embeddedAction.python_method ||
+                            embeddedAction.action_id[0] ||
+                            embeddedAction.action_id,
+                        resId: params.resId,
+                        context,
+                        type: embeddedAction.python_method ? "object" : "action",
+                        resModel: embeddedAction.parent_res_model,
+                        viewType: embeddedAction.default_view_mode,
+                    },
+                    { isEmbeddedAction: true }
+                );
                 return;
             }
         }

--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -162,7 +162,6 @@ defineEmbeddedActions([
 test("can display embedded actions linked to the current action", async () => {
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
-    browser.localStorage.clear();
     expect(".o_control_panel").toHaveCount(1, { message: "should have rendered a control panel" });
     expect(".o_kanban_view").toHaveCount(1, { message: "should have rendered a kanban view" });
     expect(".o_control_panel_navigation > button > i.fa-sliders").toHaveCount(1, {
@@ -179,7 +178,6 @@ test("can display embedded actions linked to the current action", async () => {
 test("can toggle visibility of embedded actions", async () => {
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
-    browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
     await contains(".o_embedded_actions .dropdown").click();
     expect(".o_popover.dropdown-menu .dropdown-item").toHaveCount(4, {
@@ -199,7 +197,6 @@ test("can toggle visibility of embedded actions", async () => {
 test("can click on a embedded action and execute the corresponding action (with xml_id)", async () => {
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
-    browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
     await contains(".o_embedded_actions .dropdown").click();
     await contains(
@@ -229,7 +226,6 @@ test("can click on a embedded action and execute the corresponding action (with 
         };
     });
     await getService("action").doAction(1);
-    browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
     await contains(".o_embedded_actions .dropdown").click();
     await contains(
@@ -259,7 +255,6 @@ test("breadcrumbs are updated when clicking on embeddeds", async () => {
         };
     });
     await getService("action").doAction(1);
-    browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
     await contains(".o_embedded_actions .dropdown").click();
     await contains(
@@ -306,7 +301,6 @@ test("a view coming from a embedded can be saved in the embedded actions", async
     });
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
-    browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
     await contains(".o_embedded_actions .dropdown").click();
     await contains(
@@ -365,7 +359,6 @@ test("a view coming from a embedded with python_method can be saved in the embed
     });
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
-    browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
     await contains(".o_embedded_actions .dropdown").click();
     await contains(
@@ -397,7 +390,6 @@ test("a view coming from a embedded with python_method can be saved in the embed
 test("the embedded actions should not be displayed when switching view", async () => {
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
-    browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
     await contains(".o_embedded_actions .dropdown").click();
     await contains(
@@ -414,7 +406,6 @@ test("the embedded actions should not be displayed when switching view", async (
 test("User can move the main (first) embedded action", async () => {
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
-    browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
     await contains(".o_embedded_actions .dropdown").click();
     await contains(
@@ -432,7 +423,6 @@ test("User can move the main (first) embedded action", async () => {
 test("User can unselect the main (first) embedded action", async () => {
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
-    browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
     await contains(".o_embedded_actions .dropdown").click();
     const dropdownItem =
@@ -448,7 +438,6 @@ test("User can unselect the main (first) embedded action", async () => {
 
 test("User should be redirected to the first embedded action set in localStorage", async () => {
     await mountWithCleanup(WebClient);
-    browser.localStorage.clear();
     browser.localStorage.setItem(`orderEmbedded1++${user.userId}`, JSON.stringify([2, false, 3])); // set embedded action 2 in first
     await getService("action").doActionButton({
         name: 1,
@@ -464,4 +453,31 @@ test("User should be redirected to the first embedded action set in localStorage
     expect(".o_last_breadcrumb_item > span").toHaveText("Favorite Ponies", {
         message: "'Favorite Ponies' view should be loaded",
     });
+});
+
+test("execute a regular action from an embedded action", async () => {
+    Pony._views["form,false"] = `
+        <form>
+            <button type="action" name="2" string="Execute another action"/>
+            <field name="name"/>
+        </form>`;
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+    expect(".o_kanban_view").toHaveCount(1);
+
+    await contains(".o_control_panel_navigation button .fa-sliders").click();
+    expect(".o_control_panel .o_embedded_actions button:not(.dropdown-toggle)").toHaveCount(1);
+
+    await contains(".o_embedded_actions .dropdown").click();
+    await contains(".dropdown-menu .dropdown-item span:contains('Embedded Action 2')").click();
+    expect(".o_control_panel .o_embedded_actions button:not(.dropdown-toggle)").toHaveCount(2);
+
+    await contains(".o_control_panel .o_embedded_actions button:eq(1)").click();
+    expect(".o_list_view").toHaveCount(1);
+
+    await contains(".o_data_row .o_data_cell").click();
+    expect(".o_form_view").toHaveCount(1);
+
+    await contains(".o_form_view button[type=action]").click();
+    expect(".o_control_panel .o_embedded_actions").toHaveCount(0);
 });


### PR DESCRIPTION
Before this commit, when executing a regular action from an embedded one, the context wasn't cleared, so all the embedded action feature related keys were propagated to the regular action. As a consequence, the embedded actions bar was displayed on that action as well. Clicking on an item most certainly led to a crash, because a wrong active id (referring to anothe res_model) would be used.

For instance
1) Go to Project
2) Open "AGR - S00080 - Sales Order"
3) Add Sales order embedded action
4) Click Sales order
5) Enter a sales order that has tasks or a service product 6) Click the Tasks smart button
7) The embedded actions bar is displayed and, it crashes if an item
   is clicked

opw~4253958

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
