### PR TITLE
[REV] web: tests - cache compiled templates

### DIFF
--- a/addons/web/static/tests/_framework/mock_templates.hoot.js
+++ b/addons/web/static/tests/_framework/mock_templates.hoot.js
@@ -60,35 +60,10 @@ export function makeTemplateFactory(name, factory) {
             return loader.modules.get(name);
         }
 
-        /** @type {Map<string, function>} */
-        const compiledTemplates = new Map();
-
         const factoryFn = factory.fn;
         factory.fn = (...args) => {
             const exports = factoryFn(...args);
-            const { clearProcessedTemplates, getTemplate } = exports;
-
-            // Patch "getTemplates" to access local cache
-            exports.getTemplate = function mockedGetTemplate(name) {
-                const rawTemplate = getTemplate(name) || this.rawTemplates[name];
-                if (typeof rawTemplate === "function" && !(rawTemplate instanceof Element)) {
-                    return rawTemplate;
-                }
-                if (!compiledTemplates.has(rawTemplate)) {
-                    compiledTemplates.set(rawTemplate, this._compileTemplate(name, rawTemplate));
-                }
-                return compiledTemplates.get(rawTemplate);
-            };
-
-            // Patch "clearProcessedTemplates" to clear local template cache
-            exports.clearProcessedTemplates = function mockedClearProcessedTemplates() {
-                compiledTemplates.clear();
-                return clearProcessedTemplates(...arguments);
-            };
-
-            // Replace alt & src attributes by default on all templates
             exports.registerTemplateProcessor(replaceAttributes);
-
             return exports;
         };
 


### PR DESCRIPTION
This reverts commit 14b37d5871c97d93723dc925419fa93fa2fb8250.

This is due to performance issues likely caused by the added template cache taking way too much memory and occasionnally crashing the test suite.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
