### PR TITLE
[FIX] web: ARIA attributes of field widgets not ported correctly to OWL

### DIFF
--- a/addons/web/static/src/views/fields/priority/priority_field.xml
+++ b/addons/web/static/src/views/fields/priority/priority_field.xml
@@ -10,9 +10,9 @@
                             class="o_priority_star fa"
                             role="radio"
                             t-att-class="value_index lte index ? 'fa-star' : 'fa-star-o'"
-                            t-att-tabindex="value_index === state.index ? 0 : -1"
+                            tabindex="0"
                             t-att-data-tooltip="getTooltip(value[1])"
-                            t-att-aria-checked="value_index lte index"
+                            t-att-aria-checked="value_index === index ? 'true' : 'false'"
                             t-att-aria-label="value[1]"
                         />
                     </t>
@@ -22,9 +22,9 @@
                             class="o_priority_star fa"
                             role="radio"
                             t-att-class="value_index lte index ? 'fa-star' : 'fa-star-o'"
-                            t-att-tabindex="value_index === state.index ? 0 : -1"
+                            tabindex="0"
                             t-att-data-tooltip="getTooltip(value[1])"
-                            t-att-aria-checked="value_index lte index"
+                            t-att-aria-checked="value_index === index ? 'true' : 'false'"
                             t-att-aria-label="value[1]"
                             t-on-click.prevent.stop="() => this.onStarClicked(value[0])"
                             t-on-mouseenter="() => state.index = value_index"

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.js
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.js
@@ -282,19 +282,6 @@ export class StatusBarField extends Component {
         return classNames.join(" ");
     }
 
-    /**
-     * @param {StatusBarItem} item
-     */
-    getItemTooltip(item) {
-        if (item.isSelected) {
-            return _t("Current state");
-        }
-        if (this.props.isDisabled) {
-            return _t("Not active state");
-        }
-        return _t("Not active state, click to change it");
-    }
-
     getSortedItems() {
         const before = [];
         const after = [];

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.scss
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.scss
@@ -61,7 +61,7 @@
                 }
             }
 
-            &.o_arrow_button_current:disabled, &:active:not(.o_first) {
+            &.o_arrow_button_current, &:active:not(.o_first) {
                 background-color: map-get($-btn-secondary-design, active-background);
                 border-color: map-get($-btn-secondary-design, active-border);
                 color: map-get($-btn-secondary-design, active-color);

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.xml
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.xml
@@ -16,11 +16,13 @@
     </t>
 
     <t t-name="web.StatusBarField">
-        <div class="o_statusbar_status" t-ref="root" role="radiogroup">
+        <div class="o_statusbar_status" t-ref="root" role="radiogroup" aria-label="Statusbar">
+            <t t-set="ariaLabelMore">More...</t>
             <button
                 t-ref="after"
                 type="button"
                 class="btn btn-secondary dropdown-toggle o_arrow_button o_first"
+                t-att-aria-label="ariaLabelMore"
             >
                 <t t-call="web.StatusBarField.Dropdown">
                     <t t-set="label">...</t>
@@ -36,9 +38,8 @@
                         o_arrow_button_current: item.isSelected,
                         o_last: item_last,
                     }"
-                    t-att-disabled="props.isDisabled || item.isSelected"
+                    t-att-disabled="props.isDisabled"
                     role="radio"
-                    t-att-aria-label="getItemTooltip(item)"
                     t-att-aria-checked="item.isSelected.toString()"
                     t-att-aria-current="item.isSelected and 'step'"
                     t-att-data-value="item.value"
@@ -50,6 +51,7 @@
                 t-ref="before"
                 type="button"
                 class="btn btn-secondary dropdown-toggle o_arrow_button o_last"
+                t-att-aria-label="ariaLabelMore"
             >
                 <t t-call="web.StatusBarField.Dropdown">
                     <t t-set="label">...</t>

--- a/addons/web/static/tests/views/fields/statusbar_field_tests.js
+++ b/addons/web/static/tests/views/fields/statusbar_field_tests.js
@@ -251,7 +251,6 @@ QUnit.module("Fields", (hooks) => {
             target.querySelector(".o_statusbar_status button[data-value='4']"),
             "o_arrow_button_current"
         );
-        assert.ok(target.querySelector(".o_statusbar_status button[data-value='4']").disabled);
 
         const clickableButtons = target.querySelectorAll(
             ".o_statusbar_status button.btn:not(.dropdown-toggle):not(:disabled):not(.o_arrow_button_current)"
@@ -264,7 +263,6 @@ QUnit.module("Fields", (hooks) => {
             target.querySelector(".o_statusbar_status button[data-value='1']"),
             "o_arrow_button_current"
         );
-        assert.ok(target.querySelector(".o_statusbar_status button[data-value='1']").disabled);
     });
 
     QUnit.test("statusbar with no status", async function (assert) {
@@ -461,7 +459,7 @@ QUnit.module("Fields", (hooks) => {
         });
 
         assert.strictEqual(
-            target.querySelector("[aria-label='Current state']").textContent,
+            target.querySelector("[aria-checked='true']").textContent,
             "aaa",
             "default status is 'aaa'"
         );
@@ -472,11 +470,18 @@ QUnit.module("Fields", (hooks) => {
             "...",
             "button has the correct text"
         );
+        assert.strictEqual(
+            document
+                .querySelector(".o_statusbar_status .dropdown-toggle.o_arrow_button")
+                .getAttribute("aria-label"),
+            "More...",
+            "button has the correct aria label"
+        );
 
         await click(target, ".o_statusbar_status .dropdown-toggle:not(.d-none)");
         await click(target, ".o-dropdown .dropdown-item");
         assert.strictEqual(
-            target.querySelector("[aria-label='Current state']").textContent,
+            target.querySelector("[aria-checked='true']").textContent,
             "second record",
             "status has changed to the selected dropdown item"
         );

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -10395,7 +10395,6 @@ QUnit.module("Views", (hooks) => {
                 target.querySelector('button[data-value="4"]'),
                 "o_arrow_button_current"
             );
-            assert.ok(target.querySelector('button[data-value="4"]').disabled);
 
             failFlag = true;
             await click(target.querySelector('button[data-value="1"]'));


### PR DESCRIPTION
Just to test solving of conflicts on https://github.com/odoo/odoo/pull/184259



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
