### PR TITLE
[IMP] point_of_sale: use receipt component in ticket screen

### DIFF
--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.js
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.js
@@ -7,6 +7,7 @@ export class Orderline extends Component {
         line: {
             type: Object,
             shape: {
+                id: String | Number,
                 isSelected: { type: Boolean, optional: true },
                 productName: String,
                 price: String,

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -620,6 +620,7 @@ export class PosOrderline extends Base {
 
     getDisplayData() {
         return {
+            id: this.id,
             productName: this.getFullProductName(),
             price: this.getPriceString(),
             qty: this.getQuantityStr(),

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
@@ -14,6 +14,7 @@ export class OrderReceipt extends Component {
     static props = {
         data: Object,
         formatCurrency: Function,
+        slots: { type: Object, optional: true },
         basic_receipt: { type: Boolean, optional: true },
     };
     static defaultProps = {

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -8,7 +8,11 @@
                 generalCustomerNote="props.data.general_customer_note or ''"
                 internalNote="props.data.internalNote or ''" screenName="props.data.screenName">
                 <t t-set="line" t-value="scope.line"/>
-                <Orderline basic_receipt="props.basic_receipt" line="omit(scope.line, 'customerNote')" class="{ 'px-0': true }" showTaxGroupLabels="showTaxGroupLabels">
+                <t t-if="props.slots?.default" t-slot="default" line="line"/>
+                <Orderline t-else="" basic_receipt="props.basic_receipt"
+                    line="omit(scope.line, 'customerNote')"
+                    class="{ 'px-0': true, 'selected': line.id === this.selectedLineId }"
+                    showTaxGroupLabels="showTaxGroupLabels">
                     <li t-if="line.customerNote" class="customer-note w-100 p-2 my-1 rounded text-break">
                         <i class="fa fa-sticky-note me-1" role="img" aria-label="Customer Note" title="Customer Note"/>
                         <t t-esc="line.customerNote" />

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -23,6 +23,7 @@ import { PosOrderLineRefund } from "@point_of_sale/app/models/pos_order_line_ref
 import { fuzzyLookup } from "@web/core/utils/search";
 import { parseUTCString } from "@point_of_sale/utils";
 import { useTrackedAsync } from "@point_of_sale/app/hooks/hooks";
+import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
 
 const NBR_BY_PAGE = 30;
 
@@ -34,6 +35,7 @@ export class TicketScreen extends Component {
         InvoiceButton,
         Orderline,
         OrderWidget,
+        OrderReceipt,
         CenteredIcon,
         SearchBar,
         Numpad,
@@ -136,6 +138,10 @@ export class TicketScreen extends Component {
     onClickOrderline(orderline) {
         if (this.state.selectedOrder.uiState.locked) {
             const order = this.getSelectedOrder();
+            if (this.state.selectedOrderlineIds[order.id] === orderline.id) {
+                this.state.selectedOrderlineIds[order.id] = false;
+                return;
+            }
             this.state.selectedOrderlineIds[order.id] = orderline.id;
             this.numberBuffer.reset();
         }

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -45,7 +45,7 @@
                             </div>
                             <t t-if="!ui.isSmall" t-foreach="_filteredOrderList" t-as="order" t-key="order.uuid">
                                 <div class="order-row" t-att-class="{ 'highlight bg-primary text-white': isHighlighted(order) }"
-                                    t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() => order.uiState.locked ? ()=>{} : this._setOrder(order)" >
+                                    t-on-click="() => this.onClickOrder(order)">
                                     <div class="col wide p-2 ">
                                         <div><t t-esc="getDate(order)"></t></div>
                                     </div>
@@ -120,7 +120,7 @@
                         <div t-if="isOrderSynced" t-att-class="{ 'highlight text-danger': !getHasItemsToRefund() }" class="py-2 px-3 rounded-3 bg-100 text-center">
                             Select the product(s) to refund and set the quantity
                         </div>
-                        <OrderWidget lines="_selectedSyncedOrder.lines" t-slot-scope="scope"
+                        <OrderWidget t-if="!isOrderSynced" lines="_selectedSyncedOrder.lines" t-slot-scope="scope"
                             total="env.utils.formatCurrency(_selectedSyncedOrder.getTotalWithTax())"
                             tax="!env.utils.floatIsZero(_selectedSyncedOrder.getTotalTax()) and env.utils.formatCurrency(_selectedSyncedOrder.getTotalTax()) or ''"
                             generalCustomerNote="_selectedSyncedOrder?.general_customer_note or ''"
@@ -128,28 +128,37 @@
                             <t t-set="line" t-value="scope.line" />
                             <Orderline line="line.getDisplayData()"
                                 class="{'selected': line.id === getSelectedOrderlineId()}"
-                                t-on-click="() => this.onClickOrderline(line)">
-                                <t t-set="toRefundDetail" t-value="line.order_id?.uiState?.lineToRefund?.[line.uuid]" />
-                                <li t-if="!pos.isProductQtyZero(line.refunded_qty)"
-                                    class="info refund-note mt-1">
-                                    <strong t-esc="env.utils.formatProductQty(line.refunded_qty)" />
-                                    <span> Refunded</span>
-                                </li>
-                                <li t-if="!pos.isProductQtyZero(toRefundDetail?.qty)" class="info to-refund-highlight refund-note mt-1 fw-bold text-primary">
-                                    <t t-set="_destinationOrderUid" t-value="toRefundDetail.destination_order_uuid"/>
-                                    <t t-set="refundQty" t-value="env.utils.formatProductQty(toRefundDetail.qty)"/>
-                                    <t t-if="_destinationOrderUid">
-                                        Refunding <t t-esc="refundQty" /> in
-                                        <span t-esc="_destinationOrderUid"
-                                            class="order-link ms-1 text-decoration-underline cursor-pointer"
-                                            t-on-click.stop="() => this.onClickRefundOrderUid(_destinationOrderUid)" />
-                                    </t>
-                                    <t t-else="">
-                                        To Refund: <t t-esc="refundQty" />
-                                    </t>
-                                </li>
-                            </Orderline>
+                                t-on-click="() => this.onClickOrderline(line)" />
                         </OrderWidget>
+                        <div t-elif="_selectedSyncedOrder" class="flex-grow-1 bg-white overflow-y-scroll rounded">
+                            <OrderReceipt data="pos.orderExportForPrinting(_selectedSyncedOrder)" formatCurrency="env.utils.formatCurrency"  t-slot-scope="scope">
+                                <t t-set="displayLine" t-value="scope.line" />
+                                <t t-set="line" t-value="this.pos.models['pos.order.line'].get(displayLine.id)" />
+                                <Orderline line="displayLine"
+                                    class="{'selected': line.id === getSelectedOrderlineId()}"
+                                    t-on-click="() => this.onClickOrderline(line)">
+                                     <t t-set="toRefundDetail" t-value="line.order_id?.uiState?.lineToRefund?.[line.uuid]" />
+                                    <li t-if="!pos.isProductQtyZero(line.refunded_qty)"
+                                        class="info refund-note mt-1">
+                                        <strong t-esc="env.utils.formatProductQty(line.refunded_qty)" />
+                                        <span> Refunded</span>
+                                    </li>
+                                    <li t-if="!pos.isProductQtyZero(toRefundDetail?.qty)" class="info to-refund-highlight refund-note mt-1 fw-bold text-primary">
+                                        <t t-set="_destinationOrderUid" t-value="toRefundDetail.destination_order_uuid"/>
+                                        <t t-set="refundQty" t-value="env.utils.formatProductQty(toRefundDetail.qty)"/>
+                                        <t t-if="_destinationOrderUid">
+                                            Refunding <t t-esc="refundQty" /> in
+                                            <span t-esc="_destinationOrderUid"
+                                                class="order-link ms-1 text-decoration-underline cursor-pointer"
+                                                t-on-click.stop="() => this.onClickRefundOrderUid(_destinationOrderUid)" />
+                                        </t>
+                                        <t t-else="">
+                                            To Refund: <t t-esc="refundQty" />
+                                        </t>
+                                    </li>
+                                </Orderline>
+                            </OrderReceipt>
+                        </div>
                         <div class="pads">
                             <t t-if="isOrderSynced">
                                 <div class="control-buttons d-flex gap-2 pb-2">
@@ -164,7 +173,7 @@
                                     </button>
                                 </div>
                                 <div class="subpads d-flex flex-column">
-                                    <Numpad class="'pb-2'" buttons="getNumpadButtons()"/>
+                                    <Numpad t-if="this.state.selectedOrderlineIds[_selectedSyncedOrder?.id]" class="'pb-2'" buttons="getNumpadButtons()"/>
                                     <ActionpadWidget
                                         partner="getSelectedOrder()?.getPartner()"
                                         actionName.translate="Refund"


### PR DESCRIPTION
When a paid order is selected in the `ticket_screen` the receipt component is now displayed in the right side of the screen (for open order nothing changes).

Double clicking on open order is now disabled. The most recent order is now always at the top of the list whatever the selected filter.

taskId: 4384144


