### PR TITLE
[FIX] mail: defensively add message_id in references

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -440,6 +440,16 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         self.assertTrue(bool(mail))
         if content:
             self.assertIn(content, mail.body_html)
+
+        # specific check for message_id being in references: we don't care about
+        # actual value, just that they are set and message_id present in references
+        references_message_id_check = (email_values or {}).pop('references_message_id_check', False)
+        if references_message_id_check:
+            message_id = mail['message_id']
+            self.assertTrue(message_id, 'Mail: expected value set for message_id')
+            self.assertIn(message_id, mail.references, 'Mail: expected message_id to be part of references')
+            email_values = dict({'message_id': message_id, 'references': mail.references}, **(email_values or {}))
+
         for fname, fvalue in (fields_values or {}).items():
             with self.subTest(fname=fname, fvalue=fvalue):
                 self.assertEqual(
@@ -616,7 +626,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
           either a partner record;
         :param values: dictionary of additional values to check email content;
         """
-        direct_check = ['body_alternative', 'email_from', 'references', 'reply_to', 'subject']
+        direct_check = ['body_alternative', 'email_from', 'message_id', 'references', 'reply_to', 'subject']
         content_check = ['body_alternative_content', 'body_content', 'references_content']
         list_check = ['email_bcc', 'email_cc', 'email_to']
         other_check = ['attachments', 'attachments_info', 'body', 'headers']

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -445,6 +445,16 @@ class MailComposer(models.TransientModel):
                     {'model': 'mail.message', 'res_id': 0}
                 )['attachment_ids']
 
+                # generate message_id directly; instead of letting mail_message create
+                # method doing it. Then use it to craft references, allowing to keep
+                # a trace of message_id even when email providers override it.
+                # Note that if 'auto_delete' and 'auto_delete_message' are True,
+                # mail.message is removed and parent finding based on messageID
+                # may be broken, tough life
+                message_id = self.env['mail.message']._get_message_id(mail_values)
+                mail_values['message_id'] = message_id
+                mail_values['references'] = message_id
+
             results[res_id] = mail_values
 
         results = self._process_state(results)

--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -14,16 +14,6 @@ class MailMail(models.Model):
     mailing_id = fields.Many2one('mailing.mailing', string='Mass Mailing')
     mailing_trace_ids = fields.One2many('mailing.trace', 'mail_mail_id', string='Statistics')
 
-    @api.model_create_multi
-    def create(self, values_list):
-        """ Override mail_mail creation to create an entry in mail.mail.statistics """
-        # TDE note: should be after 'all values computed', to have values (FIXME after merging other branch holding create refactoring)
-        mails = super(MailMail, self).create(values_list)
-        for mail, values in zip(mails, values_list):
-            if values.get('mailing_trace_ids'):
-                mail.mailing_trace_ids.write({'message_id': mail.message_id})
-        return mails
-
     def _get_tracking_url(self):
         token = tools.hmac(self.env(su=True), 'mass_mailing-mail_mail-open', self.id)
         return werkzeug.urls.url_join(self.get_base_url(), 'mail/track/%s/%s/blank.gif' % (self.id, token))

--- a/addons/mass_mailing/wizard/mail_compose_message.py
+++ b/addons/mass_mailing/wizard/mail_compose_message.py
@@ -51,6 +51,7 @@ class MailComposeMessage(models.TransientModel):
                         mail_values['body_html'] = body
 
                 trace_vals = {
+                    'message_id': mail_values['message_id'],
                     'model': self.model,
                     'res_id': res_id,
                     'mass_mailing_id': mass_mailing.id,

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1865,6 +1865,8 @@ class TestComposerResultsMass(TestMailComposer):
                                             ],
                                             'body_content': exp_body,
                                             'email_from': self.partner_employee_2.email_formatted,
+                                            # profit from this test to check references are set to message_id in mailing emails
+                                            'references_message_id_check': True,
                                             'subject': exp_subject,
                                         },
                                         fields_values={

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -19,7 +19,7 @@ from odoo.addons.test_mail.models.test_mail_models import MailTestGateway, MailT
 from odoo.addons.test_mail.tests.common import TestMailCommon
 from odoo.sql_db import Cursor
 from odoo.tests import tagged, RecordCapturer
-from odoo.tests.common import users
+from odoo.tests.common import Form, users
 from odoo.tools import email_split_and_format, formataddr, mute_logger
 
 
@@ -2189,6 +2189,88 @@ class TestMailGatewayLoops(MailGatewayCommon):
             f'"MAILER-DAEMON" <{self.alias_bounce}@{self.alias_domain}>',
             [customer_email],
             subject=f'Re: Re: Re: Should Bounce (initial)')
+
+
+@tagged('mail_gateway', 'mail_loop')
+class TestMailGatewayReplies(MailGatewayCommon):
+    """ Check routing of replies, using headers, references, ... """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.test_records, _partners = cls._create_records_for_batch('mail.test.gateway', 5)
+        for idx, rec in enumerate(cls.test_records):
+            rec.email_from = f'test.gateway.{idx}@test.example.com'
+
+    @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.addons.mail.models.mail_thread')
+    def test_routing_reply_mailing_references(self):
+        """ Test mass mailing emails when providers rewrite messageID: references
+        should allow to find the original message. """
+        # send mailing on records using composer, in both reply and force new modes
+        for reply_to_mode, auto_delete_message in [
+            ('new', False),
+            ('update', False),
+            ('new', True),  # reference is lost, but reply alias should be ok
+            ('update', True),  # reference is lost, hence considered as a reply to catchall, is going to crash (FIXME ?)
+        ]:
+            with self.subTest(reply_to_mode=reply_to_mode, auto_delete_message=auto_delete_message):
+                composer_form = Form(self.env['mail.compose.message'].with_context({
+                    'active_ids': self.test_records.ids,
+                    'default_auto_delete': True,
+                    'default_auto_delete_message': auto_delete_message,
+                    'default_composition_mode': 'mass_mail',
+                    'default_email_from': self.user_employee.email_formatted,
+                    'default_model': self.test_records._name,
+                    'default_subject': 'Coucou Hibou',
+                }))
+                composer_form.body = f'<p>Hello <t t-out="object.name"/></p>'
+                composer_form.reply_to_mode = reply_to_mode
+                if reply_to_mode == 'new':
+                    composer_form.reply_to = self.alias.display_name
+                composer = composer_form.save()
+                with self.mock_mail_gateway(mail_unlink_sent=True):
+                    mails, _msg = composer._action_send_mail()
+                self.assertFalse(mails.exists())
+
+                # check reply using references
+                # TDE TODO: update tooling
+                outgoing_message_ids = [outgoing['message_id'] for outgoing in self._mails]
+                self.assertEqual(len(set(outgoing_message_ids)), len(self.test_records),
+                                'All message IDs should be different')
+                for record in self.test_records:
+                    outgoing = self._find_sent_email(self.user_employee.email_formatted, [record.email_from])
+                    # for some reason, provider rewrites message_id, then customer replies
+                    outgoing['message_id'] = f'<ILikeToRewriteMessageIDFor{record.id}-{record._name}@zboing>'
+                    extra = f'In-Reply-To:{outgoing["message_id"]}\nReferences:{outgoing["message_id"]} {outgoing["references"]}\n'
+                    with RecordCapturer(self.env['mail.message'], []) as capture_messages:
+                        gateway_record = self.format_and_process(
+                            MAIL_TEMPLATE, outgoing['email_to'][0], outgoing['reply_to'],
+                            extra=extra,
+                            subject=f'Re: {outgoing["subject"]} - from {outgoing["email_to"][0]} ({reply_to_mode} {auto_delete_message})',
+                            debug_log=False,
+                        )
+                    new_message = capture_messages.records
+                    # as outgoing mail is unlinked with its mail.message -> cannot find parent -> bounce
+                    if reply_to_mode == 'update' and auto_delete_message:
+                        self.assertFalse(new_message)
+                        self.assertFalse(gateway_record)
+                        continue
+                    self.assertTrue(new_message)
+                    if reply_to_mode == 'update':
+                        self.assertFalse(gateway_record, 'No record created based on subject, as it replies to the thread')
+                        self.assertMessageFields(new_message, {
+                            'email_from': record.email_from,
+                            'model': record._name,
+                            'res_id': record.id,
+                        })
+                    else:
+                        self.assertNotEqual(gateway_record, record)
+                        self.assertMessageFields(new_message, {
+                            'email_from': record.email_from,
+                            'model': gateway_record._name,
+                            'res_id': gateway_record.id,
+                        })
 
 
 @tagged('mail_gateway', 'mail_thread')


### PR DESCRIPTION
hen email provider rewrites message_id of odoo generated emails
we lose trace of original message and/or trace in Odoo. Crafting
references as already containing the original message_id ensure to
keep a trace even if message_id is rewritten.

Continuation of https://github.com/odoo/odoo/pull/81901 but this time for mailing generated
mail records.

Task-3927616
