### PR TITLE
[IMP] hr_holidays_attendance: extra hours as allocation option

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -34,7 +34,7 @@ class HrLeaveAllocation(models.Model):
     def _domain_holiday_status_id(self):
         if self.env.user.has_group('hr_holidays.group_hr_holidays_user'):
             return [('requires_allocation', '=', 'yes')]
-        return [('employee_requests', '=', 'yes')]
+        return [('requires_allocation', '=', 'yes'), ('employee_requests', '=', 'yes')]
 
     def _domain_employee_id(self):
         domain = [('company_id', 'in', self.env.companies.ids)]

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -509,7 +509,7 @@ class HrLeaveType(models.Model):
         allocations_leaves_consumed, extra_data = employees.with_context(
             ignored_leave_ids=self.env.context.get('ignored_leave_ids')
         )._get_consumed_leaves(self, target_date)
-        leave_type_requires_allocation = self.filtered(lambda lt: lt.requires_allocation == 'yes')
+        leave_type_requires_allocation = self.filtered(lambda lt: lt.requires_allocation != 'no')
 
         for employee in employees:
             for leave_type in leave_type_requires_allocation:

--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.xml
@@ -5,7 +5,7 @@
             <TimeOffCard
                 name="holiday[0]"
                 data="holiday[1]"
-                requires_allocation="holiday[2] == 'yes'"
+                requires_allocation="holiday[2] != 'no'"
                 holidayStatusId="holiday[3]"
                 employeeId="props.employeeId"/>
         </t>

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -82,7 +82,7 @@
                         </group>
                         <group name="allocation_validation" id="allocation_requests" string="Allocation Requests">
                             <field name="requires_allocation" widget="radio" options="{'horizontal':true}"/>
-                            <field name="employee_requests" widget="radio" invisible="requires_allocation == 'no'"/>
+                            <field name="employee_requests" widget="radio" invisible="requires_allocation != 'yes'"/>
                             <field name="allocation_validation_type" string="Approval" widget="radio" invisible="requires_allocation == 'no'"/>
                         </group>
                     </group>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -247,10 +247,8 @@
                                         '&amp;',
                                             ('has_valid_allocation', '=', True),
                                             '|',
-                                                ('allows_negative', '=', True),
-                                                '&amp;',
-                                                    ('virtual_remaining_leaves', '&gt;', 0),
-                                                    ('allows_negative', '=', False),
+                                            ('allows_negative', '=', True),
+                                            ('virtual_remaining_leaves', '&gt;', 0),
                                 ]"
                                 context="{'employee_id': employee_id, 'default_date_from': date_from, 'default_date_to': date_to}"
                                 options="{'no_create': True, 'no_open': True, 'request_type': 'leave'}"

