### PR TITLE
[FIXES] web: RTL issues for general positioning and popover arrows

### DIFF
--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -2,6 +2,7 @@ import { Component, onMounted, onWillDestroy, useExternalListener, useRef } from
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 import { OVERLAY_SYMBOL } from "@web/core/overlay/overlay_container";
 import { usePosition } from "@web/core/position/position_hook";
+import { reverseForRTL } from "@web/core/position/utils";
 import { useActiveElement } from "@web/core/ui/ui_service";
 import { mergeClasses } from "@web/core/utils/classname";
 import { useForwardRefToParent } from "@web/core/utils/hooks";
@@ -201,6 +202,9 @@ export class Popover extends Component {
 
     updateArrow(direction, variant, variantOffset) {
         const { el } = this.popoverRef;
+
+        // Reverse the direction if RTL as bootstrap expects it that way
+        [direction, variant] = reverseForRTL(direction, variant);
 
         // Update the bootstrap popper placement, in order to give the arrow its shape
         el.dataset.popperPlacement = direction;

--- a/addons/web/static/src/core/popover/popover.scss
+++ b/addons/web/static/src/core/popover/popover.scss
@@ -8,13 +8,13 @@
 		opacity: 1;
 	}
 
-	/* rtl:begin:ignore */
 	&[data-popper-placement^="top"] > .popover-arrow.sucked {
 		opacity: 0;
 		transform: translateY(-100%);
 	}
 	&[data-popper-placement^="right"] > .popover-arrow.sucked {
 		opacity: 0;
+		/*rtl:ignore*/
 		transform: translateX(100%);
 	}
 	&[data-popper-placement^="bottom"] > .popover-arrow.sucked {
@@ -23,7 +23,7 @@
 	}
 	&[data-popper-placement^="left"] > .popover-arrow.sucked {
 		opacity: 0;
+		/*rtl:ignore*/
 		transform: translateX(-100%);
 	}
-	/* rtl:end:ignore */
 }

--- a/addons/web/static/src/core/position/utils.js
+++ b/addons/web/static/src/core/position/utils.js
@@ -56,6 +56,28 @@ function getIFrame(popperEl, targetEl) {
 }
 
 /**
+ * Returns the RTl adapted direction and variant if needed.
+ * If the current localization direction is "rtl":
+ *  - Direction "left" and "right" are flipped to "right" and "left".
+ *  - Variant "start" and "end" are flipped to "end" and "start".
+ *
+ * @param {Direction} direction
+ * @param {Variant} [variant="middle"] (default value is "middle")
+ * @returns {[Direction, Variant]}
+ */
+export function reverseForRTL(direction, variant = "middle") {
+    if (localization.direction === "rtl") {
+        if (["left", "right"].includes(direction)) {
+            direction = direction === "left" ? "right" : "left";
+        } else if (["start", "end"].includes(variant)) {
+            // here direction is either "top" or "bottom"
+            variant = variant === "start" ? "end" : "start";
+        }
+    }
+    return [direction, variant];
+}
+
+/**
  * Returns the best positioning solution staying in the container or falls back
  * to the requested position.
  * The positioning data used to determine each possible position is based on
@@ -76,15 +98,7 @@ function getIFrame(popperEl, targetEl) {
  */
 function computePosition(popper, target, { container, flip, margin, position }) {
     // Retrieve directions and variants
-    let [direction, variant = "middle"] = position.split("-");
-    if (localization.direction === "rtl") {
-        if (["left", "right"].includes(direction)) {
-            direction = direction === "left" ? "right" : "left";
-        } else if (["start", "end"].includes(variant)) {
-            // here direction is either "top" or "bottom"
-            variant = variant === "start" ? "end" : "start";
-        }
-    }
+    const [direction, variant = "middle"] = reverseForRTL(...position.split("-"));
     const directions = flip ? DIRECTION_FLIP_ORDER[direction] : [direction.at(0)];
     const variants = VARIANT_FLIP_ORDER[variant];
 
@@ -136,7 +150,8 @@ function computePosition(popper, target, { container, flip, margin, position }) 
     };
 
     function getPositioningData(d, v) {
-        const result = { direction: DIRECTIONS[d], variant: VARIANTS[v] };
+        const [direction, variant] = reverseForRTL(DIRECTIONS[d], VARIANTS[v]);
+        const result = { direction, variant };
         const vertical = ["t", "b"].includes(d);
         const variantPrefix = vertical ? "v" : "h";
         const directionValue = directionsData[d];

--- a/addons/web/static/tests/core/position/position_hook.test.js
+++ b/addons/web/static/tests/core/position/position_hook.test.js
@@ -737,18 +737,18 @@ test("position left === left-middle", getPositionTest("left", "left-middle"));
 test("position bottom === bottom-middle", getPositionTest("bottom", "bottom-middle"));
 test("position right === right-middle", getPositionTest("right", "right-middle"));
 // RTL
-test("position RTL top-start", getPositionTestRTL("top-start", "top-end"));
+test("position RTL top-start", getPositionTestRTL("top-start"));
 test("position RTL top-middle", getPositionTestRTL("top-middle"));
-test("position RTL top-end", getPositionTestRTL("top-end", "top-start"));
-test("position RTL bottom-start", getPositionTestRTL("bottom-start", "bottom-end"));
+test("position RTL top-end", getPositionTestRTL("top-end"));
+test("position RTL bottom-start", getPositionTestRTL("bottom-start"));
 test("position RTL bottom-middle", getPositionTestRTL("bottom-middle"));
-test("position RTL bottom-end", getPositionTestRTL("bottom-end", "bottom-start"));
-test("position RTL right-start", getPositionTestRTL("right-start", "left-start"));
-test("position RTL right-middle", getPositionTestRTL("right-middle", "left-middle"));
-test("position RTL right-end", getPositionTestRTL("right-end", "left-end"));
-test("position RTL left-start", getPositionTestRTL("left-start", "right-start"));
-test("position RTL left-middle", getPositionTestRTL("left-middle", "right-middle"));
-test("position RTL left-end", getPositionTestRTL("left-end", "right-end"));
+test("position RTL bottom-end", getPositionTestRTL("bottom-end"));
+test("position RTL right-start", getPositionTestRTL("right-start"));
+test("position RTL right-middle", getPositionTestRTL("right-middle"));
+test("position RTL right-end", getPositionTestRTL("right-end"));
+test("position RTL left-start", getPositionTestRTL("left-start"));
+test("position RTL left-middle", getPositionTestRTL("left-middle"));
+test("position RTL left-end", getPositionTestRTL("left-end"));
 
 const CONTAINER_STYLE_MAP = {
     top: { alignItems: "flex-start" },


### PR DESCRIPTION
**[FIX] web: fix usePosition flicker in RTL**
Since [1], the last positionment is memorized.
As the position is sometimes reversed on some right-to-left situations the wrong positionment value is memorized.

Before this commit, the memorized positionment in some RTL situations is reversed, which may lead to huge flickering (i.e. for Autocomplete).

After this commit, the computePosition internal function - which is the one that may reverse the position in RTL situations to compute a proper positionment in these cases - now re-reverse the positionment in the result it yield. The flickering is now avoided in those situations.

[1]: https://github.com/odoo/odoo/pull/178376

**[FIX] web: fix sucked popover arrow in RTL**
Before this commit, if the UI direction is set in RTL, a sucked popover
arrow could be wrongly animated.
When the popper is placed left/right to its target, the sucked arrow
transitions away from its target instead of transitioning inside of it.

After this commit, the animation is properly executed.