### PR TITLE
[FIX] account: prevent reversed invoice in portal overdue inv

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -57,7 +57,7 @@ class PortalAccount(CustomerPortal):
         return [
             ('state', 'not in', ('cancel', 'draft')),
             ('move_type', 'in', ('out_invoice', 'out_receipt')),
-            ('payment_state', 'not in', ('in_payment', 'paid')),
+            ('payment_state', 'not in', ('in_payment', 'paid', 'reversed', 'blocked', 'invoicing_legacy')),
             ('invoice_date_due', '<', fields.Date.today()),
             ('partner_id', '=', partner_id or request.env.user.partner_id.id),
         ]


### PR DESCRIPTION
Steps to reproduce:
- create a portal user associated with a customer
- create for this customer an invoice with a due date to yesterday
- go on its portal view -> 1 invoice to pay will be displayed
- create and confirm a credit note -> go on it portal view

Issue:
There will still be the invoice set as to be paid (even if in the detailed report it is defined as paid)

Cause:
The domain does not take into account invoice for which the payment state is `reversed`

opw-4360830

Root cause: #162762 added a feature in the 18.0 portal to remind customers of overdue invoices, but did not correctly take into account reversed or blocked invoices.