### PR TITLE
[FIX] account,*: make proforma invoice titles correctly translatable

### DIFF
--- a/addons/account/tests/test_portal_invoice.py
+++ b/addons/account/tests/test_portal_invoice.py
@@ -54,4 +54,4 @@ class TestPortalInvoice(AccountTestInvoicingHttpCommon):
         self.authenticate(self.user_portal.login, self.user_portal.login)
         res = self.url_open(url)
         self.assertEqual(res.status_code, 200)
-        self.assertIn("<span>PROFORMA</span>", res.content.decode('utf-8'))
+        self.assertIn("Proforma", res.content.decode('utf-8'))

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -51,16 +51,58 @@
                 <div class="clearfix invoice_main">
                     <div class="page mb-4">
                         <t t-set="layout_document_title">
-                            <span t-if="not proforma"></span>
-                            <span t-else="">PROFORMA</span>
-                            <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">Invoice</span>
-                            <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Invoice</span>
-                            <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled Invoice</span>
-                            <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">Credit Note</span>
-                            <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">Draft Credit Note</span>
-                            <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">Cancelled Credit Note</span>
-                            <span t-elif="o.move_type == 'in_refund'">Vendor Credit Note</span>
-                            <span t-elif="o.move_type == 'in_invoice'">Vendor Bill</span>
+                            <t t-if="not proforma">
+                                <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">
+                                    <t name="invoice_title">Invoice</t>
+                                </span>
+                                <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">
+                                    <t name="draft_invoice_title">Draft Invoice</t>
+                                </span>
+                                <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel'">
+                                    <t name="cancelled_invoice_title">Cancelled Invoice</t>
+                                </span>
+                                <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">
+                                    <t name="credit_note_title">Credit Note</t>
+                                </span>
+                                <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">
+                                    <t name="draft_credit_note_title">Draft Credit Note</t>
+                                </span>
+                                <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">
+                                    <t name="cancelled_credit_note_title">Cancelled Credit Note</t>
+                                </span>
+                                <span t-elif="o.move_type == 'in_refund'">
+                                    <t name="vendor_credit_note_title">Vendor Credit Note</t>
+                                </span>
+                                <span t-elif="o.move_type == 'in_invoice'">
+                                    <t name="vendor_bill_title">Vendor Bill</t>
+                                </span>
+                            </t>
+                            <t t-else="">
+                                <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">
+                                    <t name="proforma_invoice_title">Proforma Invoice</t>
+                                </span>
+                                <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">
+                                    <t name="draft_proforma_invoice_title">Draft Proforma Invoice</t>
+                                </span>
+                                <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel'">
+                                    <t name="cancelled_proforma_invoice_title">Cancelled Proforma Invoice</t>
+                                </span>
+                                <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">
+                                    <t name="proforma_credit_note_title">Proforma Credit Note</t>
+                                </span>
+                                <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">
+                                    <t name="draft_proforma_credit_note_title">Draft Proforma Credit Note</t>
+                                </span>
+                                <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">
+                                    <t name="cancelled_proforma_credit_note_title">Cancelled Proforma Credit Note</t>
+                                </span>
+                                <span t-elif="o.move_type == 'in_refund'">
+                                    <t name="proforma_vendor_credit_note_title">Proforma Vendor Credit Note</t>
+                                </span>
+                                <span t-elif="o.move_type == 'in_invoice'">
+                                    <t name="proforma_vendor_bill_title">Proforma Vendor Bill</t>
+                                </span>
+                            </t>
                             <span t-if="o.name != '/'" t-field="o.name">INV/2023/0001</span>
                         </t>
                         <div class="oe_structure"></div>
@@ -378,7 +420,7 @@
                     >0</span>
                 </td>
             </tr>
-            
+
             <!--Total amount with all taxes-->
             <tr class="o_total">
                 <td><strong>Total</strong></td>

--- a/addons/l10n_ae/views/report_invoice_templates.xml
+++ b/addons/l10n_ae/views/report_invoice_templates.xml
@@ -9,10 +9,82 @@
                 </b>
             </p>
         </xpath>
