### PR TITLE
[IMP] web_tour: Add state to tour recorder

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_recorder/tour_recorder.js
+++ b/addons/web_tour/static/src/tour_service/tour_recorder/tour_recorder.js
@@ -6,6 +6,7 @@ import { queryAll, queryFirst, queryOne } from "@odoo/hoot-dom";
 import { Component, useState, useExternalListener } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { x2ManyCommands } from "@web/core/orm_service";
+import { tourRecorderState } from "./tour_recorder_state";
 
 export const TOUR_RECORDER_ACTIVE_LOCAL_STORAGE_KEY = "tour_recorder_active";
 const PRECISE_IDENTIFIERS = ["data-menu-xmlid", "name", "contenteditable"];
@@ -111,6 +112,8 @@ export class TourRecorder extends Component {
             steps: [],
         });
 
+        this.state.steps = tourRecorderState.getCurrentTourRecorder();
+        this.state.recording = tourRecorderState.isRecording() === "1";
         useExternalListener(document, "pointerdown", this.setStartingEvent, { capture: true });
         useExternalListener(document, "pointerup", this.recordClickEvent, { capture: true });
         useExternalListener(document, "keydown", this.recordConfirmationKeyboardEvent, {
@@ -151,6 +154,8 @@ export class TourRecorder extends Component {
             const lastStepInput = this.state.steps.at(-1);
             lastStepInput.run = "click";
         }
+
+        tourRecorderState.setCurrentTourRecorder(this.state.steps);
     }
 
     /**
@@ -178,6 +183,7 @@ export class TourRecorder extends Component {
             });
             this.state.editedElement = undefined;
         }
+        tourRecorderState.setCurrentTourRecorder(this.state.steps);
     }
 
     /**
@@ -217,10 +223,12 @@ export class TourRecorder extends Component {
         } else {
             lastStep.run = `edit ${this.state.editedElement.value}`;
         }
+        tourRecorderState.setCurrentTourRecorder(this.state.steps);
     }
 
     toggleRecording() {
         this.state.recording = !this.state.recording;
+        tourRecorderState.setIsRecording(this.state.recording);
         this.state.editedElement = undefined;
         if (this.state.recording && !this.state.url) {
             this.state.url = browser.location.pathname + browser.location.search;
@@ -250,6 +258,7 @@ export class TourRecorder extends Component {
 
     resetTourRecorderState() {
         Object.assign(this.state, { ...TourRecorder.defaultState, steps: [] });
+        tourRecorderState.clear();
     }
 
     /**

--- a/addons/web_tour/static/src/tour_service/tour_recorder/tour_recorder_state.js
+++ b/addons/web_tour/static/src/tour_service/tour_recorder/tour_recorder_state.js
@@ -1,0 +1,32 @@
+import { browser } from "@web/core/browser/browser";
+
+const CURRENT_TOUR_RECORDER_LOCAL_STORAGE = "current_tour_recorder";
+const CURRENT_TOUR_RECORDER_RECORD_LOCAL_STORAGE = "current_tour_recorder.record";
+
+/**
+ * Wrapper around localStorage for persistence of the current recording.
+ * Useful for resuming recording when the page refreshed.
+ */
+export const tourRecorderState = {
+    isRecording() {
+        return browser.localStorage.getItem(CURRENT_TOUR_RECORDER_RECORD_LOCAL_STORAGE) || "0";
+    },
+    setIsRecording(isRecording) {
+        browser.localStorage.setItem(
+            CURRENT_TOUR_RECORDER_RECORD_LOCAL_STORAGE,
+            isRecording ? "1" : "0"
+        );
+    },
+    setCurrentTourRecorder(tour) {
+        tour = JSON.stringify(tour);
+        browser.localStorage.setItem(CURRENT_TOUR_RECORDER_LOCAL_STORAGE, tour);
+    },
+    getCurrentTourRecorder() {
+        const tour = browser.localStorage.getItem(CURRENT_TOUR_RECORDER_LOCAL_STORAGE) || "[]";
+        return JSON.parse(tour);
+    },
+    clear() {
+        browser.localStorage.removeItem(CURRENT_TOUR_RECORDER_LOCAL_STORAGE);
+        browser.localStorage.removeItem(CURRENT_TOUR_RECORDER_RECORD_LOCAL_STORAGE);
+    },
+};

--- a/addons/web_tour/static/tests/tour_recorder.test.js
+++ b/addons/web_tour/static/tests/tour_recorder.test.js
@@ -18,6 +18,7 @@ import {
 import { Component, xml } from "@odoo/owl";
 import { useAutofocus } from "@web/core/utils/hooks";
 import { WebClient } from "@web/webclient/webclient";
+import { tourRecorderState } from "@web_tour/tour_service/tour_recorder/tour_recorder_state";
 
 describe.current.tags("desktop");
 
@@ -424,4 +425,35 @@ test("Edit input after autofocus", async () => {
     expect(".o_button_record").toHaveText("Record (recording keyboard)");
     checkTourSteps([".o_input"]);
     expect(tourRecorder.state.steps.map((s) => s.run)).toEqual(["edit Bismillah"]);
+});
+
+test("Check Tour Recorder State", async () => {
+    await mountWithCleanup(
+        `
+        <div class="o_parent">
+            <div class="o_child_1 click"></div>
+            <div class="o_child_2"></div>
+            <div class="o_child_3"></div>
+        </div>
+    `,
+        { noMainContainer: true }
+    );
+
+    expect(".o_tour_recorder").toHaveCount(1);
+    expect(tourRecorderState.isRecording()).toBe("0");
+    await click(".o_button_record");
+    await animationFrame();
+    expect(tourRecorderState.isRecording()).toBe("1");
+    expect(tourRecorderState.getCurrentTourRecorder()).toEqual([]);
+    await click(".click");
+    await animationFrame();
+    checkTourSteps([".o_child_1"]);
+
+    await click(".o_child_2");
+    await animationFrame();
+    checkTourSteps([".o_child_1", ".o_child_2"]);
+    expect(tourRecorderState.getCurrentTourRecorder()).toEqual([
+        { trigger: ".o_child_1", run: "click" },
+        { trigger: ".o_child_2", run: "click" },
+    ]);
 });


### PR DESCRIPTION
Wrapper around localStorage for persistence of the current recording. Useful for resuming recording when the page refreshed.

TASK-ID: 4378081




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
