### PR TITLE
[FIX] mail: chat window more actions hover zone small adjustment

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -17,7 +17,7 @@
                 <div class="d-flex text-truncate">
                     <Dropdown position="'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="'d-flex flex-column py-0'">
                         <button
-                            class="o-mail-ChatWindow-command o-actionsMenu btn rounded-0 d-flex align-items-center p-1 mx-1 my-0 w-100 rounded-end-0"
+                            class="o-mail-ChatWindow-command o-actionsMenu btn rounded-0 d-flex align-items-center px-2 py-1 my-0 w-100 rounded-end-0"
                             t-att-class="{ 'rounded-top-3': !ui.isSmall, 'o-active': state.actionsMenuOpened, 'o-hover': actionsMenuButtonHover.isHover and !parentChannelHover.isHover }"
                             t-att-disabled="state.editingName or state.actionsDisabled"
                             t-att-title="actionsMenuTitleText"


### PR DESCRIPTION
When mouse-hovering more actions (the conversation name & avatar), the clickable zone had a small dead zone on the left. This comes from `mx-1`, which put good spacing but had the unintentional deadzone spacing.

This commit replaces the `mx-1` by equivalent extra padding, thus removing the deadzone while keeping the overall same spacing.

Before / After
<img width="391" alt="Screenshot 2024-12-04 at 16 50 52" src="https://github.com/user-attachments/assets/323d8ece-2965-49c3-acc6-d2e4590c1fb2">
<img width="390" alt="Screenshot 2024-12-04 at 16 50 38" src="https://github.com/user-attachments/assets/97ba506d-8fa4-4825-957a-5f22be9910fe">

Difference (red)
<img width="1911" alt="Screenshot 2024-12-05 at 12 44 00" src="https://github.com/user-attachments/assets/aa7c9079-f2b4-467d-8e1f-58f2ce9b8da1">
