### PR TITLE
[FIX] point_of_sale: raise access denied for user role

### DIFF
--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
@@ -58,9 +58,6 @@ export class PosKanbanRenderer extends KanbanRenderer {
         });
 
         onWillRender(() => this.checkDisplayedResult());
-        onWillStart(async () => {
-            this.isPosManager = await user.hasGroup("point_of_sale.group_pos_manager");
-        });
     }
 
     checkDisplayedResult() {
@@ -69,7 +66,8 @@ export class PosKanbanRenderer extends KanbanRenderer {
 
     async callWithViewUpdate(func) {
         try {
-            if (!this.isPosManager) {
+            const isPosManager = await user.hasGroup("point_of_sale.group_pos_manager");
+            if (!isPosManager) {
                 this.dialog.add(AlertDialog, {
                     title: _t("Access Denied"),
                     body: _t(


### PR DESCRIPTION
We encounter an error when trying to open any POS category from the ``Dashboard``, if the Administrator is assigned the role of ``User`` for ``Point of Sale``.

Steps to reproduce:
---
- Install ``point_of_sale`` module
- Open POS
- Now go to Users and Change the right from ``Admin`` -> ``User`` in ``Point of Sale``
- Now go to ``Dashboard`` and try to open any category

Traceback: 
---
```
ParseError: while parsing /home/odoo/src/odoo/saas-17.4/addons/product/data/product_demo.xml:5, somewhere inside <record id="base.group_user" model="res.groups">
            <field name="implied_ids" eval="[(4, ref('product.group_product_variant'))]"/>
        </record>
 ```

This error occurs when the POS application is opened, as the onWillStart method is triggered. However, if the user's permissions are changed, the method does not update accordingly, leading to an error.

sentry-5710465833

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
