### PR TITLE
[FIX] {l10n_}account_edi_ubl_cii{_tests}: email as electronic address for xrechnung

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
@@ -36,3 +36,15 @@ class AccountEdiXmlUBLDE(models.AbstractModel):
         })
 
         return constraints
+
+    def _get_partner_party_vals(self, partner, role):
+        # EXTENDS account.edi.xml.ubl_bis3
+        vals = super()._get_partner_party_vals(partner, role)
+
+        if not vals.get('endpoint_id') and partner.email:
+            vals.update({
+                'endpoint_id': partner.email,
+                'endpoint_id_attrs': {'schemeID': 'EM'},
+            })
+
+        return vals

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice_without_vat.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice_without_vat.xml
@@ -1,0 +1,119 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>INV/2017/01/0002</cbc:ID>
+  <cbc:IssueDate>2017-01-01</cbc:IssueDate>
+  <cbc:DueDate>2017-02-28</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:Note>test narration</cbc:Note>
+  <cbc:DocumentCurrencyCode>USD</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>ref_partner_2</cbc:BuyerReference>
+  <cac:OrderReference>
+    <cbc:ID>ref_move</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="9930">DE257486969</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Legoland-Allee 3</cbc:StreetName>
+        <cbc:CityName>Günzburg</cbc:CityName>
+        <cbc:PostalZone>89312</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>DE257486969</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID>DE257486969</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Telephone>+49 180 6 225789</cbc:Telephone>
+        <cbc:ElectronicMail>info@legoland.de</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="EM">partner_2@test.test</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Europa-Park-Straße 2</cbc:StreetName>
+        <cbc:CityName>Rust</cbc:CityName>
+        <cbc:PostalZone>77977</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_2</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_2</cbc:Name>
+        <cbc:ElectronicMail>partner_2@test.test</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentID>INV/2017/01/0002</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>DE48500105176424548921</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: 30% Advance End of Following Month</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="USD">19.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="USD">100.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="USD">19.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>19.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="USD">100.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="USD">100.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="USD">119.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="USD">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="USD">119.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1708</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">100.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>19.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">100.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from odoo import Command
 from odoo.addons.l10n_account_edi_ubl_cii_tests.tests.common import TestUBLCommon
 from odoo.tests import tagged
 import base64
@@ -121,6 +122,40 @@ class TestUBLDE(TestUBLCommon):
                 </xpath>
             ''',
             expected_file='from_odoo/xrechnung_ubl_out_invoice.xml',
+        )
+        self.assertEqual(attachment.name[-10:], "ubl_de.xml")
+        self._assert_imported_invoice_from_etree(invoice, attachment)
+
+    def test_export_import_invoice_without_vat(self):
+        self.partner_2.vat = False
+        self.partner_2.email = 'partner_2@test.test'
+        invoice = self._generate_move(
+            self.partner_1,
+            self.partner_2,
+            move_type='out_invoice',
+            invoice_line_ids=[
+                {
+                    'product_id': self.product_a.id,
+                    'quantity': 1.0,
+                    'price_unit': 100.0,
+                    'tax_ids': [Command.set(self.tax_19.ids)],
+                },
+            ],
+        )
+        attachment = self._assert_invoice_attachment(
+            invoice,
+            xpaths='''
+                <xpath expr="./*[local-name()='ID']" position="replace">
+                    <ID>___ignore___</ID>
+                </xpath>
+                <xpath expr=".//*[local-name()='InvoiceLine'][1]/*[local-name()='ID']" position="replace">
+                    <ID>___ignore___</ID>
+                </xpath>
+                <xpath expr=".//*[local-name()='PaymentMeans']/*[local-name()='PaymentID']" position="replace">
+                    <PaymentID>___ignore___</PaymentID>
+                </xpath>
+            ''',
+            expected_file='from_odoo/xrechnung_ubl_out_invoice_without_vat.xml',
         )
         self.assertEqual(attachment.name[-10:], "ubl_de.xml")
         self._assert_imported_invoice_from_etree(invoice, attachment)


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_de
- Switch to a German company
- Configure the customer invoice journal to enable "XRechnung UBL (Germany)"
- Create a German contact:
  * with a complete address
  * with an email address
  * without a VAT number
- Create an invoice for the created contact
- Confirm the invoice
- Generate the electronic invoice
- Validate the generated XML on an online XRechnung ValidationError

**Issue:**
The XRechnung (UBL Invoice) is not valid because the buyer electronic address is missing (cbc:EndpointID).

**Cause:**
`<cbc:EndpointID>` gets its value from contact's VAT, but the contact has no VAT.

**Solution:**
Since XRechnung 3.0.1, the email address can be used as electronic address with "EM" as schemeID.
So, fallback on email address if contact has no VAT.

**Reference:**
https://www.e-rechnung-bund.de/standard-xrechnung-3-0-1/
https://blog.seeburger.com/xrechnung-version-3-0-1-comes-into-force-on-february-1-2024/
https://erechnungsvalidator.service-bw.de/

opw-4261026



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
