### PR TITLE
[IMP] im_livechat: livechat operators expertise tags

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -32,6 +32,7 @@ Help your customers with this chat, and analyse their feedback.
         "views/im_livechat_channel_views.xml",
         "views/im_livechat_channel_templates.xml",
         "views/im_livechat_chatbot_templates.xml",
+        "views/im_livechat_expertise_views.xml",
         "views/res_users_views.xml",
         "views/digest_views.xml",
         "views/webclient_templates.xml",

--- a/addons/im_livechat/models/__init__.py
+++ b/addons/im_livechat/models/__init__.py
@@ -7,6 +7,7 @@ from . import chatbot_script_step
 from . import res_users
 from . import res_partner
 from . import im_livechat_channel
+from . import im_livechat_expertise
 from . import discuss_channel
 from . import discuss_channel_member
 from . import mail_message

--- a/addons/im_livechat/models/im_livechat_expertise.py
+++ b/addons/im_livechat/models/im_livechat_expertise.py
@@ -1,0 +1,51 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from collections import defaultdict
+
+from odoo import Command, fields, models
+
+
+class Im_LivechatExpertise(models.Model):
+    """Expertise of Live Chat users."""
+
+    _name = "im_livechat.expertise"
+    _description = "Live Chat Expertise"
+    _order = "name"
+
+    name = fields.Char("Name", required=True, translate=True)
+    user_ids = fields.Many2many(
+        "res.users",
+        string="Operators",
+        compute="_compute_user_ids",
+        inverse="_inverse_user_ids",
+        store=False,
+    )
+
+    _name_unique = models.UniqueIndex("(name)")
+
+    def _compute_user_ids(self):
+        users_by_expertise = self._get_users_by_expertise()
+        for expertise in self:
+            expertise.user_ids = users_by_expertise[expertise]
+
+    def _inverse_user_ids(self):
+        users_by_expertise = self._get_users_by_expertise()
+        for expertise in self:
+            for user in expertise.user_ids - users_by_expertise[expertise]:
+                # sudo: res.users: livechat manager can add expertise on users
+                user.sudo().livechat_expertise_ids = [Command.link(expertise.id)]
+            for user in users_by_expertise[expertise] - expertise.user_ids:
+                # sudo: res.users: livechat manager can remove expertise on users
+                user.sudo().livechat_expertise_ids = [Command.unlink(expertise.id)]
+
+    def _get_users_by_expertise(self):
+        users_by_expertise = defaultdict(lambda: self.env["res.users"])
+        settings_domain = [("livechat_expertise_ids", "in", self.ids)]
+        # sudo: res.users.settings: livechat manager can read expertise on users
+        user_settings = self.env["res.users.settings"].sudo().search(settings_domain)
+        for user_setting in user_settings:
+            for expertise in user_setting.livechat_expertise_ids:
+                users_by_expertise[expertise] |= user_setting.user_id
+        for expertise, users in users_by_expertise.items():
+            users_by_expertise[expertise] = users.with_prefetch(user_settings.user_id.ids)
+        return users_by_expertise

--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -12,15 +12,32 @@ class ResUsers(models.Model):
 
     livechat_username = fields.Char(string='Livechat Username', compute='_compute_livechat_username', inverse='_inverse_livechat_username', store=False)
     livechat_lang_ids = fields.Many2many('res.lang', string='Livechat Languages', compute='_compute_livechat_lang_ids', inverse='_inverse_livechat_lang_ids', store=False)
+    livechat_expertise_ids = fields.Many2many(
+        "im_livechat.expertise",
+        string="Live Chat Expertise",
+        compute="_compute_livechat_expertise_ids",
+        inverse="_inverse_livechat_expertise_ids",
+        store=False,
+        help="When forwarding live chat conversations, the chatbot will prioritize users with matching expertise.",
+    )
     has_access_livechat = fields.Boolean(compute='_compute_has_access_livechat', string='Has access to Livechat', store=False, readonly=True)
 
     @property
     def SELF_READABLE_FIELDS(self):
-        return super().SELF_READABLE_FIELDS + ['livechat_username', 'livechat_lang_ids', 'has_access_livechat']
+        return super().SELF_READABLE_FIELDS + [
+            "has_access_livechat",
+            "livechat_expertise_ids",
+            "livechat_lang_ids",
+            "livechat_username",
+        ]
 
     @property
     def SELF_WRITEABLE_FIELDS(self):
