### PR TITLE
[FIX] account: Sync js taxes helpers with the python ones

### DIFF
--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -488,16 +488,16 @@ export const accountTaxHelpers = {
 
         const rate = base_line.rate;
         const tax_details = base_line.tax_details = {
-            total_excluded_currency: taxes_computation.total_excluded,
-            total_excluded: rate ? taxes_computation.total_excluded / rate : 0.0,
-            total_included_currency: taxes_computation.total_included,
-            total_included: rate ? taxes_computation.total_included / rate : 0.0,
+            raw_total_excluded_currency: taxes_computation.total_excluded,
+            raw_total_excluded: rate ? taxes_computation.total_excluded / rate : 0.0,
+            raw_total_included_currency: taxes_computation.total_included,
+            raw_total_included: rate ? taxes_computation.total_included / rate : 0.0,
             taxes_data: []
         };
 
         if (company.tax_calculation_rounding_method === 'round_per_line') {
-            tax_details.total_excluded = roundPrecision(tax_details.total_excluded, currency_pd);
-            tax_details.total_included = roundPrecision(tax_details.total_included, currency_pd);
+            tax_details.raw_total_excluded = roundPrecision(tax_details.raw_total_excluded, currency_pd);
+            tax_details.raw_total_included = roundPrecision(tax_details.raw_total_included, currency_pd);
         }
 
         for (const tax_data of taxes_computation.taxes_data) {
@@ -511,10 +511,10 @@ export const accountTaxHelpers = {
 
             tax_details.taxes_data.push({
                 ...tax_data,
-                tax_amount_currency: tax_data.tax_amount,
-                tax_amount: tax_amount,
-                base_amount_currency: tax_data.base_amount,
-                base_amount: base_amount
+                raw_tax_amount_currency: tax_data.tax_amount,
+                raw_tax_amount: tax_amount,
+                raw_base_amount_currency: tax_data.base_amount,
+                raw_base_amount: base_amount
             });
         }
     },
@@ -534,26 +534,18 @@ export const accountTaxHelpers = {
             const tax_details = base_line.tax_details;
             tax_details.delta_base_amount_currency = 0.0;
             tax_details.delta_base_amount = 0.0;
-            tax_details.raw_total_excluded_currency = tax_details.total_excluded_currency;
-            tax_details.total_excluded_currency = roundPrecision(tax_details.total_excluded_currency, currency_pd);
-            tax_details.raw_total_excluded = tax_details.total_excluded;
-            tax_details.total_excluded = roundPrecision(tax_details.total_excluded, company_pd);
-            tax_details.raw_total_included_currency = tax_details.total_included_currency;
-            tax_details.total_included_currency = roundPrecision(tax_details.total_included_currency, currency_pd);
-            tax_details.raw_total_included = tax_details.total_included;
-            tax_details.total_included = roundPrecision(tax_details.total_included, company_pd);
+            tax_details.total_excluded_currency = roundPrecision(tax_details.raw_total_excluded_currency, currency_pd);
+            tax_details.total_excluded = roundPrecision(tax_details.raw_total_excluded, company_pd);
+            tax_details.total_included_currency = roundPrecision(tax_details.raw_total_included_currency, currency_pd);
+            tax_details.total_included = roundPrecision(tax_details.raw_total_included, company_pd);
 
             for (const tax_data of tax_details.taxes_data) {
                 const tax = tax_data.tax;
 
-                tax_data.raw_tax_amount_currency = tax_data.tax_amount_currency;
-                tax_data.tax_amount_currency = roundPrecision(tax_data.tax_amount_currency, currency_pd);
-                tax_data.raw_tax_amount = tax_data.tax_amount;
-                tax_data.tax_amount = roundPrecision(tax_data.tax_amount, company_pd);
-                tax_data.raw_base_amount_currency = tax_data.base_amount_currency;
-                tax_data.base_amount_currency = roundPrecision(tax_data.base_amount_currency, currency_pd);
-                tax_data.raw_base_amount = tax_data.base_amount;
-                tax_data.base_amount = roundPrecision(tax_data.base_amount, company_pd);
+                tax_data.tax_amount_currency = roundPrecision(tax_data.raw_tax_amount_currency, currency_pd);
+                tax_data.tax_amount = roundPrecision(tax_data.raw_tax_amount, company_pd);
+                tax_data.base_amount_currency = roundPrecision(tax_data.raw_base_amount_currency, currency_pd);
+                tax_data.base_amount = roundPrecision(tax_data.raw_base_amount, company_pd);
 
                 const key = [tax.id, currency.id];
                 if (!(key in total_per_tax)) {


### PR DESCRIPTION
Adapt the js-side of taxes computations according: https://github.com/odoo/odoo/commit/e43044582cce69ec3abc9838aa9afba06e073a80

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
