### PR TITLE
[REF] base, web, *: parse field names in widget options

### DIFF
--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -84,11 +84,11 @@
                                     <field name="least_delay_msg"/>
                                 </div>
                                 <field name="filter_pre_domain" widget="domain" groups="base.group_no_one"
-                                       options="{'model': 'model_name', 'in_dialog': True}"
+                                       options="{'model': model_name, 'in_dialog': True}"
                                        invisible="trigger in ['on_webhook', 'on_time', 'on_time_created', 'on_time_updated']"
                                 />
                                 <field name="filter_domain" widget="domain" groups="base.group_no_one"
-                                    options="{'model': 'model_name', 'in_dialog': True}"
+                                    options="{'model': model_name, 'in_dialog': True}"
                                     invisible="trigger == 'on_webhook'"
                                 />
                                 <label for="filter_domain" groups="!base.group_no_one"
@@ -100,7 +100,7 @@
                                 />
                                 <field name="filter_domain" nolabel="1" widget="domain"
                                     groups="!base.group_no_one"
-                                    options="{'model': 'model_name', 'in_dialog': False, 'foldable': True}"
+                                    options="{'model': model_name, 'in_dialog': False, 'foldable': True}"
                                     invisible="trigger not in ['on_create_or_write', 'on_change', 'on_unlink', 'on_time', 'on_time_created', 'on_time_updated']"
                                 />
                                 <field name="trigger_field_ids" string="When updating" placeholder="Select fields..."

--- a/addons/base_setup/views/res_partner_views.xml
+++ b/addons/base_setup/views/res_partner_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="base.res_partner_kanban_view"/>
             <field name="arch" type="xml">
                 <xpath expr="//main//field[@name='display_name']" position="after">
-                    <field name="category_id" widget="many2many_tags" options="{'color_field': 'color'}" class="m-0"/>
+                    <field name="category_id" widget="many2many_tags" options="{'color_field': color}" class="m-0"/>
                 </xpath>
             </field>
         </record>

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -83,7 +83,7 @@
                 <field name="user_id" widget="many2one_avatar_user" readonly="recurrency" optional="hide"/>
                 <field name="partner_ids" widget="many2many_tags" readonly="recurrency" optional="show"/>
                 <field name="alarm_ids" widget="many2many_tags" optional="hide" readonly="recurrency"/>
-                <field name="categ_ids" widget="many2many_tags" optional="hide" readonly="recurrency" options="{'color_field': 'color'}"/>
+                <field name="categ_ids" widget="many2many_tags" optional="hide" readonly="recurrency" options="{'color_field': color}"/>
                 <field name="recurrency" optional="hide" readonly="1"/>
                 <field name="privacy" optional="hide" readonly="recurrency"/>
                 <field name="show_as" optional="hide" readonly="recurrency"/>
@@ -204,7 +204,7 @@
                             </div>
                             <field name="videocall_source" invisible="1"/>
                             <field name="access_token" invisible="1" force_save="1"/>
-                            <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" readonly="not user_can_edit"/>
+                            <field name="categ_ids" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True}" readonly="not user_can_edit"/>
                             <label for="privacy"/>
                                     <div class="o_row">
                                         <field name="show_as" readonly="not user_can_edit" nolabel="1"/>
@@ -359,7 +359,7 @@
                 <field name="res_model_name" invisible="not res_model_name"
                        options="{'icon': 'fa fa-link', 'shouldOpenRecord': true}"/>
                 <field name="alarm_ids" invisible="not alarm_ids" options="{'icon': 'fa fa-bell-o'}"/>
-                <field name="categ_ids" invisible="not categ_ids" options="{'icon': 'fa fa-tag', 'color_field': 'color'}"/>
+                <field name="categ_ids" invisible="not categ_ids" options="{'icon': 'fa fa-tag', 'color_field': color}"/>
                 <!-- For recurrence update Dialog -->
                 <field name="recurrency" invisible="1"/>
                 <field name="recurrence_update" invisible="1"/>

--- a/addons/crm/report/crm_activity_report_views.xml
+++ b/addons/crm/report/crm_activity_report_views.xml
@@ -33,7 +33,7 @@
                     <field name="mail_activity_type_id"/>
                     <field name="body" optional="hide"/>
                     <field name="company_id" groups="base.group_multi_company"/>
-                    <field name="tag_ids" string="Lead Tags" optional="show" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    <field name="tag_ids" string="Lead Tags" optional="show" widget="many2many_tags" options="{'color_field': color}"/>
                 </list>
             </field>
         </record>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -239,7 +239,7 @@
                                     <field name="date_deadline" nolabel="1" class="oe_inline"/>
                                     <field name="priority" widget="priority" nolabel="1" class="oe_inline align-top"/>
                                 </div>
-                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True}"/>
                             </group>
                             <group invisible="type == 'opportunity'">
                                 <field name="user_id"
@@ -248,7 +248,7 @@
                             </group>
                             <group name="lead_priority" invisible="type == 'opportunity'">
                                 <field name="priority" widget="priority"/>
-                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True}"/>
                             </group>
                         </group>
                         <div class="d-flex">
@@ -377,7 +377,7 @@
                     <field name="source_id" optional="hide"/>
                     <field name="probability" string="Probability (%)" optional="hide"/>
                     <field name="message_needaction" column_invisible="True"/>
-                    <field name="tag_ids" optional="hide" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    <field name="tag_ids" optional="hide" widget="many2many_tags" options="{'color_field': color}"/>
                     <field name="priority" optional="hide"/>
                 </list>
             </field>
@@ -394,7 +394,7 @@
                         <t t-name="card">
                             <field name="name" class="fw-bold fs-5"/>
                             <field name="contact_name"/>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                             <footer class="pt-1 mt-0">
                                 <div class="d-flex mt-auto">
                                     <field name="priority" widget="priority" class="me-2"/>
@@ -547,7 +547,7 @@
                                 </t>
                             </div>
                             <field name="partner_id" class="text-truncate" />
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                             <field name="lead_properties" widget="properties"/>
                             <footer class="pt-1">
                                 <div class="d-flex mt-auto align-items-center">
@@ -748,7 +748,7 @@
                     <field name="active" column_invisible="True"/>
                     <field name="probability" string="Probability (%)" optional="hide"/>
                     <field name="lost_reason_id" optional="hide"/>
-                    <field name="tag_ids" optional="hide" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    <field name="tag_ids" optional="hide" widget="many2many_tags" options="{'color_field': color}"/>
                     <field name="referred" column_invisible="True"/>
                     <field name="message_needaction" column_invisible="True"/>
                     <field name="lead_properties"/>

--- a/addons/crm/views/crm_team_member_views.xml
+++ b/addons/crm/views/crm_team_member_views.xml
@@ -53,7 +53,7 @@
                         <span class="oe_inline"> (max) </span>
                     </div>
                     <field name="assignment_domain" string="Domain" widget="domain"
-                        options="{'model': 'crm.lead'}"
+                        options="{'model': crm.lead}"
                         invisible="assignment_max == 0 or assignment_optout"/>
                 </group>
             </xpath>

--- a/addons/crm/views/crm_team_views.xml
+++ b/addons/crm/views/crm_team_views.xml
@@ -190,7 +190,7 @@
                         </div>
                     </div>
                     <field name="assignment_domain" widget="domain" string="Domain"
-                        options="{'foldable': True, 'model': 'crm.lead', 'in_dialog': True}"
+                        options="{'foldable': True, 'model': crm.lead, 'in_dialog': True}"
                         invisible="not assignment_enabled"/>
                     <field name="assignment_optout" invisible="not assignment_auto_enabled"/>
                 </xpath>

--- a/addons/crm_iap_mine/views/crm_iap_lead_mining_request_views.xml
+++ b/addons/crm_iap_mine/views/crm_iap_lead_mining_request_views.xml
@@ -82,7 +82,7 @@
                             <field name="lead_type" groups="crm.group_use_lead" invisible="context.get('is_modal')" readonly="state == 'done'"/>
                             <field name="team_id" no_create="1" no_open="1" readonly="state == 'done'" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
                             <field name="user_id" no_create="1" no_open="1" readonly="state == 'done'" widget="many2one_avatar_user"/>
-                            <field name="tag_ids" string="Default Tags" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" readonly="state == 'done'"/>
+                            <field name="tag_ids" string="Default Tags" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True}" readonly="state == 'done'"/>
                         </group>
                     </group>
 
@@ -96,7 +96,7 @@
                         <group>
                             <field name="contact_filter_type" widget="radio" readonly="state == 'done'" options="{'horizontal': true}"/>
                             <field name="preferred_role_id" options="{'no_create_edit': True, 'no_quick_create': True, 'no_open': True}" invisible="contact_filter_type != 'role'" readonly="state == 'done'" required="search_type == 'people' and contact_filter_type == 'role'"/>
-                            <field name="role_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True, 'no_quick_create': True}" invisible="not preferred_role_id or contact_filter_type != 'role'" readonly="state == 'done'"/>
+                            <field name="role_ids" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True, 'no_quick_create': True}" invisible="not preferred_role_id or contact_filter_type != 'role'" readonly="state == 'done'"/>
                             <field name="seniority_id" options="{'no_create_edit': True, 'no_quick_create': True, 'no_open': True}" invisible="contact_filter_type != 'seniority'" readonly="state == 'done'" required="search_type == 'people' and contact_filter_type == 'seniority'"/>
                         </group>
                     </group>
@@ -121,7 +121,7 @@
                 <field name="industry_ids" widget="many2many_tags"/>
                 <field name="team_id" optional="hide"/>
                 <field name="user_id" optional="hide" widget="many2one_avatar_user"/>
-                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" optional="hide"/>
                 <field name="state" readonly="1" decoration-info="state == 'draft'" decoration-success="state == 'done'" decoration-danger="state == 'error'" widget="badge"/>
             </list>
         </field>

--- a/addons/data_recycle/views/data_recycle_model_views.xml
+++ b/addons/data_recycle/views/data_recycle_model_views.xml
@@ -38,7 +38,6 @@
                         <group>
                             <group>
                                 <field name="res_model_id" options="{'no_create': True, 'no_open': True}" />
-                                <field name="res_model_name" invisible="1" />
                                 <field name="active" widget="boolean_toggle" />
                             </group>
                             <group>
@@ -66,7 +65,7 @@
                             </group>
                         </group>
                         <group invisible="not res_model_id">
-                            <field name="domain" widget="domain" options="{'model': 'res_model_name'}"/>
+                            <field name="domain" widget="domain" options="{'model': res_model_name}"/>
                             <field name="time_field_id"/>
                             <field name="time_field_delta"/>
                             <field name="time_field_delta_unit"/>

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -60,7 +60,7 @@
                             <field name="date_tz"/>
                             <field name="lang"/>
                             <field name="event_type_id" string="Template"/>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_quick_create': True}"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': color, 'no_quick_create': True}"/>
                         </group>
                         <group name="right_event_details">
                             <field name="organizer_id"/>
@@ -176,7 +176,7 @@
                 <field name="company_id" groups="base.group_multi_company" readonly="1" optional="show"/>
                 <field name="date_begin" readonly="1"/>
                 <field name="date_end" readonly="1"/>
-                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" optional="hide"/>
                 <field name="seats_taken" string="Total Attendees" sum="Total" readonly="1"/>
                 <field name="seats_used" sum="Total" readonly="1"/>
                 <field name="seats_max" string="Maximum Seats" sum="Total" readonly="1" optional="hide"/>