-        return super().SELF_WRITEABLE_FIELDS + ['livechat_username', 'livechat_lang_ids']
+        return super().SELF_WRITEABLE_FIELDS + [
+            "livechat_expertise_ids",
+            "livechat_lang_ids",
+            "livechat_username",
+        ]
 
     @api.depends('res_users_settings_id.livechat_username')
     def _compute_livechat_username(self):
@@ -42,6 +59,17 @@ class ResUsers(models.Model):
             settings = self.env['res.users.settings']._find_or_create_for_user(user)
             settings.livechat_lang_ids = user.livechat_lang_ids
 
+    @api.depends("res_users_settings_id.livechat_expertise_ids")
+    def _compute_livechat_expertise_ids(self):
+        for user in self:
+            user.livechat_expertise_ids = user.res_users_settings_id.livechat_expertise_ids
+
+    def _inverse_livechat_expertise_ids(self):
+        for user in self:
+            settings = self.env["res.users.settings"]._find_or_create_for_user(user)
+            settings.livechat_expertise_ids = user.livechat_expertise_ids
+
+    @api.depends("groups_id")
     def _compute_has_access_livechat(self):
         for user in self.sudo():
             user.has_access_livechat = user.has_group('im_livechat.im_livechat_group_user')

--- a/addons/im_livechat/models/res_users_settings.py
+++ b/addons/im_livechat/models/res_users_settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
@@ -10,3 +9,8 @@ class ResUsersSettings(models.Model):
     livechat_username = fields.Char("Livechat Username", help="This username will be used as your name in the livechat channels.")
     livechat_lang_ids = fields.Many2many(comodel_name='res.lang', string='Livechat languages',
                             help="These languages, in addition to your main language, will be used to assign you to Live Chat sessions.")
+    livechat_expertise_ids = fields.Many2many(
+        "im_livechat.expertise",
+        string="Live Chat Expertise",
+        help="When forwarding live chat conversations, the chatbot will prioritize users with matching expertise.",
+    )

--- a/addons/im_livechat/security/ir.model.access.csv
+++ b/addons/im_livechat/security/ir.model.access.csv
@@ -11,6 +11,8 @@ access_livechat_channel_rule_portal,im_livechat.channel.rule,model_im_livechat_c
 access_livechat_channel_rule_employee,im_livechat.channel.rule,model_im_livechat_channel_rule,base.group_user,1,0,0,0
 access_livechat_channel_rule_user,im_livechat.channel.rule,model_im_livechat_channel_rule,im_livechat_group_user,1,1,1,0
 access_livechat_channel_rule_manager,im_livechat.channel.rule,model_im_livechat_channel_rule,im_livechat_group_manager,1,1,1,1
+access_livechat_expertise_internal_user,im_livechat.expertise.internal.user,model_im_livechat_expertise,base.group_user,1,0,0,0
+access_livechat_expertise_livechat_manager,im_livechat.expertise.manager,model_im_livechat_expertise,im_livechat_group_manager,1,1,1,1
 access_chatbot_script_user,chatbot.script.user,model_chatbot_script,im_livechat_group_user,1,1,1,1
 access_chatbot_script_step_user,chatbot.script.step.user,model_chatbot_script_step,im_livechat_group_user,1,1,1,1
 access_chatbot_script_answer,chatbot.script.answer,model_chatbot_script_answer,,0,0,0,0

--- a/addons/im_livechat/views/chatbot_script_step_views.xml
+++ b/addons/im_livechat/views/chatbot_script_step_views.xml
@@ -21,6 +21,7 @@
                                 required="step_type != 'forward_operator'"/>
                             <field name="chatbot_script_id" invisible="1"/>
                             <field name="step_type"/>
+                            <field name="operator_expertise_ids" widget="many2many_tags" options="{'edit_tags': True}" invisible="step_type != 'forward_operator'"/>
                             <field name="triggering_answer_ids" widget="chatbot_triggering_answers_widget"
                                     options="{'no_create': True}">
                                 <list>

