### PR TITLE
[FIX] survey: allow survey print without answers

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -68,9 +68,9 @@ class Survey(http.Controller):
         if answer_token and not answer_sudo:
             return 'token_wrong'
 
-        if not answer_sudo and ensure_token:
+        if not answer_sudo and ensure_token is True:
             return 'token_required'
-        if not answer_sudo and survey_sudo.access_mode == 'token':
+        if not answer_sudo and ensure_token != 'survey_only' and survey_sudo.access_mode == 'token':
             return 'token_required'
 
         if survey_sudo.users_login_required and request.env.user._is_public():
@@ -118,7 +118,8 @@ class Survey(http.Controller):
                 has_survey_access = True
             can_answer = bool(answer_sudo)
             if not can_answer:
-                can_answer = survey_sudo.access_mode == 'public'
+                can_answer = survey_sudo.access_mode == 'public' or (
+                    has_survey_access and ensure_token == 'survey_only')
 
         return {
             'survey_sudo': survey_sudo,
@@ -635,7 +636,7 @@ class Survey(http.Controller):
     def survey_print(self, survey_token, review=False, answer_token=None, **post):
         '''Display an survey in printable view; if <answer_token> is set, it will
         grab the answers of the user_input_id that has <answer_token>.'''
-        access_data = self._get_access_data(survey_token, answer_token, ensure_token=False, check_partner=False)
+        access_data = self._get_access_data(survey_token, answer_token, ensure_token='survey_only', check_partner=False)
         if access_data['validity_code'] is not True and (
                 access_data['has_survey_access'] or
                 access_data['validity_code'] not in ['token_required', 'survey_closed', 'survey_void', 'answer_deadline']):


### PR DESCRIPTION
[FIX] survey: allow survey print without answers

Issue
---
Previously, printing a survey with access mode set to "invited people only"
required an existing `survey.user_input` record.
Without it, the print route failed silently and redirected to the homepage.

FIX
---
This commit allows surveys to be printed without answers.
It introduces an option to bypass the "token_required" validity check
by allowing `ensure_token='survey_only'`. This skips token validation
specifically for the print route, while preserving it for the start route.

Reproduce
---
- -i survey
- create new Survey, with "Access Mode": "invited people only"
- click "Print" BUG -> taken to the odoo main page, instead of empty printed survey

opw-4292331


---
---
# LEGACY notes BELOW

---
### [FIX] survey: allow survey print without answers
When we set access mode to token, we need
to have existing registration `survey.user_input` to print the survey.

After this commit existing answer is not required anymore

#### Reproduce
- -i survey
- create new Survey, with "Access Mode": "invited people only"
- click "Print" BUG -> taken to the odoo main page, instead of empty printed survey

opw-4292331


---

#### Note on other solutions 
Initially explored approach was just to add a set of dummy/test answers

[FIX] survey: create empty answer when token access set

... to allow general print of the survey.

When we set access mode to token, we need
to have existing registration `survey.user_input` to print the survey.

This commit suggest solution similar to the one existing in survey_test,
so if we create test answer to use it.

Reproduce
---
- -i survey
- create new Survey, with "Access Mode": "invited people only"
- click "Print" BUG -> taken to the odoo main page, instead of empty printed survey

Def
---
What I refer to as "General print" of the survey is a request to print survey without answer_token.
This is currently possible to request from the form view of the survey.survey

![image](https://github.com/user-attachments/assets/c3f5bdea-cd00-470d-aa93-8ebdae222845)



opw-4292331
