### PR TITLE
[IMP] base: complete traceback in demo failure

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -10,6 +10,7 @@ import logging
 import sys
 import threading
 import time
+import traceback
 
 import odoo
 import odoo.modules.db
@@ -88,7 +89,7 @@ def load_demo(cr, package, idref, mode):
             with cr.savepoint(flush=False):
                 load_data(cr, idref, mode, kind='demo', package=package)
         return True
-    except Exception as e:
+    except Exception:  # noqa: BLE001
         # If we could not install demo data for this module
         _logger.warning(
             "Module %s demo data failed to install, installed without demo data",
@@ -99,7 +100,7 @@ def load_demo(cr, package, idref, mode):
         Failure = env.get('ir.demo_failure')
         if todo and Failure is not None:
             todo.state = 'open'
-            Failure.create({'module_id': package.id, 'error': str(e)})
+            Failure.create({'module_id': package.id, 'error': traceback.format_exc()})
         return False
 
 


### PR DESCRIPTION
The demo failure stores the latest traceback when a failure happens.
This does not always work well, for example when installing a chart template.
In such cases, the only error given will be a generic parsing error pointing to the xml file triggering the call to try_loading, making it difficult to understand the exact issue.

As this notification is intended for a developer in order to help investigating the error, a complete traceback would be better.

This small change will instead use the traceback module to format the exception stored in the demo failure todo, which will give information about the exact cause of the issue.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
