### PR TITLE
[FIX] mass_mailing: handle image centering

### DIFF
--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -340,7 +340,7 @@ after backport. They will now be removed in master.
         <div data-selector="span.fa, i.fa, img">
             <we-select string="Alignment" data-state-to-first-class="true">
                 <we-button data-select-class="float-start" title="Align Left">Left</we-button>
-                <we-button data-select-class="" title="Align Center">Center</we-button>
+                <we-button data-select-class="mx-auto" title="Align Center">Center</we-button>
                 <we-button data-select-class="float-end" title="Align Right">Right</we-button>
             </we-select>
 


### PR DESCRIPTION
**Problem**:
In the Marketing module, when adding an image and attempting to center it, the centering action does not work because the action is not applying any style to the image.

**Solution**:
Use the same actions as those implemented in `web_editor` to apply the appropriate styles for centering the image: https://github.com/odoo/odoo/blob/175fdc14769e530424c3b0e364a4c3495aa499d3/addons/web_editor/views/snippets.xml#L600-L602

**Steps to reproduce**:
1. Go to *Email Marketing* and open any template.
2. Add an image and resize it.
3. Change the alignment of the image to center.
4. Observe that nothing happens and the image is not centered.

opw-4348923

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
