### PR TITLE
[ADD] mail: anchors next to headings add links to clipboard

### DIFF
--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -178,16 +178,16 @@ export class SplitPlugin extends Plugin {
      */
     splitElement(element, offset) {
         /** @type {HTMLElement} **/
-        const before = element.cloneNode();
+        const firstPart = element.cloneNode();
         /** @type {HTMLElement} **/
-        const after = element.cloneNode();
-        element.before(before);
-        element.after(after);
+        const secondPart = element.cloneNode();
+        element.before(firstPart);
+        element.after(secondPart);
         const children = childNodes(element);
-        before.append(...children.slice(0, offset));
-        after.append(...children.slice(offset));
+        firstPart.append(...children.slice(0, offset));
+        secondPart.append(...children.slice(offset));
         element.remove();
-        return [before, after];
+        return [firstPart, secondPart];
     }
 
     /**

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -187,6 +187,7 @@ export class SplitPlugin extends Plugin {
         firstPart.append(...children.slice(0, offset));
         secondPart.append(...children.slice(offset));
         element.remove();
+        this.dispatchTo("after_split_element_handlers", { firstPart, secondPart });
         return [firstPart, secondPart];
     }
 

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -52,15 +52,12 @@ export class SplitPlugin extends Plugin {
             // unmergeable.
             (node) => node.classList?.contains("oe_unbreakable"),
             (node) => {
-                const isExplicitlyNotContentEditable = (node) => {
+                const isExplicitlyNotContentEditable = (node) =>
                     // In the `contenteditable` attribute consideration,
                     // disconnected nodes can be unsplittable only if they are
                     // explicitly set under a contenteditable="false" element.
-                    return (
-                        !isContentEditable(node) &&
-                        (node.isConnected || closestElement(node, "[contenteditable]"))
-                    );
-                };
+                    !isContentEditable(node) &&
+                    (node.isConnected || closestElement(node, "[contenteditable]"));
                 return (
                     isExplicitlyNotContentEditable(node) ||
                     // If node sets contenteditable='true' and is inside a non-editable

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -76,6 +76,7 @@ safe_attrs = defs.safe_attrs | frozenset(
      'data-class', 'data-mimetype', 'data-original-src', 'data-original-id', 'data-gl-filter', 'data-quality', 'data-resize-width',
      'data-shape', 'data-shape-colors', 'data-file-name', 'data-original-mimetype',
      'data-ai-field',
+     'data-heading-link-id',
      'data-mimetype-before-conversion',
      ])
 SANITIZE_TAGS = {


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/73290

This prevents the sanitizing of the `data-heading-link-id` and `data-heading-link-to` attributes used for the headings anchor feature, and adds a `after_split_element_handlers` in `splitElement` (as well as renames its parts), which will be used for the headings anchor feature.

task-3595680

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