--- a/addons/event/views/event_tag_views.xml
+++ b/addons/event/views/event_tag_views.xml
@@ -9,7 +9,7 @@
                 <list string="Event Category">
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
-                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                 </list>
             </field>
         </record>

--- a/addons/event/views/event_type_views.xml
+++ b/addons/event/views/event_type_views.xml
@@ -15,7 +15,7 @@
                    <group>
                        <group>
                            <field name="default_timezone" class="w-100"/>
-                           <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_quick_create': True}"/>
+                           <field name="tag_ids" widget="many2many_tags" options="{'color_field': color, 'no_quick_create': True}"/>
                        </group>
                        <group>
                            <label for="has_seats_limitation" string="Limit Registrations"/>
@@ -64,11 +64,11 @@
                            <group>
                                 <label for="note" string="Note" />
                                 <br />
-                                <field nolabel="1" colspan="2" name="note" 
+                                <field nolabel="1" colspan="2" name="note"
                                     placeholder="Add some internal notes (to do lists, contact info, ...)" />
                                 <label for="ticket_instructions" string="Ticket Instructions" />
                                 <br />
-                                <field nolabel="1" colspan="2" name="ticket_instructions" 
+                                <field nolabel="1" colspan="2" name="ticket_instructions"
                                     placeholder="e.g. How to get to your event, door closing time, ..." />
                             </group>
                        </page>

--- a/addons/event_crm/views/event_lead_rule_views.xml
+++ b/addons/event_crm/views/event_lead_rule_views.xml
@@ -61,7 +61,7 @@
                         </group>
                     </group>
                     <group string="If the Attendees meet these Conditions">
-                        <field name="event_registration_filter" widget="domain" options="{'foldable': True, 'model': 'event.registration'}" nolabel="1"/>
+                        <field name="event_registration_filter" widget="domain" options="{'foldable': True, 'model': event.registration}" nolabel="1"/>
                     </group>
                     <group string="Lead Default Values">
                         <group class="col">
@@ -70,7 +70,7 @@
                             <field name="lead_user_id" widget="many2one_avatar_user"/>
                         </group>
                         <group class="col">
-                            <field name="lead_tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="lead_tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                         </group>
                     </group>
                 </sheet>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -83,7 +83,7 @@
                             <field name="license_plate" class="oe_inline" placeholder="e.g. PAE 326"/>
                         </h2>
                         <label for="tag_ids" class="me-3"/>
-                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True}"/>
                     </div>
                     <group col="2">
                         <group string="Driver">
@@ -178,7 +178,7 @@
         <field name="name">fleet.vehicle.list</field>
         <field name="model">fleet.vehicle</field>
         <field name="arch" type="xml">
-            <list string="Vehicle" 
+            <list string="Vehicle"
                 decoration-warning="contract_renewal_due_soon and not contract_renewal_overdue"
                 decoration-danger="contract_renewal_overdue"
                 multi_edit="1"
@@ -194,7 +194,7 @@
                 <field name="vin_sn" readonly="1" optional="hide"/>
                 <field name="co2" string="CO2 Emissions g/km" optional="hide"  readonly="1"/>
                 <field name="acquisition_date" readonly="1"/>
-                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" readonly="1"/>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" readonly="1"/>
                 <field name="state_id" widget="badge" readonly="1" optional="hide"/>
                 <field name="contract_renewal_due_soon" invisible="1"/>
                 <field name="contract_renewal_overdue" invisible="1"/>
@@ -273,7 +273,7 @@
                                 </t>
                                 <field class="fw-bolder fs-5" name="model_id"/>
                             </div>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                             <field t-if="record.driver_id.raw_value" name="driver_id" widget="many2one_avatar" options="{'display_avatar_name': True}" class="small pt-1 pb-1"/>
                             <div class="small">
                                 <t t-if="record.future_driver_id.raw_value">Future Driver : <field name="future_driver_id"/></t>

--- a/addons/gamification/views/gamification_challenge_views.xml
+++ b/addons/gamification/views/gamification_challenge_views.xml
@@ -50,7 +50,7 @@
                         </h1>
                         <label for="user_domain" string="Assign Challenge to"/>
                         <div>
-                            <field name="user_domain" widget="domain" options="{'model': 'res.users'}" />
+                            <field name="user_domain" widget="domain" options="{'model': res.users}" />
                         </div>
                     </div>
                     <group>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -93,7 +93,7 @@
                                 <field name="work_phone" widget="phone"/>
                                 <field name="mobile_phone" widget="phone"/>
                                 <field name="category_ids" widget="many2many_tags"
-                                    options="{'color_field': 'color', 'no_create_edit': True}"
+                                    options="{'color_field': color, 'no_create_edit': True}"
                                     placeholder="Tags" groups="hr.group_hr_user"/>
                                 <field name="company_id" groups="base.group_multi_company"/>
                                 <field name="company_country_id" invisible="1"/>
@@ -287,7 +287,7 @@
                     <field name="work_location_id" optional="hide"/>
                     <field name="coach_id" widget="many2one_avatar_user" optional="hide"/>
                     <field name="active" column_invisible="True"/>
-                    <field name="category_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                    <field name="category_ids" widget="many2many_tags" options="{'color_field': color}" optional="hide"/>
                     <field name="country_id" optional="hide"/>
                 </list>
             </field>
@@ -341,7 +341,7 @@
                                     <field name="birthday_public_display_string"/>
                                 </div>
                                 <field name="employee_properties" widget="properties"/>
-                                <field class="hr_tags" name="category_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                                <field class="hr_tags" name="category_ids" widget="many2many_tags" options="{'color_field': color}" optional="hide"/>
                                 <footer>
                                     <div class="d-flex ms-auto">
                                         <field name="user_id" widget="many2one_avatar_user" readonly="1" class="mb-1 ms-2"/>

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -20,7 +20,7 @@
                 <field name="activity_date_deadline" optional="hide"/>
                 <field name="priority" widget="priority" optional="show"/>
                 <field name="email_from" readonly="1" optional="hide"/>
-                <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show"/>
+                <field name="categ_ids" widget="many2many_tags" options="{'color_field': color}" optional="show"/>
                 <field name="user_id" widget="many2one_avatar_user" optional="show"/>
                 <field name="interviewer_ids" widget="many2many_avatar_user" optional="hide"/>
                 <field name="partner_phone" widget="phone" readonly="1" optional="hide"/>
@@ -128,7 +128,7 @@
                         <field name="user_id" widget="many2one_avatar_user" placeholder="Unassigned"/>
                         <field name="interviewer_ids" options="{'no_create': True, 'no_create_edit': True}" widget="many2many_avatar_user" placeholder="Who can access candidates" />
                         <field name="date_closed" invisible="not date_closed" />
-                        <field name="categ_ids" placeholder="Tags" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                        <field name="categ_ids" placeholder="Tags" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True}"/>
                     </group>
                 </group>
                 <field name="applicant_properties" columns="2"/>
@@ -344,7 +344,7 @@
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-secondary" invisible="application_status != 'archived'"/>
                         <field t-if="record.partner_name.raw_value" class="fw-bold fs-5" name="partner_name"/>
                         <field name="job_id" invisible="context.get('search_default_job_id', False)"/>
-                        <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                        <field name="categ_ids" widget="many2many_tags" options="{'color_field': color}"/>
                         <field name="applicant_properties" widget="properties"/>
                         <footer>
                             <field name="priority" widget="priority"/>

--- a/addons/hr_recruitment/views/hr_candidate_views.xml
+++ b/addons/hr_recruitment/views/hr_candidate_views.xml
@@ -73,7 +73,7 @@
                             <field name="user_id" string="Manager"/>
                             <field name="priority" widget="priority"/>
                             <field name="availability"/>
-                            <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="categ_ids" widget="many2many_tags" options="{'color_field': color}"/>
                             <field name="employee_id" invisible="1"/>
                             <field name="emp_is_active" invisible="1"/>
                             <field name="company_id" groups="base.group_multi_company"/>
@@ -130,7 +130,7 @@
                     <t t-name="card">
                         <field t-if="record.partner_name.raw_value" class="fw-bold fs-5" name="partner_name"/>
                         <field t-else="" class="fw-bold fs-5" name="partner_id"/>
-                        <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                        <field name="categ_ids" widget="many2many_tags" options="{'color_field': color}"/>
                         <field name="candidate_properties" widget="properties"/>
                         <footer>
                             <field name="priority" widget="priority"/>
@@ -153,7 +153,7 @@
         <field name="name">hr.candidate.view.calendar</field>
         <field name="model">hr.candidate</field>
         <field name="arch" type="xml">
-            <calendar 
+            <calendar
                 string="Candidates"
                 mode="month"
                 date_start="activity_date_deadline"
@@ -216,7 +216,7 @@
             </search>
         </field>
     </record>
-    
+
     <record id="action_hr_candidate_mass_sms" model="ir.actions.act_window">
         <field name="name">Send SMS</field>
         <field name="res_model">sms.composer</field>

--- a/addons/hr_recruitment_skills/views/hr_candidate_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_candidate_views.xml
@@ -59,8 +59,8 @@
             </field>
             <field name="company_id" position="after">
                 <field name="matching_score"/>
-                <field name="matching_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                <field name="missing_skill_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="matching_skill_ids" widget="many2many_tags" options="{'color_field': color}"/>
+                <field name="missing_skill_ids" widget="many2many_tags" options="{'color_field': color}"/>
             </field>
         </field>
     </record>

--- a/addons/hr_recruitment_skills/views/hr_job_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_job_views.xml
@@ -6,10 +6,10 @@
         <field name="inherit_id" ref="hr.view_hr_job_form"/>
         <field name="arch" type="xml">
             <field name="contract_type_id" position="after">
-                <field 
+                <field
                     name="skill_ids"
                     widget="many2many_tags"
-                    options="{'color_field': 'color'}"
+                    options="{'color_field': color}"
                     context="{'search_default_group_skill_type_id': 1}"
                     />
             </field>

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -346,7 +346,7 @@
             <list string="Skill Types">
                 <field name="name" string="Skill Types"/>
                 <field name="color" widget="color_picker" optional="show"/>
-                <field name="skill_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="skill_ids" widget="many2many_tags" options="{'color_field': color}"/>
                 <field name="skill_level_ids" widget="many2many_tags_skills"/>
             </list>
         </field>

--- a/addons/loyalty/views/loyalty_reward_views.xml
+++ b/addons/loyalty/views/loyalty_reward_views.xml
@@ -45,7 +45,7 @@
                                 invisible="discount_applicability != 'order' or
                                     discount_mode not in ('per_order','per_point')"
                             />
-                            <field name="discount_product_domain" groups="base.group_no_one" widget="domain" options="{'model': 'product.product', 'in_dialog': true}" invisible="discount_applicability != 'specific'"/>
+                            <field name="discount_product_domain" groups="base.group_no_one" widget="domain" options="{'model': product.product, 'in_dialog': true}" invisible="discount_applicability != 'specific'"/>
                             <field name="discount_product_ids" widget="many2many_tags" invisible="discount_applicability != 'specific'"/>
                             <field name="discount_product_category_id" invisible="discount_applicability != 'specific'"/>
                             <field name="discount_product_tag_id" invisible="discount_applicability != 'specific'"/>

--- a/addons/loyalty/views/loyalty_rule_views.xml
+++ b/addons/loyalty/views/loyalty_rule_views.xml
@@ -5,7 +5,7 @@
         <field name="model">loyalty.rule</field>
         <field name="arch" type="xml">
             <form class="loyalty-rule-form">
