### PR TITLE
[IMP] html_editor: restrict signature command to specific modules

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -4,6 +4,7 @@ import {
     DYNAMIC_PLACEHOLDER_PLUGINS,
     EMBEDDED_COMPONENT_PLUGINS,
     MAIN_PLUGINS,
+    SIGNATURE_PLUGIN,
 } from "@html_editor/plugin_sets";
 import {
     MAIN_EMBEDDINGS,
@@ -52,9 +53,11 @@ export class HtmlField extends Component {
         codeview: { type: Boolean, optional: true },
         editorConfig: { type: Object, optional: true },
         embeddedComponents: { type: Boolean, optional: true },
+        signatureCommand: { type: Boolean, optional: true, default: false },
     };
     static defaultProps = {
         dynamicPlaceholder: false,
+        signatureCommand: false,
     };
     static components = {
         Wysiwyg,
@@ -209,6 +212,7 @@ export class HtmlField extends Component {
                 ...(this.props.isCollaborative ? COLLABORATION_PLUGINS : []),
                 ...(this.props.dynamicPlaceholder ? DYNAMIC_PLACEHOLDER_PLUGINS : []),
                 ...(this.props.embeddedComponents ? EMBEDDED_COMPONENT_PLUGINS : []),
+                ...(this.props.signatureCommand ? SIGNATURE_PLUGIN : []),
             ],
             classList: this.classList,
             onChange: this.onChange.bind(this),
@@ -326,6 +330,7 @@ export const htmlField = {
             sandboxedPreview: Boolean(options.sandboxedPreview),
             cssReadonlyAssetId: options.cssReadonly,
             codeview: Boolean(odoo.debug && options.codeview),
+            signatureCommand: options.signatureCommand,
         };
     },
 };

--- a/addons/html_editor/static/src/others/signature_plugin.js
+++ b/addons/html_editor/static/src/others/signature_plugin.js
@@ -17,10 +17,13 @@ export class SignaturePlugin extends Plugin {
                 run: this.insertSignature.bind(this),
             },
         ],
-        powerbox_categories: withSequence(100, { id: "basic_block", name: _t("Basic Bloc") }),
+        powerbox_categories: withSequence(100, {
+            id: "personalization",
+            name: _t("Personalization"),
+        }),
         powerbox_items: [
             {
-                categoryId: "basic_block",
+                categoryId: "personalization",
                 commandId: "insertSignature",
             },
         ],

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -39,7 +39,6 @@ import { PowerButtonsPlugin } from "./main/power_buttons_plugin";
 import { PositionPlugin } from "./main/position_plugin";
 import { PowerboxPlugin } from "./main/powerbox/powerbox_plugin";
 import { SearchPowerboxPlugin } from "./main/powerbox/search_powerbox_plugin";
-import { SignaturePlugin } from "./main/signature_plugin";
 import { StarPlugin } from "./main/star_plugin";
 import { TablePlugin } from "./main/table/table_plugin";
 import { TableResizePlugin } from "./main/table/table_resize_plugin";
@@ -59,6 +58,7 @@ import { FilePlugin } from "@html_editor/others/embedded_components/plugins/file
 import { TableOfContentPlugin } from "@html_editor/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin";
 import { VideoPlugin } from "@html_editor/others/embedded_components/plugins/video_plugin/video_plugin";
 import { QWebPlugin } from "./others/qweb_plugin";
