### PR TITLE
[FIX] mail: check if values exist

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -365,7 +365,7 @@ class MailActivity(models.Model):
 
         allowed_ids = defaultdict(set)
         for res_model, res_ids in model_ids.items():
-            records = self.env[res_model].browse(res_ids)
+            records = self.env[res_model].browse(res_ids).exists()
             # fall back on related document access right checks. Use the same as defined for mail.thread
             # if available; otherwise fall back on read
             operation = getattr(records, '_mail_post_access', 'read')


### PR DESCRIPTION
Browse method of orm only returns a recordset of ids provided but never checks if those ids actually exist, which when testing actvities can lead to no record found errors. This happens because the values /res_id might exist in mail_activity but not the related table.

Co-Authored By: apan-odoo apan@odoo.com

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
