### PR TITLE
[IMP] core: handling of tour screenshot error

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1335,9 +1335,13 @@ which leads to stray network requests and inconsistencies."""
 
     def take_screenshot(self, prefix='sc_', suffix=None):
         def handler(f):
-            base_png = f.result(timeout=0)['data']
+            try:
+                base_png = f.result(timeout=0)['data']
+            except Exception as e:
+                self._logger.runbot("Couldn't capture screenshot: %s", e)
+                return
             if not base_png:
-                self._logger.warning("Couldn't capture screenshot: expected image data, got ?? error ??")
+                self._logger.runbot("Couldn't capture screenshot: expected image data, got %r", base_png)
                 return
 
             decoded = base64.b64decode(base_png, validate=True)


### PR DESCRIPTION
Currently, if trying to take a screenshot results in an error the reporting is iffy: we end up with an uninformative and unexpected traceback along the lines of

    concurrent.futures: exception calling callback for <Future at 0x7f212c073110 state=finished raised ChromeBrowserException>
    Traceback (most recent call last):
      File "concurrent/futures/_base.py", line 340, in _invoke_callbacks
        callback(self)
      File "odoo/odoo/tests/common.py", line 1532, in handler
        base_png = f.result(timeout=0)['data']
                   ^^^^^^^^^^^^^^^^^^^
      File "concurrent/futures/_base.py", line 449, in result
        return self.__get_result()
               ^^^^^^^^^^^^^^^^^^^
      File "concurrent/futures/_base.py", line 401, in __get_result
        raise self._exception
    odoo.tests.common.ChromeBrowserException: Internal error

As this is mostly unhelpful, handle the thing better, and lower the concern to `RUNBOT`: giving prominence to the screenshot failure is probably less relevant than the actual reason why we tried to take a screenshot in the first place?
