### PR TITLE
[FIX] html_editor: toggle spellcheck on focus

### DIFF
--- a/addons/html_editor/static/src/wysiwyg.js
+++ b/addons/html_editor/static/src/wysiwyg.js
@@ -1,7 +1,7 @@
 import { Component, onMounted, onWillDestroy, useRef, useState, useSubEnv } from "@odoo/owl";
 import { Editor } from "./editor";
 import { Toolbar } from "./main/toolbar/toolbar";
-import { useChildRef } from "@web/core/utils/hooks";
+import { useChildRef, useSpellCheck } from "@web/core/utils/hooks";
 import { LocalOverlayContainer } from "./local_overlay_container";
 import { uniqueId } from "@web/core/utils/functions";
 
@@ -56,6 +56,9 @@ export class Wysiwyg extends Component {
         const config = this.getEditorConfig();
         this.editor = new Editor(config, this.env.services);
         this.props.onLoad(this.editor);
+        useSpellCheck({
+            refName: "content",
+        });
 
         onMounted(() => {
             // now that component is mounted, editor is attached to el, and

--- a/addons/html_editor/static/src/wysiwyg.xml
+++ b/addons/html_editor/static/src/wysiwyg.xml
@@ -10,7 +10,7 @@
                     <iframe t-ref="content" class="w-100 h-100" t-att-data-class="props.contentClass" t-on-blur="props.onBlur"/>
                 </t>
                 <t t-else="">
-                    <div t-att-class="props.contentClass" t-ref="content" t-on-blur="props.onBlur"/>
+                    <div t-att-class="props.contentClass" t-ref="content" t-on-blur="props.onBlur" contenteditable="true"/>
                 </t>
             </div>
         </div>


### PR DESCRIPTION
This commit fixes the behavior of spellcheck on the WYSIWIG component, which previously enabled this only on focus. Since we use this element in many scenarios accross Odoo, we don't want red lines to keep their visibility all the time, when the WYSIWIG is not directly focused.

~~A test has been introduced, since the contenteditable attribute was not correctly accessed by the hook.~~
