### PR TITLE
[FIX] point_of_sale: prevent order loss when clicking back button

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1395,7 +1395,7 @@ export class PosStore extends Reactive {
         const getOrder = (uuid) => this.models["pos.order"].getBy("uuid", uuid);
         const order = getOrder(uuid);
         await this.sendOrderInPreparation(order, cancelled);
-        order.updateLastOrderChange();
+        getOrder(uuid).updateLastOrderChange();
         await this.syncAllOrders();
         getOrder(uuid).updateSavedQuantity();
     }


### PR DESCRIPTION
Before this commit, when a user returns back, e.g. to the floor screen after clicking "order" but before the call to sendOrderInPreparationUpdateLastChange completed, the update to the order would not come through.

This specifically happens when a lengthy operation is performed in the calls behind the "order" button, such as calling preparation printers.

Example steps to reproduce
1. set up a clean DB with pos_restaurant installed
2. configure an epson printer as preparation printer
3. open the POS session
4. select a table and add some products
5. click on "order" and immediately click on "back"

The order status is still in the "to be sent" state, while the printer effectively printed the order. You now have to get back to the table view and send the order changes again if you ever want to complete any payment for that order. It will then send it again to the preparation printer.

The end result is inconsistencies between the pos session and the database in terms of data.
In terms of business flows and operations, it results in multiple sends of the same order, which in turn could lead to losses e.g. due to wrong preparations/unneeded preparations.

opw-4367939
opw-4246953