### PR TITLE
[IMP] spreadsheet: use field service

### DIFF
--- a/addons/spreadsheet/static/src/data_sources/data_source.js
+++ b/addons/spreadsheet/static/src/data_sources/data_source.js
@@ -153,17 +153,16 @@ export const LOADING_ERROR = new LoadingDataError();
 export class ModelNotFoundError extends Error {}
 
 /**
- * Perform a `fields_get` on the given model and return the fields.
+ * Return the fields of a given model.
  * If the model is not found, a `ModelNotFoundError` is thrown.
  *
- * @param {ServerData} serverData
+ * @param {object} fieldService
  * @param {string} model
  * @returns {Promise<import("@spreadsheet").OdooFields>}
  */
-export async function getFields(serverData, model) {
+export async function getFields(fieldService, model) {
     try {
-        const fields = await serverData.fetch(model, "fields_get");
-        return fields;
+        return await fieldService.loadFields(model);
     } catch (e) {
         if (e instanceof RPCError && e.code === 404) {
             throw new ModelNotFoundError(model);

--- a/addons/spreadsheet/static/src/data_sources/data_source.js
+++ b/addons/spreadsheet/static/src/data_sources/data_source.js
@@ -54,6 +54,10 @@ export class LoadableDataSource {
         return this.odooDataProvider.serverData;
     }
 
+    get modelDisplayNameService() {
+        return this.odooDataProvider.modelDisplayNameService;
+    }
+
     /**
      * Load data in the model
      * @param {object} [params] Params for fetching data

--- a/addons/spreadsheet/static/src/data_sources/odoo_data_provider.js
+++ b/addons/spreadsheet/static/src/data_sources/odoo_data_provider.js
@@ -6,6 +6,7 @@ export class OdooDataProvider extends EventBus {
         super();
         this.orm = env.services.orm.silent;
         this.fieldService = env.services.field;
+        this.modelDisplayNameService = env.services.modelDisplayName;
         this.serverData = new ServerData(this.orm, {
             whenDataStartLoading: (promise) => this.notifyWhenPromiseResolves(promise),
         });

--- a/addons/spreadsheet/static/src/data_sources/odoo_data_provider.js
+++ b/addons/spreadsheet/static/src/data_sources/odoo_data_provider.js
@@ -5,6 +5,7 @@ export class OdooDataProvider extends EventBus {
     constructor(env) {
         super();
         this.orm = env.services.orm.silent;
+        this.fieldService = env.services.field;
         this.serverData = new ServerData(this.orm, {
             whenDataStartLoading: (promise) => this.notifyWhenPromiseResolves(promise),
         });

--- a/addons/spreadsheet/static/src/data_sources/odoo_views_data_source.js
+++ b/addons/spreadsheet/static/src/data_sources/odoo_views_data_source.js
@@ -56,7 +56,10 @@ export class OdooViewsDataSource extends LoadableDataSource {
 
     async loadMetadata() {
         if (!this._metaData.fields) {
-            this._metaData.fields = await getFields(this.serverData, this._metaData.resModel);
+            this._metaData.fields = await getFields(
+                this.odooDataProvider.fieldService,
+                this._metaData.resModel
+            );
         }
         this._metaDataLoaded = true;
     }

--- a/addons/spreadsheet/static/src/data_sources/odoo_views_data_source.js
+++ b/addons/spreadsheet/static/src/data_sources/odoo_views_data_source.js
@@ -147,8 +147,9 @@ export class OdooViewsDataSource extends LoadableDataSource {
      * @returns {Promise<string>} Display name of the model
      */
     async getModelLabel() {
-        const model = this._metaData.resModel;
-        const result = await this.serverData.fetch("ir.model", "display_name_for", [[model]]);
-        return (result[0] && result[0].display_name) || "";
+        const displayName = await this.modelDisplayNameService.getModelDisplayName(
+            this._metaData.resModel
+        );
+        return displayName || "";
     }
 }

--- a/addons/spreadsheet/static/src/data_sources/server_data.js
+++ b/addons/spreadsheet/static/src/data_sources/server_data.js
@@ -98,8 +98,6 @@ export class ServerData {
         this.startLoadingCallback = whenDataStartLoading ?? (() => {});
         /** @type {Record<string, unknown>}*/
         this.cache = {};
-        /** @type {Record<string, Promise<unknown>>}*/
-        this.asyncCache = {};
         this.batchEndpoints = {};
     }
 
@@ -152,21 +150,6 @@ export class ServerData {
             throw error;
         }
         return this._getOrThrowCachedResponse(request);
-    }
-
-    /**
-     * Returns the request result if cached or the associated promise
-     * @param {string} resModel
-     * @param {string} method
-     * @param  {unknown[]} [args]
-     * @returns {Promise<any>}
-     */
-    async fetch(resModel, method, args) {
-        const request = new Request(resModel, method, args);
-        if (!(request.key in this.asyncCache)) {
-            this.asyncCache[request.key] = this.orm.call(resModel, method, args);
-        }
-        return this.asyncCache[request.key];
     }
 
     /**

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
@@ -34,6 +34,7 @@ export class FilterValue extends Component {
         this.getters = this.props.model.getters;
         this.relativeDateRangesTypes = RELATIVE_DATE_RANGE_TYPES;
         this.nameService = useService("name");
+        this.fieldService = useService("field");
         this.isValid = false;
         onWillStart(async () => {
             if (this.filter.type !== "relation") {
@@ -41,8 +42,7 @@ export class FilterValue extends Component {
                 return;
             }
             try {
-                const odooDataProvider = this.props.model.config.custom.odooDataProvider;
-                await getFields(odooDataProvider.serverData, this.filter.modelName);
+                await getFields(this.fieldService, this.filter.modelName);
                 this.isValid = true;
             } catch (e) {
                 if (e instanceof ModelNotFoundError) {

--- a/addons/spreadsheet/static/src/model_display_name_service.js
+++ b/addons/spreadsheet/static/src/model_display_name_service.js
@@ -1,0 +1,37 @@
+import { Cache } from "@web/core/utils/cache";
+import { registry } from "@web/core/registry";
+
+export const modelDisplayNameService = {
+    dependencies: ["orm"],
+    async: ["getModelDisplayName"],
+    start(env, { orm }) {
+        const cache = new Cache(
+            (model) =>
+                orm
+                    .call("ir.model", "display_name_for", [[model]])
+                    .then((result) => result[0]?.display_name)
+                    .catch((error) => {
+                        cache.clear(model);
+                        return Promise.reject(error);
+                    }),
+            (model) => model
+        );
+
+        env.bus.addEventListener("CLEAR-CACHES", () => cache.invalidate());
+
+        /**
+         * @param {string} model
+         * @returns {Promise<object>}
+         */
+        async function getModelDisplayName(model) {
+            if (typeof model !== "string" || !model) {
+                throw new Error(`Invalid model name: ${model}`);
+            }
+            return cache.read(model);
+        }
+
+        return { getModelDisplayName };
+    },
+};
+
+registry.category("services").add("modelDisplayName", modelDisplayNameService);

