### PR TITLE
[FIX] project: Remove focus on Chatter when opening a task in project…

### DIFF
--- a/addons/project/static/src/project_sharing/chatter/chatter_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/chatter_patch.js
@@ -13,6 +13,7 @@ patch(Chatter.prototype, {
         this.orm = useService("orm");
         useSubEnv({
             projectSharingId: this.props.projectSharingId,
+            inFrontendPortalChatter: true,
         });
     },
 


### PR DESCRIPTION
… sharing

The objective is to remove the focus on the chatter whenever a task is opened in project sharing. This aimed initially to avoid the automatic scroll to the bottom in mobile view.

As a note: the Chatter component in project_sharing refers to the mail/chatter, however as project module also includes the portal/static/src/chatter/core/chatter_patch.js, Chatter template in project is overrided leading to autofocus triggering.

To replicate:
1. Share a project with tasks to a user with Edit permission.
2. login with portal user and open the project portal view
3. Open a task. The focus should no longer be set on the Chatter automatically.
3-b. Also on Mobile, when opening a task the sreen should not scroll to the chatter.

task: 4353290


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
