### PR TITLE
[IMP] tests: remove some logs

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -877,6 +877,8 @@ class TransactionCase(BaseCase):
         cls.addClassCleanup(reset_changes)
 
         def signal_changes():
+            if not cls.registry.registry_invalidated and not cls.registry.cache_invalidated:
+                return  # avoid useless log if nothing changed after http request
             if not cls.registry.ready:
                 _logger.info('Skipping signal changes during tests')
                 return


### PR DESCRIPTION
This log was added to know when a test would call signal change, sometimes problematic during at_install. 

This information is also interesting when a change has to be signaled during HttpCase. We can skip the log in case nothing has to be done.