### PR TITLE
[FIX] mail: receive channel mentions in inbox

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -548,6 +548,7 @@ class Channel(models.Model):
                 SELECT DISTINCT ON (partner.id) partner.id,
                        partner.lang,
                        partner.partner_share,
+                       users.id as uid,
                        COALESCE(users.notification_type, 'email') as notif,
                        COALESCE(users.share, FALSE) as ushare
                   FROM res_partner partner
@@ -559,7 +560,7 @@ class Channel(models.Model):
                 sql_query,
                 (email_from or '', list(pids), [author_id] if author_id else [], )
             )
-            for partner_id, lang, partner_share, notif, ushare in self._cr.fetchall():
+            for partner_id, lang, partner_share, uid, notif, ushare in self._cr.fetchall():
                 # ocn_client: will add partners to recipient recipient_data. more ocn notifications. We neeed to filter them maybe
                 recipients_data.append({
                     'active': True,
@@ -570,7 +571,7 @@ class Channel(models.Model):
                     'notif': notif,
                     'share': partner_share,
                     'type': 'user' if not partner_share and notif else 'customer',
-                    'uid': False,
+                    'uid': uid,
                     'ushare': ushare,
                 })
 

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1212,6 +1212,28 @@ class MailCase(MockEmail):
             self.assertEqual(len(bus_notifs), len(channels))
         return bus_notifs
 
+    @contextmanager
+    def assertBusNotificationType(self, expected_pairs):
+        """Check bus notifications type.
+        :param expected_pairs: list of tuples containing the expected bus channel and bus
+        notification type"""
+        try:
+            with self.mock_bus():
+                yield
+        finally:
+            bus_notifs = (
+                self.env["bus.bus"]
+                .sudo()
+                .search([("channel", "in", [json_dump(channel) for channel, _ in expected_pairs])])
+            )
+            notif_types = [
+                (json.loads(notif.message).get("type"), notif.channel) for notif in bus_notifs
+            ]
+            expected_notif_types = [
+                (notif_type, json_dump(channel)) for channel, notif_type in expected_pairs
+            ]
+            self.assertEqual(notif_types, expected_notif_types)
+
     def assertNotified(self, message, recipients_info, is_complete=False):
         """ Lightweight check for notifications (mail.notification).
 

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -686,9 +686,24 @@ class TestChannelInternals(MailCommon, HttpCase):
         self.assertEqual(len(mentions_notif), 0, "mentions + normal message = no needaction")
         self.assertEqual(len(nothing_notif), 0, "nothing + normal message = no needaction")
 
-        # sending mention message
-        with self.with_user("employee"):
-            channel_msg = channel.message_post(body="Test @mentions", partner_ids=(all_test_user.partner_id + mentions_test_user.partner_id + nothing_test_user.partner_id).ids, message_type="comment", subtype_xmlid="mail.mt_comment")
+        partner_ids = (
+            all_test_user.partner_id + mentions_test_user.partner_id + nothing_test_user.partner_id
+        ).ids
+        self._reset_bus()
+        with self.assertBusNotificationType(
+            [
+                ((self.cr.dbname, "res.partner", partner_id), "mail.message/inbox")
+                for partner_id in partner_ids
+            ],
+        ):
+            # sending mention message
+            with self.with_user("employee"):
+                channel_msg = channel.message_post(
+                    body="Test @mentions",
+                    partner_ids=partner_ids,
+                    message_type="comment",
+                    subtype_xmlid="mail.mt_comment",
+                )
         all_notif = self.env["mail.notification"].search([
             ("mail_message_id", "=", channel_msg.id),
             ("res_partner_id", "=", all_test_user.partner_id.id)


### PR DESCRIPTION
Since odoo/odoo#171869, for inbox notification, we check if the mentioned partners have a valid uid, which makes sense. But the query to get recipients in `discuss.channel` doesn't take the `uid` into account, and this leads to not getting an inbox notification when mentioning a partner in a channel.
This commit fixes that by including the uid in the recipients computation for channels.

Steps to reproduce:
- Set the first user's notification settings, e.g. admin, to `Handle in Odoo`
- Login as another user (e.g. demo) and send a message with mentioning the first user
- The message will not appear in the first user's inbox until the page is refreshed

