### PR TITLE
[IMP] profiler: add a wizard to control the rendering of speedscope

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -20,6 +20,7 @@ This module provides the core of the Odoo Web Client.
         'views/base_document_layout_views.xml',
         'views/partner_view.xml',
         'views/speedscope_template.xml',
+        'views/speedscope_config_wizard.xml',
         'views/neutralize_views.xml',
         'data/ir_attachment.xml',
         'data/report_layout.xml',

--- a/addons/web/controllers/profiling.py
+++ b/addons/web/controllers/profiling.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import base64
 import json
 
 from odoo.exceptions import UserError
-from odoo.http import Controller, request, Response, route
-import urllib.parse
+from odoo.http import Controller, request, Response, route, content_disposition
+
 
 class Profiling(Controller):
 
@@ -23,24 +24,36 @@ class Profiling(Controller):
 
     @route([
         '/web/speedscope',
-        '/web/speedscope/<model("ir.profile"):profile>',
+        '/web/speedscope/<profile>',
     ], type='http', sitemap=False, auth='user', readonly=True)
     def speedscope(self, profile=None, action=False, **kwargs):
-        if profile and isinstance(profile, str):
-            profile = request.env['ir.profile'].browse(int(profile))
+        if not profile:
+            return
+        profile_str = profile
+        profile = request.env['ir.profile'].browse(int(profile_str))
         if not kwargs and not action:
             context = {
                 'profile': profile,
             }
             return request.render('web.config_speedscope_index', context)
+        speedscope_result = profile._generate_speedscope(profile._parse_params(kwargs))
+        if action == 'download_json':
+            headers = [
+                ('Content-Type', 'application/json'),
+                ('X-Content-Type-Options', 'nosniff'),
+                ('Content-Disposition', content_disposition(f'profile_{profile_str}.json')),
+            ]
+            return request.make_response(speedscope_result, headers)
         icp = request.env['ir.config_parameter']
         context = {
             'profile': profile,
+            'speedscope_base64': base64.b64encode(speedscope_result).decode('utf-8'),
             'url_root': request.httprequest.url_root,
             'cdn': icp.sudo().get_param('speedscope_cdn', "https://cdn.jsdelivr.net/npm/speedscope@1.13.0/dist/release/")
         }
-        if profile and action == 'download_json':
-            url_params = urllib.parse.urlencode(kwargs)
-            return request.redirect(f'/web/content/ir.profile/{profile.id}/speedscope?download=true&filename=profile_{profile.id}.json{"&" + url_params if url_params else ""}')
         response = request.render('web.view_speedscope_index', context)
+        if action == 'download_html':
+            response.headers['Content-Disposition'] = content_disposition(f'profile_{profile_str}.html')
+            response.headers['X-Content-Type-Options'] = 'nosniff'
+            response.headers['Content-Type'] = 'text/html'
         return response

--- a/addons/web/controllers/profiling.py
+++ b/addons/web/controllers/profiling.py
@@ -4,6 +4,7 @@ import json
 
 from odoo.exceptions import UserError
 from odoo.http import Controller, request, Response, route
+import urllib.parse
 
 class Profiling(Controller):
 
@@ -24,14 +25,22 @@ class Profiling(Controller):
         '/web/speedscope',
         '/web/speedscope/<model("ir.profile"):profile>',
     ], type='http', sitemap=False, auth='user', readonly=True)
-    def speedscope(self, profile=None):
-        # don't server speedscope index if profiling is not enabled
-        if not request.env['ir.profile']._enabled_until():
-            return request.not_found()
+    def speedscope(self, profile=None, action=False, **kwargs):
+        if profile and isinstance(profile, str):
+            profile = request.env['ir.profile'].browse(int(profile))
+        if not kwargs and not action:
+            context = {
+                'profile': profile,
+            }
+            return request.render('web.config_speedscope_index', context)
         icp = request.env['ir.config_parameter']
         context = {
             'profile': profile,
             'url_root': request.httprequest.url_root,
             'cdn': icp.sudo().get_param('speedscope_cdn', "https://cdn.jsdelivr.net/npm/speedscope@1.13.0/dist/release/")
         }
-        return request.render('web.view_speedscope_index', context)
+        if profile and action == 'download_json':
+            url_params = urllib.parse.urlencode(kwargs)
+            return request.redirect(f'/web/content/ir.profile/{profile.id}/speedscope?download=true&filename=profile_{profile.id}.json{"&" + url_params if url_params else ""}')
+        response = request.render('web.view_speedscope_index', context)
+        return response