--- a/addons/hr_holidays_attendance/__manifest__.py
+++ b/addons/hr_holidays_attendance/__manifest__.py
@@ -21,7 +21,7 @@ Convert employee's extra hours to leave allocations.
     ],
     'assets': {
         'web.assets_backend': [
-            'hr_holidays_attendance/static/src/xml/time_off_calendar.xml',
+            'hr_holidays_attendance/static/src/**/*',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/hr_holidays_attendance/data/hr_holidays_attendance_data.xml
+++ b/addons/hr_holidays_attendance/data/hr_holidays_attendance_data.xml
@@ -4,9 +4,8 @@
         <record id="holiday_status_extra_hours" model="hr.leave.type">
             <field name="name">Extra Hours</field>
             <field name="request_unit">hour</field>
-            <field name="requires_allocation">no</field>
+            <field name="requires_allocation">extra_hours</field>
             <field name="leave_validation_type">manager</field>
-            <field name="overtime_deductible" eval="True"/>
             <field name="active" eval="True"/>
             <field name="company_id" eval="False"/>
             <field name="country_id" eval="False"/>

--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -19,7 +19,7 @@ class HrLeave(models.Model):
     @api.depends('holiday_status_id')
     def _compute_overtime_deductible(self):
         for leave in self:
-            leave.overtime_deductible = leave.holiday_status_id.overtime_deductible and leave.holiday_status_id.requires_allocation == 'no'
+            leave.overtime_deductible = leave.holiday_status_id.requires_allocation == 'extra_hours'
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_holidays_attendance/models/hr_leave_allocation.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_allocation.py
@@ -11,17 +11,6 @@ from odoo.osv import expression
 class HrLeaveAllocation(models.Model):
     _inherit = 'hr.leave.allocation'
 
-    def default_get(self, fields):
-        res = super().default_get(fields)
-        if 'holiday_status_id' in fields and self.env.context.get('deduct_extra_hours'):
-            domain = [('overtime_deductible', '=', True), ('requires_allocation', '=', 'yes')]
-            if self.env.context.get('deduct_extra_hours_employee_request', False):
-                # Prevent loading manager allocated time off type in self request contexts
-                domain = expression.AND([domain, [('employee_requests', '=', 'yes')]])
-            leave_type = self.env['hr.leave.type'].search(domain, limit=1)
-            res['holiday_status_id'] = leave_type.id
-        return res
-
     overtime_deductible = fields.Boolean(compute='_compute_overtime_deductible')
     overtime_id = fields.Many2one('hr.attendance.overtime', string='Extra Hours', groups='hr_holidays.group_hr_holidays_user')
     employee_overtime = fields.Float(related='employee_id.total_overtime', groups='base.group_user')
@@ -29,45 +18,20 @@ class HrLeaveAllocation(models.Model):
     @api.depends('holiday_status_id')
     def _compute_overtime_deductible(self):
         for allocation in self:
-            allocation.overtime_deductible = allocation.holiday_status_id.overtime_deductible
+            allocation.overtime_deductible = allocation.holiday_status_id.requires_allocation == 'extra_hours'
 
     @api.model_create_multi
     def create(self, vals_list):
-        res = super().create(vals_list)
-        for allocation in res:
-            if allocation.overtime_deductible:
-                duration = allocation.number_of_hours_display
-                if duration > allocation.employee_id.total_overtime:
-                    raise ValidationError(_('The employee does not have enough overtime hours to request this leave.'))
-                if not allocation.overtime_id:
-                    allocation.sudo().overtime_id = self.env['hr.attendance.overtime'].sudo().create({
-                        'employee_id': allocation.employee_id.id,
-                        'date': allocation.date_from,
-                        'adjustment': True,
-                        'duration': -1 * duration,
-                    })
-        return res
-
-    def write(self, vals):
-        res = super().write(vals)
-        if 'number_of_days' not in vals:
-            return res
-        if not self.env.user.has_group("hr_holidays.group_hr_holidays_user") and any(allocation.state not in ('draft', 'confirm') for allocation in self):
-            raise ValidationError(_('Only an Officer or Administrator is allowed to edit the allocation duration in this status.'))
-        for allocation in self.sudo().filtered('overtime_id'):
-            employee = allocation.employee_id
-            duration = allocation.number_of_hours_display
-            overtime_duration = allocation.overtime_id.sudo().duration
-            if overtime_duration != -1 * duration:
-                if duration > employee.total_overtime - overtime_duration:
-                    raise ValidationError(_('The employee does not have enough extra hours to extend this allocation.'))
-                allocation.overtime_id.sudo().duration = -1 * duration
-        return res
-
-    def action_refuse(self):
-        res = super().action_refuse()
-        self.overtime_id.sudo().unlink()
-        return res
+        allocations = super().create(vals)
+        extra_hours_allocation = self.env['hr.leave.allocation']
+        for allocation in allocations:
+            if allocation.holiday_status_id.requires_allocation == 'extra_hours':
+                extra_hours_allocation += allocation
+        if extra_hours_allocation:
+            raise ValidationError(
+                _("You cannot create an allocation request for the following allocations. Because their leave type are based on extra hours. %s",
+                "\n".join(allocation.name for allocation in extra_hours_allocation)))
+        return allocations
 
     def _get_accrual_plan_level_work_entry_prorata(self, level, start_period, start_date, end_period, end_date):
         self.ensure_one()
@@ -83,3 +47,10 @@ class HrLeaveAllocation(models.Model):
         ])
         work_entry_prorata = sum(attendances.mapped('worked_hours'))
         return work_entry_prorata
