### PR TITLE
[REF] mail: make channel methods private

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -876,7 +876,7 @@ class CalendarEvent(models.Model):
         self.videocall_channel_id.channel_change_description(self.recurrence_id.name if self.recurrency else self.display_time)
 
     def _create_videocall_channel_id(self, name, partner_ids):
-        videocall_channel = self.env['discuss.channel'].create_group(partner_ids, default_display_mode='video_full_screen', name=name)
+        videocall_channel = self.env['discuss.channel']._create_group(partner_ids, default_display_mode='video_full_screen', name=name)
         # if recurrent event, set channel to all other records of the same recurrency
         if self.recurrency:
             recurrent_events_without_channel = self.env['calendar.event'].search([

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -330,7 +330,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             "/im_livechat/visitor_leave_session", {"channel_id": inactive_livechat.id}
         )
         guest = inactive_livechat.channel_member_ids.filtered(lambda m: m.guest_id).guest_id
-        non_livechat_channel = self.env['discuss.channel'].channel_create(name="General", group_id=None)
+        non_livechat_channel = self.env['discuss.channel']._create_channel(name="General", group_id=None)
         non_livechat_channel.add_members(guest_ids=guest.ids)
         non_livechat_channel.channel_member_ids.fold_state = "open"
         active_livechat = self.env["discuss.channel"].browse(

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -23,6 +23,24 @@ class DiscussChannelWebclientController(WebclientController):
 
 
 class ChannelController(http.Controller):
+    @http.route("/discuss/channel/get_or_create_chat", methods=["POST"], type="jsonrpc", auth="public")
+    @add_guest_to_context
+    def discuss_get_or_create_chat(self, partners_to, pin=True, force_open=False):
+        channel = request.env["discuss.channel"]._get_or_create_chat(partners_to, pin, force_open)
+        return Store(channel).get_result()
+
+    @http.route("/discuss/channel/create_channel", methods=["POST"], type="jsonrpc", auth="public")
+    @add_guest_to_context
+    def discuss_create_channel(self, name, group_id):
+        channel = request.env["discuss.channel"]._create_channel(name, group_id)
+        return Store(channel).get_result()
+
+    @http.route("/discuss/channel/create_group", methods=["POST"], type="jsonrpc", auth="public")
+    @add_guest_to_context
+    def discuss_create_group(self, partners_to, default_display_mode=False, name=''):
+        channel = request.env["discuss.channel"]._create_group(partners_to, default_display_mode, name)
+        return Store(channel).get_result()
+
     @http.route("/discuss/channel/members", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
     @add_guest_to_context
     def discuss_channel_members(self, channel_id, known_member_ids):

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1034,9 +1034,9 @@ class DiscussChannel(models.Model):
         store.add_records_fields(self, fields)
 
     # User methods
+
     @api.model
-    @api.returns("self", lambda channels: Store(channels).get_result())
-    def channel_get(self, partners_to, pin=True, force_open=False):
+    def _get_or_create_chat(self, partners_to, pin=True, force_open=False):
         """ Get the canonical private channel between some partners, create it if needed.
             To reuse an old channel (conversation), this one must be private, and contains
             only the given partners.
@@ -1175,8 +1175,7 @@ class DiscussChannel(models.Model):
         self.add_members(self.env.user.partner_id.ids)
 
     @api.model
-    @api.returns("self", lambda channels: Store(channels).get_result())
-    def channel_create(self, name, group_id):
+    def _create_channel(self, name, group_id):
         """ Create a channel and add the current partner, broadcast it (to make the user directly
             listen to it when polling)
             :param name : the name of the channel to create
@@ -1197,8 +1196,7 @@ class DiscussChannel(models.Model):
         return new_channel
 
     @api.model
-    @api.returns("self", lambda channels: Store(channels).get_result())
-    def create_group(self, partners_to, default_display_mode=False, name=''):
+    def _create_group(self, partners_to, default_display_mode=False, name=''):
         """ Creates a group channel.
 
             :param partners_to : list of res.partner ids to add to the conversation

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -571,7 +571,7 @@ export class Store extends BaseStore {
     }
 
     async joinChat(id, forceOpen = false) {
-        const data = await this.env.services.orm.call("discuss.channel", "channel_get", [], {
+        const data = await rpc("/discuss/channel/get_or_create_chat", {
             partners_to: [id],
             force_open: forceOpen,
         });

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -1,6 +1,7 @@
 import { Store } from "@mail/core/common/store_service";
 import { compareDatetime } from "@mail/utils/common/misc";
 
+import { rpc } from "@web/core/network/rpc";
 import { patch } from "@web/core/utils/patch";
 import { debounce } from "@web/core/utils/timing";
 
@@ -25,7 +26,7 @@ const storeServicePatch = {
         return ["away", "bot", "online"];
     },
     async createGroupChat({ default_display_mode, partners_to, name }) {
-        const data = await this.env.services.orm.call("discuss.channel", "create_group", [], {
+        const data = await rpc("/discuss/channel/create_group", {
             default_display_mode,
             partners_to,
             name,

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -3,6 +3,7 @@ import { cleanTerm } from "@mail/utils/common/format";
 import { Component, useState } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
+import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { ImStatus } from "@mail/core/common/im_status";
 import { useService } from "@web/core/utils/hooks";
@@ -74,7 +75,7 @@ class CreateChannelDialog extends Component {
             this.state.isInvalid = true;
             return;
         }
-        await makeNewChannel(name, this.orm, this.store);
+        await makeNewChannel(name, this.store);
         this.props.close();
     }
 }
@@ -111,11 +112,11 @@ commandSetupRegistry.add("@", {
     placeholder: _t("Search a conversation"),
 });
 
-async function makeNewChannel(name, orm, store) {
-    const data = await orm.call("discuss.channel", "channel_create", [
-        name,
-        store.internalUserGroupId,
-    ]);
+async function makeNewChannel(name, store) {
+    const data = await rpc("/discuss/channel/create_channel", {
+        name: name,
+        group_id: store.internalUserGroupId,
+    });
     const { Thread } = store.insert(data);
     const [channel] = Thread;
     channel.open();
@@ -254,7 +255,7 @@ export class DiscussCommandPalette {
                 action: async () => {
                     const name = this.options.searchValue.trim();
                     if (name) {
-                        makeNewChannel(name, this.orm, this.store);
+                        makeNewChannel(name, this.store);
                     } else {
                         this.dialog.add(CreateChannelDialog);
                     }

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -30,19 +30,11 @@ test("can create a new channel", async () => {
     onRpcBefore((route, args) => {
         if (
             route.startsWith("/mail") ||
+            route.startsWith("/discuss/channel/create_channel") ||
             route.startsWith("/discuss/channel/messages") ||
             route.startsWith("/discuss/search")
         ) {
             asyncStep(`${route} - ${JSON.stringify(args)}`);
-        }
-    });
-    onRpc((params) => {
-        if (params.model === "discuss.channel" && params.method === "channel_create") {
-            asyncStep(
-                `${params.route} - ${JSON.stringify(
-                    pick(params, "args", "kwargs", "method", "model")
-                )}`
-            );
         }
     });
     await start();
@@ -76,18 +68,8 @@ test("can create a new channel", async () => {
         ["partner_id", "=", serverState.partnerId],
     ]);
     await waitForSteps([
-        `/web/dataset/call_kw/discuss.channel/channel_create - ${JSON.stringify({
-            args: ["abc", null],
-            kwargs: {
-                context: {
-                    lang: "en",
-                    tz: "taht",
-                    uid: serverState.userId,
-                    allowed_company_ids: [1],
-                },
-            },
-            method: "channel_create",
-            model: "discuss.channel",
+        `/discuss/channel/create_channel - ${JSON.stringify({
+            name: "abc"
         })}`,
         `/discuss/channel/messages - {"channel_id":${channelId},"fetch_params":{"limit":60,"around":${selfMember.new_message_separator}}}`,
     ]);
@@ -105,7 +87,7 @@ test("can make a DM chat", async () => {
     onRpc((params) => {
         if (
             params.model === "discuss.channel" &&
-            ["search_read", "channel_create", "channel_get"].includes(params.method)
+            ["search_read"].includes(params.method)
         ) {
             asyncStep(
                 `${params.route} - ${JSON.stringify(
@@ -142,20 +124,9 @@ test("can make a DM chat", async () => {
     await waitForSteps([
         `/discuss/search - {"term":""}`,
         `/discuss/search - {"term":"mario"}`,
-        `/web/dataset/call_kw/discuss.channel/channel_get - ${JSON.stringify({
-            args: [],
-            kwargs: {
-                partners_to: [partnerId],
-                force_open: false,
-                context: {
-                    lang: "en",
-                    tz: "taht",
-                    uid: serverState.userId,
-                    allowed_company_ids: [1],
-                },
-            },
-            method: "channel_get",
-            model: "discuss.channel",
+        `/discuss/channel/get_or_create_chat - ${JSON.stringify({
+            partners_to: [partnerId],
+            force_open: false,
         })}`,
         `/discuss/channel/messages - {"channel_id":${channelId},"fetch_params":{"limit":60,"around":0}}`,
     ]);

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel.js
@@ -53,9 +53,9 @@ patch(MockServer.prototype, {
             const ids = args.args[0];
             return this._mockDiscussChannelChannelFetched(ids);
         }
-        if (args.model === "discuss.channel" && args.method === "channel_create") {
-            const name = args.args[0];
-            const groupId = args.args[1];
+        if (route === "/discuss/channel/create_channel") {
+            const name = args.name;
+            const groupId = args.groupId;
             return this._mockDiscussChannelChannelCreate(name, groupId);
         }
         if (args.model === "discuss.channel" && args.method === "set_message_pin") {
@@ -65,20 +65,10 @@ patch(MockServer.prototype, {
                 args.kwargs.pinned
             );
         }
-        if (args.model === "discuss.channel" && args.method === "channel_get") {
-            const partners_to = args.args[0] || args.kwargs.partners_to;
-            const pin =
-                args.args[1] !== undefined
-                    ? args.args[1]
-                    : args.kwargs.pin !== undefined
-                    ? args.kwargs.pin
-                    : undefined;
-            const force_open =
-                args.args[2] !== undefined
-                    ? args.args[2]
-                    : args.kwargs.force_open !== undefined
-                    ? args.kwargs.force_open
-                    : undefined;
+        if (route === "/discuss/channel/get_or_create_chat") {
+            const partners_to = args.partners_to;
+            const pin = args.pin || undefined;
+            const force_open = args.force_open || undefined;
             return this._mockDiscussChannelChannelGet(partners_to, pin, force_open);
         }
         if (route === "/discuss/channel/info") {
@@ -119,8 +109,8 @@ patch(MockServer.prototype, {
             const name = args.args[1] || args.kwargs.name;
             return this._mockDiscussChannelChannelSetCustomName(ids, name);
         }
-        if (args.model === "discuss.channel" && args.method === "create_group") {
-            const partners_to = args.args[0] || args.kwargs.partners_to;
+        if (route === "/discuss/channel/create_group") {
+            const partners_to = args.partners_to;
             return this._mockDiscussChannelCreateGroup(partners_to);
         }
         if (args.model === "discuss.channel" && args.method === "execute_command_leave") {

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -262,6 +262,38 @@ async function channel_call_leave(request) {
     BusBus._sendmany(notifications);
 }
 
+registerRoute("/discuss/channel/get_or_create_chat", discuss_get_or_create_chat);
+/** @type {RouteCallback} */
+async function discuss_get_or_create_chat(request) {
+    const { partners_to } = await parseRequestParams(request);
+
+    /** @type {import("mock_models").DiscussChannel} */
+    const DiscussChannel = this.env["discuss.channel"];
+    return DiscussChannel._get_or_create_chat(partners_to)
+}
+
+registerRoute("/discuss/channel/create_channel", discuss_create_channel);
+/** @type {RouteCallback} */
+async function discuss_create_channel(request) {
+    const { name, group_id } = await parseRequestParams(request);
+
+    /** @type {import("mock_models").DiscussChannel} */
+    const DiscussChannel = this.env["discuss.channel"];
+    return DiscussChannel._create_channel(name, group_id)
+}
+
+registerRoute("/discuss/channel/create_group", discuss_create_group);
+/** @type {RouteCallback} */
+async function discuss_create_group(request) {
+    const kwargs = await parseRequestParams(request);
+    const partners_to = kwargs.partners_to || [];
+    const name = kwargs.name || "";
+
+    /** @type {import("mock_models").DiscussChannel} */
+    const DiscussChannel = this.env["discuss.channel"];
+    return DiscussChannel._create_group(partners_to, name)
+}
+
 registerRoute("/discuss/channel/fold", discuss_channel_fold);
 /** @type {RouteCallback} */
 async function discuss_channel_fold(request) {

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -192,7 +192,7 @@ export class DiscussChannel extends models.ServerModel {
      * @param {string} name
      * @param {string} [group_id]
      */
-    channel_create(name, group_id) {
+    _create_channel(name, group_id) {
         const kwargs = getKwArgs(arguments, "name", "group_id");
         name = kwargs.name;
         group_id = kwargs.group_id;
@@ -316,7 +316,7 @@ export class DiscussChannel extends models.ServerModel {
      * @param {number[]} partners_to
      * @param {boolean} [pin=true]
      */
-    channel_get(partners_to, pin) {
+    _get_or_create_chat(partners_to, pin) {
         const kwargs = getKwArgs(arguments, "partners_to", "pin");
         partners_to = kwargs.partners_to || [];
         pin = kwargs.pin ?? true;
@@ -537,7 +537,7 @@ export class DiscussChannel extends models.ServerModel {
      * @param {number[]} partners_to
      * @param {string} name
      * */
-    create_group(partners_to, name) {
+    _create_group(partners_to, name) {
         const kwargs = getKwArgs(arguments, "partners_to", "name");
         partners_to = kwargs.partners_to || [];
         name = kwargs.name || "";

--- a/addons/mail/tests/discuss/test_bus_presence.py
+++ b/addons/mail/tests/discuss/test_bus_presence.py
@@ -56,7 +56,7 @@ class TestBusPresence(WebsocketCase, MailCommon):
         # Guest should not receive users's presence: no common channel.
         with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
             self._receive_presence(sender=bob, recipient=guest)
-        channel = self.env["discuss.channel"].channel_create(group_id=None, name="General")
+        channel = self.env["discuss.channel"]._create_channel(group_id=None, name="General")
         channel.add_members(guest_ids=[guest.id], partner_ids=[bob.partner_id.id])
         # Now that they share a channel, guest should receive users's presence.
         self._receive_presence(sender=bob, recipient=guest)
@@ -75,7 +75,7 @@ class TestBusPresence(WebsocketCase, MailCommon):
         # Portal should not receive users's presence: no common channel.
         with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
             self._receive_presence(sender=bob, recipient=portal)
-        channel = self.env["discuss.channel"].channel_create(group_id=None, name="General")
+        channel = self.env["discuss.channel"]._create_channel(group_id=None, name="General")
         channel.add_members(partner_ids=[portal.partner_id.id, bob.partner_id.id])
         # Now that they share a channel, portal should receive users's presence.
         self._receive_presence(sender=bob, recipient=portal)

--- a/addons/mail/tests/discuss/test_discuss_action.py
+++ b/addons/mail/tests/discuss/test_discuss_action.py
@@ -14,7 +14,7 @@ class TestDiscussAction(HttpCase):
     def test_join_call_with_client_action(self):
         inviting_user = self.env['res.users'].sudo().create({'name': "Inviting User", 'login': 'inviting'})
         invited_user = self.env['res.users'].sudo().create({'name': "Invited User", 'login': 'invited'})
-        channel = self.env['discuss.channel'].with_user(inviting_user).channel_get(partners_to=invited_user.partner_id.ids)
+        channel = self.env['discuss.channel'].with_user(inviting_user)._get_or_create_chat(partners_to=invited_user.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(
             lambda channel_member: channel_member.partner_id == inviting_user.partner_id)
         channel_member._rtc_join_call()

--- a/addons/mail/tests/discuss/test_discuss_binary_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_binary_controller.py
@@ -11,7 +11,7 @@ class TestDiscussBinaryController(MailControllerBinaryCommon):
         cls.private_channel = cls.env["discuss.channel"].create(
             {"name": "Private Channel", "channel_type": "group"}
         )
-        cls.public_channel = cls.env["discuss.channel"].channel_create(
+        cls.public_channel = cls.env["discuss.channel"]._create_channel(
             name="Public Channel", group_id=None
         )
         cls.partner_ids = (

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -22,7 +22,7 @@ class TestChannelInternals(MailCommon, HttpCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.maxDiff = None
-        cls.test_channel = cls.env['discuss.channel'].with_context(cls._test_context).channel_create(name='Channel', group_id=None)
+        cls.test_channel = cls.env['discuss.channel'].with_context(cls._test_context)._create_channel(name='Channel', group_id=None)
         cls.test_partner = cls.env['res.partner'].with_context(cls._test_context).create({
             'name': 'Test Partner',
             'email': 'test_customer@example.com',
@@ -41,7 +41,7 @@ class TestChannelInternals(MailCommon, HttpCase):
     def test_channel_member_cannot_be_public_user(self):
         """Public users can only join channels as guest."""
         user_public = mail_new_test_user(self.env, login='user_public', groups='base.group_public', name='Bert Tartignole')
-        public_channel = self.env['discuss.channel'].channel_create(name='Public Channel', group_id=None)
+        public_channel = self.env['discuss.channel']._create_channel(name='Public Channel', group_id=None)
         with self.assertRaises(ValidationError):
             public_channel.add_members(user_public.partner_id.id)
 
@@ -239,7 +239,7 @@ class TestChannelInternals(MailCommon, HttpCase):
     @users('employee')
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     def test_channel_chat_message_post_should_update_last_interest_dt(self):
-        chat = self.env['discuss.channel'].with_user(self.user_admin).channel_get((self.partner_employee | self.user_admin.partner_id).ids)
+        chat = self.env['discuss.channel'].with_user(self.user_admin)._get_or_create_chat((self.partner_employee | self.user_admin.partner_id).ids)
         post_time = fields.Datetime.now()
         # Mocks the return value of field.Datetime.now(),
         # so we can see if the `last_interest_dt` is updated correctly
@@ -266,7 +266,7 @@ class TestChannelInternals(MailCommon, HttpCase):
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     def test_channel_recipients_chat(self):
         """ Posting a message on a chat should not send emails """
-        chat = self.env['discuss.channel'].with_user(self.user_admin).channel_get((self.partner_employee | self.user_admin.partner_id).ids)
+        chat = self.env['discuss.channel'].with_user(self.user_admin)._get_or_create_chat((self.partner_employee | self.user_admin.partner_id).ids)
         with self.mock_mail_gateway():
             with self.with_user('employee'):
                 new_msg = chat.message_post(body="Test", message_type='comment', subtype_xmlid='mail.mt_comment')
@@ -288,7 +288,7 @@ class TestChannelInternals(MailCommon, HttpCase):
     @mute_logger('odoo.models.unlink')
     def test_channel_user_synchronize(self):
         """Archiving / deleting a user should automatically unsubscribe related partner from group restricted channels"""
-        group_restricted_channel = self.env['discuss.channel'].channel_create(name='Sic Mundus', group_id=self.env.ref('base.group_user').id)
+        group_restricted_channel = self.env['discuss.channel']._create_channel(name='Sic Mundus', group_id=self.env.ref('base.group_user').id)
 
         self.test_channel.add_members((self.partner_employee | self.partner_employee_nomail).ids)
         group_restricted_channel.add_members((self.partner_employee | self.partner_employee_nomail).ids)
@@ -306,7 +306,7 @@ class TestChannelInternals(MailCommon, HttpCase):
     @users('employee_nomail')
     def test_channel_info_get(self):
         # `channel_get` should return a new channel the first time a partner is given
-        channel = self.env["discuss.channel"].channel_get(partners_to=self.test_partner.ids)
+        channel = self.env["discuss.channel"]._get_or_create_chat(partners_to=self.test_partner.ids)
         init_data = Store(channel).get_result()
         initial_channel_info = init_data["discuss.channel"][0]
         self.assertEqual(
@@ -315,20 +315,20 @@ class TestChannelInternals(MailCommon, HttpCase):
         )
 
         # `channel_get` should return the existing channel every time the same partner is given
-        same_channel = self.env['discuss.channel'].channel_get(partners_to=self.test_partner.ids)
+        same_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=self.test_partner.ids)
         same_channel_info = Store(same_channel).get_result()["discuss.channel"][0]
         self.assertEqual(same_channel_info['id'], initial_channel_info['id'])
 
         # `channel_get` should return the existing channel when the current partner is given together with the other partner
         together_pids = (self.partner_employee_nomail + self.test_partner).ids
-        together_channel = self.env['discuss.channel'].channel_get(partners_to=together_pids)
+        together_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=together_pids)
         together_channel_info = Store(together_channel).get_result()["discuss.channel"][0]
         self.assertEqual(together_channel_info['id'], initial_channel_info['id'])
 
         # `channel_get` should return a new channel the first time just the current partner is given,
         # even if a channel containing the current partner together with other partners already exists
         solo_pids = self.partner_employee_nomail.ids
-        solo_channel = self.env['discuss.channel'].channel_get(partners_to=solo_pids)
+        solo_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=solo_pids)
         solo_channel_data = Store(solo_channel).get_result()
         solo_channel_info = solo_channel_data["discuss.channel"][0]
         self.assertNotEqual(solo_channel_info['id'], initial_channel_info['id'])
@@ -339,20 +339,20 @@ class TestChannelInternals(MailCommon, HttpCase):
 
         # `channel_get` should return the existing channel every time the current partner is given
         same_solo_pids = self.partner_employee_nomail.ids
-        same_solo_channel = self.env['discuss.channel'].channel_get(partners_to=same_solo_pids)
+        same_solo_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=same_solo_pids)
         same_solo_channel_info = Store(same_solo_channel).get_result()["discuss.channel"][0]
         self.assertEqual(same_solo_channel_info['id'], solo_channel_info['id'])
 
     # `channel_get` will pin the channel by default and thus last interest will be updated.
     @users('employee')
     def test_channel_info_get_should_update_last_interest_dt(self):
-        self.env['discuss.channel'].channel_get(partners_to=self.partner_admin.ids)
+        self.env['discuss.channel']._get_or_create_chat(partners_to=self.partner_admin.ids)
 
         retrieve_time = datetime(2021, 1, 1, 0, 0)
         with patch.object(fields.Datetime, 'now', lambda: retrieve_time):
             # `last_interest_dt` should be updated again when `channel_get` is called
             # because `channel_pin` is called.
-            channel = self.env["discuss.channel"].channel_get(
+            channel = self.env["discuss.channel"]._get_or_create_chat(
                 partners_to=self.partner_admin.ids
             )
         self.assertEqual(
@@ -368,7 +368,7 @@ class TestChannelInternals(MailCommon, HttpCase):
     def test_channel_info_mark_as_read(self):
         """ In case of concurrent channel_seen RPC, ensure the oldest call has no effect. """
         pids = (self.partner_employee | self.user_admin.partner_id).ids
-        chat = self.env['discuss.channel'].with_user(self.user_admin).channel_get(pids)
+        chat = self.env['discuss.channel'].with_user(self.user_admin)._get_or_create_chat(pids)
         msg_1 = self._add_messages(chat, 'Body1', author=self.user_employee.partner_id)
         msg_2 = self._add_messages(chat, 'Body2', author=self.user_employee.partner_id)
         self_member = chat.channel_member_ids.filtered(lambda m: m.partner_id == self.user_admin.partner_id)
@@ -395,7 +395,7 @@ class TestChannelInternals(MailCommon, HttpCase):
 
     @users('employee')
     def test_set_last_seen_message_should_send_notification_only_once(self):
-        chat = self.env['discuss.channel'].with_user(self.user_admin).channel_get((self.partner_employee | self.user_admin.partner_id).ids)
+        chat = self.env['discuss.channel'].with_user(self.user_admin)._get_or_create_chat((self.partner_employee | self.user_admin.partner_id).ids)
         msg_1 = self._add_messages(chat, 'Body1', author=self.user_employee.partner_id)
         member = chat.channel_member_ids.filtered(lambda m: m.partner_id == self.user_admin.partner_id)
         self._reset_bus()
@@ -510,10 +510,10 @@ class TestChannelInternals(MailCommon, HttpCase):
     @mute_logger('odoo.models.unlink')
     def test_channel_private_unfollow(self):
         """ Test that a partner can leave (unfollow) a channel/group/chat. """
-        group_restricted_channel = self.env['discuss.channel'].channel_create(name='Channel for Groups', group_id=self.env.ref('base.group_user').id)
-        public_channel = self.env['discuss.channel'].channel_create(name='Channel for Everyone', group_id=None)
-        private_group = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids, name="Group")
-        chat_user_current = self.env['discuss.channel'].channel_get(self.env.user.partner_id.ids)
+        group_restricted_channel = self.env['discuss.channel']._create_channel(name='Channel for Groups', group_id=self.env.ref('base.group_user').id)
+        public_channel = self.env['discuss.channel']._create_channel(name='Channel for Everyone', group_id=None)
+        private_group = self.env['discuss.channel']._create_group(partners_to=self.user_employee.partner_id.ids, name="Group")
+        chat_user_current = self.env['discuss.channel']._get_or_create_chat(self.env.user.partner_id.ids)
         self.assertEqual(len(group_restricted_channel.channel_member_ids), 1)
         self.assertEqual(len(public_channel.channel_member_ids), 1)
         self.assertEqual(len(private_group.sudo().channel_member_ids), 1)
@@ -569,9 +569,9 @@ class TestChannelInternals(MailCommon, HttpCase):
         self.assertEqual(messages_1, messages_2)
 
     def test_channel_should_generate_correct_default_avatar(self):
-        test_channel = self.env['discuss.channel'].channel_create(name='Channel', group_id=self.env.ref('base.group_user').id)
+        test_channel = self.env['discuss.channel']._create_channel(name='Channel', group_id=self.env.ref('base.group_user').id)
         test_channel.uuid = 'channel-uuid'
-        private_group = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
+        private_group = self.env['discuss.channel']._create_group(partners_to=self.user_employee.partner_id.ids)
         private_group.uuid = 'group-uuid'
         bgcolor_channel = html_escape('hsl(316, 61%, 45%)')  # depends on uuid
         bgcolor_group = html_escape('hsl(17, 60%, 45%)')  # depends on uuid
@@ -646,7 +646,7 @@ class TestChannelInternals(MailCommon, HttpCase):
         all_test_user.res_users_settings_id.write({"channel_notifications": "all"})
         nothing_test_user.res_users_settings_id.write({"channel_notifications": "no_notif"})
 
-        channel = self.env["discuss.channel"].channel_create(name="Channel", group_id=None)
+        channel = self.env["discuss.channel"]._create_channel(name="Channel", group_id=None)
         channel.add_members((self.partner_employee | all_test_user.partner_id | mentions_test_user.partner_id | nothing_test_user.partner_id).ids)
 
         # sending normal message
@@ -779,12 +779,12 @@ class TestChannelInternals(MailCommon, HttpCase):
         with self.with_user('employee'):
             chat = self.env['discuss.channel'].with_context(
                 allowed_company_ids=self.company_admin.ids
-            ).channel_get(self.partner_employee_c2.ids)
+            )._get_or_create_chat(self.partner_employee_c2.ids)
             self.assertTrue(chat, 'should be able to chat with multi company user')
 
     @users('employee')
     def test_create_chat_channel_should_only_pin_the_channel_for_the_current_user(self):
-        chat = self.env['discuss.channel'].channel_get(partners_to=self.test_partner.ids)
+        chat = self.env['discuss.channel']._get_or_create_chat(partners_to=self.test_partner.ids)
         member_of_current_user = self.env['discuss.channel.member'].search([('channel_id', '=', chat.id), ('partner_id', '=', self.env.user.partner_id.id)])
         member_of_correspondent = self.env['discuss.channel.member'].search([('channel_id', '=', chat.id), ('partner_id', '=', self.test_partner.id)])
         self.assertTrue(member_of_current_user.is_pinned)

--- a/addons/mail/tests/discuss/test_discuss_channel_access.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_access.py
@@ -485,13 +485,13 @@ class TestDiscussChannelAccess(MailCommon):
             partners += partner
         DiscussChannel = self.env["discuss.channel"].with_user(self.other_user)
         if channel_key == "group":
-            channel = DiscussChannel.create_group(partners.ids)
+            channel = DiscussChannel._create_group(partners.ids)
             if membership == "member":
                 channel.add_members(partner_ids=partner.ids, guest_ids=guest.ids)
         elif channel_key == "chat":
-            channel = DiscussChannel.channel_get(partners.ids)
+            channel = DiscussChannel._get_or_create_chat(partners.ids)
         else:
-            channel = DiscussChannel.channel_create("Channel", group_id=None)
+            channel = DiscussChannel._create_channel("Channel", group_id=None)
             if membership == "member":
                 channel.add_members(partner_ids=partner.ids, guest_ids=guest.ids)
         if channel_key == "no_group":

--- a/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
@@ -28,7 +28,7 @@ class TestMailPublicPage(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         )
         guest = self.env['mail.guest'].create({'name': 'Guest Mario'})
 
-        self.channel = self.env['discuss.channel'].channel_create(group_id=None, name='Test channel')
+        self.channel = self.env['discuss.channel']._create_channel(group_id=None, name='Test channel')
         self.channel.allow_public_upload = True
         self.channel.add_members(portal_user.partner_id.ids)
         self.channel.add_members(internal_user.partner_id.ids)
@@ -36,7 +36,7 @@ class TestMailPublicPage(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         internal_member = self.channel.channel_member_ids.filtered(lambda m: internal_user.partner_id == m.partner_id)
         internal_member._rtc_join_call()
 
-        self.group = self.env['discuss.channel'].create_group(partners_to=(internal_user + portal_user).partner_id.ids, name="Test group")
+        self.group = self.env['discuss.channel']._create_group(partners_to=(internal_user + portal_user).partner_id.ids, name="Test group")
         self.group.add_members(guest_ids=[guest.id])
         self.group.allow_public_upload = True
 
@@ -95,8 +95,8 @@ class TestMailPublicPage(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         self.assertEqual(len(channel), 1)
 
     def test_channel_invitation_from_token(self):
-        public_channel = self.env["discuss.channel"].channel_create(name="Public Channel", group_id=None)
-        internal_channel = self.env["discuss.channel"].channel_create(name="Internal Channel", group_id=self.env.ref("base.group_user").id)
+        public_channel = self.env["discuss.channel"]._create_channel(name="Public Channel", group_id=None)
+        internal_channel = self.env["discuss.channel"]._create_channel(name="Internal Channel", group_id=self.env.ref("base.group_user").id)
 
         public_response = self.url_open(public_channel.invitation_url)
         self.assertEqual(public_response.status_code, 200)
@@ -106,8 +106,8 @@ class TestMailPublicPage(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
 
     def test_sidebar_in_public_page(self):
         guest = self.env['mail.guest'].create({'name': 'Guest'})
-        channel_1 = self.env["discuss.channel"].channel_create(name="Channel 1", group_id=None)
-        channel_2 = self.env["discuss.channel"].channel_create(name="Channel 2", group_id=None)
+        channel_1 = self.env["discuss.channel"]._create_channel(name="Channel 1", group_id=None)
+        channel_2 = self.env["discuss.channel"]._create_channel(name="Channel 2", group_id=None)
         channel_1.add_members(guest_ids=[guest.id])
         channel_2.add_members(guest_ids=[guest.id])
         self.start_tour(f"/discuss/channel/{channel_1.id}", "sidebar_in_public_page_tour", cookies={guest._cookie_name: guest._format_auth_cookie()})

--- a/addons/mail/tests/discuss/test_discuss_channel_member.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_member.py
@@ -46,7 +46,7 @@ class TestDiscussChannelMember(MailCommon):
             'channel_type': 'channel',
             'group_public_id': cls.secret_group.id,
         })
-        cls.public_channel = cls.env['discuss.channel'].channel_create(group_id=None, name='Public channel of user 1')
+        cls.public_channel = cls.env['discuss.channel']._create_channel(group_id=None, name='Public channel of user 1')
         (cls.group | cls.group_restricted_channel | cls.public_channel).channel_member_ids.unlink()
 
     # ------------------------------------------------------------
@@ -232,7 +232,7 @@ class TestDiscussChannelMember(MailCommon):
     # ------------------------------------------------------------
 
     def test_unread_counter_with_message_post(self):
-        channel_as_user_1 = self.env['discuss.channel'].with_user(self.user_1).channel_create(group_id=None, name='Public channel')
+        channel_as_user_1 = self.env['discuss.channel'].with_user(self.user_1)._create_channel(group_id=None, name='Public channel')
         channel_as_user_1.with_user(self.user_1).add_members(self.user_1.partner_id.ids)
         channel_as_user_1.with_user(self.user_1).add_members(self.user_2.partner_id.ids)
         channel_1_rel_user_2 = self.env['discuss.channel.member'].search([
@@ -249,8 +249,8 @@ class TestDiscussChannelMember(MailCommon):
         self.assertEqual(channel_1_rel_user_2.message_unread_counter, 1, "should have 1 unread message after someone else posted a message")
 
     def test_unread_counter_with_message_post_multi_channel(self):
-        channel_1_as_user_1 = self.env['discuss.channel'].with_user(self.user_1).channel_create(group_id=None, name='wololo channel')
-        channel_2_as_user_2 = self.env['discuss.channel'].with_user(self.user_2).channel_create(group_id=None, name='walala channel')
+        channel_1_as_user_1 = self.env['discuss.channel'].with_user(self.user_1)._create_channel(group_id=None, name='wololo channel')
+        channel_2_as_user_2 = self.env['discuss.channel'].with_user(self.user_2)._create_channel(group_id=None, name='walala channel')
         channel_1_as_user_1.add_members(self.user_2.partner_id.ids)
         channel_2_as_user_2.add_members(self.user_1.partner_id.ids)
         channel_2_as_user_2.add_members(self.user_3.partner_id.ids)

--- a/addons/mail/tests/discuss/test_discuss_reaction_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_reaction_controller.py
@@ -24,10 +24,8 @@ class TestMessageReactionController(MailControllerReactionCommon):
 
     def test_message_reaction_channel_as_member(self):
         """Test access of message reaction for a channel as member."""
-        channel = self.env["discuss.channel"].browse(
-            self.env["discuss.channel"].create_group(
-                partners_to=(self.user_portal + self.user_employee).partner_id.ids
-            )["id"]
+        channel = self.env["discuss.channel"]._create_group(
+            partners_to=(self.user_portal + self.user_employee).partner_id.ids
         )
         channel.add_members(guest_ids=self.guest.ids)
         message = channel.message_post(body="invite message")
@@ -44,9 +42,7 @@ class TestMessageReactionController(MailControllerReactionCommon):
 
     def test_message_reaction_channel_as_non_member(self):
         """Test access of message reaction for a channel as non-member."""
-        channel = self.env["discuss.channel"].browse(
-            self.env["discuss.channel"].create_group(partners_to=[])["id"]
-        )
+        channel = self.env["discuss.channel"]._create_group(partners_to=[])
         message = channel.message_post(body="private message")
         self._execute_subtests(
             message,

--- a/addons/mail/tests/discuss/test_discuss_sub_channels.py
+++ b/addons/mail/tests/discuss/test_discuss_sub_channels.py
@@ -62,7 +62,7 @@ class TestDiscussSubChannels(HttpCase):
     def test_04_sub_channel_panel_search(self):
         bob_user = new_test_user(self.env, "bob_user", groups="base.group_user")
         self.authenticate("bob_user", "bob_user")
-        channel = self.env["discuss.channel"].channel_create(name="General", group_id=None)
+        channel = self.env["discuss.channel"]._create_channel(name="General", group_id=None)
         channel.add_members(partner_ids=[bob_user.partner_id.id])
         for i in range(100):
             channel._create_sub_channel(name=f"Sub Channel {i}")

--- a/addons/mail/tests/discuss/test_guest_feature.py
+++ b/addons/mail/tests/discuss/test_guest_feature.py
@@ -11,7 +11,7 @@ class TestGuestFeature(WebsocketCase, MailCommon):
     def test_mark_as_read_as_guest(self):
         guest = self.env["mail.guest"].create({"name": "Guest"})
         partner = self.env["res.partner"].create({"name": "John"})
-        channel = self.env["discuss.channel"].channel_create(
+        channel = self.env["discuss.channel"]._create_channel(
             group_id=None, name="General"
         )
         channel.add_members(guest_ids=[guest.id], partner_ids=[partner.id])
@@ -48,7 +48,7 @@ class TestGuestFeature(WebsocketCase, MailCommon):
 
     def test_subscribe_to_discuss_channel(self):
         guest = self.env["mail.guest"].create({"name": "Guest"})
-        channel = self.env["discuss.channel"].channel_create(
+        channel = self.env["discuss.channel"]._create_channel(
             group_id=None, name="General"
         )
         channel.add_members(guest_ids=[guest.id])

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -347,8 +347,8 @@ class TestMessageLinks(MailCommon, HttpCase):
         super().setUpClass()
 
         cls.user_employee_1 = mail_new_test_user(cls.env, login='tao1', groups='base.group_user', name='Tao Lee')
-        cls.public_channel = cls.env['discuss.channel'].channel_create(name='Public Channel1', group_id=None)
-        cls.private_group = cls.env['discuss.channel'].create_group(partners_to=cls.user_employee_1.partner_id.ids, name="Group")
+        cls.public_channel = cls.env['discuss.channel']._create_channel(name='Public Channel1', group_id=None)
+        cls.private_group = cls.env['discuss.channel']._create_group(partners_to=cls.user_employee_1.partner_id.ids, name="Group")
 
     @users('employee')
     def test_message_link_by_employee(self):

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -18,7 +18,7 @@ class TestChannelRTC(MailCommon):
     def test_01_join_call(self):
         """Join call should remove existing sessions, remove invitation, create a new session, and return data."""
         self.maxDiff = None
-        channel = self.env['discuss.channel'].channel_create(name='Test Channel', group_id=self.env.ref('base.group_user').id)
+        channel = self.env['discuss.channel']._create_channel(name='Test Channel', group_id=self.env.ref('base.group_user').id)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
         self._reset_bus()
@@ -139,7 +139,7 @@ class TestChannelRTC(MailCommon):
     @mute_logger('odoo.models.unlink')
     def test_10_start_call_in_chat_should_invite_all_members_to_call(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
-        channel = self.env['discuss.channel'].channel_get(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
+        channel = self.env['discuss.channel']._get_or_create_chat(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
         channel_member._rtc_join_call()
@@ -247,7 +247,7 @@ class TestChannelRTC(MailCommon):
     def test_11_start_call_in_group_should_invite_all_members_to_call(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
-        channel = self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
+        channel = self.env['discuss.channel']._create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel.add_members(guest_ids=test_guest.ids)
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
@@ -422,7 +422,7 @@ class TestChannelRTC(MailCommon):
     def test_20_join_call_should_cancel_pending_invitations(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
-        channel = self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
+        channel = self.env['discuss.channel']._create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel.add_members(guest_ids=test_guest.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
@@ -624,7 +624,7 @@ class TestChannelRTC(MailCommon):
     def test_21_leave_call_should_cancel_pending_invitations(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
-        channel = self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
+        channel = self.env['discuss.channel']._create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel.add_members(guest_ids=test_guest.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
@@ -742,7 +742,7 @@ class TestChannelRTC(MailCommon):
     def test_25_lone_call_participant_leaving_call_should_cancel_pending_invitations(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
-        channel = self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
+        channel = self.env['discuss.channel']._create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel.add_members(guest_ids=test_guest.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
@@ -860,7 +860,7 @@ class TestChannelRTC(MailCommon):
     def test_30_add_members_while_in_call_should_invite_new_members_to_call(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
-        channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
+        channel = self.env['discuss.channel']._create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda member: member.partner_id == self.user_employee.partner_id)
         now = fields.Datetime.now()
         with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=5)):
@@ -1052,7 +1052,7 @@ class TestChannelRTC(MailCommon):
     @users('employee')
     @mute_logger('odoo.models.unlink')
     def test_40_leave_call_should_remove_existing_sessions_of_user_in_channel_and_return_data(self):
-        channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
+        channel = self.env['discuss.channel']._create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
         self._reset_bus()
@@ -1089,7 +1089,7 @@ class TestChannelRTC(MailCommon):
     @mute_logger('odoo.models.unlink')
     def test_50_garbage_collect_should_remove_old_sessions_and_notify_data(self):
         self.env["discuss.channel.rtc.session"].sudo().search([]).unlink()  # clean up before test
-        channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
+        channel = self.env['discuss.channel']._create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
         channel_member.rtc_session_ids.flush_model()
@@ -1126,7 +1126,7 @@ class TestChannelRTC(MailCommon):
     @users('employee')
     @mute_logger('odoo.models.unlink')
     def test_51_action_disconnect_should_remove_selected_session_and_notify_data(self):
-        channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
+        channel = self.env['discuss.channel']._create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
         self._reset_bus()
@@ -1161,7 +1161,7 @@ class TestChannelRTC(MailCommon):
     @users('employee')
     @mute_logger('odoo.models.unlink')
     def test_60_rtc_sync_sessions_should_gc_and_return_outdated_and_active_sessions(self):
-        channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
+        channel = self.env['discuss.channel']._create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         store = Store()
         channel_member._rtc_join_call(store)

--- a/addons/mail_bot/models/res_users.py
+++ b/addons/mail_bot/models/res_users.py
@@ -33,7 +33,7 @@ class ResUsers(models.Model):
     def _init_odoobot(self):
         self.ensure_one()
         odoobot_id = self.env['ir.model.data']._xmlid_to_res_id("base.partner_root")
-        channel = self.env['discuss.channel'].channel_get([odoobot_id, self.partner_id.id])
+        channel = self.env['discuss.channel']._get_or_create_chat([odoobot_id, self.partner_id.id])
         message = Markup("%s<br/>%s<br/><b>%s</b> <span class=\"o_odoobot_command\">:)</span>") % (
             _("Hello,"),
             _("Odoo's chat helps employees collaborate efficiently. I'm here to help you discover its features."),

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -186,30 +186,30 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         self.env['discuss.channel'].sudo().search([('id', '!=', self.channel_general.id)]).unlink()
         self.user_root = self.env.ref('base.user_root')
         # create public channels
-        self.channel_channel_public_1 = Channel.channel_create(
+        self.channel_channel_public_1 = Channel._create_channel(
             name="public channel 1", group_id=None
         )
         self.channel_channel_public_1.add_members((self.users[0] + self.users[2] + self.users[3] + self.users[4] + self.users[8]).partner_id.ids)
-        self.channel_channel_public_2 = Channel.channel_create(
+        self.channel_channel_public_2 = Channel._create_channel(
             name="public channel 2", group_id=None
         )
         self.channel_channel_public_2.add_members((self.users[0] + self.users[2] + self.users[4] + self.users[7] + self.users[9]).partner_id.ids)
         # create group-restricted channels
-        self.channel_channel_group_1 = Channel.channel_create(
+        self.channel_channel_group_1 = Channel._create_channel(
             name="group restricted channel 1", group_id=self.env.ref("base.group_user").id
         )
         self.channel_channel_group_1.add_members((self.users[0] + self.users[2] + self.users[3] + self.users[6] + self.users[12]).partner_id.ids)
-        self.channel_channel_group_2 = Channel.channel_create(
+        self.channel_channel_group_2 = Channel._create_channel(
             name="group restricted channel 2", group_id=self.env.ref("base.group_user").id
         )
         self.channel_channel_group_2.add_members((self.users[0] + self.users[2] + self.users[6] + self.users[7] + self.users[13]).partner_id.ids)
         # create chats
-        self.channel_chat_1 = Channel.channel_get((self.users[0] + self.users[14]).partner_id.ids)
-        self.channel_chat_2 = Channel.channel_get((self.users[0] + self.users[15]).partner_id.ids)
-        self.channel_chat_3 = Channel.channel_get((self.users[0] + self.users[2]).partner_id.ids)
-        self.channel_chat_4 = Channel.channel_get((self.users[0] + self.users[3]).partner_id.ids)
+        self.channel_chat_1 = Channel._get_or_create_chat((self.users[0] + self.users[14]).partner_id.ids)
+        self.channel_chat_2 = Channel._get_or_create_chat((self.users[0] + self.users[15]).partner_id.ids)
+        self.channel_chat_3 = Channel._get_or_create_chat((self.users[0] + self.users[2]).partner_id.ids)
+        self.channel_chat_4 = Channel._get_or_create_chat((self.users[0] + self.users[3]).partner_id.ids)
         # create groups
-        self.channel_group_1 = Channel.create_group((self.users[0] + self.users[12]).partner_id.ids)
+        self.channel_group_1 = Channel._create_group((self.users[0] + self.users[12]).partner_id.ids)
         # create livechats
         self.im_livechat_channel = self.env['im_livechat.channel'].sudo().create({'name': 'support', 'user_ids': [Command.link(self.users[0].id)]})
         self.env['bus.presence'].create({'user_id': self.users[0].id, 'status': 'online'})  # make available for livechat (ignore leave)

--- a/addons/test_mail/tests/test_mail_push.py
+++ b/addons/test_mail/tests/test_mail_push.py
@@ -352,7 +352,7 @@ class TestWebPushNotification(SMSCommon):
     @mute_logger('odoo.tests')
     def test_notify_call_invitation(self, push_to_end_point):
         inviting_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
-        channel = self.env['discuss.channel'].with_user(inviting_user).channel_get(
+        channel = self.env['discuss.channel'].with_user(inviting_user)._get_or_create_chat(
             partners_to=[self.user_email.partner_id.id])
         inviting_channel_member = channel.sudo().channel_member_ids.filtered(
             lambda channel_member: channel_member.partner_id == inviting_user.partner_id)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Make channel methods that return a `Store` private. The controller should handle returned storage format. This allows to remove the usage of `@api.returns` - that is to be removed in #182709.

Current behavior before PR:
Public method that returns the store.

Desired behavior after PR is merged:
Private method that returns the recordset and a controller that wraps in in a `Store`.


odoo/enterprise#75013

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
