### PR TITLE
[FIX] mail: record creation message as notification

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -194,7 +194,7 @@
 </t>
 
 <t t-name="mail.Message.bodyAsNotification">
-    <div class="o-mail-Message-body text-break mb-0 w-100">
+    <div class="o-mail-Message-body text-break mb-0 w-100" t-att-class="{'o-note': message.message_type == 'notification'}">
         <t t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
     </div>
 </t>


### PR DESCRIPTION
Purpose of this commit:
Previously, the record creation message was treated as a notification but still
had the o-mail-Message-body class, which caused the traditional padding to be
applied to the message. To address this, we had to defined the message_subtype
so that the padding would not be applied. Several modules faced this issue. To
minimize the code, we adapted the message template to prevent the addition of
the o-mail-Message-body class when the message type is a notification.

Ent-PR: https://github.com/odoo/enterprise/pull/75343

task-4291913