### PR TITLE
[IMP] hr_payroll: restrict payslip without valid contract

### DIFF
--- a/addons/hr_contract/data/hr_contract_demo.xml
+++ b/addons/hr_contract/data/hr_contract_demo.xml
@@ -35,7 +35,6 @@
     <record id="hr_contract_admin_new" model="hr.contract">
         <field name="name">Contract For Mitchell Admin</field>
         <field name="date_start" eval="time.strftime('%Y-%m-16')"/>
-        <field name="date_end" eval="time.strftime('%Y')+'-12-31'"/>
         <field name="structure_type_id" ref="hr_contract.structure_type_employee"/>
         <field name="employee_id" ref="hr.employee_admin"/>
         <field name="notes">This is Mitchell Admin's contract</field>


### PR DESCRIPTION
Before this commit, a payslip was generated for employees even if they didn't have a valid contract for the payslip duration.

This commit brings a restriction on payslip generation, preventing it if the employee doesn't have a valid contract for the payslip duration.

task-3810418

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
