### PR TITLE
[FIX] l10n_jo_edi: Removed unnecessary loop from _l10n_jo_edi_send

### DIFF
--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -183,16 +183,16 @@ class AccountMove(models.Model):
         return error_msg
 
     def _l10n_jo_edi_send(self):
-        for invoice in self:
-            if not self.env['res.company']._with_locked_records(records=invoice, allow_raising=False):
-                return
-            if error_message := invoice._l10n_jo_validate_config() or invoice._l10n_jo_validate_fields() or invoice._submit_to_jofotara():
-                invoice.l10n_jo_edi_error = error_message
-                return error_message
-            else:
-                invoice.l10n_jo_edi_error = False
-                invoice.l10n_jo_edi_state = 'sent'
-                invoice.with_context(no_new_invoice=True).message_post(
-                    body=_("E-invoice (JoFotara) submitted successfully."),
-                    attachment_ids=invoice.l10n_jo_edi_xml_attachment_id.ids,
-                )
+        self.ensure_one()
+        if not self.env['res.company']._with_locked_records(records=self, allow_raising=False):
+            return
+        if error_message := self._l10n_jo_validate_config() or self._l10n_jo_validate_fields() or self._submit_to_jofotara():
+            self.l10n_jo_edi_error = error_message
+            return error_message
+        else:
+            self.l10n_jo_edi_error = False
+            self.l10n_jo_edi_state = 'sent'
+            self.with_context(no_new_invoice=True).message_post(
+                body=_("E-invoice (JoFotara) submitted successfully."),
+                attachment_ids=self.l10n_jo_edi_xml_attachment_id.ids,
+            )


### PR DESCRIPTION
The method _l10n_jo_edi_send always expects a single invoice. Therefore, the loop over the recordset makes no sense, and is misleading to whoever reads the code.

task-3895493





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
