### PR TITLE
[FIX] stock_delivery: consider adjusted order weight in shipping rates

### DIFF
--- a/addons/stock_delivery/models/delivery_carrier.py
+++ b/addons/stock_delivery/models/delivery_carrier.py
@@ -107,6 +107,8 @@ class DeliveryCarrier(models.Model):
             total_cost += self._product_price_to_company_currency(line.product_qty, line.product_id, order.company_id)
 
         total_weight = order._get_estimated_weight() + default_package_type.base_weight
+        order_weight = self.env.context.get('order_weight', False)
+        total_weight = order_weight or total_weight
         if total_weight == 0.0:
             weight_uom_name = self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
             raise UserError(_("The package cannot be created because the total weight of the products in the picking is 0.0 %s", weight_uom_name))


### PR DESCRIPTION
Before Commit:
---------------
- Shipping rates were retrieved based on the total shipping weight calculated from product.
- Manually adjusted weights were not considered in the rate retrieval, causing inconsistencies.

After Commit:
-------------
- The weight computation for the packages was updated to take into consideration the manually modified order weight.
- If an adjusted weight is provided, it will be used for rate calculations; otherwise, the calculated weight will be used.
- This fix prevents confusion and ensures that the shipping rate reflects the actual weight of the order as adjusted by the user.

task-4203065