### PR TITLE
[FIX] hr_holidays: prevent traceback error in time off overview

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -81,7 +81,7 @@ class LeaveReportCalendar(models.Model):
         records = super()._fetch_query(query, fields)
         if self.env.context.get('hide_employee_name') and 'employee_id' in self.env.context.get('group_by', []):
             self.env.cache.update(records, self._fields['name'], [
-                record.name.split(':')[-1].strip()
+                record.name.split(':')[-1].strip() if record.name else ''
                 for record in records.with_user(SUPERUSER_ID)
             ])
         return records


### PR DESCRIPTION
**Issue:**

When accessing the "Overview" menu in the Time Off module as a user without admin or officer-level access rights, a traceback error occurs.

**Steps to reproduce:**

1- Log in as a user without admin or officer-level access rights for Time Off.
2- Time Off > Overview.

A traceback error is displayed.

opw-4378432

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
