### PR TITLE
[IMP] hw_drivers: add devtools to disable features

### DIFF
--- a/addons/hw_drivers/driver.py
+++ b/addons/hw_drivers/driver.py
@@ -4,6 +4,8 @@
 from threading import Thread, Event
 
 from odoo.addons.hw_drivers.main import drivers, iot_devices
+from odoo.addons.hw_drivers.tools.helpers import toggleable
+
 from odoo.tools.lru import LRU
 
 
@@ -47,11 +49,11 @@ class Driver(Thread, metaclass=DriverMetaClass):
         """
         return False
 
+    @toggleable
     def action(self, data):
         """Helper function that calls a specific action method on the device.
 
-        :param data: the `_actions` key mapped to the action method we want to call
-        :type data: string
+        :param dict data: the `_actions` key mapped to the action method we want to call
         """
         self._actions[data.get('action', '')](data)
 

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -6,7 +6,7 @@ import contextlib
 import crypt
 import datetime
 from enum import Enum
-from functools import cache
+from functools import cache, wraps
 from importlib import util
 import io
 import logging
@@ -58,6 +58,28 @@ class IoTRestart(Thread):
     def run(self):
         time.sleep(self.delay)
         service.server.restart()
+
+
+def toggleable(function):
+    """Decorate a function to enable or disable it based on the value
+    of the associated configuration parameter.
+    """
+    fname = f"<function {function.__module__}.{function.__qualname__}>"
+
+    @wraps(function)
+    def devtools_wrapper(*args, **kwargs):
+        if function.__name__ == 'action':
+            action = args[1].get('action', 'default')  # first argument is self (containing Driver instance), second is 'data'
+            disabled_actions = (get_conf('actions', section='devtools') or '').split(',')
+            if action in disabled_actions or '*' in disabled_actions:
+                _logger.warning("Ignoring call to %s: '%s' action is disabled by devtools", fname, action)
+                return
+        elif get_conf('general', section='devtools'):
+            _logger.warning(f"Ignoring call to {fname}: method is disabled by devtools")
+            return
+
+        return function(*args, **kwargs)
+    return devtools_wrapper
 
 
 if platform.system() == 'Windows':
@@ -129,6 +151,7 @@ def check_certificate():
         return {"status": CertificateStatus.OK, "message": message}
 
 
+@toggleable
 def check_git_branch():
     """Check if the local branch is the same as the connected Odoo DB and
     checkout to match it if needed.
@@ -384,6 +407,7 @@ def delete_iot_handlers():
         _logger.exception('Failed to delete old IoT handlers')
 
 
+@toggleable
 def download_iot_handlers(auto=True):
     """Get the drivers from the configured Odoo server.
     If drivers did not change on the server, download

--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -54,6 +54,7 @@ odoo_help() {
   echo 'odoo_stop           Stops Odoo service'
   echo 'odoo_restart        Restarts Odoo service'
   echo 'odoo_dev <branch>   Resets Odoo on the specified branch from odoo-dev repository'
+  echo 'devtools            Enables/Disables specific functions for development (more help with devtools help)'
   echo ''
   echo 'Odoo IoT online help: <https://www.odoo.com/documentation/master/applications/general/iot.html>'
 }
@@ -83,6 +84,35 @@ pip() {
     additional_arg=\"--user\"
   fi
   pip3 \"\$1\" \"\$2\" --break-system-package \$additional_arg
+}
+
+devtools() {
+  if [[ -z \"\$1\" || -z \"\$2\" || ! (\"\$1\" == \"enable\" || \"\$1\" == \"disable\") || ! (\"\$2\" == \"general\" || \"\$2\" == \"actions\") || \"\$1\" == \"-h\" ]]; then
+    echo 'Usage: devtools <enable/disable> <general/actions> [action name]'
+    echo ''
+    echo 'Only provide an action name if you want do enable/disable a specific device action.'
+    echo 'If no action name is provided, all actions will be enabled/disabled.'
+    echo 'To enable/disable multiple actions, enclose them in quotes separated by commas.'
+    return 1
+  fi
+  write_mode
+  if ! grep -q '^\[devtools\]' /home/pi/odoo.conf; then
+    printf '\n[devtools]\n' >> /home/pi/odoo.conf
+  fi
+  if [ \"\$1\" == \"disable\" ]; then
+    if [[ -z \"\$3\" ]]; then
+      value=\"*\"
+    else
+      value=\"\$3\"
+    fi
+    # Remove action/general from conf to avoid duplicate keys
+    devtools enable \$2
+    write_mode
+    sed -i \"/^\[devtools\]/a\\\\\$2 = \$value\" /home/pi/odoo.conf
+  elif [ \"\$1\" == \"enable\" ]; then
+    sed -i \"/\[devtools\]/,/\[/{/\$2 =/d}\" /home/pi/odoo.conf
+  fi
+  read_mode
 }
 " | tee -a ~/.bashrc /home/pi/.bashrc
 


### PR DESCRIPTION
While developing, we often disable features like the db checkout and the IoT handlers download to save some time.

Now, instead of going in the code and comment the lines we want to remove, we can just type:

- `devtools disable general`: to disable general features (checkout, handlers download),
- `devtools disable actions <optional action name>`: to disable a device action (printing for example).

**Note:** by default, if you don't specify `<action name>`, it will disable all actions.

Task: 4291487