### PR TITLE
[FIX] website: test_tour tour

### DIFF
--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -489,7 +489,7 @@ registerWebsitePreviewTour("website_form_editor_tour", {
         trigger: '.dropdown:has([name="link_style_color"]) > button',
         run: "click",
     }, {
-        trigger: "[data-value=secondary]",
+        trigger: "[data-value=custom]",
         run: "click",
     }, {
         trigger: ".dropdown:has([name=link_style_shape]) > button",
@@ -505,7 +505,7 @@ registerWebsitePreviewTour("website_form_editor_tour", {
         run: "click",
     }, {
         content: "Check the resulting button",
-        trigger: ':iframe .s_website_form_send.btn.btn-sm.btn-secondary.rounded-circle',
+        trigger: ':iframe .s_website_form_send.btn.btn-sm.btn-custom.rounded-circle',
     },
     // Add a default value to a auto-fillable field.
     {
@@ -620,7 +620,7 @@ registerWebsitePreviewTour("website_form_editor_tour", {
      {
         content: "Write anything in C",
         trigger: `:iframe ${triggerFieldByLabel("field C")} input`,
-        run: "edit Mellon",
+        run: "edit Mellon && press Tab",
     }, {
         content: "Check that field B is visible, but field A is not",
         trigger: `:iframe .s_website_form:has(${triggerFieldByLabel("field B")}:visible)` +


### PR DESCRIPTION
In this commit, we fix the test_tour in order to reactivate it from v18. The probleme that is fixed in this commit is that we can't customize a "secondary" button in the sidebar of web editor tools but it is allowed with "custom" button.

runbot-error-id~109213

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
