### PR TITLE
[IMP] event: display timezone date on event form

### DIFF
--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -66,6 +66,8 @@
                             <field name="date_begin" string="Date" widget="daterange" options="{'end_date_field': 'date_end'}" />
                             <field name="date_end" invisible="1" />
                             <field name="date_tz"/>
+                            <field name="date_begin_located" string="Start Date in Timezone" invisible="date_tz == context.tz"/>
+                            <field name="date_end_located" string="End Date in Timezone" invisible="date_tz == context.tz"/>
                             <field name="lang"/>
                             <field name="event_type_id" string="Template"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_quick_create': True}"/>


### PR DESCRIPTION
### Issue:

Currently, the fields `date_begin`, `date_end` and `date_tz` (timezone) are all visible on the event.event form. However, when you create an event at a given time and set a timezone it should not be interpreted as this event is planned at that time in that timzone but rather: this event is planned at that time for the current user time and should the date displayed on the website should be the date of the timezone.

### Improvement:

We display both dates in the selected timezone when the values might not match.

opw-4323142
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
