### PR TITLE
[FIX] web: stat buttons should have the same size as the cog button

### DIFF
--- a/addons/web/static/src/views/form/button_box/button_box.scss
+++ b/addons/web/static/src/views/form/button_box/button_box.scss
@@ -45,10 +45,6 @@
         height: $-stat-button-height;
         min-width: 0;
 
-        &:not(.dropdown) {
-            overflow: hidden;
-        }
-
         @include media-breakpoint-up(md) {
             min-width: 7.5em; // Arbitrary
         }
@@ -65,6 +61,10 @@
         // Some buttons only display text without using StatInfo template
         > span {
             @include o-text-overflow(block);
+        }
+
+        .o_field_statinfo {
+            overflow: hidden;
         }
 
         .o_stat_info, > span, .o_field_statinfo {


### PR DESCRIPTION
Steps to reproduce
==================

- In 18, install documents,project
- Open a project then a task
- Switch to a mobile view and refresh the page
- The lightning icon is smaller than the cog icon

Cause of the issue
==================

https://github.com/odoo/odoo/pull/188986

An overflow was applied on the entire oe_stat_button

Solution
========

We can move the overflow to the `o_field_statinfo` This is better than before as now the ellipsis is visible.

task-4377703