### PR TITLE
[FIX] mail: livechat action hover style matches header color

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.dark.scss
+++ b/addons/mail/static/src/core/common/chat_window.dark.scss
@@ -1,3 +1,0 @@
-.o-mail-ChatWindow-command {
-    --mail-ChatWindow-commandHoverBg: #{mix($gray-200, $gray-300)};
-}

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -18,7 +18,7 @@
         padding: map-get($spacers, 1) / 2;
     }
     &:hover:not(.o-actionsMenu), &.o-active, &.o-hover {
-        background-color: var(--mail-ChatWindow-commandHoverBg, mix($gray-100, $gray-200));
+        backdrop-filter: invert(.15);
         border-color: transparent !important;
     }
     &:not(.o-active):not(.o-hover) .fa-caret-down {


### PR DESCRIPTION
Chat window action mouse hover effect was hardcoded for white and dark theme.

In livechat, the header color can be customised. With the default colors (purple background and white text), the hover effect had white background, which made the action not visible.

This commit fixes the issue by using a slight color invert when mouse hovering the action of a chat window, so that the color is slightly different from header color while keeping icon color distinguishable.

Before / After
<img width="390" alt="Screenshot 2024-12-04 at 17 10 23" src="https://github.com/user-attachments/assets/f4993b05-5f69-4de6-8423-fc69f7b2bdd7"> <img width="393" alt="Screenshot 2024-12-04 at 17 09 37" src="https://github.com/user-attachments/assets/1c867d1a-8df8-46e3-ae04-e68154e169a5">

White and dark theme are more catchy as a result:

Before / After (white theme)
<img width="394" alt="Screenshot 2024-12-04 at 17 11 16" src="https://github.com/user-attachments/assets/e29578ca-8b15-45d9-828a-aa65b43a6b23"> <img width="384" alt="Screenshot 2024-12-04 at 17 11 40" src="https://github.com/user-attachments/assets/025b2145-b783-4ab0-bf94-44fe24d32d81">


Before / After (dark theme)
<img width="389" alt="Screenshot 2024-12-04 at 17 11 05" src="https://github.com/user-attachments/assets/be50f34d-7468-415b-b365-734fed3e9001"> <img width="387" alt="Screenshot 2024-12-04 at 17 11 59" src="https://github.com/user-attachments/assets/8a0a8c09-c179-4e1e-befe-0fcdff3a181c">
