### PR TITLE
[FIX] im_livechat: chatbot answer containing ampersamd

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -2,6 +2,7 @@ import { AND, Record } from "@mail/core/common/record";
 import { rpc } from "@web/core/network/rpc";
 import { browser } from "@web/core/browser/browser";
 import { debounce } from "@web/core/utils/timing";
+import { escape } from "@web/core/utils/strings";
 
 export class Chatbot extends Record {
     static id = AND("script", "thread");
@@ -145,7 +146,9 @@ export class Chatbot extends Record {
         if (this.currentStep.selectedAnswer) {
             return true;
         }
-        const answer = this.currentStep.answers.find(({ name }) => message.body.includes(name));
+        const answer = this.currentStep.answers.find(({ name }) =>
+            message.body.includes(escape(name))
+        );
         this.currentStep.selectedAnswer = answer;
         await rpc("/chatbot/answer/save", {
             channel_id: this.thread.id,

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -38,6 +38,7 @@ class ChatbotCase(common.HttpCase):
             cls.step_dispatch_buy_software,
             cls.step_dispatch_pricing,
             cls.step_dispatch_operator,
+            cls.step_dispatch_documentation,
         ] = cls.env['chatbot.script.answer'].sudo().create([{
             'name': 'I want to buy the software',
             'script_step_id': cls.step_dispatch.id,
@@ -46,6 +47,9 @@ class ChatbotCase(common.HttpCase):
             'script_step_id': cls.step_dispatch.id,
         }, {
             'name': "I want to speak with an operator",
+            'script_step_id': cls.step_dispatch.id,
+        }, {
+            'name': "Other & Documentation",
             'script_step_id': cls.step_dispatch.id,
         }])
 
@@ -56,6 +60,7 @@ class ChatbotCase(common.HttpCase):
             cls.step_forward_operator,
             cls.step_no_one_available,
             cls.step_no_operator_dispatch,
+            cls.step_documentation_validated,
         ] = ChatbotScriptStep.create([{
             'step_type': 'text',
             'message': 'For any pricing question, feel free ton contact us at pricing@mycompany.com',
@@ -85,6 +90,11 @@ class ChatbotCase(common.HttpCase):
             'step_type': 'question_selection',
             'message': 'So... What can I do to help you?',
             'triggering_answer_ids': [(4, cls.step_dispatch_operator.id)],
+            'chatbot_script_id': cls.chatbot_script.id,
+        }, {
+            'step_type': 'text',
+            'message': 'Please find documentation at https://www.odoo.com/documentation/18.0/',
+            'triggering_answer_ids': [(4, cls.step_dispatch_documentation.id)],
             'chatbot_script_id': cls.chatbot_script.id,
         }])
 

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -32,7 +32,7 @@ class ChatbotCase(chatbot_common.ChatbotCase):
 
     def test_chatbot_is_forward_operator_child(self):
         self.assertEqual([step.is_forward_operator_child for step in self.chatbot_script.script_step_ids],
-                         [False, False, False, False, False, False, False, True, True, True, False, False, False, False],
+                         [False, False, False, False, False, False, False, True, True, False, True, False, False, False, False],
                          "Steps 'step_no_one_available', 'step_no_operator_dispatch', 'step_just_leaving'"
                          "should be flagged as forward operator child.")
 
@@ -40,7 +40,7 @@ class ChatbotCase(chatbot_common.ChatbotCase):
         self.chatbot_script.script_step_ids.invalidate_recordset(['is_forward_operator_child'])
 
         self.assertEqual([step.is_forward_operator_child for step in self.chatbot_script.script_step_ids],
-                         [False, False, False, False, False, False, False, True, False, False, False, False, False, False],
+                         [False, False, False, False, False, False, False, True, False, False, False, False, False, False, False],
                          "Only step 'step_no_one_available' should be flagged as forward operator child.")
 
     def test_chatbot_steps(self):

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
@@ -45,5 +45,13 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_test_page_tour
                 });
             },
         },
+        {
+            trigger: '.o-livechat-root:shadow li:contains("Other & Documentation")',
+            run: "click",
+        },
+        {
+            trigger: messagesContain("Please find documentation at"),
+            run: () => {},
+        },
     ],
 });


### PR DESCRIPTION
Before this commit, if chatbot had ampersamd character in question answers, this would lead to following crash:

```
Cannot read properties of undefined (reading 'id')
```

Steps to reproduce:

- configure chatbot with following step scripts:

```
 Message | step type | answers                   | only if
---------+-----------+---------------------------+----------------
 step    | question  | "test & step 2", "step 3" |
 step 2  | text      |                           | "test & step 2"
 step 3  | text      |                           | "step 3"
 ```

- open conversation with chatbot
- select "test & step 2" => crash

This happens because when selecting an answer, chatbot detects the selected answer by comparing user message content with all possible answer text content. The message body of user is escaped, whereas chatbot answers are not. Thus `test & step 2` is not found and therefore the crash results in `answer.id` where `answer` is `undefined`.

This commit fixes the issue by escaping the value of answer in the detection of selected answer by user, so that escaped content is compared with escaped content too.

opw-4369966