### PR TITLE
[FIX] website_livechat: prevent parseerror on installing website_livechat

### DIFF
--- a/addons/website_livechat/data/website_livechat_chatbot_demo.xml
+++ b/addons/website_livechat/data/website_livechat_chatbot_demo.xml
@@ -3,7 +3,7 @@
 
     <!-- Add a Channel Rule to demonstrate our bot on the '/contactus' page -->
 
-    <record id="website_livechat_channel_rule_chatbot" model="im_livechat.channel.rule">
+    <record id="website_livechat_channel_rule_chatbot" model="im_livechat.channel.rule" forcecreate='False'>
         <field name="regex_url">/contactus</field>
         <field name="sequence">5</field>
         <field name="action">auto_popup</field>

--- a/addons/website_livechat/data/website_livechat_data.xml
+++ b/addons/website_livechat/data/website_livechat_data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
      <data noupdate="1">
-         <record id="website.default_website" model="website">
+         <record id="website.default_website" model="website" forcecreate="False">
              <field name="channel_id" ref="im_livechat.im_livechat_channel_data"></field>
          </record>
      </data>


### PR DESCRIPTION
Currently a `ParseError` is arising when user installs the 'website_livechat' module after deleting the 'YourWebsite.com' channel from 'im_livechat' module.

To reproduce this error:
- Install 'im_livechat' module.
- Open the application and  delete 'YourWebsite.com' channel by going to 'Configure Channel'
- Now try to install the 'website_livechat' module.
- The error appears in the log.

Error: `ParseError
while parsing /home/odoo/src/odoo/18.0/addons/website_livechat/data/ website_livechat_data.xml:4, somewhere inside
<record id="website.default_website" model="website">
           <field name="channel_id" ref="im_livechat.im_livechat_channel_data"/>
       </record>`

This commit solves the above issue by using `forcecreate='False'` to bypass
record creation if it violates checks.

sentry-6107471185