### PR TITLE
[FIX] ir_ui_view: fix check on empty view arch

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -360,7 +360,7 @@ actual arch.
             try:
                 # verify the view is valid xml and that the inheritance resolves
                 if view.inherit_id:
-                    view_arch = etree.fromstring(view.arch)
+                    view_arch = etree.fromstring(view.arch or '<data/>')
                     view._valid_inheritance(view_arch)
                 combined_arch = view._get_combined_arch()
                 if view.type == 'qweb':

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -247,6 +247,10 @@ class TestViewInheritance(ViewCase):
         self.c = self.makeView('C', arch=self.arch_for("C", 'list'))
         self.c.write({'priority': 1})
 
+        self.d = self.makeView("D")
+        self.d1 = self.makeView("D1", self.d.id)
+        self.d1.arch = None
+
     def test_get_inheriting_views(self):
         self.assertEqual(
             self.view_ids['A']._get_inheriting_views(),
@@ -365,6 +369,9 @@ class TestViewInheritance(ViewCase):
             """, inherit_id=base_view.id)
         self.assertEqual(counter.hit, hit)
         self.assertEqual(counter.miss, miss)
+
+    def test_no_arch(self):
+        self.d1._check_xml()
 
 
 class TestApplyInheritanceSpecs(ViewCase):


### PR DESCRIPTION
Since the arch is not mandatory and the `_combine` method would [assume it is a data node](https://github.com/odoo/odoo/pull/182766), the `_check_xml` for child views should allow an empty arch in the same way.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
