### PR TITLE
[FIX] repair: update module dependencies

### DIFF
--- a/addons/repair/__manifest__.py
+++ b/addons/repair/__manifest__.py
@@ -20,7 +20,7 @@ The following topics are covered by this module:
     * Repair quotation report
     * Notes for the technician and for the final customer
 """,
-    'depends': ['stock', 'sale_management'],
+    'depends': ['sale_stock', 'sale_management'],
     'data': [
         'security/ir.model.access.csv',
         'security/repair_security.xml',


### PR DESCRIPTION
Considering the manifest, the module is based on `stock` and
`sale_management`. But it should therefore depend on `sale_stock`,
otherwise there may be bugs.

For instance, use of `env['sale.order'].warehouse_id`:
https://github.com/odoo/odoo/blob/8e874661322454a7df1584c7c914129b87db4324/addons/repair/models/repair.py#L434
While the field is actually defined in `sale_stock`:
https://github.com/odoo/odoo/blob/9144eb051538d5a92d403e1ad9c635ce39e090ec/addons/sale_stock/models/sale_order.py#L27

sentry-6093715030