-                <field name="program_type" invisible="1"/> 
+                <field name="program_type" invisible="1"/>
                 <field name="user_has_debug" invisible="1"/>
                 <sheet>
                     <group invisible="program_type != 'promo_code'">
@@ -23,7 +23,7 @@
                                 <field name="minimum_amount_tax_mode" class="ms-1"/>
                             </div>
                             <separator string="Among" colspan="2"/>
-                            <field name="product_domain" groups="base.group_no_one" widget="domain" options="{'model': 'product.product', 'in_dialog': true}"/>
+                            <field name="product_domain" groups="base.group_no_one" widget="domain" options="{'model': product.product, 'in_dialog': true}"/>
                             <field name="product_ids" widget="many2many_tags"/>
                             <field name="product_category_id"/>
                             <field name="product_tag_id"/>

--- a/addons/loyalty/wizard/loyalty_generate_wizard_views.xml
+++ b/addons/loyalty/wizard/loyalty_generate_wizard_views.xml
@@ -13,7 +13,7 @@
                             <field name="program_type" invisible="1"/>
                             <field name="mode" widget="radio" invisible="program_type == 'ewallet'"/>
                             <field name="customer_ids" widget="many2many_tags" placeholder="For all customers" invisible="mode == 'anonymous'"/>
-                            <field name="customer_tag_ids" widget="many2many_tags" invisible="mode == 'anonymous'" options="{'color_field': 'color'}"/>
+                            <field name="customer_tag_ids" widget="many2many_tags" invisible="mode == 'anonymous'" options="{'color_field': color}"/>
                             <field name="coupon_qty" string="Quantity to generate" readonly="mode == 'selected'" required="mode == 'anonymous'"/>
                             <label string="Coupon value" for="points_granted" groups="base.group_no_one" invisible="program_type != 'coupons'"/>
                             <span class="d-inline-block" groups="base.group_no_one" invisible="program_type != 'coupons'">
@@ -44,10 +44,10 @@
                 <footer>
                     <button name="generate_coupons" type="object" class="btn-primary" data-hotkey="q">
                         <span invisible="not will_send_mail">
-                            Generate and Send 
+                            Generate and Send
                         </span>
                         <span invisible="will_send_mail">
-                            Generate 
+                            Generate
                         </span>
                         <field name="program_type" nolabel="1"/>
                     </button>

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -24,7 +24,6 @@
                         <field name="record_alias_domain_id" invisible="1"/>
                         <field name="record_company_id" invisible="1"/>
                         <field name="record_name" invisible="1"/>
-                        <field name="render_model" invisible="1"/>
                         <field name="res_domain" invisible="1"/>
                         <field name="res_domain_user_id" invisible="1"/>
                         <field name="res_ids" invisible="1"/>
@@ -47,7 +46,7 @@
                     <div invisible="composition_mode == 'mass_mail'">
                         <field name="body" widget="html_composer_message" class="oe-bordered-editor"
                             placeholder="Write your message here..." readonly="not can_edit_body" force_save="1"
-                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'render_model'}"/>
+                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': render_model}"/>
                         <field name="attachment_ids" widget="mail_composer_attachment_list"/>
                     </div>
                     <notebook invisible="composition_mode != 'mass_mail'">
@@ -55,7 +54,7 @@
                             <div>
                                 <field name="body" widget="html_composer_message" class="oe-bordered-editor"
                                     placeholder="Write your message here..." readonly="not can_edit_body" force_save="1"
-                                    options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'render_model'}"/>
+                                    options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': render_model}"/>
                                 <field name="attachment_ids" widget="mail_composer_attachment_list"/>
                             </div>
                         </page>

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -751,7 +751,7 @@
                 <group>
                     <group>
                         <field name="active" invisible="1"/>
-                        <field name="member_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create': True}" domain="[('share', '=', False)]"/>
+                        <field name="member_ids" widget="many2many_tags" options="{'color_field': color, 'no_create': True}" domain="[('share', '=', False)]"/>
                     </group>
                     <group>
                         <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
@@ -768,7 +768,7 @@
         <field name="arch" type="xml">
             <list string="Maintenance Team" editable="bottom">
                 <field name="name"/>
-                <field name="member_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create': True}" domain="[('share', '=', False)]"/>
+                <field name="member_ids" widget="many2many_tags" options="{'color_field': color, 'no_create': True}" domain="[('share', '=', False)]"/>
                 <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
             </list>
         </field>

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -72,13 +72,12 @@
                     <group>
                         <field name="preview_record_ref" string="Recipients" placeholder="Preview on..." options="{'no_create': True}"/>
                         <field name="target_url" placeholder="Your Home Page"/>
-                        <field name="res_model" invisible="1"/><!--Get the default model for field pickers-->
                         <field name="res_model" groups="base.group_no_one"/>
                         <field name="post_suggestion" placeholder="Join me at this event!" widget="text_emojis"/>
                     </group>
                     <group>
                         <field name="user_id" widget="many2one_avatar"/>
-                        <field name="tag_ids" widget="many2many_tags"  options="{'color_field': 'color'}"/>
+                        <field name="tag_ids" widget="many2many_tags"  options="{'color_field': color}"/>
                     </group>
                 </group>
                 <notebook>
@@ -90,36 +89,36 @@
                             <div class="d-flex">
                                 <field name="content_header_dyn" title="Dynamic Field?"/>
                                 <field name="content_header" invisible="content_header_dyn" placeholder="e.g. Join Odoo Experience 2024"/>
-                                <field name="content_header_path" invisible="not content_header_dyn" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': 'res_model'}"/>
+                                <field name="content_header_path" invisible="not content_header_dyn" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': res_model}"/>
                                 <field name="content_header_color" widget="color" style="width: 40px"/>
                             </div>
                             <label for="content_sub_header"/>
                             <div class="d-flex">
                                 <field name="content_sub_header_dyn"/>
                                 <field name="content_sub_header" invisible="content_sub_header_dyn" placeholder="e.g. Aug 24, Brussels Expo"/>
-                                <field name="content_sub_header_path" invisible="not content_sub_header_dyn" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': 'res_model'}"/>
+                                <field name="content_sub_header_path" invisible="not content_sub_header_dyn" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': res_model}"/>
                                 <field name="content_sub_header_color" widget="color" style="width: 40px"/>
                             </div>
                             <label for="content_section"/>
                             <div class="d-flex">
                                 <field name="content_section_dyn"/>
                                 <field name="content_section" invisible="content_section_dyn" placeholder="e.g. Sample Talk"/>
-                                <field name="content_section_path" invisible="not content_section_dyn" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': 'res_model'}"/>
+                                <field name="content_section_path" invisible="not content_section_dyn" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': res_model}"/>
                             </div>
                             <label for="content_sub_section1"/>
                             <div class="d-flex">
                                 <field name="content_sub_section1_dyn"/>
                                 <field name="content_sub_section1" invisible="content_sub_section1_dyn" placeholder="e.g. By Lionel Messy"/>
-                                <field name="content_sub_section1_path" invisible="not content_sub_section1_dyn" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': 'res_model'}"/>
+                                <field name="content_sub_section1_path" invisible="not content_sub_section1_dyn" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': res_model}"/>
                             </div>
                              <label for="content_sub_section2"/>
                             <div class="d-flex">
                                 <field name="content_sub_section2_dyn"/>
                                 <field name="content_sub_section2" invisible="content_sub_section2_dyn" placeholder="e.g. CFO Chief Football Officer"/>
-                                <field name="content_sub_section2_path" invisible="not content_sub_section2_dyn" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': 'res_model'}"/>
+                                <field name="content_sub_section2_path" invisible="not content_sub_section2_dyn" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': res_model}"/>
                             </div>
-                            <field name="content_image1_path" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': 'res_model'}"/>
-                            <field name="content_image2_path" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': 'res_model'}"/>
+                            <field name="content_image1_path" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': res_model}"/>
+                            <field name="content_image2_path" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': res_model}"/>
                             <field name="content_button" placeholder="No button"/>
                         </group>
                         <group>
@@ -157,7 +156,7 @@
                 <templates>
                     <t t-name="card" class="o_marketing_card_campaign_kanban">
                         <field name="name" class="fw-bolder fs-5"/>
-                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" class="mt-2"/>
+                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" class="mt-2"/>
                         <footer class="pt-0">
                             <div>
                                 <a type="object" name="action_view_cards_shared" href="#" class="me-1">
@@ -191,7 +190,7 @@
                 <field name="user_id" widget="many2one_avatar"/>
                 <field name="res_model" optional="hide"/>
                 <field name="target_url" optional="hide"/>
-                <field name="tag_ids" widget="many2many_tags"  options="{'color_field': 'color'}"/>
+                <field name="tag_ids" widget="many2many_tags"  options="{'color_field': color}"/>
             </list>
         </field>
     </record>

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -121,7 +121,7 @@
                         <group>
                             <field name="create_date" readonly="1" invisible="not id"/>
                             <field name="message_bounce" readonly="1" invisible="not id"/>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"
                                    placeholder="e.g. &quot;VIP&quot;, &quot;Roadshow&quot;, ..." style="width: 100%"/>
                         </group>
                     </group>

--- a/addons/mass_mailing/views/mailing_filter_views.xml
+++ b/addons/mass_mailing/views/mailing_filter_views.xml
@@ -49,9 +49,8 @@
                         </group>
                     </group>
                     <group>
-                        <field name="mailing_model_name" invisible="1"/>
                         <field name="mailing_domain" string="Domain" widget="domain"
-                               options="{'model': 'mailing_model_name'}"
+                               options="{'model': mailing_model_name}"
                                invisible="not mailing_model_id"/>
                     </group>
                 </sheet>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -217,7 +217,7 @@
                                 invisible="1"
                                 readonly="state != 'draft'" force_save="1"/>
                             <field class="text-break" name="subject"
-                                options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'mailing_model_real'}"
+                                options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': mailing_model_real}"
                                 readonly="state in ('sending', 'done')"
                                 widget="char_emojis" placeholder="e.g. New Sale on all T-shirts"/>
                             <label for="mailing_model_id" string="Recipients"/>
@@ -242,7 +242,7 @@
                                     <div invisible="mailing_on_mailing_list" class="col-md-auto o_mailing_filter_width">
                                         <field name="mailing_filter_id" placeholder="Reload a favorite filter"
                                                class="o_mailing_filter_readonly_width" widget="mailing_filter"
-                                               options="{'no_create': 1, 'no_open': 1, 'domain_field': 'mailing_domain', 'model_field': 'mailing_model_id'}"
+                                               options="{'no_create': 1, 'no_open': 1, 'domain_field': mailing_domain, 'model_field': mailing_model_id}"
                                                readonly="state in ('sending', 'done')"/>
                                     </div>
                                     <field name="mailing_filter_count" invisible="1"/>
@@ -250,9 +250,8 @@
 
                                 <field name="mailing_model_name" invisible="1"/>
                                 <field name="mailing_on_mailing_list" invisible="1"/>
-                                <field name="mailing_model_real" invisible="1"/>
                                 <field name="mailing_domain" widget="domain"
-                                    options="{'model': 'mailing_model_real', 'foldable': true}"
+                                    options="{'model': mailing_model_real, 'foldable': true}"
                                     invisible="mailing_on_mailing_list"
                                     readonly="state in ('sending', 'done')"/>
                             </div>
