### PR TITLE
[FIX] account_edi: show EDI fields in vendor bills

### DIFF
--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -48,6 +48,19 @@
             </field>
         </record>
 
+        <record id="view_in_bill_tree_inherit" model="ir.ui.view">
+            <field name="name">account.move.tree.inherit</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_in_invoice_bill_tree" />
+            <field name="arch" type="xml">
+                <field name="state" position="before">
+                    <field name="edi_state" optional="hide"/>
+                    <field name="edi_blocking_level" optional="hide"/>
+                    <field name="edi_error_message" optional="hide"/>
+                </field>
+            </field>
+        </record>
+
         <record id="view_account_invoice_filter" model="ir.ui.view">
             <field name="name">account.invoice.select.inherit</field>
             <field name="model">account.move</field>

--- a/addons/l10n_it_edi/views/l10n_it_view.xml
+++ b/addons/l10n_it_edi/views/l10n_it_view.xml
@@ -113,9 +113,6 @@
         <field name="inherit_id" ref="account.view_in_invoice_bill_tree" />
         <field name="arch" type="xml">
             <field name="state" position="before">
-                <field name="edi_state" optional="hide"/>
-                <field name="edi_blocking_level" optional="hide"/>
-                <field name="edi_error_message" optional="hide"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/113577 this view was added in the wrong module.

Not only people using `l10n_it_edi` need to debug this information, but also those using EDI for other countries.

I know this PR kinda violates the stability guidelines. However, #113577 also did, and here I'm fixing a bug that landed there. I hope you can still consider the PR for merging. Please tell me if there are any changes needed for making it better suited for merge if needed. Thanks!

@moduon MT-8204 OPW-4362382


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
