### PR TITLE
[FIX] sales_team: Now default sales team prefers active company

### DIFF
--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -64,6 +64,9 @@ class CrmTeam(models.Model):
             filtered_teams = teams.filtered_domain(domain)
             if default_team and default_team in filtered_teams:
                 team = default_team
+            elif self.env.company_id in filtered_teams.company_id:
+                # Prefer the current company if possible
+                team = filtered_teams.filtered(lambda t: t.company_id == self.env.company_id)[:1]
             else:
                 team = filtered_teams[:1]
 
@@ -80,6 +83,9 @@ class CrmTeam(models.Model):
 
         if not team:
             teams = self.env['crm.team'].search([('company_id', 'in', valid_cids)])
+            if self.env.company_id in teams.company_id:
+                # Prefer the current company if possible
+                teams = teams.filtered(lambda t: t.company_id == self.env.company_id)
             # 4- default: based on company rule, first one matching domain
             if teams and domain:
                 team = teams.filtered_domain(domain)[:1]

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -62,11 +62,10 @@ class CrmTeam(models.Model):
         ])
         if teams and domain:
             filtered_teams = teams.filtered_domain(domain)
+            # Prefer the current company if possible
+            filtered_teams = filtered_teams.sorted(lambda team: not team.company_id or team.company_id == self.env.company, reverse=True)
             if default_team and default_team in filtered_teams:
                 team = default_team
-            elif self.env.company in filtered_teams.company_id:
-                # Prefer the current company if possible
-                team = filtered_teams.filtered(lambda t: not t.company_id or t.company_id == self.env.company)[:1]
             else:
                 team = filtered_teams[:1]
 
@@ -83,9 +82,8 @@ class CrmTeam(models.Model):
 
         if not team:
             teams = self.env['crm.team'].search([('company_id', 'in', valid_cids)])
-            if self.env.company in teams.company_id:
-                # Prefer the current company if possible
-                teams = teams.filtered(lambda t: not t.company_id or t.company_id == self.env.company)
+            # Prefer the current company if possible
+            teams = teams.sorted(lambda team: not team.company_id or team.company_id == self.env.company, reverse=True)
             # 4- default: based on company rule, first one matching domain
             if teams and domain:
                 team = teams.filtered_domain(domain)[:1]

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -64,9 +64,9 @@ class CrmTeam(models.Model):
             filtered_teams = teams.filtered_domain(domain)
             if default_team and default_team in filtered_teams:
                 team = default_team
-            elif self.env.company_id in filtered_teams.company_id:
+            elif self.env.company in filtered_teams.company_id:
                 # Prefer the current company if possible
-                team = filtered_teams.filtered(lambda t: t.company_id == self.env.company_id)[:1]
+                team = filtered_teams.filtered(lambda t: t.company_id == self.env.company)[:1]
             else:
                 team = filtered_teams[:1]
 
@@ -83,9 +83,9 @@ class CrmTeam(models.Model):
 
         if not team:
             teams = self.env['crm.team'].search([('company_id', 'in', valid_cids)])
-            if self.env.company_id in teams.company_id:
+            if self.env.company in teams.company_id:
                 # Prefer the current company if possible
-                teams = teams.filtered(lambda t: t.company_id == self.env.company_id)
+                teams = teams.filtered(lambda t: t.company_id == self.env.company)
             # 4- default: based on company rule, first one matching domain
             if teams and domain:
                 team = teams.filtered_domain(domain)[:1]

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -66,7 +66,7 @@ class CrmTeam(models.Model):
                 team = default_team
             elif self.env.company in filtered_teams.company_id:
                 # Prefer the current company if possible
-                team = filtered_teams.filtered(lambda t: t.company_id == self.env.company)[:1]
+                team = filtered_teams.filtered(lambda t: not t.company_id or t.company_id == self.env.company)[:1]
             else:
                 team = filtered_teams[:1]
 
@@ -85,7 +85,7 @@ class CrmTeam(models.Model):
             teams = self.env['crm.team'].search([('company_id', 'in', valid_cids)])
             if self.env.company in teams.company_id:
                 # Prefer the current company if possible
-                teams = teams.filtered(lambda t: t.company_id == self.env.company)
+                teams = teams.filtered(lambda t: not t.company_id or t.company_id == self.env.company)
             # 4- default: based on company rule, first one matching domain
             if teams and domain:
                 team = teams.filtered_domain(domain)[:1]

--- a/addons/sales_team/tests/test_sales_team.py
+++ b/addons/sales_team/tests/test_sales_team.py
@@ -78,14 +78,18 @@ class TestDefaultTeam(TestSalesCommon):
             team = self.env['crm.team']._get_default_team_id()
             self.assertEqual(team, self.team_responsible)
 
-        self.user_sales_leads.write({
-            'company_ids': [(4, self.company_2.id)],
-            'company_id': self.company_2.id,
-        })
         # multi company: switch company
         self.user_sales_leads.write({
             'company_id': self.company_2.id,
             'company_ids': [(4, self.company_2.id)],
+        })
+        with self.with_user('user_sales_leads'):
+            team = self.env['crm.team']._get_default_team_id()
+            self.assertEqual(team, self.team_c2)
+
+        # multi company: prefer active company
+        self.user_sales_leads.write({
+            'company_ids': [(4, self.company_main.id)]
         })
         with self.with_user('user_sales_leads'):
             team = self.env['crm.team']._get_default_team_id()


### PR DESCRIPTION
When having multiple companies selected while creating a sales order, the default sales team and the default company can mismatch due to how the default sales team is chosen.

Before the fix:
The compatible sales teams are chosen from all active companies, with no preference for the current main active company. This can cause a sales team to be chosen from another company, even if there were one available for the current company, potentially resulting in a company-mismatched sales order that causes rights issues.

After the fix:
When selecting the default sales team, it checks at appropriate spots whether the team candidates belong to the main active company and if so, gives preference to them to prevent a mismatch.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
