### PR TITLE
[FIX] web_editor: render of mailing

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -281,7 +281,7 @@ export class HtmlField extends Component {
         const value = this.getEditingValue();
         const lastValue = (this.props.record.data[this.props.name] || "").toString();
         if (
-            value !== null &&
+            value && value !== null &&
             !(!lastValue && stripHistoryIds(value) === "<p><br></p>") &&
             stripHistoryIds(value) !== stripHistoryIds(lastValue)
         ) {


### PR DESCRIPTION
Steps to reproduce:
 - Define a mail body
 - Switch between settings and mail body fast
 - mail body disapear 
Issue:
The mail body disapear and the customer loses all his changes. 
Fix:
Ensure that the value is not an empty string to not erase the mail body.

opw-4105961

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
