### PR TITLE
[FIX] website_slides: prevent embedded components in slide description

### DIFF
--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -135,7 +135,7 @@
                                 </group>
                             </page>
                             <page name="description" string="Description">
-                                <field name="description" placeholder="e.g. In this video, we'll give you the keys on how Odoo can help you to grow your business. At the end, we'll propose you a quiz to test your knowledge."/>
+                                <field name="description" options="{'embedded_components': false}" placeholder="e.g. In this video, we'll give you the keys on how Odoo can help you to grow your business. At the end, we'll propose you a quiz to test your knowledge."/>
                             </page>
                             <page string="Additional Resources" name="external_links" >
                                 <group>


### PR DESCRIPTION
Steps to reproduce
==================

- Install website_slides
- Go to eLearning > Basics of Gardening
- Click on a line
- Switch to the description tab
- Type /video
- Insert a video
- Save
- Click on the "Go to Website" action button
- Click on the line that has just been edited

=> The video does not appear

Cause of the issue
==================

The new web_editor has a plugin system, and one option that is enabled by default is `embedded_components`.

This option has been introduced in:

https://github.com/odoo/odoo/commit/03f495c696030214c17e6479076571823513f60e

According to the description,

> It is forcibly set to `false` in HtmlMailField since embedded
> components can only be rendered inside Odoo.

Solution
========

Disable the embedded components

opw-4329734