### PR TITLE
[FIX] html_editor: backspace after space removes an additional character

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -1026,9 +1026,7 @@ export class DeletePlugin extends Plugin {
 
         // If not preceded by content, it is invisible.
         if (offset) {
-            if (isWhitespace(textNode.textContent[offset - char.length])) {
-                return false;
-            }
+            return !isWhitespace(textNode.textContent[offset - char.length]);
         } else if (!(getState(...leftPos(textNode), DIRECTIONS.LEFT).cType & CTYPES.CONTENT)) {
             return false;
         }

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -485,6 +485,14 @@ describe("Selection collapsed", () => {
                 contentAfter: `<div contenteditable="false"><div contenteditable="true"><p>abc[]def</p></div></div>`,
             });
         });
+
+        test("should not remove preceding character with U+0020 whitespace", async () => {
+            await testEditor({
+                contentBefore: `<p>abcd\u0020[]</p>`,
+                stepFunction: deleteBackward,
+                contentAfter: `<p>abcd[]</p>`,
+            });
+        });
     });
 
     describe("Line breaks", () => {


### PR DESCRIPTION
Steps to reproduce:

- Open Firefox.
- Type a few characters.
- Add a space after the characters.
- Press backspace.
- Observe that both the space and the last visible character are removed.

Description of the issue/feature this PR addresses:

- In Chrome, pressing space inserts a `&nbsp` (non-breaking space, `U+00A0`), which is treated as a visible character by `isVisibleChar`. Thus, only the whitespace is removed when backspace is pressed.

- In Firefox, pressing space inserts a regular space (`U+0020`), which `isVisibleChar` identifies as invisible. As a result, the backspace action incorrectly calculates the range and removes both the space and the preceding character.

Character details:

- Chrome: `char.charCodeAt(0).toString(16)` → `U+00A0`
- Firefox: `char.charCodeAt(0).toString(16)` → `U+0020`

Desired behavior after PR is merged:

- In Firefox, pressing backspace after a whitespace removes only the invisible character without affecting the preceding visible character.

task-4363847