### PR TITLE
[FIX] web: prevent env from being reactive

### DIFF
--- a/addons/web/static/src/core/overlay/overlay_service.js
+++ b/addons/web/static/src/core/overlay/overlay_service.js
@@ -1,4 +1,4 @@
-import { reactive } from "@odoo/owl";
+import { markRaw, reactive } from "@odoo/owl";
 import { registry } from "../registry";
 import { OverlayContainer } from "./overlay_container";
 
@@ -43,7 +43,7 @@ export const overlayService = {
             overlays[id] = {
                 id,
                 component,
-                env: options.env,
+                env: options.env && markRaw(options.env),
                 props,
                 remove: removeCurrentOverlay,
                 sequence: options.sequence ?? 50,


### PR DESCRIPTION
Commit [1] allowed to pass the env to overlays, as a prop. However, when doing so, the env was inserted in a reactive array (`overlays`) which thus made it reactive as well. That reactive env was then used as childEnv for the overlay items.

Having a reactive env isn't a good idea, relying on this isn't either. Indeed, changes in the "non reactive" env wouldn't be taken into account. Moreover, it can lead to unexpected excessive re-renderings, or even to crashes (a reactive object is a proxy, and for instance, calling `difference` on a Set wrapped in a proxy crashes).

[1] odoo/odoo@7851d85f26c525a90fdb1131c5e4d51a6b140c13

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
