### PR TITLE
[FIX] website_blog: fix restricting blog to specific website

### DIFF
--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -161,7 +161,8 @@ class BlogPost(models.Model):
     def _compute_website_url(self):
         super(BlogPost, self)._compute_website_url()
         for blog_post in self:
-            blog_post.website_url = "/blog/%s/%s" % (slug(blog_post.blog_id), slug(blog_post))
+            if blog_post.id:
+                blog_post.website_url = "/blog/%s/%s" % (slug(blog_post.blog_id), slug(blog_post))
 
     def _default_content(self):
         return '''


### PR DESCRIPTION
Steps to reproduce:

- Install the Blog module and Studio app (enterprise).
- Navigate to the website editor.
- Go to Menu Configuration > Blogs.
- Select a blog to edit.
- Click on the Studio icon to customize the view.
- Add the existing field "Blog posts" to the view.
- Close Studio.
- Restrict the blog to a specific website by selecting one.
- A traceback occurs.

Since [1], invisible fields now trigger "onchange" methods and "compute" methods while processing views. This exposes a bug when attempting to slugify a website URL for a blog that hasn't been assigned an ID yet.

[1]: https://github.com/odoo/odoo/commit/db63cb770365be1f81ba051fe6ca5a246dbc9036

opw-4365920
