### PR TITLE
[FIX] base: fix company check for one2many and many2many fields

### DIFF
--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -1116,7 +1116,8 @@ class ModelChild(models.Model):
 
     name = fields.Char()
     company_id = fields.Many2one('res.company')
-    parent_id = fields.Many2one('test_new_api.model_parent', check_company=True)
+    parent_id = fields.Many2one('test_new_api.model_parent', string="Parent", check_company=True)
+    parent_ids = fields.Many2many('test_new_api.model_parent', string="Parents", check_company=True)
 
 
 class ModelChildNoCheck(models.Model):

--- a/odoo/addons/test_new_api/tests/test_company_checks.py
+++ b/odoo/addons/test_new_api/tests/test_company_checks.py
@@ -1,5 +1,6 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.exceptions import UserError, AccessError
 from odoo.tests import common
 from odoo.tools import frozendict
@@ -49,6 +50,7 @@ class TestCompanyCheck(common.TransactionCase):
             'name': 'M1',
             'company_id': self.company_a.id,
             'parent_id': self.parent_a.id,
+            'parent_ids': [Command.link(self.parent_a.id)],
         })
 
     def test_company_and_different_company(self):
@@ -59,12 +61,19 @@ class TestCompanyCheck(common.TransactionCase):
                 'company_id': self.company_b.id,
                 'parent_id': self.parent_a.id,
             })
+        with self.assertRaises(UserError):
+            self.env['test_new_api.model_child'].create({
+                'name': 'M1',
+                'company_id': self.company_b.id,
+                'parent_ids': [Command.link(self.parent_a.id), Command.link(self.parent_b.id)],
+            })
 
     def test_company_and_no_company(self):
         self.env['test_new_api.model_child'].create({
             'name': 'M1',
             'company_id': self.company_a.id,
             'parent_id': self.parent_0.id,
+            'parent_ids': [Command.link(self.parent_0.id)],
         })
 
     def test_no_company_and_no_company(self):
@@ -72,6 +81,7 @@ class TestCompanyCheck(common.TransactionCase):
             'name': 'M1',
             'company_id': False,
             'parent_id': self.parent_0.id,
+            'parent_ids': [Command.link(self.parent_0.id)],
         })
 
     def test_no_company_and_some_company(self):
@@ -80,6 +90,12 @@ class TestCompanyCheck(common.TransactionCase):
                 'name': 'M1',
                 'company_id': False,
                 'parent_id': self.parent_a.id,
+            })
+        with self.assertRaises(UserError):
+            self.env['test_new_api.model_child'].create({
+                'name': 'M1',
+                'company_id': False,
+                'parent_ids': [Command.link(self.parent_0.id), Command.link(self.parent_a.id)],
             })
 
     def test_no_company_check(self):
@@ -96,6 +112,7 @@ class TestCompanyCheck(common.TransactionCase):
             'name': 'M1',
             'company_id': self.company_a.id,
             'parent_id': self.parent_a.id,
+            'parent_ids': [Command.link(self.parent_a.id)],
         })
 
         with self.assertRaises(UserError):
@@ -104,8 +121,12 @@ class TestCompanyCheck(common.TransactionCase):
         with self.assertRaises(UserError):
             child.parent_id = self.parent_b.id
 
+        with self.assertRaises(UserError):
+            child.parent_ids = [Command.link(self.parent_b.id)]
+
         child.write({
             'parent_id': self.parent_b.id,
+            'parent_ids': [Command.unlink(self.parent_a.id), Command.link(self.parent_b.id)],
             'company_id': self.company_b.id,
         })
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4086,22 +4086,22 @@ class BaseModel(metaclass=MetaModel):
             # The first part of the check verifies that all records linked via relation fields are compatible
             # with the company of the origin document, i.e. `self.account_id.company_id == self.company_id`
             for name in regular_fields:
-                corecord = record.sudo()[name]
-                if corecord:
-                    domain = corecord._check_company_domain(company)
-                    if domain and not corecord.with_context(active_test=False).filtered_domain(domain):
-                        inconsistencies.append((record, name, corecord))
+                corecords = record.sudo()[name]
+                if corecords:
+                    domain = corecords._check_company_domain(company)
+                    if domain and corecords != corecords.with_context(active_test=False).filtered_domain(domain):
+                        inconsistencies.append((record, name, corecords))
             # The second part of the check (for property / company-dependent fields) verifies that the records
             # linked via those relation fields are compatible with the company that owns the property value, i.e.
             # the company for which the value is being assigned, i.e:
             #      `self.property_account_payable_id.company_id == self.env.company
             company = self.env.company
             for name in property_fields:
-                corecord = record.sudo()[name]
-                if corecord:
-                    domain = corecord._check_company_domain(company)
-                    if domain and not corecord.with_context(active_test=False).filtered_domain(domain):
-                        inconsistencies.append((record, name, corecord))
+                corecords = record.sudo()[name]
+                if corecords:
+                    domain = corecords._check_company_domain(company)
+                    if domain and corecords != corecords.with_context(active_test=False).filtered_domain(domain):
+                        inconsistencies.append((record, name, corecords))
 
         if inconsistencies:
             lines = [_("Incompatible companies on records:")]


### PR DESCRIPTION
Previously, the company check on a relational field was ensuring that at least one of the related records had a compatible company. This worked fine for many2one fields, which have a single related record, but not for one2many and many2many fields, which can have multiple related records (only one of them needed to have a compatible company for the check to succeed).

This fix rewrites the company check to ensure that none of the related records have an incompatible company.