### PR TITLE
[FIX] hw_posbox_homepage: add non-error certificate status

### DIFF
--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -93,9 +93,13 @@ export class Homepage extends Component {
             <div class="d-flex mb-4 flex-column align-items-center justify-content-center">
                 <h4 class="text-center m-0">IoT Box - <t t-esc="state.data.hostname" /></h4>
             </div>
-            <div t-if="this.store.advanced" class="alert alert-warning" role="alert">
-                <p class="m-0 fw-bold">HTTPS certificate</p>
-                <small>Error code: <t t-esc="state.data.certificate_details" /></small>
+            <div t-if="this.store.advanced" t-att-class="'alert ' + (state.data.is_certificate_ok === true ? 'alert-info' : 'alert-warning')" role="alert">
+                <p class="m-0 fw-bold">HTTPS Certificate</p>
+                <small>
+                    <t t-if="state.data.is_certificate_ok === true">Status: </t>
+                    <t t-else="">Error Code: </t>
+                    <t t-esc="state.data.certificate_details" />
+                </small>
             </div>
             <SingleData name="'Name'" value="state.data.hostname" icon="'fa-id-card'">
 				<t t-set-slot="button">


### PR DESCRIPTION
Certificate banner in "advanced view" on the homepage could only display an "error" message, even when the message was not an error.
This is not the case anymore.