### PR TITLE
[FIX] purchase: display discounts on pdf files

### DIFF
--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -49,10 +49,11 @@
                 <thead style="display: table-row-group">
                     <tr>
                         <th name="th_description"><strong>Description</strong></th>
-                        <th name="th_taxes"><strong>Taxes</strong></th>
                         <th name="th_date_req" class="text-center"><strong>Date Req.</strong></th>
                         <th name="th_quantity" class="text-end"><strong>Qty</strong></th>
                         <th name="th_price_unit" class="text-end"><strong>Unit Price</strong></th>
+                        <th name="th_discount" class="text-end"><strong>Disc.</strong></th>
+                        <th name="th_taxes" class="text-end"><strong>Taxes</strong></th>
                         <th name="th_subtotal" class="text-end">
                             <strong>Amount</strong>
                         </th>
@@ -68,10 +69,6 @@
                                 <td id="product">
                                     <span t-field="line.name"/>
                                 </td>
-                                <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.taxes_id])"/>
-                                <td name="td_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
-                                    <span t-out="taxes">Tax 15%</span>
-                                </td>
                                 <td class="text-center">
                                     <span t-field="line.date_planned"/>
                                 </td>
@@ -84,6 +81,13 @@
                                 </td>
                                 <td class="text-end">
                                     <span t-field="line.price_unit"/>
+                                </td>
+                                <td class="text-end">
+                                    <span class="text-align-bottom"><span t-field="line.discount"/>%</span>
+                                </td>
+                                <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.taxes_id])"/>
+                                <td name="td_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
+                                    <span t-out="taxes">Tax 15%</span>
                                 </td>
                                 <td class="text-end">
                                     <span t-field="line.price_subtotal"


### PR DESCRIPTION
**Issue:**
The discount column is not visible on Purchase Order PDF file.

**Expected:**
When a discount is configured, it should be displayed on the document.

**Steps to reproduce:**
- Activate Purchase app;
- Go to Purchase > Orders > Request for Quotations;
- Create a new RFQ with at least 1 product and a vendor;
- Setup a discount (display the column using the options on the right of the table);
- Confirm the order;
- Using the action button `Print` > `Purchase order`, generate the PDF.

**Cause:**
The field isn't displayed on the template 
https://github.com/odoo/odoo/blob/a288317f303f8176e058d04b611064bb457534b3/addons/purchase/report/purchase_order_templates.xml#L51-L56

**Fix:**
Backport the Odoo 18 fix (https://github.com/odoo/odoo/commit/6474797ee21c9547f9adb9e58bd9593870cacf6b) that adds the field to the document's XML.

opw-4346390

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
