### PR TITLE
[FIX] hr_recruitment: keep tags upon candidate creation

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -199,7 +199,7 @@ class Applicant(models.Model):
     @api.depends('candidate_id')
     def _compute_categ_ids(self):
         for applicant in self:
-            applicant.categ_ids = applicant.candidate_id.categ_ids
+            applicant.categ_ids = applicant.candidate_id.categ_ids.ids + applicant.categ_ids.ids
 
     @api.depends('refuse_reason_id', 'date_closed')
     def _compute_application_status(self):

--- a/addons/hr_recruitment/tests/__init__.py
+++ b/addons/hr_recruitment/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_recruitment_process
 from . import test_recruitment
 from . import test_utm
 from . import test_recruitment_interviewer
+from . import test_applicant

--- a/addons/hr_recruitment/tests/test_applicant.py
+++ b/addons/hr_recruitment/tests/test_applicant.py
@@ -1,0 +1,58 @@
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+
+
+@tagged('hr_applicant')
+class TestHrApplicant(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.Category = self.env['hr.applicant.category']
+        self.Candidate = self.env['hr.candidate']
+        self.Applicant = self.env['hr.applicant']
+
+        self.category_1 = self.Category.create({'name': 'Category 1'})
+        self.category_2 = self.Category.create({'name': 'Category 2'})
+        self.category_3 = self.Category.create({'name': 'Category 3'})
+
+        self.candidate_0 = self.Candidate.create({
+            'partner_name': 'Candidate without tag',
+            'categ_ids': False
+        })
+        self.candidate_1 = self.Candidate.create({
+            'partner_name': 'Candidate with first and second tags',
+            'categ_ids': [self.category_1.id, self.category_2.id]
+        })
+        self.candidate_2 = self.Candidate.create({
+            'partner_name': 'Candidate with second tag',
+            'categ_ids': [self.category_2.id]
+        })
+        self.candidate_3 = self.Candidate.create({
+            'partner_name': 'Candidate with third tag',
+            'categ_ids': [self.category_3.id]
+        })
+
+        self.applicant = self.Applicant.create({
+            'partner_name': 'Applicant',
+            'candidate_id': self.candidate_0.id,
+            'categ_ids': False
+        })
+
+    def test_compute_categ_ids(self):
+        """
+            Test that applicant.categ_ids is set correctly based on candidate_id.
+        """
+        # Applicant tags: None
+        self.assertFalse(self.applicant.categ_ids)
+        self.applicant.candidate_id = self.candidate_1.id
+        # Applicant tags: 1, 2
+        self.assertCountEqual(self.applicant.categ_ids.ids, [self.category_1.id, self.category_2.id])
+        self.applicant.candidate_id = self.candidate_2.id
+        # Applicant tags: 1, 2
+        self.assertCountEqual(self.applicant.categ_ids.ids, [self.category_1.id, self.category_2.id])
+        self.applicant.candidate_id = self.candidate_3.id
+        # Applicant tags: 1, 2, 3
+        self.assertCountEqual(self.applicant.categ_ids.ids, [self.category_1.id, self.category_2.id, self.category_3.id])
+        self.applicant.candidate_id = self.candidate_0.id
+        # Applicant tags: 1, 2, 3
+        self.assertCountEqual(self.applicant.categ_ids.ids, [self.category_1.id, self.category_2.id, self.category_3.id])


### PR DESCRIPTION
Issue:
When creating an Application, creating a new Candidate removes all tags already in use.

Steps to reproduce:
- Install Recruitment app
- Create a new Application
- Add a tag
- Create a new Candidate

Cause:
The tags of an Application are stored in the 'categ_ids' variable. This variable is changed by the '_compute_categ_ids' method, which sets them to those of the Candidate. Since categ_ids is empty for new Candidates, as of right now, this method is effectively removing all tags for new Candidates.

Desired Behaviour:
Adding a Candidate should add it's tags to the Applicant's.
Removing a Candidate should not change the Applicant's tags.

Ticket:
opw-4351837

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
