### PR TITLE
[FIX] pos_self_order: category time availability

### DIFF
--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -453,7 +453,18 @@ export class SelfOrder extends Reactive {
 
         this.availableCategoryListIds = availableCategories
             .filter((c) => {
-                return now > c.hour_after && now < c.hour_until;
+                const hourStart = c.hour_after;
+                const hourUntil = c.hour_until;
+                if (hourStart === hourUntil || (hourStart === 0 && hourUntil === 24)) {
+                    // if equal, it means open the whole day
+                    return true;
+                } else if (hourStart < hourUntil) {
+                    // in this case, if current time is in between, then shop is open
+                    return now >= hourStart && now <= hourUntil;
+                } else {
+                    // in this case, if current time is in between, then shop is closed
+                    return !(now >= hourStart && now <= hourUntil);
+                }
             })
             .map((c) => c.id);
         this.currentCategory = this.pos_category.length > 0 ? [...this.categoryList][0] : null;


### PR DESCRIPTION
The computation of available category was wrong when the current time was exactly midnight. This was causing runbot error on some test that was exactly executed at midnight.

runbot error: 104523, 66109, 107831...

