### PR TITLE
[FIX] core: fix remaining time during http tests

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -199,7 +199,7 @@ from .service import security, model as service_model
 from .tools import (config, consteq, file_path, get_lang, json_default,
                     parse_version, profiler, unique, exception_to_unicode)
 from .tools.func import filter_kwargs, lazy_property
-from .tools.misc import submap
+from .tools.misc import submap, real_time
 from .tools._vendor import sessions
 from .tools._vendor.useragents import UserAgent
 
@@ -2374,7 +2374,7 @@ class Application:
         current_thread = threading.current_thread()
         current_thread.query_count = 0
         current_thread.query_time = 0
-        current_thread.perf_t0 = time.time()
+        current_thread.perf_t0 = real_time()
         current_thread.cursor_mode = None
         if hasattr(current_thread, 'dbname'):
             del current_thread.dbname

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -99,7 +99,7 @@ class PerfFilter(logging.Filter):
             query_count = threading.current_thread().query_count
             query_time = threading.current_thread().query_time
             perf_t0 = threading.current_thread().perf_t0
-            remaining_time = time.time() - perf_t0 - query_time
+            remaining_time = tools.real_time() - perf_t0 - query_time
             record.perf_info = '%s %s %s' % self.format_perf(query_count, query_time, remaining_time)
             if tools.config['db_replica_host'] is not False:
                 cursor_mode = threading.current_thread().cursor_mode

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -32,7 +32,7 @@ import odoo
 from . import tools
 from .tools import SQL
 from .tools.func import frame_codeinfo, locked
-from .tools.misc import Callbacks
+from .tools.misc import Callbacks, real_time
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -58,9 +58,6 @@ psycopg2.extensions.register_type(psycopg2.extensions.new_array_type((1231,), 'f
 
 _logger = logging.getLogger(__name__)
 _logger_conn = _logger.getChild("connection")
-
-# ensure we have a non patched time for query times when using freezegun
-real_time = time.time.__call__  # type: ignore
 
 re_from = re.compile(r'\bfrom\s+"?([a-zA-Z_0-9]+)\b', re.IGNORECASE)
 re_into = re.compile(r'\binto\s+"?([a-zA-Z_0-9]+)\b', re.IGNORECASE)

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -107,6 +107,7 @@ __all__ = [
     'topological_sort',
     'unique',
     'ustr',
+    'real_time',
 ]
 
 _logger = logging.getLogger(__name__)
@@ -123,6 +124,8 @@ objectify.set_default_parser(default_parser)
 
 NON_BREAKING_SPACE = u'\N{NO-BREAK SPACE}'
 
+# ensure we have a non patched time for query times when using freezegun
+real_time = time.time.__call__  # type: ignore
 
 class Sentinel(enum.Enum):
     """Class for typing parameters with a sentinel as a default"""
@@ -904,7 +907,7 @@ def dumpstacks(sig=None, frame=None, thread_idents=None, log_level=logging.INFO)
             perf_t0 = thread_info.get('perf_t0')
             remaining_time = None
             if query_time is not None and perf_t0:
-                remaining_time = '%.3f' % (time.time() - perf_t0 - query_time)
+                remaining_time = '%.3f' % (real_time() - perf_t0 - query_time)
                 query_time = '%.3f' % query_time
             # qc:query_count qt:query_time pt:python_time (aka remaining time)
             code.append("\n# Thread: %s (db:%s) (uid:%s) (url:%s) (qc:%s qt:%s pt:%s)" %


### PR DESCRIPTION
During HTTP case, if freeze gun is used, the remaing time (last number of the log line of the HTTP request) is negative (= -query_time). It is the case because we used time.time() which is patched by freezegun. To avoid this no-sense number, used the same trick than in `Cursor.execute`.

