### PR TITLE
[FIX] mail: scroll to not yet loaded pinned message

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -509,6 +509,7 @@ export class Thread extends Component {
                     id: Number(oeId),
                     res_id: this.props.thread.id,
                     model: this.props.thread.model,
+                    thread: this.props.thread,
                 }),
                 this.props.thread
             );

--- a/addons/mail/static/tests/thread/message_highlight.test.js
+++ b/addons/mail/static/tests/thread/message_highlight.test.js
@@ -1,0 +1,72 @@
+import {
+    click,
+    defineMailModels,
+    isInViewportOf,
+    openDiscuss,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+import { Thread } from "@mail/core/common/thread";
+import { describe, test } from "@odoo/hoot";
+import { tick } from "@odoo/hoot-dom";
+import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+
+defineMailModels();
+describe.current.tags("desktop");
+
+test("can highlight messages that are not yet loaded", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    let middleMessageId;
+    for (let i = 0; i < 200; i++) {
+        const messageId = pyEnv["mail.message"].create({
+            body: `message ${i}`,
+            model: "discuss.channel",
+            res_id: channelId,
+        });
+        if (i === 100) {
+            middleMessageId = messageId;
+        }
+    }
+    await pyEnv["discuss.channel"].set_message_pin(channelId, middleMessageId, true);
+    await start();
+    await openDiscuss(channelId);
+    await tick(); // Wait for the scroll to first unread to complete.
+    await isInViewportOf(".o-mail-Message:contains(message 199)", ".o-mail-Thread");
+    await click("a[data-oe-type='highlight']");
+    await isInViewportOf(".o-mail-Message:contains(message 100)", ".o-mail-Thread");
+});
+
+test("can highlight message (slow ref registration)", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    let middleMessageId;
+    for (let i = 0; i < 200; i++) {
+        const messageId = pyEnv["mail.message"].create({
+            body: `message ${i}`,
+            model: "discuss.channel",
+            res_id: channelId,
+        });
+        if (i === 100) {
+            middleMessageId = messageId;
+        }
+    }
+    await pyEnv["discuss.channel"].set_message_pin(channelId, middleMessageId, true);
+    let slowRegisterMessageRef = false;
+    patchWithCleanup(Thread.prototype, {
+        async registerMessageRef() {
+            if (slowRegisterMessageRef) {
+                // Ensure scroll is made even when messages are mounted later.
+                await new Promise((res) => setTimeout(res, 250));
+            }
+            super.registerMessageRef(...arguments);
+        },
+    });
+    await start();
+    await openDiscuss(channelId);
+    await tick(); // Wait for the scroll to first unread to complete.
+    await isInViewportOf(".o-mail-Message:contains(message 199)", ".o-mail-Thread");
+    slowRegisterMessageRef = true;
+    await click("a[data-oe-type='highlight']");
+    await isInViewportOf(".o-mail-Message:contains(message 100)", ".o-mail-Thread");
+});


### PR DESCRIPTION
Before this PR, clicking on the "user pinned a message to the channel" notification linked to a not yet loaded message would not scroll to the pinned message.

This issue arises because the `highlightMessage` function does nothing if the message's thread is different from the current one. However, when a message is unknown, the thread is also unknown, and the function does nothing.

The notification is only displayed in the origin thread of the message, so we can safely pass this information, assuming the message thread and the notification thread are the same.