@@ -266,7 +265,7 @@
                                             'cssEdit': 'mass_mailing.iframe_css_assets_edit',
                                             'inline-field': 'body_html',
                                             'dynamic_placeholder': true,
-                                            'dynamic_placeholder_model_reference_field': 'mailing_model_real',
+                                            'dynamic_placeholder_model_reference_field': mailing_model_real,
                                             'cssReadonly': 'mass_mailing.iframe_css_assets_edit'
                                     }" readonly="state in ('sending', 'done')"/>
                                     <field name="is_body_empty" invisible="1"/>
@@ -332,7 +331,7 @@
                                 <group>
                                     <group string="Email Content" name="email_content" invisible="mailing_type != 'mail'">
                                         <field class="o_text_overflow" name="preview" string="Preview Text"
-                                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'mailing_model_real'}"
+                                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': mailing_model_real}"
                                             readonly="state in ('sending', 'done')"
                                             widget="char_emojis" placeholder="e.g. Check it out before it's too late!"/>
                                         <field name="email_from" readonly="state in ('sending', 'done')"/>

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -135,7 +135,7 @@
                     <field name="body_plaintext" widget="sms_widget"
                         readonly="state in ('sending', 'done')"
                         required="mailing_type == 'sms'"
-                        options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'mailing_model_real'}"
+                        options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': mailing_model_real}"
                         enable_emojis="true"/>
                 </page>
             </xpath>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -28,7 +28,7 @@
                     <field name="sequence" widget="handle"/>
                     <field name="name" optional="show"/>
                     <field name="code" optional="show"/>
-                    <field name="tag_ids" widget="many2many_tags" options="{'no_create': True, 'color_field': 'color'}" optional="show"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'no_create': True, 'color_field': color}" optional="show"/>
                     <field name="alternative_workcenter_ids" widget="many2many_tags" optional="show"/>
                     <field name="productive_time" optional="hide"/>
                     <field name="costs_hour" optional="show"/>
@@ -299,7 +299,7 @@
                                 <field name="active" invisible="1"/>
                                 <field name="company_id" invisible="1"/>
                                 <field name="name" string="Work Center Name" required="True"/>
-                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                                 <field
                                     name="alternative_workcenter_ids"
                                     widget="many2many_tags"

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -71,7 +71,7 @@
                                    widget="many2many_tags"
                                    groups="point_of_sale.group_pos_user"
                                    string="Category"
-                                   options="{'color_field': 'color'}"/>
+                                   options="{'color_field': color}"/>
                         </group>
                         <group string="Public Description" name="public_description" invisible="1">
                             <field name="public_description"

--- a/addons/privacy_lookup/wizard/privacy_lookup_wizard_views.xml
+++ b/addons/privacy_lookup/wizard/privacy_lookup_wizard_views.xml
@@ -49,7 +49,7 @@
                 <field name="res_model_id"/>
                 <field name="res_name" column_invisible="True"/>
                 <field name="res_model" column_invisible="True"/>
-                <field name="resource_ref" options="{'model_field': 'res_model_id', 'no_create': True}" invisible="not resource_ref"/>
+                <field name="resource_ref" options="{'model_field': res_model_id, 'no_create': True}" invisible="not resource_ref"/>
                 <button name="action_open_record" type="object" icon="fa-external-link" invisible="not resource_ref" title="Open Record"/>
                 <field name="res_id" string="ID"/>
                 <field name="has_active" column_invisible="True"/>

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -72,7 +72,7 @@
                             <field name="value_count" column_invisible="True"/>
                             <field name="sequence" widget="handle"/>
                             <field name="attribute_id" readonly="id"/>
-                            <field name="value_ids" widget="many2many_tags" options="{'no_create_edit': True, 'color_field': 'color'}" context="{'default_attribute_id': attribute_id, 'show_attribute': False}"/>
+                            <field name="value_ids" widget="many2many_tags" options="{'no_create_edit': True, 'color_field': color}" context="{'default_attribute_id': attribute_id, 'show_attribute': False}"/>
                             <button string="Configure" class="float-end btn-secondary"
                                 type="object" name="action_open_attribute_values"
                                 groups="product.group_product_variant"/>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -568,7 +568,7 @@
                                 <span t-if="record.default_code.value">
                                     [<field name="default_code"/>]
                                 </span>
-                                <field name="product_template_variant_value_ids" groups="product.group_product_variant" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                                <field name="product_template_variant_value_ids" groups="product.group_product_variant" widget="many2many_tags" options="{'color_field': color}"/>
                                 <span>
                                     Price: <field name="lst_price"></field>
                                 </span>
