### PR TITLE
[FIX] web_editor: display full screen iframe on top of modal

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -76,7 +76,7 @@
     }
     #oe_snippets {
         position: fixed;
-        z-index: $zindex-modal-backdrop + 1 !important;
+        z-index: $zindex-modal + 1 !important;
     }
 }
 
@@ -94,7 +94,7 @@
         top: 0 !important;
         bottom: 0 !important;
         min-height: 100% !important;
-        z-index: $zindex-modal-backdrop + 1 !important;
+        z-index: $zindex-modal + 1 !important;
         border: 0;
     }
     .tooltip-field-info {


### PR DESCRIPTION
Issue:
======
When we toggle the full screen mode it's displayed under the modal.

Steps to reproduce the issue:
=============================
- Install email automation
- Create a new one (commercial prospection)
- Click on offer free catalog to open the modal
- Click on the internal link on the right of mail template
- Toggle full screen mode of the snippets editor
- The editing area is under the modal

Origin of the issue:
====================
When we toggle the full screen mode we add the class `o_form_fullscreen_ancestor` which will add `z-index:zindex-modal-backdrop + 1` which is bascially putting the iframe under the modal.

Solution:
=========
Update the `z-index` to put the iframe and the snippets on top of the modal

opw-4318011