### PR TITLE
[IMP] web: allow using the properties in the dynamic placeholder

### DIFF
--- a/addons/web/static/src/core/field_service.js
+++ b/addons/web/static/src/core/field_service.js
@@ -71,6 +71,7 @@ export const fieldService = {
                         // differentiate definitions with same name but on different parent
                         record_id: record.id,
                         record_name: record.display_name,
+                        ...(definition.comodel ? { relation: definition.comodel } : {}),
                         ...definition,
                     };
                 }

--- a/addons/web/static/src/core/model_field_selector/model_field_selector.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector.js
@@ -14,6 +14,7 @@ export class ModelFieldSelector extends Component {
         path: { optional: true },
         allowEmpty: { type: Boolean, optional: true },
         readonly: { type: Boolean, optional: true },
+        readProperty: { type: Boolean, optional: true },
         showSearchInput: { type: Boolean, optional: true },
         isDebugMode: { type: Boolean, optional: true },
         update: { type: Function, optional: true },
@@ -56,6 +57,7 @@ export class ModelFieldSelector extends Component {
         this.popover.open(currentTarget, {
             resModel: this.props.resModel,
             path: this.props.path,
+            readProperty: this.props.readProperty,
             update: (path, _fieldInfo, debug = false) => {
                 this.newPath = path;
                 if (!debug) {

--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.xml
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.xml
@@ -43,7 +43,7 @@
                                 <t t-if="fieldDef.record_name"> (<t t-esc="fieldDef.record_name" />)</t>
                                 <div t-if="props.isDebugMode" class="o_model_field_selector_popover_item_title text-break text-muted small"><t t-esc="fieldName"/> (<t t-esc="fieldDef.type"/>)</div>
                             </button>
-                            <t t-if="(!fieldDef.is_property and fieldDef.relation and props.followRelations) or fieldDef.type === 'properties'">
+                            <t t-if="(fieldDef.relation and props.followRelations) or fieldDef.type === 'properties'">
                                 <button class="o_model_field_selector_popover_item_relation btn btn-light border-0 border-start rounded-0" t-on-click.stop="() => this.followRelation(fieldDef)">
                                     <i class="oi oi-chevron-right o_model_field_selector_popover_relation_icon" role="img" aria-label="Relation to follow" title="Relation to follow" />
                                 </button>

--- a/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
@@ -38,6 +38,9 @@ export class DynamicPlaceholderPopover extends Component {
         if (!this.isTemplateEditor && !this.allowedQwebExpressions.includes(fullPath)) {
             return false;
         }
+        if (fieldDef.is_property && fieldDef.type === "separator") {
+            return false;
+        }
         return !["one2many", "boolean", "many2many"].includes(fieldDef.type) && fieldDef.searchable;
     }
     closeFieldSelector(isPathSelected = false) {

--- a/addons/web/static/src/views/fields/dynamic_placeholder_popover.xml
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_popover.xml
@@ -56,6 +56,7 @@
                 isDebugMode="!!env.debug"
                 path="state.path"
                 resModel="props.resModel"
+                readProperty="true"
                 showSearchInput="true"
                 update.bind="setPath"
             />

--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -507,7 +507,10 @@ export class PropertiesField extends Component {
         event.preventDefault();
         if (!(await this.checkDefinitionWriteAccess())) {
             this.notification.add(
-                _t("You need edit access on the parent document to update these property fields"),
+                _t('Oops! You cannot edit the %(parentFieldLabel)s "%(parentName)s".', {
+                    parentName: this.parentName,
+                    parentFieldLabel: this.parentString,
+                }),
                 { type: "warning" }
             );
             return;
@@ -596,10 +599,16 @@ export class PropertiesField extends Component {
 
     async onPropertyCreate() {
         if (!this.state.canChangeDefinition || !(await this.checkDefinitionWriteAccess())) {
-            this.notification.add(
-                _t("You need edit access on the parent document to update these property fields"),
-                { type: "warning" }
-            );
+            const message =
+                !this.definitionRecordId || !this.definitionRecordModel
+                    ? _t("Oops! A %(parentFieldLabel)s is needed to add property fields.", {
+                          parentFieldLabel: this.parentString,
+                      })
+                    : _t('Oops! You cannot edit the %(parentFieldLabel)s "%(parentName)s".', {
+                          parentName: this.parentName,
+                          parentFieldLabel: this.parentString,
+                      });
+            this.notification.add(message, { type: "warning" });
             return;
         }
         const propertiesDefinitions = this.propertiesList || [];

--- a/addons/web/static/src/views/fields/properties/property_definition.xml
+++ b/addons/web/static/src/views/fields/properties/property_definition.xml
@@ -91,7 +91,7 @@
                     />
                 </div>
                 <div t-if="state.propertyDefinition.type === 'tags'" class="d-contents mb-3 mb-sm-0">
-                    <label t-att-for="getUniqueDomID('tags')" class="o_form_label text-900">Tag</label>
+                    <label t-att-for="getUniqueDomID('tags')" class="o_form_label text-900">Tags</label>
                     <PropertyTags
                         id="getUniqueDomID('tags')"
                         selectedTags="propertyTagValues"

--- a/addons/web/static/tests/views/fields/dynamic_placeholder.test.js
+++ b/addons/web/static/tests/views/fields/dynamic_placeholder.test.js
@@ -14,9 +14,19 @@ class Partner extends models.Model {
     char = fields.Char();
     placeholder = fields.Char({ default: "partner" });
     product_id = fields.Many2one({ relation: "product" });
+    properties = fields.Properties({
+        string: "Properties",
+        definition_record: "product_id",
+        definition_record_field: "properties_definitions",
+    });
 
     _records = [
-        { id: 1, char: "yop", product_id: 37 },
+        {
+            id: 1,
+            char: "yop",
+            product_id: 37,
+            properties: { f80b6fb58d0d4c72: 3, f424643eee1f3655: 41 },
+        },
         { id: 2, char: "blip", product_id: false },
         { id: 4, char: "abc", product_id: 41 },
     ];
@@ -43,9 +53,17 @@ class Partner extends models.Model {
 
 class Product extends models.Model {
     name = fields.Char({ string: "Product Name" });
+    properties_definitions = fields.PropertiesDefinition();
 
     _records = [
-        { id: 37, name: "xphone" },
+        {
+            id: 37,
+            name: "xphone",
+            properties_definitions: [
+                { name: "f80b6fb58d0d4c72", type: "integer", string: "prop 1" },
+                { name: "f424643eee1f3655", type: "many2one", string: "prop 2", comodel: "product" },
+            ],
+        },
         { id: 41, name: "xpad" },
     ];
 }
@@ -94,4 +112,30 @@ test("dynamic placeholder close when clicking on the cross", async () => {
     await contains(".o_model_field_selector_popover_item_relation").click();
     await contains(".o_model_field_selector_popover_close").click();
     expect(".o_model_field_selector_popover").toHaveCount(0);
+});
+
+test("dynamic placeholder properties", async () => {
+    await mountView({ type: "form", resModel: "partner", resId: 1 });
+
+    await contains(".o_field_char input").edit("#", { confirm: false });
+    expect(".o_model_field_selector_popover").toHaveCount(1);
+    expect(".o_model_field_selector_popover .o_model_field_selector_popover_item_name:contains('Properties')").toHaveCount(1);
+
+    // select the properties
+    await contains(".o_model_field_selector_popover .o_model_field_selector_popover_item_name:contains('Properties') + .o_model_field_selector_popover_item_relation").click();
+    expect(".o_model_field_selector_popover .o_model_field_selector_popover_item_name:contains('prop 1 (xphone)')").toHaveCount(1);
+    expect(".o_model_field_selector_popover .o_model_field_selector_popover_item_name:contains('prop 2 (xphone)')").toHaveCount(1);
+
+    // select the many2one property
+    await contains(".o_model_field_selector_popover .o_model_field_selector_popover_item_name:contains('prop 2 (xphone)') + .o_model_field_selector_popover_item_relation").click();
+    expect(".o_model_field_selector_popover .o_model_field_selector_popover_item_name:contains('Created on')").toHaveCount(1);
+
+    // select the product name
+    await contains(".o_model_field_selector_popover .o_model_field_selector_popover_item_name:contains('Product Name')").click();
+
+    // click on insert
+    await contains(".o_model_field_selector_popover button:contains('Insert')").click();
+
+    const value = document.querySelector(".o_field_placeholder").value.trim();
+    expect(value).toBe("{{object.properties.get('f424643eee1f3655', env['product'])['name']}}");
 });

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -304,9 +304,7 @@ test("properties: no access to parent", async () => {
 
     patchWithCleanup(formView.env.services.notification, {
         add: (message, options) => {
-            expect(message).toBe(
-                "You need edit access on the parent document to update these property fields"
-            );
+            expect(message).toBe('Oops! You cannot edit the Company "Company 1".');
         },
     });
 

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -4725,7 +4725,7 @@ class BaseModel(metaclass=MetaModel):
             if field.type != 'properties':
                 continue
             for record in self:
-                old_value = record[fname]
+                old_value = record[fname]._values
                 if not old_value:
                     continue
 
@@ -4742,7 +4742,7 @@ class BaseModel(metaclass=MetaModel):
             if fname not in self._fields or self._fields[fname].type != 'properties':
                 continue
             field_converter = self._fields[fname].convert_to_cache
-            to_write[fname] = dict(self[fname], **field_converter(values.pop(fname), self, validate=False))
+            to_write[fname] = dict(self[fname]._values, **field_converter(values.pop(fname), self, validate=False))
 
         self.write(values)
         if to_write:


### PR DESCRIPTION
Purpose
=======
Allow using the properties in the dynamic placeholder (so we can use them for
mail template, mailing, etc). Hide the separator properties, as it makes no sense
to show their value in a template.

Technical
=========
For property, we introduced a lazy object for `convert_to_record`, that will make
the verification only if we try to read a property value. That way, the performance
when reading is untouched, but we can trust the value when using `convert_to_record`.

Task-4363868