### PR TITLE
[FIX] stock_{picking_batch,fleet}: scope no content helper

### DIFF
--- a/addons/stock_fleet/views/stock_picking_batch.xml
+++ b/addons/stock_fleet/views/stock_picking_batch.xml
@@ -3,7 +3,7 @@
         <field name="name">stock.picking.batch.pivot</field>
         <field name="model">stock.picking.batch</field>
         <field name="arch" type="xml">
-            <pivot string="Batch Transfer" sample="1">
+            <pivot string="Batch Transfer" class="oe_stock_picking_batch" sample="1">
                 <field name="scheduled_date" type="row"/>
                 <field name="vehicle_id" type="col"/>
             </pivot>
@@ -14,7 +14,7 @@
         <field name="name">stock.picking.batch.graph</field>
         <field name="model">stock.picking.batch</field>
         <field name="arch" type="xml">
-            <graph string="Graph View" sample="1">
+            <graph string="Graph View" class="oe_stock_picking_batch" sample="1">
                 <field name="scheduled_date" type="row" interval="day"/>
                 <field name="vehicle_category_id" type="row"/>
             </graph>

--- a/addons/stock_picking_batch/static/src/scss/stock_picking_batch_empty_screen.scss
+++ b/addons/stock_picking_batch/static/src/scss/stock_picking_batch_empty_screen.scss
@@ -1,3 +1,3 @@
-.o_view_nocontent .o_nocontent_help {
+.oe_stock_picking_batch .o_view_nocontent .o_nocontent_help {
     max-width: 90%;
 }

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -133,7 +133,7 @@
         <field name="name">stock.picking.batch.list</field>
         <field name="model">stock.picking.batch</field>
         <field name="arch" type="xml">
-            <list string="Stock Batch Transfer" multi_edit="1" sample="1">
+            <list string="Stock Batch Transfer" multi_edit="1" sample="1" class="oe_stock_picking_batch">
                 <field name="company_id" column_invisible="True"/>
                 <field name="name" decoration-bf="1"/>
                 <field name="description"/>
@@ -151,7 +151,7 @@
         <field name="name">stock.picking.batch.kanban</field>
         <field name="model">stock.picking.batch</field>
         <field name="arch" type="xml">
-            <kanban class="o_kanban_mobile" sample="1">
+            <kanban class="o_kanban_mobile oe_stock_picking_batch" sample="1">
                 <field name="company_id"/>
                 <templates>
                     <t t-name="card">

--- a/addons/web/static/tests/views/graph/graph_view.test.js
+++ b/addons/web/static/tests/views/graph/graph_view.test.js
@@ -177,6 +177,15 @@ defineModels([Foo, Color, Product]);
 
 setupChartJsForTests();
 
+test('graph view with "class" attribute', async () => {
+    await mountView({
+        type: "graph",
+        resModel: "foo",
+        arch: `<graph class="foobar-class"/>`,
+    });
+    expect(".o_graph_view").toHaveClass("foobar-class");
+});
+
 test("simple bar chart rendering", async () => {
     const view = await mountView({ type: "graph", resModel: "foo" });
 

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -202,6 +202,15 @@ test('pivot view without "string" attribute', async () => {
     expect(model.metaData.title.toString()).toBe(_t("Untitled"));
 });
 
+test('pivot view with "class" attribute', async () => {
+    await mountView({
+        type: "pivot",
+        resModel: "partner",
+        arch: `<pivot class="foobar-class"/>`,
+    });
+    expect(".o_pivot_view").toHaveClass("foobar-class");
+});
+
 test("simple pivot rendering", async () => {
     expect.assertions(4);
 

--- a/odoo/addons/base/rng/graph_view.rng
+++ b/odoo/addons/base/rng/graph_view.rng
@@ -18,6 +18,7 @@
                     </rng:choice>
                 </rng:attribute>
             </rng:optional>
+            <rng:optional><rng:attribute name="class"/></rng:optional>
             <rng:optional><rng:attribute name="js_class"/></rng:optional>
             <rng:optional><rng:attribute name="stacked"/></rng:optional>
             <rng:optional><rng:attribute name="order"/></rng:optional>

--- a/odoo/addons/base/rng/pivot_view.rng
+++ b/odoo/addons/base/rng/pivot_view.rng
@@ -8,6 +8,7 @@
     <rng:include href="common.rng"/>
     <rng:define name="pivot">
         <rng:element name="pivot">
+            <rng:optional><rng:attribute name="class"/></rng:optional>
             <rng:optional><rng:attribute name="sample"/></rng:optional>
             <rng:optional><rng:attribute name="string"/></rng:optional>
             <rng:optional><rng:attribute name="stacked"/></rng:optional>


### PR DESCRIPTION
**[FIX] stock_{picking_batch,fleet}: scope no content helper**
Since [1], a CSS rule was changing the size of all the no content
helpers throughout Odoo when `stock_picking_batch` was installed.

This commit fixes that by scoping the rule to its original intent.

opw-4370026

[1]: https://github.com/odoo/odoo/commit/06d1d48199ccfc79a80aea314f75d649b3149dba#diff-87ad06e3496be4ac6761b7052a11d9e9f1464e291d305405aae839f1a4d2ba9cR1


---

In order to achieve this, we needed to add support for the class attribute for graph and pivot views. It is only a matter of RNG validation as the code already support the parsing of the `class` attribute. The following commit is therefore added:

**[FIX] base,web: class attr for `<graph/>` & `<pivot/>`**
Before this commit, the class attribute for `<graph/>` and `<pivot/>` views
was not allowed.

As there is no valid reason not to do so, this commit now allows it.