### PR TITLE
[FIX] account: display name duplicate on account move line

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1608,7 +1608,7 @@ class AccountMoveLine(models.Model):
     def name_get(self):
         return [(line.id, " ".join(
             element for element in (
-                line.move_id.name,
+                line.move_id.name != line.name and line.move_id.name,
                 line.ref and f"({line.ref})",
                 line.name or line.product_id.display_name,
             ) if element


### PR DESCRIPTION
On accounting reports, when displaying the display name of an account move line, it sometimes contains two times the name of the related move. This is due to the computation of the display_name field.

task-4357741


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
