### PR TITLE
[FIX] mail, loyalty: cascade mail template if model used in temp is uninstalled

### DIFF
--- a/addons/loyalty/models/loyalty_mail.py
+++ b/addons/loyalty/models/loyalty_mail.py
@@ -17,4 +17,4 @@ class LoyaltyMail(models.Model):
         ('points_reach', 'When Reaching')], string='When', required=True
     )
     points = fields.Float()
-    mail_template_id = fields.Many2one('mail.template', string="Email Template", required=True, domain=[('model', '=', 'loyalty.card')])
+    mail_template_id = fields.Many2one('mail.template', string="Email Template", required=True, domain=[('model', '=', 'loyalty.card')], ondelete='cascade')

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -41,7 +41,7 @@ class MailTemplate(models.Model):
          ('hidden_template', 'Hidden Template'),
          ('custom_template', 'Custom Template')],
          compute="_compute_template_category", search="_search_template_category")
-    model_id = fields.Many2one('ir.model', 'Applies to')
+    model_id = fields.Many2one('ir.model', 'Applies to', ondelete='cascade')
     model = fields.Char('Related Document Model', related='model_id.model', index=True, store=True, readonly=True)
     subject = fields.Char('Subject', translate=True, prefetch=True, help="Subject (placeholders may be used here)")
     email_from = fields.Char('From',


### PR DESCRIPTION
A traceback error occurs when the user uninstalls the model used in the mail template 
referenced in the loyalty program.

To reproduce this issue:

1) Install `sale`, `stock`, and enable `loyalty` from settings 
2) Create a new loyalty record from `sale/product/discount & Loyalty` 
3) Set program type as `loyalty cards` and add `mail template` from `communication`
4) Open the selected mail template and change the model to the `stock lot` 
5) Now uninstall the stock module and open the above loyalty record 
6) From the `Loyalty Cards` stat button create a record with a partner

Error:- 
```
KeyError: False
```

We used the `stock lot` in the mail template. However, when the user uninstalls 
the `stock` module, the value of `model_id` will be set to `False` in that mail template, 
which leads to the traceback mentioned above from the code below.

https://github.com/odoo/odoo/blob/28815810d9835772aa2fbe72339360f0771634a9/addons/mail/models/mail_template.py#L574-L575

We can resolve this issue by applying `ondelete` equals to `cascade` on `model_id` and 
`template_id` of the `mail_template` and the `loyalty_mail` respectively. 

As the model is deleted, `mail template` and `loyalty mail` must also deleted

Note:- 
We already solved a similar type issue from this PR https://github.com/odoo/odoo/pull/180307

sentry-6088927895

