### PR TITLE
[IMP] Discuss: recover closed calls on available tab

### DIFF
--- a/addons/bus/static/src/multi_tab_service.js
+++ b/addons/bus/static/src/multi_tab_service.js
@@ -188,6 +188,9 @@ export const multiTabService = {
             isOnMainTab() {
                 return _isOnMainTab;
             },
+            get isOnLastTab() {
+                return Object.keys(getItemFromStorage("lastPresenceByTab", {})).length === 0; // Main tab is not included.
+            },
             /**
              * Get value shared between all the tabs.
              *

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -78,15 +78,16 @@ class RtcController(http.Controller):
 
     @http.route("/mail/rtc/channel/leave_call", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
-    def channel_call_leave(self, channel_id):
+    def channel_call_leave(self, channel_id, session_id=None):
         """Disconnects the current user from a rtc call and clears any invitation sent to that user on this channel
         :param int channel_id: id of the channel from which to disconnect
+        :param int session_id: id of the leaving session
         """
         member = request.env["discuss.channel.member"].search([("channel_id", "=", channel_id), ("is_self", "=", True)])
         if not member:
             raise NotFound()
         # sudo: discuss.channel.rtc.session - member of current user can leave call
-        member.sudo()._rtc_leave_call()
+        member.sudo()._rtc_leave_call(session_id)
 
     @http.route("/mail/rtc/channel/cancel_call_invitation", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -402,9 +402,12 @@ class DiscussChannelMember(models.Model):
         json_web_token = jwt.sign(claims, key=key, ttl=60 * 60 * 8, algorithm=jwt.Algorithm.HS256)  # 8 hours
         return {"url": sfu_server_url, "channelUUID": sfu_channel_uuid, "jsonWebToken": json_web_token}
 
-    def _rtc_leave_call(self):
+    def _rtc_leave_call(self, session_id=None):
         self.ensure_one()
         if self.rtc_session_ids:
+            if session_id:
+                self.rtc_session_ids.filtered(lambda rec: rec.id == session_id).unlink()
+                return
             self.rtc_session_ids.unlink()
         else:
             self.channel_id._rtc_cancel_invitations(member_ids=self.ids)

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -132,6 +132,15 @@ test("should disconnect when closing page while in call", async () => {
                     asyncStep(`sendBeacon_leave_call:${blobData.params.channel_id}`);
                 }
             },
+            serviceWorker: {
+                controller: {
+                    postMessage(data) {
+                        if (data.name === "UNEXPECTED_CALL_TERMINATION") {
+                            asyncStep(`postMessage:${data.name}:${data.channelId}`);
+                        }
+                    },
+                },
+            },
         },
     });
 
@@ -139,7 +148,10 @@ test("should disconnect when closing page while in call", async () => {
     await contains(".o-discuss-Call");
     // simulate page close
     window.dispatchEvent(new Event("pagehide"), { bubble: true });
-    await waitForSteps([`sendBeacon_leave_call:${channelId}`]);
+    await waitForSteps([
+        `postMessage:UNEXPECTED_CALL_TERMINATION:${channelId}`,
+        `sendBeacon_leave_call:${channelId}`,
+    ]);
 });
 
 test("should display invitations", async () => {


### PR DESCRIPTION
With this commit, closing a tab in which a call is happening will
transfer the call to another tab if available.

If no tab is available, a confirmation will be asked before closing
the (last) tab.

task-3244140