+    
+    def create(self, vals):
+        records = super().create(vals)
+        for record in records:
+            if record.holiday_status_id.requires_allocation == 'extra_hours':
+                raise ValidationError(_('You cannot create an allocation request for a leave type based on extra hours.'))
+        return records

--- a/addons/hr_holidays_attendance/models/hr_leave_type.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_type.py
@@ -8,11 +8,24 @@ from odoo import _, api, fields, models
 class HrLeaveType(models.Model):
     _inherit = 'hr.leave.type'
 
-    overtime_deductible = fields.Boolean(
-        "Deduct Extra Hours", default=False,
-        help="Once a time off of this type is approved, extra hours in attendances will be deducted.")
+    requires_allocation = fields.Selection(selection_add=[('extra_hours', 'Based on Extra Hours')], ondelete={'extra_hours': 'set default'})
+    warning_multiple_types_based_on_extra_hours = fields.Boolean(compute='_compute_warning_multiple_types_based_on_extra_hours')
+    
+    @api.depends('requires_allocation')
+    def _compute_warning_multiple_types_based_on_extra_hours(self):
+        for leave_type in self:
+            if leave_type.requires_allocation != 'extra_hours':
+                self.warning_multiple_types_based_on_extra_hours = False
+            else:
+                domain = [
+                    ('company_id', 'in', self.env.company.ids + [False]),
+                    ('requires_allocation', '=', 'extra_hours'),
+                    ('id', 'not in', self.ids)
+                ]
+                leave_types = self.env['hr.leave.type'].search_count(domain)
+                self.warning_multiple_types_based_on_extra_hours = leave_types >= 1
 
-    @api.depends('overtime_deductible', 'requires_allocation')
+    @api.depends('requires_allocation')
     @api.depends_context('request_type', 'leave', 'holiday_status_display_name', 'employee_id')
     def _compute_display_name(self):
         # Exclude hours available in allocation contexts, it might be confusing otherwise
@@ -23,7 +36,7 @@ class HrLeaveType(models.Model):
         if employee.total_overtime <= 0:
             return super()._compute_display_name()
 
