### PR TITLE
[FIX] hr_recruitment: make application fields visible

### DIFF
--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -119,9 +119,9 @@
                         <field name="partner_name" invisible="1"/>
                         <field name="partner_id" invisible="1" />
                         <field name="refuse_reason_id" invisible="active"/>
-                        <field name="email_from" placeholder="e.g. john.doe@example.com" widget="email" invisible="not candidate_id"/>
-                        <field name="partner_phone" widget="phone" invisible="not candidate_id"/>
-                        <field name="linkedin_profile" placeholder="e.g. https://www.linkedin.com/in/..." widget="url"  invisible="not candidate_id"/>
+                        <field name="email_from" placeholder="e.g. john.doe@example.com" widget="email"/>
+                        <field name="partner_phone" widget="phone"/>
+                        <field name="linkedin_profile" placeholder="e.g. https://www.linkedin.com/in/..." widget="url"/>
                     </group>
                     <group>
                         <field name="job_id"/>


### PR DESCRIPTION
Steps to Reproduce:
• Install the Recruitment app.
• Open any Job Position.
• Click New to create a new application, The Email, Phone Number, and
  LinkedIn Profile fields are not visible until a candidate is assigned.

Cause:
The fields were set to be conditionally invisible based on candidate assignment.

Fix:
Removed the visibility conditions to ensure these fields are always visible.

task-4385022

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
