### PR TITLE
[PERF] point_of_sale: optimize product addition to cart

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -526,14 +526,12 @@ export class PosOrderline extends Base {
 
     display_discount_policy() {
         // Sales dropped `discount_policy`, and we only show discount if applied pricelist rule
-        // is a percentage discount. However we don't have that information in pos
-        // so this is heuristic used to imitate the same behavior.
-        if (
-            this.order_id.pricelist_id &&
-            this.order_id.pricelist_id.item_ids
-                .map((rule) => rule.compute_price)
-                .includes("percentage")
-        ) {
+        // is a percentage discount.
+        const pricelistRule = this.product_id.getPricelistRule(
+            this.order_id.pricelist_id,
+            this.get_quantity()
+        );
+        if (pricelistRule && pricelistRule.compute_price === "percentage") {
             return "without_discount";
         }
         return "with_discount";

--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -139,9 +139,8 @@ export class ProductProduct extends Base {
             );
         }
 
-        const rules = !pricelist ? [] : this.cachedPricelistRules[pricelist?.id] || [];
         let price = (list_price || this.lst_price) + (price_extra || 0);
-        const rule = rules.find((rule) => !rule.min_quantity || quantity >= rule.min_quantity);
+        const rule = this.getPricelistRule(pricelist, quantity);
         if (!rule) {
             return price;
         }
@@ -182,6 +181,10 @@ export class ProductProduct extends Base {
         return price;
     }
 
+    getPricelistRule(pricelist, quantity) {
+        const rules = !pricelist ? [] : this.cachedPricelistRules[pricelist?.id] || [];
+        return rules.find((rule) => !rule.min_quantity || quantity >= rule.min_quantity);
+    }
     getImageUrl() {
         return (
             (this.image_128 &&

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -329,15 +329,19 @@ export class ProductScreen extends Component {
             ...this.pos.session._pos_special_products_ids,
         ];
 
-        list = list
-            .filter(
-                (product) => !excludedProductIds.includes(product.id) && product.available_in_pos
-            )
-            .slice(0, 100);
+        const filteredList = [];
+        for (const product of list) {
+            if (filteredList.length >= 100) {
+                break;
+            }
+            if (!excludedProductIds.includes(product.id) && product.available_in_pos) {
+                filteredList.push(product);
+            }
+        }
 
         return this.searchWord !== ""
-            ? list
-            : list.sort((a, b) => a.display_name.localeCompare(b.display_name));
+            ? filteredList
+            : filteredList.sort((a, b) => a.display_name.localeCompare(b.display_name));
     }
 
     getProductsBySearchWord(searchWord) {


### PR DESCRIPTION
Before this commit, if you had many records and sold many products in a day, the PoS would become slow when adding products to the cart.

This commit improves performance with 5000 loaded products, 1000 existing pos order lines, and 2000 pricelist items, reducing the time from about 5 seconds to 200 ms. This commit prevents unnecessary deletions on IndexedDB, retrieves the display discount policy in O(1) time complexity compared to O(n), and filters products to display on sliced products instead of all products.

opw-4381390

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
