### PR TITLE
[FIX] mass_mailing: avoid automatic unsubscribe from mail

### DIFF
--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -102,6 +102,39 @@ class MassMailController(http.Controller):
         self.mailing_unsubscribe(mailing_id, document_id=document_id, email=email, hash_token=hash_token, **post)
         return Response(status=200)
 
+    @http.route(['/mailing/<int:mailing_id>/confirm_unsubscribe'], type='http', website=True, auth='public')
+    def mailing_confirm_unsubscribe(self, mailing_id, document_id=None, email=None, hash_token=None):
+        mailing = request.env['mailing.mailing'].sudo().browse(mailing_id)
+
+        unsubscribed_list = ''
+        email_found, hash_token_found = self._fetch_user_information(email, hash_token)
+        try:
+            mailing_sudo = self._check_mailing_email_token(
+                mailing_id, document_id, email_found, hash_token_found,
+                required_mailing_id=True
+            )
+            if mailing.mailing_model_real == 'mailing.contact':
+                unsubscribed_list = ', '.join(str(list.name) for list in mailing.contact_list_ids if list.is_public)
+        except NotFound as e:  # avoid leaking ID existence
+            raise Unauthorized() from e
+        return request.render('mass_mailing.page_confirm_unsubscribe', {
+                    'mailing_id': mailing_id,
+                    'document_id': document_id,
+                    'email': email,
+                    'hash_token': hash_token,
+                    'unsubscribed_list': unsubscribed_list,
+                })
+
+    @http.route(['/mailing/confirm_unsubscribe'], type='http', website=True, auth='public', methods=['POST'])
+    def mailing_confirm_unsubscribe_post(self, mailing_id, document_id=None, email=None, hash_token=None):
+        url = '/mailing/%(mailing_id)s/unsubscribe?document_id=%(document_id)s&email=%(email)s&hash_token=%(hash_token)s' % {
+            'mailing_id': mailing_id,
+            'document_id': document_id,
+            'email': email,
+            'hash_token': hash_token,
+        }
+        return request.redirect(url)
+
     @http.route(['/mailing/<int:mailing_id>/unsubscribe'], type='http', website=True, auth='public')
     def mailing_unsubscribe(self, mailing_id, document_id=None, email=None, hash_token=None):
         email_found, hash_token_found = self._fetch_user_information(email, hash_token)

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1037,7 +1037,7 @@ class MassMailing(models.Model):
 
     def _get_unsubscribe_url(self, email_to, res_id):
         url = werkzeug.urls.url_join(
-            self.get_base_url(), 'mailing/%(mailing_id)s/unsubscribe?%(params)s' % {
+            self.get_base_url(), 'mailing/%(mailing_id)s/confirm_unsubscribe?%(params)s' % {
                 'mailing_id': self.id,
                 'params': werkzeug.urls.url_encode({
                     'document_id': res_id,

--- a/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
@@ -1,5 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <template id="page_confirm_unsubscribe" name="Confirm Unsubscribe">
+        <t t-call="mass_mailing.layout">
+            <t t-call="mass_mailing.confirm_unsubscribe"/>
+        </t>
+    </template>
+
+    <template id="confirm_unsubscribe">
+        <div class="container o_unsubscribe_form">
+            <div class="row">
+                <form action="/mailing/confirm_unsubscribe" method="POST" class="col-lg-6 offset-lg-3 mt-4">
+                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                    <input type="hidden" name="mailing_id" t-att-value="mailing_id"/>
+                    <input type="hidden" name="document_id" t-att-value="document_id"/>
+                    <input type="hidden" name="email" t-att-value="email"/>
+                    <input type="hidden" name="hash_token" t-att-value="hash_token"/>
+
+                    <div id="info_state"  class="alert alert-success">
+                        <div class="text-center">
+                            <t t-if="len(unsubscribed_list) > 0">
+                                <p>You are about to unsubscribe from the following mailing list: <t t-out="unsubscribed_list"/></p>
+                            </t>
+                            <t t-else="">
+                                <p>You are about to unsubscribe from a mailing list.</p>
+                            </t>
+                            <div>
+                                <button type="submit" class="btn btn-primary">Unsubscribe</button>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </template>
+
     <template id="page_mailing_unsubscribe" name="Unsubscribe">
         <t t-call="mass_mailing.layout">
             <t t-call="mass_mailing.unsubscribe_form"/>

--- a/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
@@ -15,6 +15,7 @@
                     <input type="hidden" name="document_id" t-att-value="document_id"/>
                     <input type="hidden" name="email" t-att-value="email"/>
                     <input type="hidden" name="hash_token" t-att-value="hash_token"/>
+                    <input type="hidden" name="unsubscribed_list" t-att-value="unsubscribed_list"/>
 
                     <div id="info_state"  class="alert alert-success">
                         <div class="text-center">
@@ -30,6 +31,29 @@
                         </div>
                     </div>
                 </form>
+            </div>
+        </div>
+    </template>
+
+    <template id="page_unsubscribe_short">
+        <t t-call="mass_mailing.layout">
+            <t t-call="mass_mailing.unsubscribe_short"/>
+        </t>
+    </template>
+
+    <template id="unsubscribe_short">
+        <div class="container o_unsubscribe_form">
+            <div class="row">
+                <div class="col-lg-6 offset-lg-3 mt-4">
+                    <div id="info_state"  class="alert alert-success">
+                        <div class="text-center">
+                            <p>Successfully unsubscribed!</p>
+                            <div>
+                                <a t-att-href="settings_url" class="btn btn-primary">Manage Subscriptions</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </template>

--- a/addons/test_mail_full/tests/test_mass_mailing.py
+++ b/addons/test_mail_full/tests/test_mass_mailing.py
@@ -99,7 +99,7 @@ class TestMassMailing(TestMailFullCommon):
                     email['body'])
                 # rendered unsubscribe
                 self.assertIn(
-                    '%s/mailing/%s/unsubscribe' % (mailing.get_base_url(), mailing.id),
+                    '%s/mailing/%s/confirm_unsubscribe' % (mailing.get_base_url(), mailing.id),
                     email['body'])
                 unsubscribe_href = self._get_href_from_anchor_id(email['body'], "url6")
                 unsubscribe_url = werkzeug.urls.url_parse(unsubscribe_href)


### PR DESCRIPTION
 ## Do not merge; commit will be cherry-picked into fw-port PRs

Email clients have begun implementing security measures to protect users from phishing by analyzing email links, and interacting with them (see task-3972953).

This has the side effect of automatically unsubscribing email recipients from mailing lists by clicking the link in the footer of the emails.

This commit adds an intermediate step to the process, by requiring users to click on a button before they are unsubscribed.

task-4364446

16.0 PR: https://github.com/odoo/odoo/pull/189561