### PR TITLE
[FIX] stock: prevent error when clicking on replenishment information

### DIFF
--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -118,6 +118,9 @@ class StockReplenishmentOption(models.TransientModel):
     @api.depends('replenishment_info_id')
     def _compute_lead_time(self):
         for record in self:
+            if not record.warehouse_id:
+                record.lead_time = "0 days"
+                continue
             rule = self.env['procurement.group']._get_rule(record.product_id, record.location_id, {
                 'route_ids': record.route_id,
                 'warehouse_id': record.warehouse_id,


### PR DESCRIPTION
When the user clicks on replenishment information button,
A traceback will appear.

Steps to reproduce the error:
- Install ``stock`` module
- Create two warehouses: Warehouse A and Warehouse B
- Go to Warehouse B > Routes > Open any Route > Select Applicable On ``Products`` >
  Supplied Warehouse: Warehouse A
- Go to Inventory > Operations > Replenishment > Create new >
  Select Warehouse A > Select that Route > Save
- Click on ``i``(Replenishment Information) button

Traceback:
```
File "addons/stock/wizard/stock_replenishment_info.py", line 125, in _compute_lead_time
    rule = self.env['procurement.group']._get_rule(record.product_id, record.location_id, {
  File "addons/stock/models/stock_rule.py", line 567, in _get_rule
    while locations[-1].location_id:
  File "odoo/models.py", line 6985, in __getitem__
    return self.browse((self._ids[key],))
IndexError: tuple index out of range
```

https://github.com/odoo/odoo/blob/dcf0880f836423ee82f3d283ffbf940a804bc13b/addons/stock/wizard/stock_replenishment_info.py#L121
Here, ``location_id`` is Empty because ``warehouse_id`` is empty.
``warehouse_id`` depends on ``supplier_wh_id`` which is not a required field.
so eventually ``location_id`` is empty.
so, it will lead to the above traceback at
https://github.com/odoo/odoo/blob/dcf0880f836423ee82f3d283ffbf940a804bc13b/addons/stock/models/stock_rule.py#L558

sentry-6107032569

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
