### PR TITLE
[IMP] mail: display og_image in link_preview form view

### DIFF
--- a/addons/mail/views/mail_link_preview_views.xml
+++ b/addons/mail/views/mail_link_preview_views.xml
@@ -16,6 +16,7 @@
                         </group>
                         <group>
                             <field name="og_image"/>
+                            <field name="og_image" nolabel="1" widget="image_url" options="{'size': [150, 150]}" />
                             <field name="og_mimetype"/>
                             <field name="image_mimetype"/>
                             <field name="create_date"/>


### PR DESCRIPTION
Before this PR, the image was only displayed as a link. 
This PR adds an image_url widget to preview the image.
![image](https://github.com/user-attachments/assets/eb042777-6619-46c2-8c44-03c80f5ae404)
