### PR TITLE
[FIX] *: Restore the model _name

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -60,7 +60,7 @@ class IrCron(models.Model):
     # that would cause database wake-up even if the database has not been
     # loaded yet or was already unloaded (e.g. 'force_db_wakeup' or something)
     # See also odoo.cron
-
+    _name = 'ir.cron'
     _order = 'cron_name'
     _description = 'Scheduled Actions'
     _allow_sudo_commands = False

--- a/odoo/addons/base/models/ir_default.py
+++ b/odoo/addons/base/models/ir_default.py
@@ -11,6 +11,7 @@ from odoo.tools import SQL
 
 class IrDefault(models.Model):
     """ User-defined default values for fields. """
+    _name = 'ir.default'
     _description = 'Default Values'
     _rec_name = 'field_id'
     _allow_sudo_commands = False

--- a/odoo/addons/base/models/ir_demo.py
+++ b/odoo/addons/base/models/ir_demo.py
@@ -6,7 +6,6 @@ from odoo.addons.base.models.ir_module import assert_log_admin_access
 
 class IrDemo(models.TransientModel):
     _name = 'ir.demo'
-
     _description = 'Demo'
 
     @assert_log_admin_access

--- a/odoo/addons/base/models/ir_demo_failure.py
+++ b/odoo/addons/base/models/ir_demo_failure.py
@@ -4,6 +4,7 @@ from odoo import api, fields, models
 class IrDemo_Failure(models.TransientModel):
     """ Stores modules for which we could not install demo data
     """
+    _name = 'ir.demo_failure'
     _description = 'Demo failure'
 
     module_id = fields.Many2one('ir.module.module', required=True, string="Module")


### PR DESCRIPTION
Continue https://github.com/odoo/odoo/commit/9144eb051538d5a92d403e1ad9c635ce39e090ec.

**Description of the issue/feature this PR addresses:**

It seems some models are missing the `_name`. Maybe the script used was incomplete. I don't know how to exhaustively look for all of them. These ones I found was just me by randomly looking.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr