### PR TITLE
[FIX] account_edi_ubl_cii: Fix constraints after invoicing address ch…

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -36,7 +36,7 @@ class AccountEdiXmlCII(models.AbstractModel):
             ),
             # [BR-DE-9] The element "Buyer post code" (BT-53) must be transmitted. (only mandatory in Germany ?)
             'buyer_postal_address': self._check_required_fields(
-                vals['record']['commercial_partner_id'], 'zip'
+                vals['record']['partner_id'], 'zip'
             ),
             # [BR-DE-4] The element "Seller post code" (BT-38) must be transmitted. (only mandatory in Germany ?)
             'seller_post_code': self._check_required_fields(
@@ -74,9 +74,9 @@ class AccountEdiXmlCII(models.AbstractModel):
             # [BR-IG-05]-In an Invoice line (BG-25) where the Invoiced item VAT category code (BT-151) is "IGIC" the
             # invoiced item VAT rate (BT-152) shall be greater than 0 (zero).
             'igic_tax_rate': self._check_non_0_rate_tax(vals)
-                if vals['record']['commercial_partner_id']['country_id']['code'] == 'ES'
-                    and vals['record']['commercial_partner_id']['zip']
-                    and vals['record']['commercial_partner_id']['zip'][:2] in ['35', '38'] else None,
+                if vals['record']['partner_id']['country_id']['code'] == 'ES'
+                    and vals['record']['partner_id']['zip']
+                    and vals['record']['partner_id']['zip'][:2] in ['35', '38'] else None,
         })
         return constraints
 


### PR DESCRIPTION
…anges

In previous commit [1], we made changes to handle better the invoicing address partner and the commercial partner. This broke facturx constraints.

[1]: https://github.com/odoo/odoo/commit/053c6de8e48ff3fea469531cf32352d88111469e

task-no
