### PR TITLE
[FIX] core: use the original constraint definition

### DIFF
--- a/odoo/addons/base/tests/test_sql.py
+++ b/odoo/addons/base/tests/test_sql.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import BaseCase
-from odoo.tools import SQL
+from psycopg2.errors import CheckViolation
+
+from odoo.tests.common import BaseCase, TransactionCase
+from odoo.tools import SQL, mute_logger, sql
 
 
 class TestSQL(BaseCase):
@@ -40,6 +42,14 @@ class TestSQL(BaseCase):
 
         with self.assertRaises(KeyError):
             SQL("SELECT id FROM table WHERE foo=%(one)s AND bar=%(two)s", one=1, to=2)
+
+    def test_escape_pct(self):
+        sql = SQL("'%%' || %s", 'a')
+        self.assertEqual(sql.code, "'%%' || %s")
+        sql = SQL("'%'")
+        self.assertEqual(sql.code, "'%%'")
+        with self.assertRaises(TypeError):
+            SQL("'%%' || %s")
 
     def test_sql_equality(self):
         sql1 = SQL("SELECT id FROM table WHERE foo=%s", 42)
@@ -158,3 +168,18 @@ class TestSQL(BaseCase):
             repr(sql),
             """SQL('SELECT "id" FROM "table" WHERE "table"."foo"=%s AND "table"."bar"=%s', 1, 2)"""
         )
+
+
+class TestSqlTools(TransactionCase):
+
+    def test_add_constraint(self):
+        definition = "CHECK (name !~ '%')"
+        sql.add_constraint(self.env.cr, 'res_bank', 'test_constraint_dummy', definition)
+
+        # ensure the constraint with % works and it's in the DB
+        with self.assertRaises(CheckViolation), mute_logger('odoo.sql_db'):
+            self.env['res.bank'].create({'name': r'10% bank'})
+
+        # ensure the definitions match
+        db_definition = sql.constraint_definition(self.env.cr, 'res_bank', 'test_constraint_dummy')
+        self.assertEqual(definition, db_definition)

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -350,7 +350,6 @@ class Cursor(BaseCursor):
 
         start = real_time()
         try:
-            params = params or None
             res = self._obj.execute(query, params)
         except Exception as e:
             if log_exceptions:

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1869,13 +1869,10 @@ def format_frame(frame) -> str:
 
 def named_to_positional_printf(string: str, args: Mapping) -> tuple[str, tuple]:
     """ Convert a named printf-style format string with its arguments to an
-    equivalent positional format string with its arguments. This implementation
-    does not support escaped ``%`` characters (``"%%"``).
+    equivalent positional format string with its arguments.
     """
-    if '%%' in string:
-        raise ValueError(f"Unsupported escaped '%' in format string {string!r}")
     pargs = _PrintfArgs(args)
-    return string % pargs, tuple(pargs.values)
+    return string.replace('%%', '%%%%') % pargs, tuple(pargs.values)
 
 
 class _PrintfArgs:


### PR DESCRIPTION
If we replace the original definition then the check between the existing definition and the original one will always fail, thus we are always removing and re-adding the same constraint. https://github.com/odoo/odoo/blob/5ba361ddffa757cf60968f37180c7fd1304b3fd4/odoo/models.py#L3209

Replacing `%` by `%%` works for `LIKE` operator because they are equivalent. Since they are sent as-is to the DB the constraint could actually be plainly wrong.

```sql
test_17=> SELECT coalesce(d.description, pg_get_constraintdef(c.oid))
   FROM pg_constraint c
   JOIN pg_class t
     ON t.oid = c.conrelid
   LEFT JOIN pg_description d
     ON c.oid = d.objoid
  WHERE t.relname = 'ir_model_fields'
    AND conname = 'ir_model_fields_name_manual_field'
+------------------------------------------------+
| coalesce                                       |
|------------------------------------------------|
| CHECK (state != 'manual' OR name LIKE 'x\_%%') |
+------------------------------------------------+
```

Example where the definition sent to the DB is wrong:
```py
class A(models.Model):
    _inherit = "res.users"

    _sql_constraints = [("test_constraint", "CHECK (login !~ '%')", "Cannot have % in login")]
```
```sql
test_17=> \d res_users
...
Check constraints:
    "res_users_test_constraint" CHECK (login::text !~ '%%'::text)
...
```

Since 18.0, we adapt the `SQL` object so that composition with code containing '%' works and we accept single unescaped '%' if there is no arguments.

X-original-commit: 692ad8e8a969981c6171b7bef34dfee5f0b007f8

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