-        <xpath expr="//t[@t-set='layout_document_title']/span" position="before">
-            <span t-if="o.company_id.country_id.code == 'AE' and o.move_type in ['out_invoice', 'out_refund']">TAX
-            </span>
-        </xpath>
+
+        <t name="invoice_title" position="before">
+            <t name="tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Tax Invoice</t>
+        </t>
+        <t name="invoice_title" position="attributes">
+            <attribute name="t-else"/>
+        </t>
+        <t name="draft_invoice_title" position="before">
+            <t name="draft_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Draft Tax Invoice</t>
+        </t>
+        <t name="draft_invoice_title" position="attributes">
+            <attribute name="t-else"/>
+        </t>
+        <t name="cancelled_invoice_title" position="before">
+            <t name="cancelled_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Tax Invoice</t>
+        </t>
+        <t name="cancelled_invoice_title" position="attributes">
+            <attribute name="t-else"/>
+        </t>
+
+        <t name="credit_note_title" position="before">
+            <t name="tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Tax Credit Note</t>
+        </t>
+        <t name="credit_note_title" position="attributes">
+            <attribute name="t-else"/>
+        </t>
+        <t name="draft_credit_note_title" position="before">
+            <t name="draft_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Draft Tax Credit Note</t>
+        </t>
+        <t name="draft_credit_note_title" position="attributes">
+            <attribute name="t-else"/>
+        </t>
+        <t name="cancelled_credit_note_title" position="before">
+            <t name="cancelled_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Tax Credit Note</t>
+        </t>
+        <t name="cancelled_credit_note_title" position="attributes">
+            <attribute name="t-else"/>
+        </t>
+
+        <t name="proforma_invoice_title" position="before">
+            <t name="proforma_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Proforma Tax Invoice</t>
+        </t>
+        <t name="proforma_invoice_title" position="attributes">
+            <attribute name="t-else"/>
+        </t>
+        <t name="draft_proforma_invoice_title" position="before">
+            <t name="draft_proforma_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Draft Proforma Tax Invoice</t>
+        </t>
+        <t name="draft_proforma_invoice_title" position="attributes">
+            <attribute name="t-else"/>
+        </t>
+        <t name="cancelled_proforma_invoice_title" position="before">
+            <t name="cancelled_proforma_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Proforma Tax Invoice</t>
+        </t>
+        <t name="cancelled_proforma_invoice_title" position="attributes">
+            <attribute name="t-else"/>
+        </t>
+
+        <t name="proforma_credit_note_title" position="before">
+            <t name="proforma_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Proforma Tax Credit Note</t>
+        </t>
+        <t name="proforma_credit_note_title" position="attributes">
+            <attribute name="t-else"/>
+        </t>
+        <t name="draft_proforma_credit_note_title" position="before">
+            <t name="draft_proforma_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Draft Proforma Tax Credit Note</t>
+        </t>
+        <t name="draft_proforma_credit_note_title" position="attributes">
+            <attribute name="t-else"/>
+        </t>
+        <t name="cancelled_proforma_credit_note_title" position="before">
+            <t name="cancelled_proforma_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Proforma Tax Credit Note</t>
+        </t>
+        <t name="cancelled_proforma_credit_note_title" position="attributes">
+            <attribute name="t-else"/>
+        </t>
 
         <xpath expr="//thead//th[@name='th_taxes']" position="replace">
             <th name="th_taxes"

--- a/addons/l10n_au/views/report_invoice.xml
+++ b/addons/l10n_au/views/report_invoice.xml
@@ -1,19 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document" primary="True">
-        <xpath expr="//div[hasclass('page')]/t[@t-set='layout_document_title']" position="replace">
-            <t t-set="layout_document_title">
-                <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">Tax Invoice</span>
-                <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Tax Invoice</span>
-                <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled Tax Invoice</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">Tax Credit Note</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">Draft Tax Credit Note</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">Cancelled Tax Credit Note</span>
-                <span t-elif="o.move_type == 'in_refund'">Tax Vendor Credit Note</span>
-                <span t-elif="o.move_type == 'in_invoice'">Tax Vendor Bill</span>
-                <span t-if="o.name != '/'" t-field="o.name"/>
-            </t>
-        </xpath>
+        <t name="invoice_title" position="replace">
+            <t name="invoice_title">Tax Invoice</t>
+        </t>
+        <t name="draft_invoice_title" position="replace">
+            <t name="draft_invoice_title">Draft Tax Invoice</t>
+        </t>
+        <t name="cancelled_invoice_title" position="replace">
+            <t name="cancelled_invoice_title">Cancelled Tax Invoice</t>
+        </t>
+        <t name="credit_note_title" position="replace">
+            <t name="credit_note_title">Tax Credit Note</t>
+        </t>
+        <t name="draft_credit_note_title" position="replace">
+            <t name="draft_credit_note_title">Draft Tax Credit Note</t>
+        </t>
+        <t name="cancelled_credit_note_title" position="replace">
+            <t name="cancelled_credit_note_title">Cancelled Tax Credit Note</t>
+        </t>
+        <t name="vendor_credit_note_title" position="replace">
+            <t name="vendor_credit_note_title">Tax Vendor Credit Note</t>
+        </t>
+        <t name="vendor_bill_title" position="replace">
+            <t name="vendor_bill_title">Tax Vendor Bill</t>
+        </t>
+        <t name="proforma_invoice_title" position="replace">
+            <t name="proforma_invoice_title">Proforma Tax Invoice</t>
+        </t>
+        <t name="draft_proforma_invoice_title" position="replace">
+            <t name="draft_proforma_invoice_title">Draft Proforma Tax Invoice</t>
+        </t>
+        <t name="cancelled_proforma_invoice_title" position="replace">
+            <t name="cancelled_proforma_invoice_title">Cancelled Proforma Tax Invoice</t>
+        </t>
+        <t name="proforma_credit_note_title" position="replace">
+            <t name="proforma_credit_note_title">Proforma Tax Credit Note</t>
+        </t>
+        <t name="draft_proforma_credit_note_title" position="replace">
+            <t name="draft_proforma_credit_note_title">Draft Proforma Tax Credit Note</t>
+        </t>
+        <t name="cancelled_proforma_credit_note_title" position="replace">
+            <t name="cancelled_proforma_credit_note_title">Cancelled Proforma Tax Credit Note</t>
+        </t>
+        <t name="proforma_vendor_credit_note_title" position="replace">
+            <t name="proforma_vendor_credit_note_title">Proforma Tax Vendor Credit Note</t>
+        </t>
+        <t name="proforma_vendor_bill_title" position="replace">
+            <t name="proforma_vendor_bill_title">Proforma Tax Vendor Bill</t>
+        </t>
     </template>
 
     <!-- Workaround for Studio reports, see odoo/odoo#60660 -->

