### PR TITLE
[IMP] point_of_sale: add test for renderer

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -93,6 +93,9 @@
             'point_of_sale/static/src/proxy_trap.js',
             'point_of_sale/static/src/lazy_getter.js',
             'point_of_sale/static/src/app/services/data_service.js',
+
+            'point_of_sale/static/src/app/utils/html-to-image.js',
+            'point_of_sale/static/src/app/services/render_service.js',
             'point_of_sale/static/tests/unit/**/*',
         ],
 

--- a/addons/point_of_sale/static/src/app/services/render_service.js
+++ b/addons/point_of_sale/static/src/app/services/render_service.js
@@ -29,7 +29,7 @@ export class RenderContainer extends Component {
  * In order to obtain the html code that represents a component, we need to
  * actually mount the respective component in the dom.
  */
-const renderService = {
+export const renderService = {
     dependencies: [],
     start() {
         const toBeRenderedComponentData = reactive({});

--- a/addons/point_of_sale/static/tests/unit/render_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/render_service.test.js
@@ -1,0 +1,24 @@
+import { expect, test } from "@odoo/hoot";
+import { Component, xml } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { clearRegistry, mountWithCleanup, patchTranslations } from "@web/../tests/web_test_helpers";
+import { renderService } from "@point_of_sale/app/services/render_service";
+
+test("test the render service", async () => {
+    class ComponentToBeRendered extends Component {
+        static props = ["name"];
+        static template = xml`
+            <div> It's me, <t t-esc="props.name" />! </div>
+        `;
+    }
+    clearRegistry(registry.category("services"));
+    clearRegistry(registry.category("main_components"));
+    registry.category("services").add("render", renderService);
+
+    patchTranslations(); // this is needed because we are not loading the localization service
+    const comp = await mountWithCleanup("none");
+    const renderedComp = await comp.env.services.render.toHtml(ComponentToBeRendered, {
+        name: "Mario",
+    });
+    expect(renderedComp).toHaveOuterHTML("<div> It's me, Mario! </div>");
+});


### PR DESCRIPTION
In this commit we add a unit test for the `render_service`.

task: 4370377





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
