### PR TITLE
[FIX] l10n_uy: fix tax included data.

### DIFF
--- a/addons/l10n_uy/data/template/account.tax-uy.csv
+++ b/addons/l10n_uy/data/template/account.tax-uy.csv
@@ -1,4 +1,4 @@
-id,name,description,invoice_label,l10n_uy_tax_category,amount,amount_type,type_tax_use,tax_group_id,repartition_line_ids/repartition_type,repartition_line_ids/document_type,repartition_line_ids/tag_ids,repartition_line_ids/account_id,price_include,description@es,invoice_label@es
+id,name,description,invoice_label,l10n_uy_tax_category,amount,amount_type,type_tax_use,tax_group_id,repartition_line_ids/repartition_type,repartition_line_ids/document_type,repartition_line_ids/tag_ids,repartition_line_ids/account_id,price_include_override,description@es,invoice_label@es
 vat1,22%,VAT Sales (22%),VAT Sales (22%),vat,22,percent,sale,tax_group_iva_22,base,invoice,+Base Sales 22%,,,IVA Ventas (22%),IVA Ventas (22%)
 ,,,,,,,,,tax,invoice,+Sales VAT 22%,uy_code_21402,,,
 ,,,,,,,,,base,refund,-Taxable Sales Base,,,,
@@ -23,19 +23,19 @@ vat6,0% EXEMPT,Purchases Exempt from VAT,Purchases Exempt from VAT,vat,0,percent
 ,,,,,,,,,tax,invoice,,uy_code_11503,,,
 ,,,,,,,,,base,refund,-Tax Base Purchases,,,,
 ,,,,,,,,,tax,refund,,uy_code_11503,,,
-vat7,22% included,VAT Included Sales (22%),VAT Included Sales (22%),vat,22,percent,sale,tax_group_iva_22,base,invoice,+Base Sales 22%,,True,IVA Ventas Incluído (22%),IVA Ventas Incluído (22%)
+vat7,22% included,VAT Included Sales (22%),VAT Included Sales (22%),vat,22,percent,sale,tax_group_iva_22,base,invoice,+Base Sales 22%,,tax_included,IVA Ventas Incluído (22%),IVA Ventas Incluído (22%)
 ,,,,,,,,,tax,invoice,+Sales VAT 22%,uy_code_21402,,,
 ,,,,,,,,,base,refund,-Taxable Sales Base,,,,
 ,,,,,,,,,tax,refund,-VAT Sales - received,uy_code_21402,,,
-vat8,10% included,VAT Included Sales (10%),VAT Included Sales (10%),vat,10,percent,sale,tax_group_iva_10,base,invoice,+Base Sales 10%,,True,IVA Ventas Incluído (10%),IVA Ventas Incluído (10%)
+vat8,10% included,VAT Included Sales (10%),VAT Included Sales (10%),vat,10,percent,sale,tax_group_iva_10,base,invoice,+Base Sales 10%,,tax_included,IVA Ventas Incluído (10%),IVA Ventas Incluído (10%)
 ,,,,,,,,,tax,invoice,+Sales VAT 10%,uy_code_21401,,,
 ,,,,,,,,,base,refund,-Taxable Sales Base,,,,
 ,,,,,,,,,tax,refund,-VAT Sales - received,uy_code_21401,,,
-vat9,22% included,VAT Included Purchases (22%),VAT Included Purchases (22%),vat,22,percent,purchase,tax_group_iva_22,base,invoice,+Base Purchases 22%,,True,IVA Compras Incluído (22%),IVA Compras Incluído (22%)
+vat9,22% included,VAT Included Purchases (22%),VAT Included Purchases (22%),vat,22,percent,purchase,tax_group_iva_22,base,invoice,+Base Purchases 22%,,tax_included,IVA Compras Incluído (22%),IVA Compras Incluído (22%)
 ,,,,,,,,,tax,invoice,+VAT Purchases 22%,uy_code_11502,,,
 ,,,,,,,,,base,refund,-Tax Base Purchases,,,,
 ,,,,,,,,,tax,refund,-VAT Purchases - paid,uy_code_11502,,,
-vat10,10% included,VAT Included Purchases (10%),VAT Included Purchases (10%),vat,10,percent,purchase,tax_group_iva_10,base,invoice,+Base Purchases 10%,,True,IVA Compras Incluído (10%),IVA Compras Incluído (10%)
+vat10,10% included,VAT Included Purchases (10%),VAT Included Purchases (10%),vat,10,percent,purchase,tax_group_iva_10,base,invoice,+Base Purchases 10%,,tax_included,IVA Compras Incluído (10%),IVA Compras Incluído (10%)
 ,,,,,,,,,tax,invoice,+VAT Purchases 10%,uy_code_11501,,,
 ,,,,,,,,,base,refund,-Tax Base Purchases,,,,
 ,,,,,,,,,tax,refund,-VAT Purchases - paid,uy_code_11501,,,


### PR DESCRIPTION
This pull request addresses an issue in PR #186444, which aimed to update l10n_uy by introducing 22% and 10% VAT-included tax options for sales and purchases. These changes support Uruguay’s practice of handling both tax-included and tax-excluded amounts per document.

However, the tax_included_override option was mistakenly not enabled for these VAT-included tax options. This PR resolves the issue by enabling the tax_included_override option for 22% and 10% VAT-included taxes.

Task Adhoc side: 43467
Task Latam side: 1294


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
