### PR TITLE
[FIX] account: allow decimal hook in vat amount edition

### DIFF
--- a/addons/account/static/src/components/tax_totals/tax_totals.js
+++ b/addons/account/static/src/components/tax_totals/tax_totals.js
@@ -5,6 +5,7 @@ import { parseFloat } from "@web/views/fields/parsers";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
+import { useNumpadDecimal } from "@web/views/fields/numpad_decimal_hook";
 
 const { Component, onPatched, onWillUpdateProps, useRef, useState } = owl;
 
@@ -26,6 +27,7 @@ class TaxGroupComponent extends Component {
         onWillUpdateProps(() => {
             this.setState("readonly");
         });
+        useNumpadDecimal();
     }
 
     //--------------------------------------------------------------------------

--- a/addons/account/static/src/components/tax_totals/tax_totals.xml
+++ b/addons/account/static/src/components/tax_totals/tax_totals.xml
@@ -10,7 +10,7 @@
             <td  class="o_tax_group">
                 <t t-if="!props.isReadonly">
                     <t t-if="['edit', 'disable'].includes(state.value)">
-                        <span class="o_tax_group_edit_input">
+                        <span class="o_tax_group_edit_input" t-ref="numpadDecimal">
                             <input
                                 type="text"
                                 t-ref="taxValueInput"


### PR DESCRIPTION
Steps to reproduce:
- define your language as French/BE
- create a bill (facture fournisseur)
- edit the vat with '20.13' using the numpad decimal key

Issue:
the amount is '2013.00'

Cause:
numpad decimal in belgian layout is a comma `,` which in this is interpreted as a thousands separator.

Solution:
Use the `useNumpadDecimal` hook

opw-4284370
