### PR TITLE
[IMP] account: Add Total to invoice analysis

### DIFF
--- a/addons/account/report/account_invoice_report_view.xml
+++ b/addons/account/report/account_invoice_report_view.xml
@@ -44,6 +44,7 @@
                 <field name="price_subtotal_currency" optional="show" sum="Total"/>
                 <field name="price_subtotal" optional="show" sum="Total"/>
                 <field name="price_total" optional="show" sum="Total"/>
+                <field name="price_total_currency" optional="show" sum="Total"/>
                 <field name="price_margin" optional="hide"/>
                 <field name="inventory_value" optional="hide" sum="Total"/>
                 <field name="state" optional="hide"/>


### PR DESCRIPTION
In invoice analysis report, added invoice line total price in company currency.
Before that, total was only supported in document currency.

task-4344531




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