+import { SignaturePlugin } from "./others/signature_plugin";
 
 /**
  * @typedef { Object } SharedMethods
@@ -129,7 +129,6 @@ export const MAIN_PLUGINS = [
     ShortCutPlugin,
     PowerboxPlugin,
     SearchPowerboxPlugin,
-    SignaturePlugin,
     StarPlugin,
     TablePlugin,
     TableUIPlugin,
@@ -169,6 +168,8 @@ export const EMBEDDED_COMPONENT_PLUGINS = [
 ];
 
 export const DYNAMIC_PLACEHOLDER_PLUGINS = [DynamicPlaceholderPlugin, QWebPlugin];
+
+export const SIGNATURE_PLUGIN = [SignaturePlugin];
 
 export const EXTRA_PLUGINS = [
     ...COLLABORATION_PLUGINS,

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -25,6 +25,7 @@ import { PowerboxPlugin } from "@html_editor/main/powerbox/powerbox_plugin";
 import { SearchPowerboxPlugin } from "@html_editor/main/powerbox/search_powerbox_plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { execCommand } from "./_helpers/userCommands";
+import { SignaturePlugin } from "@html_editor/others/signature_plugin";
 
 function commandNames() {
     return queryAllTexts(".o-we-command-name");
@@ -74,7 +75,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(27);
+        expect(commandNames(el).length).toBe(26);
         await insertText(editor, "head");
         await animationFrame();
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
@@ -82,6 +83,30 @@ describe("search", () => {
 
     test("should hide categories when you have a search term", async () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
+        await insertText(editor, "/");
+        await animationFrame();
+        expect(commandNames(el).length).toBe(26);
+        expect(".o-we-category").toHaveCount(7);
+        expect(queryAllTexts(".o-we-category")).toEqual([
+            "STRUCTURE",
+            "BANNER",
+            "FORMAT",
+            "MEDIA",
+            "NAVIGATION",
+            "WIDGET",
+            "AI TOOLS",
+        ]);
+
+        await insertText(editor, "h");
+        await animationFrame();
+        expect(commandNames(el).length).toBe(9);
+        expect(".o-we-category").toHaveCount(0);
+    });
+
+    test("should display the signature command along with its category", async () => {
+        const { el, editor } = await setupEditor("<p>ab[]</p>", {
+            config: { Plugins: [...MAIN_PLUGINS, SignaturePlugin] },
+        });
         await insertText(editor, "/");
         await animationFrame();
         expect(commandNames(el).length).toBe(27);
@@ -94,13 +119,8 @@ describe("search", () => {
             "NAVIGATION",
             "WIDGET",
             "AI TOOLS",
-            "BASIC BLOC",
+            "PERSONALIZATION",
         ]);
-
-        await insertText(editor, "h");
-        await animationFrame();
-        expect(commandNames(el).length).toBe(9);
-        expect(".o-we-category").toHaveCount(0);
     });
 
     test.tags("iframe");
@@ -108,7 +128,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>", { props: { iframe: true } });
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(27);
+        expect(commandNames(el).length).toBe(26);
         await insertText(editor, "head");
         await animationFrame();
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
@@ -160,7 +180,7 @@ describe("search", () => {
         await insertText(editor, "/");
         await animationFrame();
         expect(".o-we-powerbox").toHaveCount(1);
-        expect(commandNames(el).length).toBe(27);
+        expect(commandNames(el).length).toBe(26);
 
         await insertText(editor, "headx");
         await animationFrame();

--- a/addons/html_editor/static/tests/signature.test.js
+++ b/addons/html_editor/static/tests/signature.test.js
@@ -5,6 +5,8 @@ import { defineModels, fields, models, serverState } from "@web/../tests/web_tes
 import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
 import { insertText, undo } from "./_helpers/user_actions";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { SignaturePlugin } from "@html_editor/others/signature_plugin";
 class ResUsers extends models.Model {
     _name = "res.users";
 
@@ -19,7 +21,9 @@ class ResUsers extends models.Model {
 defineModels([ResUsers]);
 
 test("apply 'Signature' command", async () => {
-    const { el, editor } = await setupEditor("<p>ab[]cd</p>");
+    const { el, editor } = await setupEditor("<p>ab[]cd</p>", {
+        config: { Plugins: [...MAIN_PLUGINS, SignaturePlugin] },
+    });
     await insertText(editor, "/signature");
     await animationFrame();
     expect(".active .o-we-command-name").toHaveText("Signature");
@@ -30,7 +34,9 @@ test("apply 'Signature' command", async () => {
 });
 
 test("undo a 'Signature' command", async () => {
-    const { el, editor } = await setupEditor("<p>ab[]cd</p>");
+    const { el, editor } = await setupEditor("<p>ab[]cd</p>", {
+        config: { Plugins: [...MAIN_PLUGINS, SignaturePlugin] },
+    });
     await insertText(editor, "test");
     await insertText(editor, "/signature");
     await press("enter");


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- The signature command was categorized under `BASIC_BLOC` and accessible in all modules using the editor.

### Desired behavior after PR is merged:

- The signature command is now categorized under `PERSONALIZATION`.
- It is accessible only in the `Knowledge` module.

### Approach:

- Removed `SignaturePlugin` from `MAIN_PLUGINS` and added as extra plugin.
- In `html_field`, the `signatureCommand` prop determines whether the signature command is displayed.
- Passed `signatureCommand` as `true` from the Knowledge module to enable the signature command.

enterprise: https://github.com/odoo/enterprise/pull/75123

task-4224624