### PR TITLE
[FIX] stock,product_expiry,point_of_sale: cron progress in scheduler

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1899,5 +1899,15 @@ class ProcurementGroup(models.Model):
     def _run_scheduler_tasks(self, use_new_cursor=False, company_id=False):
         super(ProcurementGroup, self)._run_scheduler_tasks(use_new_cursor=use_new_cursor, company_id=company_id)
         self.env['pos.session']._alert_old_session()
+        if 'scheduler_task_done' in self._context:
+            task_done = self._context.get('scheduler_task_done', {'task_done': 0})['task_done'] + 1
+            self._context['scheduler_task_done']['task_done'] = task_done
+        else:
+            task_done = self._get_scheduler_tasks_to_do()
         if use_new_cursor:
+            self.env['ir.cron']._notify_progress(done=task_done, remaining=self._get_scheduler_tasks_to_do() - task_done)
             self.env.cr.commit()
+
+    @api.model
+    def _get_scheduler_tasks_to_do(self):
+        return super()._get_scheduler_tasks_to_do() + 1

--- a/addons/product_expiry/models/production_lot.py
+++ b/addons/product_expiry/models/production_lot.py
@@ -96,5 +96,16 @@ class ProcurementGroup(models.Model):
     def _run_scheduler_tasks(self, use_new_cursor=False, company_id=False):
         super(ProcurementGroup, self)._run_scheduler_tasks(use_new_cursor=use_new_cursor, company_id=company_id)
         self.env['stock.lot']._alert_date_exceeded()
+        if 'scheduler_task_done' in self._context:
+            task_done = self._context.get('scheduler_task_done', {'task_done': 0})['task_done'] + 1
+            self._context['scheduler_task_done']['task_done'] = task_done
+        else:
+            task_done = self._get_scheduler_tasks_to_do()
+
         if use_new_cursor:
+            self.env['ir.cron']._notify_progress(done=task_done, remaining=self._get_scheduler_tasks_to_do() - task_done)
             self.env.cr.commit()
+
+    @api.model
+    def _get_scheduler_tasks_to_do(self):
+        return super()._get_scheduler_tasks_to_do() + 1

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -687,12 +687,17 @@ class ProcurementGroup(models.Model):
 
     @api.model
     def _run_scheduler_tasks(self, use_new_cursor=False, company_id=False):
+        task_done = 0
+
         # Minimum stock rules
         domain = self._get_orderpoint_domain(company_id=company_id)
         orderpoints = self.env['stock.warehouse.orderpoint'].search(domain)
-        if use_new_cursor:
-            self._cr.commit()
         orderpoints.sudo()._procure_orderpoint_confirm(use_new_cursor=use_new_cursor, company_id=company_id, raise_user_error=False)
+        task_done += 1
+
+        if use_new_cursor:
+            self.env['ir.cron']._notify_progress(done=task_done, remaining=self._get_scheduler_tasks_to_do() - task_done)
+            self._cr.commit()
 
         # Search all confirmed stock_moves and try to assign them
         domain = self._get_moves_to_assign_domain(company_id)
@@ -703,13 +708,26 @@ class ProcurementGroup(models.Model):
             if use_new_cursor:
                 self._cr.commit()
                 _logger.info("A batch of %d moves are assigned and committed", len(moves_chunk))
+        task_done += 1
+
+        if use_new_cursor:
+            self.env['ir.cron']._notify_progress(done=task_done, remaining=self._get_scheduler_tasks_to_do() - task_done)
+            self._cr.commit()
 
         # Merge duplicated quants
         self.env['stock.quant']._quant_tasks()
 
+        task_done += 1
         if use_new_cursor:
+            self.env['ir.cron']._notify_progress(done=task_done, remaining=self._get_scheduler_tasks_to_do() - task_done)
             self._cr.commit()
-            _logger.info("_run_scheduler_tasks is finished and committed")
+        self._context.get('scheduler_task_done', {})['task_done'] = task_done
+
+    @api.model
+    def _get_scheduler_tasks_to_do(self):
+        """ Number of task to be executed by the stock scheduler. This number will be given in log
+        message to know how many tasks succeeded."""
+        return 3
 
     @api.model
     def run_scheduler(self, use_new_cursor=False, company_id=False):
@@ -717,21 +735,10 @@ class ProcurementGroup(models.Model):
         and the availability of moves. This function is intended to be run for all the companies at the same time, so
         we run functions as SUPERUSER to avoid intercompanies and access rights issues. """
         try:
-            if use_new_cursor:
-                assert isinstance(self._cr, BaseCursor)
-                cr = Registry(self._cr.dbname).cursor()
-                self = self.with_env(self.env(cr=cr))  # TDE FIXME
-
             self._run_scheduler_tasks(use_new_cursor=use_new_cursor, company_id=company_id)
         except Exception:
             _logger.error("Error during stock scheduler", exc_info=True)
             raise
-        finally:
-            if use_new_cursor:
-                try:
-                    self._cr.close()
-                except Exception:
-                    pass
         return {}
 
     @api.model


### PR DESCRIPTION
This commit makes use of the ir.cron.progress feature in the stock scheduler. The first approach is to simply count how many tasks have been completely done among the 5 currently available

* stock
    - trigger orderpoints
    - merge quant & delete 0 quant
    - reserve confirm stock move
* point_of_sale
    - close session
* product_expiry
    - make alerts on expired lots

They will be split in 5 different crons later to be able to count exactly the remaining records number to manage in each sub tasks.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
