### PR TITLE
[FIX] mail: remove typo in UserError

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -3522,6 +3522,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/mail/models/mail_render_mixin.py:0
 #, python-format
+msgid "Failed to render inline_template template: %(template_txt)s"
+msgstr ""
+
+#. module: mail
+#. odoo-python
+#: code:addons/mail/models/mail_render_mixin.py:0
+#, python-format
 msgid "Failed to render template: %(view_ref)s"
 msgstr ""
 

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -447,7 +447,7 @@ class MailRenderMixin(models.AbstractModel):
             except Exception as e:
                 _logger.info("Failed to render inline_template: \n%s", str(template_txt), exc_info=True)
                 raise UserError(
-                    _("Failed to render inline_template template: %(template_txt)s)",
+                    _("Failed to render inline_template template: %(template_txt)s",
                       template_txt=template_txt)
                 ) from e
 


### PR DESCRIPTION
This commit removes a typo in a UserError raised when the rendering of the template fails.

Fixes #186447