### PR TITLE
[IMP] account_edi_ubl_cii: Peppol customer payment means constraint

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -300,9 +300,6 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             # Non-SEPA international credit transfer, the Payment account identifier (BT-84) shall be present.
             # note: Payment account identifier is <cac:PayeeFinancialAccount>
             # note: no need to check account_number, because it's a required field for a partner_bank
-            'cen_en16931_payment_account_identifier': self._check_required_fields(
-                invoice, 'partner_bank_id'
-            ) if vals['vals']['payment_means_vals_list'][0]['payment_means_code'] in (30, 58) else None,
             # [BR-IC-12]-In an Invoice with a VAT breakdown (BG-23) where the VAT category code (BT-118) is
             # "Intra-community supply" the Deliver to country code (BT-80) shall not be blank.
             'cen_en16931_delivery_country_code': self._check_required_fields(


### PR DESCRIPTION
Removing customer bank account constraint for Peppol credit notes and invoices.
What appears to be happening is that Peppol is enabled for a contact through setting their invoice format to "UBL BIS Billing 3.0.12", which in turn when generating an invoice through account_edi_ubl_cii/models/account_move_send methods refers to the 'cen_en16931_payment_account_identifier' constraint set in account_edi_xml_ubl_bis3.py through account_edi_common's _check_required_fields() method. For NL suppliers, bank account requirement is specified separately, so I reason I shouldn't touch that.

task: 4316460
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
