### PR TITLE
[FIX] l10n_in: prevent error when add a country to the customer address

### DIFF
--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -34,7 +34,7 @@ class ResPartner(models.Model):
     def _compute_l10n_in_gst_state_warning(self):
         for partner in self:
             if (
-                "IN" in partner.fiscal_country_codes
+                partner.fiscal_country_codes and "IN" in partner.fiscal_country_codes
                 and partner.check_vat_in(partner.vat)
             ):
                 if partner.vat[:2] == "99":


### PR DESCRIPTION
Currently, an error occurs when trying to add a country to the customer address, and fiscal Country is not available.

Step to produce:

- Install the ```l10n_in``` module.
- Open the settings of an invoice, Search 'fiscal Country', and remove a country from it.
- Create a new customer and try to add country to the address.

```TypeError: argument of type 'bool' is not iterable```

An error occurs when the system checks conditions for fiscal country code at [1] but it is (False) not available.

Link [1]: https://github.com/odoo/odoo/blob/c172695afc2af8d75fd3b0d3172b28600eec7005/addons/l10n_in/models/res_partner.py#L37

To resolve the issue, add a condition to ensure that 'fiscal Country' is not empty before checking a condition of it.

Sentry-6101261474

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
