### PR TITLE
[FIX] account, hr_expense: prevent error on removing company

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1429,7 +1429,8 @@ class AccountTax(models.Model):
             'raw_tax_amount': 0.0,
             'base_lines': [],
         })
-
+        if not company:
+            company = self.env.company
         for base_line in base_lines:
             currency = base_line['currency_id'] or company.currency_id
             tax_details = base_line['tax_details']


### PR DESCRIPTION
This error occurs when the user removes the company from the expense form view.

Steps to reproduce:
- Install ``hr_expense`` modules
- Create another Company
- Now open a new expense and remove the ``Company``

Traceback: 
``ValueError: Expected singleton: res.currency()``

At [1], the company is not set, and we are attempting to retrieve the currency ID from it.
This commit resolves the issue by ensuring that the company is present before proceeding.

[1]- https://github.com/odoo/odoo/blob/408fbf8efbbfbc47c3171d9ee082e3831016f6db/addons/hr_expense/models/hr_expense.py#L341-L355

sentry-6112771029

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
