### PR TITLE
[FIX] base: improve performance on res.device for unfiltered searches

### DIFF
--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -142,6 +142,7 @@ class ResDevice(models.Model):
     _inherit = ["res.device.log"]
     _description = "Devices"
     _auto = False
+    _order = 'last_activity desc'
 
     @check_identity
     def revoke(self):
@@ -188,15 +189,9 @@ class ResDevice(models.Model):
                 AND D.revoked = False
         """
 
-    @api.model
-    def _order_by(self):
-        return """
-            ORDER BY D.last_activity DESC
-        """
-
     @property
     def _query(self):
-        return "%s %s %s %s" % (self._select(), self._from(), self._where(), self._order_by())
+        return "%s %s %s" % (self._select(), self._from(), self._where())
 
     def init(self):
         tools.drop_view_if_exists(self.env.cr, self._table)

--- a/odoo/addons/test_http/tests/test_device.py
+++ b/odoo/addons/test_http/tests/test_device.py
@@ -281,6 +281,18 @@ class TestDevice(TestHttpBase):
         self.assertEqual(len(devices), 0)
         self.assertEqual(len(logs), 0)
 
+    def test_detection_device_default_order(self):
+        self.authenticate(self.user_admin.login, self.user_admin.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit('2024-01-01 10:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_firefox})
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_android_chrome})
+        devices, _ = self.get_devices_logs(self.user_admin)
+        self.assertEqual(
+            list(zip(devices.mapped('platform'), devices.mapped('browser'))),
+            [('linux', 'firefox'), ('android', 'chrome'), ('linux', 'chrome')],
+            "By default, devices should be found from the most recent to the least recent (according to their last activity)."
+        )
+
     # --------------------
     # DELETION
     # --------------------


### PR DESCRIPTION
Issue:
------
Commit 749e0af3639d243f1d24e40f9c0d374c634eaf79 improves the performance of the `res.device` model in the case of a filtered search (for a given user or a given id).

However, when the search is not filtered it takes a long time. This scenario occurs when an administrator goes to the list view of this model.

Cause:
------
This is because, although the data in the view is already ordered, the ORM explicitly adds an order (by default, `ORDER BY 'res_device'.'id'`). The re-sort forces an exhaustive search (before satisfying the limit) which is very time-consuming given the amount of data.

Solution:
---------
Remove the sort in the non-materialised view and let the ORM add it, thus sorting the data just once.

Note:
Optimisations on this view only work if a limit is applied.

Appendices:
-----------
For the query: `SELECT * FROM res_device ORDER BY id LIMIT 80`

Before:
```
 Limit  (cost=723566.00..723566.20 rows=80 width=154) (actual time=18565.185..18565.198 rows=80 loops=1)
   ->  Sort  (cost=723566.00..728832.00 rows=2106398 width=154) (actual time=18453.028..18453.036 rows=80 loops=1)
         Sort Key: d.id
         Sort Method: top-N heapsort  Memory: 66kB
         ->  Sort  (cost=641185.54..646451.53 rows=2106398 width=154) (actual time=17845.533..18159.999 rows=2355457 loops=1)
               Sort Key: d.last_activity DESC
               Sort Method: external merge  Disk: 348000kB
               ->  Merge Anti Join  (cost=1.11..419946.90 rows=2106398 width=154) (actual time=0.043..15869.920 rows=2355457 loops=1)
                     Merge Cond: ((d.user_id = d2.user_id) AND ((d.session_identifier)::text = (d2.session_identifier)::text))
                     Join Filter: ((NOT ((d2.platform)::text IS DISTINCT FROM (d.platform)::text)) AND (NOT ((d2.browser)::text IS DISTINCT FROM (d.browser)::text)) AND ((d2.last_activity > d.last_activity) OR ((d2.last_activity = d.last_activity) AND (d2.id > d.id))))
                     Rows Removed by Join Filter: 64036293
                     ->  Index Scan using res_device_log__composite_idx on res_device_log d  (cost=0.56..230733.16 rows=4674167 width=154) (actual time=0.018..3639.566 rows=4679317 loops=1)
                     ->  Index Only Scan using res_device_log__composite_idx on res_device_log d2  (cost=0.56..142436.83 rows=4674167 width=73) (actual time=0.005..6216.295 rows=64036294 loops=1)
                           Heap Fetches: 4284155
 Planning Time: 0.402 ms
 Execution Time: 18588.272 ms
```

After:
```
 Limit  (cost=0.99..117.94 rows=80 width=154) (actual time=0.028..0.974 rows=80 loops=1)
   ->  Nested Loop Anti Join  (cost=0.99..3079343.32 rows=2106398 width=154) (actual time=0.027..0.968 rows=80 loops=1)
         ->  Index Scan using res_device_log_pkey on res_device_log d  (cost=0.43..202459.12 rows=4674167 width=154) (actual time=0.012..0.118 rows=138 loops=1)
               Filter: (NOT revoked)
               Rows Removed by Filter: 3
         ->  Index Only Scan using res_device_log__composite_idx on res_device_log d2  (cost=0.56..0.61 rows=1 width=73) (actual time=0.006..0.006 rows=0 loops=138)
               Index Cond: ((user_id = d.user_id) AND (session_identifier = (d.session_identifier)::text))
               Filter: ((NOT ((platform)::text IS DISTINCT FROM (d.platform)::text)) AND (NOT ((browser)::text IS DISTINCT FROM (d.browser)::text)) AND ((last_activity > d.last_activity) OR ((last_activity = d.last_activity) AND (id > d.id))))
               Rows Removed by Filter: 6
               Heap Fetches: 9
 Planning Time: 0.368 ms
 Execution Time: 0.996 ms
```