### PR TITLE
[FIX] point_of_sale: cheapest tax included

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1132,7 +1132,7 @@ export class Orderline extends PosModel {
     }
     getComboTotalPriceWithoutTax() {
         const allLines = this.getAllLinesInCombo();
-        return allLines.reduce((total, line) => total + line.get_all_prices(1).priceWithoutTax, 0);
+        return allLines.reduce((total, line) => total + line.get_base_price() / line.quantity, 0);
     }
     findAttribute(values, customAttributes) {
         const listOfAttributes = [];

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
@@ -288,3 +288,17 @@ registry.category("web_tour.tours").add("PosComboSpecificProductProgram", {
             PosLoyalty.finalizeOrder("Cash", "216.00"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosCheapestProductTaxInclude", {
+    test: true,
+    url: "/pos/web",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.clickDisplayedProduct("Product"),
+            ProductScreen.addOrderline("Desk Organizer", "1"),
+            Order.hasLine({ productName: "10% on the cheapest product" }),
+            PosLoyalty.orderTotalIs("6.00"),
+        ].flat(),
+});


### PR DESCRIPTION
Tax included in price were not taken into account when using a loyalty
program applying on the cheapest product.

Steps to reproduce:
-------------------
* Create a loyalty program that apply 10% reward on cheapest product
* Create a product A that has 10% tax included in price
* Open PoS and add this product to the order (make sure this is the 
cheapest in the order)
> Observation: The discount is not taking the tax into account

opw-4243827