### PR TITLE
[FIX] website_sale: prevent error on installing website_sale

### DIFF
--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -59,7 +59,7 @@
             <field name="salesteam_id" ref="sales_team.salesteam_website_sales"/>
         </record>
 
-        <record id="delivery.free_delivery_carrier" model="delivery.carrier">
+        <record id="delivery.free_delivery_carrier" model="delivery.carrier" forcecreate="False">
             <field name="is_published" eval="True"/>
         </record>
 


### PR DESCRIPTION
Currently a ``ParseError`` is arising when the user installs the ``website_sale`` module after deleting the one shipping method from the ``sale`` module.

Steps to reproduce:
---
- Install ``sale`` and ``delivery`` modules
- Open ``Shipping Methods`` and delete one shipping method
- Now try to install the ``website_sale`` module.
- The error appears in the log.

Traceback: 
---
```
ParseError
while parsing /home/odoo/src/odoo/18.0/addons/website_sale/data/data.xml:62, somewhere inside <record id="delivery.free_delivery_carrier" model="delivery.carrier">
            <field name="is_published" eval="True"/>
        </record>
 ```

This commit solves the above issue by using ``forcecreate="False"`` to bypass record creation if it violates checks.

sentry-5731062091

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
