### PR TITLE
[FIX] pos_restaurant: concurrent closing of orders

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -105,6 +105,9 @@ patch(PosStore.prototype, {
                 } finally {
                     this.tableSyncing = false;
                 }
+            } else if (this.get_order()?.finalized && this.previousScreen !== "PaymentScreen") {
+                // if the order was paid from another device
+                this.showScreen("FloorScreen");
             }
         }
     },


### PR DESCRIPTION
Before this commit, when the same order is opened on two devices and the order is settled on one of the devices, a weird behavior is observed on the other devices, where a new empty order is being created, but the display still shows the items of the previous order.
This leads to users thinking they have more orders to settle than reality.

Steps to reproduce
------------------
1. clean DB with pos_restaurant installed and at least one product configured
2. open the pos session on two separate devices D1 and D2
3. on D1, create a new order O1
4. While keeping O1 open on D1, open it as well on D2
5. settle O1 on D2
6. the summary of O1 is still visible on D1 even though it ceated a new order in the background. You will need to go back to floor screen to see the changes.

This commit proposes to force going back to the Floor Screen in such cases, to avoid any confusion.