### PR TITLE
[IMP] stock_account: grouped valuation entries

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -107,9 +107,12 @@ class StockMove(models.Model):
     def _generate_valuation_lines_data(self, partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, svl_id, description):
         """ Overridden from stock_account to support amount_currency on valuation lines generated from po
         """
-        self.ensure_one()
 
         rslt = super(StockMove, self)._generate_valuation_lines_data(partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, svl_id, description)
+        if self:
+            self.ensure_one()
+        else:
+            return rslt
         purchase_currency = self.purchase_line_id.currency_id
         company_currency = self.company_id.currency_id
         if not self.purchase_line_id or purchase_currency == company_currency:

--- a/addons/stock_account/__manifest__.py
+++ b/addons/stock_account/__manifest__.py
@@ -43,6 +43,7 @@ Dashboard / Reports for Warehouse Management includes:
         'wizard/stock_valuation_layer_revaluation_views.xml',
         'wizard/stock_quantity_history.xml',
         'report/account_invoice_report_view.xml',
+        'views/account_move_views.xml',
     ],
     'installable': True,
     'auto_install': True,

--- a/addons/stock_account/data/stock_account_data.xml
+++ b/addons/stock_account/data/stock_account_data.xml
@@ -4,5 +4,15 @@
         <function model="ir.default" name="set" eval="('product.category', 'property_cost_method', 'standard')"/>
         <function model="ir.default" name="set" eval="('product.category', 'property_valuation', 'manual_periodic')"/>
     </data>
+    <data>
+        <record id="action_stock_valuation_entry" model="ir.actions.server">
+            <field name="name">Create Stock Valuation Entry</field>
+            <field name="model_id" ref="stock_account.model_stock_valuation_layer"/>
+            <field name="groups_id" eval="[(4, ref('account.group_account_user'))]"/>
+            <field name="binding_model_id" ref="stock_account.model_stock_valuation_layer"/>
+            <field name="state">code</field>
+            <field name="code">action = records._create_grouped_accounting_entries()</field>
+        </record>
+    </data>
 </odoo>
 

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -243,6 +243,18 @@ class AccountMove(models.Model):
     def _get_invoiced_lot_values(self):
         return []
 
+    def action_open_svls(self):
+        self.ensure_one()
+        action_dict = self.env.ref('stock_account.stock_valuation_layer_action')._get_action_dict()
+        action_dict['context'] = {
+            'pivot_column_groupby': ['create_date:month'],
+            'pivot_row_groupby': ['categ_id'],
+            'pivot_measures': ['remaining_qty', 'remaining_value'],
+            'graph_groupbys': ['create_date:day'],
+            'search_default_account_move_id': self.id,
+        }
+        return action_dict
+
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'

--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -16,3 +16,9 @@ class ResCompany(models.Model):
         default='standard',
         required=True,
     )
+
+    def action_create_am_svls(self):
+        self.ensure_one()
+        svls = self.env['stock.valuation.layer'].search([('company_id', '=', self.id)])
+        svls._create_grouped_accounting_entries()
+

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -276,6 +276,8 @@ class StockValuationLayer(models.Model):
             move = svl.stock_move_id
             if not move:
                 move = svl.stock_valuation_layer_id.stock_move_id
+            if not move:
+                continue # TODO: if there is a revaluation or something, it should also go into this account move
             am_vals = move.with_company(svl.company_id)._account_entry_move(svl.quantity, svl.description, svl.id, svl.value)
             for am_val in am_vals:
                 journal = am_val['journal_id']

--- a/addons/stock_account/views/account_move_views.xml
+++ b/addons/stock_account/views/account_move_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_move_form_svl_inherit" model="ir.ui.view">
+        <field name="name">account.move.form</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
+                <button name="action_open_svls"
+                    invisible="not stock_valuation_layer_ids"
+                    class="oe_stat_button"
+                    icon="fa-cube"
+                    type="object">
+                    Valuation
+                </button>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/stock_account/views/res_company_views.xml
+++ b/addons/stock_account/views/res_company_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="expense_account_id" position="after">
                 <field name="cost_method"/>
+                <button name="action_create_am_svls" type="object" string="Create SVLS"/>
             </field>
         </field>
     </record>

--- a/addons/stock_account/views/stock_valuation_layer_views.xml
+++ b/addons/stock_account/views/stock_valuation_layer_views.xml
@@ -144,6 +144,7 @@
                 <field name="product_tmpl_id" />
                 <field name="warehouse_id" groups="stock.group_stock_multi_warehouses"/>
                 <field name="company_id" groups="base.group_multi_company"/>
+                <field name="account_move_id"/>
                 <separator/>
                 <filter string="Incoming" name="incoming" domain="[('stock_move_id.location_id.usage', 'not in', ('internal', 'transit')), ('stock_move_id.location_dest_id.usage', 'in', ('internal', 'transit'))]"/>
                 <filter string="Outgoing" name="outgoing" domain="[('stock_move_id.location_id.usage', 'in', ('internal', 'transit')), ('stock_move_id.location_dest_id.usage', 'not in', ('internal', 'transit'))]"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The idea is to have less accounting entries, but still have the possibility to generate them semi-automatically by pushing a button: 
![image](https://github.com/user-attachments/assets/24f2aba6-55c9-4ac5-86b2-cd4160ebd367)

This is a POC.  It is just generates accounting entries for where there have not been created any in draft.  (as misc entry)


Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