--- a/addons/web/controllers/profiling.py
+++ b/addons/web/controllers/profiling.py
@@ -28,15 +28,16 @@ class Profiling(Controller):
     ], type='http', sitemap=False, auth='user', readonly=True)
     def speedscope(self, profile=None, action=False, **kwargs):
         if not profile:
-            return
+            raise request.not_found()
         profile_str = profile
-        profile = request.env['ir.profile'].browse(int(profile_str))
+        profiles = request.env['ir.profile'].browse((int(p) for p in profile.split(',')))
         if not kwargs and not action:
             context = {
-                'profile': profile,
+                'profile_str': profile_str,
+                'profiles': profiles,
             }
             return request.render('web.config_speedscope_index', context)
-        speedscope_result = profile._generate_speedscope(profile._parse_params(kwargs))
+        speedscope_result = profiles._generate_speedscope(profiles._parse_params(kwargs))
         if action == 'download_json':
             headers = [
                 ('Content-Type', 'application/json'),
@@ -46,7 +47,7 @@ class Profiling(Controller):
             return request.make_response(speedscope_result, headers)
         icp = request.env['ir.config_parameter']
         context = {
-            'profile': profile,
+            'profiles': profiles,
             'speedscope_base64': base64.b64encode(speedscope_result).decode('utf-8'),
             'url_root': request.httprequest.url_root,
             'cdn': icp.sudo().get_param('speedscope_cdn', "https://cdn.jsdelivr.net/npm/speedscope@1.13.0/dist/release/")

--- a/addons/web/tests/test_profiler.py
+++ b/addons/web/tests/test_profiler.py
@@ -55,10 +55,10 @@ class TestProfilingWeb(ProfilingHttpCase):
         self.assertTrue(res['result']['session'])
         self.assertEqual(last_profile, self.env['ir.profile'].search([], limit=1, order='id desc'), "profiling route shouldn't have been profiled")
         # Profile a page
-        res = self.url_open('/web/speedscope')  # profile a light route
+        res = self.url_open(f'/web/login')  # profile a light route
         new_profile = self.env['ir.profile'].search([], limit=1, order='id desc')
         self.assertNotEqual(last_profile, new_profile, "A new profile should have been created")
-        self.assertEqual(new_profile.name, '/web/speedscope?')
+        self.assertEqual(new_profile.name, f'/web/login?')
 
 
 @tagged('post_install', '-at_install', 'profiling')

--- a/addons/web/views/speedscope_config_wizard.xml
+++ b/addons/web/views/speedscope_config_wizard.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="config_speedscope_index">
+        <link rel="stylesheet" href="/web/assets/any/web.assets_web.min.css" />
+        <script src="/web/assets/any/web.assets_web.min.js" type="text/javascript"/>
+        
+        <div class="container-md p-0">
+            <div class="o_form_view" style="align-items: center;">
+                <div class="o_form_sheet">
+                    <!-- Single Form -->
+                    <form id="dynamicForm" method="get" t-attf-action="/web/speedscope/{{profile.id}}">
+                        <h4>Options</h4>
+                        <div class="form-check">
+                            <input type="checkbox" class="form-check-input" id="constant_time" name="constant_time" value="True" />
+                            <label class="form-check-label" for="constant_time">Constant Time</label>
+                        </div>
+                        <!-- add more variable here -->
+                        <div class="form-check">
+                            <input type="checkbox" class="form-check-input" id="aggregate_sql" name="aggregate_sql" value="True" />
+                            <label class="form-check-label" for="aggregate_sql">Aggregate SQL</label>
+                        </div>
+                        <div class="form-check">
+                            <input type="checkbox" class="form-check-input" id="use_execution_context" name="use_execution_context" value="True" checked="1"/>
+                            <label class="form-check-label" for="use_execution_context">Use execution context</label>
+                        </div>
+
+                        <h4>Profiles to display</h4>
+                        
+                        <div class="form-check" t-if="profile.sql and profile.traces_async">
+                            <input type="checkbox" class="form-check-input" id="combined_profile" name="combined_profile" value="True" checked="checked"/>
+                            <label class="form-check-label" for="combined_profile">Frames + sql (Combined)</label>
+                        </div>
+                        <div class="form-check" t-if="profile.sql">
+                            <input type="checkbox" class="form-check-input" id="sql_no_gap_profile" name="sql_no_gap_profile" value="True" checked="checked"/>
+                            <label class="form-check-label" for="sql_no_gap_profile">SQL no gap</label>
+                        </div>
+                        <div class="form-check" t-if="profile.sql">
+                            <input type="checkbox" class="form-check-input" id="sql_density_profile" name="sql_density_profile" value="True"/>
+                            <label class="form-check-label" for="sql_density_profile">SQL density</label>
+                        </div>
+                        <div class="form-check" t-if="profile.traces_async">
+                            <input type="checkbox" class="form-check-input" id="frames_profile" name="frames_profile" value="True"/>
+                            <label class="form-check-label" for="frames_profile">Frames</label>
+                        </div>
+
+                        <input type="hidden" name="profile_id" t-att-value="profile.id" />
+                        
+                        <div class="mt-3">
+                            <button type="submit" class="btn btn-secondary" name="action" value="download_json"><i class="fa fa-download"/> (json)</button>
+                            <button type="submit" class="btn btn-primary" name="action" value="open">Open</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </template>
+</odoo>

--- a/addons/web/views/speedscope_config_wizard.xml
+++ b/addons/web/views/speedscope_config_wizard.xml
@@ -8,7 +8,7 @@
             <div class="o_form_view" style="align-items: center;">
                 <div class="o_form_sheet">
                     <!-- Single Form -->
-                    <form id="dynamicForm" method="get" t-attf-action="/web/speedscope/{{profile.id}}">
+                    <form id="dynamicForm" method="get" t-attf-action="/web/speedscope/{{profile_str}}">
                         <h4>Options</h4>
                         <div class="form-check">
                             <input type="checkbox" class="form-check-input" id="constant_time" name="constant_time" value="True" />
@@ -23,30 +23,46 @@
                             <input type="checkbox" class="form-check-input" id="use_execution_context" name="use_execution_context" value="True" checked="1"/>
                             <label class="form-check-label" for="use_execution_context">Use execution context</label>
                         </div>
+                        <div t-if="len(profiles) > 1">
+                        <hr/>
+                        <h4>Multiple profile</h4>
+                            <label class="form-check-label" for="profile_aggregation_mode">Aggregation mode</label>
+                            <select class="form-select" name="profile_aggregation_mode" id="profile_aggregation_mode">
+                                <option value="tabs">Separated (one per tab)</option>
+                                <option value="temporal">Temporal (experimental)</option>
+                            </select>
+                            <span id="temporal_warning" class="alert alert-warning" style="display:none"><b>Warning:</b> Temporal mode will merge all samples.<br/>It can lead to partially invalid result in case of concurrent profiles.<br/>Use with caution </span>
+                            <script>
+                                document.getElementById('profile_aggregation_mode').addEventListener('change', function (event) {
+                                    document.getElementById('temporal_warning').style.display = event.target.value === 'temporal'? 'block': 'none';
+                                });
+                            </script>
 
-                        <h4>Profiles to display</h4>
-                        
-                        <div class="form-check" t-if="profile.sql and profile.traces_async">
+                        </div>
+                        <hr/>
+                        <h4>Display presets</h4>
+                        <div class="form-check" t-if="any((profile.sql and profile.traces_async) for profile in profiles)">
                             <input type="checkbox" class="form-check-input" id="combined_profile" name="combined_profile" value="True" checked="checked"/>
                             <label class="form-check-label" for="combined_profile">Frames + sql (Combined)</label>
                         </div>
-                        <div class="form-check" t-if="profile.sql">
+                        <div class="form-check" t-if="any(profile.sql for profile in profiles)">
                             <input type="checkbox" class="form-check-input" id="sql_no_gap_profile" name="sql_no_gap_profile" value="True" checked="checked"/>
                             <label class="form-check-label" for="sql_no_gap_profile">SQL no gap</label>
                         </div>
-                        <div class="form-check" t-if="profile.sql">
+                        <div class="form-check" t-if="any(profile.sql for profile in profiles)">
                             <input type="checkbox" class="form-check-input" id="sql_density_profile" name="sql_density_profile" value="True"/>
                             <label class="form-check-label" for="sql_density_profile">SQL density</label>
                         </div>
-                        <div class="form-check" t-if="profile.traces_async">
+                        <div class="form-check" t-if="any(profile.traces_async for profile in profiles)">
                             <input type="checkbox" class="form-check-input" id="frames_profile" name="frames_profile" value="True"/>
                             <label class="form-check-label" for="frames_profile">Frames</label>
                         </div>
 
-                        <input type="hidden" name="profile_id" t-att-value="profile.id" />
+                        <input type="hidden" name="profile_id" t-att-value="profile_str" />
                         
                         <div class="mt-3">
                             <button type="submit" class="btn btn-secondary" name="action" value="download_json"><i class="fa fa-download"/> (json)</button>
+                            <button type="submit" class="btn btn-secondary" name="action" value="download_html"><i class="fa fa-download"/> (html)</button>
                             <button type="submit" class="btn btn-primary" name="action" value="open">Open</button>
                         </div>
                     </form>

--- a/addons/web/views/speedscope_template.xml
+++ b/addons/web/views/speedscope_template.xml
@@ -6,7 +6,7 @@
             <head>
                 <meta charset="UTF-8"/>
                 <title>Speedscope for odoo</title>
-                <script t-if="profile">window.location.hash="#profileURL=<t t-esc="url_root"/>web/content/ir.profile/<t t-esc="profile.id"/>/speedscope"</script>
+                <script t-if="profile">window.location.hash="#profileURL=<t t-esc="url_root"/>web/content/ir.profile/<t t-esc="profile.id"/>/speedscope?<t t-esc="search_params"/>"</script>
                 <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet"/>
                 <link rel="stylesheet"
                     t-attf-href="{{cdn}}reset.8c46b7a1.css"

--- a/addons/web/views/speedscope_template.xml
+++ b/addons/web/views/speedscope_template.xml
@@ -6,7 +6,7 @@
             <head>
                 <meta charset="UTF-8"/>
                 <title>Speedscope for odoo</title>
-                <script t-if="profile">window.location.hash="#profileURL=<t t-esc="url_root"/>web/content/ir.profile/<t t-esc="profile.id"/>/speedscope?<t t-esc="search_params"/>"</script>
+                <script>window.location.hash="#localProfilePath=1"</script>
                 <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet"/>
                 <link rel="stylesheet"
                     t-attf-href="{{cdn}}reset.8c46b7a1.css"
@@ -20,6 +20,12 @@
                     crossorigin="anonymous"
                     integrity="sha256-CvDqAOMjq0Sv/D59O5JSbzzXoClZ3rptt6ts8D/6CWw="
                 ></script>
+                <script>
+                const b64 = '<t t-esc="speedscope_base64"/>';
+                document.addEventListener("DOMContentLoaded", () => {
+                    speedscope.loadFileFromBase64('Profile', b64);
+                });
+                </script>
             </body>
         </html>
     </template>

--- a/odoo/addons/base/models/ir_profile.py
+++ b/odoo/addons/base/models/ir_profile.py
@@ -69,16 +69,36 @@ class IrProfile(models.Model):
         }
 
     def _generate_speedscope(self, params):
-        sp = Speedscope(init_stack_trace=json.loads(self.init_stack_trace))
-        if self.sql:
-            sp.add('sql', json.loads(self.sql), params['aggregate_sql'])
-        if self.traces_async:
-            sp.add('frames', json.loads(self.traces_async))
-        if self.traces_sync:
-            sp.add('settrace', json.loads(self.traces_sync))
+        init_stack_trace = self[0].init_stack_trace
+        for record in self:
+            if record.init_stack_trace != init_stack_trace:
+                raise UserError(_('All profiles must have the same initial stack trace to be displayed together.'))
+        sp = Speedscope(init_stack_trace=json.loads(init_stack_trace))
+        for profile in self:
+            if (params['sql_no_gap_profile'] or params['sql_density_profile'] or params['combined_profile']) and profile.sql:
+                sp.add(f'sql {profile.id}', json.loads(profile.sql))
+            if (params['frames_profile'] or params['combined_profile']) and profile.traces_async:
+                sp.add(f'frames {profile.id}', json.loads(profile.traces_async))
+            if params['profile_aggregation_mode'] == 'tabs':
+                profile._add_outputs(sp, profile.id if len(self) > 1 else '', params)
 
-        result = json.dumps(sp.add_default(**params).make(**params))
-        self.speedscope = base64.b64encode(result.encode('utf-8'))
+        if params['profile_aggregation_mode'] == 'temporal':
+            self._add_outputs(sp, 'all', params)
+
+        result = json.dumps(sp.make(**params))
+        return result.encode('utf-8')
+    
+    def _add_outputs(self, sp, suffix, params):
+        sql = [f'sql {profile.id}' for profile in self]
+        frames = [f'frames {profile.id}' for profile in self]
+        if params['combined_profile']:
+            sp.add_output(sql + frames, display_name=f'Combined {suffix}', **params)
+        if params['sql_no_gap_profile']:
+            sp.add_output(sql, hide_gaps=True, display_name=f'Sql (no gap) {suffix}', **params)
+        if params['sql_density_profile']:
+            sp.add_output(sql , continuous=False, complete=False, display_name=f'Sql (density) {suffix}',**params)
+        if params['frames_profile']:
+            sp.add_output(frames, display_name=f'Frames {suffix}',**params)
 
     def _compute_speedscope_url(self):
         for profile in self:
@@ -141,6 +161,13 @@ class IrProfile(models.Model):
             'params': request.session.get('profile_params'),
         }
 
