### PR TITLE
[IMP] project: added edit_tags to some fields and changes in FormViewDialog

### DIFF
--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -46,7 +46,7 @@
                             </group>
                             <group>
                                 <field name="fold"/>
-                                <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color'}"
+                                <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color', 'edit_tags': True}"
                                        invisible="user_id"
                                        required="not user_id"/>
                             </group>


### PR DESCRIPTION
<h3>[IMP] project: added edit_tags to some fields</h3>

This commit introduces the edit_tags which open Many2X records when clicked on
fields with many2many widget type.

---
<h3>[FIX] web: changes in FormViewDialog and Many2many tags avatar</h3>

Adapted Many2ManyTagsAvatarField to work with edit_tags.

Now edit_tags work in many2many widgets in list view.

Tweaked the test cases of many2many tags as before the color editor and
edit_tags was not visble in list view.

In form view dialog when change the company and try save the record and then
save view we get a traceback saying pushStateBeforeReload is not a function, but
as FormViewDialog is not action_window, we dont need to store the state of view,
so we skip saving the state here.

task-3976577
