### PR TITLE
[IMP] pos*: introduce sale warnings when selecting a customer or product

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -223,7 +223,7 @@ export class ProductScreen extends Component {
         const partner = await this._getPartnerByBarcode(code);
         if (partner) {
             if (this.currentOrder.getPartner() !== partner) {
-                this.currentOrder.setPartner(partner);
+                this.pos.setPartnerToCurrentOrder(partner);
             }
             return;
         }

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1796,6 +1796,10 @@ export class PosStore extends WithLazyGetterTrap {
             preset.computeAvailabilities();
         }
     }
+    // There for override to do something before adding partner to current order from partner list
+    setPartnerToCurrentOrder(partner) {
+        this.getOrder().setPartner(partner);
+    }
     async selectPartner() {
         // FIXME, find order to refund when we are in the ticketscreen.
         const currentOrder = this.getOrder();
@@ -1817,11 +1821,7 @@ export class PosStore extends WithLazyGetterTrap {
             partner: currentPartner,
         });
 
-        if (payload) {
-            currentOrder.setPartner(payload);
-        } else {
-            currentOrder.setPartner(false);
-        }
+        this.setPartnerToCurrentOrder(payload || false);
 
         return payload;
     }

--- a/addons/pos_sale/__manifest__.py
+++ b/addons/pos_sale/__manifest__.py
@@ -22,6 +22,7 @@ This module adds a custom Sales Team for the Point of Sale. This enables you to 
         'views/pos_order_views.xml',
         'views/sales_team_views.xml',
         'views/res_config_settings_views.xml',
+        'views/res_partner_views.xml',
         'views/stock_template.xml',
     ],
     'installable': True,

--- a/addons/pos_sale/models/__init__.py
+++ b/addons/pos_sale/models/__init__.py
@@ -10,3 +10,4 @@ from . import pos_session
 from . import sale_order
 from . import stock_picking
 from . import res_config_settings
+from . import res_partner

--- a/addons/pos_sale/models/product_template.py
+++ b/addons/pos_sale/models/product_template.py
@@ -25,5 +25,5 @@ class ProductTemplate(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         params = super()._load_pos_data_fields(config_id)
-        params += ['invoice_policy', 'optional_product_ids', 'type']
+        params += ['invoice_policy', 'optional_product_ids', 'type', 'sale_line_warn', 'sale_line_warn_msg']
         return params

--- a/addons/pos_sale/models/res_partner.py
+++ b/addons/pos_sale/models/res_partner.py
@@ -1,0 +1,9 @@
+from odoo import api, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        return super()._load_pos_data_fields(config_id) + ['sale_warn', 'sale_warn_msg']

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -270,4 +270,29 @@ patch(PosStore.prototype, {
             this.numpadMode = "price";
         }
     },
+    setPartnerToCurrentOrder(partner) {
+        if (["warning", "block"].includes(partner.sale_warn)) {
+            this.dialog.add(AlertDialog, {
+                title: _t("Warning for %s", partner.name),
+                body: partner.sale_warn_msg || "",
+            });
+        }
+        // removing partner if it is blocked
+        partner = partner?.sale_warn !== "block" ? partner : false;
+        super.setPartnerToCurrentOrder(partner);
+    },
+    addLineToCurrentOrder(vals, opt = {}, configure = true) {
+        const productTemplate = vals.product_tmpl_id;
+        if (["warning", "block"].includes(productTemplate.sale_line_warn)) {
+            this.dialog.add(AlertDialog, {
+                title: _t("Warning for %s", productTemplate.name),
+                body: productTemplate.sale_line_warn_msg || "",
+            });
+        }
+        // product is not added to the cart if it is blocked
+        if (productTemplate.sale_line_warn !== "block") {
+            return super.addLineToCurrentOrder(vals, opt, configure);
+        }
+        return false;
+    },
 });

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -362,3 +362,43 @@ registry.category("web_tour.tours").add("PosSettleOrder5", {
             Chrome.clickMenuOption("Backend"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosSaleWarning", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Test Customer 2"),
+            {
+                content: "Check warning popup are displayed",
+                trigger:
+                    '.modal-dialog:has(.modal-header:contains("Warning for Test Customer 2")):has(.modal-body:contains("Cannot afford our services"))',
+            },
+            {
+                trigger: ".modal-footer button",
+                run: "click",
+            },
+            // Check if no customer is selected
+            ProductScreen.customerIsSelected("Customer"),
+            ProductScreen.clickDisplayedProduct("Letter Tray", true, "1"),
+            ProductScreen.selectedOrderlineHas("Letter Tray", "1"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Test Customer"),
+            {
+                content: "Check warning popup are displayed",
+                trigger:
+                    '.modal-dialog:has(.modal-header:contains("Warning for Test Customer")):has(.modal-body:contains("Highly infectious disease"))',
+            },
+            {
+                trigger: ".modal-footer button",
+                run: "click",
+            },
+            ProductScreen.customerIsSelected("Test Customer"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.remainingIs("0.0"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -886,6 +886,14 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosRepairSettleOrder', login="pos_user")
 
+    def test_pos_sale_warnings(self):
+        self.env['res.partner'].create([
+            {'name': 'Test Customer', 'sale_warn': 'warning', 'sale_warn_msg': 'Highly infectious disease'},
+            {'name': 'Test Customer 2', 'sale_warn': 'block', 'sale_warn_msg': 'Cannot afford our services'}
+        ])
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSaleWarning', login="accountman")
+
     def test_downpayment_invoice(self):
         """This test check that users that don't have the pos user group can invoice downpayments"""
         self.env['res.partner'].create({'name': 'Test Partner AAA'})

--- a/addons/pos_sale/views/res_partner_views.xml
+++ b/addons/pos_sale/views/res_partner_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="res_partner_view_buttons_pos_sale" model="ir.ui.view">
+        <field name="name">res.partner.view.buttons.pos.sale</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="sale.res_partner_view_buttons" />
+        <field name="arch" type="xml">
+            <xpath expr="//separator" position="attributes">
+                <attribute name="string">Warning on Sale</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
pos*: pos, pos_sale

In this commit:
=========
Introduce a sale warning feature when adding a customer or product to a current order (similar to sales).

The available sale warnings are:-
- **No Message (default):** No warning.
- **Warning:** A warning popup is shown, but the customer or product is still added.
- **Blocking:** A warning popup is shown, and the customer or product is not added.

Task - 4375272