### PR TITLE
[FIX] website_sale: prevent access error on tax computation

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -309,8 +309,13 @@ class ProductTemplate(models.Model):
         )
         show_tax_excluded = self.user_has_groups('account.group_show_line_subtotals_tax_excluded')
         tax_display = 'total_excluded' if show_tax_excluded else 'total_included'
-        # The list_price is always the price of one.
-        return taxes.compute_all(price, pricelist.currency_id, 1, product, partner)[tax_display]
+        return taxes.compute_all(
+            price_unit=price,
+            currency=pricelist.currency_id,
+            quantity=1,  # `list_price` is always the price of one
+            product=product.sudo(),  # tax computation may require access to restricted fields
+            partner=partner,
+        )[tax_display]
 
     def _get_image_holder(self):
         """Returns the holder of the image to use as default representation.


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps (18.0+)
-------------
1. Have the `account_tax_python` module installed;
2. define a sales tax using "Custom Formula";
3. define a formula based on `product.standard_price`;
4. have the tax enabled for products in eCommerce;
5. as a Public User, go to the eCommerce page.

Issue
-----
> 403: Forbidden

Cause
-----
Commit de302c2 changed the way company dependent fields are handled. Instead of computing them via `_compute_company_dependent`, they are now stored in the database.

Before this this change, any `groups` restriction added to a field wasn't actually checked. After this change, it does get checked, leading to the 403 error.

Solution
--------
When computing taxes, pass `product` with `sudo` to ensure access to all necessary fields.

opw-4354321
