### PR TITLE
[FIX] hr_holidays: no activity when "Notified Time Off Officer" empty

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -767,7 +767,7 @@ class HolidaysAllocation(models.Model):
 
     def _get_responsible_for_approval(self):
         self.ensure_one()
-        responsible = self.env.user
+        responsible = self.env['res.users']
 
         if self.validation_type == 'manager' or (self.validation_type == 'both' and self.state == 'confirm'):
             if self.employee_id.leave_manager_id:
@@ -804,7 +804,7 @@ class HolidaysAllocation(models.Model):
                             allocation_type=allocation.holiday_status_id.name,
                         )
                         to_second_do |= allocation
-                    user_ids = allocation.sudo()._get_responsible_for_approval().ids or self.env.user.ids
+                    user_ids = allocation.sudo()._get_responsible_for_approval().ids
                     for user_id in user_ids:
                         activity_vals.append({
                             'activity_type_id': activity_type.id,


### PR DESCRIPTION
steps to reproduce:
-Create a new time off type.
-Set the approval radio button to either "By Time Off Officer" or "By Employee's Approver and Time Off Officer."
-Leave the "Notified Time Off Officer" field empty. 
-Try to create a new allocation for the newly created time off type. 
-Notice that an activity is created for the user who created the allocation.

cause:
When the "Notified Time Off Officer" field is left empty, no activity or email should be created.

solution:
Remove self.env.user.ids to prevent the creation of an activity for the user.

task-4351747
