### PR TITLE
[IMP] core: ValueError for invalid fields in domain

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -986,16 +986,16 @@ class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
         """ verify that invalid expressions are refused, even for magic fields """
         Country = self.env['res.country']
 
-        with self.assertRaisesRegex(ValueError, r"^Invalid field res\.country\.does_not_exist in leaf \('does_not_exist', '=', 'foo'\)$"):
-            Country.search([('does_not_exist', '=', 'foo')])
+        with self.assertRaisesRegex(ValueError, r"^Invalid field.*'abcdefg'"):
+            Country.search([('abcdefg', 'in', ['foo'])])
 
-        with self.assertRaisesRegex(AssertionError, "^Invalid field 'name.\"Et plouf\"'"):
+        with self.assertRaisesRegex(ValueError, r"^Invalid field.*'name.\"Et plouf\"'"):
             Country.search([('name."Et plouf"', 'ilike', 'foo')])
 
-        with self.assertRaisesRegex(AssertionError, "^Invalid field 'name.\"Et plouf\"'"):
+        with self.assertRaisesRegex(ValueError, r"^Invalid field.*'name.\"Et plouf\"'"):
             Country.search([('name."Et plouf"', 'in', ['foo'])])
 
-        with self.assertRaisesRegex(KeyError, r"^'does_not_exist'$"):
+        with self.assertRaisesRegex(ValueError, r"'does_not_exist'"):
             Country.search([]).filtered_domain([('does_not_exist', '=', 'foo')])
 
         with self.assertRaisesRegex(ValueError, r"^Invalid leaf \('create_date', '>>', 'foo'\)$"):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -6573,20 +6573,22 @@ class BaseModel(metaclass=MetaModel):
                     continue
 
                 # determine the field with the final type for values
-                if key.endswith('.id'):
-                    key = key[:-3]
-                if '.' in key:
-                    fname, rest = key.split('.', 1)
-                    field = self._fields[fname]
-                    if field.relational:
-                        # for relational fields, evaluate as 'any'
-                        # so that negations are applied on the result of 'any' instead
-                        # of on the mapped value
-                        key, comparator, value = fname, 'any', [(rest, comparator, value)]
-                else:
-                    field = self._fields[key]
-                    if key == 'id':
-                        key = ''
+                key = key.removesuffix('.id')
+                try:
+                    if '.' in key:
+                        fname, rest = key.split('.', 1)
+                        field = self._fields[fname]
+                        if field.relational:
+                            # for relational fields, evaluate as 'any'
+                            # so that negations are applied on the result of 'any' instead
+                            # of on the mapped value
+                            key, comparator, value = fname, 'any', [(rest, comparator, value)]
+                    else:
+                        field = self._fields[key]
+                        if key == 'id':
+                            key = ''
+                except KeyError as e:
+                    raise ValueError(f"Invalid field in filter of {self._name}: {domain!r}") from e
 
                 if comparator in ('like', 'ilike', '=like', '=ilike', 'not ilike', 'not like'):
                     if comparator.endswith('ilike'):

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -371,7 +371,7 @@ def _anyfy_leaves(domain, model):
         path = left.split('.', 1)
         field = model._fields.get(path[0])
         if not field:
-            raise ValueError(f"Invalid field {model._name}.{path[0]} in leaf {item}")
+            raise ValueError(f"Invalid field {path[0]!r} on {model._name} in leaf {item}")
         if len(path) > 1 and field.relational:  # skip properties
             subdomain = [(path[1], operator, right)]
             comodel = model.env[field.comodel_name]
@@ -1390,6 +1390,8 @@ class expression(object):
             # -------------------------------------------------
 
             else:
+                if field.name != left:
+                    raise ValueError(f"Invalid field {left!r}")
                 if field.type == 'datetime' and right:
                     if isinstance(right, str) and len(right) == 10:
                         if operator in ('>', '<='):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Always raise a ValueError for invalid fields in domains. The type of error should be the same no matter where in the implementatation we have the error.

Current behavior before PR:
You can get assertion or key errors.

Desired behavior after PR is merged:
Always raise a `ValueError`.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
