### PR TITLE
[FIX] html_editor: convert self-closing `t` tags to open/closed tags

### DIFF
--- a/addons/html_editor/static/src/utils/sanitize.js
+++ b/addons/html_editor/static/src/utils/sanitize.js
@@ -59,6 +59,6 @@ export function initElementForEdition(element, options = {}) {
 }
 
 export function fixInvalidHTML(content) {
-    const regex = /<\s*(a|strong)[^<]*?\/\s*>/g;
+    const regex = /<\s*(a|strong|t)[^<]*?\/\s*>/g;
     return content.replace(regex, (match, g0) => match.replace(/\/\s*>/, `></${g0}>`));
 }

--- a/addons/html_editor/static/tests/editor.test.js
+++ b/addons/html_editor/static/tests/editor.test.js
@@ -110,3 +110,17 @@ test("Convert self closing a elements to opening/closing tags", async () => {
         '<ul> <li><a href="xyz" t-out="xyz"></a></li> </ul>'
     );
 });
+
+test("Convert self closing t elements to opening/closing tags", async () => {
+    const { el, editor } = await setupEditor(`
+        <div>
+            <t t-out="object.partner_id" data-oe-t-inline="true" contenteditable="false"/>
+        </div>
+    `);
+    expect(el.innerHTML.trim().replace(/\s+/g, " ")).toBe(
+        `<div> <t t-out="object.partner_id" data-oe-t-inline="true" contenteditable="false"></t> </div>`
+    );
+    expect(editor.getContent().trim().replace(/\s+/g, " ")).toBe(
+        '<div> <t t-out="object.partner_id" data-oe-t-inline="true" contenteditable="false"></t> </div>'
+    );
+});


### PR DESCRIPTION
**Problem**:
Self-closing `t` tags do not render properly, leading to issues in templates where the tag is opened but never closed.

**Solution**:
Extend the fix introduced in the following commit: https://github.com/odoo/odoo/commit/26b922ef5cad42da7e188195e919e54878d472fc to also cover `t` tags, ensuring proper conversion to open/closed tag format.

**Steps to reproduce**:
1. Open Email templates.
2. Add a dynamic placeholder with no default value.
3. If the record has no value for that attribute, the `t` tag is opened but never closed, causing rendering issues.

opw-4376109

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
