### PR TITLE
[FIX] survey: redirect without error

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -144,7 +144,7 @@ class Survey(http.Controller):
                     if answer_sudo.partner_id.user_ids:
                         answer_sudo.partner_id.signup_cancel()
                     else:
-                        answer_sudo.partner_id.signup_prepare(expiration=fields.Datetime.now() + relativedelta(days=1))
+                        answer_sudo.partner_id.signup_prepare()
                     redirect_url = answer_sudo.partner_id._get_signup_url_for_action(url='/survey/start/%s?answer_token=%s' % (survey_sudo.access_token, answer_sudo.access_token))[answer_sudo.partner_id.id]
                 else:
                     redirect_url = '/web/login?redirect=%s' % ('/survey/start/%s?answer_token=%s' % (survey_sudo.access_token, answer_sudo.access_token))


### PR DESCRIPTION
Steps to Reproduce
- Go to Surveys
- Select a survey > Options Tab > Check the "Require Login" box
- Save > Share the survey > Check the "Send by Email" box > Select any partner > "Send"
- Go to Settings > Technical > Emails
- Open the Email sent to the selected partner in step 3
- Try to open the link in an incognito browser instance (Not logged in)

Current behaviour:
Visiting the Survey Invite link throws "500: Internal Server Error" to the user.

Expected behaviour:
Redirect to the login page.

Cause:
The signature of `signup_prepare` changed in 94b969b035da3d4200, but `survey` code was not adapted.

Fixes #189332