### PR TITLE
[IMP] (test_)mail: improve notification-to-follower code bits

### DIFF
--- a/addons/mail/controllers/discuss/__init__.py
+++ b/addons/mail/controllers/discuss/__init__.py
@@ -3,6 +3,7 @@
 from . import binary
 from . import channel
 from . import gif
+from . import mail
 from . import public_page
 from . import rtc
 from . import search

--- a/addons/mail/controllers/discuss/mail.py
+++ b/addons/mail/controllers/discuss/mail.py
@@ -1,0 +1,16 @@
+from odoo.http import request
+from odoo.addons.mail.controllers.mail import MailController
+from odoo.addons.mail.controllers.discuss.public_page import PublicPageController
+from odoo.addons.mail.tools.discuss import Store
+
+class DiscussMailController(MailController):
+
+    def _mail_thread_message_redirect(self, message):
+        if message.model != 'discuss.channel':
+            return super()._mail_thread_message_redirect(message)
+        if not request.env.user._is_internal():
+            thread = request.env[message.model].search([('id', '=', message.res_id)])
+            store = Store().add_global_values(isChannelTokenSecret=True)
+            store.add(thread, {"highlightMessage": message.id})
+            return PublicPageController()._response_discuss_channel_invitation(store, thread)
+        return request.redirect(f'/odoo/action-mail.action_discuss?active_id={message.res_id}&highlight_message_id={message.id}')

--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import logging
 
 from werkzeug.urls import url_encode

--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -7,9 +7,7 @@ from odoo import _, http
 from odoo.exceptions import AccessError
 from odoo.http import request
 from odoo.tools import consteq
-from odoo.addons.mail.controllers.discuss.public_page import PublicPageController
 from odoo.addons.mail.models.discuss.mail_guest import add_guest_to_context
-from odoo.addons.mail.tools.discuss import Store
 
 _logger = logging.getLogger(__name__)
 
@@ -201,17 +199,12 @@ class MailController(http.Controller):
         # sudo: public user can access some relational fields of mail.message
         if message.sudo()._filter_empty():
             raise NotFound()
+        return self._mail_thread_message_redirect(message)
+
+    def _mail_thread_message_redirect(self, message):
         if not request.env.user._is_internal():
             thread = request.env[message.model].search([('id', '=', message.res_id)])
-            if message.model == 'discuss.channel':
-                store = Store().add_global_values(isChannelTokenSecret=True)
-                store.add(thread, {"highlightMessage": message.id})
-                return PublicPageController()._response_discuss_channel_invitation(store, thread)
             if hasattr(thread, "_get_share_url"):
                 return request.redirect(thread._get_share_url(share_token=False))
             raise Unauthorized()
-        if message.model == 'discuss.channel':
-            url = f'/odoo/action-mail.action_discuss?active_id={message.res_id}&highlight_message_id={message_id}'
-        else:
-            url = f'/odoo/{message.model}/{message.res_id}?highlight_message_id={message_id}'
-        return request.redirect(url)
+        return request.redirect(f'/odoo/{message.model}/{message.res_id}?highlight_message_id={message.id}')

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -55,9 +55,9 @@ class ThreadController(http.Controller):
         """Computes:
         - message_subtype_data: data about document subtypes: which are
             available, which are followed if any"""
-        request.env["mail.followers"].check_access("read")
-        follower = request.env["mail.followers"].sudo().browse(follower_id)
-        follower.ensure_one()
+        # limited to internal, who can read all followers
+        follower = request.env["mail.followers"].browse(follower_id)
+        follower.check_access("read")
         record = request.env[follower.res_model].browse(follower.res_id)
         record.check_access("read")
         # find current model subtypes, add them to a dictionary

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -13,6 +13,7 @@ from odoo.addons.mail.tools.discuss import Store
 
 
 class ThreadController(http.Controller):