-        overtime_leaves = self.filtered(lambda l_type: l_type.overtime_deductible and l_type.requires_allocation == 'no')
+        overtime_leaves = self.filtered(lambda l_type: l_type.requires_allocation == 'extra_hours')
         for leave_type in overtime_leaves:
             leave_type.display_name = "%(name)s (%(count)s)" % {
                 'name': leave_type.name,
@@ -35,19 +48,54 @@ class HrLeaveType(models.Model):
     def get_allocation_data(self, employees, date=None):
         res = super().get_allocation_data(employees, date)
         deductible_time_off_types = self.env['hr.leave.type'].search([
-            ('overtime_deductible', '=', True),
-            ('requires_allocation', '=', 'no')])
-        leave_type_names = deductible_time_off_types.mapped('name')
-        for employee in res:
-            for leave_data in res[employee]:
-                if leave_data[0] in leave_type_names:
-                    leave_data[1]['virtual_remaining_leaves'] = employee.sudo().total_overtime
-                    leave_data[1]['overtime_deductible'] = True
-                else:
-                    leave_data[1]['overtime_deductible'] = False
+            ('requires_allocation', '=', 'extra_hours')])
+        leaves = self.env['hr.leave'].search([
+            ('employee_id', 'in', employees.ids),
+            ('holiday_status_id', 'in', deductible_time_off_types.ids),
+            ('state', 'in', ['confirm', 'validate']),
+        ])
+        for employee in employees:
+            for leave_type in deductible_time_off_types:
+                confirmed_leaves = leaves.filtered(lambda l: l.employee_id == employee and l.holiday_status_id == leave_type and l.state == 'confirm')
+                validated_leaves = leaves.filtered(lambda l: l.employee_id == employee and l.holiday_status_id == leave_type and l.state == 'validate')
+                res[employee].append((leave_type.name, {
+                    'remaining_leaves': 0,
+                    'virtual_remaining_leaves': employee.sudo().total_overtime,
+                    'max_leaves': 0,
+                    'accrual_bonus': 0,
+                    'leaves_taken': 0,
+                    'virtual_leaves_taken': 0,
+                    'leaves_requested': 0,
+                    'leaves_approved': 0,
+                    'closest_allocation_remaining': 0,
+                    'closest_allocation_expire': False,
+                    'holds_changes': False,
+                    'total_virtual_excess': 0,
+                    'virtual_excess_data': {},
+                    'exceeding_duration': 0,
+                    'request_unit': leave_type.request_unit,
+                    'icon': leave_type.sudo().icon_id.url,
+                    'allows_negative': leave_type.allows_negative,
+                    'max_allowed_negative': leave_type.max_allowed_negative,
+                    'employee_company': employee.company_id.id,
+                    'closest_allocation_remaining': False,
+                    'closest_allocation_expire': False,
+                    'closest_allocation_duration': False,
+                    'holds_changes': False,
+                }, 'extra_hours', leave_type.id))
+                for leave in confirmed_leaves:
+                    if leave_type.request_unit == 'hour':
+                        res[employee][-1][1]['leaves_requested'] += leave.number_of_hours
+                    else:
+                        res[employee][-1][1]['leaves_requested'] += leave.number_of_days
+                for leave in validated_leaves:
+                    if leave_type.request_unit == 'hour':
+                        res[employee][-1][1]['leaves_approved'] += leave.number_of_hours
+                    else:
+                        res[employee][-1][1]['leaves_approved'] += leave.number_of_days
         return res
 
     def _get_days_request(self, date=None):
         res = super()._get_days_request(date)
-        res[1]['overtime_deductible'] = self.overtime_deductible
+        res[1]['overtime_deductible'] = self.requires_allocation == 'extra_hours'
         return res

--- a/addons/hr_holidays_attendance/models/res_users.py
+++ b/addons/hr_holidays_attendance/models/res_users.py
@@ -18,9 +18,8 @@ class ResUsers(models.Model):
     def _compute_request_overtime(self):
         is_holiday_user = self.env.user.has_group('hr_holidays.group_hr_holidays_user')
         time_off_types = self.env['hr.leave.type'].search_count([
-            ('requires_allocation', '=', 'yes'),
+            ('requires_allocation', '=', 'extra_hours'),
             ('employee_requests', '=', 'yes'),
-            ('overtime_deductible', '=', True)
         ])
         for user in self:
             if user.total_overtime >= 1:

--- a/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
@@ -5,6 +5,7 @@ import datetime
 from freezegun import freeze_time
 from dateutil.relativedelta import relativedelta
 
+from odoo.exceptions import UserError
 from odoo.tests import Form, tagged
 
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
@@ -22,6 +23,23 @@ class TestAccrualAllocationsAttendance(TestHrHolidaysCommon):
             'requires_allocation': 'yes',
             'allocation_validation_type': 'hr',
         })
+    
+    def test_create_allocation_based_on_extra_hours(self):
+        """
+        A UserError should be raised if the user tries to create an allocation based on extra hours
+        """
+        with self.assertRaises(UserError):
+            leave_type = self.env['hr.leave.type'].create({
+                'name': 'Extra Hours',
+                'time_type': 'leave',
+                'requires_allocation': 'extra_hours'
+            })
+            with Form(self.env['hr.leave.allocation']) as allocation_form:
+                allocation_form.employee_id = self.employee_emp
+                allocation_form.holiday_status_id = leave_type
+                allocation_form.name = 'Extra hours allocation for employee'
+                return allocation_form.save()
+
 
     def test_frequency_hourly_attendance(self):
         with freeze_time("2017-12-5"):

