### PR TITLE
[FIX] sale: avoid access error on `credit_limit` field

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -589,9 +589,12 @@ class SaleOrder(models.Model):
             show_warning = order.state in ('draft', 'sent') and \
                            order.company_id.account_use_credit_limit
             if show_warning:
-                updated_credit = order.partner_id.commercial_partner_id.credit + (order.amount_total / order.currency_rate)
+                order_sudo = order.sudo()
+                current_credit = order_sudo.partner_id.commercial_partner_id.credit
                 order.partner_credit_warning = self.env['account.move']._build_credit_warning_message(
-                    order, updated_credit)
+                    record=order_sudo,
+                    updated_credit=current_credit + order.amount_total / order.currency_rate,
+                )
 
     @api.depends_context('lang')
     @api.depends('order_line.tax_id', 'order_line.price_unit', 'amount_total', 'amount_untaxed', 'currency_id')

--- a/addons/sale/tests/test_credit_limit.py
+++ b/addons/sale/tests/test_credit_limit.py
@@ -1,5 +1,7 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.fields import Command
-from odoo.tests import tagged
+from odoo.tests import Form, tagged, users
 
 from .common import TestSaleCommon
 
@@ -29,11 +31,21 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
             'currency_id': buck_currency.id,
         })
 
+        cls.sales_user = cls.company_data['default_user_salesman']
+        cls.sales_user.write({
+            'login': "notaccountman",
+            'email': "bad@accounting.com",
+        })
+
+        cls.empty_order = cls.env['sale.order'].create({
+            'partner_id': cls.partner_a.id,
+        })
+
     def test_credit_limit_multicurrency(self):
         self.partner_a.credit_limit = 50
 
-        order = self.env['sale.order'].create({
-            'partner_id': self.partner_a.id,
+        order = self.empty_order
+        order.write({
             'pricelist_id': self.buck_pricelist.id,
             'order_line': [
                 Command.create({
@@ -63,3 +75,27 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
             "partner_a has reached its Credit Limit of : $\xa050.00\n"
             "Total amount due (including this document) : $\xa055.00"
         )
+
+    @users('notaccountman')
+    def test_credit_limit_access(self):
+        """Ensure credit warning gets displayed without Accounting access."""
+        self.empty_order.user_id = self.env.user
+        self.empty_order.partner_id.credit_limit = self.product_a.list_price
+
+        for group in self.partner_a._fields['credit'].groups.split(','):
+            self.assertFalse(self.env.user.has_group(group))
+
+        with Form(self.empty_order.with_env(self.env)) as order_form:
+            with order_form.order_line.new() as sol:
+                sol.product_id = self.product_a
+                sol.tax_id.clear()
+            self.assertFalse(
+                order_form.partner_credit_warning,
+                "No credit warning should be displayed (yet)",
+            )
+            with order_form.order_line.edit(0) as sol:
+                sol.tax_id.add(self.product_a.taxes_id)
+            self.assertTrue(
+                order_form.partner_credit_warning,
+                "Credit warning should be displayed",
+            )


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps (18.0+)
-------------
1. Enable credit limits via Accounting settings;
2. log in as a user with access to Sales but not Accounting;
3. create a Sales Order;
4. add a product.

Issue
-----
Access Error.

Cause
-----
Commit de302c2 changed the way company dependent fields are handled. Instead of computing them via `_compute_company_dependent`, they are now stored in the database.

Before this this change, any `groups` restriction added to a field wasn't actually checked. After this change, it does get checked, leading to the access error.

Solution
--------
1. Use `sudo` to access `partner_id.credit`.
2. When calling the `_build_credit_warning_message`, pass the sales order with `sudo`.


opw-4367393
