### PR TITLE
[IMP] orm: many2many auto_join parameter is not accepted

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -67,7 +67,6 @@ class HrLeaveType(models.Model):
         domain=lambda self: [('groups_id', 'in', self.env.ref('hr_holidays.group_hr_holidays_user').id),
                              ('share', '=', False),
                              ('company_ids', 'in', self.env.company.id)],
-                             auto_join=True,
         help="Choose the Time Off Officers who will be notified to approve allocation or Time Off Request. If empty, nobody will be notified")
     leave_validation_type = fields.Selection([
         ('no_validation', 'No Validation'),

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1185,7 +1185,7 @@ class TestAutoJoin(TransactionExpressionCase):
         # --------------------------------------------------
 
         patch_auto_join(partner_obj, 'category_id', True)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(AssertionError):
             partner_obj.search([('category_id.name', '=', 'foo')])
 
         # --------------------------------------------------
@@ -2121,7 +2121,7 @@ class TestMany2many(TransactionCase):
 
     def test_autojoin(self):
         self.patch(self.User._fields['groups_id'], 'auto_join', True)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(AssertionError):
             self.User.search([('groups_id.name', '=', 'foo')])
 
     def test_name_search(self):

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -30,6 +30,7 @@ class _Relational(Field[M], typing.Generic[M]):
     relational = True
     domain: DomainType = []         # domain for searching values
     context: ContextType = {}       # context for searching values
+    auto_join = False               # whether joins are generated upon search
     check_company = False
 
     def __get__(self, records, owner=None):
@@ -164,7 +165,6 @@ class Many2one(_Relational[M]):
     _column_type = ('int4', 'int4')
 
     ondelete = None                     # what to do when value is deleted
-    auto_join = False                   # whether joins are generated upon search
     delegate = False                    # whether self implements delegation
 
     def __init__(self, comodel_name: str | Sentinel = SENTINEL, string: str | Sentinel = SENTINEL, **kwargs):
@@ -596,7 +596,6 @@ class One2many(_RelationalMulti[M]):
     type = 'one2many'
 
     inverse_name = None                 # name of the inverse field
-    auto_join = False                   # whether joins are generated upon search
     copy = False                        # o2m are not copied by default
 
     def __init__(self, comodel_name: str | Sentinel = SENTINEL, inverse_name: str | Sentinel = SENTINEL,
@@ -914,12 +913,13 @@ class Many2many(_RelationalMulti[M]):
     relation = None                     # name of table
     column1 = None                      # column of table referring to model
     column2 = None                      # column of table referring to comodel
-    auto_join = False                   # whether joins are generated upon search
     ondelete = 'cascade'                # optional ondelete for the column2 fkey
 
     def __init__(self, comodel_name: str | Sentinel = SENTINEL, relation: str | Sentinel = SENTINEL,
                  column1: str | Sentinel = SENTINEL, column2: str | Sentinel = SENTINEL,
                  string: str | Sentinel = SENTINEL, **kwargs):
+        if 'auto_join' in kwargs:
+            raise NotImplementedError("auto_join is not supported on Many2many fields")
         super(Many2many, self).__init__(
             comodel_name=comodel_name,
             relation=relation,

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1139,7 +1139,7 @@ class expression(object):
                 push(('id', ANY_IN[operator], sql), model, alias)
 
             elif operator in ('any', 'not any') and field.store and field.auto_join:
-                raise NotImplementedError('auto_join attribute not supported on field %s' % field)
+                assert False, f'auto_join attribute not supported on field {field}'
 
             elif operator in ('any', 'not any') and field.type == 'many2one':
                 right_ids = comodel._search(right)


### PR DESCRIPTION
The parameter is not supported on many2many fields. Raise an assert error when trying to use it.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
