### PR TITLE
[IMP] product: add tracking for product category

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -78,6 +78,7 @@ class ProductTemplate(models.Model):
         string="Product Category",
         comodel_name='product.category',
         group_expand='_read_group_categ_id',
+        tracking=True,
     )
 
     currency_id = fields.Many2one(


### PR DESCRIPTION
* Because sometime when a product with category X is in some journal items , the account will get from category X, but after create that journal items, random user change the category on product from X to Y (with no tracking on category field), which lead to misunderstanding circumstance like: Oh why i have category Y with account 123 but my journal items has account 124 (journal item was created before the changing of category on the product)
* Therefore this commit help track the category change to prevent that kind of circumstance

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
