### PR TITLE
[FIX] point_of_sale: add rate to tax_base_line_values

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1576,6 +1576,7 @@ class PosOrderLine(models.Model):
                         line,
                         partner_id=commercial_partner,
                         currency_id=self.order_id.currency_id,
+                        rate=self.order_id.currency_rate,
                         product_id=line.product_id,
                         tax_ids=line.tax_ids_after_fiscal_position,
                         price_unit=line.price_unit,

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1496,16 +1496,13 @@ class PosSession(models.Model):
         new_amounts['amount_converted'] += amount_converted
 
         # consider base_amount if present
-        if not amounts_to_add.get('base_amount') == None:
+
+        if amounts_to_add.get('base_amount'):
             base_amount = amounts_to_add.get('base_amount')
-            if self.is_in_company_currency or force_company_currency:
-                base_amount_converted = base_amount
-            else:
-                base_amount_converted = self._amount_converter(base_amount, date, round)
 
             # update base_amount and base_amount_converted
             new_amounts['base_amount'] += base_amount
-            new_amounts['base_amount_converted'] += base_amount_converted
+            new_amounts['base_amount_converted'] += base_amount
 
         return new_amounts
 


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Activate Mexican Localization
2. In Mexican Company, add USD as Currency and give it a Rate
3. Create a Sales Journal and a Pricelist with USD as main Currency
4. _Point of Sale > Configuration > Settings_: Select a Shop and set the USD Journal and Pricelist
5. Open a Session using the USD Shop and complete some Orders, without invoicing them
6. _Point of Sale > Orders > Orders_, select the created Orders and, in the Actions, Create Global Invoice
7. The document should be accepted, but TipoCambio has a rate of 1.000000.

### Explanation:

During the creation of the Global Invoice, the rate is retrieved during `pos.order._prepare_tax_base_line_values` and, since no value is given through POS, the default value is used. https://github.com/odoo/odoo/blob/8fb7e5fd304697aebcce085602a5f3a1ecaf757a/addons/account/models/account_tax.py#L1242 https://github.com/odoo/odoo/blob/8fb7e5fd304697aebcce085602a5f3a1ecaf757a/addons/account/models/account_tax.py#L1212-L1213 https://github.com/odoo/odoo/blob/8fb7e5fd304697aebcce085602a5f3a1ecaf757a/addons/account/models/account_tax.py#L1188-L1193

### Fix reasoning:

`pos.order.currency_rate` is the rate of the Currency at the time the order was created. It is the perfect value to use for `TipoCambio`. We must also adapt workflows that were designed with the absence of `rate` in `tax_base_line_values`.
Test in Enterprise

opw-4302180