### PR TITLE
[FIX] website_sale: pass compute price args as kwargs

### DIFF
--- a/addons/website_sale/controllers/product_configurator.py
+++ b/addons/website_sale/controllers/product_configurator.py
@@ -263,11 +263,11 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
         if pricelist_rule._show_discount_on_shop():
             pricelist_base_price = self._apply_taxes_to_price(
                 pricelist_rule._compute_price_before_discount(
-                    product_or_template,
-                    1.0,
-                    product_or_template.uom_id,
-                    date,
-                    currency,
+                    product=product_or_template,
+                    quantity=1.0,
+                    uom=product_or_template.uom_id,
+                    date=date,
+                    currency=currency,
                 ),
                 product_or_template,
                 currency,


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Start a fresh database with only `website_sale` installed;
2. configure Website to show strikethrough price;
3. configure Website to let user decide on "Add to Cart";
4. create a pricelist with a discount based on another pricelist;
5. have discount apply to all product categories;
6. make pricelist selectable;
7. go to /shop;
8. add a product to cart.

Issue
-----
> ```
> AssertionError:
> Invalid value res.currency(1,) in domain term ('date_end', '>=', res.currency(1,))
>```

Cause
-----
PR https://github.com/odoo/odoo/pull/181014 changed how versions 17.4+ display strikethrough prices for discount rules.
In doing so, it added a call to `_compute_price_before_discount`, passing the parameters positionally.

The problem is that not all helper functions used in the process accept these arguments in the same order, specifically:

https://github.com/odoo/odoo/blob/4c68ce24eaf4e1b431485a3bdcd55ca0064c0ae0/addons/product/models/product_pricelist_item.py#L521

https://github.com/odoo/odoo/blob/4c68ce24eaf4e1b431485a3bdcd55ca0064c0ae0/addons/product/models/product_pricelist.py#L161-L164
 
Solution
--------
Name the arguments, so that they get passed as `**kwargs` instead of `*args`.

opw-4366956