### PR TITLE
[FIX] html_editor: better logic for deducting url from the text

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -248,6 +248,7 @@ export class ClipboardPlugin extends Plugin {
             this.handlePasteHtml(selection, ev.clipboardData) ||
             this.handlePasteText(selection, ev.clipboardData);
 
+        this.dispatchTo("after_paste_handlers", selection);
         this.dependencies.history.addStep();
     }
     /**

--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -150,6 +150,7 @@ export class DeletePlugin extends Plugin {
      */
     delete(direction, granularity) {
         const selection = this.dependencies.selection.getEditableSelection();
+        this.dispatchTo("before_delete_handlers");
 
         if (!selection.isCollapsed) {
             this.deleteSelection(selection);
@@ -1180,7 +1181,9 @@ export class DeletePlugin extends Plugin {
         if (ev.inputType === "insertText") {
             const selection = this.dependencies.selection.getSelectionData().deepEditableSelection;
             if (!selection.isCollapsed) {
+                this.dispatchTo("before_delete_handlers");
                 this.deleteSelection(selection);
+                this.dispatchTo("delete_handlers");
             }
             // Default behavior: insert text and trigger input event
         }

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -225,6 +225,11 @@ export class LinkPlugin extends Plugin {
 
         /** Handlers */
         beforeinput_handlers: withSequence(5, this.onBeforeInput.bind(this)),
+        input_handlers: this.onInputDeleteNormalizeLink.bind(this),
+        before_delete_handlers: this.updateCurrentLinkSyncState.bind(this),
+        delete_handlers: this.onInputDeleteNormalizeLink.bind(this),
+        before_paste_handlers: this.updateCurrentLinkSyncState.bind(this),
+        after_paste_handlers: this.onPasteNormalizeLink.bind(this),
         selectionchange_handlers: this.handleSelectionChange.bind(this),
         clean_for_save_handlers: ({ root }) => this.removeEmptyLinks(root),
         normalize_handlers: this.normalizeLink.bind(this),
@@ -349,15 +354,6 @@ export class LinkPlugin extends Plugin {
     }
 
     normalizeLink(root) {
-        const { anchorNode } = this.dependencies.selection.getEditableSelection();
-        const linkEl = closestElement(anchorNode, "a");
-        if (linkEl && linkEl.isContentEditable) {
-            const label = linkEl.innerText;
-            const url = deduceURLfromText(label, linkEl);
-            if (url) {
-                linkEl.setAttribute("href", url);
-            }
-        }
         for (const anchorEl of selectElements(root, "a")) {
             const { color } = anchorEl.style;
             const childNodes = [...anchorEl.childNodes];
@@ -719,6 +715,22 @@ export class LinkPlugin extends Plugin {
         }
     }
 
+    updateCurrentLinkSyncState() {
+        const { anchorNode } = this.dependencies.selection.getEditableSelection();
+        const linkEl = closestElement(anchorNode, "a");
+        if (linkEl && linkEl.isContentEditable) {
+            const label = linkEl.innerText;
+            const url = deduceURLfromText(label, linkEl);
+            const href = linkEl.getAttribute("href");
+            if (
+                url &&
+                (url === href || url + "/" === href || url === deduceURLfromText(href, linkEl))
+            ) {
+                this.isCurrentLinkInSync = true;
+            }
+        }
+    }
+
     onBeforeInput(ev) {
         if (ev.inputType === "insertParagraph" || ev.inputType === "insertLineBreak") {
             const nodeForSelectionRestore = this.handleAutomaticLinkInsertion();
@@ -749,7 +761,29 @@ export class LinkPlugin extends Plugin {
                 ev.preventDefault();
             }
         }
+        this.updateCurrentLinkSyncState();
     }
+
+    onInputDeleteNormalizeLink() {
+        const { anchorNode } = this.dependencies.selection.getEditableSelection();
+        const linkEl = closestElement(anchorNode, "a");
+        if (linkEl && linkEl.isContentEditable) {
+            const label = linkEl.innerText;
+            const url = deduceURLfromText(label, linkEl);
+            if (url && this?.isCurrentLinkInSync) {
+                linkEl.setAttribute("href", url);
+                this.isCurrentLinkInSync = false;
+                if (this.overlay.isOpen) {
+                    this.overlay.close();
+                }
+            }
+        }
+    }
+    onPasteNormalizeLink() {
+        this.updateCurrentLinkSyncState();
+        this.onInputDeleteNormalizeLink();
+    }
+
     /**
      * Inserts a link in the editor. Called after pressing space or (shif +) enter.
      * Performs a regex check to determine if the url has correct syntax.

--- a/addons/html_editor/static/tests/link/edit_label.test.js
+++ b/addons/html_editor/static/tests/link/edit_label.test.js
@@ -40,14 +40,14 @@ describe("range collapsed", () => {
             stepFunction: async (editor) => {
                 await insertText(editor, "o");
             },
-            contentAfter: '<p>a<a href="https://google.com">goo[]gle.com</a>b</p>',
+            contentAfter: '<p>a<a href="https://else.com">goo[]gle.com</a>b</p>',
         });
         await testEditor({
             contentBefore: '<p>a<a href="https://else.com">http://go[]gle.com</a>b</p>',
             stepFunction: async (editor) => {
                 await insertText(editor, "o");
             },
-            contentAfter: '<p>a<a href="http://google.com">http://goo[]gle.com</a>b</p>',
+            contentAfter: '<p>a<a href="https://else.com">http://goo[]gle.com</a>b</p>',
         });
         await testEditor({
             contentBefore: '<p>a<a href="mailto:hello@moto.com">hello@moto[].com</a></p>',
@@ -140,14 +140,14 @@ describe("range not collapsed", () => {
             stepFunction: async (editor) => {
                 await insertText(editor, "google");
             },
-            contentAfter: '<p>a<a href="https://google.com">google[].com</a>b</p>',
+            contentAfter: '<p>a<a href="https://gogle.com">google[].com</a>b</p>',
         });
         await testEditor({
             contentBefore: '<p>a<a href="https://else.com">go[gle.c]om</a>b</p>',
             stepFunction: async (editor) => {
                 await insertText(editor, ".c");
             },
-            contentAfter: '<p>a<a href="https://go.com">go.c[]om</a>b</p>',
+            contentAfter: '<p>a<a href="https://else.com">go.c[]om</a>b</p>',
         });
     });
 

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -260,11 +260,9 @@ describe("Link creation", () => {
             await animationFrame();
             expect(".active .o-we-command-name").toHaveText("Link");
             await click(".o-we-command-name:first");
-            await waitFor(".o-we-linkpopover");
-            await fill("test.com");
-            await click(".o_we_apply_link");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("test.com");
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p><a href="https://test.com">test.com[]</a></p>'
+                '<p><a href="http://test.com">test.com[]</a></p>'
             );
         });
 

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -2435,18 +2435,18 @@ describe("link", () => {
             });
         });
 
-        test("should paste and transform an URL in a existing link if pasting valid url (collapsed)", async () => {
+        test("should paste and update an URL in a existing link if label and url are aligned", async () => {
             await testEditor({
                 contentBefore: '<p>a<a href="http://existing.com">[]c</a>d</p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "https://www.xyz.xdc");
                 },
-                contentAfter: '<p>a<a href="https://www.xyz.xdcc">https://www.xyz.xdc[]c</a>d</p>',
+                contentAfter: '<p>a<a href="http://existing.com">https://www.xyz.xdc[]c</a>d</p>',
             });
             await testEditor({
-                contentBefore: '<p>a<a href="http://existing.com">b[].com</a>d</p>',
+                contentBefore: '<p>a<a href="http://bo.com">bo[].com</a>d</p>',
                 stepFunction: async (editor) => {
-                    pasteText(editor, "oom");
+                    pasteText(editor, "om");
                 },
                 contentAfter: '<p>a<a href="http://boom.com">boom[].com</a>d</p>',
             });
@@ -2540,11 +2540,24 @@ describe("link", () => {
                 stepFunction: async (editor) => {
                     pasteHtml(
                         editor,
-                        '<a href="www.odoo.com">odoo.com</a><br><a href="www.google.com">google.com</a>'
+                        '<a href="www.odoo.com">odoo.com</a><br><a href="google.com">google.com</a>'
                     );
                 },
                 contentAfter:
                     '<p><a href="www.odoo.com">odoo.com</a></p><p><a href="https://google.com">google.com[]</a></p>',
+            });
+        });
+        test("should paste html content over an empty link (collapsed) (2)", async () => {
+            await testEditor({
+                contentBefore: '<p><a href="#">[]\u200B</a></p>',
+                stepFunction: async (editor) => {
+                    pasteHtml(
+                        editor,
+                        '<a href="www.odoo.com">odoo.com</a><br><a href="www.google.com">google.com</a>'
+                    );
+                },
+                contentAfter:
+                    '<p><a href="www.odoo.com">odoo.com</a></p><p><a href="www.google.com">google.com[]</a></p>',
             });
         });
 
@@ -2823,11 +2836,24 @@ describe("link", () => {
                 stepFunction: async (editor) => {
                     pasteHtml(
                         editor,
-                        '<a href="www.odoo.com">odoo.com</a><br><a href="www.google.com">google.com</a>'
+                        '<a href="www.odoo.com">odoo.com</a><br><a href="google.com">google.com</a>'
                     );
                 },
                 contentAfter:
                     '<p><a href="www.odoo.com">odoo.com</a></p><p><a href="https://google.com">google.com[]</a></p>',
+            });
+        });
+        test("should paste html content over a link if all of its contents is selected (not collapsed) (2)", async () => {
+            await testEditor({
+                contentBefore: '<p><a href="#">[xyz]</a></p>',
+                stepFunction: async (editor) => {
+                    pasteHtml(
+                        editor,
+                        '<a href="www.odoo.com">odoo.com</a><br><a href="www.google.com">google.com</a>'
+                    );
+                },
+                contentAfter:
+                    '<p><a href="www.odoo.com">odoo.com</a></p><p><a href="www.google.com">google.com[]</a></p>',
             });
         });
     });


### PR DESCRIPTION
Before this commit:
The deduceURLfromText function was executed at the normalization step.
This caused restrictions when creating links, as the link's href would
be overridden if the label was deducible to a URL.

Example: If a user wanted to link a WhatsApp URL to a phone number, the
href would automatically change to tel:1234, making it impossible to set
a different URL.

After this commit:
The deduceURLfromText function is no longer part of the normalization
process. Instead:

1. It is executed only when the user change directly inside a link, not
when editing through a link popover. User change can be input, paste or
delete
2. If the user edits the link using the popover, the href will not be
overridden by deduceURLfromText.
3. If the current href differs from the deduced URL, the href remains
unchanged.
4. If the deduced URL matches the current href and the user changes the
link's text by typing, pasting or deleting, the href will also be
updated to reflect the text changes.

These adjustments ensure better flexibility and prevent unwanted
overrides when creating or editing links. Related link tests are also
adapted.

task-3787019




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
