### PR TITLE
[FIX] point_of_sale: fix access to currency from pos_order

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -109,8 +109,8 @@ export class PosOrder extends Base {
      * @returns See '_get_tax_totals_summary' in account_tax.py for the full details.
      */
     get taxTotals() {
-        const currency = this.config_id.currency_id;
-        const company = this.company_id;
+        const currency = this.config.currency_id;
+        const company = this.company;
         const extraValues = { currency_id: currency };
         const orderLines = this.lines;
 

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1627,10 +1627,10 @@ export class PosStore extends Reactive {
 
         const printingChanges = {
             table_name: order.table_id ? order.table_id.table_number : "",
-            config_name: order.config_id.name,
+            config_name: order.config.name,
             time: order.write_date ? time : "",
             tracking_number: order.tracking_number,
-            takeaway: order.config_id.takeaway && order.takeaway,
+            takeaway: order.config.takeaway && order.takeaway,
             employee_name: order.employee_id?.name || order.user_id?.name,
             order_note: order.general_note,
             diningModeUpdate: diningModeUpdate,


### PR DESCRIPTION
Config should not be accessed directly from the order since it can came from another config that isn't loaded in all session.

For example with shared order between config, when an order is created on config A and loaded on config B, the config A link will not be available on config B.

runbot err: 109327


