### PR TITLE
[REV] account: disable CUD for analytic items related to a journal item

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -15389,14 +15389,6 @@ msgstr ""
 
 #. module: account
 #. odoo-python
-#: code:addons/account/models/account_analytic_line.py:0
-msgid ""
-"This analytic item was created by a journal item. Please edit the analytic "
-"distribution on the journal item instead."
-msgstr ""
-
-#. module: account
-#. odoo-python
 #: code:addons/account/wizard/account_merge_wizard.py:0
 msgid "This can only be used on accounts."
 msgstr ""

--- a/addons/account/models/account_analytic_line.py
+++ b/addons/account/models/account_analytic_line.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import ValidationError
 
 class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'
@@ -39,7 +39,6 @@ class AccountAnalyticLine(models.Model):
         ondelete='cascade',
         index=True,
         check_company=True,
-        readonly=True,
     )
     code = fields.Char(size=8)
     ref = fields.Char(string='Ref.')
@@ -79,17 +78,6 @@ class AccountAnalyticLine(models.Model):
         self.amount = result
         self.general_account_id = account
         self.product_uom_id = unit
-
-    def write(self, vals):
-        if self.move_line_id and any(field != 'ref' for field in vals):
-            raise UserError(self.env._("This analytic item was created by a journal item. Please edit the analytic distribution on the journal item instead."))
-
-        return super().write(vals)
-
-    @api.ondelete(at_uninstall=False)
-    def _unlink_except_move_line_related(self):
-        if not self._context.get('force_analytic_line_delete') and self.move_line_id:
-            raise UserError(self.env._("This analytic item was created by a journal item. Please edit the analytic distribution on the journal item instead."))
 
     @api.model
     def view_header_get(self, view_id, view_type):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5184,7 +5184,7 @@ class AccountMove(models.Model):
 
         self._check_draftable()
         # We remove all the analytics entries for this journal
-        self.mapped('line_ids.analytic_line_ids').with_context(force_analytic_line_delete=True).unlink()
+        self.mapped('line_ids.analytic_line_ids').unlink()
         self.mapped('line_ids').remove_move_reconcile()
         self.state = 'draft'
 

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1157,7 +1157,7 @@ class AccountMoveLine(models.Model):
         lines_to_modify = self.env['account.move.line'].browse([
             line.id for line in self if line.parent_state == "posted"
         ])
-        lines_to_modify.analytic_line_ids.with_context(force_analytic_line_delete=True).unlink()
+        lines_to_modify.analytic_line_ids.unlink()
 
         context = dict(self.env.context)
         context.pop('default_account_id', None)


### PR DESCRIPTION
The constrains introduced in  7bc8c8be44396a8a54466fe7fa48afad4a52c201 are too restrictive for users and avoid them to mass edit there analytic items.

Another solution for keeping the analytic items and their analytic distribution synchronized is in progress.

task-3977961
