### PR TITLE
 [FIX] hr_recruitment: temp multi company module

### DIFF
--- a/addons/hr_recruitment_multicompany/__init__.py
+++ b/addons/hr_recruitment_multicompany/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details
+
+from . import models

--- a/addons/hr_recruitment_multicompany/__manifest__.py
+++ b/addons/hr_recruitment_multicompany/__manifest__.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Recruitment - multi company fix',
+    'author': 'Odoo',
+    'version': '1.0',
+    'category': 'Human Resources',
+    'description': """
+Recruitment
+========================================
+This module is only temporary for its purpose is to modify fields in a stable version (18.0) to make multicompany behaviour work.
+    """,
+    'depends': ['hr_recruitment', 'hr_recruitment_skills'],
+    'data': [
+        'views/hr_candidate_views.xml',
+    ],
+    'license': 'OEEL-1',
+    'auto_install': True,
+}

--- a/addons/hr_recruitment_multicompany/models/__init__.py
+++ b/addons/hr_recruitment_multicompany/models/__init__.py
@@ -1,0 +1,2 @@
+from . import hr_applicant
+from . import hr_candidate

--- a/addons/hr_recruitment_multicompany/models/hr_applicant.py
+++ b/addons/hr_recruitment_multicompany/models/hr_applicant.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class HrApplicant(models.Model):
+    _name = "hr.applicant"
+    _inherit = ["hr.applicant"]
+
+    department_id = fields.Many2one(
+        "hr.department",
+        "Department",
+        compute="_compute_department",
+        store=True,
+        readonly=True,
+        domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
+        tracking=True,
+    )
+    company_id = fields.Many2one(
+        "res.company",
+        "Company",
+        compute="_compute_company",
+        store=True,
+        readonly=True,
+        tracking=True,
+    )

--- a/addons/hr_recruitment_multicompany/models/hr_candidate.py
+++ b/addons/hr_recruitment_multicompany/models/hr_candidate.py
@@ -1,0 +1,44 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, fields
+from odoo.osv import expression
+
+
+class HrCandidate(models.Model):
+    _name = "hr.candidate"
+    _inherit = [
+        "hr.candidate",
+    ]
+
+    company_ids = fields.Many2many(
+        comodel_name="res.company",
+        compute="_compute_candidate_companies",
+        default=lambda self: self.env.company,
+        string="Companies",
+        readonly=False,
+        store=True,
+    )
+
+    @api.depends('applicant_ids')
+    def _compute_candidate_companies(self):
+        for candidate in self:
+            candidate.company_ids = candidate.applicant_ids.mapped("company_id")
+            candidate.company_id = False
+
+    def _get_similar_candidates_domain(self):
+        """
+            This method returns a domain for the applicants whitch match with the
+            current candidate according to email_from, partner_phone.
+            Thus, search on the domain will return the current candidate as well if any of
+            the following fields are filled.
+        """
+        self.ensure_one()
+        if not self:
+            return []
+        domain = [('id', 'in', self.ids)]
+        if self.email_normalized:
+            domain = expression.OR([domain, [('email_normalized', '=', self.email_normalized)]])
+        if self.partner_phone_sanitized:
+            domain = expression.OR([domain, [('partner_phone_sanitized', '=', self.partner_phone_sanitized)]])
+        domain = expression.AND([domain, [('company_ids', 'in', self.env.companies.ids)]])
+        return domain

--- a/addons/hr_recruitment_multicompany/security/hr_recruitment_security.xml
+++ b/addons/hr_recruitment_multicompany/security/hr_recruitment_security.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="hr_candidate_comp_rule" model="ir.rule">
+        <field name="name">Candidate multi company rule</field>
+        <field name="model_id" ref="model_hr_candidate"/>
+        <field eval="True" name="global"/>
+        <field name="domain_force">[('company_ids', 'in', company_ids + [False])]</field>
+    </record>
+</odoo>

