### PR TITLE
[FIX] point_of_sale: added label for radio product attribute

### DIFF
--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
@@ -8,7 +8,9 @@
                     <div class="attribute-name-cell form-check" t-att-class="{'ptav-not-available': value.excluded}">
                         <input class="form-check-input radio-check" type="radio" t-model="state.attribute_value_ids" t-att-name="value.attribute_id.id"
                                 t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}" t-att-value="value.id"/>
-                        <span t-esc="value.name"/>
+                        <label t-attf-for="{{ value.attribute_id.id }}_{{ value.id }}" class="form-check-label">
+                            <span t-esc="value.name"/>
+                        </label>
                         <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2">
                             <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
                                 <t t-esc="getFormatPriceExtra(value.price_extra)"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
Ensures proper association between `<span> `elements and corresponding `<input>` elements by making the `<span> `act as a label for better accessibility and user experience.

Current behavior before PR:
The `<span>` displaying the attribute name is not linked to the corresponding `<input>` radio button. Users must click the radio button itself to select an option.

Desired behavior after PR is merged:
The  `<span> `acts as a clickable label for the corresponding `<input>` radio button, allowing users to click either the text or the radio button to select an option. This improves accessibility and enhances the user experience.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
