### PR TITLE
[FIX] web: fix useSpellcheck hook

### DIFF
--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -157,7 +157,7 @@ export function useSpellCheck({ refName } = {}) {
         (el) => {
             if (el) {
                 const inputs =
-                    ["INPUT", "TEXTAREA"].includes(el.nodeName) || el.contenteditable
+                    ["INPUT", "TEXTAREA"].includes(el.nodeName) || el.isContentEditable
                         ? [el]
                         : el.querySelectorAll("input, textarea, [contenteditable=true]");
                 inputs.forEach((input) => {

--- a/addons/web/static/tests/core/utils/hooks_tests.js
+++ b/addons/web/static/tests/core/utils/hooks_tests.js
@@ -712,6 +712,28 @@ QUnit.module("utils", () => {
             }
         );
 
+        QUnit.test("ref is on an element with contenteditable attribute", async (assert) => {
+            class MyComponent extends Component {
+                static props = ["*"];
+                static template = xml`
+                    <div t-ref="spellcheck"  contenteditable="true" class="editableDiv" />`;
+                setup() {
+                    useSpellCheck();
+                }
+            }
+
+            const env = await makeTestEnv();
+            const target = getFixture();
+            await mount(MyComponent, target, { env });
+            const editableDiv = target.querySelector(".editableDiv");
+
+            assert.strictEqual(editableDiv.spellcheck, true);
+            editableDiv.focus();
+            assert.strictEqual(editableDiv.spellcheck, true);
+            editableDiv.blur();
+            assert.strictEqual(editableDiv.spellcheck, false);
+        });
+
         QUnit.module("useChildRef / useForwardRefToParent");
 
         QUnit.test("simple usecase", async function (assert) {


### PR DESCRIPTION
This commit fixes the wrong use of the contenteditable attribute inside the useSpellcheck implementation. Now, the isContentEditable attribute is used to find the right element.

A test has been added too, using the contenteditable='true' attribute.