--- a/addons/l10n_in/i18n/l10n_in.pot
+++ b/addons/l10n_in/i18n/l10n_in.pot
@@ -174,13 +174,15 @@ msgid "CGST (RC)"
 msgstr ""
 
 #. module: l10n_in
-#: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
-msgid "Cancelled"
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Cancelled %(journal_name)s"
 msgstr ""
 
 #. module: l10n_in
-#: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
-msgid "Cancelled Credit Note"
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Cancelled Proforma %(journal_name)s"
 msgstr ""
 
 #. module: l10n_in
@@ -262,11 +264,6 @@ msgid "Created on"
 msgstr ""
 
 #. module: l10n_in
-#: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
-msgid "Credit Note"
-msgstr ""
-
-#. module: l10n_in
 #: model:iap.service,unit_name:l10n_in.iap_service_l10n_in_edi
 msgid "Credits"
 msgstr ""
@@ -300,13 +297,15 @@ msgid "Display pan warning"
 msgstr ""
 
 #. module: l10n_in
-#: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
-msgid "Draft"
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Draft %(journal_name)s"
 msgstr ""
 
 #. module: l10n_in
-#: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
-msgid "Draft Credit Note"
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Draft Proforma %(journal_name)s"
 msgstr ""
 
 #. module: l10n_in
@@ -526,6 +525,11 @@ msgid "India Port Code"
 msgstr ""
 
 #. module: l10n_in
+#: model:res.country.group,name:l10n_in.inter_state_group
+msgid "India inter-state group"
+msgstr ""
+
+#. module: l10n_in
 #: model:ir.model.fields,field_description:l10n_in.field_res_config_settings__module_l10n_in_edi
 msgid "Indian Electronic Invoicing"
 msgstr ""
@@ -577,6 +581,12 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_in/models/account_move_line.py:0
 msgid "Invalid HSN Code (%(hsn_code)s) in product line %(product_line)s"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Invalid HSN/SAC Code digit"
 msgstr ""
 
 #. module: l10n_in
@@ -903,6 +913,12 @@ msgid "Products"
 msgstr ""
 
 #. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Proforma %(journal_name)s"
+msgstr ""
+
+#. module: l10n_in
 #: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
 msgid "Quantity"
 msgstr ""
@@ -1087,16 +1103,6 @@ msgstr ""
 #. module: l10n_in
 #: model_terms:ir.ui.view,arch_db:l10n_in.res_config_settings_view_form_inherit_l10n_in
 msgid "Use this if setup with Reseller(E-Commerce)."
-msgstr ""
-
-#. module: l10n_in
-#: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
-msgid "Vendor Bill"
-msgstr ""
-
-#. module: l10n_in
-#: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
-msgid "Vendor Credit Note"
 msgstr ""
 
 #. module: l10n_in

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -329,3 +329,29 @@ class AccountMove(models.Model):
             l10n_in_tax_details["%s_amount" % (tax_detail["line_code"])] += tax_detail["tax_amount"]
             l10n_in_tax_details["%s_amount_currency" % (tax_detail["line_code"])] += tax_detail["tax_amount_currency"]
         return l10n_in_tax_details
