### PR TITLE
[FIX] mail: full composer recipients combine explicit and mentions

### DIFF
--- a/addons/mail/static/src/views/web/form/form_controller.js
+++ b/addons/mail/static/src/views/web/form/form_controller.js
@@ -41,7 +41,7 @@ patch(FormController.prototype, {
                 if (changes.partner_ids[0] && changes.partner_ids[0][0] === x2ManyCommands.SET) {
                     partnerIds.push(...changes.partner_ids[0][2]);
                 }
-                changes.partner_ids = [x2ManyCommands.set(partnerIds)];
+                changes.partner_ids.push(...partnerIds.map((pid) => x2ManyCommands.link(pid)));
             }
         }
     },

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -120,6 +120,15 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
             trigger: '.o-mail-Message-body:contains("blahblah @Not A Demo User")',
         },
         {
+            content: "Click on envelope to see recipients of message",
+            trigger:
+                '.o-mail-Message:has(.o-mail-Message-body:contains("blahblah @Not A Demo User")) .o-mail-Message-notification',
+        },
+        {
+            content: "Check message has correct recipients",
+            trigger: ".o-mail-MessageNotificationPopover:contains('Not A Demo UserJane')",
+        },
+        {
             content: "Check message contains the attachment",
             trigger: '.o-mail-Message .o-mail-AttachmentCard:contains("text.txt")',
             isCheck: true,


### PR DESCRIPTION
Before this commit, when sending a message in full composer to explicit recipients and message contains mentions, the resulting recipients of the message were only mentioned users.

Steps to reproduce:
- Open a form view with suggested recipient (e.g. any contacts with demo data)
- Click "Send message" then full composer button ("expand" button)
- Type `@Marc Demo` mention in the full composer text area
- Click on "Send"

=> The new message shows envelope with only "Marc Demo" in the recipients, instead of "Marc Demo" and the suggested recipient.

This happens because when making a mention, the code to enrich the `partner_ids` of `mail.compose.message` was basically setting its content with mentions, without taking into account whether there were some explicit values with other means than with `@mention`.

This commit fixes the issue by adding mentions with the current value of `partner_ids`, so that mentions and explicit recipients are the resulting recipients of message as expected

Task-4366608