### PR TITLE
[FIX] mrp, repair: create new operation type when duplicating warehouse

### DIFF
--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -22,10 +22,10 @@ class StockWarehouse(models.Model):
         'stock.rule', 'Stock After Manufacturing Rule', copy=False)
     manu_type_id = fields.Many2one(
         'stock.picking.type', 'Manufacturing Operation Type',
-        domain="[('code', '=', 'mrp_operation'), ('company_id', '=', company_id)]", check_company=True)
+        domain="[('code', '=', 'mrp_operation'), ('company_id', '=', company_id)]", check_company=True, copy=False)
 
-    pbm_type_id = fields.Many2one('stock.picking.type', 'Picking Before Manufacturing Operation Type', check_company=True)
-    sam_type_id = fields.Many2one('stock.picking.type', 'Stock After Manufacturing Operation Type', check_company=True)
+    pbm_type_id = fields.Many2one('stock.picking.type', 'Picking Before Manufacturing Operation Type', check_company=True, copy=False)
+    sam_type_id = fields.Many2one('stock.picking.type', 'Stock After Manufacturing Operation Type', check_company=True, copy=False)
 
     manufacture_steps = fields.Selection([
         ('mrp_one_step', 'Manufacture (1 step)'),

--- a/addons/repair/models/stock_warehouse.py
+++ b/addons/repair/models/stock_warehouse.py
@@ -7,7 +7,7 @@ from odoo import fields, models, _
 class StockWarehouse(models.Model):
     _inherit = 'stock.warehouse'
 
-    repair_type_id = fields.Many2one('stock.picking.type', 'Repair Operation Type', check_company=True)
+    repair_type_id = fields.Many2one('stock.picking.type', 'Repair Operation Type', check_company=True, copy=False)
 
     def _get_sequence_values(self, name=False, code=False):
         values = super(StockWarehouse, self)._get_sequence_values(name=name, code=code)


### PR DESCRIPTION
Steps to reproduce the issue:
- Go to the settings and enable multi-routes.
- Navigate to the warehouse and attempt to duplicate it.

Problem:
The operation types “Repair,” “Stock After Manufacturing Operation,”
“Picking Before Manufacturing,” and “Manufacturing” are copied instead
of creating new records.

opw-4386529