### PR TITLE
[FIX] website_sale: website_sale_add_to_cart_snippet_tour tour

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -27,15 +27,27 @@ function assertCssVariable(variableName, variableValue, trigger = ':iframe body'
         },
     };
 }
-function assertPathName(pathName, trigger) {
+export function assertPathName(pathname, trigger) {
     return {
-        content: `Check if we have been redirected to ${pathName}`,
+        content: `Check if we have been redirected to ${pathname}`,
         trigger: trigger,
-        run: () => {
-            if (!window.location.pathname.startsWith(pathName)) {
-                console.error(`We should be on ${pathName}.`);
-            }
-        }
+        async run() {
+            await new Promise((resolve) => {
+                let elapsedTime = 0;
+                const intervalTime = 100;
+                const interval = setInterval(() => {
+                    if (window.location.pathname.startsWith(pathname)) {
+                        clearInterval(interval);
+                        resolve();
+                    }
+                    elapsedTime += intervalTime;
+                    if (elapsedTime >= 5000) {
+                        clearInterval(interval);
+                        console.error(`The pathname ${pathname} has not been found`);
+                    }
+                }, intervalTime);
+            });
+        },
     };
 }
 

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -29,7 +29,7 @@ wTourUtils.registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         ...wTourUtils.selectElementInWeSelectWidget('product_template_picker_opt', 'Product Yes Variant 1', true),
         ...wTourUtils.clickOnSave(),
         wTourUtils.clickOnElement('add to cart button', ':iframe .s_add_to_cart_btn'),
-        wTourUtils.clickOnElement('continue shopping', ':iframe span:contains(Continue Shopping)'),
+        wTourUtils.clickOnElement('continue shopping', ':iframe .modal button:contains(Continue Shopping)'),
 
         // Product with 2 variants with a variant selected
         ...editAddToCartSnippet(),
@@ -47,7 +47,7 @@ wTourUtils.registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         {
             // wait for the page to load, as the next check was sometimes too fast
             content: "Wait for the redirection to the payment page",
-            trigger: 'body',
+            trigger: ":iframe h3:contains(order overview)",
         },
         wTourUtils.assertPathName('/shop/payment', ':iframe a[href="/shop/cart"]'),
 


### PR DESCRIPTION
In this commit, we fix a undeterministic behavior about check the pathname of window in function assertPathName.
In this function, we check the url of the window but the url can changes few ms after the DOM has been loaded. So the check can occurs after the DOM has been loaded.
To avoid this behavior, we wait for the pathname instead of check it direclty.

runbot-error-id~70316
