### PR TITLE
[REF] web: simplify `reload` and `reload_context` actions

### DIFF
--- a/addons/web/static/src/webclient/actions/client_actions.js
+++ b/addons/web/static/src/webclient/actions/client_actions.js
@@ -43,7 +43,6 @@ function reload(env, action) {
         }
     }
 
-    env.bus.trigger("CLEAR-CACHES");
     router.pushState(route, { replace: true, reload: true });
 }
 
@@ -70,13 +69,10 @@ async function home() {
 registry.category("actions").add("home", home);
 
 /**
- * Client action to refresh the session context (making sure
- * HTTP requests will have the right one) then reload the
- * whole interface.
+ * Client action to refresh the session context (making sure HTTP requests will
+ * have the right one). It simply reloads the page.
  */
 async function reloadContext(env, action) {
-    // side-effect of get_session_info is to refresh the session context
-    await rpc("/web/session/get_session_info");
     reload(env, action);
 }
 


### PR DESCRIPTION
Historically [1], the `reload` client action didn't **always** produce a page reload. For that reason, it was necessary to manually clear the (RAM) caches, to ensure that fresh and up-to-date data would be used after the "reload". Since wowl [2], this is no longer necessary as the `reload` client action always produces a page reload, which implies that RAM caches are cleared.

The same observation applies to the `reload_context` action, for which we manually reloaded the `session_info` before reloading. As the page is always reloaded now, we get the new `session_info` with it.

[1] odoo/odoo@79c9f0a7a52b0d88339efcb69296ab3b66f444
[2] odoo/odoo@79c89438a787e96a378d1ad1606c314aa336a32a

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
