### PR TITLE
[FIX] web: list: do not allow deletion if delete control invisible

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -302,13 +302,14 @@
             <t t-set="hasX2ManyAction" t-value="isX2Many and (useUnlink ? activeActions.unlink : activeActions.delete)" />
             <t t-if="displayOptionalFields or hasX2ManyAction">
                 <t t-if="hasX2ManyAction">
+                    <t t-set="hasDeleteButton" t-value="this.displayDeleteIcon(record)"/>
                     <td class="o_list_record_remove w-print-0 p-print-0 text-center"
                         t-on-keydown="(ev) => this.onCellKeydown(ev, group, record)"
-                        t-on-click.stop="(ev) => this.onRemoveCellClicked(record, ev)"
+                        t-on-click.stop="hasDeleteButton ? (ev) => this.onRemoveCellClicked(record, ev) : () => {}"
                         tabindex="-1"
                     >
                         <button class="fa d-print-none"
-                            t-if="this.displayDeleteIcon(record)"
+                            t-if="hasDeleteButton"
                             t-att-class="{
                                 'fa-trash-o': !useUnlink and activeActions.delete,
                                 'fa-times': useUnlink and activeActions.unlink,

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -9035,6 +9035,9 @@ test("one2many list with delete control with invisible modifier", async () => {
     expect(".first .o_data_row").toHaveCount(2);
     expect(".first .o_data_row:eq(0) .o_list_record_remove button").toHaveCount(1);
     expect(".first .o_data_row:eq(1) .o_list_record_remove button").toHaveCount(0);
+    await contains(".first .o_data_row:eq(1) td.o_list_record_remove").click();
+    expect(".first .o_data_row").toHaveCount(2);
+
     expect(".second .o_data_row").toHaveCount(2);
     expect(".second .o_data_row .o_list_record_remove button").toHaveCount(2);
 });


### PR DESCRIPTION
Commit [1] recently introduced the possibility to define a `delete` control with and `invisible` modifier, allowing to disable the deletion feature in an editable x2many list, row by row. However, even though the delete icon isn't there, the delete handler is set on the outer `td`, and before this commit, the handler was alive even if the icon wasn't displayed. Clicking on the empty cell thus deleted the row. This commit fixes the issue.

[1] odoo/odoo@ba7e30908e25222f79db49be578b2869a0c10b64

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
