### PR TITLE
[FIX] hr_holidays: restrain time off (,type) on overview

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -28,7 +28,8 @@ class LeaveReportCalendar(models.Model):
         ('validate', 'Approved')
     ], readonly=True)
     description = fields.Char("Description", readonly=True, groups='hr_holidays.group_hr_holidays_user')
-    holiday_status_id = fields.Many2one('hr.leave.type', readonly=True, string="Time Off Type")
+    holiday_status_id = fields.Many2one('hr.leave.type', readonly=True, string="Time Off Type",
+        groups='hr_holidays.group_hr_holidays_user')
 
     is_hatched = fields.Boolean('Hatched', readonly=True)
     is_striked = fields.Boolean('Striked', readonly=True)
@@ -97,7 +98,7 @@ class LeaveReportCalendar(models.Model):
                 # Include the time off type name
                 leave.name += f" {leave.leave_id.holiday_status_id.name}"
             # Include the time off duration.
-            leave.name += f": {leave.leave_id.sudo().duration_display}"
+            leave.name += f": {leave.sudo().leave_id.duration_display}"
 
     @api.depends('leave_manager_id')
     def _compute_is_manager(self):


### PR DESCRIPTION
FIX 1:
Before this commit, it was possible for anyone to group by time off type on the overview, allowing users without the right to see the time off type of other employee's leaves.

Steps to reproduce:
- Log with an employee without time off rights
- Go on the time off overview so that you see leaves that aren't for the user
- add a groupby on time off type

This commit adds a group constraint on that field for the overview.

FIX 2:
Before this commit, PR odoo/odoo#188393 introduced a restriction on the `leave_id` field for the overview, breaking at the same time the "view" option.

Steps to reproduce:
- Log with an employee without time off rights
- Go on the time off overview
- click on any leave
- click on "View"
- an access error is raised

This commit adds some sudo where needed to fetch the info on the `leave_id` field while keeping the restriction introduced in the mentioned PR.

task-4381185