### PR TITLE
[IMP] mail: remove chat bot from channel once operator is found

### DIFF
--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -71,7 +71,7 @@ class LivechatChatbotScriptController(http.Controller):
                 "isLast": next_step._is_last_step(discuss_channel),
                 "message": posted_message.id,
                 "operatorFound": next_step.step_type == "forward_operator"
-                and len(discuss_channel.channel_member_ids) > 2,
+                and discuss_channel.livechat_operator_id != chatbot.operator_partner_id,
                 "scriptStep": next_step.id,
             },
         )

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -70,7 +70,7 @@ class DiscussChannel(models.Model):
                 "scriptStep": current_step_sudo.id,
                 "message": step_message.mail_message_id.id,
                 "operatorFound": current_step_sudo.step_type == "forward_operator"
-                and len(channel.channel_member_ids) > 2,
+                and channel.livechat_operator_id != chatbot_script.operator_partner_id,
             }
             store.add(current_step_sudo)
             store.add(chatbot_script)

--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -52,7 +52,7 @@ class MailMessage(models.Model):
                         "message": message.id,
                         "scriptStep": step.id,
                         "operatorFound": step.step_type == "forward_operator"
-                        and len(channel.channel_member_ids) > 2,
+                        and channel.livechat_operator_id != chatbot
                     }
                     if answer := chatbot_message.user_script_answer_id:
                         step_data["selectedAnswer"] = answer.id

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -78,7 +78,9 @@ export class Chatbot extends Record {
                 { html: true }
             );
         }
-        this.thread.messages.add(this.currentStep.message);
+        if (this.currentStep.message) {
+            this.thread.messages.add(this.currentStep.message);
+        }
     }
 
     get completed() {

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
@@ -103,7 +103,7 @@ export class ChatBotService {
      * completed or the current step expects an answer from the user.
      */
     async _triggerNextStep() {
-        if (this.chatbot.completed) {
+        if (!this.chatbot || this.chatbot.completed) {
             return;
         }
         await this.chatbot.triggerNextStep();

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
@@ -1,0 +1,26 @@
+import { registry } from "@web/core/registry";
+
+const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:contains("${text}")`;
+
+registry.category("web_tour.tours").add("website_livechat.chatbot_forward", {
+    url: "/",
+    steps: () => [
+        {
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
+            run: "click",
+        },
+        {
+            trigger: messagesContain("Hello, what can I do for you?"),
+        },
+        {
+            trigger: ".o-livechat-root:shadow li:contains(Forward to operator)",
+            run: "click",
+        },
+        {
+            trigger: messagesContain("I'll forward you to an operator."),
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input:enabled",
+        },
+    ],
+});


### PR DESCRIPTION
Until now, the chat bot stayed as a member of the channel after the
"forward_operator" step. It makes more sense to remove it from the
channel.

task-4354075
