### PR TITLE
[FIX] mail: fix mail_message_load_order_tour tour

### DIFF
--- a/addons/mail/static/tests/tours/mail_message_load_order_tour.js
+++ b/addons/mail/static/tests/tours/mail_message_load_order_tour.js
@@ -30,7 +30,8 @@ registry.category("web_tour.tours").add("mail_message_load_order_tour", {
             // the thread service. Thus, at first load the message range
             // will be (31 - 60). This trigger ensures the next messages
             // are fetched after jumping to the message.
-            trigger: ".o-mail-Thread .o-mail-Message:first:not(:contains(31))",
+            trigger:
+                ".o-mail-Thread .o-mail-Message:first .o-mail-Message-textContent:not(:contains(31))",
             async run() {
                 await contains(".o-mail-Thread .o-mail-Message", { count: 16 });
                 await contains(".o-mail-Thread", { scroll: 0 });
@@ -52,7 +53,7 @@ registry.category("web_tour.tours").add("mail_message_load_order_tour", {
             // was (1 -16): 15 before (but none were found), 15 after
             // and the pinned message itself. This trigger ensures the
             // next messages are fetched after scrolling to the bottom.
-            trigger: ".o-mail-Thread .o-mail-Message:contains(17)",
+            trigger: ".o-mail-Thread .o-mail-Message .o-mail-Message-textContent:contains(17)",
             async run() {
                 await contains(".o-mail-Thread .o-mail-Message", { count: 46 });
                 // ensure 1 - 46  are loaded in order.


### PR DESCRIPTION
In this commit, we fix this tour that failed each hour at minute 31 when the tour is runned at this time. The goal is to check the message text content and not the hour it was sent.

runbot-error-id~108435

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
