### PR TITLE
[IMP] html_editor: link popover fixes & improvements

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -37,6 +37,8 @@ import {
  * @property { Node } commonAncestorContainer
  * @property { boolean } isCollapsed
  * @property { boolean } direction
+ * @property { () => string } textContent
+ * @property { (node: Node) => boolean } intersectsNode
  */
 
 /**

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -30,7 +30,7 @@ import { withSequence } from "@html_editor/utils/resource";
 export class ColorPlugin extends Plugin {
     static id = "color";
     static dependencies = ["selection", "split", "history", "format"];
-    static shared = ["colorElement", "getPropsForColorSelector"];
+    static shared = ["colorElement", "getPropsForColorSelector", "removeAllColor"];
     resources = {
         user_commands: [
             {

--- a/addons/html_editor/static/src/main/link/link_paste_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_paste_plugin.js
@@ -6,7 +6,7 @@ import { leftPos } from "@html_editor/utils/position";
 
 export class LinkPastePlugin extends Plugin {
     static id = "linkPaste";
-    static dependencies = ["link", "clipboard", "selection", "dom"];
+    static dependencies = ["link", "clipboard", "selection", "dom", "history"];
     resources = {
         before_paste_handlers: this.removeFullySelectedLink.bind(this),
         paste_text_overrides: this.handlePasteText.bind(this),

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -12,10 +12,10 @@
                 <div t-else="" class="d-flex">
                     <div class="col p-2" style="max-width: 250px;">
                         <div class="input-group mb-1">
-                            <input t-ref="label" class="o_we_label_link form-control form-control-sm" t-model="state.label" title="Label" placeholder="Type your link label"/>
+                            <input t-ref="label" class="o_we_label_link form-control form-control-sm" t-model="state.label" title="Label" placeholder="Add a label for your link"/>
                         </div>
                         <div class="input-group mb-1">
-                            <input t-ref="url" class="o_we_href_input_link form-control form-control-sm" t-model="state.url" title="URL" placeholder="Type your URL" t-on-keydown="onKeydownEnter"/>
+                            <input t-ref="url" class="o_we_href_input_link form-control form-control-sm" t-model="state.url" title="URL" placeholder="Paste or type your URL" t-on-keydown="onKeydownEnter"/>
                             <span class="ms-1" t-if="props.canUpload and !state.url">
                                 or <button class="btn btn-secondary btn-sm" t-on-click="uploadFile">Upload File</button>
                             </span>
@@ -109,7 +109,7 @@
                         </span>
                     </div>
                 </div>
-                <div t-if="state.urlTitle and ((state.url === state.label and state.urlTitle !== state.label ) || (state.url === state.label+'/' and state.urlTitle !== state.label+'/'))" class="d-flex align-items-baseline" style="background-color: var(--primary);">
+                <div t-if="!state.isImage and state.urlTitle and state.label === ''" class="d-flex align-items-baseline" style="background-color: var(--primary);">
                     <i class="fa fa-magic fa-fw m-1" style="color: var(--o-cc1-btn-primary-text);"></i>
                     <span class="me-2 flex-grow-1" style="color: var(--o-cc1-btn-primary-text);font-size: smaller;">Replace URL with its title?</span>
                     <button class=" btn btn-sm btn-primary o_we_replace_title_btn" style="margin: 1px;font-size: smaller;" t-on-click="onClickReplaceTitle">Yes</button>

--- a/addons/html_editor/static/src/main/link/utils.js
+++ b/addons/html_editor/static/src/main/link/utils.js
@@ -64,7 +64,7 @@ export function deduceURLfromText(text, link) {
             // Avoid converting a http link to https.
             return currentHttpProtocol + match[0];
         } else {
-            return "http://" + match[0];
+            return "https://" + match[0];
         }
     }
     // Check for telephone url.

--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -149,7 +149,7 @@ export async function testEditor(config) {
     if (!compareFunction) {
         compareFunction = (content, expected, phase) => {
             expect(content).toBe(expected, {
-                message: `(testEditor) ${phase} is strictly equal to %actual%"`,
+                message: `(testEditor) ${phase} is strictly equal to "${expected}"`,
             });
         };
     }

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -1,5 +1,4 @@
 import { describe, test } from "@odoo/hoot";
-import { press } from "@odoo/hoot-dom";
 import { tick } from "@odoo/hoot-mock";
 import { testEditor } from "../_helpers/editor";
 import { insertText, splitBlock } from "../_helpers/user_actions";
@@ -488,15 +487,12 @@ describe("Selection collapsed", () => {
         test("should insert a paragraph break outside the ending edge of an anchor", async () => {
             await testEditor({
                 contentBefore: "<p><a>ab[]</a></p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    await press("enter");
-                    editor.shared.selection.focusEditable();
-                    await tick();
-                },
-                contentAfterEdit: `<p>\ufeff<a href="">\ufeffab\ufeff</a>\ufeff</p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
-                contentAfter: `<p><a href="">ab</a></p><p>[]<br></p>`,
+                stepFunction: splitBlockA,
+                contentAfterEdit: `<p>\ufeff<a>\ufeffab\ufeff</a>\ufeff</p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+                contentAfter: `<p><a>ab</a></p><p>[]<br></p>`,
             });
+        });
+        test("should insert a paragraph break outside the ending edge of an anchor (2)", async () => {
             await testEditor({
                 contentBefore: "<p><a>ab[]</a>cd</p>",
                 stepFunction: splitBlockA,

--- a/addons/html_editor/static/tests/link/edit_label.test.js
+++ b/addons/html_editor/static/tests/link/edit_label.test.js
@@ -88,7 +88,7 @@ describe("range collapsed", () => {
             stepFunction: async (editor) => {
                 deleteBackward(editor);
             },
-            contentAfter: '<p>a<a href="http://hellomoto.com">hello[]moto.com</a></p>',
+            contentAfter: '<p>a<a href="https://hellomoto.com">hello[]moto.com</a></p>',
         });
     });
 

--- a/addons/html_editor/static/tests/link/transform.test.js
+++ b/addons/html_editor/static/tests/link/transform.test.js
@@ -89,17 +89,17 @@ test("should transform url followed by punctuation characters after space", asyn
     await testEditor({
         contentBefore: "<p>test.com...[]</p>",
         stepFunction: (editor) => insertSpace(editor),
-        contentAfter: '<p><a href="http://test.com">test.com</a>... []</p>',
+        contentAfter: '<p><a href="https://test.com">test.com</a>... []</p>',
     });
     await testEditor({
         contentBefore: "<p>test.com,[]</p>",
         stepFunction: (editor) => insertSpace(editor),
-        contentAfter: '<p><a href="http://test.com">test.com</a>, []</p>',
+        contentAfter: '<p><a href="https://test.com">test.com</a>, []</p>',
     });
     await testEditor({
         contentBefore: "<p>test.com,hello[]</p>",
         stepFunction: (editor) => insertSpace(editor),
-        contentAfter: '<p><a href="http://test.com">test.com</a>,hello []</p>',
+        contentAfter: '<p><a href="https://test.com">test.com</a>,hello []</p>',
     });
     await testEditor({
         contentBefore: "<p>http://test.com[]</p>",
@@ -166,12 +166,12 @@ test("transform text url into link and undo it", async () => {
     const { el, editor } = await setupEditor(`<p>[]</p>`);
     await insertText(editor, "www.abc.jpg ");
     expect(cleanLinkArtifacts(getContent(el))).toBe(
-        '<p><a href="http://www.abc.jpg">www.abc.jpg</a> []</p>'
+        '<p><a href="https://www.abc.jpg">www.abc.jpg</a> []</p>'
     );
 
     undo(editor);
     expect(cleanLinkArtifacts(getContent(el))).toBe(
-        '<p><a href="http://www.abc.jpg">www.abc.jpg</a>[]</p>'
+        '<p><a href="https://www.abc.jpg">www.abc.jpg</a>[]</p>'
     );
 
     undo(editor);

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -2546,6 +2546,10 @@ describe("link", () => {
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p>abc <a href="${url}">${url}</a> def[]</p>`
             );
+            undo(editor);
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                `<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`
+            );
         });
 
         test("should paste and transform image URL among text (collapsed)", async () => {
@@ -2576,6 +2580,10 @@ describe("link", () => {
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p><a href="${url}">${url}</a> <a href="${videoUrl}">${videoUrl}</a> <a href="${imgUrl}">${imgUrl}</a>[]</p>`
             );
+            undo(editor);
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                `<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`
+            );
         });
 
         test("should paste and transform multiple URLs (collapsed) (2)", async () => {
@@ -2585,6 +2593,10 @@ describe("link", () => {
             expect(".o-we-powerbox").toHaveCount(0);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p><a href="${url}">${url}</a> abc <a href="${videoUrl}">${videoUrl}</a> def <a href="${imgUrl}">${imgUrl}</a>[]</p>`
+            );
+            undo(editor);
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                `<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`
             );
         });
 


### PR DESCRIPTION
Fixes :
 * Prevent the Link creation when the selection span multiples Block.
 * Prevent the link extension / link Tool opening when the selection span multiple links.
 * Fix some styles loss during link creation (expect color/bgcolor, see: spec changes).

Specs changes :
 * When creating a new link on existing text, remove the color and background color style.

Improvements :
 * Change the link creation behavior to avoid inserting link in the DOM before the user validate link popover.

task-4266410


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
