### PR TITLE
[IMP] point_of_sale: log cash in/out reason

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.js
@@ -51,7 +51,8 @@ export class CashMovePopup extends Component {
             true
         );
         await this.pos.logEmployeeMessage(
-            `${_t("Cash")} ${translatedType} - ${_t("Amount")}: ${formattedAmount}`,
+            `${_t("Cash")} ${translatedType} - ${_t("Amount")}: ${formattedAmount} - 
+            ${_t("Reason")}: ${reason}`,
             "CASH_DRAWER_ACTION"
         );
         await this.printer.print(CashMoveReceipt, {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Enhances cashbox operations by logging the reason for cash in/out movements along with the amount and move type.

Current behavior before PR:
When a cashbox move is made, only the cash type and amount are logged.

Desired behavior after PR is merged:
The reason for the cash in/out move will also be logged.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
