### PR TITLE
[FIX] web, web_editor, html_editor, hr_expense: show name in file viewer

### DIFF
--- a/addons/hr_expense/static/src/views/expense_line_widget.js
+++ b/addons/hr_expense/static/src/views/expense_line_widget.js
@@ -42,7 +42,7 @@ export class ExpenseLinesKanbanRecord extends KanbanRecord {
         const files = attachments.map((attachment, index) => ({
             isImage: true,
             isViewable: true,
-            displayName: expenseName + ` (${index + 1})`,
+            name: expenseName + ` (${index + 1})`,
             defaultSource: attachment,
             downloadUrl: attachment,
         }));

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -244,7 +244,7 @@ export class ImagePlugin extends Plugin {
         const fileModel = {
             isImage: true,
             isViewable: true,
-            displayName: selectedImg.src,
+            name: selectedImg.src,
             defaultSource: selectedImg.src,
             downloadUrl: selectedImg.src,
         };

--- a/addons/web/static/src/core/file_viewer/file_viewer.js
+++ b/addons/web/static/src/core/file_viewer/file_viewer.js
@@ -4,7 +4,7 @@ import { hidePDFJSButtons } from "@web/core/utils/pdfjs";
 
 /**
  * @typedef {Object} File
- * @property {string} displayName
+ * @property {string} name
  * @property {string} downloadUrl
  * @property {boolean} [isImage]
  * @property {boolean} [isPdf]

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1653,7 +1653,7 @@ export class Wysiwyg extends Component {
                 files: [{
                         isImage: true,
                         isViewable: true,
-                        displayName: url,
+                        name: url,
                         defaultSource: url,
                         downloadUrl: url,
                 }],


### PR DESCRIPTION
Since commit [1], the property `displayName` was removed from attachments, in favor of `name`. However, in several instances, a file viewer was instanciated with files using `displayName` rather than `name`, resulting in their name not showing in the file viewer.

[1]: https://github.com/odoo/odoo/commit/9192d5a6a0c296f4f75fa6eaa3fa9493bf69715e

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
