### PR TITLE
[IMP] mail, sms, various: don't display canceled message in the chatter

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -71,6 +71,7 @@ For more specific needs, you may also assign custom-defined actions
         'wizard/mail_followers_edit_views.xml',
         'wizard/mail_template_reset_views.xml',
         'views/fetchmail_views.xml',
+        'views/ir_cron_views.xml',
         'views/mail_message_subtype_views.xml',
         'views/mail_tracking_value_views.xml',
         'views/mail_notification_views.xml',

--- a/addons/mail/views/ir_cron_views.xml
+++ b/addons/mail/views/ir_cron_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_cron_view_form" model="ir.ui.view">
+        <field name="name">ir.cron.view.form.inherit</field>
+        <field name="model">ir.cron</field>
+        <field name="inherit_id" ref="base.ir_cron_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='user_id']" position="attributes">
+                <attribute name="widget">many2one_avatar_user</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/mass_mailing/tests/common.py
+++ b/addons/mass_mailing/tests/common.py
@@ -36,7 +36,7 @@ class MassMailCase(MailCase, MockLinkTracker):
             )
 
     def assertMailTraces(self, recipients_info, mailing, records,
-                         check_mail=True, sent_unlink=False,
+                         check_mail=True, is_cancel_not_sent=True, sent_unlink=False,
                          author=None, mail_links_info=None):
         """ Check content of traces. Traces are fetched based on a given mailing
         and records. Their content is compared to recipients_info structure that
@@ -69,12 +69,15 @@ class MassMailCase(MailCase, MockLinkTracker):
         :param records: records given to mailing that generated traces. It is
           used notably to find traces using their IDs;
         :param check_mail: if True, also check mail.mail records that should be
-          linked to traces;
+          linked to traces unless not sent (trace_status == 'cancel');
+        :param is_cancel_not_sent: if True, also check that no mail.mail/mail.message
+          related to "cancel trace" have been created and disable check_mail for those.
         :param sent_unlink: it True, sent mail.mail are deleted and we check gateway
           output result instead of actual mail.mail records;
         :param mail_links_info: if given, should follow order of ``recipients_info``
           and give details about links. See ``assertLinkShortenedHtml`` helper for
-          more details about content to give;
+          more details about content to give.
+          Not tested for mail with trace status == 'cancel' if is_cancel_not_sent;
         :param author: author of sent mail.mail;
         """
         # map trace state to email state
@@ -141,13 +144,22 @@ class MassMailCase(MailCase, MockLinkTracker):
                     email, partner, status, record,
                     len(recipient_trace), debug_info)
             )
-            self.assertTrue(bool(recipient_trace.mail_mail_id_int))
+            mail_not_created = is_cancel_not_sent and recipient_trace.trace_status == 'cancel'
+            self.assertTrue(mail_not_created or bool(recipient_trace.mail_mail_id_int))
             if 'failure_type' in recipient_info or status in ('error', 'cancel', 'bounce'):
                 self.assertEqual(recipient_trace.failure_type, failure_type)
             if 'failure_reason' in recipient_info:
                 self.assertEqual(recipient_trace.failure_reason, failure_reason)
+            if mail_not_created:
+                self.assertFalse(recipient_trace.mail_mail_id_int)
+                self.assertFalse(self.env['mail.mail'].sudo().search(
+                    [('model', '=', record._name), ('res_id', '=', record.id),
+                     ('id', 'in', self._new_mails.ids)]))
+                self.assertFalse(self.env['mail.message'].sudo().search(
+                    [('model', '=', record._name), ('res_id', '=', record.id),
+                     ('id', 'in', self._new_mails.mail_message_id.ids)]))
 
-            if check_mail:
+            if check_mail and not mail_not_created:
                 if author is None:
                     author = self.env.user.partner_id
 
@@ -194,7 +206,7 @@ class MassMailCase(MailCase, MockLinkTracker):
                         fields_values=fields_values,
                     )
 
-            if link_info:
+            if link_info and not mail_not_created:
                 trace_mail = self._find_mail_mail_wrecord(record)
                 for (anchor_id, url, is_shortened, add_link_params) in link_info:
                     link_params = {'utm_medium': 'Email', 'utm_source': mailing.name}

--- a/addons/mass_mailing_sms/views/mailing_trace_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_trace_views.xml
@@ -84,6 +84,12 @@
         <field name="priority">20</field>
         <field name="arch" type="xml">
             <form string="SMS Trace" create="0" edit="0">
+                <div class="alert alert-info text-center"
+                    invisible="trace_status != 'error' or
+                               failure_type in ('sms_not_delivered', 'sms_not_allowed', 'sms_invalid_destination', 'sms_rejected', 'sms_rejected')"
+                    role="alert">
+                    <strong>This SMS could not be sent.</strong>
+                </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button name="action_view_contact"
@@ -93,12 +99,6 @@
                     </div>
                     <field name="is_test_trace" invisible="1"/>
                     <widget name="web_ribbon" title="Test" bg_color="text-bg-danger" invisible="is_test_trace != True"/>
