### PR TITLE
[REF] point_of_sale: related models

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -26,7 +26,7 @@ const ProductProductTemplateProxy = new Proxy(ProductProduct, {
             get(target, prop) {
                 const val = Reflect.get(target, prop);
 
-                if (val || target.model.modelFields[prop] || typeof prop === "symbol") {
+                if (val || target.model.fields[prop] || typeof prop === "symbol") {
                     return val;
                 }
 

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -147,7 +147,7 @@ export class PosData extends Reactive {
 
         const preLoadData = await this.preLoadData(data);
         const missing = await this.missingRecursive(preLoadData);
-        const results = this.models.loadData(this.models, missing, [], true);
+        const results = this.models.loadData(missing, [], true);
         for (const data of Object.values(results)) {
             for (const record of data) {
                 if (record.raw.JSONuiState) {
@@ -243,8 +243,8 @@ export class PosData extends Reactive {
         delete data["pos.order"];
         delete data["pos.order.line"];
 
-        this.models.loadData(this.models, data, this.modelToLoad);
-        this.models.loadData(this.models, { "pos.order": order, "pos.order.line": orderlines });
+        this.models.loadData(data, this.modelToLoad);
+        this.models.loadData({ "pos.order": order, "pos.order.line": orderlines });
     }
 
     async loadFieldsAndRelations() {
@@ -291,15 +291,9 @@ export class PosData extends Reactive {
             };
         }
 
-        const { models, records, indexedRecords, baseData } = createRelatedModels(
-            relations,
-            modelClasses,
-            this.opts
-        );
+        const { models, baseData } = createRelatedModels(relations, modelClasses, this.opts);
 
         this.baseData = baseData;
-        this.records = records;
-        this.indexedRecords = indexedRecords;
         this.fields = fields;
         this.relations = relations;
         this.models = models;
@@ -471,7 +465,7 @@ export class PosData extends Reactive {
             ) {
                 const data = await this.missingRecursive({ [model]: result });
                 this.synchronizeServerDataInIndexedDB(data);
-                const results = this.models.loadData(this.models, data);
+                const results = this.models.loadData(data);
                 result = results[model];
             } else if (type === "write") {
                 const baseData = Object.assign(this.baseData[model][ids[0]], values);
@@ -672,7 +666,7 @@ export class PosData extends Reactive {
 
     async callRelated(model, method, args = [], kwargs = {}, queue = true) {
         const data = await this.execute({ type: "call", model, method, args, kwargs, queue });
-        const results = this.models.loadData(this.models, data, [], true);
+        const results = this.models.loadData(data, [], true);
         return results;
     }
 
@@ -708,7 +702,7 @@ export class PosData extends Reactive {
         // Delete all children records before main record
         this.indexedDB.delete(recordModel, [record.uuid]);
         for (const item of recordsToDelete) {
-            this.indexedDB.delete(item.model.modelName, [item.uuid]);
+            this.indexedDB.delete(item.model.name, [item.uuid]);
             item.delete();
         }
 

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1129,7 +1129,7 @@ export class PosStore extends WithLazyGetterTrap {
                 context,
             });
             const missingRecords = await this.data.missingRecursive(data);
-            const newData = this.models.loadData(this.models, missingRecords);
+            const newData = this.models.loadData(missingRecords);
 
             for (const line of newData["pos.order.line"]) {
                 const refundedOrderLine = line.refunded_orderline_id;

--- a/addons/point_of_sale/static/src/app/utils/debug/debug_widget.js
+++ b/addons/point_of_sale/static/src/app/utils/debug/debug_widget.js
@@ -178,7 +178,7 @@ export class DebugWidget extends Component {
             }
 
             const missing = await this.pos.data.missingRecursive(data);
-            this.pos.data.models.loadData(this.models, missing, [], true);
+            this.pos.data.models.loadData(missing, [], true);
             this.notification.add(_t("%s orders imported", data["pos.order"].length));
         }
     }

--- a/addons/pos_hr/static/src/app/services/pos_store.js
+++ b/addons/pos_hr/static/src/app/services/pos_store.js
@@ -86,7 +86,7 @@ patch(PosStore.prototype, {
         if (this.config.module_pos_hr) {
             const cashier = this.getCashier();
 
-            if (cashier && cashier.model.modelName === "hr.employee") {
+            if (cashier && cashier.model.name === "hr.employee") {
                 const order = this.getOrder();
                 order.employee_id = this.getCashier();
             }

--- a/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -173,7 +173,7 @@ patch(OrderSummary.prototype, {
                 this.currentOrder.processGiftCard(code, points, expirationDate);
 
                 // update indexedDB
-                this.pos.data.synchronizeLocalDataInIndexedDB(this.pos.data.records);
+                this.pos.data.synchronizeLocalDataInIndexedDB();
             },
         });
     },

--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -40,7 +40,7 @@ patch(PosStore.prototype, {
                     this.updateOrder(order);
                 }
             }),
-            [this.data.records["pos.order"]]
+            [this.data.models.records["pos.order"]]
         );
     },
     async updateOrder(order) {
@@ -537,7 +537,7 @@ patch(PosStore.prototype, {
 
         this.computeDiscountProductIdsForAllRewards({
             model: "product.product",
-            ids: Array.from(this.data.records["product.product"].keys()),
+            ids: Array.from(this.data.models.records["product.product"].keys()),
         });
 
         this.models["product.product"].addEventListener(

--- a/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
@@ -7,7 +7,7 @@ patch(SelfOrder.prototype, {
         await super.setup(...args);
         this.onlinePaymentStatus = null;
         this.onNotified("ONLINE_PAYMENT_STATUS", ({ status, data }) => {
-            this.models.loadData(this.models, data, [], false);
+            this.models.loadData(data, [], false);
             this.onlinePaymentStatus = status;
             this.paymentError = status === "fail";
 

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -69,7 +69,7 @@ export class ConfirmationPage extends Component {
             access_token: this.selfOrder.access_token,
             order_access_tokens: [this.props.orderAccessToken],
         });
-        this.selfOrder.models.loadData(this.selfOrder.models, data);
+        this.selfOrder.models.loadData(data);
         const order = this.selfOrder.models["pos.order"].find(
             (o) => o.access_token === this.props.orderAccessToken
         );

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -76,7 +76,7 @@ export class SelfOrder extends Reactive {
 
         this.onNotified = getOnNotified(this.bus, this.access_token);
         this.onNotified("PRODUCT_CHANGED", (payload) => {
-            this.models.loadData(this.models, payload);
+            this.models.loadData(payload);
         });
         if (this.config.self_ordering_mode === "kiosk") {
             this.onNotified("STATUS", ({ status }) => {
@@ -91,7 +91,7 @@ export class SelfOrder extends Reactive {
             });
             this.onNotified("PAYMENT_STATUS", ({ payment_result, data }) => {
                 if (payment_result === "Success") {
-                    this.models.loadData(this.models, data);
+                    this.models.loadData(data);
                     const order = this.models["pos.order"].find(
                         (o) => o.access_token === data["pos.order"][0].access_token
                     );
@@ -156,7 +156,7 @@ export class SelfOrder extends Reactive {
 
         const handleMessage = (data) => {
             let message = "";
-            this.models.loadData(this.models, data);
+            this.models.loadData(data);
             const oUpdated = data["pos.order"].find((o) => o.uuid === this.selectedOrderUuid);
 
             if (["paid", "invoiced", "done"].includes(oUpdated?.state)) {
@@ -712,7 +712,7 @@ export class SelfOrder extends Reactive {
                     table_identifier: this.currentOrder?.table_id?.identifier || false,
                 }
             );
-            this.models.loadData(this.models, data);
+            this.models.loadData(data);
             for (const order of data["pos.order"]) {
                 this.subscribeToOrderChannel(order);
             }
@@ -746,7 +746,7 @@ export class SelfOrder extends Reactive {
                 access_token: this.access_token,
                 order_access_tokens: [...accessTokens, ...localAccessToken],
             });
-            this.models.loadData(this.models, data);
+            this.models.loadData(data);
             this.selectedOrderUuid = null;
         } catch (error) {
             this.handleErrorNotification(


### PR DESCRIPTION
In this PR, we refactor the related_models module. There is now `Models` class
that contains all the models. Also, a `CRUD` class is introduced to represent
each model. We can get the model records from the `CRUD` methods. This
refactoring is introduced so that the `Models` and the `CRUD` methods don't need
to accept the instances as first param. `this` becomes usable in the `Models`
and `CRUD` methods.

Related: https://github.com/odoo/enterprise/pull/75089