### PR TITLE
[IMP] point_of_sale: automatically create DateTime object for field

### DIFF
--- a/addons/point_of_sale/models/pos_preset.py
+++ b/addons/point_of_sale/models/pos_preset.py
@@ -92,7 +92,6 @@ class PosPreset(models.Model):
                         'periode': attendance_id.day_period,
                         'datetime': start,
                         'sql_datetime': start.strftime("%Y-%m-%d %H:%M:%S"),
-                        'humain_readable': start.strftime("%H:%M"),
                     }
                     start += interval
 

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -170,7 +170,7 @@ export class Navbar extends Component {
                 await this.pos.selectPreset(this.pos.models["pos.preset"].get(data.presetId));
             }
 
-            order.preset_time = data.slot.sql_datetime;
+            order.preset_time = data.slot.datetime;
             if (data.slot.datetime > DateTime.now()) {
                 this.pos.addPendingOrder([order.id]);
                 await this.pos.syncAllOrders();

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -62,10 +62,9 @@ export class ClosePosPopup extends Component {
     }
     get orderForNextDays() {
         const today = DateTime.now();
-        return this.pos.models["pos.order"].filter((o) => {
-            const presetTime = DateTime.fromSQL(o.preset_time);
-            return o.lines.length > 0 && presetTime > today && o.state === "draft";
-        }).length;
+        return this.pos.models["pos.order"].filter(
+            (o) => o.lines.length > 0 && o.preset_time > today && o.state === "draft"
+        ).length;
     }
     async cashMove() {
         await this.pos.cashMove();

--- a/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.js
@@ -17,9 +17,9 @@ export class PresetSlotsPopup extends Component {
         this.pos = usePos();
         this.state = useState({
             selectedPresetId: this.pos.getOrder().preset_id.id,
-            selectedDate: DateTime.fromSQL(
-                this.pos.getOrder().preset_time || DateTime.now().toSQL()
-            ).toFormat("yyyy-MM-dd"),
+            selectedDate: (this.pos.getOrder().preset_time || DateTime.now()).toFormat(
+                "yyyy-MM-dd"
+            ),
         });
 
         onWillStart(async () => {
@@ -34,9 +34,9 @@ export class PresetSlotsPopup extends Component {
     }
 
     getSlotColor(slot, preset) {
-        const isSelected = this.isSelected(slot.sql_datetime, preset);
+        const isSelected = this.isSelected(slot, preset);
         const isFull = slot.isFull;
-        const isPast = DateTime.fromSQL(slot.sql_datetime) < DateTime.now();
+        const isPast = slot.datetime < DateTime.now();
 
         if (!isSelected && isFull) {
             return "o_colorlist_item_color_transparent_1"; // Red
@@ -49,9 +49,9 @@ export class PresetSlotsPopup extends Component {
             : "o_colorlist_item_color_transparent_10"; // Green
     }
 
-    isSelected(time, preset) {
+    isSelected(slot, preset) {
         const order = this.pos.getOrder();
-        return order.preset_time === time && order.preset_id?.id === preset.id;
+        return order.preset_time.ts === slot.datetime.ts && order.preset_id?.id === preset.id;
     }
 
     getSlotsForDate(preset, date) {

--- a/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.xml
@@ -41,7 +41,7 @@
                                         class="btn"
                                         t-attf-class="{{getSlotColor(slot, preset)}}"
                                         t-on-click="() => this.confirm(slot, preset)">
-                                            <span t-esc="slot.humain_readable" />
+                                            <span t-esc="slot.datetime.toFormat('HH:mm')" />
                                     </button>
                                 </div>
                             </div>

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 import { Base } from "./related_models";
 import { _t } from "@web/core/l10n/translation";
-import { serializeDateTime } from "@web/core/l10n/dates";
 import { random5Chars, uuidv4 } from "@point_of_sale/utils";
 import { floatIsZero, roundPrecision } from "@web/core/utils/numbers";
 import { computeComboItems } from "./utils/compute_combo_items";
@@ -22,9 +21,7 @@ export class PosOrder extends Base {
         }
 
         // Data present in python model
-        this.date_order = vals.date_order || serializeDateTime(luxon.DateTime.now());
         this.to_invoice = vals.to_invoice || false;
-        this.shipping_date = vals.shipping_date || false;
         this.state = vals.state || "draft";
         this.uuid = vals.uuid ? vals.uuid : uuidv4();
         this.last_order_preparation_change = vals.last_order_preparation_change
@@ -39,6 +36,10 @@ export class PosOrder extends Base {
         this.internal_note = vals.internal_note || "";
         if (!vals.lines) {
             this.lines = [];
+        }
+
+        if (!this.date_order) {
+            this.date_order = DateTime.now();
         }
 
         // !!Keep all uiState in one object!!
@@ -98,8 +99,9 @@ export class PosOrder extends Base {
     }
 
     get presetTime() {
-        const dateTime = DateTime.fromSQL(this.preset_time);
-        return dateTime.isValid ? dateTime.toFormat("HH:mm") : false;
+        return this.preset_time && this.preset_time.isValid
+            ? this.preset_time.toFormat("HH:mm")
+            : false;
     }
 
     getEmailItems() {

--- a/addons/point_of_sale/static/src/app/models/pos_payment.js
+++ b/addons/point_of_sale/static/src/app/models/pos_payment.js
@@ -1,6 +1,5 @@
 import { registry } from "@web/core/registry";
 import { Base } from "./related_models";
-import { serializeDateTime } from "@web/core/l10n/dates";
 import { roundDecimals } from "@web/core/utils/numbers";
 import { uuidv4 } from "@point_of_sale/utils";
 
@@ -11,7 +10,7 @@ export class PosPayment extends Base {
 
     setup(vals) {
         super.setup(...arguments);
-        this.payment_date = serializeDateTime(DateTime.now());
+        this.payment_date = DateTime.now();
         this.uuid = vals.uuid ? vals.uuid : uuidv4();
         this.amount = vals.amount || 0;
         this.ticket = vals.ticket || "";

--- a/addons/point_of_sale/static/src/app/models/pos_preset.js
+++ b/addons/point_of_sale/static/src/app/models/pos_preset.js
@@ -108,8 +108,6 @@ export class PosPreset extends Base {
                         slots[date][sqlDatetime] = {
                             periode: attendance.day_period,
                             datetime: start,
-                            sql_datetime: sqlDatetime,
-                            humain_readable: start.toFormat("HH:mm"),
                             order_ids: new Set(usage[sqlDatetime] || []),
                         };
                     }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -75,8 +75,7 @@ export class ProductScreen extends Component {
                 this.currentOrder.preset_id &&
                 this.currentOrder.preset_time
             ) {
-                const orderDateTime = DateTime.fromSQL(this.currentOrder.preset_time);
-                if (orderDateTime > DateTime.now()) {
+                if (this.currentOrder.preset_time > DateTime.now()) {
                     this.pos.addPendingOrder([this.currentOrder.id]);
                     await this.pos.syncAllOrders();
                 }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
@@ -2,12 +2,9 @@ import { Component } from "@odoo/owl";
 import { Orderline } from "@point_of_sale/app/components/orderline/orderline";
 import { ReceiptHeader } from "@point_of_sale/app/screens/receipt_screen/receipt/receipt_header/receipt_header";
 import { OrderDisplay } from "@point_of_sale/app/components/order_display/order_display";
-import { parseUTCString, qrCodeSrc } from "@point_of_sale/utils";
+import { qrCodeSrc } from "@point_of_sale/utils";
 import { _t } from "@web/core/l10n/translation";
-import { formatDate, formatDateTime } from "@web/core/l10n/dates";
 import { formatCurrency } from "@web/core/currency";
-
-const { DateTime } = luxon;
 
 export class OrderReceipt extends Component {
     static template = "point_of_sale.OrderReceipt";
@@ -39,14 +36,6 @@ export class OrderReceipt extends Component {
             this.order.finalized &&
             qrCodeSrc(`${baseUrl}/pos/ticket/`)
         );
-    }
-
-    get formattedShippingDate() {
-        return formatDate(DateTime.fromSQL(this.order.shipping_date));
-    }
-
-    get orderDate() {
-        return formatDateTime(parseUTCString(this.order.date_order));
     }
 
     get paymentLines() {

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -128,7 +128,7 @@
             <t t-if="order.shipping_date">
                 <div class="pos-receipt-order-data">
                     Expected delivery:
-                    <div><t t-esc="formattedShippingDate" /></div>
+                    <div><t t-esc="order.formatDateOrTime('shipping_date')" /></div>
                 </div>
             </t>
 
@@ -136,7 +136,7 @@
             <div class="pos-receipt-order-data">
                 <p>Powered by Odoo</p>
                 <div t-esc="order.pos_reference" />
-                <div id="order-date" t-esc="orderDate" />
+                <div id="order-date" t-esc="order.formatDateOrTime('date_order')" />
             </div>
 
         </div>

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -20,7 +20,6 @@ import {
 } from "@point_of_sale/app/components/numpad/numpad";
 import { PosOrderLineRefund } from "@point_of_sale/app/models/pos_order_line_refund";
 import { fuzzyLookup } from "@web/core/utils/search";
-import { parseUTCString } from "@point_of_sale/utils";
 import { useTrackedAsync } from "@point_of_sale/app/hooks/hooks";
 import { OrderDisplay } from "@point_of_sale/app/components/order_display/order_display";
 
@@ -354,8 +353,8 @@ export class TicketScreen extends Component {
 
         const sortOrders = (orders, ascending = false) =>
             orders.sort((a, b) => {
-                const dateA = parseUTCString(a.date_order, "yyyy-MM-dd HH:mm:ss");
-                const dateB = parseUTCString(b.date_order, "yyyy-MM-dd HH:mm:ss");
+                const dateA = a.date_order;
+                const dateB = b.date_order;
 
                 if (a.date_order !== b.date_order) {
                     return ascending ? dateA - dateB : dateB - dateA;
@@ -380,7 +379,7 @@ export class TicketScreen extends Component {
         }
     }
     getDate(order) {
-        return formatDateTime(parseUTCString(order.date_order));
+        return formatDateTime(order.date_order);
     }
     getTotal(order) {
         return this.env.utils.formatCurrency(order.getTotalWithTax());
@@ -731,7 +730,7 @@ export class TicketScreen extends Component {
             .filter((orderInfo) => {
                 const order = this.pos.models["pos.order"].get(orderInfo[0]);
 
-                if (order && parseUTCString(orderInfo[1]) > parseUTCString(order.date_order)) {
+                if (order && parseDateTime(orderInfo[1]) > order.date_order) {
                     return true;
                 }
 

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -50,7 +50,7 @@
                                 <div class="order-row" t-att-class="{ 'highlight bg-primary text-white': isHighlighted(order) }"
                                     t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() => order.uiState.locked ? ()=>{} : this._setOrder(order)" >
                                     <div class="col wide p-2 ">
-                                        <div><t t-esc="getDate(order)"></t></div>
+                                        <div><t t-esc="order.formatDateOrTime('date_order')"></t></div>
                                     </div>
                                     <div class="col wide p-2">
                                         <div><t t-esc="order.getName()"></t></div>

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1518,12 +1518,7 @@ export class PosStore extends WithLazyGetterTrap {
     }
 
     async printReceipts(order, printer, title, lines, fullReceipt = false, diningModeUpdate) {
-        let time;
-        if (order.write_date) {
-            time = order.write_date?.split(" ")[1].split(":");
-            time = time[0] + "h" + time[1];
-        }
-
+        const time = order.write_date ? order.write_date?.toFormat("HH:mm") : false;
         const printingChanges = {
             table_name: order.table_id ? order.table_id.table_number : "",
             config_name: order.config_id.name,
@@ -1761,7 +1756,7 @@ export class PosStore extends WithLazyGetterTrap {
 
             if (preset.use_timing && !order.preset_time) {
                 await this.syncPresetSlotAvaibility(preset);
-                order.preset_time = preset.nextSlot?.sql_datetime || false;
+                order.preset_time = preset.nextSlot?.datetime || false;
             } else if (!preset.use_timing) {
                 order.preset_time = false;
             }

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -1,5 +1,3 @@
-import { parseDateTime } from "@web/core/l10n/dates";
-
 /*
  * comes from o_spreadsheet.js
  * https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
@@ -123,9 +121,6 @@ export function loadAllImages(el) {
 
     const images = el.querySelectorAll("img");
     return Promise.all(Array.from(images).map((img) => loadImage(img.src)));
-}
-export function parseUTCString(utcStr) {
-    return parseDateTime(utcStr, { format: "yyyy-MM-dd HH:mm:ss", tz: "utc" });
 }
 
 export class Counter {

--- a/addons/pos_self_order/static/src/app/components/slots_popup/slots_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/slots_popup/slots_popup.xml
@@ -16,7 +16,7 @@
                 </option>
                 <t t-foreach="slots" t-as="slot" t-key="slot_index">
                     <option t-att-value="slot[0]" t-esc="slot[0]" disabled="1" />
-                    <option t-foreach="Object.values(slot[1])" t-as="s" t-key="s_index" t-att-value="s.sql_datetime" t-esc="s.humain_readable" />
+                    <option t-foreach="Object.values(slot[1])" t-as="s" t-key="s_index" t-att-value="s.datetime.ts" t-esc="s.toFormat('HH:mm')" />
                 </t>
             </select>
             <a

--- a/addons/pos_self_order/static/src/app/pages/order_history_page/order_history_page.js
+++ b/addons/pos_self_order/static/src/app/pages/order_history_page/order_history_page.js
@@ -2,7 +2,7 @@ import { Component, useState } from "@odoo/owl";
 import { useSelfOrder } from "@pos_self_order/app/services/self_order_service";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { deserializeDateTime } from "@web/core/l10n/dates";
+
 export class OrdersHistoryPage extends Component {
     static template = "pos_self_order.OrdersHistoryPage";
     static props = {};
@@ -17,9 +17,6 @@ export class OrdersHistoryPage extends Component {
         await this.loadOrder();
     }
 
-    getOrderDate(order) {
-        return deserializeDateTime(order.date_order).toFormat("dd/MM/yyyy");
-    }
     async loadOrder() {
         await this.selfOrder.getOrdersFromServer();
         this.state.loadingProgress = false;

--- a/addons/pos_self_order/static/src/app/pages/order_history_page/order_history_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/order_history_page/order_history_page.xml
@@ -17,7 +17,7 @@
                                 <div class="d-flex align-items-center justify-content-between">
                                     <div class="d-flex flex-column">
                                         <h6 class="m-0" t-esc="order.pos_reference"/>
-                                        <span class="text-muted">#<t t-esc="order.tracking_number" /> - <t t-esc="getOrderDate(order)" /></span>
+                                        <span class="text-muted">#<t t-esc="order.tracking_number" /> - <t t-esc="order.date_order.toFormat('dd/MM/yyyy')" /></span>
                                     </div>
                                     <div class="d-flex justify-content-around gap-5 align-items-center">
                                         <i t-if="selfOrder.showDownloadButton(order)" class="fa fa-download" aria-hidden="true" t-on-click="() => this.selfOrder.downloadReceipt(order)"/>


### PR DESCRIPTION
Before this commit, field of type Date or DateTime in the POS model were not automatically converted to a DateTime object. This commit fixes this issue by automatically converting the field to a DateTime object when the field is of type Date or DateTime.

taskId: 4378842


