### PR TITLE
[FIX] stock,mrp_subcontracting_purchase: global lead time count once

### DIFF
--- a/addons/mrp_subcontracting_purchase/models/stock_rule.py
+++ b/addons/mrp_subcontracting_purchase/models/stock_rule.py
@@ -25,7 +25,7 @@ class StockRule(models.Model):
             return super()._get_lead_days(product, **values)
 
         delays, delay_description = super(StockRule, self - buy_rule)._get_lead_days(product, **values)
-        extra_delays, extra_delay_description = super(StockRule, buy_rule.with_context(ignore_vendor_lead_time=True))._get_lead_days(product, **values)
+        extra_delays, extra_delay_description = super(StockRule, buy_rule.with_context(ignore_vendor_lead_time=True, ignore_global_visibility_days=True))._get_lead_days(product, **values)
         if seller.delay >= bom.produce_delay + bom.days_to_prepare_mo:
             delays['total_delay'] += seller.delay
             delays['purchase_delay'] += seller.delay

--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -3,7 +3,9 @@
 
 import logging
 
+from datetime import datetime, timedelta
 from freezegun import freeze_time
+from json import loads
 
 from odoo import Command
 from odoo.exceptions import UserError
@@ -901,3 +903,42 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         return_picking = self.env['stock.picking'].browse(return_picking_id)
         return_picking.button_validate()
         self.assertEqual(return_picking.state, 'done')
+
+    def test_global_visibility_days_affect_lead_time(self):
+        """ Don't count global visibility days more than once, make sure a PO generated from
+        replenishment/orderpoint has a sensible planned reception date.
+        """
+        wh = self.env.user._get_default_warehouse_id()
+        self.env['ir.config_parameter'].sudo().set_param('stock.visibility_days', '365')
+        self.finished2.seller_ids = [Command.create({
+            'partner_id': self.subcontractor_partner1.id,
+            'delay': 0,
+        })]
+        final_product = self.finished2
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({'product_id': final_product.id})
+        out_picking = self.env['stock.picking'].create({
+            'picking_type_id': self.env.ref('stock.picking_type_out').id,
+            'location_id': wh.lot_stock_id.id,
+            'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+            'move_ids': [Command.create({
+                'name': 'TGVDALT out move',
+                'product_id': final_product.id,
+                'product_uom_qty': 2,
+                'location_id': wh.lot_stock_id.id,
+                'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+            })],
+        })
+        out_picking.action_assign()
+        r = orderpoint.action_stock_replenishment_info()
+        repl_info = self.env[r['res_model']].browse(r['res_id'])
+        lead_days_date = datetime.strptime(
+            loads(repl_info.json_lead_days)['lead_days_date'],'%m/%d/%Y').date()
+        self.assertEqual(lead_days_date, Date.today() + timedelta(days=365))
+
+        orderpoint.action_replenish()
+        purchase_order = self.env['purchase.order'].search([
+            ('order_line', 'any', [
+                ('product_id', '=', self.finished2.id),
+            ]),
+        ], limit=1)
+        self.assertEqual(purchase_order.date_planned.date(), Date.today())

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -377,7 +377,10 @@ class StockRule(models.Model):
         delays = defaultdict(float)
         delay = sum(self.filtered(lambda r: r.action in ['pull', 'pull_push']).mapped('delay'))
         delays['total_delay'] += delay
-        global_visibility_days = self.env['ir.config_parameter'].sudo().get_param('stock.visibility_days')
+        global_visibility_days = (
+            not self.env.context.get('ignore_global_visibility_days') and
+            self.env['ir.config_parameter'].sudo().get_param('stock.visibility_days')
+        )
         if global_visibility_days:
             delays['total_delay'] += int(global_visibility_days)
         if self.env.context.get('bypass_delay_description'):


### PR DESCRIPTION
**Current behavior:**
Setting a global lead time may result in this time being counted twice in the breakdown of the replenishment for some orderpoint.

**Expected behavior:**
The global lead time should be counted one time.

**Steps to reproduce:**
1. Create a product with a subcontracted BoM

2. Set the system parameter stock.visiblity_days = 365

3. Create a supplierinfo (vendor) on the subcontracted product with 0 delay (lead time)

4. Create a sale order for the subcontracted product

5. In the replenishment report, create an orderpoint for the product and click the (i) on the tree view line

6. See that global visibility days are double-counted

**Cause of the issue:**
`_get_lead_days()` is called twice here, the second time it ignores vendor lead time but re-counts global visibility days.

**Fix:**
Ignore the global visibility in a similar manner via context the second time.

opw-4370201