### PR TITLE
[FIX] purchase_requisition: copy description lines in alternative PO

### DIFF
--- a/addons/purchase_requisition_sale/wizard/purchase_requisition_create_alternative.py
+++ b/addons/purchase_requisition_sale/wizard/purchase_requisition_create_alternative.py
@@ -8,8 +8,8 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
     _inherit = 'purchase.requisition.create.alternative'
 
     @api.model
-    def _get_alternative_line_value(self, order_line):
-        res_line = super()._get_alternative_line_value(order_line)
+    def _get_alternative_line_value(self, order_line, product_tmpl_ids_with_description):
+        res_line = super()._get_alternative_line_value(order_line, product_tmpl_ids_with_description)
         if order_line.sale_line_id:
             res_line['sale_line_id'] = order_line.sale_line_id.id
 

--- a/addons/purchase_requisition_stock/wizard/purchase_requisition_create_alternative.py
+++ b/addons/purchase_requisition_stock/wizard/purchase_requisition_create_alternative.py
@@ -16,8 +16,8 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
         return vals
 
     @api.model
-    def _get_alternative_line_value(self, order_line):
-        res_line = super()._get_alternative_line_value(order_line)
+    def _get_alternative_line_value(self, order_line, product_tmpl_ids_with_description):
+        res_line = super()._get_alternative_line_value(order_line, product_tmpl_ids_with_description)
         if order_line.move_dest_ids:
             res_line['move_dest_ids'] = [Command.set(order_line.move_dest_ids.ids)]
 


### PR DESCRIPTION
Issue Before This Commit:
-----------------------------------------------
Creating an alternative for a RFQ does not copy the description.

Steps to Produce:
-----------------------------------------------
1. Create RFQ.
2. Add Products.
3. Add description of this products.
4. Create Alternative RFQ.
5. Turn On 'Copy Products' and then Generate Alternatives.

Problem: Alternative RFQ does not copy the description.

With this commit:
-----------------------------------------------
Creating an alternative for a RFQ will copy the description too.

Note: If there are multiple records of the same vendor in the same product then
we expect either all of them have to have a product code/name or none of them
to have one. This means in cases with a mix of both set and not set product
code/name values for the same vendor, the POL will NOT be copied.

This fix will also handle case of: https://github.com/odoo/odoo/pull/181312

Task-id: 4373285