### PR TITLE
[FIX] sale: fix access rights to credit limit

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -732,7 +732,7 @@ class SaleOrder(models.Model):
                            order.company_id.account_use_credit_limit
             if show_warning:
                 order.partner_credit_warning = self.env['account.move']._build_credit_warning_message(
-                    order,
+                    order.sudo(),
                     current_amount=(order.amount_total / order.currency_rate),
                 )
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install Sales
- Go to Invoicing settings
- Enable "Sales Credit limit"
- Create a user with Sales rights and no Invoicing rights
- Connect with the created user
- Create a SO

**Issue:**
When a customer is set, an access error on "credit_limit" field is raised when adding a product.

**Cause:**
"credit_limit" is a company-dependent field.
Since the refactoring of the company-dependent fields, the value is not retrieved with "sudo()" anymore.

opw-4280420




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