--- a/addons/hr_recruitment_multicompany/views/hr_candidate_views.xml
+++ b/addons/hr_recruitment_multicompany/views/hr_candidate_views.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="hr_candidate_view_form" model="ir.ui.view">
+        <field name="name">hr.candidate.view.form.inherit</field>
+        <field name="model">hr.candidate</field>
+        <field name="inherit_id" ref="hr_recruitment.hr_candidate_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group/field[@name='company_id']" position="replace">
+                <field name="company_ids" groups="base.group_multi_company" widget="many2many_tags"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="hr_candidate_view_tree" model="ir.ui.view">
+        <field name="name">hr.candidate.view.tree.inherit</field>
+        <field name="model">hr.candidate</field>
+        <field name="inherit_id" ref="hr_recruitment.hr_candidate_view_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='company_id']" position="replace">
+                <field name="company_ids" groups="base.group_multi_company" optional="hide" widget="many2many_tags"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="hr_candidate_view_tree" model="ir.ui.view">
+        <field name="name">hr.candidate.view.tree.inherit</field>
+        <field name="model">hr.candidate</field>
+        <field name="inherit_id" ref="hr_recruitment_skills.hr_candidate_view_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='company_id']" position="replace">
+                <field name="company_ids" position="after">
+                    <field name="matching_score"/>
+                    <field name="matching_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    <field name="missing_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                </field>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -352,12 +352,23 @@ class WebsiteHrRecruitment(WebsiteForm):
         return super()._should_log_authenticate_message(record)
 
     def extract_data(self, model, values):
-        candidate = False
+        candidate = request.env['hr.candidate']
         if model.model == 'hr.applicant':
             # pop the fields since there are only useful to generate a candidate record
             partner_name = values.pop('partner_name')
             partner_phone = values.pop('partner_phone', None)
             partner_email = values.pop('email_from', None)
+
+            company_id = (
+                request.env["hr.department"]
+                .sudo()
+                .search([("id", "=", values.get("department_id"))])
+                .company_id.id
+                or request.env["hr.job"]
+                .sudo()
+                .search([("id", "=", values.get("job_id"))])
+                .company_id.id
+            )
             if partner_phone and partner_email:
                 candidate = request.env['hr.candidate'].sudo().search([
                     ('email_from', '=', partner_email),
@@ -368,6 +379,7 @@ class WebsiteHrRecruitment(WebsiteForm):
                     'partner_name': partner_name,
                     'email_from': partner_email,
                     'partner_phone': partner_phone,
+                    'company_id': company_id,
                 })
         data = super().extract_data(model, values)
         if candidate:

--- a/addons/website_hr_recruitment/static/src/js/website_hr_applicant_form.js
+++ b/addons/website_hr_recruitment/static/src/js/website_hr_applicant_form.js
@@ -31,13 +31,13 @@ publicWidget.registry.hrRecruitment = publicWidget.Widget.extend({
 
     hideWarningMessage(targetEl, messageContainerId) {
         targetEl.classList.remove("border-warning");
-        document.querySelector(messageContainerId).classList.add("d-none");
+        document.querySelector(messageContainerId)?.classList.add("d-none");
     },
 
     showWarningMessage(targetEl, messageContainerId, message) {
         targetEl.classList.add("border-warning");
         document.querySelector(messageContainerId).textContent = message;
-        document.querySelector(messageContainerId).classList.remove("d-none");
+        document.querySelector(messageContainerId)?.classList.remove("d-none");
     },
 
     async _onFocusOutName(ev) {


### PR DESCRIPTION
The problem:
With the introduction candidate/applicant models in 18.0 a subtle bug got introduced. The core of the bug is that most of the field on an application are related/inherited from the candidate of that application except company_id. This means that both models have a company_id and those are not synced. This can become an issue in a multi company issue where a candidate is assigned to company A while their application is in company B. The recruiter in company B will then get constant access errors because they don't have write permission on a record(candidate) in a different company.

The fix:
This PR aims to fix this by doing 2 things.
1. Every time the company on a application gets changed the company of the candidate is also updated. This still means that if the company of the candidate is manually changed we will have this issue again but there's no way around that (that can be implemented in stable).
2. Makes sure that candidates created through the website are assigned to the company of the job posting or no company, preventing a mismatch from happening.

There was also trace-back happening on the job application form on odoo.com as a warning message div is missing there for some reason so I added a simple condition to check if that div exists to prevent the trace-back.

task-4350838

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
