### PR TITLE
[FIX] payment_razorpay_oauth: fix cancel action on the authorization page

### DIFF
--- a/addons/payment_razorpay_oauth/controllers/onboarding.py
+++ b/addons/payment_razorpay_oauth/controllers/onboarding.py
@@ -33,7 +33,7 @@ class RazorpayController(Controller):
 
         # Retrieve the Razorpay data and Odoo metadata from the redirect data.
         provider_id = int(data['provider_id'])
-        authorization_code = data['authorization_code']
+        authorization_code = data.get('authorization_code')
         csrf_token = data['csrf_token']
         provider_sudo = request.env['payment.provider'].sudo().browse(provider_id).exists()
         if not provider_sudo or provider_sudo.code != 'razorpay':
@@ -53,6 +53,8 @@ class RazorpayController(Controller):
             'view_type': 'form',
         }
         redirect_url = f'/web#{urlencode(url_params)}'  # TODO: change to /odoo in saas-17.2!
+        if not authorization_code: # The user cancelled the authorization.
+            return request.redirect(redirect_url)
         try:
             response_content = provider_sudo._razorpay_make_proxy_request(
                 '/get_access_token', payload={'authorization_code': authorization_code}


### PR DESCRIPTION
Version:
- 17.0

Steps to reproduce:
- Click on the Connect button, which redirects to the authentication wizard.
- On the authorization page, click on the Cancel button.

issue:
- Clicking on the Cancel button does not return an authorization code, causing a traceback error.

solution:
- Added a condition to handle the Cancel action. If the user clicks Cancel, redirect to the provider form view without causing an error.

opw-4377802

