### PR TITLE
[IMP] bus: enable websocket during tours

### DIFF
--- a/addons/bus/tests/__init__.py
+++ b/addons/bus/tests/__init__.py
@@ -6,5 +6,6 @@ from . import test_ir_model
 from . import test_ir_websocket
 from . import test_notify
 from . import test_websocket_caryall
+from . import test_close_websocket_after_tour
 from . import test_websocket_controller
 from . import test_websocket_rate_limiting

--- a/addons/bus/tests/test_close_websocket_after_tour.py
+++ b/addons/bus/tests/test_close_websocket_after_tour.py
@@ -1,0 +1,38 @@
+import gc
+from unittest.mock import patch
+from weakref import WeakSet
+
+from odoo.tests import tagged
+from .. import websocket as websocket_module
+from .common import WebsocketCase
+
+
+@tagged("-at_install", "post_install")
+class TestCloseWebsocketAfterTour(WebsocketCase):
+    @patch("odoo.tests.common.ChromeBrowser")
+    def test_ensure_websocket_closed_after_tour(self, mocked_brower_class):
+        """Sometimes, Chrome does not close the WebSocket connections properly after
+        calling `HttpCase@_browser_js`. In such cases, the WebSocket connection
+        remains open and can interfere with the test cursor, leading to
+        concurrency errors. To resolve this issue, `HttpCase@_browser_js` ensures
+        that the WebSocket connections are properly cleaned up. This test ensures
+        that this behavior is reliable.
+        """
+        websocket_created = False
+
+        def navigate_to_side_effect(*args, **kwargs):
+            self.websocket_connect()
+            self.assertEqual(len(websocket_module._websocket_instances), 1)
+            nonlocal websocket_created
+            websocket_created = True
+
+        # Open a socket that won't be closed when calling browser.close()
+        mocked_brower_class.return_value.navigate_to.side_effect = navigate_to_side_effect
+
+        with patch.object(websocket_module, "_websocket_instances", WeakSet()):
+            self.browser_js("/odoo", "")
+            self.assertTrue(websocket_created)
+            # serve_forever_patch prevent websocket instances from being collected. Stop it now.
+            self._serve_forever_patch.stop()
+            gc.collect()
+            self.assertEqual(len(websocket_module._websocket_instances), 0)

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -15,7 +15,9 @@ import time
 from collections import defaultdict, deque
 from contextlib import closing, suppress
 from enum import IntEnum
+from itertools import count
 from psycopg2.pool import PoolError
+from queue import PriorityQueue
 from urllib.parse import urlparse
 from weakref import WeakSet
 
