### PR TITLE
[IMP] auth_ldap: disable chasing references

### DIFF
--- a/addons/auth_ldap/models/res_company_ldap.py
+++ b/addons/auth_ldap/models/res_company_ldap.py
@@ -89,7 +89,7 @@ class ResCompanyLdap(models.Model):
         uri = 'ldap://%s:%d' % (conf['ldap_server'], conf['ldap_server_port'])
 
         connection = ldap.initialize(uri)
-        ldap_chase_ref_disabled = self.env['ir.config_parameter'].sudo().get_param('auth_ldap.disable_chase_ref')
+        ldap_chase_ref_disabled = self.env['ir.config_parameter'].sudo().get_param('auth_ldap.disable_chase_ref', 'True')
         if str2bool(ldap_chase_ref_disabled):
             connection.set_option(ldap.OPT_REFERRALS, ldap.OPT_OFF)
         if conf['ldap_tls']:


### PR DESCRIPTION
According to
https://github.com/odoo/odoo/pull/86436#issuecomment-1073681076 chase should be disabled by default and only have the option of opting in to it on master. However this was never put in master. This PR hopes to rectify this.