### PR TITLE
[FIX] point_of_sale: return the current config currency

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -74,7 +74,7 @@ export class PosOrder extends Base {
     }
 
     get currency() {
-        return this.session_id.config_id.currency_id;
+        return this.config.currency_id;
     }
 
     get pickingType() {


### PR DESCRIPTION
Before this commit, when opening a shared table from another session, it tried to get the currency from the other order while the session and config record were not loaded, causing an error.

opw-4381857

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