@@ -121,6 +123,27 @@ class RateLimitExceededException(Exception):
     """
 
 
+# Idea taken from the python cookbook:
+# https://github.com/dabeaz/python-cookbook/blob/6e46b7/src/12/polling_multiple_thread_queues/pqueue.py
+class PollablePriorityQueue(PriorityQueue):
+    """A custom PriorityQueue than can be polled"""
+
+    def __init__(self, maxsize=0):
+        super().__init__(maxsize)
+        self._putsocket, self._getsocket = socket.socketpair()
+
+    def fileno(self):
+        return self._getsocket.fileno()
+
+    def put(self, item, *args, **kwargs):
+        super().put(item, *args, **kwargs)
+        self._putsocket.send(b'.')
+
+    def get(self, *args, **kwargs):
+        self._getsocket.recv(1)
+        return super().get(*args, **kwargs)
+
+
 # ------------------------------------------------------
 # WEBSOCKET LIFECYCLE
 # ------------------------------------------------------
@@ -167,6 +190,16 @@ class ConnectionState(IntEnum):
     OPEN = 0
     CLOSING = 1
     CLOSED = 2
+
+
+# Used to maintain order of commands in the queue according to their priority
+# (IntEnum) and then the order of reception.
+_command_uid = count(0)
+
+
+class ControlCommand(IntEnum):
+    CLOSE = 0
+    DISPATCH = 1
 
 
 DATA_OP = {Opcode.TEXT, Opcode.BINARY}
@@ -268,9 +301,10 @@ class Websocket:
         self._timeout_manager = TimeoutManager()
         # Used for rate limiting.
         self._incoming_frame_timestamps = deque(maxlen=self.RL_BURST)
-        # Used to notify the websocket that bus notifications are
-        # available.
-        self.__notif_sock_w, self.__notif_sock_r = socket.socketpair()
+        # Command queue used to manage the websocket instance externally, such
+        # as triggering notification dispatching or terminating the connection.
+        self.__cmd_queue = PollablePriorityQueue()
+        self._waiting_for_dispatch = False
         self._channels = set()
         # For ``_last_notif_sent_id and ``_notif_history``, see
         # ``MAX_NOTIFICATION_HISTORY_SEC`` for more details.
@@ -286,7 +320,7 @@ class Websocket:
             else selectors.DefaultSelector()
         )
         self.__selector.register(self.__socket, selectors.EVENT_READ)
-        self.__selector.register(self.__notif_sock_r, selectors.EVENT_READ)
+        self.__selector.register(self.__cmd_queue, selectors.EVENT_READ)
         self.state = ConnectionState.OPEN
         _websocket_instances.add(self)
         self._trigger_lifecycle_event(LifecycleEvent.OPEN)
@@ -303,7 +337,7 @@ class Websocket:
                     self.__selector.select(self.INACTIVITY_TIMEOUT)
                 }
                 if self._timeout_manager.has_timed_out() and self.state is ConnectionState.OPEN:
-                    self.disconnect(
+                    self._disconnect(
                         CloseCode.ABNORMAL_CLOSURE
                         if self._timeout_manager.timeout_reason is TimeoutReason.NO_RESPONSE
                         else CloseCode.KEEP_ALIVE_TIMEOUT
@@ -312,8 +346,11 @@ class Websocket:
                 if not readables:
                     self._send_ping_frame()
                     continue
-                if self.__notif_sock_r in readables:
-                    self._dispatch_bus_notifications()
+                if self.__cmd_queue in readables:
+                    cmd, _, data = self.__cmd_queue.get_nowait()
+                    self._process_control_command(cmd, data)
+                    if self.state is ConnectionState.CLOSED:
+                        continue
                 if self.__socket in readables:
                     message = self._process_next_message()
                     if message is not None:
@@ -321,19 +358,11 @@ class Websocket:
             except Exception as exc:
                 self._handle_transport_error(exc)
 
-    def disconnect(self, code, reason=None):
+    def close(self, code, reason=None):
+        """Notify the socket to initiate closure. The closing handshake
+        will start in the subsequent iteration of the event loop.
         """
-        Initiate the closing handshake that is, send a close frame
-        to the other end which will then send us back an
-        acknowledgment. Upon the reception of this acknowledgment,
-        the `_terminate` method will be called to perform an
-        orderly shutdown. Note that we don't need to wait for the
-        acknowledgment if the connection was failed beforewards.
-        """
-        if code is not CloseCode.ABNORMAL_CLOSURE:
-            self._send_close_frame(code, reason)
-        else:
-            self._terminate()
+        self._send_control_command(ControlCommand.CLOSE, {'code': code, 'reason': reason})
 
     @classmethod
     def onopen(cls, func):
