### PR TITLE
[FIX] website_google_map: map zoom issue on locationless partners

### DIFF
--- a/addons/website_google_map/static/src/js/website_google_map.js
+++ b/addons/website_google_map/static/src/js/website_google_map.js
@@ -88,7 +88,9 @@ function initialize_map() {
         if (odooPartnerData) { /* odoo_partner_data special variable should have been defined in google_map.xml */
             const markerPromises = [];
             for (var i = 0; i < odoo_partner_data.counter; i++) {
-                markerPromises.push(set_marker(odoo_partner_data.partners[i]));
+                const prom = set_marker(odoo_partner_data.partners[i])
+                    .catch(error => console.error(error));
+                markerPromises.push(prom);
             }
             await Promise.all(markerPromises);
             new MarkerClusterer(map, markers, options);


### PR DESCRIPTION
The World Map view when you are on the "/partners" page doesn't zoom.
This happens when any of the partners that are getting rendered doesn't
have a location (longitude and latitude).

Geocoder is then used to locate those addresses on the map.
We use Promises, and when there is an error, we're not catching it
where we are calling it from. The failed Geocode triggers the reject,
which is not caught, and we're stuck in the await Promise. The zoom-in
line never gets called.

Steps to Reproduce on Runbot:

Integrate the Google Place Map key via
Settings -> Geolocation -> Google Place Map.
Go to "/partners."
Toggle on the world map view for the page via the editor.
Ensure one partner on the page lacks a location.
Go to the "map" view, and the map will not zoom in.

opw-4319619