### PR TITLE
[IMP] base, http: detect untrusted location

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -9,6 +9,7 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.fields import Domain
+from odoo.tools import str2bool
 
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 from odoo.addons.auth_signup.models.res_partner import SignupError
@@ -254,6 +255,12 @@ class ResUsers(models.Model):
             if not self.env['ir.cron']._commit_progress(len(invited_users)):
                 _logger.info("send_unregistered_user_reminder: timeout reached, stopping")
                 break
+
+    def _alert_untrusted_location(self):
+        ICP = self.env['ir.config_parameter'].sudo()
+        if not str2bool(ICP.get_param("auth_signup.alert_untrusted_location", 'true')):
+            return
+        self._alert_new_device()
 
     @api.model
     def web_create_users(self, emails):

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1345,6 +1345,13 @@ class ResUsers(models.Model):
             arch = etree.tostring(tree)
         return arch, models
 
+    def _alert_untrusted_location(self):
+        """Deal with new untrusted geoip location detected during login.
+
+        To be overriden.
+        """
+        pass
+
 
 ResUsersPatchedInTest = ResUsers
 

--- a/odoo/addons/test_http/tests/test_common.py
+++ b/odoo/addons/test_http/tests/test_common.py
@@ -19,7 +19,7 @@ class TestHttpBase(HttpCaseWithUserDemo):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        geoip_resolver = MemoryGeoipResolver()
+        cls.geoip_resolver = MemoryGeoipResolver()
         session_store = MemorySessionStore(session_class=Session)
 
         reset_cached_properties(odoo.http.root)
@@ -28,8 +28,8 @@ class TestHttpBase(HttpCaseWithUserDemo):
             'server_wide_modules': ['base', 'web', 'rpc', 'test_http']
         }))
         cls.classPatch(odoo.http.Application, 'session_store', session_store)
-        cls.classPatch(odoo.http.Application, 'geoip_city_db', geoip_resolver)
-        cls.classPatch(odoo.http.Application, 'geoip_country_db', geoip_resolver)
+        cls.classPatch(odoo.http.Application, 'geoip_city_db', cls.geoip_resolver)
+        cls.classPatch(odoo.http.Application, 'geoip_country_db', cls.geoip_resolver)
 
     def setUp(self):
         super().setUp()

--- a/odoo/addons/test_http/utils.py
+++ b/odoo/addons/test_http/utils.py
@@ -24,6 +24,35 @@ TEST_IP_GEOIP_COUNTRY = geoip2.models.Country(
      'traits': {'ip_address': TEST_IP, 'prefix_len': 21},
     }, ['en']
 )
+
+TEST_IPv4_locations = {
+    # IP: (Country, Latitude, Longitude, Accuracy radius [km])
+    '192.0.1.1': ('Belgium', 'Bruges', 51.2608836, 3.0573057, 100),
+    '192.0.1.2': ('Belgium', 'Antwerpen', 51.2605815, 4.1929726, 100),
+    '192.0.1.3': ('Belgium', 'Brussels', 50.8552021, 4.2930167, 100),
+    '192.0.2.1': ('Netherlands', 'Rotterdam', 51.9280632, 4.4084283, 100),
+    '192.0.3.1': ('Germany', 'Frankfurt', 50.1213155, 8.4717592, 100),
+    '192.0.4.1': ('France', 'Toulouse', 43.600798, 1.3504423, 100),
+    '192.0.4.2': ('France', 'Paris', 48.8589384, 2.264635, 100),
+    '192.0.5.1': ('Luxembourg', 'Rambrouch', 49.8398831, 5.7814468, 100),
+    '192.0.6.1': ('United Kingdom', 'London', 51.5287398, -0.266403, 100),
+    '192.0.7.1': ('Italy', 'Rome', 41.9102088, 12.3711918, 100),
+}
+
+TEST_IPv6_locations = {
+    # IP: (Country, Latitude, Longitude, Accuracy radius [km])
+    'fe80:0000:0000:0001:abcd:1234:5678:9abc': ('Belgium', 'Bruges', 51.2608836, 3.0573057, 10),
+    'fe80:0000:0000:0001:bcde:2345:6789:abcd': ('Belgium', 'Antwerpen', 51.2605815, 4.1929726, 10),
+    'fe80:0000:0000:0001:cdef:3456:789a:bcde': ('Belgium', 'Brussels', 50.8552021, 4.2930167, 10),
+    'fe80:0000:0000:0001:def1:4567:89ab:cdef': ('Netherlands', 'Rotterdam', 51.9280632, 4.4084283, 10),
+    'fe80:0000:0000:0002:abcd:1234:5678:9abc': ('Germany', 'Frankfurt', 50.1213155, 8.4717592, 10),
+    'fe80:0000:0000:0003:abcd:1234:5678:9abc': ('France', 'Toulouse', 43.600798, 1.3504423, 10),
+    'fe80:0000:0000:0003:bcde:2345:6789:abcd': ('France', 'Paris', 48.8589384, 2.264635, 10),
+    'fe80:0000:0000:0004:abcd:1234:5678:9abc': ('Luxembourg', 'Rambrouch', 49.8398831, 5.7814468, 10),
+    'fe80:0000:0000:0005:abcd:1234:5678:9abc': ('United Kingdom', 'London', 51.5287398, -0.266403, 10),
+    'fe80:0000:0000:0006:abcd:1234:5678:9abc': ('Italy', 'Rome', 41.9102088, 12.3711918, 10),
+}
+
 USER_AGENT_linux_chrome = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36'
 USER_AGENT_linux_firefox = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0'
 USER_AGENT_android_chrome = 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Mobile Safari/537.36'
@@ -33,6 +62,14 @@ class MemoryGeoipResolver:
     def __init__(self):
         self.country_db = {TEST_IP: TEST_IP_GEOIP_COUNTRY}
         self.city_db = {TEST_IP: TEST_IP_GEOIP_CITY}
+
+    def add_locations(self, locations):
+        for ip, (country, city, latitude, longitude, accuracy_radius) in locations.items():
+            self.city_db[ip] = geoip2.models.City({
+                'city': {'names': {'en': city}},
+                'country': {'names': {'en': country}},
+                'location': {'latitude': latitude, 'longitude': longitude, 'accuracy_radius': accuracy_radius},
+            }, ['en'])
 
     def country(self, ip):
         record = self.country_db.get(ip)


### PR DESCRIPTION
Objective:
----------
In terms of geolocation, certain malicious behaviour can be detected and an incident prevented.
Users need to be warned when we detect suspicious behaviour, without blocking their workflow.

Solution:
---------
Each time we detect a new device defined by the `platform`, `browser` and `ip_address` tuple,
we record a new trace in the session.

After inserting a new trace, we check whether it is plausible in relation to the other
traces already existing in the session.
This means that once a device has been trusted for a session, it will not be checked again.
To check this, we check the distance between the two geolocations of the IP addresses.
If the two IP addresses are too far apart, there is a potential risk of malicious behaviour.

The IP addresses to be compared are found according to a given day range in relation
to the trace that has just been created.
The number of days during which an IP address is checked can be modified using
the `ir.config.parameter` named `base.number_trusted_days_ip`.

If the `auth_signup` module is installed, an email will be sent to the user so that they can
change their password (which has the effect of invalidating all their active sessions).
The user can ignore this email.

It is possible not to send an email by forcing the `ir.config.parameter` named
`auth_signup.alert_untrusted_location` to the value `false`.

In all cases, a log will be generated.

task-4281529