### PR TITLE
[FIX] hr_attendance: correctly declare props

### DIFF
--- a/addons/hr_attendance/static/src/components/manual_selection/manual_selection.js
+++ b/addons/hr_attendance/static/src/components/manual_selection/manual_selection.js
@@ -39,5 +39,6 @@ KioskManualSelection.props = {
     employees : {type : Array},
     displayBackButton : {type : Boolean},
     departments: {type : Array},
-    onSelectEmployee : {type : Function}
+    onSelectEmployee : {type : Function},
+    onClickBack : {type : Function}
 };

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
@@ -14,7 +14,15 @@ import {KioskPinCode} from "@hr_attendance/components/pin_code/pin_code";
 import {KioskBarcodeScanner} from "@hr_attendance/components/kiosk_barcode/kiosk_barcode";
 
 class kioskAttendanceApp extends Component{
-    static props = [];
+    static props = {
+        token: {type : String},
+        companyId: {type : Number},
+        companyName: {type : String},
+        employees: {type : Array},
+        departments: {type : Array},
+        kioskMode: {type : String},
+        barcodeSource: {type : String}
+    };
     static components = {
         KioskBarcodeScanner,
         CardLayout,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Unable to reach Kiosk mode while in debug mode due to props validation
```
Error: Invalid props for component 'kioskAttendanceApp': unknown key 'token', unknown key 'companyId', unknown key 'companyName', unknown key 'employees', unknown key 'departments', unknown key 'kioskMode', unknown key 'barcodeSource'
```

### Steps to reproduce 
- Install `hr_attendance`
- Open Kiosk Mode
- Enable debug mode
=> Blank screen


## Current behavior before PR
Before this commit, when we were in debug mode, we couldn't access Kiosk mode (white screen with message in console). This was because the props were not fully declared, and, in debug mode, we validated the props here : https://github.com/odoo/odoo/blob/c3e7ee585a58fc07c11d07677d1d64dbd357d6b7/addons/web/static/lib/owl/owl.js#L5715-L5717 As the components are only used in one place each, I've updated the props declaration to match the usage.
