### PR TITLE
[17.0][FIX]: Error computing field plan_available_ids when having multiple scheduler

### DIFF
--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -134,7 +134,7 @@ class MailActivitySchedule(models.TransientModel):
     @api.depends('company_id', 'res_model_id')
     def _compute_plan_available_ids(self):
         for scheduler in self:
-            scheduler.plan_available_ids = self.env['mail.activity.plan'].search(self._get_plan_available_base_domain())
+            scheduler.plan_available_ids = self.env['mail.activity.plan'].search(scheduler._get_plan_available_base_domain())
 
     @api.depends_context('plan_mode')
     @api.depends('plan_available_ids')

--- a/doc/cla/corporate/komit.md
+++ b/doc/cla/corporate/komit.md
@@ -16,3 +16,4 @@ Cuong NGUYEN MINH TRAN MANH cuong.nmtm@komit-consulting.com https://github.com/c
 Duc TRUONG DINH MINH duc.tdm@komit-consulting.com https://github.com/DucTruongKomit
 Hieu VO MINH BAO hieu.vmb@komit-consulting.com https://github.com/hieulucky111
 Jean-Charles DRUBAY jc@komit-consulting.com https://github.com/jcdrubay
+QUOC PHAM NGOC quoc-pn@komit-consulting.com https://github.com/quoc-pn


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When there is more than one mail.activity.schedule records created in a process, the function `_compute_plan_available_ids()` will face the error Expected singleton.

Current behavior before PR:

This issue will not happen when launching the activity plan on WUI because users open one launch plan wizard at a time.
When activity plans need to launch simultaneously, we need to create a separate wizard for each plan, this process will cause the issue.

Desired behavior after PR is merged:
The function `_compute_plan_available_ids()` will work properly.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
