### PR TITLE
[FIX] l10n_ar_website_sale: traceback on address save

### DIFF
--- a/addons/l10n_ar_website_sale/controllers/main.py
+++ b/addons/l10n_ar_website_sale/controllers/main.py
@@ -48,6 +48,11 @@ class L10nARWebsiteSale(WebsiteSale):
 
                 id_type = request.env['l10n_latam.identification.type'].browse(id_type_id) if id_type_id else False
                 afip_resp = request.env['l10n_ar.afip.responsibility.type'].browse(afip_resp_id) if afip_resp_id else False
+
+                if not id_type or not afip_resp:
+                    # Those two values were not provided and are not required, skip the validation
+                    return error, error_message
+
                 cuit_id_type = request.env.ref('l10n_ar.it_cuit')
 
                 # Check if the AFIP responsibility is different from Final Consumer or Foreign Customer,


### PR DESCRIPTION
Commit 1e0183d506d265c978de61e5316e8d35fcbacb05 made sure that child addresses where the commercial fields (vat, company name, ...) are not displayed are considered valid since those fields will be taken from the commercial partner (parent contact).

Nevertheless, the code in the argentinian localization doesn't handle the cases where those values are not provided, which led to a traceback being displayed to the customers, which shouldn't ever happen in the ecommerce checkout:

> if afip_resp.code not in ['5', '9'] and id_type != cuit_id_type
'bool' object has no attribute 'code'

This commit skips the validation in case those fields are not given. Either they are required and the main validation ensures they are provided (and they'll be verified by the override), or they are not provided and shouldn't be, in which case the validation can be skipped here.

opw-4373610

Fixes #189227