### PR TITLE
[IMP] website: use SDK for facebook snippet

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -15111,6 +15111,12 @@ msgid "We couldn't find the Facebook page"
 msgstr ""
 
 #. module: website
+#. odoo-javascript
+#: code:addons/website/static/src/snippets/s_facebook_page/facebook_page.js:0
+msgid "Uh-oh! It looks like your Facebook page took a detour. Could be your internet connection or some extensions blocking its way!"
+msgstr ""
+
+#. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_faq_list
 msgid ""
 "We deliver personalized solutions, ensuring that every customer receives "

--- a/addons/website/static/src/snippets/s_facebook_page/facebook_page.js
+++ b/addons/website/static/src/snippets/s_facebook_page/facebook_page.js
@@ -1,16 +1,31 @@
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
-
-import { _t } from "@web/core/l10n/translation";
-import { clamp } from "@web/core/utils/numbers";
 import { pick } from "@web/core/utils/objects";
+import { AssetsLoadingError, loadJS } from "@web/core/assets";
+import { _t } from "@web/core/l10n/translation";
+import { renderToElement } from "@web/core/utils/render";
 
+/* global FB */
 export class FacebookPage extends Interaction {
     static selector = ".o_facebook_page";
+    dynamicContent = {
+        _document: {
+            "t-on-optionalCookiesAccepted": this.onOptionalCookiesAccepted,
+        },
+    };
 
     setup() {
         this.previousWidth = 0;
-        const params = pick(this.el.dataset, "href", "id", "height", "tabs", "small_header", "hide_cover");
+        const params = pick(
+            this.el.dataset,
+            "href",
+            "id",
+            "height",
+            "width",
+            "tabs",
+            "small_header",
+            "hide_cover"
+        );
         if (!params.href) {
             return;
         }
@@ -18,36 +33,103 @@ export class FacebookPage extends Interaction {
             params.href = `https://www.facebook.com/${params.id}`;
             delete params.id;
         }
-
-        this.renderIframe(params);
-
-        this.resizeObserver = new ResizeObserver(this.debounced(this.renderIframe.bind(this, params), 100));
-        this.resizeObserver.observe(this.el.parentElement);
+        // Handle cookie warning fallback
+        if (this.el.dataset.needCookiesApproval) {
+            const fallbackEl = renderToElement("website.cookiesWarning");
+            this.el.replaceChildren(fallbackEl);
+        }
+        this.renderFacebookPlugin(params);
+        this.resizeObserver = new ResizeObserver(
+            this.debounced(this.handleResize.bind(this, params), 100)
+        );
+        this.resizeObserver.observe(this.el);
         this.registerCleanup(() => { this.resizeObserver.disconnect() });
     }
 
+    async willStart() {
+       await this.loadFacebookSDK();
+    }
+
     /**
-     * Prepare iframe element & replace it with existing iframe.
+     * Loads the Facebook SDK asynchronously by injecting the SDK script into the page.
+     * If the script fails to load, it handles the error by checking the type of error
+     * and whether the browser is online. In case of failure, it displays a warning
+     * notification to the user about potential network issues or browser extensions
+     * causing the problem.
+     *
+     * @async
+     * @function
+     * @throws {AssetsLoadingError} If the SDK script fails to load due to an asset loading issue.
+     * @throws {Error} If there is a general error while loading the SDK script.
+     */
+    async loadFacebookSDK() {
+        await loadJS("https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v10.0").catch(
+            (error) => {
+                if (!(error instanceof AssetsLoadingError || navigator.onLine)) {
+                    const message = _t(
+                        "Unable to load your Facebook page. This could be due to a network issue or browser extensions."
+                    );
+                    this.env.services.notification.add(message, { type: "warning" });
+                }
+            }
+        );
+    }
+
+    /**
+     * Handle resize events and render Facebook plugin if necessary.
      *
      * @param {Object} params
-    */
-    renderIframe(params) {
-        params.width = clamp(Math.floor(this.el.getBoundingClientRect().width), 180, 500);
-        if (this.previousWidth !== params.width) {
-            this.previousWidth = params.width;
-            const searchParams = new URLSearchParams(params);
+     */
+    handleResize(params) {
+        const currentWidth = this.el.offsetWidth;
+        // Only re-render if width change is significant
+        if (Math.abs(currentWidth - this.previousWidth) > 10) {
+            this.previousWidth = currentWidth;
+            this.renderFacebookPlugin(params);
+        }
+    }
 
-            const iframeEl = document.createElement("iframe");
-            iframeEl.setAttribute("style", "border: none; overflow: hidden;");
-            iframeEl.setAttribute("aria-label", _t("Facebook"));
-            iframeEl.height = params.height;
-            iframeEl.width = params.width;
-
-            this.el.replaceChildren(iframeEl);
-            this.registerCleanup(() => { iframeEl.remove(); });
-
-            const src = "https://www.facebook.com/plugins/page.php?" + searchParams;
-            this.services.website_cookies.manageIframeSrc(iframeEl, src);
+    /**
+     * Prepare Facebook plugin element & replace it with existing content.
+     *
+     * @param {Object} params
+     */
+    renderFacebookPlugin(params) {
+        if (typeof FB !== "undefined") {
+            const fbDiv = document.createElement("div");
+            fbDiv.className = "fb-page";
+            fbDiv.setAttribute("data-href", params.href);
+            fbDiv.setAttribute("data-tabs", params.tabs || "");
+            fbDiv.setAttribute("data-width", params.width);
+            fbDiv.setAttribute("data-height", params.height);
+            fbDiv.setAttribute("data-small-header", params.small_header || "false");
+            fbDiv.setAttribute("data-hide-cover", params.hide_cover || "false");
+            this.el.replaceChildren(fbDiv);
+            this.registerCleanup(() => {
+                fbDiv.remove();
+            });
+            // After accepting cookies there is not enough time to load the SDK
+            setTimeout(() => {
+                FB.XFBML.parse(this.el);
+            }, 100); // 100ms delay
+        }
+    }
+    /**
+     * Load Facebook SDK and initialize the plugin.
+     */
+    async onOptionalCookiesAccepted() {
+        // Remove the fallback element (cookie warning) if it exists
+        const fallbackEl = this.el.querySelector(".o_no_optional_cookie");
+        if (fallbackEl) {
+            fallbackEl.remove();
+        }
+        await this.loadFacebookSDK();
+        if (typeof FB !== "undefined") {
+            FB.init({
+                xfbml: true,
+                version: "v10.0",
+            });
+            this.renderFacebookPlugin(this.el.dataset);
         }
     }
 }

--- a/addons/website/views/snippets/s_facebook_page.xml
+++ b/addons/website/views/snippets/s_facebook_page.xml
@@ -3,8 +3,8 @@
 
 <!-- Snippet template -->
 <template id="s_facebook_page" name="Facebook">
-    <div class="o_facebook_page o_not_editable">
-        <iframe class="mw-100 o_facebook_page_preview" src="https://www.facebook.com/plugins/page.php?height=70&amp;hide_cover=true&amp;href=https%3A%2F%2Fwww.facebook.com%2FOdoo&amp;show_facepile=false&amp;small_header=true&amp;tabs=&amp;width=500" style="width: 500px; height: 70px; border: medium none; overflow: hidden;" aria-label="Facebook"/>
+    <div class="o_facebook_page o_not_editable" data-vxml="001">
+        <div class="fb_page"></div>
     </div>
 </template>
 
@@ -18,6 +18,10 @@
             <we-checkbox string="Events" data-option-name="tab.events" data-toggle-option="true" data-no-preview="true"/>
             <we-checkbox string="Messages" data-option-name="tab.messages" data-toggle-option="true" data-no-preview="true"/>
             <we-checkbox string="Small Header" data-option-name="small_header" data-toggle-option="true" data-no-preview="true"/>
+            <we-input class="o_we_large" string="Height" data-set-height="" data-no-preview="true" data-unit="px"
+                data-tooltip="Facebook snippet height: 70 to 2673px."/>
+            <we-input class="o_we_large" string="Width" data-set-width="" data-no-preview="true" data-unit="px"
+                data-tooltip="Facebook snippet width: 180 to 500px."/>
         </div>
     </xpath>
 </template>


### PR DESCRIPTION
This commit integrates the Facebook SDK for the Facebook snippet, allowing users to share content from the website on their Facebook profiles.

This commit includes the following changes:
- Replaced the "Iframe" implementation with the "connect.facebook.net" SDK script, ensuring compatibility across all devices, including Android.
- Added user notifications for SDK load failures due to internet issues or blockers.
- Introduced a customizable feature to dynamically adjust the Facebook plugin's height and width for greater integration flexibility. The default height is set to 700px, and the width is set to parents width or 500px, whichever is smaller.

task-4366715