### PR TITLE
[FIX] project: don't use cumulative graph by default on burndown chart

### DIFF
--- a/addons/project/report/project_task_burndown_chart_report_views.xml
+++ b/addons/project/report/project_task_burndown_chart_report_views.xml
@@ -37,7 +37,7 @@
         <field name="name">project.task.burndown.chart.report.view.graph</field>
         <field name="model">project.task.burndown.chart.report</field>
         <field name="arch" type="xml">
-            <graph string="Burndown Chart" type="line" sample="1" disable_linking="1" js_class="burndown_chart" cumulated="1">
+            <graph string="Burndown Chart" type="line" sample="1" disable_linking="1" js_class="burndown_chart">
                 <field name="date" string="Date" interval="week"/>
                 <field name="stage_id"/>
                 <field name="is_closed"/>


### PR DESCRIPTION
Before this commit, task-4295656 make the graph view in burndown chart report cumulative by default. However, the cumulative feature in the graph view will sum the values given in the previous points and so the data displayed in the last point will show more tasks than expected.

This commit does not active by default the cumulative feature in the graph view of burndown chart report.

task-4295656
