### PR TITLE
[FIX] pos_mrp: handle zero quantity in price unit calculation

### DIFF
--- a/addons/pos_mrp/models/pos_order.py
+++ b/addons/pos_mrp/models/pos_order.py
@@ -27,6 +27,6 @@ class PosOrder(models.Model):
         for comp in components:
             price_unit = super()._get_pos_anglo_saxon_price_unit(comp[0].product_id, partner_id, comp[1]['qty'])
             price_unit = comp[0].product_id.uom_id._compute_price(price_unit, comp[0].product_uom_id)
-            qty_per_kit = comp[1]['qty'] / bom.product_qty / quantity
+            qty_per_kit = comp[1]['qty'] / bom.product_qty / (quantity or 1)
             total_price_unit += price_unit * qty_per_kit
         return total_price_unit


### PR DESCRIPTION
Before this commit, if the orderline quantity was zero, it would cause a division by zero error when calculating the anglo-saxon price unit.

opw-4370055

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
