### PR TITLE
[FIX] web: list: reset column widths after resize

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -203,7 +203,7 @@ export class ListRenderer extends Component {
             () => [this.state.columns, this.isEmpty, this.props.list.offset, this.props.list.limit]
         );
         useExternalListener(window, "resize", () => {
-            this.columnWidths = null;
+            this.keepColumnWidths = false;
             this.freezeColumnWidths();
         });
 
@@ -348,6 +348,10 @@ export class ListRenderer extends Component {
             // Set table layout auto and remove inline style to make sure that css
             // rules apply (e.g. fixed width of record selector)
             table.style.tableLayout = "auto";
+            if (this.rootWidthFixed) {
+                this.rootRef.el.style.width = null;
+            }
+            table.style.width = null;
             headers.forEach((th) => {
                 th.style.width = null;
                 th.style.maxWidth = null;
@@ -2013,6 +2017,7 @@ export class ListRenderer extends Component {
 
         // fix the width so that if the resize overflows, it doesn't affect the layout of the parent
         if (!this.rootRef.el.style.width) {
+            this.rootWidthFixed = true;
             this.rootRef.el.style.width = `${Math.floor(
                 this.rootRef.el.getBoundingClientRect().width
             )}px`;

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -17588,6 +17588,35 @@ QUnit.module("Views", (hooks) => {
         );
     });
 
+    QUnit.test("list: resize column, then resize window", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `
+                <tree>
+                    <field name="foo"/>
+                    <field name="int_field"/>
+                </tree>`,
+        });
+
+        // 1. Resize column foo to middle of column int_field.
+        const th2 = target.querySelector("th:nth-child(2)");
+        const th3 = target.querySelector("th:nth-child(3)");
+        const resizeHandle = th2.querySelector(".o_resize");
+
+        await dragAndDrop(resizeHandle, th3);
+
+        // 2. Simulate a window resize
+        const currentWidth = target.getBoundingClientRect().width;
+        target.style.width = currentWidth / 2 + "px";
+        window.dispatchEvent(new Event("resize"));
+        await nextTick();
+
+        const tableWidth = target.querySelector(".o_list_table").getBoundingClientRect().width;
+        assert.strictEqual(tableWidth, currentWidth / 2);
+    });
+
     QUnit.test("list: resize column and toggle check all", async function (assert) {
         await makeView({
             type: "list",
@@ -20944,7 +20973,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 3);
         assert.containsNone(target, ".o_group_header .o_pager");
     });
-    
+
     QUnit.test("open record, with invalid record in list", async function (assert) {
         // in this scenario, the record is already invalid in db, so we should be allowed to
         // leave it


### PR DESCRIPTION
In a list view, first manually resize a column. Doing so, the table can either overflow (if the column has been extended), or be smaller that the available space. Then, resize the page. Before this commit, the table kept is previous width, i.e. it could not benefit from the potential available space that came from resizing the window. With this commit, we force the whole widths computation to be reset after a window resize.

opw~4318312

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
