### PR TITLE
[FIX] point_of_sale: Replace 'tree' with 'list' in outstanding rescue…

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -661,7 +661,7 @@ class PosConfig(models.Model):
             return {
                 'name': _('Rescue Sessions'),
                 'res_model': 'pos.session',
-                'view_mode': 'tree,form',
+                'view_mode': 'list,form',
                 'domain': [('id', 'in', rescue_session_ids.ids)],
                 'type': 'ir.actions.act_window',
             }

--- a/doc/cla/individual/kripal.md
+++ b/doc/cla/individual/kripal.md
@@ -1,0 +1,11 @@
+India, 2024-12-02
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Kripal K kripal259@gmail.com https://github.com/kripal754


### PR DESCRIPTION
… session action.

Description of the issue/feature this PR addresses:
1. Usage of 'tree' in outstanding rescue session action.
2. Missing CLA for contributions.

Current behavior before PR:
1. The outstanding rescue session action uses 'tree' .
2. CLA file is not included.

Desired behavior after PR is merged:
1. 'list' replaces 'tree' in the outstanding rescue session action.
2. CLA file is added for future contributions.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
