### PR TITLE
[FIX] mail: normalized when formatting email_to / email_cc

### DIFF
--- a/addons/base_setup/models/res_users.py
+++ b/addons/base_setup/models/res_users.py
@@ -20,7 +20,8 @@ class ResUsers(models.Model):
 
         # Process new email addresses : create new users
         for email in new_emails:
-            default_values = {'login': email, 'name': email.split('@')[0], 'email': email, 'active': True}
+            name, email_normalized = self.env['res.partner']._parse_partner_name(email)
+            default_values = {'login': email_normalized, 'name': name or email_normalized, 'email': email_normalized, 'active': True}
             user = self.with_context(signup_valid=True).create(default_values)
 
         return True

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -356,7 +356,7 @@ class MailMail(models.Model):
             ]
         else:
             email_to_normalized = tools.email_normalize_all(self.email_to)
-            email_to = tools.email_split_and_format(self.email_to)
+            email_to = tools.email_split_and_format_normalize(self.email_to)
         # email_cc is added to the "to" when invoking send_email
         email_to_normalized += tools.email_normalize_all(self.email_cc)
         res = {
@@ -387,7 +387,7 @@ class MailMail(models.Model):
         group_per_email_from = defaultdict(list)
         for values in mail_values:
             # protect against ill-formatted email_from when formataddr was used on an already formatted email
-            emails_from = tools.email_split_and_format(values['email_from'])
+            emails_from = tools.email_split_and_format_normalize(values['email_from'])
             email_from = emails_from[0] if emails_from else values['email_from']
             mail_server_id = values['mail_server_id'][0] if values['mail_server_id'] else False
             group_per_email_from[mail_server_id, email_from].append(values['id'])
@@ -526,7 +526,7 @@ class MailMail(models.Model):
                     notifs.flush_recordset(['notification_status', 'failure_type', 'failure_reason'])
 
                 # protect against ill-formatted email_from when formataddr was used on an already formatted email
-                emails_from = tools.email_split_and_format(mail.email_from)
+                emails_from = tools.email_split_and_format_normalize(mail.email_from)
                 email_from = emails_from[0] if emails_from else mail.email_from
 
                 # build an RFC2822 email.message.Message object and send it without queuing
@@ -553,7 +553,7 @@ class MailMail(models.Model):
                         subject=mail.subject,
                         body=email.get('body'),
                         body_alternative=email.get('body_alternative'),
-                        email_cc=tools.email_split(mail.email_cc),
+                        email_cc=tools.email_split_and_format_normalize(mail.email_cc),
                         reply_to=mail.reply_to,
                         attachments=attachments,
                         message_id=mail.message_id,

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -470,7 +470,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         for email_to in emails:
             found_mail = self._find_mail_mail_wemail(
                 email_to, status, mail_message=mail_message,
-                author=author, email_from=fields_values.get('email_from')
+                author=author, email_from=(fields_values or {}).get('email_from')
             )
             self.assertTrue(bool(found_mail))
             self._assertMailMail(

--- a/addons/mail/tests/test_res_users.py
+++ b/addons/mail/tests/test_res_users.py
@@ -5,10 +5,11 @@ from psycopg2 import IntegrityError
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
-from odoo.tests import tagged
+from odoo.tests import RecordCapturer, tagged
 from odoo.tools import mute_logger
 
 
+@tagged('-at_install', 'post_install', 'mail_tools', 'res_users')
 class TestUser(MailCommon):
 
     @mute_logger('odoo.sql_db')
@@ -23,6 +24,39 @@ class TestUser(MailCommon):
                 groups='base.group_portal',
             )
 
+    def test_web_create_users(self):
+        src = [
+            'POILUCHETTE@test.example.com',
+            '"Jean Poilvache" <POILVACHE@test.example.com>',
+        ]
+        with self.mock_mail_gateway(), \
+             RecordCapturer(self.env['res.users'], []) as capture:
+            self.env['res.users'].web_create_users(src)
+
+        exp_emails = ['poiluchette@test.example.com', 'poilvache@test.example.com']
+        # check reset password are effectively sent
+        for user_email in exp_emails:
+            self.assertMailMailWEmails(
+                [user_email], 'sent',
+                author=self.user_root.partner_id,
+                email_values={
+                    'email_from': self.env.company.partner_id.email_formatted,
+                },
+                fields_values={
+                    'email_from': self.env.company.partner_id.email_formatted,
+                },
+            )
+
+        # order does not seem guaranteed
+        self.assertEqual(len(capture.records), 2, 'Should create one user / entry')
+        self.assertEqual(
+            sorted(capture.records.mapped('name')),
+            sorted(('poiluchette@test.example.com', 'Jean Poilvache'))
+        )
+        self.assertEqual(
+            sorted(capture.records.mapped('email')),
+            sorted(exp_emails)
+        )
 
 @tagged('-at_install', 'post_install')
 class TestUserTours(HttpCaseWithUserDemo):

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -1803,7 +1803,10 @@ class TestMailgateway(TestMailCommon):
 
         self.assertEqual(set(records.mapped('email_from')), {self.email_from})
 
-        for email_from in (self.email_from, self.email_from.upper()):
+        for email_from, exp_to in [
+            (self.email_from, formataddr(("Sylvie Lelitre", "test.sylvie.lelitre@agrolait.com"))),
+            (self.email_from.upper(), formataddr(("SYLVIE LELITRE", "test.sylvie.lelitre@agrolait.com"))),
+        ]:
             with self.mock_mail_gateway():
                 self.format_and_process(
                     MAIL_TEMPLATE,
@@ -1819,7 +1822,7 @@ class TestMailgateway(TestMailCommon):
                 new_record,
                 msg='The loop should have been detected and the record should not have been created')
 
-            self.assertSentEmail('"MAILER-DAEMON" <bounce.test@test.com>', [email_from])
+            self.assertSentEmail('"MAILER-DAEMON" <bounce.test@test.com>', [exp_to])
             self.assertIn('-loop-detection-bounce-email@', self._mails[0]['references'],
                 msg='The "bounce email" tag must be in the reference')
 

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -615,6 +615,14 @@ def email_split_and_format(text):
         return []
     return [formataddr((name, email)) for (name, email) in email_split_tuples(text)]
 
+def email_split_and_format_normalize(text):
+    """ Same as 'email_split_and_format' but normalizing email. """
+    return [
+        formataddr(
+            (name, _normalize_email(email))
+        ) for (name, email) in email_split_tuples(text)
+    ]
+
 def email_normalize(text, strict=True):
     """ Sanitize and standardize email address entries. As of rfc5322 section
     3.4.1 local-part is case-sensitive. However most main providers do consider


### PR DESCRIPTION
When preparing final outgoing email, partner email is normalized. We take their formatted email, which is their name and their normalized email. However email_to and email_cc are taken from input using 'email_split(_and_format)', which finds emails but do not format them.

This leads to incoherent behavior as most emails are normalized as we generally always use partners, but not all. In this commit we now split, normalize and format email_to and email_cc in outgoing emails.

This fixes a first issue where name are lost if a formatted email was entered in email_cc field. Only address was kept, now the name is correctly found and put back.

This also fixes an issue for validated email detection, in order to compare normalized emails. This was introduced at odoo/odoo#185793 and may skip valid emails entered in email_to or email_cc.

This commit backports a tool introduced at odoo/odoo@dd4709e579841672b0c2a57d5f2941f3ce770801 which aims at allowing a quick convert from a string holding emails to a list of nicely formatted emails, using normalize version of email addresses. This is the standard we use in most flows.

Task-4376876
Followup of task-3704658