@@ -675,7 +675,7 @@ action = {
                                         widget="many2many_tags"
                                         domain="[('id', 'in', parent.ids)]"
                                         groups="product.group_product_variant"
-                                        options="{'color_field': 'color'}"/>
+                                        options="{'color_field': color}"/>
                             </div>
                             <field name="image_128" widget="image" alt="Product" invisible="not image_128" class="ms-auto" options="{'size': [55, 55]}"/>
                         </div>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -68,7 +68,7 @@
                         <group>
                             <field name="label_tasks" string="Name of the Tasks" placeholder="e.g. Tasks"/>
                             <field name="partner_id" widget="res_partner_many2one"/>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                         </group>
                         <group>
@@ -230,7 +230,7 @@
                     />
                     <field name="user_id" optional="show" string="Project Manager" widget="many2one_avatar_user" options="{'no_open':True, 'no_create': True, 'no_create_edit': True}"/>
                     <field name="last_update_color" column_invisible="True"/>
-                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" optional="hide"/>
                     <field name="last_update_status" string="Status" nolabel="1" width="20px" optional="show" widget="project_state_selection"/>
                     <field name="stage_id" options="{'no_open': True}" domain="[('company_id', 'in', (company_id, False))]" optional="show"/>
                     <button string="View Tasks" name="action_view_tasks" type="object"/>
@@ -454,7 +454,7 @@
                                             <field name="rating_avg" nolabel="1" widget="float" digits="[1, 1]"/>
                                         </t> / 5
                                     </div>
-                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                                 </div>
                             </div>
                             <footer class="mt-auto pt-0 ms-1">
@@ -547,7 +547,7 @@
                     <field name="stage_id" groups="project.group_project_stages" invisible="not stage_id"/>
                     <field name="last_update_color" invisible="1"/>
                     <field name="last_update_status" string="Status" widget="status_with_color" invisible="last_update_status == 'to_define'"/>
-                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="not tag_ids"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" invisible="not tag_ids"/>
                 </calendar>
             </field>
         </record>

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -49,7 +49,7 @@
                         </span>
                         <field t-if="record.partner_id.value" name="partner_id" class="text-truncate text-muted d-block"/>
                     </div>
-                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" context="{'project_id': project_id}"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" context="{'project_id': project_id}"/>
                     <field t-if="record.date_deadline.raw_value" name="date_deadline" invisible="state in ['1_done', '1_canceled']" widget="remaining_days"/>
                     <field t-if="record.displayed_image_id.value" groups="base.group_user" name="displayed_image_id" widget="attachment_image"/>
                     <footer t-if="!selection_mode">
@@ -168,7 +168,7 @@
                             <field name="portal_user_names"
                                 string="Assignees"
                                 class="o_task_user_field"/>
-                            <field name="tag_ids" context="{'project_id': project_id}" widget="many2many_tags" options="{'color_field': 'color', 'no_create': True, 'no_edit': True, 'no_edit_color': True}"/>
+                            <field name="tag_ids" context="{'project_id': project_id}" widget="many2many_tags" options="{'color_field': color, 'no_create': True, 'no_edit': True, 'no_edit_color': True}"/>
                         </group>
                         <group>
                             <field name="active" invisible="1"/>
@@ -227,7 +227,7 @@
                                     <field name="user_ids" column_invisible="True" />
                                     <field name="portal_user_names" string="Assignees" optional="show"/>
                                     <field name="date_deadline" decoration-danger="date_deadline &lt; current_date and state not in ['1_done', '1_canceled']" optional="show"/>
-                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" optional="hide"/>
                                     <field name="stage_id" domain="[('user_id', '=', False), ('project_ids', 'in', [project_id])]"/>
                                     <button name="action_open_task" type="object" title="View Task" string="View Task" class="btn btn-link float-end"
                                             context="{'form_view_ref': 'project.project_sharing_project_task_view_form', 'search_view_ref': 'project.project_sharing_project_task_view_search'}"
@@ -262,7 +262,7 @@
                                     <field name="partner_id" options="{'no_open': True, 'no_create': True, 'no_edit': True}" optional="hide" invisible="not project_id"/>
                                     <field name="portal_user_names" string="Assignees" optional="show"/>
                                     <field name="date_deadline" decoration-danger="date_deadline &lt; current_date and state not in ['1_done', '1_canceled']" optional="show"/>
-                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" optional="hide"/>
                                     <field name="stage_id" optional="show"/>
                                     <button name="action_open_task" type="object" title="View Task" string="View Task" class="btn btn-link float-end"
                                             context="{'form_view_ref': 'project.project_sharing_project_task_view_form'}"
@@ -325,7 +325,7 @@
             <field name="user_ids" position="after">
                 <field name="portal_user_names" string="Assignees" optional="show"/>
             </field>
-            
+
         </field>
     </record>
 

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -43,7 +43,7 @@
                             </group>
                             <group>
                                 <field name="fold"/>
-                                <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color'}"
+                                <field name="project_ids" widget="many2many_tags" options="{'color_field': color}"
                                        invisible="user_id"
                                        required="not user_id"/>
                             </group>
@@ -77,7 +77,7 @@
                 <xpath expr="//field[@name='name']" position="after">
                     <field name="mail_template_id" optional="hide"/>
                     <field name="rating_template_id" optional="hide" groups="project.group_project_rating"/>
-                    <field name="project_ids" required="1" optional="show" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    <field name="project_ids" required="1" optional="show" widget="many2many_tags" options="{'color_field': color}"/>
                 </xpath>
             </field>
         </record>
@@ -90,7 +90,7 @@
                     <templates>
                         <t t-name="card">
                             <field name="name" class="fw-bolder text-truncate"/>
-                            <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="project_ids" widget="many2many_tags" options="{'color_field': color}"/>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -433,7 +433,7 @@
                                 class="o_task_user_field"
                                 options="{'no_open': True, 'no_quick_create': True}"
                                 widget="many2many_avatar_user"/>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" context="{'project_id': project_id}"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True}" context="{'project_id': project_id}"/>
                         </group>
                         <group>
                             <field name="active" invisible="1"/>
@@ -507,7 +507,7 @@
                                     <field name="rating_last_text" string="Rating" decoration-danger="rating_last_text == 'ko'"
                                         decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
                                         class="fw-bold" widget="badge" optional="hide" invisible="rating_last_text == 'none'" column_invisible="True" groups="project.group_project_rating"/>
-                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" optional="hide"/>
                                     <field name="stage_id" optional="hide" context="{'default_project_id': project_id}"/>
                                 </list>
                             </field>
@@ -552,7 +552,7 @@
                                     <field name="rating_last_text" string="Rating" decoration-danger="rating_last_text == 'ko'"
                                         decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
                                         class="fw-bold" widget="badge" optional="hide" invisible="rating_last_text == 'none'" column_invisible="True" groups="project.group_project_rating"/>
-                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" optional="hide"/>
                                     <field name="stage_id" optional="hide"/>
                                 </list>
                             </field>
@@ -680,10 +680,10 @@
                                 <div class="text-muted d-flex flex-column">
                                     <field t-if="record.parent_id.raw_value" invisible="context.get('default_parent_id', False)" name="parent_id"/>
                                     <field invisible="context.get('default_project_id', False)" name="project_id" options="{'no_open': True}"/>
-                                    <field name="partner_id"/>    
+                                    <field name="partner_id"/>
                                     <field t-if="record.allow_milestones.raw_value and record.milestone_id.raw_value" t-att-class="record.has_late_and_unreached_milestone.raw_value and !record.state.raw_value.startsWith('1_') ? 'text-danger' : ''" name="milestone_id" options="{'no_open': True}"/>
                                 </div>
-                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                                 <field t-if="record.date_deadline.raw_value" invisible="state in ['1_done', '1_canceled']" name="date_deadline" widget="remaining_days"/>
                                 <field name="task_properties" widget="properties"/>
                                 <field name="displayed_image_id" widget="attachment_image"/>
@@ -751,7 +751,7 @@
                     <field name="company_id" groups="base.group_multi_company" optional="show" column_invisible="context.get('default_project_id')" options="{'no_create': True}"/>
                     <field name="company_id" column_invisible="True"/>
                     <field name="date_deadline" optional="hide" widget="remaining_days" invisible="state in ['1_done', '1_canceled']"/>
-                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show" context="{'project_id': project_id}"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" optional="show" context="{'project_id': project_id}"/>
                     <field name="date_last_stage_update" optional="hide"/>
                     <field name="stage_id" column_invisible="context.get('set_visible', False)" optional="show"/>
                 </list>
@@ -823,7 +823,7 @@
                     <field name="user_ids" widget="many2many_avatar_user" invisible="not user_ids"/>
                     <field name="partner_id" invisible="not partner_id"/>
                     <field name="priority" widget="priority" readonly="1"/>
-                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="not tag_ids"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" invisible="not tag_ids"/>
                     <field name="stage_id" invisible="not project_id or not stage_id" widget="task_stage_with_state_selection"/>
                     <field name="personal_stage_id" string="Personal Stage" options="{'no_open': True}" invisible="project_id or not personal_stage_id"/>
                     <field name="task_properties" invisible="not task_properties"/>

--- a/addons/project_todo/static/tests/todo_conversion_form_view.test.js
+++ b/addons/project_todo/static/tests/todo_conversion_form_view.test.js
@@ -32,7 +32,7 @@ beforeEach(() => {
                             widget="many2many_avatar_user"
                             domain="[('share', '=', False), ('active', '=', True)]"/>
                         <field name="tag_ids" widget="many2many_tags"
-                            options="{'color_field': 'color', 'no_create_edit': True}"
+                            options="{'color_field': color, 'no_create_edit': True}"
                             context="{'project_id': project_id}"
                             placeholder="Choose tags from the selected project"/>
                     </group>

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -30,7 +30,7 @@
                         <t t-set="todoHasAssignees" t-value="record.user_ids.raw_value.length &gt; 1"/>
                         <div t-att-class="{'opacity-50': ['1_done', '1_canceled'].includes(record.state.raw_value)}">
                             <field name="name" class="fw-bolder fs-5" widget="name_with_subtask_count"/>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                             <field t-if="record.displayed_image_id.value" name="displayed_image_id" widget="attachment_image"/>
                         </div>
                         <div class="d-flex pt-2">
@@ -66,7 +66,7 @@
                 <field name="state" widget="todo_done_checkmark" nolabel="1"/>
                 <field name="name"/>
                 <field name="user_ids" optional="show" required="1" widget="many2many_avatar_user" options="{'no_quick_create': True}"/>
-                <field name="tag_ids" optional="show" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                <field name="tag_ids" optional="show" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True}"/>
                 <field name="personal_stage_type_id" string="Stage" optional="hide"/>
                 <field name="activity_ids" optional="show" widget="list_activity"/>
             </list>
@@ -112,7 +112,7 @@
                         <group>
                             <field name="tag_ids"
                                 widget="many2many_tags"
-                                options="{'color_field': 'color', 'no_create_edit': True}"
+                                options="{'color_field': color, 'no_create_edit': True}"
                                 class="me-2"/>
                         </group>
                     </group>
@@ -160,7 +160,7 @@
                                options="{'no_open': True, 'no_quick_create': True}"
                                widget="many2many_avatar_user"/>
                         <field name="tag_ids" widget="many2many_tags"
-                               options="{'color_field': 'color', 'no_create_edit': True}"
+                               options="{'color_field': color, 'no_create_edit': True}"
                                context="{'project_id': project_id}"
                                placeholder="Choose tags from the selected project"/>
                     </group>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -120,7 +120,7 @@
                             <field name="schedule_date" readonly="state in ['done', 'cancel']"/>
                             <field name="user_id" domain="[('share', '=', False)]"/>
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True}"/>
                             <field name="parts_availability_state" invisible="True"/>
                             <field name="parts_availability"
                                 invisible="state not in ['confirmed', 'under_repair']"
@@ -218,7 +218,7 @@
                             <field name="state" class="col-6 text-end mb-1" widget="label_selection" options="{'classes': {'draft': 'info', 'cancel': 'danger', 'done': 'success', 'under_repair': 'secondary'}}"/>
                             <div class="col-6 text-muted">
                                 <field name="product_id" />
-                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                             </div>
                             <div class="col-6">
                                 <field name="partner_id" class="float-end"/>

--- a/addons/resource/views/resource_calendar_views.xml
+++ b/addons/resource/views/resource_calendar_views.xml
@@ -64,8 +64,7 @@
                         <group name="resource_company">
                             <field name="active" invisible="1"/>
                             <field name="company_id" groups="base.group_multi_company"/>
-                            <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset', 'mismatch_title': 'Timezone Mismatch : This timezone is different from that of your browser.\nPlease, be mindful of this when setting the working hours or the time off.'}" />
-                            <field name="tz_offset" invisible="1"/>
+                            <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': tz_offset, 'mismatch_title': 'Timezone Mismatch : This timezone is different from that of your browser.\nPlease, be mindful of this when setting the working hours or the time off.'}" />
                         </group>
                     </group>
                     <notebook>

--- a/addons/sale/views/product_template_views.xml
+++ b/addons/sale/views/product_template_views.xml
@@ -12,7 +12,7 @@
             <group name="upsell" position="inside">
                 <field name="optional_product_ids"
                     widget="many2many_tags"
-                    options="{'color_field': 'color'}"
+                    options="{'color_field': color}"
                     domain="[('id', '!=', id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]"
                     context="{'search_product_product': True}"
                     placeholder="Recommend when 'Adding to Cart' or quotation"/>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -155,7 +155,7 @@
                        optional="show"/>
                 <field name="tag_ids"
                       widget="many2many_tags"
-                      options="{'color_field': 'color'}"
+                      options="{'color_field': color}"
                       optional="hide"/>
                 <field name="state"
                     decoration-success="state == 'sale'"
@@ -771,7 +771,7 @@
                                 </div>
                                 <field name="reference" readonly="1" invisible="not reference"/>
                                 <field name="client_order_ref"/>
-                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True}"/>
                             </group>
                             <group name="sale_info" string="Invoicing">
                                 <field name="show_update_fpos" invisible="1"/>

--- a/addons/sms/wizard/sms_composer_views.xml
+++ b/addons/sms/wizard/sms_composer_views.xml
@@ -30,7 +30,6 @@
                         <field name="comment_single_recipient" invisible="1"/>
                         <field name="res_id" invisible="1"/>
                         <field name="res_ids" invisible="1"/>
-                        <field name="res_model" invisible="1"/>
                         <field name="mass_force_send" invisible="1"/>
                         <field name="recipient_single_valid" invisible="1"/>
                         <field name="recipient_single_number" invisible="1"/>
@@ -47,9 +46,9 @@
                             <field name="recipient_single_number_itf" class="oe_inline" nolabel="1" onchange_on_keydown="True" placeholder="e.g. +1 415 555 0100"/>
                         </div>
                         <field name="body" widget="sms_widget" invisible="comment_single_recipient or recipient_single_valid"
-                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'res_model'}"/>
+                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': res_model}"/>
                         <field name="body" widget="sms_widget" invisible="comment_single_recipient or not recipient_single_valid" default_focus="1"
-                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'res_model'}"/>
+                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': res_model}"/>
                         <field name="body" widget="sms_widget" invisible="not comment_single_recipient"/>
                         <field name="mass_keep_log" invisible="1"/>
                     </group>

--- a/addons/stock/views/stock_rule_views.xml
+++ b/addons/stock/views/stock_rule_views.xml
@@ -110,7 +110,7 @@
                                 <div><field name="delay" class="oe_inline"/> days</div>
                             </group>
                         </group>
-                        <field name="push_domain" invisible="action not in ['push', 'pull_push']" widget="domain" options="{'model': 'stock.move'}"/>
+                        <field name="push_domain" invisible="action not in ['push', 'pull_push']" widget="domain" options="{'model': stock.move}"/>
                     </sheet>
                 </form>
             </field>

--- a/addons/uom/views/uom_uom_views.xml
+++ b/addons/uom/views/uom_uom_views.xml
@@ -120,7 +120,7 @@
         <field name="arch" type="xml">
             <list string="Units of Measure categories">
                 <field name="name"/>
-                <field name="uom_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="uom_ids" widget="many2many_tags" options="{'color_field': color}"/>
             </list>
         </field>
     </record>

--- a/addons/utm/views/utm_campaign_views.xml
+++ b/addons/utm/views/utm_campaign_views.xml
@@ -42,7 +42,7 @@
                         <field class="text-break" name="title" string="Campaign Name" placeholder="e.g. Black Friday"/>
                         <field name="name" invisible="1"/>
                         <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
-                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True}"/>
                     </group>
                     <notebook>
                     </notebook>
@@ -60,7 +60,7 @@
                 <field name="name" column_invisible="True"/>
                 <field name="user_id" widget="many2one_avatar_user"/>
                 <field name="stage_id" decoration-bf="1"/>
-                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
             </list>
         </field>
     </record>
@@ -75,7 +75,7 @@
                     <field name="name" invisible="1"/>
                     <field class="o_text_overflow" name="title" string="Campaign Name" placeholder="e.g. Black Friday"/>
                     <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
-                    <field name="tag_ids" widget="many2many_tags" class="o_field_highlight" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                    <field name="tag_ids" widget="many2many_tags" class="o_field_highlight" options="{'color_field': color, 'no_create_edit': True}"/>
                 </group>
             </form>
         </field>
@@ -104,7 +104,7 @@
                     </t>
                     <t t-name="card">
                         <field name="title" class="fw-bold fs-5"/>
-                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                         <ul id="o_utm_actions" class="list-group list-group-horizontal my-0"/>
                         <footer class="mt-2 mb-0 pt-0">
                             <div class="py-auto"/>

