### PR TITLE
[FIX] l10n_in: incorrect tax applied on invoice in demo data

### DIFF
--- a/addons/l10n_in/demo/account_demo.py
+++ b/addons/l10n_in/demo/account_demo.py
@@ -422,7 +422,7 @@ class AccountChartTemplate(models.AbstractModel):
                             'product_id': 'product.product_product_4',
                             'quantity': 30,
                             'price_unit': 8000.0,
-                            'tax_ids': [Command.set([_get_tax_by_id('igst_sale_18')])],
+                            'tax_ids': [Command.set([_get_tax_by_id('igst_sale_18_sez_exp')])],
                         }),
                     ]
                 },


### PR DESCRIPTION
### Before this commit:
> In one of the demo invoices representing Export/SEZ, an incorrect inter-state tax was applied. The tax should have been specific to Export/SEZ transactions.

### After this commit:
> The issue has been resolved by correctly applying the Export/SEZ tax, replacing the incorrectly applied inter-state tax.