### PR TITLE
[FIX] html_editor: selection rendered in odd position in Chrome

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -453,14 +453,7 @@ export class SelectionPlugin extends Plugin {
         const documentSelectionIsInEditable = selection && this.isSelectionInEditable(selection);
         if (selection) {
             if (documentSelectionIsInEditable || selection.anchorNode === null) {
-                if (
-                    selection.anchorNode !== anchorNode ||
-                    selection.focusNode !== focusNode ||
-                    selection.anchorOffset !== anchorOffset ||
-                    selection.focusOffset !== focusOffset
-                ) {
-                    selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
-                }
+                selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
                 this.activeSelection = this.makeActiveSelection(selection, true);
             } else {
                 let range = new Range();


### PR DESCRIPTION
Steps:
- place the cursor at the end of a paragraph containing a link among other text, e.g.:
    `<p>abc <a href="#">some link</a> def[]</p>`
- press shift + enter
- the cursor is displayed in an odd position, e.g.: `<p>abc <a href="#">some link</a>[] def<br><br></p>`

There seems to be a bug in Chrome that renders the selection in a different position than the one returned by document.getSelection() in some cases. Setting the selection (even if it's the same as the current one) seems to solve the issue.

In the example above involving a link, after updating ZWNBSP (zero-width non-breaking space) nodes around the link, preserveSelection's restore is called but, when about to set the document selection, setBaseAndExtent is skipped because the selection is the same as the current one. This commit ensures that setBaseAndExtent is always called when restoring the selection.

task-4360915
