### PR TITLE
[IMP] point_of_sale: add generic components test

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -99,6 +99,12 @@
             'point_of_sale/static/src/app/utils/html-to-image.js',
             'point_of_sale/static/src/app/services/render_service.js',
             'point_of_sale/static/tests/unit/**/*',
+
+            'point_of_sale/static/src/app/components/odoo_logo/*',
+            'point_of_sale/static/src/app/components/centered_icon/*',
+            'point_of_sale/static/src/app/components/inputs/**/*',
+            'point_of_sale/static/tests/generic_components/**/*',
+
         ],
 
         # PoS assets

--- a/addons/point_of_sale/static/tests/generic_components/mount_generic_components.test.js
+++ b/addons/point_of_sale/static/tests/generic_components/mount_generic_components.test.js
@@ -1,0 +1,40 @@
+import { expect, test } from "@odoo/hoot";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { Component, useState, xml } from "@odoo/owl";
+import { OdooLogo } from "@point_of_sale/app/components/odoo_logo/odoo_logo";
+import { CenteredIcon } from "@point_of_sale/app/components/centered_icon/centered_icon";
+import { Input } from "@point_of_sale/app/components/inputs/input/input";
+import { NumericInput } from "@point_of_sale/app/components/inputs/numeric_input/numeric_input";
+import { registry } from "@web/core/registry";
+import { waitFor } from "@odoo/hoot-dom";
+
+test("test that generic components can be mounted; the goal is to ensure that they don't have any unmet dependencies", async () => {
+    class TestComponent extends Component {
+        static props = [];
+        static components = {
+            OdooLogo,
+            CenteredIcon,
+            Input,
+            NumericInput,
+        };
+        static template = xml`
+            <div class="test-container">
+                <OdooLogo />
+                <CenteredIcon icon="'fa-smile'"/>
+                <Input tModel="[state, 'number']"/>
+                <NumericInput tModel="[state, 'number']" />
+            </div>
+        `;
+        setup() {
+            this.state = useState({ number: 1 });
+        }
+    }
+
+    registry.category("services").content = {};
+
+    await mountWithCleanup(TestComponent, {
+        noMainContainer: true,
+    });
+    await waitFor("div.test-container");
+    expect(true).toBe(true);
+});


### PR DESCRIPTION
In this commit we add a unit test where we mount the generic components from pos. The idea of these components is that they should not depend on any specific pos object. As such, this new unit test allows us to verify that the components are usable outside of the context of pos. ( many of them are already tested in the pos tours )

Task: 4370403





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