--- a/addons/im_livechat/views/im_livechat_expertise_views.xml
+++ b/addons/im_livechat/views/im_livechat_expertise_views.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+        <record id="im_livechat_expertise_view_list" model="ir.ui.view">
+            <field name="name">im.livechat.expertise.list</field>
+            <field name="model">im_livechat.expertise</field>
+            <field name="arch" type="xml">
+                <list editable="bottom">
+                    <field name="name"/>
+                    <field name="user_ids" widget="many2many_tags" options="{'no_create': True}"/>
+                </list>
+            </field>
+        </record>
+
+        <record id="im_livechat_expertise_view_form" model="ir.ui.view">
+            <field name="name">im.livechat.expertise.form</field>
+            <field name="model">im_livechat.expertise</field>
+            <field name="arch" type="xml">
+                <form>
+                    <sheet>
+                        <group>
+                            <field name="name"/>
+                            <field name="user_ids" widget="many2many_tags" options="{'no_create': True}"/>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="expertise_action" model="ir.actions.act_window">
+            <field name="name">Expertise</field>
+            <field name="res_model">im_livechat.expertise</field>
+            <field name="view_mode">list,form</field>
+        </record>
+
+        <menuitem
+            id="expertise_menu"
+            name="Expertise"
+            parent="livechat_config"
+            action="im_livechat.expertise_action"
+            sequence="25"
+        />
+    </data>
+</odoo>

--- a/addons/im_livechat/views/res_users_views.xml
+++ b/addons/im_livechat/views/res_users_views.xml
@@ -16,6 +16,7 @@
                         invisible="not has_access_livechat"
                         options="{'no_create': True, 'no_edit': True, 'no_quick_create': True}"
                         widget="many2many_tags"/>
+                    <field name="livechat_expertise_ids" widget="many2many_tags" options="{'no_create': True, 'no_create_edit': True}" invisible="not has_access_livechat"/>
                 </xpath>
             </field>
         </record>
@@ -34,6 +35,7 @@
                             <field name="livechat_lang_ids" string="Online Chat Language"
                                 options="{'no_create': True, 'no_edit': True, 'no_quick_create': True}"
                                 widget="many2many_tags"/>
+                            <field name="livechat_expertise_ids" widget="many2many_tags" options="{'no_create_edit': True}"/>
                         </group>
                     </xpath>
             </field>

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -19,13 +19,14 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - _compute_im_status (_read_format/_to_store)
     #       - _get_on_leave_ids (_compute_im_status override)
     #       - fetch res_users (_to_store)
-    #   5: settings:
+    #   6: settings:
     #       - search (_find_or_create_for_user)
     #       - fetch res_partner (_format_settings: display_name of user_id because classic load)
     #       - fetch res_users_settings (_format_settings)
     #       - search res_users_settings_volumes (_format_settings)
     #       - search res_lang_res_users_settings_rel (_format_settings)
-    _query_count_init_store = 11
+    #       - search im_livechat_expertise_res_users_settings_rel (_format_settings)
+    _query_count_init_store = 12
     # Queries for _query_count_init_messaging (in order):
     #   1: insert res_device_log
     #   1: fetch res_users (for current user, first occurence _get_channels_as_member of _init_messaging)
@@ -396,6 +397,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "id": self.env["res.users.settings"]._find_or_create_for_user(self.users[0]).id,
                     "is_discuss_sidebar_category_channel_open": True,
                     "is_discuss_sidebar_category_chat_open": True,
+                    "livechat_expertise_ids": [],
                     "livechat_lang_ids": [],
                     "livechat_username": False,
                     "push_to_talk_key": False,

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -18,16 +18,16 @@ class TestPerfSessionInfo(common.HttpCase):
         self.authenticate(user.login, "info")
 
         self.env.registry.clear_all_caches()
-        # cold ormcache (only web: 42, all module: 112)
-        with self.assertQueryCount(112):
+        # cold ormcache (only web: 42, all module: 113)
+        with self.assertQueryCount(113):
             self.url_open(
                 "/web/session/get_session_info",
                 data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),
                 headers={"Content-Type": "application/json"},
             )
 
-        # cold fields cache - warm ormcache (only web: 6, all module: 22)
-        with self.assertQueryCount(22):
+        # cold fields cache - warm ormcache (only web: 6, all module: 23)
+        with self.assertQueryCount(23):
             self.url_open(
                 "/web/session/get_session_info",
                 data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),


### PR DESCRIPTION
\* = test_discuss_full, web

This commit introduces expertise tags for the Live Chat feature.
Each user can now have specific Live Chat Expertise tags.

In the "Forward to Operator" chatbot step expertise tags can be defined.

While language remains the primary filter, expertise tags allow further filtering of operators according to the user's needs.

task-4354297