### PR TITLE
[IMP] base_automation,mail: support dynamic followers actions

### DIFF
--- a/addons/base_automation/models/ir_actions_server.py
+++ b/addons/base_automation/models/ir_actions_server.py
@@ -37,7 +37,7 @@ class IrActionsServer(models.Model):
             rule_model = action.base_automation_id.model_id
             action.available_model_ids = rule_model.ids if rule_model in action.available_model_ids else []
 
-    @api.depends('state', 'update_field_id', 'crud_model_id', 'value', 'evaluation_type', 'template_id', 'partner_ids', 'activity_summary', 'sms_template_id', 'webhook_url')
+    @api.depends('state', 'update_field_id', 'crud_model_id', 'value', 'evaluation_type', 'template_id', 'partner_ids', 'activity_summary', 'sms_template_id', 'webhook_url', 'followers_type', 'followers_partner_field_name')
     def _compute_name(self):
         ''' Only server actions linked to a base_automation get an automatic name. '''
         to_update = self.filtered('base_automation_id')
@@ -65,15 +65,27 @@ class IrActionsServer(models.Model):
                         template_name=action.template_id.name
                     )
                 case 'followers':
-                    action.name = _(
-                        'Add followers: %(partner_names)s',
-                        partner_names=', '.join(action.partner_ids.mapped('name'))
-                    )
+                    if action.followers_type == 'generic':
+                        action.name = _(
+                            'Add followers based on field: %(field_name)s',
+                            field_name=action.followers_partner_field_name
+                        )
+                    else:
+                        action.name = _(
+                            'Add followers: %(partner_names)s',
+                            partner_names=', '.join(action.partner_ids.mapped('name'))
+                        )
                 case 'remove_followers':
-                    action.name = _(
-                        'Remove followers: %(partner_names)s',
-                        partner_names=', '.join(action.partner_ids.mapped('name'))
-                    )
+                    if action.followers_type == 'generic':
+                        action.name = _(
+                            'Remove followers based on field: %(field_name)s',
+                            field_name=action.followers_partner_field_name
+                        )
+                    else:
+                        action.name = _(
+                            'Remove followers: %(partner_names)s',
+                            partner_names=', '.join(action.partner_ids.mapped('name'))
+                        )
                 case 'next_activity':
                     action.name = _(
                         'Create activity: %(activity_name)s',

--- a/addons/mail/views/ir_actions_server_views.xml
+++ b/addons/mail/views/ir_actions_server_views.xml
@@ -26,14 +26,23 @@
                     <field name="activity_note" class="oe-bordered-editor" placeholder="Add a description to your activity..." invisible="state != 'next_activity'"/>
                 </xpath>
                 <xpath expr="//field[@name='link_field_id']" position="after">
+                    <!-- Add/Remove Followers -->
+                    <field name="followers_type"
+                           invisible="state not in ['followers', 'remove_followers']"
+                           required="state in ['followers', 'remove_followers']"/>
                     <field name="partner_ids" string="Followers to add" widget="many2many_tags"
-                           placeholder="Choose a user..."
-                           invisible="state != 'followers'"
-                           required="state == 'followers'"/>
+                           placeholder="Choose a contact..."
+                           invisible="state != 'followers' or followers_type != 'specific'"
+                           required="state == 'followers' and followers_type == 'specific'"/>
                     <field name="partner_ids" string="Followers to remove" widget="many2many_tags"
-                           placeholder="Choose a user..."
-                           invisible="state != 'remove_followers'"
-                           required="state == 'remove_followers'"/>
+                           placeholder="Choose a contact..."
+                           invisible="state != 'remove_followers' or followers_type != 'specific'"
+                           required="state == 'remove_followers' and followers_type == 'specific'"/>
+                    <field name="followers_partner_field_name"
+                           placeholder="e.g. partner_id"
+                           invisible="state not in ['followers', 'remove_followers'] or followers_type != 'generic'"
+                           required="state in ['followers', 'remove_followers'] and followers_type == 'generic'"/>
+                    <!-- Send Email -->
                     <field name="template_id"
                            placeholder="Choose a template..."
                            invisible="state != 'mail_post'"

--- a/addons/test_base_automation/models/test_base_automation.py
+++ b/addons/test_base_automation/models/test_base_automation.py
@@ -61,6 +61,7 @@ class BaseAutomationLeadThreadTest(models.Model):
     _description = "Automated Rule Test With Thread"
     _inherit = ['base.automation.lead.test', 'mail.thread']
 
+    user_id = fields.Many2one("res.users")
 
 class BaseAutomationLineTest(models.Model):
     _name = 'base.automation.line.test'

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -926,6 +926,38 @@ if env.context.get('old_values', None):  # on write
         self.assertEqual(len(copy_action_ids), len(action_ids))
         self.assertNotEqual(copy_action_ids, action_ids)
 
+    def test_add_followers_1(self):
+        create_automation(self,
+            model_id=self.env["ir.model"]._get("base.automation.lead.thread.test").id,
+            trigger="on_create",
+            _actions={
+                "state": "followers",
+                "followers_type": "generic",
+                "followers_partner_field_name": "user_id.partner_id"
+            }
+        )
+        user = self.env["res.users"].create({"login": "maggot_brain", "name": "Eddie Hazel"})
+        thread_test = self.env["base.automation.lead.thread.test"].create({
+            "name": "free your mind",
+            "user_id": user.id,
+        })
+        self.assertEqual(thread_test.message_follower_ids.partner_id, user.partner_id)
+
+    def test_add_followers_2(self):
+        user = self.env["res.users"].create({"login": "maggot_brain", "name": "Eddie Hazel"})
+        create_automation(self,
+            model_id=self.env["ir.model"]._get("base.automation.lead.thread.test").id,
+            trigger="on_create",
+            _actions={
+                "state": "followers",
+                "followers_type": "specific",
+                "partner_ids": [Command.link(user.partner_id.id)]
+            }
+        )
+        thread_test = self.env["base.automation.lead.thread.test"].create({
+            "name": "free your mind",
+        })
+        self.assertEqual(thread_test.message_follower_ids.partner_id, user.partner_id)
 
 @common.tagged('post_install', '-at_install')
 class TestCompute(common.TransactionCase):


### PR DESCRIPTION
Before:
- "Add/Remove Followers" server actions type can only use a fixed list of partners to add/remove

After:
- one can now choose a related record's field to get the followers to add/remove dynamically.

opw-4381183