### PR TITLE
[FIX] html_editor: banner selection issue

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -96,8 +96,6 @@ export class DeletePlugin extends Plugin {
         // @todo @phoenix: move these predicates to different plugins
         unremovable_node_predicates: [
             (node) => node.classList?.contains("oe_unremovable"),
-            // Website stuff?
-            (node) => node.classList?.contains("o_editable"),
             // Monetary field
             (node) => node.matches?.("[data-oe-type='monetary'] > span"),
         ],

--- a/addons/html_editor/static/src/core/sanitize_plugin.js
+++ b/addons/html_editor/static/src/core/sanitize_plugin.js
@@ -1,3 +1,4 @@
+import { selectElements } from "@html_editor/utils/dom_traversal";
 import { Plugin } from "../plugin";
 
 /**
@@ -7,7 +8,7 @@ import { Plugin } from "../plugin";
 
 export class SanitizePlugin extends Plugin {
     static id = "sanitize";
-    static shared = ["sanitize"];
+    static shared = ["sanitize", "restoreSanitizedContentEditable"];
     setup() {
         if (!window.DOMPurify) {
             throw new Error("DOMPurify is not available");
@@ -27,5 +28,11 @@ export class SanitizePlugin extends Plugin {
             ADD_TAGS: ["#document-fragment", "fake-el"],
             ADD_ATTR: ["contenteditable"],
         });
+    }
+
+    restoreSanitizedContentEditable(root) {
+        for (const node of selectElements(root, ".o_not_editable, .o_editable")) {
+            node.contentEditable = node.matches(".o_editable");
+        }
     }
 }

--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -10,8 +10,9 @@ function isAvailable(selection) {
 }
 export class BannerPlugin extends Plugin {
     static id = "banner";
-    static dependencies = ["baseContainer", "history", "dom", "emoji", "selection"];
+    static dependencies = ["baseContainer", "history", "dom", "emoji", "selection", "sanitize"];
     resources = {
+        normalize_handlers: this.normalize.bind(this),
         user_commands: [
             {
                 id: "banner_info",
@@ -91,9 +92,9 @@ export class BannerPlugin extends Plugin {
         const baseContainerHtml = baseContainer.outerHTML;
         const bannerElement = parseHTML(
             this.document,
-            `<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-${alertClass} pb-0 pt-3" role="status" contenteditable="false">
+            `<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-${alertClass} pb-0 pt-3" role="status">
                 <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="${title}">${emoji}</i>
-                <div class="w-100 px-3" contenteditable="true">
+                <div class="w-100 px-3 o_editable">
                     ${baseContainerHtml}
                 </div>
             </div`
@@ -121,5 +122,9 @@ export class BannerPlugin extends Plugin {
                 this.dependencies.history.addStep();
             },
         });
+    }
+
+    normalize(root) {
+        this.dependencies.sanitize.restoreSanitizedContentEditable(root);
     }
 }

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -19,7 +19,7 @@ test("should insert a banner with focus inside followed by a paragraph", async (
         unformat(
             `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3" contenteditable="true">
+                    <div class="w-100 px-3 o_editable" contenteditable="true">
                         <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
                     </div>
                 </div><p><br></p>`
@@ -51,7 +51,7 @@ test("should insert a banner with DIV as basecontainer and focus inside it", asy
             `<div class="o-paragraph">Test</div>
             <div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                 <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                <div class="w-100 px-3" contenteditable="true">
+                <div class="w-100 px-3 o_editable" contenteditable="true">
                     <div class="o-paragraph o-we-hint" placeholder='Type "/" for commands'>[]<br></div>
                 </div>
             </div>
@@ -74,7 +74,7 @@ test("press 'ctrl+a' inside a banner should select all the banner content", asyn
         unformat(
             `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3" contenteditable="true">[
+                    <div class="w-100 px-3 o_editable" contenteditable="true">[
                         <p>Test1</p><p>Test2<br></p>
                     ]</div>
                 </div><p><br></p>`
@@ -96,7 +96,7 @@ test("remove all content should preserves the first paragraph tag inside the ban
         unformat(
             `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3" contenteditable="true">[
+                    <div class="w-100 px-3 o_editable" contenteditable="true">[
                         <p>Test1</p><p>Test2<br></p>
                     ]</div>
                 </div><p><br></p>`
@@ -108,7 +108,7 @@ test("remove all content should preserves the first paragraph tag inside the ban
         unformat(
             `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3" contenteditable="true"><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></div>
+                    <div class="w-100 px-3 o_editable" contenteditable="true"><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></div>
                 </div><p><br></p>`
         )
     );
@@ -130,7 +130,7 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
         unformat(
             `[\u200b<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3" contenteditable="true">
+                    <div class="w-100 px-3 o_editable" contenteditable="true">
                         <p><br></p>
                     </div>
                 </div><p>Test1</p><p>Test2<br></p>]`
@@ -184,7 +184,7 @@ test("add banner inside empty list", async () => {
         unformat(
             `<ul><li><br><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3" contenteditable="true">
+                    <div class="w-100 px-3 o_editable" contenteditable="true">
                         <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
                     </div>
                 </div><br></li></ul>`
@@ -200,7 +200,7 @@ test("add banner inside non-empty list", async () => {
         unformat(
             `<ul><li>Test<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                     <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3" contenteditable="true">
+                    <div class="w-100 px-3 o_editable" contenteditable="true">
                         <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
                     </div>
                 </div><br></li></ul>`

--- a/addons/html_editor/static/tests/field.test.js
+++ b/addons/html_editor/static/tests/field.test.js
@@ -5,18 +5,24 @@ import { deleteBackward } from "./_helpers/user_actions";
 
 describe("monetary field", () => {
     test("should make a span inside a monetary field be unremovable", async () => {
-        const content = unformat(`
-            <p>
-                <span data-oe-model="product.template" data-oe-id="27" data-oe-field="list_price" data-oe-type="monetary" data-oe-expression="product.list_price" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]" class="o_editable">
-                    $&nbsp;
-                    <span class="oe_currency_value">[]</span>
-                </span>
-            </p>
-        `);
         await testEditor({
-            contentBefore: content,
+            contentBefore: unformat(`
+                <p>
+                    <span data-oe-model="product.template" data-oe-id="27" data-oe-field="list_price" data-oe-type="monetary" data-oe-expression="product.list_price" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]" class="o_editable">
+                        $&nbsp;
+                        <span class="oe_currency_value">[]</span>
+                    </span>
+                </p>
+            `),
             stepFunction: deleteBackward,
-            contentAfter: content,
+            contentAfter: unformat(`
+                <p>
+                    <span data-oe-model="product.template" data-oe-id="27" data-oe-field="list_price" data-oe-type="monetary" data-oe-expression="product.list_price" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]" class="o_editable" contenteditable="true">
+                        $&nbsp;
+                        <span class="oe_currency_value">[]</span>
+                    </span>
+                </p>
+            `),
         });
     });
 });


### PR DESCRIPTION
**Current behavior before PR:**

- The html_sanitize method sanitized certain banner attributes, such as contenteditable, role, and aria-label. This caused an issue where, when a blur event was triggered, the innerHTML of the current banner would be replaced with sanitized HTML. As a result, these attributes were removed, and the absence of the contenteditable attribute made it impossible to place the cursor inside the banner.

**Desired behavior after PR is merged:**

- Now, when the normalize method is called, the `contenteditable="true"` attribute will be applied to all elements with the 
  `o_editable` class, and the `contenteditable="false"` attribute will be applied to all elements with the `o_not_editable` class.

task-4297729

