### PR TITLE
[FIX] spreadsheet: localize chart scale ticks

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_bar_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_bar_chart.js
@@ -6,7 +6,7 @@ import { OdooChart } from "./odoo_chart";
 
 const { chartRegistry } = spreadsheet.registries;
 
-const { getDefaultChartJsRuntime, chartFontColor, ChartColors } = spreadsheet.helpers;
+const { getDefaultChartJsRuntime, chartFontColor, ChartColors, formatValue } = spreadsheet.helpers;
 
 export class OdooBarChart extends OdooChart {
     constructor(definition, sheetId, getters) {
@@ -86,6 +86,11 @@ function getBarConfiguration(chart, labels, locale) {
             ticks: {
                 color,
                 // y axis configuration
+                callback: (value) =>
+                    formatValue(value, {
+                        locale,
+                        format: Math.abs(value) >= 1000 ? "#,##" : undefined,
+                    }),
             },
             beginAtZero: true, // the origin of the y axis is always zero
         },

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
@@ -14,6 +14,7 @@ const {
     getFillingMode,
     colorToRGBA,
     rgbaToHex,
+    formatValue,
 } = spreadsheet.helpers;
 
 export class OdooLineChart extends OdooChart {
@@ -122,6 +123,11 @@ function getLineConfiguration(chart, labels, locale) {
             ticks: {
                 color: fontColor,
                 // y axis configuration
+                callback: (value) =>
+                    formatValue(value, {
+                        locale,
+                        format: Math.abs(value) >= 1000 ? "#,##" : undefined,
+                    }),
             },
             beginAtZero: true, // the origin of the y axis is always zero
         },

--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin_test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin_test.js
@@ -16,6 +16,16 @@ import { getBasicServerData } from "../../utils/data";
 
 const { toZone } = spreadsheet.helpers;
 
+const fr_FR = {
+    name: "French",
+    code: "fr_FR",
+    thousandsSeparator: " ",
+    decimalSeparator: ",",
+    dateFormat: "dd/mm/yyyy",
+    timeFormat: "hh:mm:ss",
+    formulaArgSeparator: ";",
+};
+
 QUnit.module("spreadsheet > odoo chart plugin", {}, () => {
     QUnit.test("Can add an Odoo Bar chart", async (assert) => {
         const { model } = await createSpreadsheetWithChart({ type: "odoo_bar" });
@@ -632,4 +642,41 @@ QUnit.module("spreadsheet > odoo chart plugin", {}, () => {
             "The data source should have been recreated"
         );
     });
+
+    QUnit.test(
+        "Displays correct thousand separator for positive value in Odoo Bar chart Y-axis",
+        async (assert) => {
+            const { model } = await createSpreadsheetWithChart({ type: "odoo_bar" });
+            const sheetId = model.getters.getActiveSheetId();
+            const chartId = model.getters.getChartIds(sheetId)[0];
+            const runtime = model.getters.getChartRuntime(chartId);
+            assert.strictEqual(
+                runtime.chartJsConfig.options.scales.y?.ticks.callback(60000000),
+                "60,000,000"
+            );
+            assert.strictEqual(
+                runtime.chartJsConfig.options.scales.y?.ticks.callback(-60000000),
+                "-60,000,000"
+            );
+        }
+    );
+
+    QUnit.test(
+        "Thousand separator in Odoo Bar chart Y-axis is locale-dependent",
+        async (assert) => {
+            const { model } = await createSpreadsheetWithChart({ type: "odoo_bar" });
+            model.dispatch("UPDATE_LOCALE", { locale: fr_FR });
+            const sheetId = model.getters.getActiveSheetId();
+            const chartId = model.getters.getChartIds(sheetId)[0];
+            const runtime = model.getters.getChartRuntime(chartId);
+            assert.strictEqual(
+                runtime.chartJsConfig.options.scales.y?.ticks.callback(60000000),
+                "60 000 000"
+            );
+            assert.strictEqual(
+                runtime.chartJsConfig.options.scales.y?.ticks.callback(-60000000),
+                "-60 000 000"
+            );
+        }
+    );
 });


### PR DESCRIPTION
## Description

Previously, the scale ticks in Odoo charts did not respect localization settings. This PR resolves the issue by leveraging the formatValue method within the scale tick callback function.

Task: [4273769](https://www.odoo.com/odoo/project/2328/tasks/4273769)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
