### PR TITLE
[FIX] {,sale_purchase_}stock: update replenishment quantities

### DIFF
--- a/addons/sale_purchase_stock/tests/__init__.py
+++ b/addons/sale_purchase_stock/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_sale_purchase_stock_flow
 from . import test_access_rights
+from . import test_lead_time

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -251,7 +251,7 @@ class StockWarehouseOrderpoint(models.Model):
         return self.action_replenish()
 
     @api.depends('product_id', 'location_id', 'product_id.stock_move_ids', 'product_id.stock_move_ids.state',
-                 'product_id.stock_move_ids.date', 'product_id.stock_move_ids.product_uom_qty')
+                 'product_id.stock_move_ids.date', 'product_id.stock_move_ids.product_uom_qty', 'product_id.seller_ids.delay')
     def _compute_qty(self):
         orderpoints_contexts = defaultdict(lambda: self.env['stock.warehouse.orderpoint'])
         for orderpoint in self:
@@ -271,7 +271,8 @@ class StockWarehouseOrderpoint(models.Model):
                 orderpoint.qty_on_hand = products_qty[orderpoint.product_id.id]['qty_available']
                 orderpoint.qty_forecast = products_qty[orderpoint.product_id.id]['virtual_available'] + products_qty_in_progress[orderpoint.id]
 
-    @api.depends('qty_multiple', 'product_min_qty', 'product_max_qty', 'visibility_days', 'product_id', 'location_id')
+    @api.depends('qty_multiple', 'product_min_qty', 'product_max_qty', 'visibility_days', 'product_id', 'location_id',
+                 'product_id.seller_ids.delay')
     def _compute_qty_to_order(self):
         for orderpoint in self:
             if not orderpoint.product_id or not orderpoint.location_id:


### PR DESCRIPTION
**Current behavior:**
Changing the `delay` field on a `product.supplierinfo` then
looking at the replenishment report will not have updated the
qty fields of the orderpoint which were affected by the increase
in delay (delivery lead time in the 'Purchase' tab on Product
form).

**Expected behavior:**
The `qty_forecast` and `qty_to_order` fields update to reflect
moves which should be captured according to JiT forecasting.

**Steps to reproduce:**
1. Create some productA with a vendor that has some lead time

2. Create a sale order for that product, edit the sale order
`commitment_date` field
(Sale Order -> Other Info -> Delivery Date)
to some future date such that the delay would not necessitate
any replenishment at the current date
(i.e., today + delay + 1 day)

3. Create an orderpoint for the productA, see that the
`qty_to_order` is 0 -> this makes sense

4. Increase the delay for the vendor on productA enough that a
purchase order would be required to fulfill the sale order on
time

5. Go back to the replenishment report -> qty to order still 0

**Cause of the issue:**
`qty_to_order` is stored and computed, in this sequence none of
its dependencies are modified and so it remains 0 after `delay`
on the supplier info record is changed.

**Fix:**
Add `product_id.seller_ids.delay` to the dependency list of
`_compute_qty` and `_compute_qty_to_order`.

opw-4333016