### PR TITLE
[FIX] sales_team: align team member company to team company

### DIFF
--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -129,6 +129,19 @@ class CrmTeam(models.Model):
     dashboard_button_name = fields.Char(string="Dashboard Button", compute='_compute_dashboard_button_name')
     dashboard_graph_data = fields.Text(compute='_compute_dashboard_graph')
 
+    @api.constrains('company_id')
+    def _constrains_company_members(self):
+        for team in self.filtered('company_id'):
+            invalid_members = team.crm_team_member_ids.filtered(
+                lambda m: team.company_id not in m.user_id.company_ids
+            )
+            if invalid_members:
+                raise UserError(_("The following team members are not allowed in company '%(company)s' of the Sales Team '%(team)s': %(users)s",
+                    company=team.company_id.display_name,
+                    team=team.name,
+                    users=", ".join(invalid_members.mapped('user_id.name'))
+                ))
+
     @api.depends('sequence')  # TDE FIXME: force compute in new mode
     def _compute_is_membership_multi(self):
         multi_enabled = self.env['ir.config_parameter'].sudo().get_param('sales_team.membership_multi', False)
@@ -224,9 +237,9 @@ class CrmTeam(models.Model):
 
     def write(self, values):
         res = super(CrmTeam, self).write(values)
-        # manually launch company sanity check
-        if values.get('company_id'):
-            self.crm_team_member_ids._check_company(fnames=['crm_team_id'])
+
+        if values.get('company_id'):  # Force re-check of memberships constraint for this team
+            self.crm_team_member_ids._constrains_membership()
 
         if values.get('member_ids'):
             self._add_members_to_favorites()

--- a/addons/sales_team/models/crm_team_member.py
+++ b/addons/sales_team/models/crm_team_member.py
@@ -16,7 +16,7 @@ class CrmTeamMember(models.Model):
         'crm.team', string='Sales Team',
         group_expand='_read_group_expand_full',  # Always display all the teams
         default=False,  # TDE: temporary fix to activate depending computed fields
-        check_company=True, index=True, ondelete="cascade", required=True)
+        check_company=False, index=True, ondelete="cascade", required=True)
     user_id = fields.Many2one(
         'res.users', string='Salesperson',  # TDE FIXME check responsible field
         check_company=True, index=True, ondelete='cascade', required=True,
@@ -76,6 +76,16 @@ class CrmTeamMember(models.Model):
                 _("You are trying to create duplicate membership(s). We found that %(duplicates)s already exist(s).",
                   duplicates=", ".join("%s (%s)" % (m.user_id.name, m.crm_team_id.name) for m in duplicates)
                  ))
+
+    @api.constrains('crm_team_id', 'user_id')
+    def _constrains_company_membership(self):
+        for membership in self.filtered(lambda m: m.crm_team_id.company_id):
+            if membership.crm_team_id.company_id not in membership.user_id.company_ids:
+                raise exceptions.UserError(_("User '%(user)s' is not allowed in the company '%(company)s' of the Sales Team '%(team)s'.",
+                    user=membership.user_id.name,
+                    company=membership.crm_team_id.company_id.display_name,
+                    team=membership.crm_team_id.name
+                ))
 
     @api.depends('crm_team_id', 'is_membership_multi', 'user_id')
     @api.depends_context('default_crm_team_id')

--- a/addons/sales_team/tests/test_sales_team.py
+++ b/addons/sales_team/tests/test_sales_team.py
@@ -3,6 +3,7 @@
 
 from odoo import exceptions
 from odoo.tests import tagged, users
+from odoo.addons.mail.tests.common import mail_new_test_user
 
 from odoo.addons.sales_team.tests.common import SalesTeamCommon, TestSalesCommon, TestSalesMC
 
@@ -164,7 +165,7 @@ class TestMultiCompany(TestSalesMC):
         team_c2.write({'member_ids': [(4, self.env.user.id)]})
         self.assertEqual(team_c2.member_ids, self.env.user)
 
-        # cannot add someone from another company
+        # cannot add someone from another company (when user allowed only in c1 and team is in c2)
         with self.assertRaises(exceptions.UserError):
             team_c2.write({'member_ids': [(4, self.user_sales_salesman.id)]})
 
@@ -174,9 +175,24 @@ class TestMultiCompany(TestSalesMC):
         team_c2.write({'member_ids': [(4, self.user_sales_salesman.id)]})
         self.assertEqual(team_c2.member_ids, self.user_sales_salesman)
 
-        # cannot change company as it breaks memberships mc check
+        # cannot change team company if its users aren't allowed in the new company
         with self.assertRaises(exceptions.UserError):
             team_c2.write({'company_id': self.company_2.id})
+
+        # a user allowed in multiple companies can be added to a team of any of these companies
+        team_c2.write({'member_ids': [(5, 0)]})
+        team_c2.write({'company_id': self.company_2.id})
+        c1, c2 = self.company_main, self.company_2
+        with self.with_user('admin'):  # user_sales_manager can't create user
+            user_c1_c2 = mail_new_test_user(
+                self.env,
+                login=f"Test_user_default_to_c{c1.id}_allowed_c{'c'.join(map(str, [c1.id, c2.id]))}",
+                company_id=c1.id,
+                company_ids=[(4, company.id) for company in c1 + c2]
+            )
+        user_c1_c2 = user_c1_c2.with_env(self.env)
+        team_c2.write({'member_ids': [(4, user_c1_c2.id)]})
+        self.assertIn(user_c1_c2, team_c2.member_ids)
 
     @users('user_sales_manager')
     def test_team_memberships(self):


### PR DESCRIPTION
### Steps to reproduce the issue:

(Easier to reproduce client side with CRM installed)

0. Install crm
1. Create Second Company
2. Create New User with Current Company as Default Company and Second Company in Allowed Companies
3. Create CRM Team belonging to Second Company
4. Add New User to Members of CRM Team
5. Receive error:

>     [New User] belongs to company [Current Company] and "Sales Team" (crm_team_id: [CRM Team]) belongs to another company.

### Explanation:

`crm.team.member` is created when adding `res.users` to `crm.team.member_ids`. Contrary to `res.users`, a company_check is done when linking `crm.team` and `crm.team.member` together. `crm.team.member.company_id` is related to `user_id.company_id` and, in the case above, does not match `crm.team.company_id`, raising an error because of it.

### Fix reasoning:

Removing restriction, as we want to avoid other multi-company issues by changing the behaviour.

opw-4214192

---

@nd-dew note:
Situation recap
![image](https://github.com/user-attachments/assets/9377ec70-0a57-4a48-b071-de588cde06a6)

So it was proposed to modify the field definition, seems to me that removing `check_company` from the field definition is a legal move, since it is an ORM level constraint (doesn't change db schema). 

However looking at the tests it seems like this is desired limitation.

Note that https://github.com/odoo/odoo/pull/171079 introduced checking for allowed companies, but the **default company** still takes priority.