### PR TITLE
[FIX] crm: display tooltip on crm stage hover if requirements set

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -518,6 +518,7 @@
             <field name="arch" type="xml">
                 <kanban  highlight_color="color" default_group_by="stage_id" class="o_kanban_small_column o_opportunity_kanban" on_create="quick_create" quick_create_view="crm.quick_create_opportunity_form"
                     archivable="false" sample="1" js_class="crm_kanban">
+                    <field name="stage_id" options='{"group_by_tooltip": {"requirements": "Description"}}'/>
                     <field name="probability"/>
                     <field name="active"/>
                     <field name="company_currency"/>


### PR DESCRIPTION
**Issue:**
No tooltips are displayed on hovering CRM leads stages in Kanban view.

**Expected:**
As for versions up to 17.4, on hovering the stage, if requirements are set, a tooltip box should appear.

**Steps to reproduce:**
- Activate CRM app;
- Open a CRM leads pipeline in Kanban view;
- Edit a stage by adding a requirement text and save;
- Place the mouse over the stage and wait.

**Cause:**
The tooltip box display has been removed for over simplification.

**Fix:**
Add a tooltip box display based on stage title hover and reverting 1 line of https://github.com/odoo-dev/odoo/commit/232c218d87a94e1d77fc69afdbfd77e340504cad#diff-62eff7f830df5fbafad68abd5de0373654a620f6685cbcf3a4b8c20db64f0b7cL540.


opw-4359292

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
