### PR TITLE
[FIX] sale_timesheet: fix visibility of 'time remaining on SO' in pro…

### DIFF
--- a/addons/sale_timesheet/views/project_sharing_views.xml
+++ b/addons/sale_timesheet/views/project_sharing_views.xml
@@ -17,13 +17,14 @@
                     optional="hide"/>
             </xpath>
             <xpath expr="//field[@name='child_ids']/tree/field[@name='remaining_hours']" position="after">
-                <field name="remaining_hours_so" optional="hide" widget="timesheet_uom"/>
+                <field name="remaining_hours_so" optional="hide" widget="timesheet_uom"
+                    attrs="{'column_invisible': ['|', ('parent.allow_billable', '=', False), ('parent.allow_timesheets', '=', False)]}" />
             </xpath>
             <xpath expr="//field[@name='remaining_hours']" position="after">
                 <field name="allow_billable" invisible="1" />
                 <field name="remaining_hours_available" invisible="1"/>
                 <field name="sale_order_id" invisible="1"/>
-                <span id="remaining_hours_so_label" attrs="{'invisible': ['|', '|', '|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('partner_id', '=', False), ('sale_line_id', '=', False), ('remaining_hours_available', '=', False)]}" class="o_td_label float-start">
+                <span id="remaining_hours_so_label" attrs="{'invisible': ['|', '|', ('allow_billable', '=', False), ('allow_timesheets', '=', False), ('remaining_hours_available', '=', False)]}" class="o_td_label float-start">
                     <label class="fw-bold" for="remaining_hours_so" string="Remaining Hours on SO"
                             attrs="{'invisible': ['|', ('encode_uom_in_days', '=', True), ('remaining_hours_so', '&lt;', 0)]}"/>
                     <label class="fw-bold" for="remaining_hours_so" string="Remaining Days on SO"
@@ -33,7 +34,7 @@
                     <label class="fw-bold text-danger" for="remaining_hours_so" string="Remaining Days on SO"
                             attrs="{'invisible': ['|', ('encode_uom_in_days', '=', False), ('remaining_hours_so', '&gt;=', 0)]}"/>
                 </span>
-                <field name="remaining_hours_so" nolabel="1" widget="timesheet_uom" attrs="{'invisible': ['|', '|', '|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('partner_id', '=', False), ('sale_line_id', '=', False), ('remaining_hours_available', '=', False)]}" decoration-danger="remaining_hours_so &lt; 0"></field>
+                <field name="remaining_hours_so" nolabel="1" widget="timesheet_uom" attrs="{'invisible': ['|', '|',('allow_billable', '=', False), ('allow_timesheets', '=', False), ('remaining_hours_available', '=', False)]}" decoration-danger="remaining_hours_so &lt; 0"></field>
             </xpath>
         </field>
     </record>
@@ -44,7 +45,10 @@
         <field name="inherit_id" ref="hr_timesheet.project_sharing_inherit_project_task_view_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='remaining_hours']" position="after">
-                <field name="remaining_hours_so" optional="hide" widget="timesheet_uom"/>
+                <field name="allow_billable" invisible="1" />
+                <field name="allow_timesheets" invisible="1"/>
+                <field name="remaining_hours_so" optional="hide" widget="timesheet_uom"
+                    attrs="{'column_invisible': ['|', ('allow_billable', '=', False), ('allow_timesheets', '=', False)]}" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
…ject sharing

In project sharing, the field 'time remaining on SO' should not be available when the project has no billable and no timesheets enabled. This commit aims to fix the visibility of this field by adding condition to the field in the List view.

To reproduce the bug:
1. Create Project with No billable and No timesheets enabled
2. Create some task in the new Project
3. Go to Project > Settings > Project Sharing with portal user
4. Login as Portal User and open the List view on the Project
5. The field 'time remaining on SO' is available among the Field to add.

After the fix:
In Step 5, the field 'time remaining on SO' should not be available.

Note: the issue is observed in 16.0 until saas-17.2

Task: 4369886

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