@@ -361,15 +390,10 @@ class Websocket:
         dispatch is already planned or if the socket is already in the
         closing state.
         """
-        if self.state is not ConnectionState.OPEN:
+        if self.state is not ConnectionState.OPEN or self._waiting_for_dispatch:
             return
-        readables = {
-            selector_key[0].fileobj for selector_key in
-            self.__selector.select(0)
-        }
-        if self.__notif_sock_r not in readables:
-            # Send a random bit to mark the socket as readable.
-            self.__notif_sock_w.send(b'x')
+        self._waiting_for_dispatch = True
+        self._send_control_command(ControlCommand.DISPATCH)
 
     # ------------------------------------------------------
     # PRIVATE METHODS
@@ -549,7 +573,7 @@ class Websocket:
             return self._terminate()
         # After sending a control frame indicating the connection
         # should be closed, a peer does not send any further data.
-        self.__selector.unregister(self.__notif_sock_r)
+        self.__selector.unregister(self.__cmd_queue)
 
     def _send_close_frame(self, code, reason=None):
         """ Send a close frame. """
@@ -563,6 +587,19 @@ class Websocket:
         """ Send a pong frame """
         self._send_frame(Frame(Opcode.PONG, payload))
 
+    def _disconnect(self, code, reason=None):
+        """Initiate the closing handshake. Once the acknowledgment is received,
+        `self._terminate` will be invoked to execute a graceful shutdown of the
+        TCP connection. If the connection is already dead, skip the handshake
+        and terminate immediately. This is a low level method, meant to be
+        called from the WebSocket event loop. To close the connection, use
+        `self.close`.
+        """
+        if code is CloseCode.ABNORMAL_CLOSURE:
+            self._terminate()
+        else:
+            self._send_close_frame(code, reason)
+
     def _terminate(self):
         """ Close the underlying TCP socket. """
         with suppress(OSError, TimeoutError):
@@ -574,7 +611,8 @@ class Websocket:
             self.__socket.settimeout(1)
             while self.__socket.recv(4096):
                 pass
-        self.__selector.unregister(self.__socket)
+        with suppress(KeyError):
+            self.__selector.unregister(self.__socket)
         self.__selector.close()
         self.__socket.close()
         self.state = ConnectionState.CLOSED
@@ -604,7 +642,7 @@ class Websocket:
     def _handle_transport_error(self, exc):
         """
         Find out which close code should be sent according to given
-        exception and call `self.disconnect` in order to close the
+        exception and call `self._disconnect` in order to close the
         connection cleanly.
         """
         code, reason = CloseCode.SERVER_ERROR, str(exc)
@@ -629,7 +667,7 @@ class Websocket:
                 _logger.warning("Bus operation aborted; registry has been reloaded")
             else:
                 _logger.error(exc, exc_info=True)
-        self.disconnect(code, reason)
+        self._disconnect(code, reason)
 
     def _limit_rate(self):
         """
@@ -666,6 +704,26 @@ class Websocket:
                         exc_info=True
                     )
 
