### PR TITLE
[FIX] base: add company field on child partner form

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -283,6 +283,7 @@
                                                 <field name="email" widget="email"/>
                                                 <field name="phone" widget="phone"/>
                                                 <field name="mobile" widget="phone"/>
+                                                <field name="company_id" invisible="1"/>    <!-- Need to save value from parented record, cf onchange -->
                                             </group>
                                         </group>
                                         <group>


### PR DESCRIPTION
To reproduce the issue:
(Need more than one company)
1. Create a partner and link him to a specific company
2. In "Contacts & Addresses", add a new partner
3. Open this "child partner"

Error: the child partner does not belong to the company defined at
step 1

Commit [1] removed the field from the company, but this field is
needed so we can define its value thanks to the onchange
https://github.com/odoo/odoo/blob/988b47c0ca409a38c2f429a6db017eef17053c04/odoo/addons/base/models/res_partner.py#L529-L532

[1] https://github.com/odoo/odoo/commit/5639ed865c5a3b82bab25b0ecac28c68c02e9306

OPW-4247914