### PR TITLE
[IMP] l10n_mx: Update Mexican banks

### DIFF
--- a/addons/l10n_mx/data/res_bank_data.xml
+++ b/addons/l10n_mx/data/res_bank_data.xml
@@ -40,11 +40,6 @@
         <field name='l10n_mx_edi_code'>030</field>
         <field name='country' ref="base.mx"/>
     </record>
-    <record id='acc_bank_032_IXE' model='res.bank'>
-        <field name='name'>IXE</field>
-        <field name='l10n_mx_edi_code'>032</field>
-        <field name='country' ref="base.mx"/>
-    </record>
     <record id='acc_bank_036_INBURSA' model='res.bank'>
         <field name='name'>INBURSA</field>
         <field name='l10n_mx_edi_code'>036</field>
@@ -86,7 +81,7 @@
         <field name='country' ref="base.mx"/>
     </record>
     <record id='acc_bank_072_BANORTE' model='res.bank'>
-        <field name='name'>BANORTE</field>
+        <field name='name'>BANORTE/IXE</field>
         <field name='l10n_mx_edi_code'>072</field>
         <field name='country' ref="base.mx"/>
     </record>
@@ -123,11 +118,6 @@
     <record id='acc_bank_113_VE_POR_MAS' model='res.bank'>
         <field name='name'>VE POR MAS</field>
         <field name='l10n_mx_edi_code'>113</field>
-        <field name='country' ref="base.mx"/>
-    </record>
-    <record id='acc_bank_116_ING' model='res.bank'>
-        <field name='name'>ING</field>
-        <field name='l10n_mx_edi_code'>116</field>
         <field name='country' ref="base.mx"/>
     </record>
     <record id='acc_bank_124_DEUTSCHE' model='res.bank'>
@@ -175,18 +165,13 @@
         <field name='l10n_mx_edi_code'>133</field>
         <field name='country' ref="base.mx"/>
     </record>
-    <record id='acc_bank_134_WAL-MART' model='res.bank'>
-        <field name='name'>WAL-MART</field>
-        <field name='l10n_mx_edi_code'>134</field>
-        <field name='country' ref="base.mx"/>
-    </record>
     <record id='acc_bank_135_NAFIN' model='res.bank'>
         <field name='name'>NAFIN</field>
         <field name='l10n_mx_edi_code'>135</field>
         <field name='country' ref="base.mx"/>
     </record>
     <record id='acc_bank_136_INTERBANCO' model='res.bank'>
-        <field name='name'>INTERBANCO</field>
+        <field name='name'>INTERCAM BANCO</field>
         <field name='l10n_mx_edi_code'>136</field>
         <field name='country' ref="base.mx"/>
     </record>
@@ -381,7 +366,7 @@
         <field name='country' ref="base.mx"/>
     </record>
     <record id='acc_bank_638_AKALA' model='res.bank'>
-        <field name='name'>AKALA</field>
+        <field name='name'>NU</field>
         <field name='l10n_mx_edi_code'>638</field>
         <field name='country' ref="base.mx"/>
     </record>
@@ -463,6 +448,81 @@
     <record id='acc_bank_999_NA' model='res.bank'>
         <field name='name'>N/A</field>
         <field name='l10n_mx_edi_code'>999</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_154_BANCO_FINTERRA' model='res.bank'>
+        <field name='name'>BANCO FINTERRA</field>
+        <field name='l10n_mx_edi_code'>154</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_160_BANCO_S3' model='res.bank'>
+        <field name='name'>BANCO S3</field>
+        <field name='l10n_mx_edi_code'>160</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_152_BANCREA' model='res.bank'>
+        <field name='name'>BANCREA</field>
+        <field name='l10n_mx_edi_code'>152</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_159_BANK_OF_CHINA' model='res.bank'>
+        <field name='name'>BANK OF CHINA</field>
+        <field name='l10n_mx_edi_code'>159</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_147_BANKAOOL' model='res.bank'>
+        <field name='name'>BANKAOOL</field>
+        <field name='l10n_mx_edi_code'>147</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_151_DONDÉ' model='res.bank'>
+        <field name='name'>DONDÉ</field>
+        <field name='l10n_mx_edi_code'>151</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_149_FORJADORES' model='res.bank'>
+        <field name='name'>FORJADORES</field>
+        <field name='l10n_mx_edi_code'>149</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_155_ICBC' model='res.bank'>
+        <field name='name'>ICBC</field>
+        <field name='l10n_mx_edi_code'>155</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_150_INMOBILIARIO' model='res.bank'>
+        <field name='name'>INMOBILIARIO</field>
+        <field name='l10n_mx_edi_code'>150</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_136_INTERCAM_BANCO' model='res.bank'>
+        <field name='name'>INTERCAM BANCO</field>
+        <field name='l10n_mx_edi_code'>136</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_158_MIZUHO_BANK' model='res.bank'>
+        <field name='name'>MIZUHO BANK</field>
+        <field name='l10n_mx_edi_code'>158</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_148_PAGATODO' model='res.bank'>
+        <field name='name'>PAGATODO</field>
+        <field name='l10n_mx_edi_code'>148</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_153_PROGRESO' model='res.bank'>
+        <field name='name'>PROGRESO</field>
+        <field name='l10n_mx_edi_code'>153</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_156_SABADELL' model='res.bank'>
+        <field name='name'>SABADELL</field>
+        <field name='l10n_mx_edi_code'>156</field>
+        <field name='country' ref="base.mx"/>
+    </record>
+    <record id='acc_bank_157_SHINHAN' model='res.bank'>
+        <field name='name'>SHINHAN</field>
+        <field name='l10n_mx_edi_code'>157</field>
         <field name='country' ref="base.mx"/>
     </record>
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- The last update on Mexican banks was five years ago. Since then, several new banks have emerged, while others have closed.

Current behavior before PR:
- 3 banks in our data no longer exist in real life.
- 3 banks have outdated names.
- 15 new banks aren't included, since they emerged after our bank data was updated.

Desired behavior after PR is merged:
- To align the bank list with those specified by the SAT (_Servicio de Administración Tributaria_, Mexico's highest tax authority responsible for tax collection), you can refer to their [official documentation](http://omawww.sat.gob.mx/fichas_tematicas/buzon_tributario/Documents/catalogo_bancos.pdf).

opw-[4327242](https://www.odoo.com/odoo/project.task/project.task/4327242)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
