### PR TITLE
[FIX] calendar: don't send reminders for past events

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -164,6 +164,7 @@ class AlarmManager(models.AbstractModel):
                AND "event"."active"
                AND "event"."start" - CAST("alarm"."duration" || ' ' || "alarm"."interval" AS Interval) >= %s
                AND "event"."start" - CAST("alarm"."duration" || ' ' || "alarm"."interval" AS Interval) < now() at time zone 'utc'
+               AND "event"."stop" > now() at time zone 'utc'
              )''', [alarm_type, lastcall])
 
         events_by_alarm = {}


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Schedule the "Calendar: Event Reminder" to run once a day;
2. create an event that started 2 hours ago, and ended 1 hour ago;
3. run the event reminder cron.

Issue
-----
A reminder email is sent, event though the event has passed.

Cause
-----
The alarm manager doesn't check whether the reminders it sends are still relevant.

Solution
--------
When looking querying events to send reminders for, ensure their `stop` date is before the current time.

opw-4191612
