### PR TITLE
[FIX] base: prevent error when ISO code is not available in language

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -175,15 +175,14 @@ class Currency(models.Model):
         parts = formatted.partition('.')
         integer_value = int(parts[0])
         fractional_value = int(parts[2] or 0)
-
-        lang = tools.get_lang(self.env)
+        lang = tools.get_lang(self.env).iso_code or 'en'
         amount_words = tools.ustr('{amt_value} {amt_word}').format(
-                        amt_value=_num2words(integer_value, lang=lang.iso_code),
+                        amt_value=_num2words(integer_value, lang=lang),
                         amt_word=self.currency_unit_label,
                         )
         if not self.is_zero(amount - integer_value):
             amount_words += ' ' + _('and') + tools.ustr(' {amt_value} {amt_word}').format(
-                        amt_value=_num2words(fractional_value, lang=lang.iso_code),
+                        amt_value=_num2words(fractional_value, lang=lang),
                         amt_word=self.currency_subunit_label,
                         )
         return amount_words


### PR DESCRIPTION
Currently, an error occurs when trying to create a payment for an invoice, and ISO code is not available in the currently active language.

Step to produce:

- Install the ```account``` module.
- Go to Settings / Translations / Languages, Open the currently active language, and remove the ISO code from it.
- Create a new invoice add a customer and invoice line, and confirm it.
- Click on 'Register Payment',  and try to create a payment for that invoice.

```TypeError: argument of type 'bool' is not iterable```

An error occurs when the system tries to get ISO code from language at [1], but it is not available.

Link [1]: https://github.com/odoo/odoo/blob/347b2eb1aa2ec576e9d228d2dd2019c38160e636/odoo/addons/base/models/res_currency.py#L181

To resolve the issue, add a condition to check if the ISO code is missing in the language or not available, then set a default ISO code as 'en'.

Sentry-6108349395

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
