### PR TITLE
[FIX] calendar: res_users_settings error

### DIFF
--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -17,7 +17,6 @@ class Users(models.Model):
          ('confidential', 'Only internal users')],
         compute="_compute_calendar_default_privacy",
         inverse="_inverse_calendar_res_users_settings",
-        compute_sudo=True,
     )
 
     @property


### PR DESCRIPTION
Before this commit, an access error was being triggered when opening the user form of different internal users than self. This happened because of the `compute_sudo` flag in the calendar_default_privacy computation function.

The sudo flag was introduced for allowing the read of the ResUsersSettings configuration during the computation of calendar_default_privacy. Turns out that this flag is not needed, since the sudo() flags in the inverse function is already sufficient. Thus, we're removing it from the computation.

Issue-from: odoo/odoo#183887