### PR TITLE
[FIX] portal: handle missing country

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -519,7 +519,7 @@
             <select name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}" t-att-disabled="None if partner_can_edit_vat else '1'">
                 <option value="">Country...</option>
                 <t t-foreach="countries or []" t-as="country">
-                    <option t-att-value="country.id" t-att-selected="country.id == int(country_id) if country_id else country.id == partner.country_id.id">
+                    <option t-att-value="country.id" t-att-selected="country.id == int(country_id) if country_id and country_id.isdigit() else country.id == partner.country_id.id">
                         <t t-esc="country.name" />
                     </option>
                 </t>


### PR DESCRIPTION
Reproduce
---
1. Set a fresh database, with just Website and Contacts apps installed.
2. Enable Developer Mode.
3. Create a new Internal User of type Portal, save and set a password.
4. In the Contacts app, create a new contact of type company and save.
5. Navigate to the automatically created contact of the Portal User we just created (at step 3).
6. Set the parent_id (Related Company) of this user contact to be the company contact we just created (at step 4) and save.
7. Log in with the Portal User we created (at step 3).
8. Navigate to /my/home and click Edit information (/my/account).
9. Without making any changes to the form (or even with changes, it's the same), click SAVE, 500: Internal Server Error will appear and the log will be

opw-4335353
