### PR TITLE
[IMP] mail, im_livechat: updated message params as a dict

### DIFF
--- a/addons/im_livechat/controllers/cors/thread.py
+++ b/addons/im_livechat/controllers/cors/thread.py
@@ -12,8 +12,6 @@ class LivechatThreadController(ThreadController):
         return self.mail_message_post(thread_model, thread_id, post_data, context, **kwargs)
 
     @route("/im_livechat/cors/message/update_content", methods=["POST"], type="jsonrpc", auth="public", cors="*")
-    def livechat_message_update_content(
-        self, guest_token, message_id, body, attachment_ids, attachment_tokens=None, partner_ids=None
-    ):
+    def livechat_message_update_content(self, guest_token, message_id, update_data, **kwargs):
         force_guest_env(guest_token)
-        return self.mail_message_update_content(message_id, body, attachment_ids, attachment_tokens, partner_ids)
+        return self.mail_message_update_content(message_id, update_data, **kwargs)

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -680,14 +680,20 @@ export class Composer extends Component {
         this.props.messageToReplyTo?.cancel();
     }
 
+    get updateData() {
+        const composer = toRaw(this.props.composer);
+        return {
+            attachments: composer.attachments,
+            mentionedChannels: composer.mentionedChannels,
+            mentionedPartners: composer.mentionedPartners,
+        };
+    }
+
     async editMessage() {
         const composer = toRaw(this.props.composer);
         if (composer.text || composer.message.attachment_ids.length > 0) {
             await this.processMessage(async (value) =>
-                composer.message.edit(value, composer.attachments, {
-                    mentionedChannels: composer.mentionedChannels,
-                    mentionedPartners: composer.mentionedPartners,
-                })
+                composer.message.edit({ ...this.updateData, body: value })
             );
         } else {
             this.env.services.dialog.add(MessageConfirmDialog, {

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -503,6 +503,32 @@ export class Store extends BaseStore {
         return params;
     }
 
+    /**
+     * Get the parameters to pass to the message update route.
+     */
+    async getMessageUpdateParams({ message, updateData }) {
+        const {
+            body,
+            attachments = [],
+            mentionedChannels = [],
+            mentionedPartners = [],
+        } = updateData;
+        const validMentions = this.getMentionsFromText(body, {
+            mentionedChannels,
+            mentionedPartners,
+        });
+        return {
+            attachment_ids: attachments
+                .concat(message.attachment_ids)
+                .map((attachment) => attachment.id),
+            attachment_tokens: attachments
+                .concat(message.attachment_ids)
+                .map((attachment) => attachment.access_token),
+            body: await prettifyMessageContent(body, validMentions),
+            partner_ids: validMentions?.partners?.map((partner) => partner.id),
+        };
+    }
+
     getNextTemporaryId() {
         const lastMessageId = this.getLastMessageId();
         if (prevLastMessageId === lastMessageId) {

--- a/addons/mail/static/src/discuss/core/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_model_patch.js
@@ -56,15 +56,15 @@ const messagePatch = {
     /**
      * @override
      */
-    async edit(body, attachments = [], { mentionedChannels = [], mentionedPartners = [] } = {}) {
+    async edit(updateData) {
         const validChannels = (await Promise.all(this.mentionedChannelPromises)).filter(
             (channel) => channel !== undefined
         );
-        const allChannels = this.store.Thread.insert([...validChannels, ...mentionedChannels]);
-        super.edit(body, attachments, {
-            mentionedChannels: allChannels,
-            mentionedPartners,
-        });
+        updateData.mentionedChannels = this.store.Thread.insert([
+            ...validChannels,
+            ...(updateData.mentionedChannels || []),
+        ]);
+        super.edit(updateData);
     },
 };
 patch(Message.prototype, messagePatch);

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -150,9 +150,8 @@ test("Adding attachments", async () => {
         mimetype: "text/plain",
     });
     rpc("/mail/message/update_content", {
-        body: "Hello world!",
-        attachment_ids: [attachmentId],
         message_id: messageId,
+        update_data: { body: "Hello world!", attachment_ids: [attachmentId] },
     });
     await contains(".o-mail-AttachmentCard", { target: env2, text: "test.txt" });
 });

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2256,8 +2256,7 @@ test("Read of unread chat where new message is deleted should mark as read", asy
     // simulate deleted message
     rpc("/mail/message/update_content", {
         message_id: messageId,
-        body: "",
-        attachment_ids: [],
+        update_data: { body: "", attachment_ids: [] },
     });
     await click("button", { text: "Marc Demo" });
     await contains(".o-mail-DiscussSidebar-item", {

--- a/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
@@ -130,8 +130,8 @@ patch(MockServer.prototype, {
         }
         if (route === "/mail/message/update_content") {
             this.pyEnv["mail.message"].write([args.message_id], {
-                body: args.body,
-                attachment_ids: args.attachment_ids,
+                body: args.update_data.body,
+                attachment_ids: args.update_data.attachment_ids,
             });
             this.pyEnv["bus.bus"]._sendone(
                 this._mockMailMessage__busNotificationTarget(args.message_id),
@@ -139,9 +139,9 @@ patch(MockServer.prototype, {
                 {
                     "mail.message": {
                         id: args.message_id,
-                        body: args.body,
+                        body: args.update_data.body,
                         attachment_ids: this._mockIrAttachment_attachmentFormat(
-                            args.attachment_ids
+                            args.update_data.attachment_ids
                         ),
                     },
                 }

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -991,8 +991,7 @@ test("preview for channel should show latest non-deleted message", async () => {
     // Simulate deletion of message-2
     rpc("/mail/message/update_content", {
         message_id: messageId_2,
-        body: "",
-        attachment_ids: [],
+        update_data: { attachment_ids: [], body: "" },
     });
     await contains(".o-mail-NotificationItem-text", { text: "Partner1: message-1" });
 });

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -692,7 +692,10 @@ async function mail_message_update_content(request) {
     /** @type {import("mock_models").MailMessage} */
     const MailMessage = this.env["mail.message"];
 
-    const { attachment_ids, body, message_id } = await parseRequestParams(request);
+    const {
+        message_id,
+        update_data: { attachment_ids, body },
+    } = await parseRequestParams(request);
     const [message] = MailMessage.browse(message_id);
     const msg_values = {};
     if (body !== null) {

--- a/addons/mail/tests/common_controllers.py
+++ b/addons/mail/tests/common_controllers.py
@@ -282,8 +282,7 @@ class MailControllerUpdateCommon(MailControllerCommon):
             route="/mail/message/update_content",
             params={
                 "message_id": message_id,
-                "body": body,
-                "attachment_ids": [],
+                "update_data": {"attachment_ids": [], "body": body},
                 **route_kw,
             },
         )

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -121,9 +121,11 @@ class TestMessageController(HttpCaseWithUserDemo):
                 {
                     "params": {
                         "message_id": data1["mail.message"][0]["id"],
-                        "body": "test",
-                        "attachment_ids": [self.attachments[1].id],
-                        "attachment_tokens": ["wrong token"],
+                        "update_data": {
+                            "attachment_ids": [self.attachments[1].id],
+                            "attachment_tokens": ["wrong token"],
+                            "body": "test",
+                        },
                     },
                 }
             ),
@@ -142,9 +144,11 @@ class TestMessageController(HttpCaseWithUserDemo):
                 {
                     "params": {
                         "message_id": data1["mail.message"][0]["id"],
-                        "body": "test",
-                        "attachment_ids": [self.attachments[1].id],
-                        "attachment_tokens": [self.attachments[1].access_token],
+                        "update_data": {
+                            "attachment_ids": [self.attachments[1].id],
+                            "attachment_tokens": [self.attachments[1].access_token],
+                            "body": "test",
+                        },
                     },
                 }
             ),
@@ -189,8 +193,10 @@ class TestMessageController(HttpCaseWithUserDemo):
                 {
                     "params": {
                         "message_id": data2["mail.message"][0]["id"],
-                        "body": "test",
-                        "attachment_ids": [self.attachments[1].id],
+                        "update_data": {
+                            "attachment_ids": [self.attachments[1].id],
+                            "body": "test",
+                        },
                     },
                 }
             ),

--- a/addons/mail/tests/test_mail_message_translate.py
+++ b/addons/mail/tests/test_mail_message_translate.py
@@ -81,11 +81,16 @@ class TestTranslationController(HttpCaseWithUserDemo):
         self.assertEqual(self.env["mail.message.translation"].search_count([]), 1)
         # The translation records should not be discarded if the body did not change.
         self.make_jsonrpc_request(
-            "/mail/message/update_content", {"message_id": self.message.id, "body": None, "attachment_ids": []}
+            "/mail/message/update_content",
+            {"message_id": self.message.id, "update_data": {"attachment_ids": [], "body": None}},
         )
         self.assertEqual(self.env["mail.message.translation"].search_count([]), 1)
         self.make_jsonrpc_request(
-            "/mail/message/update_content", {"message_id": self.message.id, "body": "update", "attachment_ids": []}
+            "/mail/message/update_content",
+            {
+                "message_id": self.message.id,
+                "update_data": {"attachment_ids": [], "body": "update"},
+            },
         )
         self.assertFalse(self.env["mail.message.translation"].search_count([]))
 


### PR DESCRIPTION
`/mail/message/update_content` will be used in more use cases in the portal (popup rating composer). To do this, we need to pass more update params to the route (updated `rating_value`). This is a preparation PR to make passing update params simpler. This way, the updated data that should be handled in `_message_update_content` is sent as `update_data` dict so it's possible to manipulate it when it's needed. Non-update params such as security params are
sent in `kwargs` as before.