### PR TITLE
[FIX] account: resModel in OpenMoveWidget

### DIFF
--- a/addons/account/static/src/components/open_move_widget/open_move_widget.js
+++ b/addons/account/static/src/components/open_move_widget/open_move_widget.js
@@ -18,7 +18,7 @@ class OpenMoveWidget extends Component {
             type: "object",
             resId: this.props.record.resId,
             name: "action_open_business_doc",
-            resModel: "account.move.line",
+            resModel: this.props.record.resModel,
         });
     }
 }


### PR DESCRIPTION
The `OpenMoveWidget` was usually called from
an `account.move.line`, since https://github.com/odoo/enterprise/commit/6ec55979a79a959b0a7a784ceaa5cdc0b7854182
it is called from `account.move`.
With this commit, by using `this.props.record.resModel`, we allow
the model to be either `account.move` or `account.move.line`, any other
models would raise an error as there is no `action_open_business_doc`
defined in other models.

Steps:

- Install 'Accounting`
- Create an asset with passed depreciation entries and confirm it
- Go to 'Depreciation Board' tab
- Click on a posted entry name
-> We land on an other move (in fact, move that have the line with the
   same id as the depreciation move) or an error (non existing record)

opw-4357468
