### PR TITLE
[FIX] purchase: set_vendor_price_po_company

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -638,7 +638,7 @@ class ProductProduct(models.Model):
     #=== BUSINESS METHODS ===#
 
     def _prepare_sellers(self, params=False):
-        sellers = self.seller_ids.filtered(lambda s: s.partner_id.active and (not s.product_id or s.product_id == self))
+        sellers = self.seller_ids._get_filtered_supplier(self.env.company, self, params)
         return sellers.sorted(lambda s: (s.sequence, -s.min_qty, s.price, s.id))
 
     def _get_filtered_sellers(self, partner_id=False, quantity=0.0, date=None, uom_id=False, params=False):
@@ -648,7 +648,6 @@ class ProductProduct(models.Model):
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
 
         sellers_filtered = self._prepare_sellers(params)
-        sellers_filtered = sellers_filtered.filtered(lambda s: not s.company_id or s.company_id.id == self.env.company.id)
         sellers = self.env['product.supplierinfo']
         for seller in sellers_filtered:
             # Set quantity in UoM of seller

--- a/addons/product/models/product_supplierinfo.py
+++ b/addons/product/models/product_supplierinfo.py
@@ -100,3 +100,6 @@ class SupplierInfo(models.Model):
     def write(self, vals):
         self._sanitize_vals(vals)
         return super().write(vals)
+
+    def _get_filtered_supplier(self, company_id, product_id, params=False):
+        return self.filtered(lambda s: (not s.company_id or s.company_id.id == company_id.id) and (s.partner_id.active and (not s.product_id or s.product_id == product_id)))

--- a/addons/purchase/models/product.py
+++ b/addons/purchase/models/product.py
@@ -87,6 +87,10 @@ class ProductSupplierinfo(models.Model):
     def _onchange_partner_id(self):
         self.currency_id = self.partner_id.property_purchase_currency_id.id or self.env.company.currency_id.id
 
+    def _get_filtered_supplier(self, company_id, product_id, params):
+        if params and 'order_id' in params and params['order_id'].company_id:
+            company_id = params['order_id'].company_id
+        return super()._get_filtered_supplier(company_id, product_id, params)
 
 class ProductPackaging(models.Model):
     _inherit = 'product.packaging'

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -364,7 +364,7 @@ class PurchaseOrderLine(models.Model):
 
             # record product names to avoid resetting custom descriptions
             default_names = []
-            vendors = line.product_id._prepare_sellers({})
+            vendors = line.product_id._prepare_sellers(params=params)
             product_ctx = {'seller_id': None, 'partner_id': None, 'lang': get_lang(line.env, line.partner_id.lang).code}
             default_names.append(line._get_product_purchase_description(line.product_id.with_context(product_ctx)))
             for vendor in vendors:

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -799,3 +799,43 @@ class TestPurchase(AccountTestInvoicingCommon):
             {'product_id': product_no_branch_tax.id, 'taxes_id': (tax_a + tax_b).ids},
             {'product_id': product_no_tax.id, 'taxes_id': []},
         ])
+
+    def test_vendor_price_by_purchase_order_company(self):
+        """
+        Test that in case a vendor has multiple price for two company A and B,
+        and the purchase_order.company_id != env.company_id
+        the price of chosen is the one of the company specified in the purchase order
+        """
+        company_a = self.env.company
+        company_b = self.env['res.company'].create({'name': 'Saucisson Inc.'})
+        self.env.company = company_a
+
+        self.product_a.write({
+            'seller_ids': [
+                Command.create({
+                    'partner_id': self.partner_a,
+                    'product_code': 'A',
+                    'company_id': company_a.id,
+                    'price': 10.0,
+                }),
+                Command.create({
+                    'partner_id': self.partner_a,
+                    'product_code': 'B',
+                    'company_id': company_b.id,
+                    'price': 15.0,
+                }),
+            ]
+        })
+
+        po = self.env['purchase.order'].with_context(allowed_company_ids=[company_a.id, company_b.id]).with_company(company_b).create({
+            'partner_id': self.partner_a.id,
+            'company_id': company_b.id,
+            'order_line': [Command.create({
+                'name': self.product_a.name,
+                'product_id': self.product_a.id,
+            })],
+        })
+
+        self.assertEqual(po.amount_untaxed, 15.0)
+        po.company_id = company_a.id
+        self.assertEqual(po.amount_untaxed, 10.0)


### PR DESCRIPTION
The issue:
When a vendor has multiple prices for two companies (A and B), and the purchase order's company is set to B (while the user's main company is A), the price incorrectly defaults to the main company A's price.

How to reproduce the issue:
1) Create a new product with 2 vendor pricelist records that have different "Unit Prices" under the "Purchase" tab of the product -> each pricelist record should belong to a different company 

2) Create an RFQ for this product with both of these companies active

3) Change the "Company" on the PO under the "Other Information" tab to the company that is NOT shown in the top right-hand corner, but is still selected 

4) Add the product to the RFQ order line
- The "Unit Price" will be pulled from the main company shown in the top-right hand corner, thereby ignoring the "Company" selected for the PO.

After this commit, the price from the purchase order's company (B) is prioritized over the main company (A).

opw-4347134


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