+
+    def _get_l10n_in_customer_invoice_title(self, proforma=False):
+        """
+        Get the title to display in front of a customer invoice number.
+        The title is generated based on the state of the invoice and the `proforma` parameter.
+
+        :param proforma: Is the invoice a proforma one, defaults to False
+        :type proforma: bool, optional
+        :return: A customer invoice title
+        :rtype: str
+        """
+        self.ensure_one()
+        if not proforma:
+            if self.state == 'posted':
+                return self.journal_id.name
+            elif self.state == 'draft':
+                return _("Draft %(journal_name)s", journal_name=self.journal_id.name)
+            elif self.state == 'cancel':
+                return _("Cancelled %(journal_name)s", journal_name=self.journal_id.name)
+        else:
+            if self.state == 'posted':
+                return _("Proforma %(journal_name)s", journal_name=self.journal_id.name)
+            elif self.state == 'draft':
+                return _("Draft Proforma %(journal_name)s", journal_name=self.journal_id.name)
+            elif self.state == 'cancel':
+                return _("Cancelled Proforma %(journal_name)s", journal_name=self.journal_id.name)

--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -50,19 +50,24 @@
             </t>
         </xpath>
 
-        <xpath expr="//t[@t-set='layout_document_title']" position="replace">
-            <t t-set="layout_document_title">
-                <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'" t-field="o.journal_id.name"/>
-                <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">Draft <span t-field="o.journal_id.name"/></span>
-                <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled <span t-field="o.journal_id.name"/></span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">Credit Note</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">Draft Credit Note</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">Cancelled Credit Note</span>
-                <span t-elif="o.move_type == 'in_refund'">Vendor Credit Note</span>
-                <span t-elif="o.move_type == 'in_invoice'">Vendor Bill</span>
-                <span t-if="o.name != '/'" t-field="o.name"/>
-            </t>
-        </xpath>
+        <t name="invoice_title" position="replace">
+            <t name="invoice_title" t-out="o._get_l10n_in_customer_invoice_title()"/>
+        </t>
+        <t name="draft_invoice_title" position="replace">
+            <t name="draft_invoice_title" t-out="o._get_l10n_in_customer_invoice_title()"/>
+        </t>
+        <t name="cancelled_invoice_title" position="replace">
+            <t name="cancelled_invoice_title" t-out="o._get_l10n_in_customer_invoice_title()"/>
+        </t>
+        <t name="proforma_invoice_title" position="replace">
+            <t name="proforma_invoice_title" t-out="o._get_l10n_in_customer_invoice_title(proforma=True)"/>
+        </t>
+        <t name="draft_proforma_invoice_title" position="replace">
+            <t name="draft_proforma_invoice_title" t-out="o._get_l10n_in_customer_invoice_title(proforma=True)"/>
+        </t>
+        <t name="cancelled_proforma_invoice_title" position="replace">
+            <t name="cancelled_proforma_invoice_title" t-out="o._get_l10n_in_customer_invoice_title(proforma=True)"/>
+        </t>
 
         <xpath expr="//div[@id='payment_term']" position="after">
             <t t-if="o.company_id.account_fiscal_country_id.code == 'IN'">

--- a/addons/l10n_mu_account/views/report_invoice.xml
+++ b/addons/l10n_mu_account/views/report_invoice.xml
@@ -4,19 +4,25 @@
         <xpath expr="//div[@id='informations']" position="before">
             <t t-set="forced_vat" t-value="o.company_id.vat"/>
         </xpath>
-        <xpath expr="//div[hasclass('page')]/t[@t-set='layout_document_title']" position="replace">
-            <t t-set="layout_document_title">
-                <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">VAT Invoice</span>
-                <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">Draft VAT Invoice</span>
-                <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled VAT Invoice</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">Credit Note</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">Draft Credit Note</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">Cancelled Credit Note</span>
-                <span t-elif="o.move_type == 'in_refund'">Vendor Credit Note</span>
-                <span t-elif="o.move_type == 'in_invoice'">Vendor Bill</span>
-                <span t-if="o.name != '/'" t-field="o.name"/>
-            </t>
-        </xpath>
+
+        <t name="invoice_title" position="replace">
+            <t name="invoice_title">VAT Invoice</t>
+        </t>
+        <t name="draft_invoice_title" position="replace">
+            <t name="draft_invoice_title">Draft VAT Invoice</t>
+        </t>
+        <t name="cancelled_invoice_title" position="replace">
+            <t name="cancelled_invoice_title">Cancelled VAT Invoice</t>
+        </t>
+        <t name="proforma_invoice_title" position="replace">
+            <t name="proforma_invoice_title">Proforma VAT Invoice</t>
+        </t>
+        <t name="draft_proforma_invoice_title" position="replace">
+            <t name="draft_proforma_invoice_title">Draft Proforma VAT Invoice</t>
+        </t>
+        <t name="cancelled_proforma_invoice_title" position="replace">
+            <t name="cancelled_proforma_invoice_title">Cancelled Proforma VAT Invoice</t>
+        </t>
     </template>
     <template id="report_invoice" inherit_id="account.report_invoice">
         <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">

