### PR TITLE
[IMP] hw_posbox_homepage: improve message for subscription certificate errors

### DIFF
--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -93,6 +93,14 @@ export class Homepage extends Component {
             <div class="d-flex mb-4 flex-column align-items-center justify-content-center">
                 <h4 class="text-center m-0">IoT Box - <t t-esc="state.data.hostname" /></h4>
             </div>
+            <div t-if="!this.store.advanced and !state.data.is_certificate_ok" class="alert alert-warning" role="alert">
+                <p class="m-0 fw-bold">
+                    No subscription linked to your IoT Box.
+                </p>
+                <small>
+                    Please contact your account manager to take advantage of your IoT Box's full potential.
+                </small>
+            </div>
             <div t-if="this.store.advanced" class="alert alert-warning" role="alert">
                 <p class="m-0 fw-bold">HTTPS certificate</p>
                 <small>Error code: <t t-esc="state.data.certificate_details" /></small>


### PR DESCRIPTION
In this commit:
===============
- Display a warning alert on the homepage when no HTTPS certificate is linked or
  there's an issue with the certificate, and the technical tab is inactive.
- The alert notifies the user that their IoT Box subscription is not linked and
  advises contacting the account manager to unlock full potential.
- On opening the technical tab, show a detailed error code retrieved from the
  IoT Box to assist in diagnosing HTTPS certificate issues.

Task-4364406

Related enterprise PR-https://github.com/odoo/enterprise/pull/74949

![image](https://github.com/user-attachments/assets/6e97e106-d2ad-40ee-af70-eccd65a67bfd)

