### PR TITLE
[FIX] point_of_sale: do not mix order and refunds

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -508,8 +508,17 @@ export class PosOrder extends Base {
         }
         return false;
     }
+
     doNotAllowRefundAndSales() {
-        return false;
+        return true;
+    }
+
+    _isRefundAndSalesNotAllowed(values, options) {
+        return (
+            this._isRefundOrder() &&
+            this.doNotAllowRefundAndSales() &&
+            (!values.qty || values.qty > 0)
+        );
     }
 
     getSelectedOrderline() {

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -587,14 +587,10 @@ export class PosStore extends WithLazyGetterTrap {
         };
 
         // Handle refund constraints
-        if (
-            order.doNotAllowRefundAndSales() &&
-            order._isRefundOrder() &&
-            (!values.qty || values.qty > 0)
-        ) {
+        if (order._isRefundAndSalesNotAllowed(values, options)) {
             this.dialog.add(AlertDialog, {
-                title: _t("Refund and Sales not allowed"),
-                body: _t("It is not allowed to mix refunds and sales"),
+                title: _t("Oops.."),
+                body: _t("Ensure you validate the refund before taking another order."),
             });
             return;
         }

--- a/addons/pos_loyalty/static/src/app/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order.js
@@ -1461,4 +1461,11 @@ patch(PosOrder.prototype, {
         }
         return lines;
     },
+
+    _isRefundAndSalesNotAllowed(values, options) {
+        // Allow gift cards to be added to a refund
+        return (
+            super._isRefundAndSalesNotAllowed(values, options) && !options.eWalletGiftCardProgram
+        );
+    },
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When making a refund, we should not allow any more lines on it. It should just contain the items being refunded. This will be good for accounting.

Current behavior before PR:
A refund could include non-refunded items.

Desired behavior after PR is merged:
A refund will only contains the items being refunded.

task-4369388

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
