### PR TITLE
[FIX] mail: fold open a channel when `force_open=True`

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -995,7 +995,7 @@ class Channel(models.Model):
             # get the existing channel between the given partners
             channel = self.browse(result[0].get('channel_id'))
             # pin or open the channel for the current partner
-            if pin or open:
+            if pin or force_open:
                 member = self.env['discuss.channel.member'].search([('partner_id', '=', self.env.user.partner_id.id), ('channel_id', '=', channel.id)])
                 vals = {'last_interest_dt': fields.Datetime.now()}
                 if pin:


### PR DESCRIPTION
Following 17fa8a4531df0cd7281962211797ba60df06f775, `force_open` was introduced as a parameter to the function, but the condition to set the folding state references `open` (python's default function to open a file), not `force_open` (the parameter), probably a typo.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
