### PR TITLE
[MOV] account, google_calendar: inline 'search on user' tool

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5876,7 +5876,10 @@ class AccountMove(models.Model):
 
         # Search for partners using the user.
         if not senders:
-            senders = partners = list(self._mail_search_on_user(from_mail_addresses))
+            user_partners = self.env['res.users'].sudo().search(
+                [('email_normalized', 'in', from_mail_addresses)]
+            ).mapped('partner_id')
+            senders = partners = list(self.env['res.partner'].search([('id', 'in', user_partners.ids)]))
 
         if partners:
             # Check we are not in the case when an internal user forwarded the mail manually.

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -354,7 +354,10 @@ class GoogleCalendarSync(models.AbstractModel):
     @api.model
     def _get_sync_partner(self, emails):
         normalized_emails = [email_normalize(contact) for contact in emails if email_normalize(contact)]
-        user_partners = self.env['mail.thread']._mail_search_on_user(normalized_emails, extra_domain=[('share', '=', False)])
+        user_partners = self.env['res.users'].sudo().search(
+            [('email_normalized', 'in', normalized_emails), ('share', '=', False)]
+        ).mapped('partner_id')
+        user_partners = self.env['res.partner'].search([('id', 'in', user_partners.ids)])
         partners = list(user_partners)
         remaining = [email for email in normalized_emails if
                      email not in [partner.email_normalized for partner in partners]]


### PR DESCRIPTION
This small tool is used three times. It is used as a custom search in account and google_calendar, and usage in mail is going to be removed. Better inline its call and remove it.
