### PR TITLE
[IMP] website_sale: add video from frontend

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -114,7 +114,7 @@ export class MediaDialog extends Component {
     }
 
     addTabs() {
-        const onlyImages = this.props.onlyImages || this.props.multiImages || (this.props.media && this.props.media.parentElement && (this.props.media.parentElement.dataset.oeField === 'image' || this.props.media.parentElement.dataset.oeType === 'image'));
+        const onlyImages = this.props.onlyImages || (this.props.media && this.props.media.parentElement && (this.props.media.parentElement.dataset.oeField === 'image' || this.props.media.parentElement.dataset.oeType === 'image'));
         const noDocuments = onlyImages || this.props.noDocuments;
         const noIcons = onlyImages || this.props.noIcons;
         const noVideos = onlyImages || this.props.noVideos;

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import base64
 import json
 from datetime import datetime
 
@@ -29,6 +30,7 @@ from odoo.addons.portal.controllers.portal import _build_url_w_params
 from odoo.addons.sale.controllers import portal as sale_portal
 from odoo.addons.website.controllers.main import QueryURL
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
+from odoo.addons.web_editor.tools import get_video_thumbnail
 
 
 class TableCompute:
@@ -495,22 +497,41 @@ class WebsiteSale(payment_portal.PaymentPortal):
         # Compatibility pre-v14
         return request.redirect(_build_url_w_params("/shop/%s" % request.env['ir.http']._slug(product), request.params), code=301)
 
-    @route(['/shop/product/extra-images'], type='jsonrpc', auth='user', website=True)
-    def add_product_images(self, images, product_product_id, product_template_id, combination_ids=None):
+    @route(['/shop/product/extra-media'], type='jsonrpc', auth='user', website=True)
+    def add_product_media(self, media, type, product_product_id, product_template_id, combination_ids=None):
         """
-        Turns a list of image ids refering to ir.attachments to product.images,
+        Handles adding both images and videos to product variants or templates,
         links all of them to product.
+        :param type: [...] can be either image or video
         :raises NotFound : If the user is not allowed to access Attachment model
         """
 
         if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise NotFound()
 
-        image_ids = request.env["ir.attachment"].browse(i['id'] for i in images)
-        image_create_data = [Command.create({
-                    'name': image.name,                          # Images uploaded from url do not have any datas. This recovers them manually
-                    'image_1920': image.datas if image.datas else request.env['ir.qweb.field.image'].load_remote_url(image.url),
-                }) for image in image_ids]
+        if type == 'image':  # Image case
+            image_ids = request.env["ir.attachment"].browse(i['id'] for i in media)
+            media_create_data = [Command.create({
+                'name': image.name,   # Images uploaded from url do not have any datas. This recovers them manually
+                'image_1920': image.datas
+                    if image.datas
+                    else request.env['ir.qweb.field.image'].load_remote_url(image.url),
+            }) for image in image_ids]
+        elif type == 'video':  # Video case
+            video_data = media[0]
+            thumbnail = None
+            if video_data.get('src'):  # Check if a valid video URL is provided
+                try:
+                    thumbnail = base64.b64encode(get_video_thumbnail(video_data['src']))
+                except Exception:
+                    thumbnail = None
+            else:
+                raise ValidationError(_("Invalid video URL provided."))
+            media_create_data = [Command.create({
+                'name': video_data.get('name', 'Odoo Video'),
+                'video_url': video_data['src'],
+                'image_1920': thumbnail,
+            })]
 
         product_product = request.env['product.product'].browse(int(product_product_id)) if product_product_id else False
         product_template = request.env['product.template'].browse(int(product_template_id)) if product_template_id else False
@@ -525,11 +546,11 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 product_product = product_template._create_product_variant(combination)
         if product_template.has_configurable_attributes and product_product and not all(pa.create_variant == 'no_variant' for pa in product_template.attribute_line_ids.attribute_id):
             product_product.write({
-                'product_variant_image_ids': image_create_data
+                'product_variant_image_ids': media_create_data
             })
         else:
             product_template.write({
-                'product_template_image_ids': image_create_data
+                'product_template_image_ids': media_create_data
             })
 
     @route(['/shop/product/clear-images'], type='jsonrpc', auth='user', website=True)

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -360,7 +360,7 @@
             <we-row string="Main Image">
                 <we-button class="o_we_bg_success" data-name="o_wsale_replace_main_image" data-replace-main-image="true" data-no-preview="true">Replace</we-button>
             </we-row>
-            <we-row string="Extra Images">
+            <we-row string="Extra Media">
                 <we-button class="o_we_bg_success" data-name="o_wsale_add_extra_images" data-add-images="true" data-no-preview="true">Add</we-button>
                 <we-button class="o_we_bg_danger" data-name="o_wsale_clear_extra_images" data-clear-images="true" data-no-preview="true">Remove all</we-button>
             </we-row>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -3120,7 +3120,25 @@
     </template>
 
     <template id="website_sale.shop_product_image">
-        <div t-if="product_image._name == 'product.image' and product_image.embed_code" t-att-class="image_classes + ' ratio ratio-16x9'">
+        <div
+            t-if="'video_url' in product_image"
+            t-att-data-oe-model="product_image._name"
+            t-att-data-oe-id="product_image.id"
+            t-att-class="image_classes + ' ratio ratio-16x9'"
+        >
+            <div class="media_iframe_video">
+                <div class="css_editable_mode_display"/>
+                <div class="media_iframe_video_size" contenteditable="false"/>
+                <iframe
+                    t-att-src="product_image.video_url"
+                    allowfullscreen="allowfullscreen">
+                </iframe>
+            </div>
+        </div>
+        <div
+            t-elif="product_image._name == 'product.image' and product_image.embed_code"
+            t-att-class="image_classes + ' ratio ratio-16x9'"
+        >
             <t t-out="product_image.embed_code"/>
         </div>
         <div


### PR DESCRIPTION
**Prior to this commit:**

- Only images were supported for upload in product templates and variants.
- The handling for videos was missing, limiting multimedia options for products.
- The AttachmentMediaDialog was set to handle only images using the onlyImages property, blocking video uploads.
- Image processing was limited to certain formats and required extra handling for webp conversion.

**Post this commit:**

- Both images and videos are now supported for upload in product templates and variants.
- The backend can differentiate between image and video types and process them accordingly.
- The frontend now uses extraMediaSave to handle different media types (image or video).

**Why This Approach:**

- This approach ensures flexibility for handling both images and videos in the same dialog without needing additional props or complex changes.
- By modifying the existing structure, we avoid introducing unnecessary complexity while keeping backward compatibility.
- The use of **extraMediaSave** allows clear and reusable logic to process different media types.

**Challenges Faced:**

- Ensuring that both image and video tabs were displayed correctly in the dialog.
- Handling video files while maintaining the existing image-specific logic.
- Properly generating and storing video thumbnails alongside the video URL in the backend.

**Affected version**: master
task-3733878