### PR TITLE
[FIX] base: interval type is require

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -86,9 +86,9 @@ class ir_cron(models.Model):
             self = self.with_context(default_state='code')
         return super(ir_cron, self).default_get(fields_list)
 
-    @api.onchange('active', 'interval_number')
+    @api.onchange('active', 'interval_number', 'interval_type')
     def _onchange_interval_number(self):
-        if self.active and self.interval_number <= 0:
+        if self.active and (self.interval_number <= 0 or not self.interval_type):
             self.active = False
             return {'warning': {
                 'title': _("Scheduled action disabled"),


### PR DESCRIPTION
[FIX] base: interval_type is required

Steps:
- Install CRM
- Open Settings/CRM
    - "Rule-Based Assignment" is disabled
- Go to open the scheduled action: "CRM: Lead Assignment"
    - No interval type defined
- Enable it

Other steps:
- Install CRM
- Open Settings/CRM
    - Enable "Rule-Based Assignment" Repeatedly
- Go to open the scheduled action: "CRM: Lead Assignment"
- Change the interval to nothing

Actual result:
- Scheduled actions will not run anymore (cron)
- KeyError: None
- `interval = _intervalTypes[job['interval_type']](job['interval_number'])`

Expected result:
- You cannot enable a scheduled action without an interval_type defined

opw-4370139
opw-4318230