### PR TITLE
[FIX] web: drag&drop text between fields in the form view

### DIFF
--- a/addons/web/static/src/core/dropzone/dropzone_hook.js
+++ b/addons/web/static/src/core/dropzone/dropzone_hook.js
@@ -20,12 +20,23 @@ export function useCustomDropzone(targetRef, dropzoneComponent, dropzoneComponen
     useExternalListener(document, "dragleave", onDragLeave, { capture: true });
     // Prevents the browser to open or download the file when it is dropped
     // outside of the dropzone.
-    useExternalListener(window, "dragover", (ev) => ev.preventDefault());
-    useExternalListener(window, "drop", (ev) => {
-        ev.preventDefault();
-        dragCount = 0;
-        updateDropzone();
-    }, { capture: true });
+    useExternalListener(window, "dragover", (ev) => {
+        if (ev.dataTransfer && ev.dataTransfer.types.includes("Files")) {
+            ev.preventDefault();
+        }
+    });
+    useExternalListener(
+        window,
+        "drop",
+        (ev) => {
+            if (ev.dataTransfer && ev.dataTransfer.types.includes("Files")) {
+                ev.preventDefault();
+            }
+            dragCount = 0;
+            updateDropzone();
+        },
+        { capture: true }
+    );
 
     function updateDropzone() {
         const hasDropzone = !!removeDropzone;


### PR DESCRIPTION
Before this commit:
It is not able to drag and drop text between fields in the form view.

After this commit:
It is possible to drag and drop text between fields in the form view.

Task-4286285
