### PR TITLE
[FIX] web: remove tooltip on cog menu icon

### DIFF
--- a/addons/web/static/src/search/cog_menu/cog_menu.xml
+++ b/addons/web/static/src/search/cog_menu/cog_menu.xml
@@ -5,7 +5,7 @@
         <div t-if="hasItems" class="o_cp_action_menus d-flex align-items-center gap-1" t-att-class="{'pe-2': !env.isSmall}">
             <div class="lh-1">
                 <Dropdown menuClass="'lh-base'" beforeOpen.bind="loadPrintItems">
-                    <button class="d-print-none btn" t-att-class="env.isSmall ? 'btn-secondary' : 'lh-sm p-0 border-0'" data-hotkey="u" data-tooltip="Actions">
+                    <button class="d-print-none btn" t-att-class="env.isSmall ? 'btn-secondary' : 'lh-sm p-0 border-0'" data-hotkey="u">
                         <i class="fa fa-cog"/>
                     </button>
 


### PR DESCRIPTION
Before this commit, the tootip was above the drop-down menu. This was particularly annoying for small screens.

Task-ID: 4377708

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
