### PR TITLE
[FIX] point_of_sale: prevent error when loading PoS in other currency

### DIFF
--- a/addons/point_of_sale/models/res_currency.py
+++ b/addons/point_of_sale/models/res_currency.py
@@ -7,6 +7,9 @@ class ResCurrency(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data):
+        company_currency_id = self.env['res.company'].browse(data['pos.config']['data'][0]['company_id']).currency_id.id
+        if company_currency_id != data['pos.config']['data'][0]['currency_id']:
+            return [('id', 'in', [company_currency_id, data['pos.config']['data'][0]['currency_id']])]
         return [('id', '=', data['pos.config']['data'][0]['currency_id'])]
 
     @api.model

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -74,7 +74,7 @@ export class PosOrder extends Base {
     }
 
     get currency() {
-        return this.models["res.currency"].getFirst();
+        return this.session_id.config_id.currency_id;
     }
 
     get pickingType() {

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -99,7 +99,7 @@ export class PosOrderline extends Base {
     }
 
     get currency() {
-        return this.models["res.currency"].getFirst();
+        return this.order_id.currency;
     }
 
     get pickingType() {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -235,7 +235,7 @@ export class PosStore extends Reactive {
         this.config = this.data.models["pos.config"].getFirst();
         this.company = this.data.models["res.company"].getFirst();
         this.user = this.data.models["res.users"].getFirst();
-        this.currency = this.data.models["res.currency"].getFirst();
+        this.currency = this.config.currency_id;
         this.pickingType = this.data.models["stock.picking.type"].getFirst();
         this.models = this.data.models;
 

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -46,7 +46,7 @@ export class SelfOrder extends Reactive {
         this.session = this.models["pos.session"].getFirst();
         this.config = this.models["pos.config"].getFirst();
         this.company = this.models["res.company"].getFirst();
-        this.currency = this.models["res.currency"].getFirst();
+        this.currency = this.config.currency_id;
 
         this.markupDescriptions();
         this.access_token = this.config.access_token;


### PR DESCRIPTION
Before this commit, it wasn't possible to open a PoS in a different currency than the company currency.

opw-4378523

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
