### PR TITLE
[FIX] account,*: multiple fixes related to UBL, Peppol and Hungary

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -60,7 +60,7 @@ EAS_MAPPING = {
     'GB': {'9932': 'vat'},
     'GR': {'9933': 'vat'},
     'HR': {'9934': 'vat'},
-    'HU': {'9910': 'vat'},
+    'HU': {'9910': 'l10n_hu_eu_vat'},
     'IE': {'9935': 'vat'},
     'IS': {'0196': 'vat'},
     'IT': {'0211': 'vat', '0210': 'l10n_it_codice_fiscale'},

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -56,11 +56,22 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _get_partner_party_tax_scheme_vals_list(self, partner, role):
+        # [BR-CO-09] if the PartyTaxScheme/TaxScheme/ID == 'VAT', CompanyID must start with a country code prefix.
+        # In some countries however, the CompanyID can be with or without country code prefix and still be perfectly
+        # valid (RO, HU, non-EU countries).
+        # We have to handle their cases by changing the TaxScheme/ID to 'something other than VAT',
+        # preventing the trigger of the rule.
+        tax_scheme_id = 'VAT'
+        if (
+            partner.country_id
+            and partner.vat and not partner.vat[:2].isalpha()
+        ):
+            tax_scheme_id = 'NOT_EU_VAT'
         return [{
             'registration_name': partner.name,
             'company_id': partner.vat,
             'registration_address_vals': self._get_partner_address_vals(partner),
-            'tax_scheme_vals': {'id': 'VAT'},
+            'tax_scheme_vals': {'id': tax_scheme_id},
         }]
 
     def _get_partner_party_legal_entity_vals_list(self, partner):

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -60,15 +60,6 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             vals.pop('registration_name', None)
             vals.pop('registration_address_vals', None)
 
-            # Some extra european countries use Bis 3 but do not prepend their VAT with the country code (i.e.
-            # Australia). Allow them to use Bis 3 without raising BR-CO-09.
-            if (
-                partner.country_id
-                and partner.country_id not in self.env.ref('base.europe').country_ids
-                and not partner.vat[:2].isalpha()
-            ):
-                vals['company_id'] = partner.country_id.code + partner.vat
-
         # sources:
         #  https://anskaffelser.dev/postaward/g3/spec/current/billing-3.0/norway/#_applying_foretaksregisteret
         #  https://docs.peppol.eu/poacc/billing/3.0/bis/#national_rules (NO-R-002 (warning))

--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -7,6 +7,7 @@ from stdnum.fr import siret
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
 from odoo.addons.account_edi_ubl_cii.models.account_edi_common import EAS_MAPPING
+from odoo.addons.account.models.company import PEPPOL_DEFAULT_COUNTRIES
 
 
 class ResPartner(models.Model):
@@ -168,7 +169,7 @@ class ResPartner(models.Model):
             country_code = partner._deduce_country_code()
             if country_code in format_mapping:
                 partner.ubl_cii_format = format_mapping[country_code]
-            elif country_code in EAS_MAPPING:
+            elif country_code in PEPPOL_DEFAULT_COUNTRIES and country_code in EAS_MAPPING:
                 partner.ubl_cii_format = 'ubl_bis3'
             else:
                 partner.ubl_cii_format = partner.ubl_cii_format

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -771,6 +771,12 @@ class ResPartner(models.Model):
             vat_number = format_func(vat_number)
         return vat_country.upper() + vat_number
 
+    @api.model
+    def _convert_hu_local_to_eu_vat(self, local_vat):
+        if self.__check_tin_hu_companies_re.match(local_vat):
+            return f'HU{local_vat[:8]}'
+        return False
+
     @api.model_create_multi
     def create(self, vals_list):
         for values in vals_list:

--- a/addons/l10n_hu/models/__init__.py
+++ b/addons/l10n_hu/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import template_hu
 from . import account_move
+from . import res_partner

--- a/addons/l10n_hu/models/res_partner.py
+++ b/addons/l10n_hu/models/res_partner.py
@@ -1,0 +1,15 @@
+from odoo import api, fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    l10n_hu_eu_vat = fields.Char(compute='_compute_l10n_hu_eu_vat')
+
+    @api.depends('vat')
+    def _compute_l10n_hu_eu_vat(self):
+        for partner in self:
+            if partner.country_code == 'HU' and partner.vat:
+                partner.l10n_hu_eu_vat = partner._convert_hu_local_to_eu_vat(partner.vat)
+            else:
+                partner.l10n_hu_eu_vat = False

--- a/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
+++ b/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
@@ -51,16 +51,9 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
 
         if not partner.vat and partner.company_registry:
             # Use company_registry (Company ID) as the VAT replacement
-            vals_list = [{'company_id': partner.company_registry, 'tax_scheme_vals': {'id': 'VAT'}}]
-
-        # The validator for CIUS-RO (which extends the validations from the BIS3 Schematron) asserts a rule where:
-        # [BR-CO-09] if the PartyTaxScheme/TaxScheme/ID == 'VAT', CompanyID must start with a country code prefix.
-        # In Romania however, the CompanyID can be with or without country code prefix and still be perfectly valid.
-        # We have to handle their cases by changing the TaxScheme/ID to 'something other than VAT',
-        # preventing the trigger of the rule and allow Romanian companies without prefixed VAT to use CIUS-RO.
-        for vals in vals_list:
-            if partner.country_code == 'RO' and not (vals['company_id'] or '').upper().startswith('RO'):
-                vals['tax_scheme_vals']['id'] = 'NO_VAT'
+            for vals in vals_list:
+                tax_scheme_id = 'VAT' if partner.company_registry[:2].isalpha() else 'NOT_EU_VAT'
+                vals.update({'company_id': partner.company_registry, 'tax_scheme_vals': {'id': tax_scheme_id}})
 
         return vals_list
 

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
@@ -37,7 +37,7 @@
       <cac:PartyTaxScheme>
         <cbc:CompanyID>1234567897</cbc:CompanyID>
         <cac:TaxScheme>
-          <cbc:ID>NO_VAT</cbc:ID>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
@@ -68,7 +68,7 @@
       <cac:PartyTaxScheme>
         <cbc:CompanyID>1234567897</cbc:CompanyID>
         <cac:TaxScheme>
-          <cbc:ID>NO_VAT</cbc:ID>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>

--- a/addons/l10n_sa_edi/tests/compliance/simplified/credit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/credit.xml
@@ -77,7 +77,7 @@
           </cac:Country>
         </cac:RegistrationAddress>
         <cac:TaxScheme>
-          <cbc:ID>VAT</cbc:ID>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>

--- a/addons/l10n_sa_edi/tests/compliance/simplified/debit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/debit.xml
@@ -77,7 +77,7 @@
           </cac:Country>
         </cac:RegistrationAddress>
         <cac:TaxScheme>
-          <cbc:ID>VAT</cbc:ID>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>

--- a/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
@@ -72,7 +72,7 @@
           </cac:Country>
         </cac:RegistrationAddress>
         <cac:TaxScheme>
-          <cbc:ID>VAT</cbc:ID>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>

--- a/addons/l10n_sa_edi/tests/compliance/standard/credit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/credit.xml
@@ -71,7 +71,7 @@
                     </cac:Country>
                 </cac:RegistrationAddress>
                 <cac:TaxScheme>
-                    <cbc:ID>VAT</cbc:ID>
+                    <cbc:ID>NOT_EU_VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>

--- a/addons/l10n_sa_edi/tests/compliance/standard/debit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/debit.xml
@@ -71,7 +71,7 @@
                 </cac:Country>
                 </cac:RegistrationAddress>
                 <cac:TaxScheme>
-                    <cbc:ID>VAT</cbc:ID>
+                    <cbc:ID>NOT_EU_VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>

--- a/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
@@ -65,7 +65,7 @@
                     </cac:Country>
                 </cac:RegistrationAddress>
                 <cac:TaxScheme>
-                    <cbc:ID>VAT</cbc:ID>
+                    <cbc:ID>NOT_EU_VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>


### PR DESCRIPTION
### [FIX] account_edi_ubl_cii,l10n_ro_edi: Allow NO VAT tax scheme ID
Rule [BR-CO-09] enforce the VAT number to start with a country code
if the tax scheme id is "VAT".
In some countries (RO, HU, non-EU countries, ...) it is perfectly valid
to have a VAT that doesn't follow this format.
To avoid the rule to raise, we should set the tax scheme ID to something
else than "VAT".

### [FIX] account_edi_ubl_cii: only set BIS3 format by default on restricted countries
BIS3 is an electronic format closely related to Peppol.
It therefore only make sense to enable it by default on partners
that are in countries where it's actively used or will become
mandatory soon.

### [FIX] account_edi_ubl_cii,base_vat,l10n_hu: VAT conversion to EU format
Hungary may have different format of VAT number.
It is possible to convert their local format (xxxxxxxx-y-zz) to the EU
format (HUxxxxxxxx).
We should use this converted format when computing the Peppol Endpoint.

Enterprise: https://github.com/odoo/enterprise/pull/75671

task-4374458