### PR TITLE
[FIX] point_of_sale: allow search partners by VAT

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerListScreen.js
@@ -201,7 +201,13 @@ odoo.define('point_of_sale.PartnerListScreen', function(require) {
             let domain = [];
             const limit = 30;
             if(this.state.query) {
-                const search_fields = ["name", "parent_name", "phone_mobile_search", "email"];
+                const search_fields = [
+                    "name",
+                    "parent_name",
+                    "phone_mobile_search",
+                    "email",
+                    "vat",
+                ];
                 domain = [
                     ...Array(search_fields.length - 1).fill('|'),
                     ...search_fields.map(field => [field, "ilike", this.state.query + "%"])


### PR DESCRIPTION
Before this commit, "search more" would not find any matches if searching partners by VAT numbers.

After this commit, it becomes possible to search and "load more" partners by VAT number.

opw-4379852