### PR TITLE
[FIX] website: duplicate dialog issue and closure on button click

### DIFF
--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -480,7 +480,7 @@ export function checkAndNotifySEO(seo_data, OptimizeSEODialog, services) {
             message = _t("Page description not set.");
         }
         if (message) {
-            services.notification.add(message, {
+            const closeNotification = services.notification.add(message, {
                 type: "warning",
                 sticky: false,
                 buttons: [
@@ -488,6 +488,7 @@ export function checkAndNotifySEO(seo_data, OptimizeSEODialog, services) {
                         name: _t("Optimize SEO"),
                         onClick: () => {
                             services.dialog.add(OptimizeSEODialog);
+                            closeNotification();
                         },
                     },
                 ],


### PR DESCRIPTION
Since [1], clicking the button while the SEO toaster was
visible could repeatedly open the SEO optimization dialog, resulting in
multiple instances of the dialog box being opened.

This commit addresses this issue by:

- Adding logic to ensure toasters close properly when a button is
  clicked. (i.e the SEO toaster when you publish a page with missing
  important SEO informations).

[1]: https://github.com/odoo/odoo/commit/45ea6e4a4a5c8e314b110a45198fbe3d57bb996e

task-4384773