### PR TITLE
[IMP] mail: enhance accessibility of the quick reaction menu

### DIFF
--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -28,13 +28,10 @@ export class QuickReactionMenu extends Component {
         this.store = useState(useService("mail.store"));
         this.picker = useEmojiPicker(
             null,
-            { onSelect: this.toggleReaction.bind(this) },
+            { onSelect: this.toggleReaction.bind(this), class: "overflow-hidden rounded-2" },
             {
-                arrow: false,
-                position: "bottom-start",
+                position: "bottom-middle",
                 popoverClass: "o-mail-QuickReactionMenu-pickerPopover",
-                onPositioned: (el, { direction, variant }) =>
-                    el.classList.add(`o-popover--${direction[0]}${variant[0]}`),
             }
         );
         this.dropdown = useState(useDropdownState());
@@ -52,9 +49,12 @@ export class QuickReactionMenu extends Component {
         onPatched(() => void this.state.emojiLoaded);
     }
 
-    openPicker() {
-        this.dropdown.close();
-        this.picker.open(this.toggle);
+    togglePicker() {
+        if (this.picker.isOpen) {
+            this.picker.close();
+        } else {
+            this.picker.open(this.toggle);
+        }
     }
 
     getEmojiShortcode(emoji) {
@@ -81,6 +81,7 @@ export class QuickReactionMenu extends Component {
             this.frequentEmojiService.incrementEmojiUsage(emoji);
         }
         this.dropdown.close();
+        this.picker.close();
     }
 
     get attClass() {

--- a/addons/mail/static/src/core/common/quick_reaction_menu.scss
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.scss
@@ -7,7 +7,7 @@
 // Menu slide in effect
 //==========================================================
 
-$quick-reaction-menu-slide-in-duration: 0.25s;
+$quick-reaction-menu-slide-in-duration: 0.20s;
 
 @keyframes qrm-menuSlideInAnimation {
     to {
@@ -24,7 +24,7 @@ $quick-reaction-menu-slide-in-duration: 0.25s;
     gap: 1px;
     padding-top: map-get($spacers, 1) / 2;
     padding-bottom: map-get($spacers, 1) / 2;
-    transform: scaleX(0.2);
+    transform: scaleX(0.3);
     transform-origin: left;
     animation: qrm-menuSlideInAnimation $quick-reaction-menu-slide-in-duration cubic-bezier(0.6, 0, 0.4, 1) forwards;
 }
@@ -33,6 +33,7 @@ $quick-reaction-menu-slide-in-duration: 0.25s;
     &.bg-secondary {
         --bg-opacity: .35;
     }
+
     &:hover {
         background-color: rgba($o-action, .1);
         outline: 1px solid rgba($o-action, .2);
@@ -90,10 +91,11 @@ $quick-reaction-menu-emoji-pop-out-duration: 0.15s;
 // Picker grow effect
 //==========================================================
 
-$quick-reaction-menu-picker-grow-duration: 0.3s;
+$quick-reaction-menu-picker-grow-duration: 0.25s;
 
 @keyframes qrm-pickerGrowAnimation {
     to {
+        opacity: 1;
         transform: scale(1);
     }
 }
@@ -101,32 +103,26 @@ $quick-reaction-menu-picker-grow-duration: 0.3s;
 .o-mail-QuickReactionMenu-pickerPopover {
     background-color: unset;
     border: none;
+    box-shadow: none;
 
-    & .o-EmojiPicker {
-        transform: scale(0);
+    --originY: top;
+    --arrowTranslateY: 1px;
+
+    &[data-popper-placement="top"] {
+        --originY: bottom;
+        --arrowTranslateY: -1px;
     }
 
-    &[class*="o-popover--"] {
-        --fromY: top;
-        --fromX: unset;
+    & .popover-arrow {
+        z-index: 1 !important;
+        transform: translateY(var(--arrowTranslateY));
+    }
 
-        &[class*="o-popover--t"] {
-            --fromY: bottom;
-        }
-
-        &.o-popover--te,
-        &.o-popover--be {
-            --fromX: right;
-        }
-
-        &.o-popover--ts,
-        &.o-popover--bs {
-            --fromX: left;
-        }
-
-        & .o-EmojiPicker {
-            transform-origin: var(--fromY) var(--fromX);
-            animation: qrm-pickerGrowAnimation $quick-reaction-menu-picker-grow-duration ease forwards;
-        }
+    & .o-EmojiPicker {
+        opacity: 0;
+        border: var(--popover-border-width) solid var(--popover-border-color);
+        transform: scale(0.8);
+        transform-origin: var(--originY);
+        animation: qrm-pickerGrowAnimation $quick-reaction-menu-picker-grow-duration cubic-bezier(0.25, 0.8, 0.25, 1) forwards;
     }
 }

--- a/addons/mail/static/src/core/common/quick_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.xml
@@ -2,15 +2,15 @@
 <templates xml:space="preserve">
     <t t-name="mail.QuickReactionMenu">
         <Dropdown state="dropdown" manual="true" menuClass="`o-mail-QuickReactionMenu-popover shadow-none`" position="'top-middle'">
-            <button class="btn border-0 px-1 py-0" t-att-class="attClass" t-att-title="props.action.title" t-att-aria-label="props.action.title" t-on-click="onClick" t-ref="toggle">
+            <button class="btn border-0 px-1 py-0" t-att-class="attClass" t-att-title="props.action.title" t-att-aria-label="props.action.title" t-on-click="onClick">
                 <i class="fa-lg" t-att-class="props.action.icon"/>
             </button>
             <t t-set-slot="content">
-                <div class="o-mail-QuickReactionMenu d-flex align-items-center px-1 bg-view border rounded-pill shadow-sm">
+                <div class="o-mail-QuickReactionMenu d-flex align-items-center px-1 bg-view border rounded-pill shadow-sm" t-ref="toggle">
                     <button t-foreach="mostFrequentEmojis" t-as="emoji" t-key="emoji" class="o-mail-QuickReactionMenu-emoji o-mail-QuickReactionMenu-popEffect d-flex justify-content-center align-items-center rounded-circle btn lh-1 p-1" t-att-class="{ 'bg-secondary': reactedBySelf(emoji) }" t-att-title="getEmojiShortcode(emoji)" t-on-click="() => this.toggleReaction(emoji)">
                         <span class="fs-2" t-esc="emoji"/>
                     </button>
-                    <button class="o-mail-QuickReactionMenu-emojiPicker o-mail-QuickReactionMenu-popEffect o-mail-QuickReactionMenu-popEffect--smaller text-muted d-flex justify-content-center align-items-center btn btn-secondary rounded-circle" title="Open Emoji Picker" t-on-click="openPicker">
+                    <button class="o-mail-QuickReactionMenu-emojiPicker o-mail-QuickReactionMenu-popEffect o-mail-QuickReactionMenu-popEffect--smaller text-muted d-flex justify-content-center align-items-center btn btn-secondary rounded-circle" title="Toggle Emoji Picker" t-on-click="togglePicker">
                         <i class="oi oi-close"/>
                     </button>
                 </div>

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -548,7 +548,7 @@ test("Can open emoji picker after edit mode", async () => {
     await click(".o-mail-Message-moreMenu [title='Edit']");
     await click(".o-mail-Message a", { text: "save" });
     await click("[title='Add a Reaction']");
-    await click(".o-mail-QuickReactionMenu [title='Open Emoji Picker']");
+    await click(".o-mail-QuickReactionMenu [title='Toggle Emoji Picker']");
     await contains(".o-EmojiPicker");
 });
 
@@ -567,7 +567,7 @@ test("Can add a reaction", async () => {
     await start();
     await openDiscuss(channelId);
     await click("[title='Add a Reaction']");
-    await click(".o-mail-QuickReactionMenu [title='Open Emoji Picker']");
+    await click(".o-mail-QuickReactionMenu [title='Toggle Emoji Picker']");
     await click(".o-Emoji", { text: "😅" });
     await contains(".o-mail-MessageReaction", { text: "😅1" });
 });

--- a/addons/mail/static/tests/quick_reaction_menu/quick_reaction_menu.test.js
+++ b/addons/mail/static/tests/quick_reaction_menu/quick_reaction_menu.test.js
@@ -29,7 +29,7 @@ test("can toggle reaction from quick reaction menu", async () => {
     await contains(".o-mail-MessageReaction", { text: "👍1", count: 0 });
 });
 
-test("can open emoji picker from quick reaction menu", async () => {
+test("toggle emoji picker from quick reaction menu", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
@@ -37,11 +37,10 @@ test("can open emoji picker from quick reaction menu", async () => {
     await insertText(".o-mail-Composer-input", "Hello world!");
     await press("Enter");
     await click("[title='Add a Reaction']");
-    await click(".o-mail-QuickReactionMenu [title='Open Emoji Picker']");
+    await click(".o-mail-QuickReactionMenu [title='Toggle Emoji Picker']");
     await contains(".o-EmojiPicker");
-    await contains(".o-mail-QuickReactionMenu", { count: 0 });
-    await click("[title='Add a Reaction']");
-    await contains(".o-mail-QuickReactionMenu");
+    await click(".o-mail-QuickReactionMenu [title='Toggle Emoji Picker']");
+    await contains(".o-EmojiPicker", { count: 0 });
 });
 
 test("show default emojis when no frequent emojis are available", async () => {
@@ -58,11 +57,11 @@ test("show default emojis when no frequent emojis are available", async () => {
     for (const emoji of QuickReactionMenu.DEFAULT_EMOJIS) {
         await contains(".o-mail-QuickReactionMenu-emoji", { text: emoji });
     }
-    await click(".o-mail-QuickReactionMenu [title='Open Emoji Picker']");
+    await click(".o-mail-QuickReactionMenu [title='Toggle Emoji Picker']");
     await click(".o-Emoji", { text: "🤢" });
     await click("[title='Add a Reaction']");
     await contains(".o-mail-QuickReactionMenu-emoji", {
-        text: QuickReactionMenu.DEFAULT_EMOJIS[0],
+        text: QuickReactionMenu.DEFAULT_EMOJIS.at(-1),
         count: 0,
     });
     await contains(".o-mail-QuickReactionMenu-emoji", { text: "🤢" });

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -108,7 +108,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             run: "hover && click .o-mail-Message [title='Add a Reaction']",
         },
         {
-            trigger: ".o-mail-QuickReactionMenu [title='Open Emoji Picker']",
+            trigger: ".o-mail-QuickReactionMenu [title='Toggle Emoji Picker']",
             run: "click",
         },
         {

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -83,7 +83,7 @@ export const PICKER_PROPS = [
 ];
 
 export class EmojiPicker extends Component {
-    static props = PICKER_PROPS;
+    static props = [...PICKER_PROPS, "class?"];
     static template = "web.EmojiPicker";
 
     categories = null;

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="web.EmojiPicker">
-    <div class="o-EmojiPicker bg-view d-flex flex-column justify-content-center" t-att-class="{ 'align-items-center': emojis.length === 0, 'h-100': props.mobile }" t-on-click="onClick" t-on-keydown="onKeydown">
+    <div class="o-EmojiPicker bg-view d-flex flex-column justify-content-center" t-att-class="{ 'align-items-center': emojis.length === 0, 'h-100': props.mobile }" t-attf-class="{{props.class}}" t-on-click="onClick" t-on-keydown="onKeydown">
         <t t-if="emojis.length === 0">
             <span class="o-EmojiPicker-empty">😵‍💫</span>
             <span class="fs-5 text-muted">Failed to load emojis...</span>


### PR DESCRIPTION
The quick reaction menu allows users to quickly select from recently
used emojis to react to messages. Additionally, it provides the option
to open an emoji picker if a different emoji is needed.

Previously, the anchor for the emoji picker popover was the button
that opened the quick reaction menu, and the quick reaction popover
would close when the picker was opened.

This behavior caused the picker to open too far from the click that
triggered it, leading to unnecessary cursor and eye movement, which
was not user-friendly.

This PR addresses the issue by anchoring the emoji picker to the quick
reaction menu itself, resulting in a more natural and ergonomic
experience with reduced movement required.


| Before | After |
| ------------- | ------------- |
| ![qrm_before](https://github.com/user-attachments/assets/e6208bcb-b004-4a05-a42f-dfb7dd76dc84) | ![qrm_after](https://github.com/user-attachments/assets/ddc00c0f-ef2e-40b4-b756-8d989f844152)  |
