### PR TITLE
[FIX] mass_mailing: avoid automatic unsubscribe from mail

### DIFF
--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -2,10 +2,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
+import urllib.parse
 
 from odoo import _, exceptions, http, tools
 from odoo.http import request, Response
 from odoo.tools import consteq
+from lxml import etree
 from werkzeug.exceptions import BadRequest, NotFound
 
 
@@ -33,6 +35,60 @@ class MassMailController(http.Controller):
         self.mailing(mailing_id, email=email, res_id=res_id, token=token, **post)
         return Response(status=200)
 
+    @http.route('/mailing/<int:mailing_id>/confirm_unsubscribe', type='http', website=True, auth='public')
+    def mailing_confirm_unsubscribe(self, mailing_id, email=None, res_id=None, token="", **post):
+        mailing = request.env['mailing.mailing'].sudo().browse(mailing_id)
+        # Check access (note that this will also raise AccessDenied if the mailing does not exist)
+        if not self._valid_unsubscribe_token(mailing_id, res_id, email, str(token)):
+            raise exceptions.AccessDenied()
+
+        unsubscribed_str = _("Are you sure you want to unsubscribe from our mailing list?")
+        # Display list name if list is public
+        if mailing.mailing_model_real == 'mailing.contact':
+            unsubscribed_lists = ', '.join(mailing_list.name for mailing_list in mailing.contact_list_ids if mailing_list.is_public)
+            if unsubscribed_lists:
+                unsubscribed_str = _(
+                    'Are you sure you want to unsubscribe from the mailing list "%(unsubscribed_lists)s"?',
+                    unsubscribed_lists=unsubscribed_lists
+                )
+        unsubscribe_btn = _("Unsubscribe")
+
+        template = etree.fromstring("""
+            <t t-call="mass_mailing.layout">
+                <div class="container o_unsubscribe_form">
+                    <form action="/mailing/confirm_unsubscribe" method="POST" class="col-lg-6 offset-lg-3 mt-4">
+                        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                        <input type="hidden" name="email" t-att-value="email"/>
+                        <input type="hidden" name="mailing_id" t-att-value="mailing_id"/>
+                        <input type="hidden" name="res_id" t-att-value="res_id"/>
+                        <input type="hidden" name="token" t-att-value="token"/>
+                        <div id="info_state"  class="alert alert-success">
+                            <div class="text-center">
+                                <p t-out="unsubscribed_str"/>
+                                <button type="submit" class="btn btn-primary" t-out="unsubscribe_btn"/>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </t>
+        """)
+        return request.render(template, {
+            'token': token,
+            'email': email,
+            'mailing_id': mailing_id,
+            'unsubscribed_str': unsubscribed_str,
+            'res_id': res_id,
+            'unsubscribe_btn': unsubscribe_btn,
+        })
+
+    # kept for backwards compatibility, must eventually be merged with mailing/<mailing_id>/unsubscribe
+    @http.route('/mailing/confirm_unsubscribe', type='http', website=True, auth='public', methods=['POST'])
+    def mailing_confirm_unsubscribe_post(self, mailing_id, email=None, res_id=None, token="", **post):
+        url_params = urllib.parse.urlencode({'email': email, 'res_id': res_id, 'token': token})
+        url = f'/mail/mailing/{int(mailing_id)}/unsubscribe?{url_params}'
+        return request.redirect(url)
+
+    # todo: merge this route with /mail/mailing/confirm_unsubscribe on next minor version
     @http.route(['/mail/mailing/<int:mailing_id>/unsubscribe'], type='http', website=True, auth='public')
     def mailing(self, mailing_id, email=None, res_id=None, token="", **post):
         mailing = request.env['mailing.mailing'].sudo().browse(mailing_id)

--- a/addons/mass_mailing/i18n/mass_mailing.pot
+++ b/addons/mass_mailing/i18n/mass_mailing.pot
@@ -938,6 +938,22 @@ msgstr ""
 
 #. module: mass_mailing
 #. odoo-python
+#: code:addons/mass_mailing/controllers/main.py:0
+#, python-format
+msgid "Are you sure you want to unsubscribe from our mailing list?"
+msgstr ""
+
+#. module: mass_mailing
+#. odoo-python
+#: code:addons/mass_mailing/controllers/main.py:0
+#, python-format
+msgid ""
+"Are you sure you want to unsubscribe from the mailing list "
+"\"%(unsubscribed_lists)s\"?"
+msgstr ""
+
+#. module: mass_mailing
+#. odoo-python
 #: code:addons/mass_mailing/models/mailing_list.py:0
 #, python-format
 msgid ""
@@ -4498,6 +4514,13 @@ msgstr ""
 #. module: mass_mailing
 #: model:ir.model.fields.selection,name:mass_mailing.selection__mailing_trace__failure_type__unknown
 msgid "Unknown error"
+msgstr ""
+
+#. module: mass_mailing
+#. odoo-python
+#: code:addons/mass_mailing/controllers/main.py:0
+#, python-format
+msgid "Unsubscribe"
 msgstr ""
 
 #. module: mass_mailing

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1017,7 +1017,7 @@ class MassMailing(models.Model):
 
     def _get_unsubscribe_url(self, email_to, res_id):
         url = werkzeug.urls.url_join(
-            self.get_base_url(), 'mail/mailing/%(mailing_id)s/unsubscribe?%(params)s' % {
+            self.get_base_url(), 'mailing/%(mailing_id)s/confirm_unsubscribe?%(params)s' % {
                 'mailing_id': self.id,
                 'params': werkzeug.urls.url_encode({
                     'res_id': res_id,

--- a/addons/test_mail_full/tests/test_mass_mailing.py
+++ b/addons/test_mail_full/tests/test_mass_mailing.py
@@ -98,7 +98,7 @@ class TestMassMailing(TestMailFullCommon):
                     email['body'])
                 # rendered unsubscribe
                 self.assertIn(
-                    '%s/mail/mailing/%s/unsubscribe' % (mailing.get_base_url(), mailing.id),
+                    '%s/mailing/%s/confirm_unsubscribe' % (mailing.get_base_url(), mailing.id),
                     email['body'])
                 unsubscribe_href = self._get_href_from_anchor_id(email['body'], "url6")
                 unsubscribe_url = werkzeug.urls.url_parse(unsubscribe_href)


### PR DESCRIPTION
Email clients have begun implementing security measures to protect users from phishing by analyzing email links, and interacting with them (see task-3972953).

This has the side effect of automatically unsubscribing email recipients from mailing lists by clicking the link in the footer of the emails.

This commit adds an intermediate step to the process, by requiring users to click on a button before they are unsubscribed.

task-4364446