### PR TITLE
[FIX] account_edi_ubl_cii,*: Fix UBL Credit Note Payment Means Code

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -156,9 +156,9 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return vals
 
     def _get_invoice_payment_means_vals_list(self, invoice):
+        payment_means_code, payment_means_name = (30, 'credit transfer') if invoice.move_type == 'out_invoice' else (57, 'standing agreement')
         # in Denmark payment code 30 is not allowed. we hardcode it to 1 ("unknown") for now
         # as we cannot deduce this information from the invoice
-        payment_means_code, payment_means_name = 30, 'credit transfer'
         if invoice.partner_id.country_code == 'DK':
             payment_means_code, payment_means_name = 1, 'unknown'
 

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_refund.xml
@@ -72,7 +72,7 @@
     </cac:Party>
   </cac:AccountingCustomerParty>
   <cac:PaymentMeans>
-    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>
     <cbc:PaymentID>RINV/2017/00001</cbc:PaymentID>
     <cac:PayeeFinancialAccount>
       <cbc:ID>93999574162167</cbc:ID>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_refund.xml
@@ -70,7 +70,7 @@
     </cac:Party>
   </cac:AccountingCustomerParty>
   <cac:PaymentMeans>
-    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>
     <cbc:PaymentID>RINV/2017/01/0001</cbc:PaymentID>
     <cac:PayeeFinancialAccount>
       <cbc:ID>BE90735788866632</cbc:ID>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
@@ -83,7 +83,7 @@
     </cac:Party>
   </cac:AccountingCustomerParty>
   <cac:PaymentMeans>
-    <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+    <cbc:PaymentMeansCode>57</cbc:PaymentMeansCode>
     <cbc:PaymentID>RINV/2017/00001</cbc:PaymentID>
     <cac:PayeeFinancialAccount>
       <cbc:ID>NL93999574162167</cbc:ID>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_refund.xml
@@ -72,7 +72,7 @@
     </cac:Party>
   </cac:AccountingCustomerParty>
   <cac:PaymentMeans>
-    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>
     <cbc:PaymentID>RINV/2017/01/0001</cbc:PaymentID>
     <cac:PayeeFinancialAccount>
       <cbc:ID>DE50500105175653254743</cbc:ID>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_peppol-bis-invoice-3_doc/bis3_credit_note.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_peppol-bis-invoice-3_doc/bis3_credit_note.xml
@@ -106,7 +106,7 @@
     </cac:Delivery>
 
     <cac:PaymentMeans>
-        <cbc:PaymentMeansCode name="Credit transfer">30</cbc:PaymentMeansCode>
+        <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>
         <cbc:PaymentID>Snippet1</cbc:PaymentID>
         <cac:PayeeFinancialAccount>
             <cbc:ID>IBAN32423940</cbc:ID>


### PR DESCRIPTION
*: l10n_account_edi_ubl_cii_tests

Previously, we always set code 30 "Credit transfer" for both customer invoices
and credit notes. When you set this code to 30, the UBL rule BR-61 [1] fail if you
don't set the payee's bank account number.
It's not handy to be forced to set the bank account number while we don't really know
if the payment will happen through credit transfer at this stage.
We now set code 57 "Standing agreement" for refunds, which seems more general and
still a valid method.

[1]: https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-tc434/BR-61/

task-no