### PR TITLE
[FIX] website: fix mobile navbar text color for overlay header

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -344,7 +344,7 @@ $-seen-urls: ();
 // navbar text, there is no :hover effect, the active item is not visible and
 // the selector is probably too specific and should rather be about extending
 // bootstrap if possible.
-#wrapwrap:not(.o_header_overlay) header, header.o_header_is_scrolled {
+#wrapwrap:not(.o_header_overlay) header, header.o_header_is_scrolled, header .o_navbar_mobile {
     .nav-item > .nav-link > *, .nav-item > .nav-link::after, .js_language_selector span, .badge {
         $header-text-color: o-website-value('header-text-color');
         // Check if the value is wrapped in quotes (initially it wasn't, and it


### PR DESCRIPTION
Since commit [1], a new option was added to set the text color of the navbar in "over the content" mode. However, this option also affects the text color of the "mobile navbar", which it should not. This commit fixes the issue by stopping the "over the content" text color from applying to the mobile navbar.

Steps to reproduce:

- Enter "Website" edit mode.
- Click on the "header".
- Set the "Header Position" option to "Over The Content".
- Select a "red" color in the colorpicker of the "Navbar" option.
- Click the "Mobile Preview" button.
- Click the "Hamburger menu" button to open the mobile navbar.
- Bug: The text color is not "red".

[1]: https://github.com/odoo/odoo/commit/1e30600d9e0e12e43fcbca60760a64f2551e3c8f

opw-4364765