### PR TITLE
[IMP] website: restore fixed parallax on mobile

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1289,14 +1289,8 @@ $-o-carousel-controllers-size: map-get($spacers, 5);
     > .s_parallax_bg {
         @extend %o-we-background-layer;
     }
-    @include media-breakpoint-up(xl) {
-        // Fixed backgrounds are disabled when using a mobile/tablet device,
-        // which is not a big deal but, on some of them (iOS...), defining the
-        // background as fixed breaks the background-size/position props.
-        // So we enable this only for >= XL devices.
-        &.s_parallax_is_fixed > .s_parallax_bg {
-            background-attachment: fixed;
-        }
+    &.s_parallax_is_fixed > .s_parallax_bg {
+        background-attachment: fixed;
     }
 }
 // Keeps parallax snippet element selectable when Height = auto.


### PR DESCRIPTION
This reverts [1]. As indicated by that commit from 5+ years ago, we explicitly disabled fixed parallax effect on mobile as:
- Most browsers were already disabling it implicitly anyway.
- On some browsers (iOS), it was causing rendering issues (background was super-zoomed).

5+ years later:
- Most browsers are enabling fixed parallax on mobile.
- No browser was found to have rendering issues anymore, some (iOS) have an imperfect parallax effect but still better than nothing.

For this reason, we re-enable it and hope support will continue improving in the future.

[1]: https://github.com/odoo/odoo/commit/412117c2a789a24191cda040614d01fe290e77cc

task-3487850
