### PR TITLE
[IMP] sale,stock: retain filtered data after reload

### DIFF
--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -72,13 +72,6 @@ class ResPartner(models.Model):
             [('partner_id', 'child_of', self.commercial_partner_id.id)]
         )
 
-    @api.readonly
-    def action_view_sale_order(self):
-        action = self.env['ir.actions.act_window']._for_xml_id('sale.act_res_partner_2_sale_order')
-        all_child = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
-        action["domain"] = [("partner_id", "in", all_child.ids)]
-        return action
-
     def _compute_credit_to_invoice(self):
         # EXTENDS 'account'
         super()._compute_credit_to_invoice()

--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -5,7 +5,8 @@
         <field name="name">Quotations and Sales</field>
         <field name="res_model">sale.order</field>
         <field name="view_mode">list,kanban,form,graph</field>
-        <field name="context">{'default_partner_id': active_id}</field>
+        <field name="domain">[('partner_id', 'child_of', active_ids)]</field>
+        <field name="context">{'default_partner_id': active_id, 'active_test': False}</field>
         <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
@@ -43,7 +44,10 @@
         <field name="priority" eval="3"/>
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
-                <button class="oe_stat_button" type="object" name="action_view_sale_order"
+                <button
+                    class="oe_stat_button"
+                    type="action"
+                    name="sale.act_res_partner_2_sale_order"
                     groups="sales_team.group_sale_salesman"
                     icon="fa-usd">
                     <field string="Sales" name="sale_order_count" widget="statinfo"/>

--- a/addons/stock/models/res_partner.py
+++ b/addons/stock/models/res_partner.py
@@ -20,9 +20,3 @@ class ResPartner(models.Model):
     picking_warn = fields.Selection(WARNING_MESSAGE, 'Stock Picking', help=WARNING_HELP, default='no-message')
     picking_warn_msg = fields.Text('Message for Stock Picking')
 
-    def action_view_stock_lots(self):
-        action = self.env['ir.actions.act_window']._for_xml_id('stock.action_lot_report')
-        all_child = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
-        action["domain"] = [("partner_id", "in", all_child.ids)]
-        action["context"] = {'search_default_filter_not_has_return': True}
-        return action

--- a/addons/stock/report/stock_lot_customer.xml
+++ b/addons/stock/report/stock_lot_customer.xml
@@ -21,6 +21,8 @@
         <field name="name">Customer lots</field>
         <field name="res_model">stock.lot.report</field>
         <field name="view_mode">list</field>
+        <field name="domain">[('partner_id', 'child_of', active_ids)]</field>
+        <field name="context">{'search_default_filter_not_has_return': True, 'active_test': False}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No data yet!

--- a/addons/stock/views/res_partner_views.xml
+++ b/addons/stock/views/res_partner_views.xml
@@ -39,9 +39,12 @@
             </page>
 
             <xpath expr="//div[@name='button_box']" position="inside">
-                <button type="object"
-                    name="action_view_stock_lots"
-                    class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot">
+                <button
+                    type="action"
+                    name="stock.action_lot_report"
+                    class="oe_stat_button"
+                    icon="fa-bars"
+                    groups="stock.group_production_lot">
                     <div class="o_stat_info">
                         <span class="o_stat_text">Lot/Serial Numbers</span>
                     </div>


### PR DESCRIPTION
**Before this commit:**

When a user was redirected to a window through a stat button, the window displayed only filtered data using a domain set by a Python function. However, when the user reloaded the page, the window displayed unfiltered data.

**After this commit:**

- After a reload, the window will display the same filtered data by creating a
  new XML action window with a specified domain.
- For dedicated action windows related to stat buttons, the domain and context
  have been directly added to the action window.
- Redundant and unused functions have been removed from the codebase to improve
  efficiency.

Enterprise: https://github.com/odoo/enterprise/pull/74959

Task-4229211

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
