### PR TITLE
[FIX] point_of_sale: extend customer search fields

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -190,7 +190,18 @@ export class PartnerListScreen extends Component {
         let domain = [];
         const limit = 30;
         if (this.state.query) {
-            const search_fields = ["name", "parent_name", "phone_mobile_search", "email", "barcode"];
+            const search_fields = [
+                "name",
+                "parent_name",
+                "phone_mobile_search",
+                "email",
+                "barcode",
+                "street",
+                "zip",
+                "city",
+                "state_id",
+                "country_id",
+            ];
             domain = [
                 ...Array(search_fields.length - 1).fill('|'),
                 ...search_fields.map(field => [field, "ilike", this.state.query + "%"])

--- a/addons/point_of_sale/static/tests/tours/Chrome.tour.js
+++ b/addons/point_of_sale/static/tests/tours/Chrome.tour.js
@@ -5,6 +5,7 @@ import * as ReceiptScreen from "@point_of_sale/../tests/tours/helpers/ReceiptScr
 import * as PaymentScreen from "@point_of_sale/../tests/tours/helpers/PaymentScreenTourMethods";
 import * as TicketScreen from "@point_of_sale/../tests/tours/helpers/TicketScreenTourMethods";
 import * as Chrome from "@point_of_sale/../tests/tours/helpers/ChromeTourMethods";
+import * as Utils from "@point_of_sale/../tests/tours/helpers/utils";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("ChromeTour", {
@@ -117,5 +118,18 @@ registry.category("web_tour.tours").add("ChromeTour", {
             PaymentScreen.clickInvoiceButton(),
             PaymentScreen.clickValidate(),
             ReceiptScreen.isShown(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("SearchMoreCustomer", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.inputCustomerSearchbar("1111"),
+            Utils.selectButton("Search more"),
+            ProductScreen.clickCustomer("BPartner"),
+            ProductScreen.isShown(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -121,6 +121,26 @@ export function clickCustomer(name) {
         },
     ];
 }
+export function inputCustomerSearchbar(value) {
+    return [
+        {
+            trigger: ".pos-search-bar input",
+            run: `text ${value}`,
+        },
+        {
+            /**
+             * Manually trigger keyup event to show the search field list
+             * because the previous step do not trigger keyup event.
+             */
+            trigger: ".pos-search-bar input",
+            run: function () {
+                document
+                    .querySelector(".pos-search-bar input")
+                    .dispatchEvent(new KeyboardEvent("keyup", { key: "" }));
+            },
+        },
+    ];
+}
 export function clickRefund() {
     return [
         clickReview(),

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -11,6 +11,8 @@ from odoo.addons.account.tests.common import AccountTestInvoicingHttpCommon
 from odoo.addons.point_of_sale.tests.common_setup_methods import setup_pos_combo_items
 from datetime import date, timedelta
 from odoo.addons.point_of_sale.tests.common import archive_products
+from odoo.addons.point_of_sale.models.pos_config import PosConfig
+from unittest.mock import patch
 
 _logger = logging.getLogger(__name__)
 
@@ -1270,6 +1272,18 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.env['ir.config_parameter'].sudo().set_param('barcode.max_time_between_keys_in_ms', 1)
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CashRoundingPayment', login="accountman")
+
+    def test_customer_search_more(self):
+        partner_test_a = self.env["res.partner"].create({"name": "APartner"})
+        self.env["res.partner"].create({"name": "BPartner", "zip": 1111})
+
+        def mocked_get_limited_partners_loading(self):
+            return [(partner_test_a.id,)]
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        with patch.object(PosConfig, 'get_limited_partners_loading', mocked_get_limited_partners_loading):
+            self.main_pos_config.open_ui()
+            self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'SearchMoreCustomer', login="pos_user")
 
 
 # This class just runs the same tests as above but with mobile emulation


### PR DESCRIPTION
Currently, when searching the through the customers loaded in pos you can search using the zip code but if the customer is not loaded you cannot search those in db using the zip code.

Steps to reproduce:
-------------------
* Create a customer and set his zip code.
* Open pos shop
* Search for customers
* Enter the zip code, normally you shouldn't see the customer
* Select "Search more"
> Observation: No customer found

Note: If you search with the customer name it will find it.

Why the fix:
------------
Adding a few search values when loeading customers in the session.

opw-4334412