### PR TITLE
[FIX] iap: raising exception for not enough credits in iap

### DIFF
--- a/addons/iap/i18n/iap.pot
+++ b/addons/iap/i18n/iap.pot
@@ -153,6 +153,12 @@ msgid ""
 msgstr ""
 
 #. module: iap
+#. odoo-python
+#: code:addons/iap/tools/iap_tools.py:0
+msgid "It appears that your IAP (In-App Purchase) account does not have enough credit to complete this action. This may be due to an unregistered account or insufficient funds."
+msgstr ""
+
+#. module: iap
 #. odoo-javascript
 #: code:addons/iap/static/src/action_buttons_widget/action_buttons_widget.xml:0
 #: code:addons/iap/static/src/xml/iap_templates.xml:0

--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -154,6 +154,10 @@ def iap_jsonrpc(url, method='call', params=None, timeout=15):
             e.data = response['error']['data']
             raise e
         return response.get('result')
+    except (InsufficientCreditError):
+        raise exceptions.UserError(
+            _("It appears that your IAP (In-App Purchase) account does not have enough credit to complete this action. This may be due to an unregistered account or insufficient funds.")
+        )
     except (ValueError, requests.exceptions.ConnectionError, requests.exceptions.MissingSchema, requests.exceptions.Timeout, requests.exceptions.HTTPError):
         _logger.exception("iap jsonrpc %s failed", url)
         raise exceptions.AccessError(


### PR DESCRIPTION
Currently a `InsufficientCreditError` is arising when user don't have an IAP
 account registered for this service or have insufficient credits.

Error: `InsufficientCreditError: {"title": "Insufficient Balance", "message": "You don't have an IAP account registered for this service.", "base_url": "https://iap.odoo.com/iap/1/credit/", "service_name": "l10n_br_avatax_proxy", "credit": 1, "trial": true}`

This commit solves the above issue by raising the exception when the user does not have sufficient credits.

sentry-5724094438