### PR TITLE
[FIX] hr_recruitment: candidates in right company when receiving email

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -590,10 +590,17 @@ class Applicant(models.Model):
         # found.
         self = self.with_context(default_user_id=False, mail_notify_author=True)  # Allows sending stage updates to the author
         stage = False
+        candidate_defaults = {}
         if custom_values and 'job_id' in custom_values:
-            stage = self.env['hr.job'].browse(custom_values['job_id'])._get_first_stage()
+            job = self.env['hr.job'].browse(custom_values['job_id'])
+            stage = job._get_first_stage()
+            candidate_defaults['company_id'] = job.company_id.id
+
         partner_name, email_from_normalized = tools.parse_contact_from_email(msg.get('from'))
-        candidate = self.env['hr.candidate'].create({'partner_name': partner_name or email_from_normalized})
+        candidate = self.env['hr.candidate'].create({
+            'partner_name': partner_name or email_from_normalized,
+            **candidate_defaults,
+        })
         defaults = {
             'candidate_id': candidate.id,
         }


### PR DESCRIPTION
When an application is received through email, an `hr.candidate` is created without `company_id`. The default for this field is self.env.company. When processing an email this will be the company of OdooBot. `hr.applicant` on the other hand, will compute its default company based on the linked `hr.job`.

Because of this, it's possible that these two records are created in different companies leading to:

File ".../addons/hr_recruitment/models/hr_applicant.py", line 351, in create
  raise ValidationError(_("You cannot create an applicant in a different company than the candidate"))

Fix it by creating the candidate in the same company the job is in.

opw-4384806