### PR TITLE
[FIX] sms, mail: resolve widget ui issues

### DIFF
--- a/addons/mail/static/src/views/web/fields/emojis_text_field/emojis_text_field.xml
+++ b/addons/mail/static/src/views/web/fields/emojis_text_field/emojis_text_field.xml
@@ -8,5 +8,8 @@
         <xpath expr="//*[hasclass('o_field_input_buttons')]" position="inside">
             <t t-call="mail.EmojisFieldButton"/>
         </xpath>
+        <xpath expr="//*[hasclass('o_field_input_buttons')]" position="attributes">
+             <attribute name="class" add="h-auto" separator=" "/>
+        </xpath>
     </t>
 </templates>

--- a/addons/sms/wizard/sms_composer_views.xml
+++ b/addons/sms/wizard/sms_composer_views.xml
@@ -50,7 +50,7 @@
                             options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'res_model'}"/>
                         <field name="body" widget="sms_widget" invisible="comment_single_recipient or not recipient_single_valid" default_focus="1"
                             options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'res_model'}"/>
-                        <field name="body" widget="sms_widget" invisible="not comment_single_recipient"/>
+                        <field name="body" widget="sms_widget" invisible="not comment_single_recipient" default_focus="1"/>
                         <field name="mass_keep_log" invisible="1"/>
                     </group>
                 </sheet>


### PR DESCRIPTION
This PR addresses the following issues:

Issue 1:
The SMS widget previously displayed an unwanted scrollbar due to the height of o_field_input_buttons. This has been resolved by adjusting the height to fit within the parent, preventing the scrollbar.

Issue 2:
In the SMS widget, the focus was initially set on the recipient field instead of the message body. This issue has been resolved, and the focus is now correctly set on the message body.

Task-[3996903](https://www.odoo.com/odoo/my-tasks/3996903)