### PR TITLE
[FIX] repaire: fix dependency on repaire

### DIFF
--- a/addons/repair/__manifest__.py
+++ b/addons/repair/__manifest__.py
@@ -20,7 +20,7 @@ The following topics are covered by this module:
     * Repair quotation report
     * Notes for the technician and for the final customer
 """,
-    'depends': ['stock', 'sale_management'],
+    'depends': ['sale_stock', 'sale_management'],
     'data': [
         'security/ir.model.access.csv',
         'security/repair_security.xml',


### PR DESCRIPTION
Before this commit:
===============
When we install repair and then manually uninstall the `sale_stock` and creating a repair order will throw trackback.

Steps to produce:
==============
1. Install the repair module
2. uninstall the `sale_stock` module (it is not a direct dependency module it is a transitive dependency module)
3. Then try to create a new repair order with a product we get the following traceback

After this commit:
==============
Add `sale_stock` in dependency of repair instead of only stock

Reference feedback task: https://www.odoo.com/odoo/project.task/4378246
