### PR TITLE
[IMP] stock: check for merge flag in context before merging moves in StockMove._action_confirm()

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1506,6 +1506,7 @@ Please change the quantity done or the rounding precision of your unit of measur
 
         self._check_company()
         moves = self
+        merge = self.env.context.get("merge_moves") if "merge_moves" in self.env.context else merge
         if merge:
             moves = self._merge_moves(merge_into=merge_into)
 


### PR DESCRIPTION
Small flexibility improvement for method `StockMove._action_confirm()`.

Use case example: call `StockPicking.action_confirm()` by code without merging moves. In this case it wouldn't be possible to propagate the merge flag to method `StockMove._action_confirm()`. It would be possible to call `_action_confirm(merge=False)` directly on stock moves, but it will bypass the picking "mark as todo" button behaviour.

After this commit you are able to force merge flag to `False` by calling `StockPicking.with_context(merge_moves=False).action_confirm()` so you don't bypass the "mark as todo" part of the process.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
