### PR TITLE
[FIX] website: fix scrolling issue on mobile devices

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -301,7 +301,10 @@ publicWidget.registry.StandardAffixedHeader = BaseAnimatedHeader.extend({
      * @override
      */
     destroy() {
+        this.options.wysiwyg?.odooEditor.observerUnactive("destroyStandardHeader");
         this.$el.css('transform', '');
+        this.el.classList.remove("o_transformed_not_affixed");
+        this.options.wysiwyg?.odooEditor.observerActive("destroyStandardHeader");
         this._super(...arguments);
     },
 
@@ -329,7 +332,11 @@ publicWidget.registry.StandardAffixedHeader = BaseAnimatedHeader.extend({
         const fixedUpdate = (this.fixedHeader !== mainPosScrolled);
         const showUpdate = (this.fixedHeaderShow !== reachPosScrolled);
 
+        this.options.wysiwyg?.odooEditor.observerUnactive("updateHeaderOnScroll");
         if (fixedUpdate || showUpdate) {
+            if (fixedUpdate && (reachPosScrolled || mainPosScrolled)) {
+                this.el.classList.add("o_transformed_not_affixed");
+            }
             this.$el.css('transform',
                 reachPosScrolled
                 ? `translate(0, -${this.topGap}px)`
@@ -344,9 +351,11 @@ publicWidget.registry.StandardAffixedHeader = BaseAnimatedHeader.extend({
 
         if (fixedUpdate) {
             this._toggleFixedHeader(mainPosScrolled);
+            this.el.classList.remove("o_transformed_not_affixed");
         } else if (showUpdate) {
             this._adaptToHeaderChange();
         }
+        this.options.wysiwyg?.odooEditor.observerActive("updateHeaderOnScroll");
     },
 });
 

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1450,6 +1450,20 @@ header {
     &.o_header_is_scrolled, &.o_transitioning.o_header_affixed {
         background-color: transparent !important;
     }
+    // When the page starts scrolling with the "standard" header, there’s a
+    // brief moment where the header has a "translate: transform" applied
+    // without being "affixed" yet. This causes the "off-canvas mobile" navbar
+    // to temporarily increase the page size, creating sometimes a scrolling bug
+    // that prevents further scrolling (e.g. "checkout shop" page on mobile
+    // device). To prevent this bug, we add a "display: none" to the "off-canvas
+    // mobile" navbar so it no longer affects the page dimensions. TODO: Check
+    // if this code can be removed once the "#wrapwrap" element is permanently
+    // removed.
+    &.o_transformed_not_affixed {
+        .o_navbar_mobile {
+            display: none;
+        }
+    }
 }
 
 @if o-website-value('header-template') == 'sidebar' {


### PR DESCRIPTION
Since [commit [1]](https://github.com/odoo/odoo/commit/189a7c96e6e26825dc05c0c6466576fe63aa091e), where the frontend scrolling was moved back out of the
'#wrapwrap', an issue sometimes occurs with the standard effect when
scrolling on mobile page.

Steps to reproduce:

- Go to a website with "e-commerce" installed.
- Use the devtools to display the website on a mobile device (note that
the bug may only occur on certain mobile devices, so it might be
necessary to test several to reproduce it).
- Add a product to the cart and go to the "/shop/checkout" page.
- Try scrolling down.
- Bug: scrolling is blocked.

The bug happens because, when the page starts scrolling with the
"standard" header, there’s a short moment when the header has a
"translate: transform" applied but is not yet "affixed." This creates a
new coordinate system for the header and affects its child elements,
like the "off-canvas mobile" navbar. As a result, the
"off-canvas mobile" navbar temporarily changes the page size, which
causes scrolling issues, especially on mobile devices.

To fix this, we add "display: none" to the "off-canvas mobile" navbar
during this short moment so it no longer affects the page size.

[opw-4303667](https://www.odoo.com/web#id=4303667&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)
[opw-4305493](https://www.odoo.com/web#id=4305493&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)