### PR TITLE
[FIX] web_tour: stop listen error at the end of tour

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -106,6 +106,9 @@ export class TourAutomatic {
             transitionConfig.disabled = false;
             tourState.clear();
             pointer.stop();
+            //No need to catch error yet.
+            window.addEventListener("error", (ev) => ev.preventDefault());
+            window.addEventListener("unhandledrejection", (ev) => ev.preventDefault());
         };
 
         this.macro = new Macro({


### PR DESCRIPTION
In this commit, we stop listening for errors that might occur asynchronously after the browser is stopped. This avoids having errors like:

Exception received after termination:
Uncaught (in promise)Event(isTrusted=true, type='error', target=null, currentTarget=null, eventPhase=0)

runbot-error-id~70404

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