--- a/addons/l10n_nz/views/report_invoice.xml
+++ b/addons/l10n_nz/views/report_invoice.xml
@@ -2,19 +2,54 @@
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document" primary="True">
         <xpath expr="//div[hasclass('page')]/t[@t-set='layout_document_title']" position="replace">
-            <t t-set="layout_document_title">
-                <span t-if="not proforma"/>
-                <span t-else="">PROFORMA</span>
-                <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">Tax Invoice</span>
-                <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Tax Invoice</span>
-                <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled Tax Invoice</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">Tax Credit Note</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">Draft Tax Credit Note</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">Cancelled Tax Credit Note</span>
-                <span t-elif="o.move_type == 'in_refund'">Tax Vendor Credit Note</span>
-                <span t-elif="o.move_type == 'in_invoice'">Tax Vendor Bill</span>
-                <span t-if="o.name != '/'" t-field="o.name">INV/2024/0001</span>
-            </t>
+        <t name="invoice_title" position="replace">
+            <t name="invoice_title">Tax Invoice</t>
+        </t>
+        <t name="draft_invoice_title" position="replace">
+            <t name="draft_invoice_title">Draft Tax Invoice</t>
+        </t>
+        <t name="cancelled_invoice_title" position="replace">
+            <t name="cancelled_invoice_title">Cancelled Tax Invoice</t>
+        </t>
+        <t name="credit_note_title" position="replace">
+            <t name="credit_note_title">Tax Credit Note</t>
+        </t>
+        <t name="draft_credit_note_title" position="replace">
+            <t name="draft_credit_note_title">Draft Tax Credit Note</t>
+        </t>
+        <t name="cancelled_credit_note_title" position="replace">
+            <t name="cancelled_credit_note_title">Cancelled Tax Credit Note</t>
+        </t>
+        <t name="vendor_credit_note_title" position="replace">
+            <t name="vendor_credit_note_title">Tax Vendor Credit Note</t>
+        </t>
+        <t name="vendor_bill_title" position="replace">
+            <t name="vendor_bill_title">Tax Vendor Bill</t>
+        </t>
+        <t name="proforma_invoice_title" position="replace">
+            <t name="proforma_invoice_title">Proforma Tax Invoice</t>
+        </t>
+        <t name="draft_proforma_invoice_title" position="replace">
+            <t name="draft_proforma_invoice_title">Draft Proforma Tax Invoice</t>
+        </t>
+        <t name="cancelled_proforma_invoice_title" position="replace">
+            <t name="cancelled_proforma_invoice_title">Cancelled Proforma Tax Invoice</t>
+        </t>
+        <t name="proforma_credit_note_title" position="replace">
+            <t name="proforma_credit_note_title">Proforma Tax Credit Note</t>
+        </t>
+        <t name="draft_proforma_credit_note_title" position="replace">
+            <t name="draft_proforma_credit_note_title">Draft Proforma Tax Credit Note</t>
+        </t>
+        <t name="cancelled_proforma_credit_note_title" position="replace">
+            <t name="cancelled_proforma_credit_note_title">Cancelled Proforma Tax Credit Note</t>
+        </t>
+        <t name="proforma_vendor_credit_note_title" position="replace">
+            <t name="proforma_vendor_credit_note_title">Proforma Tax Vendor Credit Note</t>
+        </t>
+        <t name="proforma_vendor_bill_title" position="replace">
+            <t name="proforma_vendor_bill_title">Proforma Tax Vendor Bill</t>
+        </t>
         </xpath>
     </template>
 

--- a/addons/l10n_th/i18n/l10n_th.pot
+++ b/addons/l10n_th/i18n/l10n_th.pot
@@ -4,60 +4,57 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0+e\n"
+"Project-Id-Version: Odoo Server 18.1alpha1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 02:16+0000\n"
-"PO-Revision-Date: 2025-01-22 10:30+0800\n"
+"POT-Creation-Date: 2024-12-04 19:10+0000\n"
+"PO-Revision-Date: 2024-12-04 19:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.5\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_out_tax_sale
 msgid "1. Sales amount"
-msgstr "1. ยอดขาย"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_vat_payment_last_period
 msgid "10. Excess tax payment carried forward from last period"
-msgstr "10. ภาษีส่วนเกินถูกยกมาจากงวดก่อน"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_net_vat_payable
 msgid "11. Net tax payable (if 8. is greater than 10.)"
