### PR TITLE
[FIX] survey: unlock survey certificate generation for other companies members

### DIFF
--- a/addons/survey/report/survey_templates.xml
+++ b/addons/survey/report/survey_templates.xml
@@ -37,7 +37,7 @@
                                 </t>
                                 <span t-att-style="certif_style" class="user-name" t-out="certified_name">DEMO_CERTIFIED_NAME</span>
 
-                                <br/> <span>by</span> <span class="certification-company" t-field="user_input.create_uid.company_id.display_name">Odoo</span> <span>for successfully completing</span>
+                                <br/> <span>by</span> <span class="certification-company" t-field="user_input.create_uid.sudo().company_id.display_name">Odoo</span> <span>for successfully completing</span>
                                 <br/><b><span class="certification-name" t-field="user_input.survey_id.display_name">Functional Training</span></b>
                              </p>
                             <div class="oe_structure"/>
@@ -56,7 +56,7 @@
                             <span>Date</span>
                         </div>
                         <div class="certification-company">
-                            <span class="certification-company-logo" t-field="user_input.create_uid.company_id.logo" t-options="{'widget': 'image'}" role="img"/>
+                            <span class="certification-company-logo" t-field="user_input.create_uid.sudo().company_id.partner_id.image_1920" t-options="{'widget': 'image'}" role="img"/>
                         </div>
                     </div>
                     <div t-if="user_input.test_entry" class="test-entry"/>


### PR DESCRIPTION

**Issue:**
Survey's PDF certifications generation is only allowed to users having rights on the company of the user who answered the survey.

**Expected:**
Any user having generation rights to surveys should be able to generate the certification PDF.

**Steps to reproduce:**
- Activate Survey app and ensure there are, at least, 2 companies;
- Create a survey with certification and ensure `Require Login` is unchecked;
- Share the survey (copy the `Survey Link`);
- Navigate to Settings / Users & Companies / Users;
- Filter on `Inactive Users` and select `Public user`;
- Setup the user's `Default Company` on Company A;
- Setup an active user's `Default Company` on Company B and ensure its `Allowed Companies` don't contain Company A;
- In a private navigator (to ensure no login data are saved), answer the survey (using the copied link above);
- Log in as the active user and go to Surveys / Participations;
- Look for the record of your test (`Contact` field should be empty);
- Click the `Certifications` action button;

**Cause:**
The user is not allowed to retrieve the other company's data to fill needed texts to display on the certificate.

**Fix:**
Allow any user to retrieve the logo and name of the restricted company using a `sudo` on these fields.


opw-4266445

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
