### PR TITLE
[FIX] web_editor: fix sidebar overflow issue

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1615,6 +1615,14 @@
                     font-weight: 600;
                 }
             }
+            // For layout having button-group + we-select, to avoid the long
+            // text to overflow the row.
+            &:has(div > we-button-group + we-select.o_grid) {
+                we-button-group we-selection-items {
+                    display: grid !important;
+                    grid-template-columns: auto auto;
+                }
+            }
         }
 
         %o-we-inline {


### PR DESCRIPTION
Step to reproduce:
- Set the odoo backend language to spanish (tested in V16.0)
- Go to edit mode
- Drop "Text-Image" snippet.
- Click on Image from dropped snippet.
- Bug: The sidebar "Layout" menu overflows, there is a horizontal
  scrollbar.

Issue:
There was an issue with the dynamic width of the we-buttons within the
button group. The text in the "Layout" options was overflowing, causing
the sidebar to overflow.

Solution:
This commit addresses the specific issue with the layout option.
Without altering any other styles and assuming this is the only case,
we equally divide the available space between the buttons using the
grid template.

task-4378522