### PR TITLE
[FIX] point_of_sale: typo in function name

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -402,7 +402,7 @@ export class PosOrder extends Base {
         this.lines.forEach((line) => line.updateSavedQuantity());
     }
 
-    assetEditable() {
+    assertEditable() {
         if (this.finalized) {
             throw new Error("Finalized Order cannot be modified");
         }
@@ -552,7 +552,7 @@ export class PosOrder extends Base {
                 delete this.uiState.lineToRefund[lineToRemove.refunded_orderline_id.uuid];
             }
 
-            if (this.assetEditable()) {
+            if (this.assertEditable()) {
                 lineToRemove.delete();
             }
         }
@@ -599,7 +599,7 @@ export class PosOrder extends Base {
 
     /* ---- Payment Lines --- */
     addPaymentline(payment_method) {
-        this.assetEditable();
+        this.assertEditable();
         if (this.electronicPaymentInProgress()) {
             return false;
         } else {
@@ -629,7 +629,7 @@ export class PosOrder extends Base {
     }
 
     removePaymentline(line) {
-        this.assetEditable();
+        this.assertEditable();
 
         if (this.getSelectedPaymentline() === line) {
             this.selectPaymentline(undefined);
@@ -838,7 +838,7 @@ export class PosOrder extends Base {
 
     /* ---- Invoice --- */
     setToInvoice(to_invoice) {
-        this.assetEditable();
+        this.assertEditable();
         this.to_invoice = to_invoice;
     }
 
@@ -850,7 +850,7 @@ export class PosOrder extends Base {
     /* ---- Partner --- */
     // the partner related to the current order.
     setPartner(partner) {
-        this.assetEditable();
+        this.assertEditable();
         this.partner_id = partner;
         this.updatePricelistAndFiscalPosition(partner);
     }

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -204,7 +204,7 @@ export class PosOrderline extends Base {
             quantity = -Math.abs(quantity);
         }
 
-        this.order_id.assetEditable();
+        this.order_id.assertEditable();
         const quant =
             typeof quantity === "number" ? quantity : parseFloat("" + (quantity ? quantity : 0));
 
@@ -337,7 +337,7 @@ export class PosOrderline extends Base {
     }
 
     merge(orderline) {
-        this.order_id.assetEditable();
+        this.order_id.assertEditable();
         this.setQuantity(this.getQuantity() + orderline.getQuantity());
         this.update({
             pack_lot_ids: [["link", ...orderline.pack_lot_ids]],

--- a/addons/point_of_sale/static/src/app/models/pos_payment.js
+++ b/addons/point_of_sale/static/src/app/models/pos_payment.js
@@ -22,7 +22,7 @@ export class PosPayment extends Base {
     }
 
     setAmount(value) {
-        this.pos_order_id.assetEditable();
+        this.pos_order_id.assertEditable();
         this.amount = roundDecimals(
             parseFloat(value) || 0,
             this.pos_order_id.currency.decimal_places

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -580,7 +580,7 @@ export class PosStore extends WithLazyGetterTrap {
     async addLineToCurrentOrder(vals, opts = {}, configure = true) {
         let merge = true;
         let order = this.getOrder();
-        order.assetEditable();
+        order.assertEditable();
 
         if (!order) {
             order = await this.addNewOrder();


### PR DESCRIPTION
Fix :
-----
A previous refactor [PR](https://github.com/odoo/odoo/pull/185252) introduced a typo in a function name. This fixes it.

Related Enterprise PR: https://github.com/odoo/enterprise/pull/75353