### PR TITLE
[IMP] html_editor: add undo/redo buttons to mobile toolbar

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -1,5 +1,8 @@
+import { _t } from "@web/core/l10n/translation";
 import { Plugin } from "../plugin";
 import { childNodes, descendants, getCommonAncestor } from "../utils/dom_traversal";
+import { hasTouch } from "@web/core/browser/feature_detection";
+import { withSequence } from "@html_editor/utils/resource";
 
 /**
  * @typedef { import("./selection_plugin").EditorSelection } EditorSelection
@@ -122,9 +125,26 @@ export class HistoryPlugin extends Plugin {
     ];
     resources = {
         user_commands: [
-            { id: "historyUndo", run: this.undo.bind(this) },
-            { id: "historyRedo", run: this.redo.bind(this) },
+            { id: "historyUndo", title: _t("Undo"), icon: "fa-undo", run: this.undo.bind(this) },
+            { id: "historyRedo", title: _t("Redo"), icon: "fa-repeat", run: this.redo.bind(this) },
         ],
+        ...(hasTouch() && {
+            toolbar_groups: withSequence(5, { id: "historyMobile" }),
+            toolbar_items: [
+                {
+                    id: "undo",
+                    groupId: "historyMobile",
+                    commandId: "historyUndo",
+                    isDisabled: () => !this.canUndo(),
+                },
+                {
+                    id: "redo",
+                    groupId: "historyMobile",
+                    commandId: "historyRedo",
+                    isDisabled: () => !this.canRedo(),
+                },
+            ],
+        }),
         shortcuts: [
             { hotkey: "control+z", commandId: "historyUndo" },
             { hotkey: "control+y", commandId: "historyRedo" },

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -29,6 +29,7 @@ import {
 } from "./_helpers/selection";
 import { withSequence } from "@html_editor/utils/resource";
 import { strong } from "./_helpers/tags";
+import { insertText } from "./_helpers/user_actions";
 
 test.tags("desktop");
 test("toolbar is only visible when selection is not collapsed in desktop", async () => {
@@ -932,5 +933,48 @@ describe("toolbar open and close on user interaction", () => {
             await advanceTime(500);
             expect(".o-we-toolbar").toHaveCount(1);
         });
+    });
+});
+
+describe.tags("mobile");
+describe("history", () => {
+    test("toolbar should have history buttons on mobile", async () => {
+        const { el, editor } = await setupEditor("<p>test</p>");
+        setContent(el, "<p>test[]</p>");
+        await waitFor(".o-we-toolbar");
+        expect(".o-we-toolbar").toHaveCount(1);
+
+        // Check that the history buttons are present and disabled
+        expect(".btn[name='undo']").toHaveClass("disabled");
+        expect(".btn[name='redo']").toHaveClass("disabled");
+
+        // Make changes
+        await insertText(editor, "X");
+        expect(getContent(el)).toBe("<p>testX[]</p>");
+
+        // Undo becomes available
+        await waitFor(".btn[name='undo']:not(.disabled)");
+        expect(".btn[name='undo']").not.toHaveClass("disabled");
+        expect(".btn[name='redo']").toHaveClass("disabled");
+
+        // Click on undo
+        click(".btn[name='undo']");
+        await animationFrame();
+        expect(getContent(el)).toBe("<p>test[]</p>");
+
+        // Redo becomes available, and undo disabled
+        await waitFor(".btn[name='redo']:not(.disabled)");
+        expect(".btn[name='undo']").toHaveClass("disabled");
+        expect(".btn[name='redo']").not.toHaveClass("disabled");
+
+        // Click on redo
+        click(".btn[name='redo']");
+        await animationFrame();
+        expect(getContent(el)).toBe("<p>testX[]</p>");
+
+        // Same state as before (can undo, cannot redo)
+        await waitFor(".btn[name='undo']:not(.disabled)");
+        expect(".btn[name='undo']").not.toHaveClass("disabled");
+        expect(".btn[name='redo']").toHaveClass("disabled");
     });
 });


### PR DESCRIPTION
This commit adds undo and redo buttons to the toolbar on mobile devices.

They are particularly useful when a physical keyboard is not available and thus the user cannot use the keyboard shortcuts to undo and redo (control+z and control+y).

task-4267107