+
     @http.route("/mail/thread/data", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
     def mail_thread_data(self, thread_model, thread_id, request_list, **kwargs):
         thread = request.env[thread_model]._get_thread_with_access(thread_id, **kwargs)

--- a/addons/mail/data/mail_templates_email_layouts.xml
+++ b/addons/mail/data/mail_templates_email_layouts.xml
@@ -84,7 +84,7 @@
 <div style="color: #555555; font-size:11px;">
     Powered by <a target="_blank" href="https://www.odoo.com?utm_source=db&amp;utm_medium=email"
                   t-att-style="'color: ' + (company.email_secondary_color or '#875A7B') + ';'">Odoo</a>
-    <span id="mail_unfollow">
+    <span t-if="show_unfollow" id="mail_unfollow">
         | <a href="/mail/unfollow" style="text-decoration:none; color:#555555;">Unfollow</a>
     </span>
 </div>
@@ -158,7 +158,7 @@
 <tr><td align="center" style="min-width: 590px;">
         Powered by <a target="_blank" href="https://www.odoo.com?utm_source=db&amp;utm_medium=email"
                       t-att-style="'color: ' + (company.email_secondary_color or '#875A7B') + ';'">Odoo</a>
-    <span id="mail_unfollow">
+    <span t-if="show_unfollow" id="mail_unfollow">
         | <a href="/mail/unfollow" style="text-decoration:none; color:#555555;">Unfollow</a>
     </span>
 </td></tr>

--- a/addons/mail/data/mail_templates_invite.xml
+++ b/addons/mail/data/mail_templates_invite.xml
@@ -25,7 +25,7 @@
             <xpath expr="//tr[td/p[@t-if='subtype_internal']]" position="replace"/>
             <xpath expr="//span[@id='mail_unfollow']" position="replace"/>
             <xpath expr="//div[@style='margin-top:16px;']/hr" position="before">
-                <span id="mail_unfollow" style="font-size: 13px;">
+                <span t-if="show_unfollow" id="mail_unfollow" style="font-size: 13px;">
                     Not interested by this? <a href="/mail/unfollow" style="text-decoration:none; color:#555555;">Unfollow</a>
                 </span>
             </xpath>

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -584,7 +584,9 @@ class DiscussChannel(models.Model):
             self.env['res.users'].flush_model(['notification_type', 'partner_id'])
             sql_query = """
                 SELECT DISTINCT ON (partner.id) partner.id,
+                       partner.email_normalized,
                        partner.lang,
+                       partner.name,
                        partner.partner_share,
                        users.id as uid,
                        COALESCE(users.notification_type, 'email') as notif,
@@ -598,14 +600,16 @@ class DiscussChannel(models.Model):
                 sql_query,
                 (email_from or '', list(pids), [author_id] if author_id else [], )
             )
-            for partner_id, lang, partner_share, uid, notif, ushare in self._cr.fetchall():
+            for partner_id, email_normalized, lang, name, partner_share, uid, notif, ushare in self._cr.fetchall():
                 # ocn_client: will add partners to recipient recipient_data. more ocn notifications. We neeed to filter them maybe
                 recipients_data.append({
                     'active': True,
+                    'email_normalized': email_normalized,
                     'id': partner_id,
                     'is_follower': False,
                     'groups': [],
                     'lang': lang,
+                    'name': name,
                     'notif': notif,
                     'share': partner_share,
                     'type': 'user' if not partner_share and notif else 'customer',

--- a/addons/mail/models/mail_activity_plan_template.py
+++ b/addons/mail/models/mail_activity_plan_template.py
@@ -9,8 +9,8 @@ from odoo.exceptions import ValidationError
 
 class MailActivityPlanTemplate(models.Model):
     _name = 'mail.activity.plan.template'
-    _order = 'sequence,id'
     _description = 'Activity plan template'
+    _order = 'sequence, id'
     _rec_name = 'summary'
 
     plan_id = fields.Many2one(

--- a/addons/mail/models/mail_activity_type.py
+++ b/addons/mail/models/mail_activity_type.py
@@ -13,8 +13,8 @@ class MailActivityType(models.Model):
     available for all models using activities; or specific to a model in which
     case res_model field should be used. """
     _description = 'Activity Type'
-    _rec_name = 'name'
     _order = 'sequence, id'
+    _rec_name = 'name'
 
     def _get_model_selection(self):
         return [

--- a/addons/mail/models/mail_alias.py
+++ b/addons/mail/models/mail_alias.py
@@ -30,9 +30,9 @@ class MailAlias(models.Model):
        created, it becomes immediately usable and Odoo will accept email for it.
      """
     _description = "Email Aliases"
+    _order = 'alias_model_id, alias_name'
     _rec_name = 'alias_name'
     _rec_names_search = ['alias_name', 'alias_domain']
-    _order = 'alias_model_id, alias_name'
 
     # email definition
     alias_name = fields.Char(

--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -92,11 +92,11 @@ class MailFollowers(models.Model):
         # mail_mail_res_partner_rel is the join table for the m2m recipient_ids field
         self.env.cr.execute("""
             SELECT message.model, message.res_id, mail_partner.res_partner_id
-              FROM mail_mail mail        
+              FROM mail_mail mail
               JOIN mail_mail_res_partner_rel mail_partner ON mail_partner.mail_mail_id = mail.id
               JOIN mail_message message ON mail.mail_message_id = message.id AND message.model != 'discuss.channel'
-              JOIN mail_followers follower ON message.model = follower.res_model 
-               AND message.res_id = follower.res_id 
+              JOIN mail_followers follower ON message.model = follower.res_model
+               AND message.res_id = follower.res_id
                AND mail_partner.res_partner_id = follower.partner_id
              WHERE mail.id IN %(mail_ids)s
         """, {'mail_ids': tuple(mail_ids)})

--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -86,7 +86,7 @@ class MailFollowers(models.Model):
             recipients of the mails as a set of tuple (model, res_id, partner_id).
         :rtype: set
         """
-        self.env['mail.mail'].flush_model(['message_id', 'recipient_ids'])
+        self.env['mail.mail'].flush_model(['mail_message_id', 'recipient_ids'])
         self.env['mail.followers'].flush_model(['partner_id', 'res_model', 'res_id'])
         self.env['mail.message'].flush_model(['model', 'res_id'])
         # mail_mail_res_partner_rel is the join table for the m2m recipient_ids field

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -18,7 +18,7 @@ class MailTemplate(models.Model):
     "Templates for sending email"
     _inherit = ['mail.render.mixin', 'template.reset.mixin']
     _description = 'Email Templates'
-    _order = 'user_id,name,id'
+    _order = 'user_id, name, id'
 
     _unrestricted_rendering = True
 

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1299,7 +1299,7 @@ class MailThread(models.AbstractModel):
                 subtype_id = thread._creation_subtype().id
 
             # switch to odoobot for all incoming message creation
-            # to have a priviledged archived user so real_author_id is correctly computed
+            # to have a high-privilege archived user so real_author_id is correctly computed
             thread_root = thread.with_user(self.env.ref('base.user_root'))
             # replies to internal message are considered as notes, but parent message
             # author is added in recipients to ensure they are notified of a private answer
@@ -1323,9 +1323,9 @@ class MailThread(models.AbstractModel):
             if thread_root._name == 'mail.thread':  # message with parent_id not linked to record
                 new_msg = thread_root.message_notify(**post_params)
             else:
-                # parsing should find an author independently of user running mail gateway, and ensure it is not odoobot
-                partner_from_found = message_dict.get('author_id') and message_dict['author_id'] != self.env['ir.model.data']._xmlid_to_res_id('base.partner_root')
-                thread_root = thread_root.with_context(from_alias=True, mail_create_nosubscribe=not partner_from_found)
+                # if no author, skip any author subscribe check; otherwise message_post
+                # checks anyway for real author and filters inactive (like odoobot)
+                thread_root = thread_root.with_context(from_alias=True, mail_create_nosubscribe=not message_dict.get('author_id'))
                 new_msg = thread_root.message_post(**post_params)
 
             if new_msg and original_partner_ids:
@@ -2227,12 +2227,12 @@ class MailThread(models.AbstractModel):
             # if current user is active, they are the one doing the action and should
             # be notified of answers. If they are inactive they are posting on behalf
             # of someone else (a custom, mailgateway, ...) and the real author is the
-            # message author
-            if self.env.user.active:
+            # message author. In any case avoid odoobot.
+            if self.env.user.active:  # note that odoobot is always inactive, there is a python check
                 real_author_id = self.env.user.partner_id.id
             elif msg_values['author_id']:
                 author = self.env['res.partner'].browse(msg_values['author_id'])
-                if author.active:
+                if author.active and author != self.env.ref('base.partner_root'):  # that happened :(
                     real_author_id = author.id
             if real_author_id:
                 self._message_subscribe(partner_ids=[real_author_id])

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3422,6 +3422,12 @@ class MailThread(models.AbstractModel):
                 render_values['subtitles'] = subtitles
 
             for recipients_group in recipients_groups_list:
+                if not render_values['show_unfollow']:
+                    render_values['show_unfollow'] = any(
+                        r['is_follower']
+                        for r in recipients_group['recipients_data']
+                        if r['id'] and r['uid'] and not r['ushare']
+                    )
                 yield (lang, render_values, recipients_group)
 
     def _notify_by_email_prepare_rendering_context(self, message, msg_vals=False,
@@ -3526,6 +3532,7 @@ class MailThread(models.AbstractModel):
             'company': company,
             'email_add_signature': email_add_signature,
             'lang': lang,
+            'show_unfollow': getattr(self, '_partner_unfollow_enabled', False),
             'signature': signature,
             'website_url': website_url,
             # tools

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -921,9 +921,11 @@ class MailCase(MockEmail):
         return [
             {'id': partner.id,
              'active': partner.active,
+             'email_normalized': partner.email_normalized,
              'is_follower': partner in record.message_partner_ids if record else False,
              'groups': partner.user_ids.groups_id.ids,
              'lang': partner.lang,
+             'name': partner.name,
              'notif': partner.user_ids.notification_type or 'email',
              'share': partner.partner_share,
              'type': 'user' if partner.user_ids and not partner.partner_share else partner.user_ids and 'portal' or 'customer',

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -5,6 +5,7 @@ import base64
 import email
 import email.policy
 import json
+import re
 import time
 
 from ast import literal_eval
@@ -14,7 +15,9 @@ from freezegun import freeze_time
 from functools import partial
 from lxml import html
 from unittest.mock import patch
+from urllib.parse import urlparse, urlencode, parse_qsl
 
+from odoo import tools
 from odoo.addons.base.models.ir_mail_server import IrMail_Server
 from odoo.addons.base.tests.common import MockSmtplibCase
 from odoo.addons.bus.models.bus import BusBus, json_dump
@@ -907,7 +910,6 @@ class MailCase(MockEmail):
         cls.email_template = cls.env['mail.template'].create(create_values)
         return cls.email_template
 
-
     def _generate_notify_recipients(self, partners, record=None):
         """ Tool method to generate recipients data according to structure used
         in notification methods. Purpose is to allow testing of internals of
@@ -929,6 +931,38 @@ class MailCase(MockEmail):
              'ushare': all(user.share for user in partner.user_ids) if partner.user_ids else False,
             } for partner in partners
         ]
+
+    def _message_post_and_get_unfollow_urls(self, record, partner_ids):
+        """ Post a message on the record for the partners and extract the unfollow URLs. """
+        with self.mock_mail_gateway():
+            _message = record.message_post(
+                body='test message',
+                partner_ids=partner_ids.ids,
+                subtype_id=self.env.ref('mail.mt_comment').id,
+            )
+        self.assertEqual(len(self._mails), len(partner_ids))
+        mail_by_email = {
+            email_normalize(email_to, strict=False): mail
+            for mail in self._mails for email_to in mail['email_to']
+        }
+
+        # Extract unfollow URL for each partner from the body of the emails
+        results = []
+        for partner in partner_ids:
+            mail_body = mail_by_email[partner.email_normalized]['body']
+            unfollow_urls = [
+                link_url
+                for _, link_url, _, _ in re.findall(tools.mail.HTML_TAG_URL_REGEX, mail_body)
+                if '/mail/unfollow' in link_url
+            ]
+            self.assertLessEqual(len(unfollow_urls), 1)
+            results.append(unfollow_urls[0] if unfollow_urls else False)
+        self.assertEqual(len(results), len(partner_ids))
+        return results
+
+    def _url_update_query_parameters(self, url, **kwargs):
+        parsed_url = urlparse(url)
+        return parsed_url._replace(query=urlencode(dict(parse_qsl(parsed_url.query), **kwargs))).geturl()
 
     # ------------------------------------------------------------
     # MAIL ASSERTS WRAPPERS

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1122,7 +1122,7 @@ class MailComposeMessage(models.TransientModel):
                     [{
                         'active': True,
                         'id': pid,
-                        'is_follower': True,
+                        'is_follower': False,
                         'lang': lang,
                         'groups': [],
                         'notif': 'email',

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1121,9 +1121,11 @@ class MailComposeMessage(models.TransientModel):
                     message_inmem,
                     [{
                         'active': True,
+                        'email_normalized': False,  # not used in this flow anyway
                         'id': pid,
                         'is_follower': False,
                         'lang': lang,
+                        'name': False,  # not used in this flow anyway
                         'groups': [],
                         'notif': 'email',
                         'share': True,

--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -63,11 +63,11 @@ class MailMail(models.Model):
             )
         return body
 
-    def _prepare_outgoing_list(self, mail_server=False):
+    def _prepare_outgoing_list(self, mail_server=False, doc_to_followers=None):
         """ Update mailing specific links to replace generic unsubscribe and
         view links by email-specific links. Also add headers to allow
         unsubscribe from email managers. """
-        email_list = super()._prepare_outgoing_list(mail_server=mail_server)
+        email_list = super()._prepare_outgoing_list(mail_server=mail_server, doc_to_followers=doc_to_followers)
         if not self.res_id or not self.mailing_id:
             return email_list
 

--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -63,12 +63,11 @@ class MailMail(models.Model):
             )
         return body
 
-    def _prepare_outgoing_list(self, mail_server=False, recipients_follower_status=None):
+    def _prepare_outgoing_list(self, mail_server=False):
         """ Update mailing specific links to replace generic unsubscribe and
         view links by email-specific links. Also add headers to allow
         unsubscribe from email managers. """
-        email_list = super()._prepare_outgoing_list(mail_server=mail_server,
-                                                    recipients_follower_status=recipients_follower_status)
+        email_list = super()._prepare_outgoing_list(mail_server=mail_server)
         if not self.res_id or not self.mailing_id:
             return email_list
 

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -3,7 +3,7 @@
 import copy
 import re
 from unittest.mock import patch
-from urllib.parse import urlparse, urlencode, parse_qsl
+from urllib.parse import urlparse
 
 from markupsafe import Markup
 
@@ -13,7 +13,7 @@ from odoo.addons.mail.tests.common import MailCommon
 from odoo.exceptions import AccessError
 from odoo.tests import tagged, users
 from odoo.tests.common import HttpCase
-from odoo.tools import email_normalize, mail, mute_logger, parse_contact_from_email
+from odoo.tools import mute_logger
 
 
 @tagged('mail_followers')
@@ -801,175 +801,8 @@ class RecipientsNotificationTest(MailCommon):
 
 
 @tagged('mail_followers', 'post_install', '-at_install')
-class UnfollowUnreadableRecordTest(MailCommon):
-    """ Test message_unsubscribe on unreadable record. """
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test'})
-        cls.user_portal = cls._create_portal_user()
-
-    def _message_unsubscribe_unreadable_record(self, user):
-        def raise_access_error(*args, **kwargs):
-            raise AccessError('Unreadable')
-
-        with patch.object(self.test_record.__class__, 'check_access', side_effect=raise_access_error):
-            self.test_record.with_user(user).message_unsubscribe(user.partner_id.ids)
-
-    def test_initial_data(self):
-        """ Test some initial value. """
-        self.assertTrue(self.user_employee._is_internal())
-        self.assertFalse(self.user_portal._is_internal())
-        record_employee = self.test_record.with_user(self.user_employee)
-        record_employee.check_access('read')
-        record_portal = self.test_record.with_user(self.user_portal)
-        with self.assertRaises(AccessError):
-            record_portal.check_access('write')
-
-    def test_internal_user_can_unsubscribe_from_unreadable_record(self):
-        self.test_record._message_subscribe(partner_ids=self.partner_employee.ids)
-
-        self.assertIn(self.partner_employee, self.test_record.message_follower_ids.mapped('partner_id'))
-        self._message_unsubscribe_unreadable_record(self.user_employee)
-        self.assertNotIn(self.partner_employee, self.test_record.message_follower_ids.mapped('partner_id'))
-
-    def test_portal_user_cannot_unsubscribe_from_unreadable_record(self):
-        self.test_record._message_subscribe(partner_ids=self.partner_portal.ids)
-
-        self.assertIn(self.partner_portal, self.test_record.message_follower_ids.mapped('partner_id'))
-        with self.assertRaises(AccessError):
-            self._message_unsubscribe_unreadable_record(self.user_portal)
-
-
-@tagged('mail_followers', 'post_install', '-at_install')
-class UnfollowFromInboxTest(MailCommon, HttpCase):
-    """ Test unfollow mechanism from inbox (server part). """
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test'})
-        cls.user_employee.write({'notification_type': 'inbox'})
-
-    @users('employee')
-    @mute_logger('odoo.models')
-    def test_inbox_notification_follower(self):
-        """ Check follow-up information for displaying inbox messages used to
-        implement "unfollow" in the inbox.
-
-        Note that the actual mechanism to unfollow a record from a message is
-        tested in the client part.
-        """
-        self.maxDiff = None
-        test_record = self.env['mail.test.simple'].browse(self.test_record.ids)
-        message = test_record.with_user(self.user_admin).message_post(
-            body="test message",
-            subtype_id=self.env.ref("mail.mt_comment").id,
-            partner_ids=self.partner_employee.ids,
-        )
-        notif = message.notification_ids.filtered(
-            lambda n: n.res_partner_id == self.env.user.partner_id
-        )
-        # The user doesn't follow the record
-        self.authenticate(self.env.user.login, self.env.user.login)
-        data = self.make_jsonrpc_request("/mail/inbox/messages")["data"]
-        expected = {
-            "mail.message": self._filter_messages_fields(
-                {
-                    "attachment_ids": [],
-                    "author": {"id": self.user_admin.partner_id.id, "type": "partner"},
-                    "body": "<p>test message</p>",
-                    "create_date": fields.Datetime.to_string(message.create_date),
-                    "date": fields.Datetime.to_string(message.date),
-                    "default_subject": "Test",
-                    "email_from": '"Mitchell Admin" <test.admin@test.example.com>',
-                    "id": message.id,
-                    "is_discussion": True,
-                    "is_note": False,
-                    "link_preview_ids": [],
-                    "message_type": "notification",
-                    "model": "mail.test.simple",
-                    "needaction": True,
-                    "notification_ids": [notif.id],
-                    "pinned_at": False,
-                    "rating_id": False,
-                    "reactions": [],
-                    "recipients": [{"id": self.env.user.partner_id.id, "type": "partner"}],
-                    "record_name": "Test",
-                    "res_id": test_record.id,
-                    "scheduledDatetime": False,
-                    "starred": False,
-                    "subject": False,
-                    "subtype_description": False,
-                    "thread": {"id": test_record.id, "model": "mail.test.simple"},
-                    "trackingValues": [],
-                    "write_date": fields.Datetime.to_string(message.write_date),
-                },
-            ),
-            "mail.notification": [
-                {
-                    "failure_type": False,
-                    "id": notif.id,
-                    "mail_message_id": message.id,
-                    "notification_status": "sent",
-                    "notification_type": "inbox",
-                    "persona": {"id": self.env.user.partner_id.id, "type": "partner"},
-                },
-            ],
-            "mail.thread": self._filter_threads_fields(
-                {
-                    "display_name": "Test",
-                    "id": test_record.id,
-                    "model": "mail.test.simple",
-                    "module_icon": "/base/static/description/icon.png",
-                    "selfFollower": False,
-                },
-            ),
-            "res.partner": self._filter_partners_fields(
-                {
-                    "id": self.env.user.partner_id.id,
-                    "name": "Ernest Employee",
-                    "write_date": fields.Datetime.to_string(self.env.user.write_date),
-                },
-                {
-                    "id": self.user_admin.partner_id.id,
-                    "isInternalUser": True,
-                    "is_company": False,
-                    "name": "Mitchell Admin",
-                    "userId": self.user_admin.id,
-                    "write_date": fields.Datetime.to_string(self.user_admin.write_date),
-                },
-            ),
-        }
-        self.assertEqual(data, expected)
-
-        # The user follows the record
-        test_record._message_subscribe(partner_ids=self.env.user.partner_id.ids)
-        follower = test_record.message_follower_ids.filtered(
-            lambda follower: follower.partner_id == self.env.user.partner_id
-        )
-        data = self.make_jsonrpc_request("/mail/inbox/messages")["data"]
-        expected_with_follower = copy.deepcopy(expected)
-        expected_with_follower["mail.followers"] = [
-            {
-                "id": follower.id,
-                "is_active": True,
-                "partner": {"id": self.env.user.partner_id.id, "type": "partner"},
-            },
-        ]
-        expected_with_follower["mail.thread"][0]["selfFollower"] = follower.id
-        self.assertEqual(data, expected_with_follower)
-
-        # The user doesn't follow the record anymore
-        test_record.message_unsubscribe(partner_ids=self.partner_employee.ids)
-        data = self.make_jsonrpc_request("/mail/inbox/messages")["data"]
-        self.assertEqual(data, expected)
-
-
-@tagged('mail_followers', 'post_install', '-at_install')
-class UnfollowFromEmailTest(MailCommon, HttpCase):
-    """ Test unfollow mechanism from email. """
+class UnfollowLinkTest(MailCommon, HttpCase):
+    """ Test unfollow links, notably used in notification emails """
 
     @classmethod
     def setUpClass(cls):
@@ -977,6 +810,7 @@ class UnfollowFromEmailTest(MailCommon, HttpCase):
         cls.user_portal = cls._create_portal_user()
         cls.partner_portal = cls.user_portal.partner_id
         cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test'})
+        cls.test_record_copy = cls.test_record.copy()
         cls.test_record_unfollow = cls.env['mail.test.simple.unfollow'].with_context(cls._test_context).create(
             {'name': 'unfollow'})
         cls.partner_without_user = cls.env['res.partner'].create({
@@ -985,35 +819,13 @@ class UnfollowFromEmailTest(MailCommon, HttpCase):
         })
         cls.user_employee.write({'notification_type': 'email'})
 
-    def _post_message_and_get_unfollow_urls(self, record, partner_ids):
-        """ Post a message on the record for the partners and extract the unfollow URLs. """
-        with self.mock_mail_gateway():
-            record.message_post(body='test message', subtype_id=self.env.ref('mail.mt_comment').id,
-                                partner_ids=partner_ids.ids)
-        self.assertEqual(len(self._mails), len(partner_ids))
-        mail_by_email = {parse_contact_from_email(email_to)[1]: mail
-                         for mail in self._mails
-                         for email_to in mail['email_to']}
+    def _message_unsubscribe_unreadable_record(self, user):
+        def raise_access_error(*args, **kwargs):
+            raise AccessError('Unreadable')
 
-        # Extract unfollow URL for each partner from the body of the emails
-        results = []
-        for partner in partner_ids:
-            mail_body = mail_by_email[email_normalize(partner.email)]['body']
+        with patch.object(self.test_record.__class__, 'check_access', side_effect=raise_access_error):
+            self.test_record.with_user(user).message_unsubscribe(user.partner_id.ids)
 
-            urls = list({link_url for _, link_url, _, _ in re.findall(mail.HTML_TAG_URL_REGEX, mail_body)
-                         if '/mail/unfollow' in link_url})
-            n_url = len(urls)
-            self.assertLessEqual(n_url, 1)
-            results.append(urls[0] if urls else False)
-        self.assertEqual(len(results), len(partner_ids))
-        return results
-
-    def _url_with_query_parameters_overridden(self, url, **kwargs):
-        """ Return the url with overridden query parameters by the additional
-        parameters.
-        """
-        parsed_url = urlparse(url)
-        return parsed_url._replace(query=urlencode(dict(parse_qsl(parsed_url.query), **kwargs))).geturl()
 
     def _test_tampered_unfollow_url(self, record, unfollow_url, partner):
         """ Test that tampered urls doesn't work.
@@ -1024,23 +836,17 @@ class UnfollowFromEmailTest(MailCommon, HttpCase):
         - when trying to use the same URL with another partner, it also returns a
         403 and doesn't unsubscribe the other partner.
         """
-        for param, value in (('token', '0000000000000000000000000000000000000000'),
-                             ('model', 'mail.test.gateway'),
-                             ('res_id', record.copy().id)):
+        for param, value in (
+            ('token', '0000000000000000000000000000000000000000'),
+            ('model', 'mail.test.gateway'),
+            ('res_id', self.test_record_copy.id),
+            ('partner_id', self.partner_admin.id),
+        ):
             with self.subTest(f'Tampered {param}'):
-                tampered_unfollow_url = self._url_with_query_parameters_overridden(unfollow_url, **{param: value})
+                tampered_unfollow_url = self._url_update_query_parameters(unfollow_url, **{param: value})
                 response = self.url_open(tampered_unfollow_url)
                 self.assertEqual(response.status_code, 403)
                 self.assertIn(partner, record.message_partner_ids)
-
-        with self.subTest('Tampered partner id'):
-            record._message_subscribe(partner_ids=self.partner_admin.ids)
-            tampered_unfollow_url = self._url_with_query_parameters_overridden(unfollow_url, pid=self.partner_admin.id)
-            response = self.url_open(tampered_unfollow_url)
-            self.assertEqual(response.status_code, 403)
-            self.assertIn(partner, record.message_partner_ids)
-            self.assertIn(self.partner_admin, record.message_partner_ids)
-            record.message_unsubscribe(partner_ids=self.partner_admin.ids)
 
     def _test_unfollow_url(self, record, unfollow_url, partner):
         """ Test that the unfollow url works.
@@ -1061,10 +867,8 @@ class UnfollowFromEmailTest(MailCommon, HttpCase):
                 finally:
                     record._message_subscribe(partner_ids=partner.ids)
 
-    def test_initial_data(self):
+    def test_assert_initial_data(self):
         """ Test some initial value. """
-        self.assertTrue(self.user_employee._is_internal())
-        self.assertFalse(self.user_portal._is_internal())
         record_employee = self.test_record.with_user(self.user_employee)
         record_employee.check_access('read')
         record_portal = self.test_record.with_user(self.user_portal)
@@ -1076,93 +880,105 @@ class UnfollowFromEmailTest(MailCommon, HttpCase):
                 self.assertIn('/mail/unfollow', mail_template_arch)
                 self.assertNotIn('/mail/unfollow', re.sub(_UNFOLLOW_REGEX, '', mail_template_arch))
 
+    @users('employee')
+    @mute_logger('odoo.models')
+    def test_inbox_unfollow_information(self):
+        """ Check follow-up information for displaying inbox messages used to
+        implement "unfollow" in the inbox.
+
+        Note that the actual mechanism to unfollow a record from a message is
+        tested in the client part.
+        """
+        self.user_employee.write({'notification_type': 'inbox'})
+
+        test_record = self.env['mail.test.simple'].browse(self.test_record.ids)
+        _message = test_record.with_user(self.user_admin).message_post(
+            body="test message",
+            subtype_id=self.env.ref("mail.mt_comment").id,
+            partner_ids=self.partner_employee.ids,
+        )
+        # The user doesn't follow the record
+        self.authenticate(self.env.user.login, self.env.user.login)
+        message_data = self.make_jsonrpc_request("/mail/inbox/messages")["data"]
+        self.assertFalse(message_data["mail.thread"][0]["selfFollower"])
+        self.assertFalse(message_data.get("mail.followers"), "Should not have void followers data")
+        self.assertFalse(test_record.with_user(self.user_employee).message_is_follower)
+
+        # The user follows the record
+        test_record._message_subscribe(partner_ids=self.env.user.partner_id.ids)
+        follower = test_record.message_follower_ids.filtered(
+            lambda follower: follower.partner_id == self.env.user.partner_id
+        )
+        message_data = self.make_jsonrpc_request("/mail/inbox/messages")["data"]
+        self.assertEqual(message_data["mail.followers"], [
+            {
+                "id": follower.id,
+                "is_active": True,
+                "partner": {"id": self.env.user.partner_id.id, "type": "partner"},
+            },
+        ])
+        self.assertEqual(message_data["mail.thread"][0]["selfFollower"], follower.id, "Should have follower ID")
+
     @mute_logger('odoo.addons.base.models', 'odoo.addons.mail.controllers.mail', 'odoo.http', 'odoo.models')
-    def test_unfollow_internal_user(self):
+    def test_notification_email_unfollow_link(self):
         """ Internal user must receive an unfollow URL, that cannot be tampered
         and redirects to the correct page.
         """
-        test_partner = self.partner_employee
-        test_record = self.test_record
-
-        # Test that the user receives an unfollow URL when following the record
-        test_record._message_subscribe(partner_ids=test_partner.ids)
-        with self.subTest('Internal user receives unfollow URL'):
-            unfollow_url = self._post_message_and_get_unfollow_urls(test_record, test_partner)[0]
-            self.assertTrue(unfollow_url)
-
-        # Test unfollowing URL when user is not logged
-        self._test_unfollow_url(test_record, unfollow_url, test_partner)
-        self._test_tampered_unfollow_url(test_record, unfollow_url, test_partner)
-
-        # Test unfollowing URL when user is logged
-        self.authenticate(self.user_employee.login, self.user_employee.login)
-        self._test_unfollow_url(test_record, unfollow_url, test_partner)
-
-        # Test that the user doesn't receive the unfollow URL when not following the record
-        test_record.message_unsubscribe(partner_ids=test_partner.ids)
-        with self.subTest('Internal user simple notification (without unfollow URL)'):
-            unfollow_url = self._post_message_and_get_unfollow_urls(test_record, test_partner)[0]
-            self.assertFalse(unfollow_url)
-
-    @mute_logger('odoo.models')
-    def test_unfollow_partner_with_no_user(self):
-        """ External partner must not receive an unfollow URL. """
-        test_partner = self.partner_without_user
-        test_record = self.test_record
-
-        test_record._message_subscribe(partner_ids=test_partner.ids)
-        with self.subTest('External partner must not receive an unfollow URL'):
-            unfollow_url = self._post_message_and_get_unfollow_urls(test_record, test_partner)[0]
-            self.assertFalse(unfollow_url)
-
-    @mute_logger('odoo.addons.mail.controllers.mail', 'odoo.models', 'odoo.http')
-    def test_unfollow_partner_without_access_on_record_unfollow_enabled(self):
-        """ Partner without access must receive an unfollow URL for message
-        related to record with unfollow enabled.
-        """
-        test_record = self.test_record_unfollow
-        for descr, test_partner in (('Partner without user', self.partner_without_user),
-                                    ('Portal partner without access', self.partner_portal)):
-            with self.subTest(descr):
+        for test_partners, test_record, exp_has_url in [
+            (self.partner_employee, self.test_record, [True]),
+            # customer should not receive an unfollow URL
+            (self.partner_without_user, self.test_record, [False]),
+            (self.partner_portal, self.test_record, [False]),
+            # always unfollow link (model definition)
+            (self.partner_without_user, self.test_record_unfollow, [True]),
+            (self.partner_portal, self.test_record_unfollow, [True]),
+            # multi partners
+            (
+                self.partner_without_user + self.partner_portal + self.partner_employee,
+                self.test_record, [False, False, True],
+            ),
+            (
+                self.partner_without_user + self.partner_portal + self.partner_employee,
+                self.test_record_unfollow, [True, True, True],
+            ),
+        ]:
+            with self.subTest(partners=test_partners.mapped('name')):
                 # Test that the user receives an unfollow URL when following the record
-                test_record._message_subscribe(partner_ids=test_partner.ids)
-                with self.subTest('External partner receives an unfollow URL'):
-                    unfollow_url = self._post_message_and_get_unfollow_urls(test_record, test_partner)[0]
-                    self.assertTrue(unfollow_url)
+                test_record._message_subscribe(partner_ids=test_partners.ids)
+                unfollow_urls = self._message_post_and_get_unfollow_urls(test_record, test_partners)
+                for test_partner, unfollow_url, has_url in zip(test_partners, unfollow_urls, exp_has_url):
+                    self.assertEqual(bool(unfollow_url), has_url)
 
-                # Test unfollowing URL when user is not logged
-                self._test_unfollow_url(test_record, unfollow_url, test_partner)
-                self._test_tampered_unfollow_url(test_record, unfollow_url, test_partner)
+                    # Test unfollowing URL when user is not logged
+                    if has_url:
+                        self.authenticate(None, None)
+                        self._test_unfollow_url(test_record, unfollow_url, test_partner)
+                        self._test_tampered_unfollow_url(test_record, unfollow_url, test_partner)
+
+                        if test_partner == self.partner_employee:
+                            # Test unfollowing URL when user is logged
+                            self.authenticate(self.user_employee.login, self.user_employee.login)
+                            self._test_unfollow_url(test_record, unfollow_url, test_partner)
 
                 # Test that the user doesn't receive the unfollow URL when not following the record
-                test_record.message_unsubscribe(partner_ids=test_partner.ids)
-                with self.subTest('External partner not following must not receive unfollow URL'):
-                    unfollow_url = self._post_message_and_get_unfollow_urls(test_record, test_partner)[0]
+                test_record.message_unsubscribe(partner_ids=test_partners.ids)
+                unfollow_urls = self._message_post_and_get_unfollow_urls(test_record, test_partners)
+                for test_partner, unfollow_url in zip(test_partners, unfollow_urls):
                     self.assertFalse(unfollow_url)
 
-    def test_unfollow_partner_multi_recipients_multi_messages(self):
-        """ Test most of the cases above but with multiple recipients and messages. """
-        # On a record with unfollow attribute disabled.
-        test_record = self.test_record
-        partners = self.partner_without_user + self.partner_portal + self.partner_employee
-        test_record._message_subscribe(partner_ids=partners.ids)
-        urls = self._post_message_and_get_unfollow_urls(test_record, partners)
-        url_partner_without_user, url_partner_portal, url_employee = urls[0], urls[1], urls[2]
-
-        self.assertFalse(url_partner_without_user)
-        self.assertFalse(url_partner_portal)
-        self.assertTrue(url_employee)
-        self._test_unfollow_url(test_record, url_employee, self.partner_employee)
-
-        # On a record with unfollow attribute enabled.
-        test_record = self.test_record_unfollow
-        test_record._message_subscribe(partner_ids=partners.ids)
-        urls = self._post_message_and_get_unfollow_urls(test_record, partners)
-        url_partner_without_user, url_partner_portal, url_employee = urls[0], urls[1], urls[2]
-
-        self.assertTrue(url_partner_without_user)
-        self.assertTrue(url_partner_portal)
-        self.assertTrue(url_employee)
-        self._test_unfollow_url(test_record, url_partner_without_user, self.partner_without_user)
-        self._test_unfollow_url(test_record, url_partner_portal, self.partner_portal)
-        self._test_unfollow_url(test_record, url_employee, self.partner_employee)
+    def test_unsubscribe_unreadable(self):
+        """ Check internal can always unsubscribe form records while portal are
+        limited to records they can access. Other records are considered as customer
+        oriented and we don't want to lose emails. """
+        for user, can_unsubscribe in [
+            (self.user_employee, True),
+            (self.user_portal, False),
+        ]:
+            self.test_record._message_subscribe(partner_ids=user.partner_id.ids)
+            self.assertIn(user.partner_id, self.test_record.message_partner_ids)
+            if can_unsubscribe:
+                self._message_unsubscribe_unreadable_record(user)
+                self.assertNotIn(user.partner_id, self.test_record.message_partner_ids)
+            else:
+                with self.assertRaises(AccessError):
+                    self._message_unsubscribe_unreadable_record(user)

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -582,6 +582,9 @@ class RecipientsNotificationTest(MailCommon):
                     if not user:
                         user = next((user for user in partner.user_ids), self.env['res.users'])
                 self.assertEqual(partner_data['active'], partner.active)
+                self.assertEqual(partner_data['email_normalized'], partner.email_normalized)
+                self.assertEqual(partner_data['lang'], partner.lang)
+                self.assertEqual(partner_data['name'], partner.name)
                 if user:
                     self.assertEqual(partner_data['groups'], set(user.groups_id.ids))
                     self.assertEqual(partner_data['notif'], user.notification_type)

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -762,7 +762,7 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
                         'res_id': test_record.id,
                         'subtype_id': self.env.ref('mail.mt_comment'),
                     },
-                }
+                },
             ):
             new_message = test_record.message_post(
                 body='Body',


### PR DESCRIPTION
Main purpose of this PR is to cleanup some code bits related to followers
computation and manipulation related to outgoing notification emails.

Notably
 * cleanup and simplify unsubscribe (link) tests;
 * lint and slightly cleanup SQL code fetching followers of records based on
   outgoing emails;
 * remove "unfollow" box from notification emails if we already know it won't
   be used, allowing to remove useless computation when sending emails;
 * include recipients name and email in '_get_recipient_data' so that it is
   available for other branches that deal with recipients computation (see
   related tasks for more details);

Prepares Task-4281157: [mail] Allow to alter email.message To
Prepares Task-4128966: [mail] Less encapsulation, more standard emails
Prepares Task-4273479: [mail] Email-like recipients
