### PR TITLE
[FIX] l10n_es_edi_sii: don't die on 0€ not_subject_loc invoices

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -6,7 +6,6 @@ from urllib3.contrib.pyopenssl import inject_into_urllib3
 from OpenSSL.crypto import load_certificate, load_privatekey, FILETYPE_PEM
 
 from odoo import fields, models, _
-from odoo.exceptions import UserError
 from odoo.tools import html_escape, zeep
 
 import math
@@ -114,6 +113,8 @@ class AccountEdiFormat(models.Model):
         tax_amount_retention = 0.0
         base_amount_not_subject = 0.0
         base_amount_not_subject_loc = 0.0
+        has_not_subject = False
+        has_not_subject_loc = False
         tax_subject_info_list = []
         tax_subject_isp_info_list = []
         for tax_values in tax_details['tax_details'].values():
@@ -150,8 +151,10 @@ class AccountEdiFormat(models.Model):
                 elif tax_values['l10n_es_type'] == 'retencion':
                     tax_amount_retention += tax_values['tax_amount']
                 elif tax_values['l10n_es_type'] == 'no_sujeto':
+                    has_not_subject = True
                     base_amount_not_subject += tax_values['base_amount']
                 elif tax_values['l10n_es_type'] == 'no_sujeto_loc':
+                    has_not_subject_loc = True
                     base_amount_not_subject_loc += tax_values['base_amount']
                 elif tax_values['l10n_es_type'] == 'ignore':
                     continue
@@ -163,8 +166,10 @@ class AccountEdiFormat(models.Model):
                 elif tax_values['l10n_es_type'] == 'retencion':
                     tax_amount_retention += tax_values['tax_amount']
                 elif tax_values['l10n_es_type'] == 'no_sujeto':
+                    has_not_subject = True
                     base_amount_not_subject += tax_values['base_amount']
                 elif tax_values['l10n_es_type'] == 'no_sujeto_loc':
+                    has_not_subject_loc = True
                     base_amount_not_subject_loc += tax_values['base_amount']
                 elif tax_values['l10n_es_type'] == 'ignore':
                     continue
@@ -204,9 +209,9 @@ class AccountEdiFormat(models.Model):
             tax_details_info['Sujeta']['NoExenta']['DesgloseIVA'].setdefault('DetalleIVA', [])
             tax_details_info['Sujeta']['NoExenta']['DesgloseIVA']['DetalleIVA'] += tax_subject_isp_info_list
 
-        if not invoice.company_id.currency_id.is_zero(base_amount_not_subject) and invoice.is_sale_document():
+        if has_not_subject and invoice.is_sale_document():
             tax_details_info['NoSujeta']['ImportePorArticulos7_14_Otros'] = round(sign * base_amount_not_subject, 2)
-        if not invoice.company_id.currency_id.is_zero(base_amount_not_subject_loc) and invoice.is_sale_document():
+        if has_not_subject_loc and invoice.is_sale_document():
             tax_details_info['NoSujeta']['ImporteTAIReglasLocalizacion'] = round(sign * base_amount_not_subject_loc, 2)
 
         return {
@@ -360,11 +365,6 @@ class AccountEdiFormat(models.Model):
                         invoice_node.setdefault('TipoDesglose', {})
                         invoice_node['TipoDesglose'].setdefault('DesgloseTipoOperacion', {})
                         invoice_node['TipoDesglose']['DesgloseTipoOperacion']['Entrega'] = tax_details_info_consu_vals['tax_details_info']
-                    if not invoice_node.get('TipoDesglose'):
-                        raise UserError(_(
-                            "In case of a foreign customer, you need to configure the tax scope on taxes:\n%s",
-                            "\n".join(invoice.line_ids.tax_ids.mapped('name'))
-                        ))
 
                     invoice_node['ImporteTotal'] = round(sign * (
                         tax_details_info_service_vals['tax_details']['base_amount']


### PR DESCRIPTION
Consider this situation:
- Customer invoice.
- All invoice lines use a tax type with l10n_es_type=no_sujeto_loc.
- The sum of the invoice is 0€.
- Sent to SII.

Before this patch, the process would raise a wrong `UserError`. If the process was being executed by the cron, **no invoice would be sent**, even if there was only one failing.

After this patch, the invoice will be notified nevertheless. If there's any kind of real validation problem, the SII servers will return an error that will get logged in the invoice. No exceptions raised in Odoo. The process can continue. Faulty invoices are marked; others work.

Apart from that, there's also the fix to support the specific case outlined above.

@moduon MT-7949 OPW-4344661



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
