### PR TITLE
[FIX] mrp_subcontracting: don’t mark subcontracted moves as picked

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -58,6 +58,10 @@ class StockMove(models.Model):
             move.show_details_visible = True
         return res
 
+    def _compute_picked(self):
+       subcontracted_moves = self.filtered(lambda m: m.is_subcontract)
+       super(StockMove, self - subcontracted_moves)._compute_picked()
+
     def _set_quantity_done(self, qty):
         to_set_moves = self
         for move in self:

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -635,6 +635,45 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         avail_qty_comp1 = self.env['stock.quant']._get_available_quantity(self.comp1, self.subcontractor_partner1.property_stock_subcontractor, allow_negative=True)
         self.assertEqual(avail_qty_comp1, -5)
 
+    def test_backorder_with_subcontracting(self):
+        """Test that a subcontracted move is not marked as picked when its quantity is updated.
+        """
+        self.bom.consumption = 'warning'
+        # Create incoming shipment.
+        with Form(self.env['stock.picking']) as picking_form:
+            picking_form.picking_type_id = self.warehouse.in_type_id
+            picking_form.partner_id = self.subcontractor_partner1
+            with picking_form.move_ids_without_package.new() as move:
+                move.product_id = self.finished
+                move.product_uom_qty = 5
+            with picking_form.move_ids_without_package.new() as move:
+                move.product_id = self.comp1
+                move.product_uom_qty = 5
+            receipt = picking_form.save()
+        receipt.action_confirm()
+
+        # Record the over-consumption of a component
+        self.assertTrue(receipt._get_subcontract_production())
+        action_record = receipt.action_record_components()
+        sbc_mo = self.env['mrp.production'].browse(action_record['res_id'])
+
+        self.assertEqual(receipt.move_ids.mapped('picked'), [False, False])
+        self.assertEqual(receipt.move_ids.mapped('quantity'), [5.0, 5.0])
+        receipt.move_ids[0].quantity = 2
+        receipt.move_ids[1].quantity = 4
+        self.assertEqual(receipt.move_ids.mapped('picked'), [False, False])
+        self.assertEqual(receipt.move_ids.mapped('quantity'), [2.0, 4.0])
+        res = receipt.button_validate()
+        wizard = Form(self.env[res['res_model']].with_context(res['context'])).save()
+        wizard.process()
+        backorder = receipt.backorder_ids
+        self.assertEqual(receipt.move_ids.mapped('quantity'), [2.0, 4.0])
+        self.assertEqual(backorder.move_ids.mapped('quantity'), [3.0, 1.0])
+        backorder.button_validate()
+        self.assertEqual(backorder.state, 'done')
+        self.assertEqual(backorder.move_ids.mapped('quantity'), [3.0, 1.0])
+        self.assertEqual(backorder.move_ids.mapped('picked'), [True, True])
+
     def test_flow_warning_bom_2(self):
         """ For an initial demand of 10 subcontracted products
             - The production of 3 is recorded, with an over-consumption of its components

--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -187,12 +187,14 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
         purchase_order.button_confirm()
         dropship_transfer = purchase_order.picking_ids[0]
         dropship_transfer.move_ids[0].quantity = 50
-        dropship_transfer.with_context(cancel_backorder=False)._action_done()
+        res = dropship_transfer.button_validate()
+        wizard = Form(self.env[res['res_model']].with_context(res['context'])).save()
+        wizard.process()
         account_move_1 = sale_order._create_invoices()
         account_move_1.action_post()
         dropship_backorder = dropship_transfer.backorder_ids[0]
         dropship_backorder.move_ids[0].quantity = 50
-        dropship_backorder._action_done()
+        dropship_backorder.button_validate()
         account_move_2 = sale_order._create_invoices()
         account_move_2.action_post()
 


### PR DESCRIPTION
Steps to reproduce the issue:
- Create a storable product P1.
- Create a subcontracted product P2.
- Create a receipt with 5 units of P1 and  P2.
    - Mark it as To Do.
    - Set the quantities as follows:
- P1 -> 2 units
- P2 -> 2 units
      - Validate the receipt and create a backorder.

Problem:
A picking is validated with only 2 units of P2, and a backorder is
created with 5 units of P1 and 3 units of P2, instead of correctly
validating the picking with:
 - P1 -> 2 units
 - P2 -> 2 units
And creating a backorder with:
 - 3 units of P1
 - 3 units of P2

This occurs because, when updating the move for P2 from 5 to 2, a move
line is created and marked as picked. As a result, when computing the
picked value for the move, it is also marked as picked:
 https://github.com/odoo/odoo/blob/7dda6bb92715ea25b2818a62fec5e646f3678b81/addons/stock/models/stock_move.py#L206-L207
Thus, when validating the picking, since only the move for P2 is marked
as picked, it is the only one that gets validated.

opw-4357997