### PR TITLE
[FIX] calendar: organizer can't edit or delete event

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.js
+++ b/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.js
@@ -62,14 +62,14 @@ export class AttendeeCalendarCommonPopover extends CalendarCommonPopover {
      * @override
      */
     get isEventDeletable() {
-        return super.isEventDeletable && this.isCurrentUserAttendee && !this.isEventArchivable;
+        return super.isEventDeletable && (this.isCurrentUserAttendee || this.isCurrentUserOrganizer) && !this.isEventArchivable;
     }
 
     /**
      * @override
      */
     get isEventEditable() {
-        return this.isEventPrivate ? this.isCurrentUserAttendee : super.isEventEditable;
+        return this.isEventPrivate ? this.isCurrentUserAttendee || this.isCurrentUserOrganizer : super.isEventEditable;
     }
 
     async changeAttendeeStatus(selectedStatus) {


### PR DESCRIPTION
* STEP TO REPRODUCE: In Form view Michelle Admin create a private event with attendee not inlcude him, then he forgot that he need to attend that too but no 'Edit' button appear in calendar popover.
* REASON: In order to display the Edit button for private event , user need to be in attendees list
* SOLUTION: This commit fix that by allow organizer to do the same thing , can edit and delete the event

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
