### PR TITLE
[FIX] auth_signup: singleton when duplicating multiple users

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -347,7 +347,6 @@ class ResUsers(models.Model):
         return users
 
     def copy(self, default=None):
-        self.ensure_one()
         if not default or not default.get('email'):
             # avoid sending email to the user we are duplicating
             self = self.with_context(no_reset_password=True)

--- a/addons/auth_signup/tests/test_auth_signup.py
+++ b/addons/auth_signup/tests/test_auth_signup.py
@@ -64,3 +64,15 @@ class TestAuthSignupFlow(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
 
         with self.assertRaises(AccessError):
             partner.with_user(user.id).signup_url
+
+    def test_copy_multiple_users(self):
+        users = self.env['res.users'].create([
+            {'login': 'testuser1', 'name': 'Test User 1', 'email': 'test1@odoo.com'},
+            {'login': 'testuser2', 'name': 'Test User 2', 'email': 'test2@odoo.com'},
+        ])
+        initial_user_count = self.env['res.users'].search_count([])
+        users.copy()
+        self.assertEqual(
+            self.env['res.users'].search_count([]),
+            initial_user_count + len(users)
+        )


### PR DESCRIPTION
Issue:
When 'website' is installed a singleton error is thrown when duplicating multiple users

In previous versions, such as [17.0]
The copy method would be called multiple times, once per record. However, starting with version 17.2+, self becomes a record set that can potentially contain multiple records, which changes the behavior.
res.users(1), res.users(2) --> res.users(1,2)

see IMP: [#154132](https://github.com/odoo/odoo/pull/154132)

Steps to reproduce:
- Install 'website'
- Navigate to user list view (Settings / Users & Companies / Users)
- Select multiple users and try to duplicate them

Current behavior before PR:
- ValueError: Expected singleton

Desired behavior after PR is merged:
- Resolves expected singleton error

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
