### PR TITLE
[FIX] hr: fix employee image in the mobile view.

### DIFF
--- a/addons/hr/static/src/components/background_image/background_image.scss
+++ b/addons/hr/static/src/components/background_image/background_image.scss
@@ -1,6 +1,13 @@
 div.o_field_widget.o_field_background_image {
     display: inline-block;
 
+    @include media-breakpoint-down(md) {
+        height: calc(100% + var(--KanbanRecord-padding-v)* 2);
+        margin-top: calc(var(--KanbanRecord-padding-v)* -1);
+        margin-bottom: calc(var(--KanbanRecord-padding-v)* -1);
+        margin-left: calc(var(--KanbanRecord-padding-h)* -1);
+    }
+
     > img {
         display: block;
         width: 100%;


### PR DESCRIPTION
Steps to Reproduce:
• Install the Employee app.
• Switch to mobile view.
• Open the Employee app; employee images are not visible.

Cause:
CSS was not defined for screen sizes smaller than medium.

Fix:
Added CSS rules for screens smaller than medium to ensure employee images are displayed correctly in mobile view.

task-4380126

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
