### PR TITLE
[FIX] stock: reload reception report with values

### DIFF
--- a/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.js
+++ b/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.js
@@ -5,7 +5,7 @@ import { useBus, useService } from "@web/core/utils/hooks";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { ReceptionReportTable } from "../reception_report_table/stock_reception_report_table";
 
-const { Component, onWillStart, useState } = owl;
+const { Component, onMounted, onWillStart, useState } = owl;
 
 export class ReceptionReportMain extends Component {
     setup() {
@@ -15,30 +15,51 @@ export class ReceptionReportMain extends Component {
         };
         this.ormService = useService("orm");
         this.actionService = useService("action");
+        this.routerService = useService("router");
         this.reportName = "stock.report_reception";
-        const defaultDocIds = Object.entries(this.context).find(([k,v]) => k.startsWith("default_"));
-        this.contextDefaultDoc = { field: defaultDocIds[0], ids: defaultDocIds[1] };
         this.state = useState({
             sourcesToLines: {},
         });
         useBus(this.env.bus, "update-assign-state", (ev) => this._changeAssignedState(ev.detail));
 
         onWillStart(async () => {
+            // Check the router if report was already loaded.
+            let defaultDocIds;
+            const { rfield, rids } = this.routerService.current.hash;
+            if (rfield && rids) {
+                const parsedIds = JSON.parse(rids);
+                defaultDocIds = [ rfield, parsedIds instanceof Array ? parsedIds : [parsedIds] ];
+            } else {
+                defaultDocIds = Object.entries(this.context).find(([k, v]) => k.startsWith("default_"));
+                if (!defaultDocIds) {
+                    // If nothing could be found, just ask for empty data.
+                    defaultDocIds = [false, [0]];
+                }
+            }
+            this.contextDefaultDoc = { field: defaultDocIds[0], ids: defaultDocIds[1] };
             this.data = await this.getReportData();
             this.state.sourcesToLines = this.data.sources_to_lines;
         });
+
+        onMounted(() => {
+            if (this.data.docs) {
+                // Add the field/ids to the URL, so we can properly reload them after a page refresh.
+                this.routerService.pushState({ rfield: this.contextDefaultDoc.field, rids: JSON.stringify(this.contextDefaultDoc.ids)}, { replace: true });
+            }
+        })
     }
 
     async getReportData() {
+        const context = { ...this.context, [this.contextDefaultDoc.field]: this.contextDefaultDoc.ids };
         const args = [
             this.contextDefaultDoc.ids,
-            { context: this.context, report_type: "html" },
+            { context, report_type: "html" },
         ];
         return this.ormService.call(
             "report.stock.report_reception",
             "get_report_data",
             args,
-            { context: this.context }
+            { context },
         );
     }
 


### PR DESCRIPTION
Steps to reproduce:
- Enable 'Reception Report' in Inventory Configuration
- Make an outgoing shipment for a storable product
- Make an incoming shipment for that same product
- Open the allocation report
- Reload the page

Issue:
The context is lost when reloading the page, meaning that we lose the the `default_picking_ids`/`default_production_ids` in the context, making it unable to open the report.

To avoid this, we add the key and values to the router (and thus the URL) so it can be properly picked up when reloading the report.

opw-4321072

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