--- a/addons/spreadsheet/static/src/pivot/odoo_pivot_loader.js
+++ b/addons/spreadsheet/static/src/pivot/odoo_pivot_loader.js
@@ -96,7 +96,7 @@ export class OdooPivotLoader {
      * @returns {Promise<OdooFields>} Fields of the model
      */
     async getFields(model) {
-        return getFields(this.odooDataProvider.serverData, model);
+        return getFields(this.odooDataProvider.fieldService, model);
     }
     /**
      * @param {string} model Technical name of the model

--- a/addons/spreadsheet/static/src/pivot/odoo_pivot_loader.js
+++ b/addons/spreadsheet/static/src/pivot/odoo_pivot_loader.js
@@ -103,12 +103,10 @@ export class OdooPivotLoader {
      * @returns {Promise<string>} Display name of the model
      */
     async getModelLabel(model) {
-        const result = await this.odooDataProvider.serverData.fetch(
-            "ir.model",
-            "display_name_for",
-            [[model]]
+        const displayName = await this.odooDataProvider.modelDisplayNameService.getModelDisplayName(
+            model
         );
-        return (result[0] && result[0].display_name) || "";
+        return displayName || "";
     }
 
     isModelValid() {

--- a/addons/spreadsheet/static/tests/data_fetching/server_data.test.js
+++ b/addons/spreadsheet/static/tests/data_fetching/server_data.test.js
@@ -48,60 +48,6 @@ test("synchronous get which returns an error", async () => {
     expect.verifySteps([]);
 });
 
-test("simple async fetch", async () => {
-    const orm = {
-        call: async (model, method, args) => {
-            expect.step(`${model}/${method}`);
-            return args[0];
-        },
-    };
-    const serverData = new ServerData(orm, {
-        whenDataStartLoading: () => expect.step("data-fetching-notification"),
-    });
-    const result = await serverData.fetch("partner", "get_something", [5]);
-    expect(result).toBe(5);
-    expect.verifySteps(["partner/get_something"]);
-    expect(await serverData.fetch("partner", "get_something", [5])).toBe(5);
-    expect.verifySteps([]);
-});
-
-test("async fetch which throws an error", async () => {
-    const orm = {
-        call: async (model, method, args) => {
-            expect.step(`${model}/${method}`);
-            throw new Error("error while fetching data");
-        },
-    };
-    const serverData = new ServerData(orm, {
-        whenDataStartLoading: () => expect.step("data-fetching-notification"),
-    });
-    expect(serverData.fetch("partner", "get_something", [5])).rejects.toThrow();
-    expect.verifySteps(["partner/get_something"]);
-    expect(serverData.fetch("partner", "get_something", [5])).rejects.toThrow();
-    expect.verifySteps([]);
-});
-
-test("two identical concurrent async fetch", async () => {
-    const orm = {
-        call: async (model, method, args) => {
-            expect.step(`${model}/${method}`);
-            return args[0];
-        },
-    };
-    const serverData = new ServerData(orm, {
-        whenDataStartLoading: () => expect.step("data-fetching-notification"),
-    });
-    const [result1, result2] = await Promise.all([
-        serverData.fetch("partner", "get_something", [5]),
-        serverData.fetch("partner", "get_something", [5]),
-    ]);
-    // it should have fetch the data once
-    expect.verifySteps(["partner/get_something"]);
-    expect(result1).toBe(5);
-    expect(result2).toBe(5);
-    expect.verifySteps([]);
-});
-
 test("batch get with a single item", async () => {
     const deferred = new Deferred();
     const orm = {
@@ -190,78 +136,6 @@ test("batch get with one error", async () => {
     expect(serverData.batch.get("partner", "get_something_in_batch", 4)).toBe(4);
     expect(() => serverData.batch.get("partner", "get_something_in_batch", 5)).toThrow(Error);
     expect(serverData.batch.get("partner", "get_something_in_batch", 6)).toBe(6);
-    expect.verifySteps([]);
-});
-
-test("concurrently fetch then get the same request", async () => {
-    const orm = {
-        call: async (model, method, args) => {
-            expect.step(`${model}/${method}`);
-            return args[0];
-        },
-    };
-    const serverData = new ServerData(orm, {
-        whenDataStartLoading: () => expect.step("data-fetching-notification"),
-    });
-    const promise = serverData.fetch("partner", "get_something", [5]);
-    expect(() => serverData.get("partner", "get_something", [5])).toThrow(LoadingDataError);
-    // it loads the data independently
-    expect.verifySteps([
-        "partner/get_something",
-        "partner/get_something",
-        "data-fetching-notification",
-    ]);
-    const result = await promise;
-    await animationFrame();
-    expect(result).toBe(5);
-    expect(serverData.get("partner", "get_something", [5])).toBe(5);
-    expect.verifySteps([]);
-});
-
-test("concurrently get then fetch the same request", async () => {
-    const orm = {
-        call: async (model, method, args) => {
-            expect.step(`${model}/${method}`);
-            return args[0];
-        },
-    };
-    const serverData = new ServerData(orm, {
-        whenDataStartLoading: () => expect.step("data-fetching-notification"),
-    });
-    expect(() => serverData.get("partner", "get_something", [5])).toThrow(LoadingDataError);
-    const result = await serverData.fetch("partner", "get_something", [5]);
-    // it should have fetch the data once
-    expect.verifySteps([
-        "partner/get_something",
-        "data-fetching-notification",
-        "partner/get_something",
-    ]);
-    expect(result).toBe(5);
-    expect(serverData.get("partner", "get_something", [5])).toBe(5);
-    expect.verifySteps([]);
-});
-
-test("concurrently batch get then fetch the same request", async () => {
-    const orm = {
-        call: async (model, method, args) => {
-            expect.step(`${model}/${method}`);
-            return args[0];
-        },
-    };
-    const serverData = new ServerData(orm, {
-        whenDataStartLoading: () => expect.step("data-fetching-notification"),
-    });
-    expect(() => serverData.batch.get("partner", "get_something", 5)).toThrow(LoadingDataError);
-    const result = await serverData.fetch("partner", "get_something", [5]);
-    await animationFrame();
-    // it should have fetch the data once
-    expect.verifySteps([
-        "partner/get_something",
-        "partner/get_something",
-        "data-fetching-notification",
-    ]);
-    expect(result).toBe(5);
-    expect(serverData.batch.get("partner", "get_something", 5)).toBe(5);
     expect.verifySteps([]);
 });
 


### PR DESCRIPTION
With this commit, we use `field` service to get the fields of the model instead of using `fields_get` with our serverData. This will allow us to take advantage of the cache of the field service and avoid making unnecessary requests to the server.

Note that we already had a cache system with our serverData, but with the `field` service, we use only one cache for all the fields of the models, which is more efficient.

Task: 4384807

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
