### PR TITLE
[FIX] stock: properly load menu on app refresh

### DIFF
--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -213,6 +213,7 @@
         <field name="name">Replenishment</field>
         <field name="model_id" ref="model_stock_warehouse_orderpoint"/>
         <field name="state">code</field>
+        <field name="path">replenishment</field>
         <field name="code">
             action = model.with_context(
                 search_default_filter_to_reorder=True,


### PR DESCRIPTION
**Problem**:
In saas-17.2, the new URL structure no longer includes `menu_id`, which was previously used to set the current menu upon page refresh:
https://github.com/odoo/odoo/blob/1443e5503c7396512a078f9f52fd4cb31b62e202/addons/web/static/src/webclient/webclient.js#L76

This change causes issues for actions like `action_orderpoint_replenish`, which are not directly tied to any `ir.ui.menu` and lack a `menu_id` in the URL:
https://github.com/odoo/odoo/blob/535a02565f9e9142f0ef1fe9f44d1935f7b42075/addons/web/static/src/webclient/webclient.js#L59-L65

As a result, the menuId becomes `undefined`, leading to the top menu not being loaded properly.

**Solution**:
Add a path to action to ensure that it is properly reloaded.

**Steps to reproduce**:
1. Navigate to *Inventory > Replenishment*.
2. Refresh the page.
3. Observe that the top menu disappears.

opw-4350871