--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -261,7 +261,10 @@ export class Field extends Component {
             } else if (name === "on_change") {
                 fieldInfo.onChange = exprToBoolean(value);
             } else if (name === "options") {
-                fieldInfo.options = evaluateExpr(value);
+                const evalContext = Object.fromEntries(
+                    Object.keys(fields).map((fieldName) => [fieldName, fieldName])
+                );
+                fieldInfo.options = evaluateExpr(value, evalContext);
             } else if (name === "force_save") {
                 fieldInfo.forceSave = exprToBoolean(value);
             } else if (name.startsWith("decoration-")) {

--- a/addons/web/static/src/views/fields/reference/reference_field.js
+++ b/addons/web/static/src/views/fields/reference/reference_field.js
@@ -243,9 +243,9 @@ export const referenceField = {
     supportedTypes: ["reference", "char"],
     extractProps({ options }) {
         /*
-        1 - <field name="ref" options="{'model_field': 'model_id'}" />
+        1 - <field name="ref" options="{'model_field': model_id}" />
         2 - <field name="ref" options="{'hide_model': True}" />
-        3 - <field name="ref" options="{'model_field': 'model_id' 'hide_model': True}" />
+        3 - <field name="ref" options="{'model_field': model_id 'hide_model': True}" />
         4 - <field name="ref"/>
 
         We want to display the model selector only in the 4th case.

--- a/addons/web/static/tests/core/domain_field.test.js
+++ b/addons/web/static/tests/core/domain_field.test.js
@@ -55,7 +55,7 @@ test("The domain editor should not crash the view when given a dynamic filter", 
         resId: 1,
         arch: `
                 <form>
-                    <field name="foo" widget="domain" options="{'model': 'partner'}" />
+                    <field name="foo" widget="domain" options="{'model': partner}" />
                     <field name="int" invisible="1" />
                 </form>`,
     });
@@ -75,7 +75,7 @@ test("The domain editor should not crash the view when given a dynamic filter ( 
         resId: 1,
         arch: `
                 <form>
-                    <field name="foo" widget="domain" options="{'model': 'partner'}" />
+                    <field name="foo" widget="domain" options="{'model': partner}" />
                 </form>`,
     });
 
@@ -106,7 +106,7 @@ test("basic domain field usage is ok", async function () {
             <form>
                 <sheet>
                     <group>
-                        <field name="foo" widget="domain" options="{'model': 'partner.type'}" />
+                        <field name="foo" widget="domain" options="{'model': partner.type}" />
                     </group>
                 </sheet>
             </form>`,
@@ -160,7 +160,7 @@ test("using binary field in domain widget", async function () {
             <form>
                 <sheet>
                     <group>
-                        <field name="foo" widget="domain" options="{'model': 'partner'}" />
+                        <field name="foo" widget="domain" options="{'model': partner}" />
                     </group>
                 </sheet>
             </form>`,
@@ -190,7 +190,7 @@ test("domain field is correctly reset on every view change", async function () {
                 <sheet>
                     <group>
                         <field name="bar" />
-                        <field name="foo" widget="domain" options="{'model': 'bar'}" />
+                        <field name="foo" widget="domain" options="{'model': bar}" />
                     </group>
                 </sheet>
             </form>`,
@@ -250,7 +250,7 @@ test("domain field can be reset with a new domain (from onchange)", async functi
         arch: `
                 <form>
                     <field name="name" />
-                    <field name="foo" widget="domain" options="{'model': 'partner'}" />
+                    <field name="foo" widget="domain" options="{'model': partner}" />
                 </form>`,
     });
 
@@ -290,7 +290,7 @@ test("domain field: handle false domain as []", async function () {
                 <sheet>
                     <group>
                         <field name="bar" />
-                        <field name="foo" widget="domain" options="{'model': 'bar'}" />
+                        <field name="foo" widget="domain" options="{'model': bar}" />
                     </group>
                 </sheet>
             </form>`,
@@ -315,7 +315,7 @@ test("basic domain field: show the selection", async function () {
             <form>
                 <sheet>
                     <group>
-                        <field name="foo" widget="domain" options="{'model': 'partner.type'}" />
+                        <field name="foo" widget="domain" options="{'model': partner.type}" />
                     </group>
                 </sheet>
             </form>`,
@@ -353,7 +353,7 @@ test("field context is propagated when opening selection", async function () {
         resId: 1,
         arch: `
             <form>
-                <field name="foo" widget="domain" options="{'model': 'partner.type'}" context="{'list_view_ref': 3}"/>
+                <field name="foo" widget="domain" options="{'model': partner.type}" context="{'list_view_ref': 3}"/>
             </form>`,
     });
 
@@ -378,7 +378,7 @@ test("domain field: manually edit domain with textarea", async function () {
         form: `
             <form>
                 <field name="bar"/>
-                <field name="foo" widget="domain" options="{'model': 'bar'}"/>
+                <field name="foo" widget="domain" options="{'model': bar}"/>
             </form>`,
         search: `<search />`,
     };
@@ -423,7 +423,7 @@ test("domain field: manually set an invalid domain with textarea", async functio
         form: `
                 <form>
                     <field name="bar"/>
-                    <field name="foo" widget="domain" options="{'model': 'bar'}"/>
+                    <field name="foo" widget="domain" options="{'model': bar}"/>
                 </form>`,
         search: `<search />`,
     };
@@ -490,7 +490,7 @@ test("domain field: reload count by clicking on the refresh button", async funct
         form: `
                 <form>
                     <field name="bar"/>
-                    <field name="foo" widget="domain" options="{'model': 'bar'}"/>
+                    <field name="foo" widget="domain" options="{'model': bar}"/>
                 </form>`,
         search: `<search />`,
     };
@@ -539,7 +539,7 @@ test("domain field: does not wait for the count to render", async function () {
         arch: `
             <form>
                 <field name="bar"/>
-                <field name="foo" widget="domain" options="{'model': 'bar'}"/>
+                <field name="foo" widget="domain" options="{'model': bar}"/>
             </form>`,
     });
 
@@ -572,7 +572,7 @@ test("domain field: edit domain with dynamic content", async function () {
         form: `
             <form>
                 <field name="bar"/>
-                <field name="foo" widget="domain" options="{'model': 'bar'}"/>
+                <field name="foo" widget="domain" options="{'model': bar}"/>
             </form>`,
         search: `<search />`,
     };
@@ -616,7 +616,7 @@ test("domain field: edit through selector (dynamic content)", async function () 
         form: `
             <form>
                 <field name="bar"/>
-                <field name="foo" widget="domain" options="{'model': 'bar'}"/>
+                <field name="foo" widget="domain" options="{'model': bar}"/>
             </form>`,
         search: `<search />`,
     };
@@ -673,7 +673,7 @@ test("domain field without model", async function () {
         arch: `
             <form>
                 <field name="model_name"/>
-                <field name="name" widget="domain" options="{'model': 'model_name'}"/>
+                <field name="name" widget="domain" options="{'model': model_name}"/>
             </form>`,
     });
 
@@ -704,7 +704,7 @@ test("domain field in kanban view", async function () {
             <kanban>
                 <templates>
                     <t t-name="card">
-                        <field name="foo" widget="domain" options="{'model': 'partner.type'}" />
+                        <field name="foo" widget="domain" options="{'model': partner.type}" />
                     </t>
                 </templates>
             </kanban>`,
@@ -731,7 +731,7 @@ test("domain field with 'inDialog' options", async function () {
         resModel: "partner",
         arch: `
             <form>
-                <field name="name" widget="domain" options="{'model': 'partner', 'in_dialog': True}"/>
+                <field name="name" widget="domain" options="{'model': partner, 'in_dialog': True}"/>
             </form>`,
     });
     expect(SELECTORS.condition).toHaveCount(0);
@@ -752,7 +752,7 @@ test("invalid value in domain field with 'inDialog' options", async function () 
         resModel: "partner",
         arch: `
             <form>
-                <field name="name" widget="domain" options="{'model': 'partner', 'in_dialog': True}"/>
+                <field name="name" widget="domain" options="{'model': partner, 'in_dialog': True}"/>
             </form>`,
     });
     expect(SELECTORS.condition).toHaveCount(0);
@@ -779,7 +779,7 @@ test("edit domain button is available even while loading records count", async f
         resModel: "partner",
         arch: `
             <form>
-                <field name="name" widget="domain" options="{'model': 'partner', 'in_dialog': True}"/>
+                <field name="name" widget="domain" options="{'model': partner, 'in_dialog': True}"/>
             </form>`,
     });
     expect(".modal").toHaveCount(0);
@@ -804,7 +804,7 @@ test("debug input editing sets the field as dirty even without a focus out", asy
         resModel: "partner",
         arch: `
             <form>
-                <field name="name" widget="domain" options="{'model': 'partner'}"/>
+                <field name="name" widget="domain" options="{'model': partner}"/>
             </form>`,
     });
     await contains(".o_form_button_save").click();
@@ -822,7 +822,7 @@ test("debug input corrections don't need a focus out to be saved", async functio
         resModel: "partner",
         arch: `
             <form>
-                <field name="name" widget="domain" options="{'model': 'partner'}"/>
+                <field name="name" widget="domain" options="{'model': partner}"/>
             </form>`,
     });
     await contains(".o_form_button_save").click();
@@ -852,7 +852,7 @@ test("quick check on save if domain has been edited via the debug input", async 
         resModel: "partner",
         arch: `
             <form>
-                <field name="name" widget="domain" options="{'model': 'partner'}"/>
+                <field name="name" widget="domain" options="{'model': partner}"/>
             </form>`,
     });
     expect(".o_domain_show_selection_button").toHaveText("0 record(s)");
@@ -873,7 +873,7 @@ test("domain field can be foldable", async function () {
             <form>
                 <sheet>
                     <group>
-                        <field name="foo" widget="domain" options="{'model': 'partner.type', 'foldable': true}" />
+                        <field name="foo" widget="domain" options="{'model': partner.type, 'foldable': true}" />
                     </group>
                 </sheet>
             </form>`,
@@ -936,7 +936,7 @@ test("add condition in empty foldable domain", async function () {
             <form>
                 <sheet>
                     <group>
-                        <field name="foo" widget="domain" options="{'model': 'partner.type', 'foldable': true}" />
+                        <field name="foo" widget="domain" options="{'model': partner.type, 'foldable': true}" />
                     </group>
                 </sheet>
             </form>`,
@@ -972,7 +972,7 @@ test("foldable domain field unfolds and hides caret when domain is invalid", asy
             <form>
                 <sheet>
                     <group>
-                        <field name="foo" widget="domain" options="{'model': 'partner.type', 'foldable': true}" />
+                        <field name="foo" widget="domain" options="{'model': partner.type, 'foldable': true}" />
                     </group>
                 </sheet>
             </form>`,
@@ -995,7 +995,7 @@ test("folded domain field with any operator", async function () {
             <form>
                 <sheet>
                     <group>
-                        <field name="foo" widget="domain" options="{'model': 'partner', 'foldable': true}" />
+                        <field name="foo" widget="domain" options="{'model': partner, 'foldable': true}" />
                     </group>
                 </sheet>
             </form>`,
@@ -1018,7 +1018,7 @@ test("folded domain field with withinh operator", async function () {
             <form>
                 <sheet>
                     <group>
-                        <field name="foo" widget="domain" options="{'model': 'partner', 'foldable': true}" />
+                        <field name="foo" widget="domain" options="{'model': partner, 'foldable': true}" />
                     </group>
                 </sheet>
             </form>`,

--- a/addons/web/static/tests/views/fields/dynamic_placeholder.test.js
+++ b/addons/web/static/tests/views/fields/dynamic_placeholder.test.js
@@ -24,14 +24,13 @@ class Partner extends models.Model {
     _views = {
         form: /* xml */ `
             <form>
-                <field name="placeholder" invisible="1"/>
                 <sheet>
                     <group>
                         <field
                             name="char"
                             options="{
                                 'dynamic_placeholder': true,
-                                'dynamic_placeholder_model_reference_field': 'placeholder'
+                                'dynamic_placeholder_model_reference_field': placeholder
                             }"
                         />
                     </group>

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -129,7 +129,7 @@ test("Many2ManyTagsField with and without color on desktop", async () => {
         resModel: "partner",
         arch: `
             <form>
-                <field name="partner_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="partner_ids" widget="many2many_tags" options="{'color_field': color}"/>
                 <field name="timmy" widget="many2many_tags"/>
             </form>`,
     });
@@ -187,7 +187,7 @@ test("Many2ManyTagsField with and without color on mobile", async () => {
         resModel: "partner",
         arch: `
             <form>
-                <field name="partner_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="partner_ids" widget="many2many_tags" options="{'color_field': color}"/>
                 <field name="timmy" widget="many2many_tags"/>
             </form>`,
     });
@@ -247,7 +247,7 @@ test("Many2ManyTagsField with color: rendering and edition on desktop", async ()
         resModel: "partner",
         arch: `
             <form>
-                <field name="timmy" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True }"/>
+                <field name="timmy" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True }"/>
             </form>`,
         resId: 1,
     });
@@ -307,7 +307,7 @@ test("Many2ManyTagsField in list view on desktop", async () => {
         resModel: "partner",
         arch: `
             <list>
-                <field name="timmy" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="timmy" widget="many2many_tags" options="{'color_field': color}"/>
                 <field name="foo"/>
             </list>`,
         selectRecord: () => {
@@ -344,7 +344,7 @@ test("Many2ManyTagsField in list view -- multi edit on desktop", async () => {
         resModel: "partner",
         arch: `
             <list multi_edit="1">
-                <field name="timmy" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="timmy" widget="many2many_tags" options="{'color_field': color}"/>
                 <field name="foo"/>
             </list>`,
         selectRecord: () => {
@@ -624,7 +624,7 @@ test("Many2ManyTagsField: update color", async () => {
         resModel: "partner",
         arch: `
             <form>
-                <field name="timmy" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="timmy" widget="many2many_tags" options="{'color_field': color}"/>
             </form>`,
         resId: 1,
     });
@@ -684,7 +684,7 @@ test("Many2ManyTagsField with no_edit_color option", async () => {
         resModel: "partner",
         arch: `
             <form>
-                <field name="timmy" widget="many2many_tags" options="{'color_field': 'color', 'no_edit_color': 1}"/>
+                <field name="timmy" widget="many2many_tags" options="{'color_field': color, 'no_edit_color': 1}"/>
             </form>`,
         resId: 1,
     });
@@ -809,7 +809,7 @@ test("Many2ManyTagsField: toggle colorpicker with multiple tags", async () => {
         resModel: "partner",
         arch: `
                 <form>
-                    <field name="timmy" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    <field name="timmy" widget="many2many_tags" options="{'color_field': color}"/>
                 </form>`,
         resId: 1,
     });
@@ -842,7 +842,7 @@ test("Many2ManyTagsField: toggle colorpicker multiple times", async () => {
         resModel: "partner",
         arch: `
             <form>
-                <field name="timmy" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="timmy" widget="many2many_tags" options="{'color_field': color}"/>
             </form>`,
         resId: 1,
     });
@@ -1959,7 +1959,7 @@ test("Many2ManyTagsField with edit_tags option overrides color edition", async (
         resModel: "partner",
         arch: `
             <form>
-                <field name="timmy" widget="many2many_tags" options="{'edit_tags': 1, 'color_field': 'color'}"/>
+                <field name="timmy" widget="many2many_tags" options="{'edit_tags': 1, 'color_field': color}"/>
             </form>`,
         resId: 1,
     });

--- a/addons/web/static/tests/views/fields/reference_field.test.js
+++ b/addons/web/static/tests/views/fields/reference_field.test.js
@@ -648,7 +648,7 @@ test("ReferenceField with model_field option", async () => {
         arch: /* xml */ `
             <form>
                 <field name="model_id" />
-                <field name="reference" options="{'model_field': 'model_id'}" />
+                <field name="reference" options="{'model_field': model_id}" />
             </form>
         `,
     });
@@ -702,7 +702,7 @@ test("ReferenceField with model_field option (model_field not synchronized with 
         arch: /* xml */ `
             <form>
                 <field name="model_id" />
-                <field name="reference" options="{'model_field': 'model_id'}" />
+                <field name="reference" options="{'model_field': model_id}" />
            </form>
         `,
     });
@@ -770,7 +770,7 @@ test("ReferenceField with model_field option (tree list in form view)", async ()
                     <list editable="bottom">
                         <field name="name" />
                         <field name="model_id" />
-                        <field name="reference" options="{'model_field': 'model_id'}" class="reference_field" />
+                        <field name="reference" options="{'model_field': model_id}" class="reference_field" />
                     </list>
                 </field>
             </form>
@@ -848,7 +848,7 @@ test("Change model field of a ReferenceField then select an invalid value (tree 
                     <list editable="bottom">
                         <field name="name" />
                         <field name="model_id"/>
-                        <field name="reference" required="true" options="{'model_field': 'model_id'}" class="reference_field" />
+                        <field name="reference" required="true" options="{'model_field': model_id}" class="reference_field" />
                     </list>
                 </field>
             </form>
@@ -892,10 +892,10 @@ test("model selector is displayed only when it should be", async () => {
         arch: /* xml */ `
             <form>
                 <group>
-                    <field name="reference" options="{'model_field': 'model_id'}" />
+                    <field name="reference" options="{'model_field': model_id}" />
                 </group>
                 <group>
-                    <field name="reference" options="{'model_field': 'model_id', 'hide_model': True}" />
+                    <field name="reference" options="{'model_field': model_id, 'hide_model': True}" />
                 </group>
                 <group>
                     <field name="reference" options="{'hide_model': True}" />
@@ -940,7 +940,7 @@ test("reference field should await fetch model before render", async () => {
         arch: /* xml */ `
             <form>
                 <field name="model_id" invisible="1"/>
-                <field name="reference" options="{'model_field': 'model_id'}" />
+                <field name="reference" options="{'model_field': model_id}" />
             </form>
         `,
     });

--- a/addons/web/static/tests/views/fields/text_field.test.js
+++ b/addons/web/static/tests/views/fields/text_field.test.js
@@ -205,14 +205,13 @@ test("with dynamic placeholder", async () => {
         resModel: "product",
         arch: `
             <form>
-                <field name="placeholder" invisible="1"/>
                 <sheet>
                     <group>
                         <field
                             name="description"
                             options="{
                                 'dynamic_placeholder': true,
-                                'dynamic_placeholder_model_reference_field': 'placeholder'
+                                'dynamic_placeholder_model_reference_field': placeholder
                             }"
                         />
                     </group>
@@ -235,14 +234,13 @@ test("with dynamic placeholder in mobile", async () => {
         resModel: "product",
         arch: `
             <form>
-                <field name="placeholder" invisible="1"/>
                 <sheet>
                     <group>
                         <field
                             name="description"
                             options="{
                                 'dynamic_placeholder': true,
-                                'dynamic_placeholder_model_reference_field': 'placeholder'
+                                'dynamic_placeholder_model_reference_field': placeholder
                             }"
                         />
                     </group>

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -554,7 +554,7 @@ test(`form with o2m having a many2many fields using the many2many_tags widget al
                     <field name="partner_ids">
                         <list>
                             <field name="name"/>
-                            <field name="type_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="type_ids" widget="many2many_tags" options="{'color_field': color}"/>
                         </list>
                     </field>
                 </form>

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -4200,7 +4200,7 @@ test("many2many_tags in kanban views", async () => {
             <kanban>
                 <templates>
                     <t t-name="card">
-                        <field name="category_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                        <field name="category_ids" widget="many2many_tags" options="{'color_field': color}"/>
                         <field name="foo"/>
                         <field name="state" widget="priority"/>
                     </t>

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
@@ -1356,7 +1356,7 @@ test("clicking a button with dirty settings -- discard", async () => {
         arch: /* xml */ `
             <form js_class="base_settings">
                 <app string="CRM" name="crm">
-                    <field name="product_ids" widget="many2many_tags" options="{ 'color_field': 'color' }"/>
+                    <field name="product_ids" widget="many2many_tags" options="{ 'color_field': color }"/>
                     <field name="bar" />
                     <field name="foo" />
                     <button type="object" name="mymethod" class="myBtn"/>

--- a/addons/website/views/website_controller_pages_views.xml
+++ b/addons/website/views/website_controller_pages_views.xml
@@ -21,8 +21,7 @@
                     </group>
                     <group colspan="1" string="Settings">
                         <field name="model_id" readonly="id"/>
-                        <field name="model" invisible="1" />
-                        <field name="record_domain" widget="domain" options="{'in_dialog': True, 'model': 'model'}"/>
+                        <field name="record_domain" widget="domain" options="{'in_dialog': True, 'model': model}"/>
                         <field name="default_layout"/>
                     </group>
                 </group>

--- a/addons/website_blog/views/website_pages_views.xml
+++ b/addons/website_blog/views/website_pages_views.xml
@@ -16,7 +16,7 @@
                     <field name="active" invisible="1"/>
                     <field name="name" placeholder="Blog Post Title"/>
                     <field name="subtitle" placeholder="Blog Subtitle"/>
-                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                     <field name="website_id" groups="website.group_multi_website"/>
                 </group>
                 <group name="publishing_details" string="Publishing Options">

--- a/addons/website_crm_iap_reveal/views/crm_reveal_views.xml
+++ b/addons/website_crm_iap_reveal/views/crm_reveal_views.xml
@@ -52,7 +52,7 @@
                     </div>
                     <group>
                         <group string="Opportunity Generation Conditions">
-                            <field name="industry_tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True, 'no_quick_create': True}"/>
+                            <field name="industry_tag_ids" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True, 'no_quick_create': True}"/>
                             <field name="filter_on_size"/>
                             <label for="company_size_min" invisible="not filter_on_size"/>
                             <div invisible="not filter_on_size">
@@ -65,7 +65,7 @@
                             <field name="extra_contacts"/>
                             <field name="contact_filter_type" widget="radio"/>
                             <field name="preferred_role_id" invisible="contact_filter_type != 'role'" options="{'no_create_edit': True, 'no_quick_create': True}"/>
-                            <field name="other_role_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True, 'no_quick_create': True}" invisible="not preferred_role_id or contact_filter_type != 'role'"/>
+                            <field name="other_role_ids" widget="many2many_tags" options="{'color_field': color, 'no_create_edit': True, 'no_quick_create': True}" invisible="not preferred_role_id or contact_filter_type != 'role'"/>
                             <field name="seniority_id" invisible="contact_filter_type != 'seniority'" options="{'no_create_edit': True, 'no_quick_create': True}"/>
                         </group>
                     </group>

--- a/addons/website_event/views/event_event_views.xml
+++ b/addons/website_event/views/event_event_views.xml
@@ -53,9 +53,9 @@
             </field>
 
             <field name="tag_ids" position="after">
-                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_quick_create': True}" invisible="website_id"></field>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color, 'no_quick_create': True}" invisible="website_id"></field>
             </field>
-            
+
         </field>
     </record>
 

--- a/addons/website_event_track/views/event_track_tag_views.xml
+++ b/addons/website_event_track/views/event_track_tag_views.xml
@@ -28,7 +28,7 @@
             <list string="Track Tags Category">
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
-                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
             </list>
         </field>
     </record>

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -47,7 +47,7 @@
                     <t t-name="card">
                         <field name="name" class="fw-medium fs-5"/>
                         <div t-if="duration" class="d-flex"><field name="duration" widget="float_time"/>hours</div>
-                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                         <footer class="pt-0">
                             <div class="d-flex align-items-center">
                                 <field name="priority" widget="priority"/>
@@ -169,7 +169,7 @@
                             <field name="company_id" invisible="1"/>
                             <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
                             <field name="event_id"/>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                             <field name="color" widget="color_picker"/>
                         </group>
                     </group>

--- a/addons/website_forum/views/forum_post_views.xml
+++ b/addons/website_forum/views/forum_post_views.xml
@@ -27,7 +27,7 @@
                         <field name="parent_id" invisible="not parent_id"/>
                     </group>
                     <group name="post_details">
-                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
                         <field name="state"/>
                         <field name="closed_reason_id" invisible="not closed_reason_id"/>
                         <field name="closed_uid" invisible="not closed_uid"/>

--- a/addons/website_slides/views/slide_channel_add.xml
+++ b/addons/website_slides/views/slide_channel_add.xml
@@ -12,7 +12,7 @@
             </div>
             <group>
                 <field name="website_url" invisible="1"/>
-                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags"/>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" placeholder="Tags"/>
                 <field name="channel_type" widget="image_radio" options="{'images': ['/website_slides/static/src/img/channel-training-layout.png', '/website_slides/static/src/img/channel-documentation-layout.png']}" string="Choose a layout"/>
                 <field name="description" placeholder="Common tasks for a computer scientist is asking the right questions and answering questions..." class="mb-3"/>
                 <field name="allow_comment" string="Allow Rating"/>

--- a/addons/website_slides/views/slide_channel_tag_views.xml
+++ b/addons/website_slides/views/slide_channel_tag_views.xml
@@ -95,7 +95,7 @@
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="is_published" string="Menu Entry"/>
-                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}"/>
             </list>
         </field>
     </record>

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -69,7 +69,7 @@
                         </div>
                         <div>
                             <field name="active" invisible="1"/>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': color}" placeholder="Tags"/>
                         </div>
                         <notebook colspan="4">
                             <page name="content" string="Content">
@@ -262,7 +262,7 @@
                             <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                             <widget name="web_ribbon" title="Published" bg_color="text-bg-success" invisible="not website_published or not active"/>
                             <field name="name" class="fw-bold fs-4 me-auto ms-1"/>
-                            <field t-if="record.tag_ids" name="tag_ids" widget="many2many_tags"  options="{'color_field': 'color'}" class="mb-4 w-75 ms-1"/>
+                            <field t-if="record.tag_ids" name="tag_ids" widget="many2many_tags"  options="{'color_field': color}" class="mb-4 w-75 ms-1"/>
                             <div class="row g-0 mb16 mt-1 ms-2 me-2">
                                 <div name="card_primary_left" class="col-6">
                                     <button class="btn btn-primary" name="open_website_url" type="object">View course</button>

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1293,6 +1293,10 @@ actual arch.
             if context:
                 vnames = get_expression_field_names(context)
                 name_manager.must_have_fields(node, vnames, node_info, ('context', context))
+            options = node.get('options')
+            if options:
+                vnames = get_expression_field_names(options)
+                name_manager.must_have_fields(node, vnames, node_info, ('options', options))
 
             for child in node:
                 if child.tag in ('form', 'list', 'graph', 'kanban', 'calendar'):

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -341,14 +341,13 @@
                         <separator string="Action Details" groups="base.group_no_one" />
                         <div class="d-flex flex-row flex-wrap gap-2" invisible="state != 'object_write'">
                             <field name="evaluation_type" class="oe_inline"/>
-                            <field name="update_path" widget="DynamicModelFieldSelectorChar" class="oe_inline" options="{'model': 'model_name'}"/>
+                            <field name="update_path" widget="DynamicModelFieldSelectorChar" class="oe_inline" options="{'model': model_name}"/>
                             <field name="update_field_id" invisible="True"/>  <!-- The field is store=True and readonly=False, in this view we want to save the value from compute/onchange -->
-                            <field name="update_related_model_id" invisible="True"/> <!-- This field is required for 'resource_ref' to compute possible m2m and m2o values -->
                             <span invisible="evaluation_type != 'value' or not update_field_type == 'many2many'">by</span>
                             <field name="update_m2m_operation" class="oe_inline" invisible="evaluation_type != 'value' or not update_field_type == 'many2many'" required="update_field_type == 'many2many'"/>
                             <span invisible="evaluation_type != 'value' or update_field_type == 'many2many'">to</span>
                             <field name="value" class="oe_inline" placeholder="Set a value..." invisible="update_field_id == False or value_field_to_show != 'value' or evaluation_type != 'value'" string="Custom Value"/>
-                            <field name="resource_ref" class="oe_inline" placeholder="Choose a value..." string="Custom Value" options="{'model_field': 'update_related_model_id', 'no_create': True, 'no_open': True}" invisible=" update_field_id == False or value_field_to_show != 'resource_ref' or evaluation_type == 'equation' or update_m2m_operation == 'clear'"/>
+                            <field name="resource_ref" class="oe_inline" placeholder="Choose a value..." string="Custom Value" options="{'model_field': update_related_model_id, 'no_create': True, 'no_open': True}" invisible=" update_field_id == False or value_field_to_show != 'resource_ref' or evaluation_type == 'equation' or update_m2m_operation == 'clear'"/>
                             <field name="selection_value" class="oe_inline" placeholder="Choose a value..." options="{'no_create': True, 'no_open': True}" invisible=" update_field_id == False or value_field_to_show != 'selection_value' or evaluation_type == 'equation'"/>
                             <field name="update_boolean_value" class="oe_inline" invisible="evaluation_type != 'value' or value_field_to_show != 'update_boolean_value'" required="value_field_to_show == 'update_boolean_value'"/>
                             <span invisible="update_field_id != False or evaluation_type == 'equation'" class="text-muted">Set a value...</span>

--- a/odoo/addons/base/views/ir_filters_views.xml
+++ b/odoo/addons/base/views/ir_filters_views.xml
@@ -15,7 +15,7 @@
                         <field name="active" widget="boolean_toggle"/>
                     </group>
                     <group>
-                        <field name="domain" widget="domain" options="{'model': 'model_id'}"/>
+                        <field name="domain" widget="domain" options="{'model': model_id}"/>
                         <field name="context"/>
                         <field name="sort"/>
                     </group>

--- a/odoo/addons/base/views/res_company_views.xml
+++ b/odoo/addons/base/views/res_company_views.xml
@@ -67,7 +67,7 @@
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="partner_id" required="0"/>
-                    <field name="child_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    <field name="child_ids" widget="many2many_tags" options="{'color_field': color}"/>
                 </list>
             </field>
         </record>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -67,7 +67,7 @@
                     <field name="state_id" optional="hide" readonly="1"/>
                     <field name="country_id" optional="show" readonly="1"/>
                     <field name="vat" optional="hide" readonly="1"/>
-                    <field name="category_id" optional="hide" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    <field name="category_id" optional="hide" widget="many2many_tags" options="{'color_field': color}"/>
                     <field name="company_id" groups="base.group_multi_company" readonly="1"/>
                 </list>
             </field>
@@ -207,7 +207,7 @@
                             <field name="title" options='{"no_open": True}' placeholder="e.g. Mister"
                                 invisible="is_company"/>
                             <field name="lang" invisible="active_lang_count &lt;= 1"/>
-                            <field name="category_id" widget="many2many_tags" options="{'color_field': 'color'}"
+                            <field name="category_id" widget="many2many_tags" options="{'color_field': color}"
                                    placeholder='e.g. "B2B", "VIP", "Consulting", ...'/>
                         </group>
                     </group>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -158,7 +158,7 @@
                             <label for="groups_id" string="Access Rights"
                                     invisible="id &gt; 0" groups="base.group_no_one"/>
                             <div invisible="id &gt; 0" groups="base.group_no_one">
-                                <field name="groups_id" readonly="1" widget="many2many_tags" options="{'color_field': 'color'}" style="display: inline;"/> You will be able to define additional access rights by editing the newly created user under the Settings / Users menu.
+                                <field name="groups_id" readonly="1" widget="many2many_tags" options="{'color_field': color}" style="display: inline;"/> You will be able to define additional access rights by editing the newly created user under the Settings / Users menu.
                             </div>
                             <field name="phone" widget="phone"/>
                             <field name="mobile" widget="phone"/>
@@ -215,7 +215,7 @@
                         <notebook colspan="4">
                             <page name="access_rights" string="Access Rights">
                                 <group string="Multi Companies" invisible="companies_count &lt;= 1">
-                                    <field string="Allowed Companies" name="company_ids" widget="many2many_tags" options="{'no_create': True, 'color_field': 'color'}"/>
+                                    <field string="Allowed Companies" name="company_ids" widget="many2many_tags" options="{'no_create': True, 'color_field': color}"/>
                                     <field string="Default Company" name="company_id" context="{'user_preference': 0}"/>
                                 </group>
                                 <field name="groups_id"/>
@@ -233,7 +233,7 @@
                                                 aria-label="Add a language"
                                                 title="Add a language"/>
                                         </div>
-                                        <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset'}" />
+                                        <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': tz_offset}" />
                                     </group>
                                     <group string="Menus Customization" groups="base.group_no_one"
                                         invisible="share">
@@ -446,7 +446,7 @@
                                             title="Add a language"
                                         />
                                     </div>
-                                    <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset'}" readonly="0"/>
+                                    <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': tz_offset}" readonly="0"/>
                                 </group>
                             </group>
                             <group name="signature">

--- a/odoo/addons/base/wizard/base_export_language_views.xml
+++ b/odoo/addons/base/wizard/base_export_language_views.xml
@@ -13,8 +13,7 @@
                         <field name="export_type"/>
                         <field name="modules" widget="many2many_tags" options="{'no_create': True}" invisible="export_type == 'model'"/>
                         <field name="model_id" options="{'no_create': True}" invisible="export_type == 'module'" required="export_type == 'model'"/>
-                        <field name="model_name" invisible="1"/> <!-- The model_name is needed for the option of the domain -->
-                        <field name="domain" widget="domain" options="{'model': 'model_name'}" invisible="export_type == 'module'"/>
+                        <field name="domain" widget="domain" options="{'model': model_name}" invisible="export_type == 'module'"/>
                     </group>
                     <div invisible="state != 'get'">
                         <h2>Export Complete</h2>

--- a/odoo/addons/test_new_api/views/test_new_api_views.xml
+++ b/odoo/addons/test_new_api/views/test_new_api_views.xml
@@ -47,7 +47,7 @@
                             <!--
                                 Bug if the view contains at least 5 fields.
                                 The order of the dic values changes and the _check_author constraint raise.
-                                <field name="categories" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                                <field name="categories" widget="many2many_tags" options="{'color_field': color}"/>
                             -->
                             <field name="moderator"/>
                         </group>
@@ -118,7 +118,7 @@
                     <sheet>
                         <group>
                             <field name="name"/>
-                            <field name="categories" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="categories" widget="many2many_tags" options="{'color_field': color}"/>
                         </group>
                         <notebook>
                             <page string="Messages">


### PR DESCRIPTION
This commit allows to parse field names inside widget options. In doing so, the js code will still treat them as strings while the python is able to detect the field as being mandatory to be included in the view. It is therefore no longer needed to add these fields to the archs as invisible when they aren't already defined.

task-4365253