+    def action_view_speedscope(self):
+        ids = ",".join(str(p.id) for p in self)
+        return {
+            'type': 'ir.actions.act_url',
+            'url': f'/web/speedscope/{ids}',
+            'target': 'new',
+        }
 
 class BaseEnableProfilingWizard(models.TransientModel):
     _name = 'base.enable.profiling.wizard'

--- a/odoo/addons/base/tests/test_profiler.py
+++ b/odoo/addons/base/tests/test_profiler.py
@@ -113,7 +113,6 @@ class TestSpeedscope(BaseCase):
     def test_converts_profile_no_end(self):
         profile = self.example_profile()
         profile['result'].pop()
-
         sp = Speedscope(init_stack_trace=profile['init_stack_trace'])
         sp.add('profile', profile['result'])
         sp.add_output(['profile'], complete=False)
@@ -206,6 +205,49 @@ class TestSpeedscope(BaseCase):
                 (10.35, 'C', 'do_stuff1'),
             (10.35, 'C', 'main'),
         ])
+
+    def test_following_queries_dont_merge(self):
+        sql_profile = self.example_profile()['result']
+        stack = sql_profile[1]['stack']
+        # make sql_profile two frames, separataed by some time
+        sql_profile = [
+            {
+                'start': 0.0,
+                'time': 1,
+                'query': 'SELECT 1',
+                'full_query': 'SELECT 1',
+                'stack': stack[:]
+            },
+            {
+                'start': 10.0,
+                'time': 1,
+                'query': 'SELECT 1',
+                'full_query': 'SELECT 1',
+                'stack': stack[:]
+            }
+        ]
+        sp = Speedscope(init_stack_trace=[])
+        sp.add('sql', sql_profile)
+        sp.add_output(['sql'], complete=False, hide_gaps=True)
+        res = sp.make()
+        sql_output = res['profiles'][0]
+        events = [
+            (e['at'], e['type'], res['shared']['frames'][e['frame']]['name'])
+            for e in sql_output['events']
+        ]
+        self.assertEqual(events, [
+            # pylint: disable=bad-continuation
+            (0.0, 'O', 'main'),
+                (0.0, 'O', 'do_stuff1'),
+                    (0.0, 'O', 'execute'),
+                        (0.0, 'O', "sql('SELECT 1')"),
+                        (2.0, 'C', "sql('SELECT 1')"),
+                    (2.0, 'C', 'execute'),
+                (2.0, 'C', 'do_stuff1'),
+            (2.0, 'C', 'main'),
+        ])
+
+
 
     def test_converts_context(self):
         stack = [

--- a/odoo/addons/base/views/ir_profile_views.xml
+++ b/odoo/addons/base/views/ir_profile_views.xml
@@ -18,6 +18,9 @@
         <field name="model">ir.profile</field>
         <field name="arch" type="xml">
             <list string="Profile Session" default_order="session desc, id desc">
+                <header>
+                    <button name="action_view_speedscope" type="object" string="View in speedscope"/>
+                </header>
                 <field name="create_date"/>
                 <field name="session"/>
                 <field name="name"/>

--- a/odoo/tools/speedscope.py
+++ b/odoo/tools/speedscope.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import reprlib
-from .func import filter_kwargs
 
 shortener = reprlib.Repr()
 shortener.maxstring = 150
 shorten = shortener.repr
-
 
 class Speedscope:
     def __init__(self, name='Speedscope', init_stack_trace=None):
@@ -24,13 +22,13 @@ class Speedscope:
         self.frame_count = 0
         self.profiles = []
 
-    def add(self, key, profile, aggregate_sql=False):
+    def add(self, key, profile):
         for entry in profile:
             self.caller_frame = self.init_caller_frame
             self.convert_stack(entry['stack'] or [])
             if 'query' in entry:
                 query = entry['query']
-                full_query = entry['full_query'] if not aggregate_sql else query
+                full_query = entry['full_query']
                 entry['stack'].append((f'sql({shorten(query)})', full_query, None))
         self.profiles_raw[key] = profile
 
@@ -45,13 +43,25 @@ class Speedscope:
             stack[index] = (method, line, number,)
             self.caller_frame = frame
 
-    def add_output(self, names, complete=True, display_name=None, use_context=True, constant_time=False, **params):
+    def add_output(self, names, complete=True, display_name=None, use_context=True, constant_time=False, context_per_name = None, **params):
+        """
+        Add a profile output to the list of profiles
+        :param names: list of keys to combine in this output. Keys corresponds to the one used in add
+        :param display_name: name of the tab for this output
+        :param complete: display the complete stack. If False, don't display the stack bellow the profiler.
+        :param use_context: use execution context (added by ExecutionContext context manager) to display the profile.
+        :param constant_time: hide temporality. Useful to compare query counts
+        :param context_per_name: a dictionary of additionnal context per name
+        """
         entries = []
         display_name = display_name or ','.join(names)
         for name in names:
-            entries += self.profiles_raw[name]
+            raw = self.profiles_raw.get(name)
+            if not raw:
+                continue
+            entries += raw
         entries.sort(key=lambda e: e['start'])
-        result = self.process(entries, use_context=use_context, constant_time=constant_time)
+        result = self.process(entries, use_context=use_context, constant_time=constant_time, **params)
         if not result:
             return self
         start = result[0]['at']
@@ -124,7 +134,7 @@ class Speedscope:
             self.frame_count += 1
         return self.frames_indexes[frame]
 
-    def stack_to_ids(self, stack, context, stack_offset=0):
+    def stack_to_ids(self, stack, context, aggregate_sql=False, stack_offset=0):
         """
             :param stack: A list of hashable frame
             :param context: an iterable of (level, value) ordered by level
@@ -141,6 +151,8 @@ class Speedscope:
         while context_level is not None and context_level < stack_offset:
             context_level, context_value = next(context_iterator, (None, None))
         for level, frame in enumerate(stack, start=stack_offset + 1):
+            if aggregate_sql:
+                frame = (frame[0], '', frame[2])
             while context_level == level:
                 context_frame = (", ".join(f"{k}={v}" for k, v in context_value.items()), '', '')
                 stack_ids.append(self.get_frame_id(context_frame))
@@ -148,7 +160,7 @@ class Speedscope:
             stack_ids.append(self.get_frame_id(frame))
         return stack_ids
 
-    def process(self, entries, continuous=True, hide_gaps=False, use_context=True, constant_time=False):
+    def process(self, entries, continuous=True, hide_gaps=False, use_context=True, constant_time=False, aggregate_sql=False, **params):
         # constant_time parameters is mainly useful to hide temporality when focussing on sql determinism
         entry_end = previous_end = None
         if not entries:
@@ -167,7 +179,6 @@ class Speedscope:
                 entry_start = close_time = index
             else:
                 previous_end = entry_end
-
                 if hide_gaps and previous_end:
                     entry_start = previous_end
                 else:
@@ -188,6 +199,7 @@ class Speedscope:
             entry_stack_ids = self.stack_to_ids(
                 entry['stack'] or [],
                 use_context and entry.get('exec_context'),
+                aggregate_sql,
                 self.init_stack_trace_level
             )
             level = 0


### PR DESCRIPTION
This pr aims to improve the profiling, and mainly speedscope rendering experience.

Right now, visualizing a speedscope result:
- Gives a static result. The  makes the usage of some options like constant time impossible without editing the code. It also generate to much different types of output at the same time making it slow and leads faster to memory error.
- Needs to enable the profiling on the database to be able to visualize the result.  This can be painful mainly when trying to access result after some time, or just after profiling in python.

This pr removes the need to enable the profiling to visualize the results. 

This pr adds a wizard to enable or disable some options.

As a bonus it is now possible to combine multiple profile in the same view (experimental)


