### PR TITLE
[FIX] l10n_hu_edi: allow re-generation of the invoices

### DIFF
--- a/addons/l10n_hu_edi/wizard/account_move_send.py
+++ b/addons/l10n_hu_edi/wizard/account_move_send.py
@@ -74,6 +74,15 @@ class AccountMoveSend(models.TransientModel):
             return invoice._l10n_hu_edi_get_valid_actions()
 
     @api.model
+    def _prepare_invoice_pdf_report(self, invoice, invoice_data): 
+        # EXTENDS 'account'
+        # If we want to re-generate the PDF, we need to unlink the previous one.
+        if invoice.country_code == 'HU':
+            invoice.invoice_pdf_report_file = False
+            invoice.invoice_pdf_report_id = False
+        return super()._prepare_invoice_pdf_report(invoice, invoice_data)
+
+    @api.model
     def _call_web_service_before_invoice_pdf_render(self, invoices_data):
         # EXTENDS 'account'
         super()._call_web_service_before_invoice_pdf_render(invoices_data)


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_hu_edi" and switch to a Hungarian company
- Create an invoice
- Click "Send & Print", uncheck "NAV 3.0" and send it
- Repeat step 3
- Error

### Cause:
With l10n_hu_edi, Odoo is supposed to regenerate the invoices at each Send&Print. The way it was done is by overriding `_need_invoice_document` to not check anymore if `invoice.invoice_pdf_report_id` is empty. As the function `_prepare_invoice_pdf_report` from `account` is called when `_need_invoice_document` returns True, it is always called. But this function checks again if `invoice.invoice_pdf_report_id` is empty (https://github.com/odoo/odoo/blob/17.0/addons/account/wizard/account_move_send.py#L394-L395). So `invoice_data` doesn't have the key 'pdf_attachment_values' and it crashes at this line: 
`pdf_values = invoice_data.get('pdf_attachment_values') or invoice_data['proforma_pdf_attachment_values']` 
because it tries reading 'proforma_pdf_attachment_values' but the key is not there either.

### Solution:
Extend `_prepare_invoice_pdf_report` to remove `invoice.invoice_pdf_report_id`.

opw-4363559