### PR TITLE
[FIX] web_editor: fix stripped domain of links

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -306,6 +306,8 @@ export class Link extends Component {
         var doStripDomain = this._doStripDomain();
         if (this.state.url.indexOf(location.origin) === 0 && doStripDomain) {
             this.state.url = this.state.url.slice(location.origin.length);
+        } else {
+            this.state.url = url
         }
         var allWhitespace = /\s+/gi;
         var allStartAndEndSpace = /^\s+|\s+$/gi;

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -183,6 +183,7 @@ export class LinkDialog extends Link {
      * @override
      */
     _onURLInput() {
+        super._onURLInput(...arguments);
         this.$el.find('#o_link_dialog_url_input').closest('.o_url_input').removeClass('o_has_error').find('.form-control, .form-select').removeClass('is-invalid');
         this._adaptPreview();
     }


### PR DESCRIPTION
**Steps to reproduce:**
- Create a new mailing
- Add a link with "Link" widget
- Enter a link with the same domain (e.g. a link to an event)
- Insert the link

**Issue:**
The link is automatically converted to a relative link. This may cause some issue in a multi-company environment where each company has a website (i.e. has its own domain url) and "web.base.url" is configured with the domain of the other company.

**Cause 1:**
The "Autoconvert to relative link" checkbox is never displayed and is always applied as it is checked by default. The display toggle is done in "_onURLInput" function of "Link" component, but it is never called by the override function in "LinkDialog".

**Cause 2:**
Even if the "Autoconvert to relative link" checkbox is displayed, the link will be stripped from its domain as soon as an URL is inputted and save in "this.state.url".
When the checkbox is unchecked, "this.state.url" stays unchanged because it is not possible to retrieve the stripped domain from "this.state.url".

**Solution 1:**
Call the super function in "_onURLInput" function of "LinkDialog".

**Solution 2:**
Retrieve the URL from the input when the domain should not be stripped and update "this.state.url" with it.

opw-4357095



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
