### PR TITLE
[FIX] account: make accounting fields not required

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -538,6 +538,7 @@ class ResPartner(models.Model):
     duplicated_bank_account_partners_count = fields.Integer(
         compute='_compute_duplicated_bank_account_partners_count',
     )
+    is_coa_installed = fields.Boolean(store=False, default=lambda partner: bool(partner.env.company.chart_template_id))
 
     def _compute_bank_count(self):
         bank_data = self.env['res.partner.bank']._read_group([('partner_id', 'in', self.ids)], ['partner_id'], ['partner_id'])

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -222,9 +222,10 @@
                                 />
                             </group>
                             <group string="Accounting Entries" name="accounting_entries" groups="account.group_account_readonly">
+                                <field name="is_coa_installed" invisible="1"/>
                                 <field name="currency_id" invisible="1"/>
-                                <field name="property_account_receivable_id"/>
-                                <field name="property_account_payable_id"/>
+                                <field name="property_account_receivable_id" attrs="{'required': [('is_coa_installed', '=', True)]}"/>
+                                <field name="property_account_payable_id" attrs="{'required': [('is_coa_installed', '=', True)]}"/>
                             </group>
                             <group string="Credit Limits"
                                    name="credit_limits"


### PR DESCRIPTION
When having Accounting installed with a company without chart template,
we can not create a partner as bot `property_account_payable_id` and
`property_account_receivable_id` are required.

With this commit we add a non stored computed field to handle the
`required` attribute on the partner view.

Note: a computed field with an `api.depends_context('company')` could no be used, because it wasn't not triggered at partner creation. It's a known ORM limitation.

opw-4323694
