### PR TITLE
[FIX] web: list: reset column widths after resize

### DIFF
--- a/addons/web/static/src/views/list/column_width_hook.js
+++ b/addons/web/static/src/views/list/column_width_hook.js
@@ -255,6 +255,7 @@ export function useMagicColumnWidths(tableRef, getState) {
     let columnWidths = null;
     let allowedWidth = 0;
     let hasAlwaysBeenEmpty = true;
+    let parentWidthFixed = false;
     let hash;
     let _resizing = false;
 
@@ -316,8 +317,11 @@ export function useMagicColumnWidths(tableRef, getState) {
      */
     function resetWidths() {
         columnWidths = null;
-        // Unset width that might have been set on the table by resizing a column
+        // Unset widths that might have been set on the table by resizing a column
         tableRef.el.style.width = null;
+        if (parentWidthFixed) {
+            tableRef.el.parentElement.style.width = null;
+        }
     }
 
     /**
@@ -343,6 +347,7 @@ export function useMagicColumnWidths(tableRef, getState) {
 
         // Fix the width so that if the resize overflows, it doesn't affect the layout of the parent
         if (!table.parentElement.style.width) {
+            parentWidthFixed = true;
             table.parentElement.style.width = `${Math.floor(
                 table.parentElement.getBoundingClientRect().width
             )}px`;

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -1306,6 +1306,41 @@ test(`resize column and toggle one checkbox`, async () => {
     });
 });
 
+test(`resize column, then resize window`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <tree>
+                <field name="int_field"/>
+                <field name="foo"/>
+            </tree>
+        `,
+    });
+
+    expect(getColumnWidths()).toEqual([40, 80, 680]);
+
+    // Resize column foo to middle of column int_field.
+    await contains(`th:eq(1) .o_resize`, { visible: false }).dragAndDrop(`th:eq(2)`);
+    expect(getColumnWidths()).toEqual([40, 520, 679]);
+
+    // Resize the window
+    resize({ width: 1200 });
+    await runAllTimers();
+    await animationFrame();
+    expect(getColumnWidths()).toEqual([40, 80, 1080]); // all available space should be used again
+
+    // Reduce size of column foo
+    await contains(`th:eq(2) .o_resize`, { visible: false }).dragAndDrop(`th:eq(2)`);
+    expect(getColumnWidths()).toEqual([40, 80, 591]);
+
+    // Resize the window
+    resize({ width: 1000 });
+    await runAllTimers();
+    await animationFrame();
+    expect(getColumnWidths()).toEqual([40, 80, 880]); // all available space should be used again
+});
+
 test(`resize column and toggle check all`, async () => {
     await mountView({
         resModel: "foo",


### PR DESCRIPTION
In a list view, first manually resize a column. Doing so, the table can either overflow (if the column has been extended), or be smaller that the available space. Then, resize the page. Before this commit, the table kept is previous width, i.e. it could not benefit from the potential available space that came from resizing the window. With this commit, we force the whole widths computation to be reset after a window resize.

Followup of https://github.com/odoo/odoo/pull/170511

opw~4318312
task~4221195

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
