### PR TITLE
[FIX] base: decorate api key create method

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -2473,6 +2473,7 @@ class APIKeyDescription(models.TransientModel):
             }
             return {'warning': warning}
 
+    @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)
         self.env['res.users.apikeys']._check_expiration_date(res.expiration_date)

--- a/odoo/addons/base/tests/test_xmlrpc.py
+++ b/odoo/addons/base/tests/test_xmlrpc.py
@@ -12,6 +12,7 @@ import odoo.tools
 from odoo.tests import common
 from odoo.service import common as auth, model
 from odoo.tools import DotDict
+from odoo.api import call_kw
 
 
 @common.tagged('post_install', '-at_install')
@@ -222,6 +223,14 @@ class TestAPIKeys(common.HttpCase):
             'res.users', 'context_get', []
         ])
         self.assertEqual(ctx['tz'], 'Australia/Eucla')
+
+        api_key = call_kw(
+            model=self.env['res.users.apikeys.description'],
+            name='create',
+            args=[{'name': 'Name of the key'}],
+            kwargs={}
+        )
+        self.assertTrue(isinstance(api_key, int))
 
     def test_delete(self):
         env = self.env(user=self._user)


### PR DESCRIPTION
Reproduce
---
- tick "Customers can generate API Keys" in settings
- login as portal user
- Connection & Security -> New API key -> give name -> Confirm ->BUG

```
TypeError: APIKeyDescription.create() missing 1 required positional argument: 'vals_list'
```

opw-4385632
