### PR TITLE
[FIX] hr{_attendance}: fix overtime/attendance timezone consistency

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime.py
@@ -18,7 +18,7 @@ class HrAttendanceOvertime(models.Model):
         required=True, ondelete='cascade', index=True)
     company_id = fields.Many2one(related='employee_id.company_id')
 
-    date = fields.Date(string='Day')
+    date = fields.Date(string='Day', index=True, required=True)
     duration = fields.Float(string='Extra Hours', default=0.0, required=True)
     duration_real = fields.Float(
         string='Extra Hours (Real)', default=0.0,

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -11,6 +11,12 @@ class TestHrAttendanceOvertime(TransactionCase):
 
     @classmethod
     def setUpClass(cls):
+        def set_calendar_and_tz(employee, tz):
+            employee.resource_calendar_id = cls.env['resource.calendar'].create({
+                'name': f'Default Calendar ({tz})',
+                'tz': tz,
+            })
+
         super().setUpClass()
         cls.company = cls.env['res.company'].create({
             'name': 'SweatChipChop Inc.',
@@ -40,16 +46,22 @@ class TestHrAttendanceOvertime(TransactionCase):
             'company_id': cls.company.id,
             'tz': 'Asia/Tokyo',
         })
+        set_calendar_and_tz(cls.jpn_employee, 'Asia/Tokyo')
+
         cls.honolulu_employee = cls.env['hr.employee'].create({
             'name': 'Susan',
             'company_id': cls.company.id,
             'tz': 'Pacific/Honolulu',
         })
+        set_calendar_and_tz(cls.honolulu_employee, 'Pacific/Honolulu')
+
         cls.europe_employee = cls.env['hr.employee'].with_company(cls.company_1).create({
             'name': 'Schmitt',
             'company_id': cls.company_1.id,
             'tz': 'Europe/Brussels',
         })
+        set_calendar_and_tz(cls.europe_employee, 'Europe/Brussels')
+
         cls.calendar_flex_40h = cls.env['resource.calendar'].create({
             'name': 'Flexible 40 hours/week',
             'company_id': cls.company.id,
@@ -382,6 +394,23 @@ class TestHrAttendanceOvertime(TransactionCase):
         overtime_record = self.env['hr.attendance.overtime'].search([('employee_id', '=', self.europe_employee.id),
                                                               ('date', '=', datetime(2024, 5, 28))])
         self.assertAlmostEqual(overtime_record.duration, 5)
+
+        # Check that the calendar's timezones take priority and that overtimes and attendances dates are consistent
+        self.europe_employee.resource_calendar_id.tz = 'America/New_York'
+        early_attendance2 = self.env['hr.attendance'].create({
+            'employee_id': self.europe_employee.id,
+            'check_in': datetime(2024, 5, 30, 3, 0),  # 23:00 NY prev day -- attendance should be for the 29th
+            'check_out': datetime(2024, 5, 30, 16, 0)  # 12:00 NY
+        })
+
+        # expected = 5 (13 - 8 work) -- since attendance is for the next day the lunch isn't accounted for
+        self.assertAlmostEqual(early_attendance2.overtime_hours, 5)
+
+        # Total overtime for the 29th (not the 30th): 5 hours
+        overtime_record2 = self.env['hr.attendance.overtime'].search([('employee_id', '=', self.europe_employee.id),
+                                                              ('date', '=', datetime(2024, 5, 29))])
+        self.assertAlmostEqual(overtime_record2.duration, 5)
+
 
     @freeze_time("2024-02-1 23:00:00")
     def test_auto_check_out(self):

--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -151,7 +151,7 @@ class HrEmployee(models.Model):
         ])
         contracts_by_employee = defaultdict(lambda: self.env['hr.contract'])
         for contract in contracts:
-            contracts_by_employee[contract.employee_id] += contract
+            contracts_by_employee[contract.employee_id.id] += contract
         for employee in self:
             employee_contracts = contracts_by_employee[employee.id]
             if employee_contracts:

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=108, admin=109):
+        with self.assertQueryCount(__system__=109, admin=110):
             leave.action_validate()
         leave.action_refuse()
 


### PR DESCRIPTION
Steps
---
* install hr_contract, hr_attendance
* On some employee with a running contract (Anita Oliver)
  set the schedule's timezone to America/New_York
  (Assuming we're in Europe/Brussels, otherwise adjust)
* create an attendance for today:
  4:15 (or any time local time before 0:00 New York) -> 21:00
* The overtime stays 0 (unless there is an overtime for the previous day,
  in which case the hours are taken from it and aren't affected
  by the attendance times)

Cause
---
* when we compute the date for an attendance from the `check_in`,
  we preferentially use the employee timezone - when defined -
  as per `_get_tz` rules
  (https://github.com/odoo/odoo/blob/b9439513e3e99abc5d748ae30e79e367209b18a5/addons/hr_attendance/models/hr_attendance.py#L222)
* but in the sql query where we try to match attendances with overtimes
  we only look at the calendar timezone
  (https://github.com/odoo/odoo/blob/b9439513e3e99abc5d748ae30e79e367209b18a5/addons/hr_attendance/models/hr_attendance.py#L79-L83)

Fix
---
* Decide the timezone to consider in priority is that of the employee's
  contract
* Refactor the sql query with orm based approach that uses the same
  method to get the timezone

Note
---
When we try to get the schedule's timezone we sometimes have to find a
contract that was effective at the relevant time to use its timezone.
But on boundaries, what contract was effective at the relevant time
may depend on the timezone -- in this case we use `_get_tz` first.

task-3937428