### PR TITLE
[FIX] base : cannot instantiate monetary field without currency_field

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1281,7 +1281,7 @@ class IrModelFields(models.Model):
         elif field_data['ttype'] == 'monetary':
             # be sure that custom monetary field are always instanciated
             if not self.pool.loaded and \
-                not (field_data['currency_field'] and self._is_manual_name(field_data['currency_field'])):
+                field_data['currency_field'] and not self._is_manual_name(field_data['currency_field']):
                 return
             attrs['currency_field'] = field_data['currency_field']
         # add compute function if given


### PR DESCRIPTION
Steps:
- have an industry module with a monetary field and don't specify its currency_field
- use that field in a view of the module
- Try installing the module via the source (not a module import) -> Validation error, the field is not present on the model

This happens because we verify if the registry is loaded or not, but when installing from the source, we instantiate a new registry.

Since we don't specify a currency_field, the _instantiate_attrs method would return nothing and the monetray field would not be registered on the model.

The issue didn't appear when importing the module because the registry is loaded at that time, so we don't enter the condition.