### PR TITLE
[FIX] html_editor: remove format toolbar button

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -141,8 +141,12 @@ export class FormatPlugin extends Plugin {
     };
 
     removeFormat() {
+        const traversedNodes = this.dependencies.selection.getTraversedNodes();
         for (const format of Object.keys(formatsSpecs)) {
-            if (!formatsSpecs[format].removeStyle || !this.hasSelectionFormat(format)) {
+            if (
+                !formatsSpecs[format].removeStyle ||
+                !this.hasSelectionFormat(format, traversedNodes)
+            ) {
                 continue;
             }
             this._formatSelection(format, { applyStyle: false });
@@ -152,15 +156,15 @@ export class FormatPlugin extends Plugin {
     }
 
     /**
-     * Return true if the current selection on the editable contain a formated
+     * Return true if the current selection on the editable contains a formated
      * node
      *
-     * @param {Element} editable
      * @param {String} format 'bold'|'italic'|'underline'|'strikeThrough'|'switchDirection'
+     * @param {Node[]} [traversedNodes]
      * @returns {boolean}
      */
-    hasSelectionFormat(format) {
-        const selectedNodes = this.dependencies.selection.getTraversedNodes().filter(isTextNode);
+    hasSelectionFormat(format, traversedNodes = this.dependencies.selection.getTraversedNodes()) {
+        const selectedNodes = traversedNodes.filter(isTextNode);
         const isFormatted = formatsSpecs[format].isFormatted;
         return selectedNodes.some((n) => isFormatted(n, this.editable));
     }
@@ -180,14 +184,13 @@ export class FormatPlugin extends Plugin {
     }
 
     // @todo: issues:
-    // - this method mixes every (isSelectionFormat) with some (hasAnyNodesColor)
     // - the calls to hasAnyColor should probably be replaced by calls to predicates
     //   registered as resources (e.g. by the ColorPlugin).
     hasAnyFormat(traversedNodes) {
         for (const format of Object.keys(formatsSpecs)) {
             if (
                 formatsSpecs[format].removeStyle &&
-                this.isSelectionFormat(format, traversedNodes)
+                this.hasSelectionFormat(format, traversedNodes)
             ) {
                 return true;
             }

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -722,6 +722,20 @@ describe("Toolbar", () => {
         );
     });
 
+    test("Remove format button should be available if selection contains formatted nodes among unformatted nodes", async () => {
+        const { el } = await setupEditor(`<p>this <b>is[ a UX</b> te]st.</p>`);
+        await waitFor(".o-we-toolbar");
+        expect(".o-we-toolbar").toHaveCount(1); // toolbar open
+        expect(".btn[name='remove_format']").toHaveCount(1); // remove format
+        expect(".btn[name='remove_format']").not.toHaveClass("disabled"); // remove format button should not be disabled
+
+        await click(".btn[name='remove_format']");
+        await animationFrame();
+        expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+        expect(".btn[name='remove_format']").toHaveClass("disabled"); // remove format button should now be disabled
+        expect(getContent(el)).toBe(`<p>this <b>is</b>[ a UX te]st.</p>`);
+    });
+
     test("Remove format button should be the last one in the decoration button group", async () => {
         await setupEditor("<p>[abc]</p>");
         await waitFor(".o-we-toolbar");


### PR DESCRIPTION
When the selection contains formatted nodes among unformatted nodes, the remove format toolbar button should be available.

This is not the case currently because the `hasAnyFormat` method, which is used to determine whether the button should be disabled, checks if **every** node in the selection is formatted.

This commit fixes the issue by checking if **any** node in the selection is formatted instead.

task-4385246
