### PR TITLE
[FIX] auth_oauth: exclude routes from readonly transactions

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -119,7 +119,7 @@ class OAuthLogin(Home):
 
 class OAuthController(http.Controller):
 
-    @http.route('/auth_oauth/signin', type='http', auth='none')
+    @http.route('/auth_oauth/signin', type='http', auth='none', readonly=False)
     @fragment_to_query_string
     def signin(self, **kw):
         state = json.loads(kw['state'])
@@ -176,7 +176,7 @@ class OAuthController(http.Controller):
         redirect.autocorrect_location_header = False
         return redirect
 
-    @http.route('/auth_oauth/oea', type='http', auth='none')
+    @http.route('/auth_oauth/oea', type='http', auth='none', readonly=False)
     def oea(self, **kw):
         """login user via Odoo Account provider"""
         dbname = kw.pop('db', None)


### PR DESCRIPTION
Follow-up of #186319 and #186786

These routes are auth=none but aren't technically read-only, as they can create the user record and need to record the login event anyway.

The signin one even as a broad catch for Exception, which would prevent the readonly->read-write fallback to work, leading to a failed login.
