### PR TITLE
[FIX] website: correct carousel controllers options handling

### DIFF
--- a/addons/website/static/src/snippets/s_carousel_intro/options.js
+++ b/addons/website/static/src/snippets/s_carousel_intro/options.js
@@ -5,22 +5,37 @@ options.registry.CarouselIntro = options.registry.Carousel.extend({
     /**
      * @override
      */
-    async _computeWidgetState(methodName, params) {
+    async _renderCustomXML(uiFragment) {
+        // To remove in MASTER.
+        const arrowsOptionsEl = uiFragment
+            .querySelector(`[data-select-class="s_carousel_default"]`)
+            .closest("we-select");
+        const indicatorsOptionsEl = uiFragment
+            .querySelector(`[data-select-class="s_carousel_indicators_dots"]`)
+            .closest("we-select");
+        arrowsOptionsEl.dataset.name = "arrows_opt";
+        indicatorsOptionsEl.dataset.name = "indicators_opt";
+    },
+    /**
+     * @override
+     */
+    async selectClass(previewMode, widgetValue, params) {
         // Prevent the "Controllers" option from being "centered" when
-        // arrows and indicators are displayed.
-        if (methodName === "selectClass" && params.name === "carousel_controllers_centered_opt") {
-            const controllersEl = this.$target[0];
-            const carouselEl = controllersEl.closest(".carousel");
-            const indicatorsEl = controllersEl.querySelector(".carousel-indicators");
-            if (
-                !carouselEl.classList.contains("s_carousel_arrows_hidden")
-                && !indicatorsEl.classList.contains("s_carousel_indicators_hidden")
-            )
-            {
-                controllersEl.classList.toggle("justify-content-center");
-                controllersEl.classList.toggle("justify-content-between");
-            }
+        // arrows and indicators are displayed
+        await this._super(...arguments);
+        if (["arrows_opt", "indicators_opt"].includes(params.name)) {
+            const carouselEl = this.$target[0].closest(".carousel");
+            const controllersEl = carouselEl.querySelector(".s_carousel_intro_controllers_row");
+            const indicatorsEl = carouselEl.querySelector(".carousel-indicators");
+
+            const hasHiddenArrows = carouselEl.classList.contains("s_carousel_arrows_hidden");
+            const hasHiddenIndicators = indicatorsEl.classList.contains(
+                "s_carousel_indicators_hidden"
+            );
+
+            const contentBetween = !hasHiddenIndicators && !hasHiddenArrows;
+            controllersEl.classList.toggle("justify-content-between", contentBetween);
+            controllersEl.classList.toggle("justify-content-center", !contentBetween);
         }
-        return this._super(...arguments);
     },
 });

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -515,13 +515,13 @@
             <we-button data-select-class="s_carousel_controllers_indicators_outside">Indicators outside</we-button>
         </we-select>
         <we-checkbox string="Invert colors" class="o_we_sublevel_1" data-select-class="carousel-dark"/>
-        <we-select string="Arrows" class="o_we_sublevel_1">
+        <we-select string="Arrows" class="o_we_sublevel_1" data-name="arrows_opt">
             <we-button data-select-class="s_carousel_default">Default</we-button>
             <we-button data-select-class="s_carousel_boxed">Boxed</we-button>
             <we-button data-select-class="s_carousel_rounded">Rounded</we-button>
             <we-button data-select-class="s_carousel_arrows_hidden">Hidden</we-button>
         </we-select>
-        <we-select string="Indicators" data-apply-to=".carousel-indicators" class="o_we_sublevel_1">
+        <we-select string="Indicators" data-apply-to=".carousel-indicators" class="o_we_sublevel_1" data-name="indicators_opt">
             <we-button data-select-class="">Bars</we-button>
             <we-button data-select-class="s_carousel_indicators_dots">Dots</we-button>
             <we-button data-select-class="s_carousel_indicators_numbers">Numbers</we-button>


### PR DESCRIPTION
Since [1], a method was introduced to prevent the "controllers" options from being centered when arrows and indicators are displayed. However, it was implemented in the wrong overridden method (computeWidgetState), which cannot update the DOM. Additionally, it failed to account for the preview mode.

This commit resolves these issues.

Steps to reproduce:

- Website - Edit mode
- Drag and drop a "carousel intro" snippet onto the page.
- Select the option "Controllers > Arrows > Hidden."
- Then select the option "Controllers > Centered."
- The controllers are now displayed as centered.
- Hover over the "Controllers > Arrows" options and preview a value other than "Hidden."
- The preview does not update correctly.

[1]: https://github.com/odoo/odoo/commit/454d743ed631c068b7b0bc72e4fd81b225a5ac52

Related to:
task-4094405