--- a/addons/hr_holidays_attendance/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_leave_allocation_views.xml
@@ -26,7 +26,7 @@
                 <attribute name="invisible">1</attribute>
             </div>
             <xpath expr="//field[@name='holiday_status_id']" position="attributes">
-                <attribute name="domain">[('overtime_deductible', '=', True), ('requires_allocation', '=', 'yes'), ('employee_requests', '=', 'yes')]</attribute>
+                <attribute name="domain">[('requires_allocation', '=', 'extra_hours'), ('employee_requests', '=', 'yes')]</attribute>
                 <attribute name="options">{'no_create': True, 'no_open': True}</attribute>
             </xpath>
             <xpath expr="//sheet" position="after">
@@ -45,7 +45,7 @@
         <field name="priority">70</field>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='holiday_status_id']" position="attributes">
-                <attribute name="domain">[('overtime_deductible', '=', True), ('requires_allocation', '=', 'yes')]</attribute>
+                <attribute name="domain">[('requires_allocation', '=', 'extra_hours')]</attribute>
             </xpath>
         </field>
     </record>

--- a/addons/hr_holidays_attendance/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_leave_type_views.xml
@@ -5,9 +5,12 @@
         <field name="model">hr.leave.type</field>
         <field name="inherit_id" ref="hr_holidays.edit_holiday_status_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='configuration']" position="inside">
-                <field name="overtime_deductible" nolabel="1"/>
-                <label for="overtime_deductible"/>
+            <xpath expr="/form/sheet/div[2]" position="before">
+                <div class="oe_inline" invisible="not warning_multiple_types_based_on_extra_hours">
+                    <div class="alert alert-danger oe_text_center" role="alert">
+                        There are multiple time off types with allocation based on extra hours.
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>

--- a/addons/hr_holidays_attendance/views/hr_leave_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_leave_views.xml
@@ -11,4 +11,43 @@
             </field>
         </field>
     </record>
+
+    <record id="hr_leave_view_form_inherit" model="ir.ui.view">
+        <field name="model">hr.leave</field>
+        <field name="inherit_id" ref="hr_holidays.hr_leave_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='holiday_status_id']" position="replace">
+                <field name="holiday_status_id" force_save="1"
+                    invisible="employee_overtime &lt;= 0"
+                    domain="[
+                        '|',
+                        ('requires_allocation', 'in', ('extra_hours', 'no')),
+                        '&amp;',
+                            ('has_valid_allocation', '=', True),
+                            '|',
+                                ('allows_negative', '=', True),
+                                ('virtual_remaining_leaves', '&gt;', 0),
+                    ]"
+                    context="{'employee_id': employee_id, 'default_date_from': date_from, 'default_date_to': date_to}"
+                    options="{'no_create': True, 'no_open': True, 'request_type': 'leave'}"
+                    readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
+                <field name="holiday_status_id" force_save="1"
+                    invisible="employee_overtime &gt; 0"
+                    domain="[
+                        '|',
+                            ('requires_allocation', '=', 'no'),
+                            '&amp;',
+                                ('has_valid_allocation', '=', True),
+                                '|',
+                                    ('allows_negative', '=', True),
+                                    '&amp;',
+                                        ('virtual_remaining_leaves', '&gt;', 0),
+                                        ('allows_negative', '=', False),
+                    ]"
+                    context="{'employee_id': employee_id, 'default_date_from': date_from, 'default_date_to': date_to}"
+                    options="{'no_create': True, 'no_open': True, 'request_type': 'leave'}"
+                    readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
This commit adds "Based on Extra Hours" as a selection for the field `requires_allocation` and removes the corresponding bool field. The reason is that the option does not work when the time off type requires allocation.


task-4317343


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
