### PR TITLE
[FIX] web_editor: fix shapes selector partially hidden on safari

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2008,7 +2008,11 @@
             // does not make a scrollbar appear for no reason
             flex: 1 1 auto;
 
-            &::after {
+            // The backdrop is not added for "o_we_select_pager". This is
+            // because it covers the entire panel, making it unnecessary.
+            // Additionally, using the backdrop with an "o_we_select_pager"
+            // causes a CSS bug on Safari.
+            &:not(:has(.o_we_select_pager.o_we_widget_opened))::after {
                 content: "";
                 // We use a "sticky" position because it ensures that the
                 // backdrop covers the entire "customize panel" element, even


### PR DESCRIPTION
Steps to reproduce the bug (only on Safari):

- Drag and drop 4-5 "Text" blocks onto the page.
- Hide all of them in desktop view by clicking the "Hide on desktop" button for each one. This should create a list of "Invisible Elements" at the bottom of the right panel.
- Drag and drop a "Text - Image" block onto the page.
- Click the image in the "Text - Image" block.
- In the image options, click the "Shape" selector.
- Bug: The "Shape" selector is partially hidden behind the "Invisible Elements" list, and it is not possible to scroll to the bottom of the "shapes" list to access the last shapes.

After investigation, we found that the issue comes from the backdrop, which is positioned as sticky behind the shape selector. Since the backdrop isn't needed for the "shape selector" (it covers the entire right panel), we simply disabled it for the "shape selector".

opw-4357397