### PR TITLE
[IMP] hw_posbox_homepage: remove reboot button

### DIFF
--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -69,14 +69,6 @@ class IotBoxOwlHomePage(Home):
             'message': 'Odoo service restarted',
         })
 
-    @http.route('/hw_posbox_homepage/restart_iotbox', auth='none', type='http', cors='*')
-    def iotbox_restart(self):
-        subprocess.call(['sudo', 'reboot'])
-        return json.dumps({
-            'status': 'success',
-            'message': 'IoT Box is restarting',
-        })
-
     @http.route('/hw_posbox_homepage/iot_logs', auth='none', type='http', cors='*')
     def get_iot_logs(self):
         with open("/var/log/odoo/odoo-server.log", encoding="utf-8") as file:

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/RemoteDebugDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/RemoteDebugDialog.js
@@ -57,18 +57,6 @@ export class RemoteDebugDialog extends Component {
         }
     }
 
-    async restartIotBox() {
-        try {
-            await this.store.rpc({
-                url: "/hw_posbox_homepage/restart_iotbox",
-            });
-
-            this.state.waitRestart = true;
-        } catch {
-            console.warn("Error while restarting IoT Box");
-        }
-    }
-
     static template = xml`
         <LoadingFullScreen t-if="this.state.waitRestart">
             <t t-set-slot="body">
@@ -103,7 +91,6 @@ export class RemoteDebugDialog extends Component {
                 </div>
             </t>
             <t t-set-slot="footer">
-                <button type="submit" class="btn btn-danger btn-sm" t-on-click="restartIotBox">Restart IOT Box</button>
                 <button type="button" class="btn btn-primary btn-sm" data-bs-dismiss="modal">Close</button>
             </t>
         </BootstrapDialog>


### PR DESCRIPTION
LNE Certification (scales certification) requires not to be able to reboot the IoT Box with a simple button.  
We removed it from the homepage.

Enterprise PR: [https://github.com/odoo/enterprise/pull/75074](https://github.com/odoo/enterprise/pull/75074)
Task: 4345731