-msgstr "11. ภาษีสุทธิที่ต้องชำระ (ถ้า 8. มากกว่า 10.)"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_net_vat_excess
 msgid ""
 "12. Net excess tax payable ((if 10. is greater than 8.) or (9. plus 10.))"
 msgstr ""
-"12. ภาษีสุทธิส่วนเกินที่ต้องชำระ ((ถ้า 10. มากกว่า 8.) หรือ (9. บวก 10.))"
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_out_tax_less_sales_0_rate
 msgid "2. Less sales subject to 0% tax rate "
-msgstr "2. หักยอดขายโดยคิดอัตราภาษี 0% "
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_out_tax_less_exempted_sales
 msgid "3. Less exempted sales"
-msgstr "3. หักยอดขายที่ได้รับการยกเว้น"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_out_tax_taxable_sales_amount
 msgid "4. Taxable sales amount(1. -2. -3.)"
-msgstr "4. ยอดขายที่ต้องเสียภาษี(1. -2. -3.)"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_out_tax
 msgid "5. Output tax"
-msgstr "5. ภาษีขาย"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_input_tax_purchase_from_out_tax
@@ -65,56 +62,54 @@ msgid ""
 "6. Purchase amount that is entitled to deduction of input tax from output "
 "tax in tax computation"
 msgstr ""
-"6. จำนวนเงินซื้อที่มีสิทธิ์ได้รับการหักภาษีซื้อ จากภาษีขายในการคำนวณภาษี"
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_input_tax
 msgid "7. Input tax (according to invoice of purchase amount in 6.)"
-msgstr "7. ภาษีซื้อ (ตามใบแจ้งหนี้ของจำนวนการซื้อในข้อ 6. )"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_vat_payable
 msgid "8. Tax payable (5. minus 7. (if 5. is greater than 7.))"
-msgstr "8. ภาษีที่ต้องชำระ (5. ลบ 7. (ถ้า 5. มากกว่า 7. ))"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_vat_excess
 msgid "9. Excess tax payable (7. minus 5. (if 5. is less than 7.))"
-msgstr "9. ภาษีเกินที่ต้องชำระ (7. ลบ 5. (ถ้า 5. น้อยกว่า 7.))"
+msgstr ""
 
 #. module: l10n_th
 #: model:ir.model,name:l10n_th.model_account_chart_template
 msgid "Account Chart Template"
-msgstr "เทมเพลตแผนภูมิบัญชี"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.column,name:l10n_th.tax_report_balance
 #: model:account.report.column,name:l10n_th.tax_report_pnd3_balance
 #: model:account.report.column,name:l10n_th.tax_report_pnd53_balance
 msgid "Balance"
-msgstr "ยอดคงเหลือ"
+msgstr ""
 
 #. module: l10n_th
 #: model:ir.model,name:l10n_th.model_res_partner_bank
 msgid "Bank Accounts"
-msgstr "บัญชีธนาคาร"
+msgstr ""
 
 #. module: l10n_th
 #. odoo-python
 #: code:addons/l10n_th/models/res_bank.py:0
 msgid "Can't generate a PayNow QR code with a currency other than THB."
 msgstr ""
-"ไม่สามารถสร้างรหัส QR โค้ดของ PayNow ด้วยสกุลเงินอื่นนอกเหนือจาก THB ได้"
 
 #. module: l10n_th
 #: model:ir.actions.report,name:l10n_th.action_report_commercial_invoice
 msgid "Commercial Invoice"
-msgstr "ใบกำกับสินค้าพาณิชย์"
+msgstr ""
 
 #. module: l10n_th
 #: model:ir.model,name:l10n_th.model_res_partner
 msgid "Contact"
-msgstr "รายชื่อผู้ติดต่อ"
+msgstr ""
 
 #. module: l10n_th
 #: model:ir.model.fields,field_description:l10n_th.field_account_chart_template__display_name
@@ -123,12 +118,12 @@ msgstr "รายชื่อผู้ติดต่อ"
 #: model:ir.model.fields,field_description:l10n_th.field_res_partner__display_name
 #: model:ir.model.fields,field_description:l10n_th.field_res_partner_bank__display_name
 msgid "Display Name"
-msgstr "ชื่อที่แสดง"
+msgstr ""
 
 #. module: l10n_th
 #: model:ir.model.fields.selection,name:l10n_th.selection__res_partner_bank__proxy_type__ewallet_id
 msgid "Ewallet ID"
-msgstr "Ewallet ID"
+msgstr ""
 
 #. module: l10n_th
 #: model:ir.model.fields,field_description:l10n_th.field_account_chart_template__id
@@ -137,86 +132,86 @@ msgstr "Ewallet ID"
 #: model:ir.model.fields,field_description:l10n_th.field_res_partner__id
 #: model:ir.model.fields,field_description:l10n_th.field_res_partner_bank__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_input_tax_title
 msgid "Input Tax"
