### PR TITLE
[FIX] im_livechat, mail: do not add chat bot to calls

### DIFF
--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta
 
 from odoo import api, models, fields
+from odoo.osv import expression
 from odoo.addons.mail.tools.discuss import Store
 
 
@@ -40,3 +41,15 @@ class ChannelMember(models.Model):
         if self.channel_id.channel_type == 'livechat':
             return ["active", "country", "is_public", "user_livechat_username", "write_date"]
         return super()._get_store_partner_fields(fields)
+
+    def _get_rtc_invite_members_domain(self, *a, **kw):
+        domain = super()._get_rtc_invite_members_domain(*a, **kw)
+        chatbot = self.channel_id.chatbot_current_step_id.chatbot_script_id
+        if self.channel_id.channel_type == "livechat" and chatbot:
+            domain = expression.AND(
+                [
+                    domain,
+                    [("partner_id", "!=", chatbot.operator_partner_id.id)],
+                ]
+            )
+        return domain

--- a/addons/im_livechat/static/src/core/web/channel_member_list_patch.js
+++ b/addons/im_livechat/static/src/core/web/channel_member_list_patch.js
@@ -3,6 +3,6 @@ import { patch } from "@web/core/utils/patch";
 
 patch(ChannelMemberList.prototype, {
     canOpenChatWith(member) {
-        return super.canOpenChatWith(member) && !member.persona.is_public;
+        return super.canOpenChatWith(member) && !member.persona.is_public && !member.is_bot;
     },
 });

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -108,3 +108,26 @@ class ChatbotCase(chatbot_common.ChatbotCase):
         welcome_steps = self.chatbot_script._get_welcome_steps()
         self.assertEqual(len(welcome_steps), 1)
         self.assertEqual(welcome_steps, self.chatbot_script.script_step_ids[0])
+
+    def test_chatbot_not_invited_to_rtc_calls(self):
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "anonymous_name": "Test Visitor",
+                "channel_id": self.livechat_channel.id,
+                "chatbot_script_id": self.chatbot_script.id,
+            },
+        )
+        discuss_channel = (
+            self.env["discuss.channel"].sudo().browse(data["discuss.channel"][0]["id"])
+        )
+        self.assertEqual(discuss_channel.livechat_operator_id, self.chatbot_script.operator_partner_id)
+        discuss_channel.add_members(partner_ids=self.env.user.partner_id.ids)
+        self_member = discuss_channel.channel_member_ids.filtered(lambda m: m.is_self)
+        bot_member = discuss_channel.channel_member_ids.filtered(
+            lambda m: m.partner_id == self.chatbot_script.operator_partner_id
+        )
+        guest_member = discuss_channel.channel_member_ids.filtered(lambda m: bool(m.guest_id))
+        self_member._rtc_join_call()
+        self.assertTrue(guest_member.rtc_inviting_session_id)
+        self.assertFalse(bot_member.rtc_inviting_session_id)


### PR DESCRIPTION
This PR fixes two issues:
- Chatbot is added to calls while it makes no sense.
- Clicking on the bot in the channel member list leads to a crash.

task-4354075

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
