### PR TITLE
[FIX] point_of_sale: fix runbot focus error

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -53,6 +53,7 @@ export class Navbar extends Component {
         if (
             !this.ui.isSmall &&
             this.inputRef &&
+            this.inputRef.el &&
             document.activeElement !== this.inputRef.el &&
             !this.pos.getOrder()?.getSelectedOrderline() &&
             this.noOpenDialogs() &&


### PR DESCRIPTION
Previously we wasn't checking if the `el` was existing before calling `focus` on it. This was causing an error on runbot.

Runbot error id: 108406
