### PR TITLE
[FIX] bus: fetch vacuum info silently

### DIFF
--- a/addons/bus/static/src/outdated_page_watcher_service.js
+++ b/addons/bus/static/src/outdated_page_watcher_service.js
@@ -27,9 +27,11 @@ export class OutdatedPageWatcherService {
                 return;
             }
             if (!this.lastAutovacuumDt || DateTime.now() >= this.nextAutovacuumDt) {
-                const { lastcall, nextcall } = await rpc("/bus/get_autovacuum_info", {
-                    silent: true,
-                });
+                const { lastcall, nextcall } = await rpc(
+                    "/bus/get_autovacuum_info",
+                    {},
+                    { silent: true }
+                );
                 this.lastAutovacuumDt = deserializeDateTime(lastcall);
                 this.nextAutovacuumDt = deserializeDateTime(nextcall);
                 multi_tab.setSharedValue("bus.autovacuum_info", { lastcall, nextcall });


### PR DESCRIPTION

The get_vacuum_info route was intended to be silent. However, silent
should be passed in the "setting" parameter of the rpc method, not the
"option" one. This PR fixes the issue.