-msgstr "ภาษีซื้อ"
+msgstr ""
 
 #. module: l10n_th
 #: model:ir.model,name:l10n_th.model_account_move
 msgid "Journal Entry"
-msgstr "รายการสมุดรายวัน"
+msgstr ""
 
 #. module: l10n_th
 #: model:ir.model.fields,field_description:l10n_th.field_res_partner__l10n_th_branch_name
 #: model:ir.model.fields,field_description:l10n_th.field_res_users__l10n_th_branch_name
 msgid "L10N Th Branch Name"
-msgstr "ชื่อสาขา L10N"
+msgstr ""
 
 #. module: l10n_th
 #: model:ir.model.fields.selection,name:l10n_th.selection__res_partner_bank__proxy_type__merchant_tax_id
 msgid "Merchant Tax ID"
-msgstr "หมายเลขประจำตัวผู้เสียภาษีของผู้ค้า"
+msgstr ""
 
 #. module: l10n_th
 #: model:ir.model.fields.selection,name:l10n_th.selection__res_partner_bank__proxy_type__mobile
 msgid "Mobile Number"
-msgstr "หมายเลขโทรศัพท์มือถือ"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_net_vat
 msgid "Net Tax"
-msgstr "ภาษีสุทธิ"
+msgstr ""
 
 #. module: l10n_th
 #. odoo-python
 #: code:addons/l10n_th/models/ir_actions_report.py:0
 msgid "Only invoices could be printed."
-msgstr "สามารถพิมพ์ได้เฉพาะใบแจ้งหนี้เท่านั้น"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_out_tax_title
 msgid "Output Tax"
-msgstr "ภาษีขาย"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report,name:l10n_th.tax_report_pnd3
 msgid "PND3"
-msgstr "ภ.ง.ด. 3"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report,name:l10n_th.tax_report_pnd53
 msgid "PND53"
-msgstr "ภ.ง.ด. 53"
+msgstr ""
 
 #. module: l10n_th
 #: model:ir.model.fields,field_description:l10n_th.field_account_setup_bank_manual_config__proxy_type
 #: model:ir.model.fields,field_description:l10n_th.field_res_partner_bank__proxy_type
 msgid "Proxy Type"
-msgstr "ประเภทพร็อกซี"
+msgstr ""
 
 #. module: l10n_th
 #: model:ir.model,name:l10n_th.model_ir_actions_report
 msgid "Report Action"
-msgstr "รายงานการดำเนินการ"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_surcharge_pnd3_line
 #: model:account.report.line,name:l10n_th.tax_report_surcharge_pnd53_line
 msgid "Surcharge"
-msgstr "ค่าธรรมเนียมเพิ่มเติม"
+msgstr ""
 
 #. module: l10n_th
 #: model_terms:ir.ui.view,arch_db:l10n_th.report_invoice_document
 msgid "Tax Invoice"
-msgstr "ใบกำกับภาษี"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report,name:l10n_th.tax_report
 msgid "Tax Report"
-msgstr "รายงานภาษี"
+msgstr ""
 
 #. module: l10n_th
 #. odoo-python
@@ -225,7 +220,6 @@ msgid ""
 "The Merchant Tax ID must be in the format 1234567890123 for account number "
 "%s."
 msgstr ""
-"หมายเลขภาษีผู้ค้าจะต้องอยู่ในรูปแบบ 1234567890123 สำหรับหมายเลขบัญชี %s"
 
 #. module: l10n_th
 #. odoo-python
@@ -233,7 +227,6 @@ msgstr ""
 msgid ""
 "The Mobile Number must be in the format 0812345678 for account number %s."
 msgstr ""
-"หมายเลขโทรศัพท์มือถือจะต้องอยู่ในรูปแบบ 0812345678 สำหรับหมายเลขบัญชี %s"
 
 #. module: l10n_th
 #. odoo-python
@@ -242,8 +235,6 @@ msgid ""
 "The PayNow Type must be either Ewallet ID, Merchant Tax ID or Mobile Number "
 "to generate a Thailand Bank QR code"
 msgstr ""
-"ประเภท PayNow จะต้องเป็นรหัส Ewallet, รหัสภาษีผู้ค้า "
-"หรือหมายเลขโทรศัพท์มือถือ เพื่อสร้างรหัส QR โค้ดของธนาคารไทย"
 
 #. module: l10n_th
 #. odoo-python
@@ -252,29 +243,26 @@ msgid ""
 "The QR Code Type must be either Ewallet ID, Merchant Tax ID or Mobile Number"
 " to generate a Thailand Bank QR code for account number %s."
 msgstr ""
