### PR TITLE
[IMP] mail: clarity of PWA and push notif items in messaging menu

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1109,10 +1109,13 @@ class MailMessage(models.Model):
                 ),
                 Store.One(
                     "thread",
-                    Store.Attr(
-                        "modelName",
-                        lambda thread: self.env["ir.model"]._get(thread._name).display_name,
-                    ),
+                    [
+                        Store.Attr(
+                            "modelName",
+                            lambda thread: self.env["ir.model"]._get(thread._name).display_name,
+                        ),
+                        "display_name",
+                    ],
                     as_thread=True,
                 ),
             ],

--- a/addons/mail/static/src/core/common/failure_model.js
+++ b/addons/mail/static/src/core/common/failure_model.js
@@ -65,6 +65,11 @@ export class Failure extends Record {
     }
 
     get body() {
+        if (this.notifications.length === 1 && this.lastMessage?.thread) {
+            return _t("An error occurred when sending an email on “%(record_name)s”", {
+                record_name: this.lastMessage.thread.display_name,
+            });
+        }
         return _t("An error occurred when sending an email");
     }
 

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -21,6 +21,8 @@
                     onClick="(isMarkAsRead) => this.onClickThread(isMarkAsRead, thread)"
                     onSwipeRight="hasTouch() and thread.isUnread ? { action: () => this.markAsRead(thread), icon: 'fa-check-circle', bgColor: 'bg-success' } : undefined"
                     onSwipeLeft="hasTouch() and thread.canUnpin ? { action: () => thread.unpin(), icon: 'fa-times-circle', bgColor: 'bg-danger' } : undefined"
+                    nameMaxLine="1"
+                    textMaxLine="2"
                 >
                     <t t-set-slot="name">
                         <div t-if="thread.parent_channel_id" class="d-flex align-items-center">

