### PR TITLE
[FIX] account,website_sale: _filter_taxes_by_company by company branch

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2350,7 +2350,7 @@ class AccountTax(models.Model):
         taxes, company = self.env['account.tax'], company_id
         while not taxes and company:
             taxes = self.filtered(lambda t: t.company_id == company)
-            company = company.parent_id
+            company = company.sudo().parent_id
         return taxes
 
     @api.model


### PR DESCRIPTION
Scenario:

- create a company branch, with a website and a product for that branch
- add that product to a cart from that website branch with a user that
  only has that branch in its allowed companies (eg. public user)

=> an AccessError is raised because we can't read "parent_id" of parent
   company when passing in method account.tax()._filter_taxes_by_company

Note:

The error doesn't happen if the product is not in the company, because
then we will check access rules which will set the parent res.company
record in the cache, so no access error happen.

Fix:

Add sudo in account.tax()._filter_taxes_by_company method. The sudo
could be put on company_id argument by the calling method (eg. 4 calls
in website_sale) but it's hard to know that sudo is necessary since it
works in a lot of case by chance because the res.company records are
already in cache.

Note: added test fails with odoo.exceptions.AccessError because we try
to read "parent_id" of the branch company.

opw-4282334