### PR TITLE
[REF] web_tour: decrease debounce delay to 300ms

### DIFF
--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -54,7 +54,6 @@ registry.category("web_tour.tours").add("self_multi_attribute_selector", {
 });
 
 registry.category("web_tour.tours").add("selfAlwaysAttributeVariants", {
-    test: true,
     steps: () => [
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Chair"),

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -7,6 +7,7 @@ import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
 
 registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
+    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -27,6 +28,7 @@ registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
 });
 
 registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_out", {
+    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -44,6 +46,7 @@ registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_out", {
 });
 
 registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_in", {
+    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -61,6 +64,7 @@ registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_in", {
 });
 
 registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_out", {
+    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -78,6 +82,7 @@ registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_out", 
 });
 
 registry.category("web_tour.tours").add("self_order_kiosk_cancel", {
+    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -96,6 +101,7 @@ registry.category("web_tour.tours").add("self_order_kiosk_cancel", {
 });
 
 registry.category("web_tour.tours").add("self_simple_order", {
+    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -109,6 +115,7 @@ registry.category("web_tour.tours").add("self_simple_order", {
 });
 
 registry.category("web_tour.tours").add("self_order_price_null", {
+    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -122,6 +129,7 @@ registry.category("web_tour.tours").add("self_order_price_null", {
 });
 
 registry.category("web_tour.tours").add("self_order_language_changes", {
+    checkDelay: 100,
     steps: () => [
         LandingPage.checkLanguageSelected("English"),
         LandingPage.checkCountryFlagShown("us"),

--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -36,7 +36,6 @@ export class TourAutomatic {
         const macroSteps = this.steps
             .filter((step) => step.index >= this.currentIndex)
             .flatMap((step) => {
-                const timeout = (step.timeout || 10000) + this.config.stepDelay;
                 return [
                     {
                         action: async () => {
@@ -63,7 +62,7 @@ export class TourAutomatic {
                             return this.previousStepIsJustACheck ? 0 : null;
                         },
                         trigger: () => step.findTrigger(),
-                        timeout,
+                        timeout: (step.timeout || 10000) + this.config.stepDelay,
                         action: async () => {
                             if (this.checkForUndeterminisms) {
                                 try {
@@ -113,7 +112,7 @@ export class TourAutomatic {
 
         this.macro = new Macro({
             name: this.name,
-            checkDelay: this.checkDelay || 400,
+            checkDelay: this.checkDelay || 300,
             steps: macroSteps,
             onError: (error) => {
                 this.throwError([error]);


### PR DESCRIPTION
By default, the checkdelay is 400ms when it is not stipulated in a tour. For performance reasons (runbot time), we reduce this delay to 300ms.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
