### PR TITLE
[FIX] mrp: highlight consumption for SN Product component

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1326,7 +1326,7 @@ class MrpProduction(models.Model):
     def set_qty_producing(self):
         # This method is used to call `_set_lot_producing` when the onchange doesn't apply.
         self.ensure_one()
-        self._set_qty_producing()
+        self._set_qty_producing(False)
 
     def _set_lot_producing(self):
         self.ensure_one()
@@ -1403,7 +1403,7 @@ class MrpProduction(models.Model):
         self.ensure_one()
         self._set_lot_producing()
         if self.product_id.tracking == 'serial':
-            self._set_qty_producing()
+            self._set_qty_producing(False)
         if self.picking_type_id.auto_print_generated_mrp_lot:
             return self._autoprint_generated_lot(self.lot_producing_id)
 

--- a/addons/mrp/wizard/mrp_batch_produce.py
+++ b/addons/mrp/wizard/mrp_batch_produce.py
@@ -113,7 +113,6 @@ class MrpBatchProduct(models.TransientModel):
         for production in productions:
             production.qty_producing = production.product_uom_qty
             production.set_qty_producing()
-            production.move_raw_ids.picked = True
 
         if mark_done:
             return productions.with_context(from_wizard=True).button_mark_done()


### PR DESCRIPTION
Before this commit:
----------------------------------
- Components set as 'highlight consumption' in the BOM of serial-number tracked products were being automatically consumed when serial numbers were generated or via the mass produce option, causing unintended stock reductions.

After this commit:
----------------------------------
- Fixed the issue where 'highlight consumption' components were incorrectly consumed during serial number generation. Components are now only consumed when explicitly required by the production process.

Task-id: 4373005