### PR TITLE
[IMP] mail: quick reactions navigation using tab/arrow keys

### DIFF
--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -109,4 +109,24 @@ export class QuickReactionMenu extends Component {
             )
         );
     }
+
+    get navigationOptions() {
+        return {
+            // Bypass nested dropdown behavior to allow initial focus.
+            onEnabled: null,
+            hotkeys: {
+                arrowright(index, items) {
+                    const target = index === items.length - 1 ? items[0] : items[index + 1];
+                    target.setActive();
+                },
+                arrowleft(index, items) {
+                    const target = index === 0 ? items.at(-1) : items[index - 1];
+                    target.setActive();
+                },
+                // Disable up and down navigation as it does not make sense for horizontal menu.
+                arrowdown: null,
+                arrowup: null,
+            },
+        };
+    }
 }

--- a/addons/mail/static/src/core/common/quick_reaction_menu.scss
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.scss
@@ -34,7 +34,8 @@ $quick-reaction-menu-slide-in-duration: 0.20s;
         --bg-opacity: .35;
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
         background-color: rgba($o-action, .1);
         outline: 1px solid rgba($o-action, .2);
     }

--- a/addons/mail/static/src/core/common/quick_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.QuickReactionMenu">
-        <Dropdown state="dropdown" manual="true" menuClass="`o-mail-QuickReactionMenu-popover shadow-none`" position="'top-middle'">
+        <Dropdown state="dropdown" manual="true" menuClass="`o-mail-QuickReactionMenu-popover shadow-none`" position="'top-middle'" navigationOptions="navigationOptions">
             <button class="btn border-0 px-1 py-0" t-att-class="attClass" t-att-title="props.action.title" t-att-aria-label="props.action.title" t-on-click="onClick">
                 <i class="fa-lg" t-att-class="props.action.icon"/>
             </button>
             <t t-set-slot="content">
                 <div class="o-mail-QuickReactionMenu d-flex align-items-center px-1 bg-view border rounded-pill shadow-sm" t-ref="toggle">
-                    <button t-foreach="mostFrequentEmojis" t-as="emoji" t-key="emoji" class="o-mail-QuickReactionMenu-emoji o-mail-QuickReactionMenu-popEffect d-flex justify-content-center align-items-center rounded-circle btn lh-1 p-1" t-att-class="{ 'bg-secondary': reactedBySelf(emoji) }" t-att-title="getEmojiShortcode(emoji)" t-on-click="() => this.toggleReaction(emoji)">
+                    <button t-foreach="mostFrequentEmojis" t-as="emoji" t-key="emoji" class="o-mail-QuickReactionMenu-emoji o-mail-QuickReactionMenu-popEffect o-navigable d-flex justify-content-center align-items-center rounded-circle btn lh-1 p-1" t-att-class="{ 'bg-secondary': reactedBySelf(emoji) }" t-att-title="getEmojiShortcode(emoji)" t-on-click="() => this.toggleReaction(emoji)">
                         <span class="fs-2" t-esc="emoji"/>
                     </button>
-                    <button class="o-mail-QuickReactionMenu-emojiPicker o-mail-QuickReactionMenu-popEffect o-mail-QuickReactionMenu-popEffect--smaller text-muted d-flex justify-content-center align-items-center btn btn-secondary rounded-circle" title="Toggle Emoji Picker" t-on-click="togglePicker">
+                    <button class="o-mail-QuickReactionMenu-emojiPicker o-mail-QuickReactionMenu-popEffect o-mail-QuickReactionMenu-popEffect--smaller o-navigable text-muted d-flex justify-content-center align-items-center btn btn-secondary rounded-circle" title="Toggle Emoji Picker" t-on-click="togglePicker">
                         <i class="oi oi-close"/>
                     </button>
                 </div>

--- a/addons/mail/static/tests/quick_reaction_menu/quick_reaction_menu.test.js
+++ b/addons/mail/static/tests/quick_reaction_menu/quick_reaction_menu.test.js
@@ -1,5 +1,3 @@
-import { describe, test } from "@odoo/hoot";
-import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
 import {
     click,
     contains,
@@ -9,6 +7,8 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
+import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
+import { describe, test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 
 describe.current.tags("desktop");
@@ -65,4 +65,40 @@ test("show default emojis when no frequent emojis are available", async () => {
         count: 0,
     });
     await contains(".o-mail-QuickReactionMenu-emoji", { text: "🤢" });
+});
+
+test("navigate quick reaction menu using tab key", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await insertText(".o-mail-Composer-input", "Hello world!");
+    await press("Enter");
+    await click("[title='Add a Reaction']");
+    for (const emoji of QuickReactionMenu.DEFAULT_EMOJIS) {
+        await contains(".o-mail-QuickReactionMenu-emoji:focus", { text: emoji });
+        await press("Tab");
+    }
+    await contains(".o-mail-QuickReactionMenu-emojiPicker:focus");
+});
+
+test("navigate quick reaction menu using arrow keys", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await insertText(".o-mail-Composer-input", "Hello world!");
+    await press("Enter");
+    await click("[title='Add a Reaction']");
+    for (const emoji of QuickReactionMenu.DEFAULT_EMOJIS) {
+        await contains(".o-mail-QuickReactionMenu-emoji:focus", { text: emoji });
+        await press("ArrowRight");
+    }
+    await contains(".o-mail-QuickReactionMenu-emojiPicker:focus");
+    await press("ArrowLeft");
+    for (const emoji of QuickReactionMenu.DEFAULT_EMOJIS.reverse()) {
+        await contains(".o-mail-QuickReactionMenu-emoji:focus", { text: emoji });
+        await press("ArrowLeft");
+    }
+    await contains(".o-mail-QuickReactionMenu-emojiPicker:focus");
 });


### PR DESCRIPTION
This PR enables keyboard navigation in the quick reaction menu. It's makes the selection of frequent emojis event faster which is the intent of this menu.