-                    <div class="alert alert-info text-center"
-                        invisible="trace_status != 'error' or
-                                   failure_type in ('sms_not_delivered', 'sms_not_allowed', 'sms_invalid_destination', 'sms_rejected', 'sms_rejected')"
-                        role="alert">
-                        <strong>This SMS could not be sent.</strong>
-                    </div>
                     <div class="alert alert-info text-center"
                         invisible="trace_status != 'error' or
                                    failure_type not in ('sms_not_delivered', 'sms_not_allowed', 'sms_invalid_destination', 'sms_rejected', 'sms_rejected')"

--- a/addons/mass_mailing_sms/wizard/sms_composer.py
+++ b/addons/mass_mailing_sms/wizard/sms_composer.py
@@ -77,16 +77,19 @@ class SmsComposer(models.TransientModel):
         return all_bodies
 
     def _prepare_mass_sms_values(self, records):
+        # In mass mailing only, add 'mailing.trace' values directly in the o2m field
         result = super()._prepare_mass_sms_values(records)
-        if self.composition_mode == 'mass' and self.mailing_id:
-            for record in records:
-                sms_values = result[record.id]
+        if not self._is_mass_sms():
+            return result
 
-                trace_values = self._prepare_mass_sms_trace_values(record, sms_values)
-                sms_values.update({
-                    'mailing_id': self.mailing_id.id,
-                    'mailing_trace_ids': [(0, 0, trace_values)],
-                })
+        for record in records:
+            sms_values = result[record.id]
+
+            trace_values = self._prepare_mass_sms_trace_values(record, sms_values)
+            sms_values.update({
+                'mailing_id': self.mailing_id.id,
+                'mailing_trace_ids': [(0, 0, trace_values)],
+            })
         return result
 
     def _prepare_mass_sms(self, records, sms_record_values):
@@ -96,3 +99,25 @@ class SmsComposer(models.TransientModel):
             for sms in sms_all:
                 sms.body = updated_bodies[sms.id]
         return sms_all
+
+    def _is_mass_sms(self):
+        return self.composition_mode == 'mass' and self.mailing_id
+
+    def _filter_out_and_handle_revoked_sms_values(self, sms_values_all):
+        # Filter out canceled sms of mass mailing and create traces for canceled ones.
+        results = super()._filter_out_and_handle_revoked_sms_values(sms_values_all)
+        if not self._is_mass_sms():
+            return results
+        self.env['mailing.trace'].sudo().create([
+            trace_commands[0][2]
+            for mail_values in results.values()
+            if mail_values.get('state') == 'canceled' and mail_values['mailing_trace_ids']
+            for trace_commands in (mail_values['mailing_trace_ids'],)
+            # Ensure it is a create command
+            if len(trace_commands) == 1 and len(trace_commands[0]) == 3 and trace_commands[0][0] == 0
+        ])
+        return {
+            res_id: sms_values
+            for res_id, sms_values in results.items()
+            if sms_values.get('state') != 'canceled'
+        }

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -101,6 +101,8 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
 
         self.assertEqual(mailing.sent, 50)
         self.assertEqual(mailing.delivered, 50)
+        self.assertEqual(mailing.canceled, 12)
 
-        cancelled_mail_count = self.env['mail.mail'].sudo().search([('mailing_id', '=', mailing.id)])
-        self.assertEqual(len(cancelled_mail_count), 12, 'Should not have auto deleted the blacklisted emails')
+        mail_mail_count = len(self.env['mail.mail'].sudo().search([('mailing_id', '=', mailing.id)]))
+        self.assertEqual(mail_mail_count, 0,
+                         "Mail_mail for blacklisted emails mustn't have been created and others must have been deleted")


### PR DESCRIPTION
[IMP] mail, {test_}mass_mailing: don't display canceled message

For mailing only, in order to not display most messages not sent to the recipient in the chatter, when sending the messages, we filter out canceled ones and directly create traces for them in _filter_out_and_handle_revoked_mail_values.

The mails sent without a mailing will be handled in another PR using mail notification instead of traces for handling errors.

[IMP] mass_mailing_sms, sms, test_mailing_sms: don't display canceled message

For mailing only, in order to not display most messages not sent to the recipient in the chatter, when sending the messages, we filter out canceled ones and directly create traces for them in _filter_out_and_handle_revoked_sms_values.

The sms sent without a mailing will be handled in another PR using mail notification instead of traces for handling errors.

We also ensure that when a sms is logged in the chatter using a mail message, the mail message is linked to the sms.

[IMP] mail: add the avatar widget on the user field of the cron form

We add the avatar widget on the user field of the cron form. We do it in the mail module rather than in base as that widget is defined in mail.

Task-3264570