### PR TITLE
[IMP] mail: slight messaging menu improvements

### DIFF
--- a/addons/mail/static/src/core/public_web/notification_item.js
+++ b/addons/mail/static/src/core/public_web/notification_item.js
@@ -44,6 +44,9 @@ export class NotificationItem extends Component {
         if (isToday(this.props.datetime)) {
             return this.props.datetime?.toLocaleString(DateTime.TIME_SIMPLE);
         }
+        if (this.props.datetime?.year === DateTime.now().year) {
+            return this.props.datetime?.toLocaleString({ month: "short", day: "numeric" });
+        }
         return this.props.datetime?.toLocaleString(DateTime.DATE_MED);
     }
 

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -61,4 +61,8 @@
     color: darken($info, 5%);
     font-size: 0.5rem;
     left: map-get($spacers, 1);
+
+    .o-mail-NotificationItem.o-small & {
+        left: map-get($spacers, 1) / 2;
+    }
 }

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -7,9 +7,9 @@
             'o-important': props.muted === 0,
             'text-muted border-transparent': props.muted === 1,
             'opacity-50 border-transparent': props.muted === 2,
-            'py-2 o-small': ui.isSmall,
+            'p-2 o-small': ui.isSmall,
             'border-top-0': props.first,
-            'px-3 py-2': !ui.isSmall,
+            'ps-3 pe-2 py-2': !ui.isSmall,
             'o-active': props.isActive,
         }">
             <span class="o-mail-NotificationItem-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': props.muted, 'opacity-50': !props.muted }"><i class="fa fa-circle"/></span>
@@ -23,9 +23,10 @@
                         <t t-slot="name"/>
                     </span>
                     <span class="flex-grow-1"/>
-                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2 opacity-75" t-att-class="{ 'fw-bolder': !props.muted, 'text-muted': props.muted }" t-att-title="props.datetime?.toLocaleString(DateTime.DATETIME_SHORT) ?? ''">
-                        <t t-esc="dateText"/>
-                    </small>
+                    <div class="d-flex align-items-center">
+                        <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted === 2 ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter"><t t-esc="props.counter"/></span>
+                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer" title="Mark As Read" t-ref="markAsRead"/>
+                    </div>
                 </div>
                 <div class="d-flex">
                     <div class="o-mail-NotificationItem-text text-truncate opacity-75" t-att-class="{ 'fw-bold': !props.muted }">
@@ -33,10 +34,9 @@
                         <t t-if="props.body" t-esc="props.body" name="notificationBody"/>
                     </div>
                     <div class="flex-grow-1"/>
-                    <div class="d-flex align-items-center">
-                        <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted === 2 ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter"><t t-esc="props.counter"/></span>
-                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer" title="Mark As Read" t-ref="markAsRead"/>
-                    </div>
+                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2 me-1 opacity-75 flex-shrink-0 align-self-end" t-att-class="{ 'fw-bold': !props.muted }" t-att-title="props.datetime?.toLocaleString(DateTime.DATETIME_SHORT) ?? ''">
+                        <t t-esc="dateText"/>
+                    </small>
                 </div>
             </div>
             <t t-if="props.slots and props.slots.requestContent">

--- a/addons/mail/static/tests/messaging_menu/notification.test.js
+++ b/addons/mail/static/tests/messaging_menu/notification.test.js
@@ -51,7 +51,7 @@ test("basic layout", async () => {
         contains: [
             [".o-mail-NotificationItem-name", { text: "Discussion Channel" }],
             [".o-mail-NotificationItem-counter", { text: "2" }],
-            [".o-mail-NotificationItem-date", { text: "Jan 1, 2019" }],
+            [".o-mail-NotificationItem-date", { text: "Jan 1" }],
             [
                 ".o-mail-NotificationItem-text",
                 {


### PR DESCRIPTION
- badge counter is top-right rather than bottom-right
- date is bottom-right rather than top-right
- date is smaller and doesn't show year if matches current year
- reduced horizontal padding in mobile

Before / After
<img width="478" alt="Screenshot 2024-12-04 at 16 25 48" src="https://github.com/user-attachments/assets/b2cc3edd-ccbf-474d-b216-16e78403be02">
<img width="483" alt="Screenshot 2024-12-04 at 16 25 20" src="https://github.com/user-attachments/assets/85e9333d-8e4b-4f47-922e-56ab269f79cd">

Before / After
<img width="401" alt="Screenshot 2024-12-04 at 16 26 00" src="https://github.com/user-attachments/assets/c085afc2-934e-4100-9e07-3f67f0f941f2"><img width="406" alt="Screenshot 2024-12-04 at 16 25 32" src="https://github.com/user-attachments/assets/d95ba7a1-ea08-4f96-bd40-485dc763f546">
