### PR TITLE
[FIX] portal_rating: missed default_rating_value

### DIFF
--- a/addons/portal_rating/static/src/js/portal_rating_composer.js
+++ b/addons/portal_rating/static/src/js/portal_rating_composer.js
@@ -127,7 +127,7 @@ const RatingPopupComposer = publicWidget.Widget.extend({
                 (data["mail.message"] && data["mail.message"][0].body.replace(/<[^>]+>/g, "")),
             default_message_id: data.default_message_id || data["mail.message"][0].id,
             default_attachment_ids: data.default_attachment_ids || data["ir.attachment"],
-            default_rating_value: data.default_rating_value || this.rating_value,
+            default_rating_value: data.default_rating_value ?? this.rating_value,
         };
         Object.assign(data, defaultOptions);
         this.options = Object.assign(this.options, data);


### PR DESCRIPTION
Since odoo/odoo#172475, in order to use the mail post message route in the portal, we have adjusted the required data in the public widget regarding where the data comes from. We assume that when a user edits a message in the portal rating composer, there is always a rating value associated with that message. There is a rare corner case where this doesn't happen. 
Steps to reproduce:
- Login as an internal user (admin or demo)
- Comment on a course in the frontend  (website slide)
- Go to the same course in the backend
- Add another comment
- Go back to the frontend and click on the edit review button
- After submitting the edited message, there is a rendering error because the `default_rating_value` is undefined

This commit changes the condition so that if only the server-side `default_rating_value` is undefined, the default_rating_value will be set by the widget's rating_value.
