### PR TITLE
[FIX] analytic: mark analytic plan field as indexed

### DIFF
--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -272,7 +272,7 @@ class AccountAnalyticPlan(models.Model):
                 prev.field_description = plan.name
             elif not plan.parent_id:
                 column = plan._strict_column_name()
-                self.env['ir.model.fields'].with_context(update_custom_fields=True).sudo().create({
+                field = self.env['ir.model.fields'].with_context(update_custom_fields=True).sudo().create({
                     'name': column,
                     'field_description': plan.name,
                     'state': 'manual',
@@ -286,6 +286,9 @@ class AccountAnalyticPlan(models.Model):
                 tablename = self.env['account.analytic.line']._table
                 indexname = make_index_name(tablename, column)
                 create_index(self.env.cr, indexname, tablename, [column], 'btree', f'{column} IS NOT NULL')
+                field.write({
+                    'index': True,
+                })
 
 
 class AccountAnalyticApplicability(models.Model):

--- a/doc/cla/corporate/hunki-enterprises.md
+++ b/doc/cla/corporate/hunki-enterprises.md
@@ -1,0 +1,15 @@
+Netherlands, 2025-03-06
+
+Hunki Enterprises BV agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Holger Brunn mail@hunki-enterprises.com https://github.com/hbrunn
+
+List of contributors:
+
+Holger Brunn mail@hunki-enterprises.com https://github.com/hbrunn

--- a/doc/cla/corporate/therp.md
+++ b/doc/cla/corporate/therp.md
@@ -5,6 +5,7 @@ Updated:
     2017-06-27
     2020-10-08
     2021-03-02
+    2025-03-06
 
 Therp BV agrees to the terms of the Odoo Corporate 
 Contributor License Agreement v1.0.
@@ -19,7 +20,7 @@ Signed,
 List of contributors:
 
 *  Giovanni Capalbo giovanni@therp.nl https://github.com/gfcapalbo
-*  Holger Brunn hbrunn@therp.nl https://github.com/hbrunn
+*  Holger Brunn hbrunn@therp.nl https://github.com/hbrunn (up to 2020-05-31)
 *  Lara Freeke lfreeke@therp.nl https://github.com/lfreeke
 *  Ronald Portier ronald@therp.nl https://github.com/nl66278
 *  George Daramouskas gdaramouskas@therp.nl https://github.com/daramousk


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Spurious log entries

Current behavior before PR: Odoo [logs](https://github.com/odoo/odoo/blob/17.0/odoo/modules/registry.py#L653-L654) indexes created by [_sync_plan_column](https://github.com/odoo/odoo/blob/17.0/addons/analytic/models/analytic_plan.py#L281) as unexpected

Desired behavior after PR is merged: No log entry for expected index

Steps to reproduce:

- create a new analytic plan, ie 'Test plan'
- go to technical/database structure/fields, search for the custom field created on model account.analytic.line, named `x_plan{the id of the plan you created in step 1}_id`
- observe the field is not marked as indexed, even though the code creates an index
- update the analytic module, observe there will be an entry of the form `Keep unexpected index account_analytic_line__x_plan{the id of the plan you created in step 1}_id_index on table account_analytic_line`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
