### PR TITLE
[FIX] mass_mailing_event: recompute mass mailing domain

### DIFF
--- a/addons/mass_mailing_event/models/event_registration.py
+++ b/addons/mass_mailing_event/models/event_registration.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
+
 from odoo import models
 
 
@@ -9,4 +11,8 @@ class EventRegistration(models.Model):
     _mailing_enabled = True
 
     def _mailing_get_default_domain(self, mailing):
-        return [('state', '!=', 'cancel')]
+        default_domain = [('state', 'not in', ['cancel', 'draft'])]
+        default_mailing_model_id = self.env.context.get('default_mailing_model_id')
+        if mailing.mailing_model_id.id == default_mailing_model_id and self.env.context.get('default_mailing_domain'):
+            return ast.literal_eval(self.env.context['default_mailing_domain'])
+        return default_domain


### PR DESCRIPTION
When creating a new mass mailing from an event, the default domain
retrieved when switching mailing type is missing the event id filter

Steps to reproduce (mass_mailing_sms required):
- Open an event with attendees
- Click 'Contact Attendees'
- Take note of the mailing domain
- Switch Mailing Type from Email to SMS

Issue: Domain is missing the event_id
This does not occur when opening the form view because the default
mailing domain is given via context

opw-4337256