### PR TITLE
[FIX] sale: prevent error when related order is not available of sale order line

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -308,7 +308,7 @@ class SaleOrderLine(models.Model):
         for line in self:
             if not line.product_id:
                 continue
-            lang = line.order_id._get_lang()
+            lang = line.order_id and line.order_id._get_lang()
             if lang != self.env.lang:
                 line = line.with_context(lang=lang)
             name = line._get_sale_order_line_multiline_description_sale()


### PR DESCRIPTION
An error occurs when the system tries to get language from the sale order.

```ValueError: Expected singleton: sale.order()```

A singleton error occurs when the system tries to get language from 'order_id' from the sale order line at [1], But it is not available.

Link [1]: https://github.com/odoo/odoo/blob/b7439e821f0f6fccaf96b64e4bb24b8712c73600/addons/sale/models/sale_order_line.py#L311C13-L311C45

To avoid the singleton error, add a condition to ensure that 'order_id' is present in the sale order line before trying to get a language from it.

Sentry-6105337128

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
