### PR TITLE
[FIX] account: CoA access error after archiving company

### DIFF
--- a/addons/account/models/account_code_mapping.py
+++ b/addons/account/models/account_code_mapping.py
@@ -50,7 +50,7 @@ class AccountCodeMapping(models.Model):
                 return self.browse([
                     account_id * COMPANY_OFFSET + company.id
                     for account_id in account_ids
-                    for company in self.env.user.company_ids.sorted(lambda c: (c.sequence, c.name))
+                    for company in self.env.user.company_ids.filtered('active').sorted(lambda c: (c.sequence, c.name))
                 ]).filtered_domain(remaining_domain)._as_query()
         raise NotImplementedError
 


### PR DESCRIPTION
After archiving a company users encounter an error when accessing any account in the CoA
Steps to reproduce:
- Create a second company
- Archive it
- Go to the Chart of Accounts
- Open an account Issue: "Access to unauthorized or invalid companies" error will block the action.

It occurs because the mapping is dynamically computed from the user companies, without filtering the actually active records

opw-4270320

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
