### PR TITLE
16.0 fix bom qty round afu

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -292,12 +292,13 @@ class ProductProduct(models.Model):
                         "free_qty": float_round(component.free_qty, precision_rounding=rounding),
                     }
                 )
-                ratios_virtual_available.append(float_round(component_res["virtual_available"] / qty_per_kit, precision_rounding=rounding))
-                ratios_qty_available.append(float_round(component_res["qty_available"] / qty_per_kit, precision_rounding=rounding))
-                ratios_incoming_qty.append(float_round(component_res["incoming_qty"] / qty_per_kit, precision_rounding=rounding))
-                ratios_outgoing_qty.append(float_round(component_res["outgoing_qty"] / qty_per_kit, precision_rounding=rounding))
-                ratios_free_qty.append(float_round(component_res["free_qty"] / qty_per_kit, precision_rounding=rounding))
+                ratios_virtual_available.append(component_res["virtual_available"] / qty_per_kit)
+                ratios_qty_available.append(component_res["qty_available"] / qty_per_kit)
+                ratios_incoming_qty.append(component_res["incoming_qty"] / qty_per_kit)
+                ratios_outgoing_qty.append(component_res["outgoing_qty"] / qty_per_kit)
+                ratios_free_qty.append(component_res["free_qty"] / qty_per_kit)
             if bom_sub_lines and ratios_virtual_available:  # Guard against all cnsumable bom: at least one ratio should be present.
+                rounding = product.uom_id.rounding
                 res[product.id] = {
                     'virtual_available': float_round(min(ratios_virtual_available) * bom_kits[product].product_qty, precision_rounding=rounding) // 1,
                     'qty_available': float_round(min(ratios_qty_available) * bom_kits[product].product_qty, precision_rounding=rounding) // 1,

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1321,30 +1321,34 @@ class TestBoM(TestMrpCommon):
         self.assertEqual(orderpoint.qty_to_order, 4000.0)
 
     def test_bom_kit_with_sub_kit(self):
-        p1, p2, p3, p4, p5, p6 = self.make_prods(6)
-        prod1, prod2 = self.make_prods(2)
+        p1, p2, p3, p4 = self.make_prods(4)
         self.make_bom(p1, p2, p3)
         self.make_bom(p2, p3, p4)
-        bom = self.make_bom(prod1, prod2)
-        bom.product_qty = 100
-
-        bom = self.make_bom(p5, p6)
-        bom.bom_line_ids[0].product_qty = 0.1
 
         loc = self.env.ref("stock.stock_location_stock")
         self.env["stock.quant"]._update_available_quantity(p3, loc, 10)
         self.env["stock.quant"]._update_available_quantity(p4, loc, 10)
-        self.env["stock.quant"]._update_available_quantity(prod2, loc, 5.57)
-        self.env["stock.quant"]._update_available_quantity(prod2, loc, -5)
-        self.env["stock.quant"]._update_available_quantity(p6, loc, 5.5)
-        self.env["stock.quant"]._update_available_quantity(p6, loc, -5.2)
 
         self.assertEqual(p1.qty_available, 5.0)
         self.assertEqual(p2.qty_available, 10.0)
         self.assertEqual(p3.qty_available, 10.0)
-        self.assertEqual(prod1.qty_available, 57.0)
-        self.assertEqual(p5.qty_available, 3.0)
 
+    def test_bom_round(self):
+        p1, p2, p3, p4 = self.make_prods(4)
+
+        bom = self.make_bom(p1, p2)
+        bom.product_qty = 100
+        bom = self.make_bom(p3, p4)
+        bom.bom_line_ids[0].product_qty = 0.1
+
+        loc = self.env.ref("stock.stock_location_stock")
+        self.env["stock.quant"]._update_available_quantity(p2, loc, 5.57)  # 5.57 - 5.0 != 0.57 at float level repr
+        self.env["stock.quant"]._update_available_quantity(p2, loc, -5.0)
+        self.env["stock.quant"]._update_available_quantity(p4, loc, 5.5)  # 5.5 - 5.2 != 0.3 at float level repr
+        self.env["stock.quant"]._update_available_quantity(p4, loc, -5.2)
+
+        self.assertEqual(p1.qty_available, 57.0)
+        self.assertEqual(p3.qty_available, 3.0)
 
     def test_operation_blocked_by_another_operation(self):
         """ Test that an operation is not blocked by another operation if the variant is different


### PR DESCRIPTION
## [IMP] mrp: put test case in separate method

The test case introduced in odoo/odoo@a603ec16 is not about BoMs with
sub kits. It is instead about rounding quantities.

The same for odoo/odoo@70b85484

Here we move the test cases to a dedicated test method.

## [FIX] mrp: round according to BoM product UoM

The variable `rounding` was bound to the rounding precision of each
`component` in the components loop. The final rounding for the product's
quantity must be done with the info from the product's UoM, not with the
rounding from the last component in the BoM sub-lines.

Intermediate ratios do not need to be rounded. They are ratios thus
rounding them to an UoM's precision is meaningless. Performing the
rounding in the last step for the main product still pass the tests.

See:
odoo/odoo@a603ec16
odoo/odoo@70b85484

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
