### PR TITLE
[FIX] tools: prevent warning override behaviour

### DIFF
--- a/odoo/tools/pdf/_pypdf2_1.py
+++ b/odoo/tools/pdf/_pypdf2_1.py
@@ -1,4 +1,4 @@
-from PyPDF2 import filters, generic, utils as errors, PdfFileReader as PdfReader, PdfFileWriter
+from PyPDF2 import filters, generic, utils as errors, PdfFileReader, PdfFileWriter
 from PyPDF2.generic import createStringObject as create_string_object
 
 __all__ = [
@@ -9,6 +9,13 @@ __all__ = [
     "filters",
     "generic",
 ]
+
+# by default PdfFileReader will overwrite warnings.showwarning which is what
+# logging.captureWarnings does, meaning it essentially reverts captureWarnings
+# every time it's called which is undesirable
+class PdfReader(PdfFileReader):
+    def __init__(self, stream, strict=True, warndest=None, overwriteWarnings=True):
+        super().__init__(stream, strict=strict, warndest=warndest, overwriteWarnings=False)
 
 
 class PdfWriter(PdfFileWriter):


### PR DESCRIPTION
current behaviour:
when buggy server action is introduced, we don't handle it well, eg:
```
name = record.name
if name != record.partner_id:
    raise UserError("Datatype")
```
here, comparing `name` and `record.partner_id` doesn't make sense, therefore our ORM default behaviour is to return false and rise `AttributeError`, but the problem occurs when pypdf2 attempts to format the warning message, which rises an error which isn't being handled:
```
  File "/home/odoo/.local/lib/python3.10/site-packages/PyPDF2/pdf.py", line 1069, in _showwarning
    file.write(formatWarning(message, category, filename, lineno, line))
  File "/home/odoo/.local/lib/python3.10/site-packages/PyPDF2/utils.py", line 69, in formatWarning
    file = filename.replace("/", "\\").rsplit("\\", 1)[1] # find the file name
IndexError: list index out of range
```
it is problematic since it is server action.

expected behaviour:
Even when buggy code is introduced, comparision should return False and error should be handled well.

steps to reproduce:
1) Create new database from scratch and create server action with the buggy code above, set model to `sale.orde` and add it to `contextual action`
2) Go to any `sale.order` record and trigger the action. 3) it outputs the error.
4) please note that, if you restart the server, error doesn't happen, because places where override happens doesn't get invoked.

task-4365106

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