--- a/addons/mail/static/src/core/public_web/notification_item.js
+++ b/addons/mail/static/src/core/public_web/notification_item.js
@@ -24,6 +24,8 @@ export class NotificationItem extends Component {
         "onSwipeRight?",
         "slots?",
         "isActive?",
+        "nameMaxLine?",
+        "textMaxLine?",
     ];
     static defaultProps = {
         counter: 0,
@@ -52,5 +54,14 @@ export class NotificationItem extends Component {
 
     onClick(ev) {
         this.props.onClick(ev.target === this.markAsReadRef.el);
+    }
+
+    webkitLineClamp(maxLine) {
+        return `
+            display: -webkit-box;
+            overflow: hidden;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: ${maxLine};
+        `;
     }
 }

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -20,6 +20,8 @@
 }
 
 .o-mail-NotificationItem-avatarContainer {
+    height: 40px;
+    aspect-ratio: 1;
     margin-top: map-get($spacers, 1) / 2;
     margin-bottom: map-get($spacers, 1) / 2;
 
@@ -61,6 +63,8 @@
     color: darken($info, 5%);
     font-size: 0.5rem;
     left: map-get($spacers, 1);
+    top: 40px;
+    transform: translateY(-125%);
 
     .o-mail-NotificationItem.o-small & {
         left: map-get($spacers, 1) / 2;

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -13,13 +13,13 @@
             'o-active': props.isActive,
         }">
             <span class="o-mail-NotificationItem-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': props.muted, 'opacity-50': !props.muted }"><i class="fa fa-circle"/></span>
-            <div class="o-mail-NotificationItem-avatarContainer position-relative bg-inherit flex-shrink-0" t-att-class="{ 'o-small': ui.isSmall }" style="width:40px;height:40px;">
+            <div class="o-mail-NotificationItem-avatarContainer position-relative bg-inherit flex-shrink-0 align-self-start" t-att-class="{ 'o-small': ui.isSmall }">
                 <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>
             </div>
             <div class="d-flex flex-column flex-grow-1 align-self-start overflow-auto">
                 <div class="d-flex text-nowrap">
-                    <span class="o-mail-NotificationItem-name text-truncate fw-bold" t-att-class="{ 'fw-bold': props.muted, 'fw-bolder': !props.muted }">
+                    <span class="o-mail-NotificationItem-name fw-bold" t-att-class="{ 'fw-bold': props.muted, 'fw-bolder': !props.muted }" t-att-style="props.nameMaxLine !== undefined ? webkitLineClamp(props.nameMaxLine) : ''">
                         <t t-slot="name"/>
                     </span>
                     <span class="flex-grow-1"/>
@@ -29,7 +29,7 @@
                     </div>
                 </div>
                 <div class="d-flex">
-                    <div class="o-mail-NotificationItem-text text-truncate opacity-75" t-att-class="{ 'fw-bold': !props.muted }">
+                    <div class="o-mail-NotificationItem-text opacity-75" t-att-class="{ 'fw-bold': !props.muted, 'text-truncate': props.textTruncate, 'text-start': !props.textTruncate  }" t-att-style="props.textMaxLine !== undefined ? webkitLineClamp(props.textMaxLine) : ''">
                         <t t-slot="body-icon"/>
                         <t t-if="props.body" t-esc="props.body" name="notificationBody"/>
                     </div>
@@ -39,8 +39,8 @@
                     </small>
                 </div>
             </div>
-            <t t-if="props.slots and props.slots.requestContent">
-                <t t-slot="requestContent" />
+            <t t-if="props.slots and props.slots.extraContent">
+                <t t-slot="extraContent" />
             </t>
         </button>
     </ActionSwiper>

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -77,8 +77,8 @@ patch(MessagingMenu.prototype, {
     },
     get installationRequest() {
         return {
-            body: _t("Come here often? Install Odoo on your device!"),
-            displayName: _t("%s has a suggestion", this.store.odoobot.name),
+            body: _t("Come here often? Install the app for quick and easy access!"),
+            displayName: _t("Install Odoo"),
             onClick: () => {
                 this.pwa.show();
             },
@@ -89,8 +89,8 @@ patch(MessagingMenu.prototype, {
     },
     get notificationRequest() {
         return {
-            body: _t("Enable desktop notifications to chat"),
-            displayName: _t("%s has a request", this.store.odoobot.name),
+            body: _t("Stay tuned! Enable push notifications to never miss a message."),
+            displayName: _t("Turn on notifications"),
             iconSrc: this.store.odoobot.avatarUrl,
             partner: this.store.odoobot,
             isShown: this.store.discuss.activeTab === "main" && this.shouldAskPushPermission,
@@ -177,5 +177,11 @@ patch(MessagingMenu.prototype, {
     },
     get shouldAskPushPermission() {
         return this.notification.permission === "prompt";
+    },
+    getFailureNotificationName(failure) {
+        if (failure.type === "email") {
+            return _t("Email Failure: %(modelName)s", { modelName: failure.modelName });
+        }
+        return _t("Failure: %(modelName)s", { modelName: failure.modelName });
     },
 });

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -51,7 +51,7 @@
                     <t t-set-slot="icon">
                         <ImStatus persona="installationRequest.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
                     </t>
-                    <t t-set-slot="requestContent">
+                    <t t-set-slot="extraContent">
                         <a t-if="ui.isSmall" class="btn fa fa-cloud-download" />
                         <t t-else="">
                             <a class="btn btn-primary px-2 py-1 smaller">Install</a>
@@ -72,6 +72,12 @@
                     <t t-set-slot="icon">
                         <ImStatus persona="notificationRequest.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
                     </t>
+                    <t t-set-slot="extraContent">
+                        <a t-if="ui.isSmall" class="btn fa fa-bell" />
+                        <t t-else="">
+                            <a class="btn btn-primary px-2 py-1 smaller">Enable</a>
+                        </t>
+                    </t>
                 </NotificationItem>
                 <t t-set="itemIndex" t-value="itemIndex + 1"/>
             </t>
@@ -87,7 +93,7 @@
                         onClick="(isMarkAsRead) => isMarkAsRead ? this.cancelNotifications(failure) : this.onClickFailure(failure)"
                         onSwipeRight="hasTouch() ? { action: () => this.cancelNotifications(failure), icon: 'fa-times-circle', bgColor: 'bg-warning' } : undefined"
                     >
-                        <t t-set-slot="name"><t t-esc="failure.modelName"/></t>
+                        <t t-set-slot="name"><t t-esc="getFailureNotificationName(failure)"/></t>
                     </NotificationItem>
                     <t t-set="itemIndex" t-value="itemIndex + 1"/>
                 </t>

--- a/addons/mail/static/tests/messaging_menu/notification.test.js
+++ b/addons/mail/static/tests/messaging_menu/notification.test.js
@@ -49,15 +49,10 @@ test("basic layout", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem", {
         contains: [
-            [".o-mail-NotificationItem-name", { text: "Discussion Channel" }],
+            [".o-mail-NotificationItem-name", { text: "Email Failure: Discussion Channel" }],
             [".o-mail-NotificationItem-counter", { text: "2" }],
             [".o-mail-NotificationItem-date", { text: "Jan 1" }],
-            [
-                ".o-mail-NotificationItem-text",
-                {
-                    text: "An error occurred when sending an email",
-                },
-            ],
+            [".o-mail-NotificationItem-text", { text: "An error occurred when sending an email" }],
         ],
     });
 });
@@ -77,11 +72,16 @@ test("mark as read", async () => {
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await triggerEvents(".o-mail-NotificationItem", ["mouseenter"], { text: "Discussion Channel" });
-    await click(".o-mail-NotificationItem-markAsRead", {
-        parent: [".o-mail-NotificationItem", { text: "Discussion Channel" }],
+    await triggerEvents(".o-mail-NotificationItem", ["mouseenter"], {
+        text: "Email Failure: Discussion Channel",
     });
-    await contains(".o-mail-NotificationItem", { count: 0, text: "Discussion Channel" });
+    await click(".o-mail-NotificationItem-markAsRead", {
+        parent: [".o-mail-NotificationItem", { text: "Email Failure: Discussion Channel" }],
+    });
+    await contains(".o-mail-NotificationItem", {
+        count: 0,
+        text: "Email Failure: Discussion Channel",
+    });
 });
 
 test("open non-channel failure", async () => {

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -513,7 +513,7 @@ export class MailMessage extends models.ServerModel {
                 ),
                 thread: mailDataHelpers.Store.one(
                     message.model ? this.env[message.model].browse(message.res_id) : false,
-                    makeKwArgs({ as_thread: true, fields: ["modelName"] })
+                    makeKwArgs({ as_thread: true, fields: ["modelName", "display_name"] })
                 ),
             });
         }

--- a/addons/sms/static/src/core/failure_model_patch.js
+++ b/addons/sms/static/src/core/failure_model_patch.js
@@ -11,6 +11,11 @@ patch(Failure.prototype, {
     },
     get body() {
         if (this.type === "sms") {
+            if (this.notifications.length === 1 && this.lastMessage?.thread) {
+                return _t("An error occurred when sending an SMS on “%(record_name)s”", {
+                    record_name: this.lastMessage.thread.display_name,
+                });
+            }
             return _t("An error occurred when sending an SMS");
         }
         return super.body;

--- a/addons/sms/static/src/messaging_menu/messaging_menu_patch.js
+++ b/addons/sms/static/src/messaging_menu/messaging_menu_patch.js
@@ -23,4 +23,10 @@ patch(MessagingMenu.prototype, {
         });
         this.dropdown.close();
     },
+    getFailureNotificationName(failure) {
+        if (failure.type === "sms") {
+            return _t("SMS Failure: %(modelName)s", { modelName: failure.modelName });
+        }
+        return super.getFailureNotificationName(...arguments);
+    },
 });

--- a/addons/sms/static/tests/messaging_menu/messaging_menu_patch.test.js
+++ b/addons/sms/static/tests/messaging_menu/messaging_menu_patch.test.js
@@ -3,7 +3,7 @@ import {
     contains,
     start,
     startServer,
-    triggerEvents
+    triggerEvents,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
 import { defineSMSModels } from "@sms/../tests/sms_test_helpers";
@@ -30,7 +30,7 @@ test("mark as read", async () => {
     await triggerEvents(".o-mail-NotificationItem", ["mouseenter"], { text: "" });
     await contains(".o-mail-NotificationItem [title='Mark As Read']");
     await contains(".o-mail-NotificationItem-text", {
-        text: "An error occurred when sending an SMS",
+        text: "An error occurred when sending an SMS on “Mitchell Admin”",
     });
     await click(".o-mail-NotificationItem [title='Mark As Read']");
     await contains(".o-mail-NotificationItem", { count: 0 });
@@ -78,14 +78,14 @@ test("notifications grouped by notification_type", async () => {
     await contains(".o-mail-NotificationItem", { count: 2 });
     await contains(":nth-child(1 of .o-mail-NotificationItem)", {
         contains: [
-            [".o-mail-NotificationItem-name", { text: "Contact" }],
+            [".o-mail-NotificationItem-name", { text: "Email Failure: Contact" }],
             [".o-mail-NotificationItem-counter", { text: "2" }],
             [".o-mail-NotificationItem-text", { text: "An error occurred when sending an email" }],
         ],
     });
     await contains(":nth-child(2 of .o-mail-NotificationItem)", {
         contains: [
-            [".o-mail-NotificationItem-name", { text: "Contact" }],
+            [".o-mail-NotificationItem-name", { text: "SMS Failure: Contact" }],
             [".o-mail-NotificationItem-counter", { text: "2" }],
             [".o-mail-NotificationItem-text", { text: "An error occurred when sending an SMS" }],
         ],
@@ -94,7 +94,7 @@ test("notifications grouped by notification_type", async () => {
 
 test("grouped notifications by document model", async () => {
     const pyEnv = await startServer();
-    const [partnerId_1, partnerId_2 ]= pyEnv["res.partner"].create([{}, {}]);
+    const [partnerId_1, partnerId_2] = pyEnv["res.partner"].create([{}, {}]);
     const [messageId_1, messageId_2] = pyEnv["mail.message"].create([
         {
             message_type: "sms",
@@ -125,7 +125,11 @@ test("grouped notifications by document model", async () => {
             expect(action.name).toBe("SMS Failures");
             expect(action.type).toBe("ir.actions.act_window");
             expect(action.view_mode).toBe("kanban,list,form");
-            expect(action.views).toEqual([[false, "kanban"],[false, "list"],[false, "form"]]);
+            expect(action.views).toEqual([
+                [false, "kanban"],
+                [false, "list"],
+                [false, "form"],
+            ]);
             expect(action.target).toBe("current");
             expect(action.res_model).toBe("res.partner");
             expect(action.domain).toEqual([["message_has_sms_error", "=", true]]);
@@ -134,7 +138,7 @@ test("grouped notifications by document model", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem", {
-        text: "Contact",
+        text: "SMS Failure: Contact",
         contains: [".badge", { text: "2" }],
     });
     await waitForSteps(["do_action"]);

--- a/addons/snailmail/static/src/core/failure_model_patch.js
+++ b/addons/snailmail/static/src/core/failure_model_patch.js
@@ -11,6 +11,12 @@ patch(Failure.prototype, {
     },
     get body() {
         if (this.type === "snail") {
+            if (this.notifications.length === 1 && this.lastMessage?.thread) {
+                return _t(
+                    "An error occurred when sending a letter with Snailmail on “%(record_name)s”",
+                    { record_name: this.lastMessage.thread.display_name }
+                );
+            }
             return _t("An error occurred when sending a letter with Snailmail.");
         }
         return super.body;

--- a/addons/snailmail/static/src/messaging_menu/messaging_menu_patch.js
+++ b/addons/snailmail/static/src/messaging_menu/messaging_menu_patch.js
@@ -22,4 +22,10 @@ patch(MessagingMenu.prototype, {
         });
         this.dropdown.close();
     },
+    getFailureNotificationName(failure) {
+        if (failure.type === "snail") {
+            return _t("Snailmail Failure: %(modelName)s", { modelName: failure.modelName });
+        }
+        return super.getFailureNotificationName(...arguments);
+    },
 });

--- a/addons/snailmail/static/tests/messaging_menu/messaging_menu_patch.test.js
+++ b/addons/snailmail/static/tests/messaging_menu/messaging_menu_patch.test.js
@@ -29,7 +29,7 @@ test("mark as read", async () => {
     await contains(".o-mail-NotificationItem");
     await triggerEvents(".o-mail-NotificationItem", ["mouseenter"]);
     await contains(".o-mail-NotificationItem-text", {
-        text: "An error occurred when sending a letter with Snailmail.",
+        text: "An error occurred when sending a letter with Snailmail on “Mitchell Admin”",
     });
     await click(".o-mail-NotificationItem [title='Mark As Read']");
     await contains(".o-mail-NotificationItem", { count: 0 });
@@ -77,14 +77,14 @@ test("notifications grouped by notification_type", async () => {
     await contains(".o-mail-NotificationItem", { count: 2 });
     await contains(":nth-child(1 of .o-mail-NotificationItem)", {
         contains: [
-            [".o-mail-NotificationItem-name", { text: "Contact" }],
+            [".o-mail-NotificationItem-name", { text: "Email Failure: Contact" }],
             [".o-mail-NotificationItem-counter", { text: "2" }],
             [".o-mail-NotificationItem-text", { text: "An error occurred when sending an email" }],
         ],
     });
     await contains(":nth-child(2 of .o-mail-NotificationItem)", {
         contains: [
-            [".o-mail-NotificationItem-name", { text: "Contact" }],
+            [".o-mail-NotificationItem-name", { text: "Snailmail Failure: Contact" }],
             [".o-mail-NotificationItem-counter", { text: "2" }],
             [
                 ".o-mail-NotificationItem-text",
@@ -143,7 +143,7 @@ test("grouped notifications by document model", async (assert) => {
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem", { text: "Contact" });
+    await contains(".o-mail-NotificationItem", { text: "Snailmail Failure: Contact" });
     await contains(".o-mail-NotificationItem-counter", { text: "2" });
     await click(".o-mail-NotificationItem");
     await waitForSteps(["do_action"]);


### PR DESCRIPTION
- Renamed "OdooBot has a suggestion" to "Install Odoo"
- Renamed "OdooBot has a request" to "Turn on notifications"
- Renamed failure name, e.g. "Contacts" to "Failure: Contact"
- Type of failure is in prefix, e.g. "Email Failure: Contact"
- When failure is related to a single record, it names the record name in notification body.
- Make chat notification take max 1 line for name (same as before), text message preview can take up to 2 lines (up from 1).
- All other notifications (failures, odoobot suggestions) does not truncate in title and body.

Motivation:

Before this commit, the items in messaging menu to suggest to install Odoo PWA and Enabling chat push notifications looked too similar and had cryptic header name:

- "OdooBot has a suggestion" for PWA install
- "OdooBot has a request" for chat push notification enabling

This commit improves the wording of title as follow:
- "Install Odoo"
- "Turn on notifications"

Also notification items had their title and body truncated on a single line each.
This is intended to keep chat items short, but for other notifications there's not really a reason to truncate the content.
This commit also adds a feature on `NotificationItem` to specify the max amount of lines for title and body of a given notification. By default there's none.

Chat notifications had title and body max line set to 1.
This commit keeps max line 1 for name, but increases to 2 for text.
This means the items take slightly more space but more text preview of message is visible in messaging menu item.

Before
![Screenshot 2024-12-10 at 13 24 45](https://github.com/user-attachments/assets/f6a9338c-113a-4082-83df-a3b4b09008e3)


After
![Screenshot 2024-12-10 at 13 24 29](https://github.com/user-attachments/assets/7c260f01-46a6-4d6d-8644-7665fbdf79db)