-"ประเภทรหัส QR โค้ดจะต้องเป็นรหัส Ewallet, รหัสผู้เสียภาษีของผู้ค้า "
-"หรือหมายเลขโทรศัพท์มือถือ เพื่อสร้างรหัส QR "
-"โค้ดของธนาคารไทยสำหรับหมายเลขบัญชี %s"
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_total_pnd3_line
 #: model:account.report.line,name:l10n_th.tax_report_total_pnd53_line
 msgid "Total"
-msgstr "รวมยอดภาษีที่นำส่งทั้งสิ้น และเงินเพิ่ม (2. + 3.)"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_total_income_pnd3_line
 #: model:account.report.line,name:l10n_th.tax_report_total_income_pnd53_line
 msgid "Total Income"
-msgstr "รวมยอดเงินได้ทั้งสิ้น"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_total_remittance_pnd3_line
 #: model:account.report.line,name:l10n_th.tax_report_total_remittance_pnd53_line
 msgid "Total Remittance"
-msgstr "รวมยอดภาษีที่นำส่งทั้งสิ้น"
+msgstr ""
 
 #. module: l10n_th
 #: model:account.report.line,name:l10n_th.tax_report_vat
 msgid "Value Added Tax"
-msgstr "ภาษีมูลค่าเพิ่ม"
+msgstr ""

--- a/addons/l10n_th/views/report_invoice.xml
+++ b/addons/l10n_th/views/report_invoice.xml
@@ -11,12 +11,9 @@
         <xpath expr="//div[@name='no_shipping']//span[@t-field='o.partner_id.vat']" position="after">
             <span t-esc="o.partner_id.l10n_th_branch_name"/>
         </xpath>
-        <xpath expr="//t[@t-set='layout_document_title']/span[contains(@t-if, 'posted')]" position="replace">
-            <t t-if="o.move_type == 'out_invoice' and o.state == 'posted'">
-                <span t-if="o.company_id.account_fiscal_country_id.code == 'TH' and not commercial_invoice">Tax Invoice</span>
-                <span t-else="">Invoice</span>
-            </t>
-        </xpath>
+        <t name="invoice_title" position="replace">
+            <t name="invoice_title">Tax Invoice</t>
+        </t>
     </template>
 
     <template id="report_commercial_invoice">

--- a/addons/l10n_zm_account/views/report_invoice.xml
+++ b/addons/l10n_zm_account/views/report_invoice.xml
@@ -4,19 +4,25 @@
         <xpath expr="//div[@id='informations']" position="before">
             <t t-set="forced_vat" t-value="o.company_id.vat"/>
         </xpath>
-        <xpath expr="//div[hasclass('page')]/t[@t-set='layout_document_title']" position="replace">
-            <t t-set="layout_document_title">
-                <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">Fiscal Tax Invoice</span>
-                <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Tax Invoice</span>
-                <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled Tax Invoice</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">Credit Note</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">Draft Credit Note</span>
-                <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">Cancelled Credit Note</span>
-                <span t-elif="o.move_type == 'in_refund'">Vendor Credit Note</span>
-                <span t-elif="o.move_type == 'in_invoice'">Vendor Bill</span>
-                <span t-if="o.name != '/'" t-field="o.name"/>
-            </t>
-        </xpath>
+
+        <t name="invoice_title" position="replace">
+            <t name="invoice_title">Fiscal Tax Invoice</t>
+        </t>
+        <t name="draft_invoice_title" position="replace">
+            <t name="draft_invoice_title">Draft Tax Invoice</t>
+        </t>
+        <t name="cancelled_invoice_title" position="replace">
+            <t name="cancelled_invoice_title">Cancelled Tax Invoice</t>
+        </t>
+        <t name="proforma_invoice_title" position="replace">
+            <t name="proforma_invoice_title">Proforma Fiscal Tax Invoice</t>
+        </t>
+        <t name="draft_proforma_invoice_title" position="replace">
+            <t name="draft_proforma_invoice_title">Draft Proforma Tax Invoice</t>
+        </t>
+        <t name="cancelled_proforma_invoice_title" position="replace">
+            <t name="cancelled_proforma_invoice_title">Cancelled Proforma Tax Invoice</t>
+        </t>
     </template>
     <template id="report_invoice" inherit_id="account.report_invoice">
         <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">


### PR DESCRIPTION
*l10n_ae,l10n_au,l10n_in,l10n_mu_account,l10n_nz,l10n_th,l10n_zm_account

Currently the word "PROFORMA" was put before any invoice type title without considering the order of the total title, e.g. "PROFORMA Draft Invoice" instead of "Draft Proforma Invoice".

Also this is a problem for translations, since other languages cannot change the order of the full title either.

This commit makes the titles with "Proforma" as full terms that can be translated as a whole and reordered accordingly.

Related to https://github.com/odoo/enterprise/pull/75181