### PR TITLE
[FIX] account_edi_ubl_cii: wrong field name in test

### DIFF
--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -239,4 +239,4 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
         bill = self.import_attachment(xml_attachment)
 
         self.assertRecordValues(bill.partner_id, [partner_vals])
-        self.assertEqual(bill.partner_id.contact_address_complete, "270 rte d'Arlon, 8010 Strassen, Luxembourg")
+        self.assertEqual(bill.partner_id.contact_address, "270 rte d'Arlon\n\n8010 Strassen \nLuxembourg")


### PR DESCRIPTION
commit 4a384ec28ab11 introduced a reference to an unknown field contact_address_complete.

runbot-107874




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