+    def _send_control_command(self, command, data=None):
+        """Send a command to the websocket event loop.
+
+        :param ControlCommand command: The command to be executed.
+        :param dict | None data: An optional dictionary of parameters.
+        """
+        self.__cmd_queue.put((command, next(_command_uid), data))
+
+    def _process_control_command(self, command, data):
+        """Process a command received in `self.__cmd_queue`.
+
+        :param ControlCommand command: The command to be executed. This key is required.
+        :param dict | None data: An optional dictionary of parameters.
+        """
+        match command:
+            case ControlCommand.DISPATCH:
+                self._dispatch_bus_notifications()
+            case ControlCommand.CLOSE:
+                self._disconnect(data['code'], data.get('reason'))
+
     def _dispatch_bus_notifications(self):
         """
         Dispatch notifications related to the registered channels. If
@@ -676,12 +734,12 @@ class Websocket:
         session = root.session_store.get(self._session.sid)
         if not session:
             raise SessionExpiredException()
+         # Mark the notification request as processed.
+        self._waiting_for_dispatch = False
         with acquire_cursor(session.db) as cr:
             env = self.new_env(cr, session)
             if session.uid is not None and not check_session(session, env):
                 raise SessionExpiredException()
-            # Mark the notification request as processed.
-            self.__notif_sock_r.recv(1)
             notifications = env["bus.bus"]._poll(
                 self._channels, self._last_notif_sent_id, [n[0] for n in self._notif_history]
             )
@@ -1040,15 +1098,15 @@ class WebsocketConnectionHandler:
             # reconnect, preventing old workers from lingering after updates.
             # Non browsers are ignored since IOT devices do not provide the
             # worker version.
-            websocket.disconnect(CloseCode.CLEAN, "OUTDATED_VERSION")
+            websocket.close(CloseCode.CLEAN, "OUTDATED_VERSION")
         for message in websocket.get_messages():
             with WebsocketRequest(db, httprequest, websocket) as req:
                 try:
                     req.serve_websocket_message(message)
                 except SessionExpiredException:
-                    websocket.disconnect(CloseCode.SESSION_EXPIRED)
+                    websocket.close(CloseCode.SESSION_EXPIRED)
                 except PoolError:
-                    websocket.disconnect(CloseCode.TRY_LATER)
+                    websocket.close(CloseCode.TRY_LATER)
                 except Exception:
                     _logger.exception("Exception occurred during websocket request handling")
 
@@ -1057,7 +1115,7 @@ def _kick_all():
     """ Disconnect all the websocket instances. """
     for websocket in _websocket_instances:
         if websocket.state is ConnectionState.OPEN:
-            websocket.disconnect(CloseCode.GOING_AWAY)
+            websocket.close(CloseCode.GOING_AWAY)
 
 
 CommonServer.on_stop(_kick_all)

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -19,9 +19,17 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
                 }
                 document.body.classList.add("o_discuss_channel_public_modules_loaded");
                 if (
-                    document.title !== document.querySelector(".o-mail-Discuss-threadName")?.value
+                    !document.title.includes(
+                        document.querySelector(".o-mail-Discuss-threadName")?.value
+                    )
                 ) {
-                    console.error("Tab title should match conversation name.");
+                    console.error(
+                        `Tab title should match conversation name. Got "${
+                            document.title
+                        }" instead of "${
+                            document.querySelector(".o-mail-Discuss-threadName")?.value
+                        }".`
+                    );
                 }
             },
         },

--- a/addons/mail/tests/discuss/test_discuss_action.py
+++ b/addons/mail/tests/discuss/test_discuss_action.py
@@ -1,9 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.tests import HttpCase, tagged
+from odoo.addons.mail.tests.common import MailCommon
 
 
 @tagged("post_install", "-at_install", "discuss_action")
-class TestDiscussAction(HttpCase):
+class TestDiscussAction(HttpCase, MailCommon):
     def test_go_back_to_thread_from_breadcrumbs(self):
         self.start_tour(
             "/odoo/discuss?active_id=mail.box_inbox",
@@ -17,6 +18,7 @@ class TestDiscussAction(HttpCase):
         channel = self.env['discuss.channel'].with_user(inviting_user)._get_or_create_chat(partners_to=invited_user.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(
             lambda channel_member: channel_member.partner_id == inviting_user.partner_id)
+        self._reset_bus()
         channel_member._rtc_join_call()
         self.start_tour(
             f"/odoo/{channel.id}/action-mail.action_discuss?call=accept",

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -33,7 +33,6 @@ export class PosData extends Reactive {
         this.records = {};
         this.opts = new DataServiceOptions();
         this.channels = [];
-        this.onNotified = getOnNotified(this.bus, odoo.access_token);
 
         this.network = {
             warningTriggered: false,
@@ -42,6 +41,7 @@ export class PosData extends Reactive {
             unsyncData: [],
         };
 
+        this.initializeWebsocket();
         await this.intializeDataRelation();
         browser.addEventListener("online", () => {
             if (this.network.offline) {
@@ -59,9 +59,12 @@ export class PosData extends Reactive {
         this.bus.addEventListener("connect", this.reconnectWebSocket.bind(this));
     }
 
-    reconnectWebSocket() {
+    initializeWebsocket() {
         this.onNotified = getOnNotified(this.bus, odoo.access_token);
+    }
 
+    reconnectWebSocket() {
+        this.initializeWebsocket();
         const channels = [...this.channels];
         this.channels = [];
         while (channels.length) {

--- a/addons/pos_adyen/static/src/app/utils/payment/payment_adyen.js
+++ b/addons/pos_adyen/static/src/app/utils/payment/payment_adyen.js
@@ -238,18 +238,18 @@ export class PaymentAdyen extends PaymentInterface {
         // that will be resolved when the payment response is received.
         // In case this resolver is lost ( for example on a refresh ) we
         // we use the handlePaymentResponse method on the payment line
-        const resolver = this.paymentLineResolvers?.[line.uuid];
+        const resolver = this.paymentLineResolvers?.[line?.uuid];
         if (resolver) {
             resolver(isPaymentSuccessful);
         } else {
-            line.handlePaymentResponse(isPaymentSuccessful);
+            line?.handlePaymentResponse(isPaymentSuccessful);
         }
     }
     isPaymentSuccessful(notification, response) {
         return (
             notification &&
             notification.SaleToPOIResponse.MessageHeader.ServiceID ==
-                this.pendingAdyenline().terminalServiceId &&
+                this.pendingAdyenline()?.terminalServiceId &&
             response.Result === "Success"
         );
     }

--- a/addons/pos_adyen/static/tests/tours/adyen_tour.js
+++ b/addons/pos_adyen/static/tests/tours/adyen_tour.js
@@ -106,11 +106,6 @@ registry.category("web_tour.tours").add("PosAdyenTour", {
                     if (!resp.ok) {
                         throw new Error("Failed to notify Adyen webhook");
                     }
-                    // Normally, when the pos webhook controllers receives the notification from adyen,
-                    // the controller will notify the pos client via the bus, but
-                    // the bus is not working in tours, so we manually call the method that
-                    // would be called in the callback of the bus event
-                    payment_terminal.handleAdyenStatusResponse();
                 },
             },
 

--- a/addons/pos_self_order/static/src/app/services/data_service.js
+++ b/addons/pos_self_order/static/src/app/services/data_service.js
@@ -15,6 +15,9 @@ patch(PosData.prototype, {
     get databaseName() {
         return `self_order-config-id_${session.data.config_id}_${session.data.access_token}`;
     },
+    initializeWebsocket() {
+        return false;
+    },
     initIndexedDB() {
         return session.data.self_ordering_mode === "mobile"
             ? super.initIndexedDB(...arguments)

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -252,7 +252,12 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 trigger: messagesContain("I will transfer you to a human."),
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:enabled",
+                trigger:
+                    ".o-livechat-root:shadow .o-mail-NotificationMessage:contains(joined the channel)",
+            },
+            {
+                trigger:
+                    ".o-livechat-root:shadow .o-mail-NotificationMessage:contains(Testing Bot left the channel)",
             },
         ];
     },

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
@@ -20,7 +20,12 @@ registry.category("web_tour.tours").add("website_livechat.chatbot_forward", {
             trigger: messagesContain("I'll forward you to an operator."),
         },
         {
-            trigger: ".o-livechat-root:shadow .o-mail-Composer-input:enabled",
+            trigger:
+                ".o-livechat-root:shadow .o-mail-NotificationMessage:contains(joined the channel)",
+        },
+        {
+            trigger:
+                ".o-livechat-root:shadow .o-mail-NotificationMessage:contains(Forward Bot left the channel)",
         },
     ],
 });

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_fw_operator_matching_lang.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_fw_operator_matching_lang.js
@@ -12,7 +12,12 @@ registry.category("web_tour.tours").add("chatbot_fw_operator_matching_lang", {
             run: "click",
         },
         {
-            trigger: ".o-livechat-root:shadow .o-mail-Composer-input:enabled",
+            trigger:
+                ".o-livechat-root:shadow .o-mail-NotificationMessage:contains(joined the channel)",
+        },
+        {
+            trigger:
+                ".o-livechat-root:shadow .o-mail-NotificationMessage:contains(left the channel)",
         },
     ],
 });

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -260,7 +260,7 @@ class TestLivechatChatbotUI(TestGetOperatorCommon, TestWebsiteLivechatCommon, Ch
         )
         self.livechat_channel.user_ids = fr_op + en_op
         self.env["discuss.channel"].search([("livechat_channel_id", "=", self.livechat_channel.id)]).unlink()
-        self.start_tour("/fr", "chatbot_fw_operator_matching_lang", timeout=1e6)
+        self.start_tour("/fr", "chatbot_fw_operator_matching_lang")
         channel = self.livechat_channel.channel_ids[0]
         self.assertIn(channel.channel_member_ids.partner_id.user_ids, fr_op)
         self.assertNotIn(channel.channel_member_ids.partner_id.user_ids, en_op)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2034,7 +2034,29 @@ class HttpCase(TransactionCase):
             self._logger.warning('watch mode is only suitable for local testing')
 
         browser = ChromeBrowser(self, headless=not watch, success_signal=success_signal, debug=debug)
+        sendone_patch = None
+        websocket_allowed_patch = None
+        kick_all_websockets = None
         try:
+            if "bus.bus" in self.env.registry:
+                from odoo.addons.bus.websocket import CloseCode, _kick_all, WebsocketConnectionHandler
+                from odoo.addons.bus.models.bus import BusBus
+
+                kick_all_websockets = partial(_kick_all, CloseCode.KILL_NOW)
+                original_send_one = BusBus._sendone
+
+                def sendone_wrapper(self, target, notification_type, message):
+                    original_send_one(self, target, notification_type, message)
+                    self.env.cr.precommit.run()  # Trigger the creation of bus.bus records
+                    self.env.cr.postcommit.run()  # Trigger notification dispatching
+
+                sendone_patch = patch.object(BusBus, "_sendone", sendone_wrapper)
+                websocket_allowed_patch = patch.object(
+                    WebsocketConnectionHandler, "websocket_allowed", return_value=True
+                )
+                sendone_patch.start()
+                websocket_allowed_patch.start()
+
             self.authenticate(login, login, browser=browser)
             # Flush and clear the current transaction.  This is useful in case
             # we make requests to the server, as these requests are made with
@@ -2078,6 +2100,12 @@ class HttpCase(TransactionCase):
 
         finally:
             browser.stop()
+            if sendone_patch:
+                sendone_patch.stop()
+            if websocket_allowed_patch:
+                websocket_allowed_patch.stop()
+            if kick_all_websockets:
+                kick_all_websockets()
             self._wait_remaining_requests()
 
     def start_tour(self, url_path, tour_name, step_delay=None, **kwargs):


### PR DESCRIPTION
This PR aims to enable WebSocket functionality during tours. Applications that rely heavily on the bus, such as Discuss or POS, require the bus connection to be active to write relevant tests.

#### 1. Allow to close websockets from outside of the event loop

Previously, a socketpair was used to wake up the WebSocket event loop for notifications. This method is too restrictive, as it doesn't allow communication with the event loop in other scenarios. For example, the disconnect method is not thread-safe and should only be used in the WebSocket thread. However, situations like server shutdown or test
cleanup require closing WebSockets from outside the event loop thread.

This PR enhances communication with the WebSocket event loop:
- The `socketpair` is replaced by a pollable queue that allows controlling the WebSocket instances from outside of the event loop.
- Two control commands are available for now: `CLOSE` and `DISPATCH`. This approach allows for the future addition of more commands.
- The `disconnect` method is removed from the public API: This method is not thread-safe and should only be called from internal code running in the WebSocket thread.
- Expose the `close` method to the public API, which relies on the command queue to properly order disconnections from outside the WebSocket thread.

#### 2. Enable WebSocket during tours

During Python tests, only one cursor is used. RPCs and WebSocket use the `TestCursor` wrapper, which relies on a lock to prevent race conditions. WebSocket connections can be opened during tours, provided they are properly cleaned up afterward to avoid conflicts with the test cursor, which is not subject to any locking.  

This PR adapts the `Websocket` and `HttpCase` classes to enable WebSockets during tours.

Before this change, it was suspected that in rare cases a websocket connection could remain open after the test, the tests _wait_remaining_requests would wait but reach the time limit and continue. 
This corner case is tested with TestCloseWebsocketAfterTour. Websocket connections are cleanly killed at the end of each test to avoid this issue.

enterprise: https://github.com/odoo/enterprise/pull/75984