### PR TITLE
[FIX] core: support escaping in SQL wrapper

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -419,7 +419,6 @@ class Cursor(BaseCursor):
 
         start = real_time()
         try:
-            params = params or None
             self._obj.execute(query, params)
         except Exception as e:
             if log_exceptions:

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1863,13 +1863,10 @@ def format_frame(frame) -> str:
 
 def named_to_positional_printf(string: str, args: Mapping) -> tuple[str, tuple]:
     """ Convert a named printf-style format string with its arguments to an
-    equivalent positional format string with its arguments. This implementation
-    does not support escaped ``%`` characters (``"%%"``).
+    equivalent positional format string with its arguments.
     """
-    if '%%' in string:
-        raise ValueError(f"Unsupported escaped '%' in format string {string!r}")
     pargs = _PrintfArgs(args)
-    return string % pargs, tuple(pargs.values)
+    return string.replace('%%', '%%%%') % pargs, tuple(pargs.values)
 
 
 class _PrintfArgs:


### PR DESCRIPTION
The `SQL` wrapper now handles '%' argument correctly. The input code must be correctly escaped. As of that moment, the composition works correctly.

Original fix: Use the original constraint definition.

If we replace the original definition then the check between the existing definition and the original one will always fail, thus we are always removing and re-adding the same constraint. https://github.com/odoo/odoo/blob/5ba361ddffa757cf60968f37180c7fd1304b3fd4/odoo/models.py#L3209

Replacing `%` by `%%` works for `LIKE` operator because they are equivalent. Since they are sent as-is to the DB the constraint could actually be plainly wrong.

```sql
test_17=> SELECT coalesce(d.description, pg_get_constraintdef(c.oid))
   FROM pg_constraint c
   JOIN pg_class t
     ON t.oid = c.conrelid
   LEFT JOIN pg_description d
     ON c.oid = d.objoid
  WHERE t.relname = 'ir_model_fields'
    AND conname = 'ir_model_fields_name_manual_field'
+------------------------------------------------+
| coalesce                                       |
|------------------------------------------------|
| CHECK (state != 'manual' OR name LIKE 'x\_%%') |
+------------------------------------------------+
```

Example where the definition sent to the DB is wrong:
```py
class A(models.Model):
    _inherit = "res.users"

    _sql_constraints = [("test_constraint", "CHECK (login !~ '%')", "Cannot have % in login")]
```
```sql
test_17=> \d res_users
...
Check constraints:
    "res_users_test_constraint" CHECK (login::text !~ '%%'::text)
...
```

X-original-commit: 692ad8e8a969981c6171b7bef34dfee5f0b007f8

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
