### PR TITLE
[18.0][FIX] stock,*: hide uom when option is disabled

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -204,7 +204,7 @@
                         <t t-name="card">
                             <div>
                                 <field name="product_tmpl_id" class="fw-medium fs-5"/>
-                                <span class="float-end badge rounded-pill"><field name="product_qty"/> <field name="product_uom_id" class="small"/></span>
+                                <span class="float-end badge rounded-pill"><field name="product_qty"/> <field name="product_uom_id" class="small" groups="uom.group_uom"/></span>
                             </div>
                             <footer class="pt-1">
                                 <field name="code"/>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -357,7 +357,7 @@
                                 <list editable="bottom">
                                     <field name="product_id" readonly="state == 'done'"/>
                                     <field name="product_uom_qty" readonly="state == 'done'"/>
-                                    <field name="product_uom"/>
+                                    <field name="product_uom" groups="uom.group_uom"/>
                                     <field name="operation_id"/>
                                     <field name="byproduct_id"/>
                                     <field name="name"/>
@@ -576,7 +576,7 @@
                                 <field name="priority" widget="priority"/>
                                 <field name="product_id" class="fw-bolder fs-6 ms-1"/>
                                 <field name="product_qty" class="ms-auto"/>
-                                <field name="product_uom_id" class="small ms-1"/>
+                                <field name="product_uom_id" class="small ms-1" groups="uom.group_uom"/>
                             </div>
                             <footer class="text-muted">
                                 <div class="d-flex">

--- a/addons/mrp/views/mrp_unbuild_views.xml
+++ b/addons/mrp/views/mrp_unbuild_views.xml
@@ -54,7 +54,7 @@
                             <div class="d-flex fw-bold mb-1">
                                 <field name="name" class="fs-5"/>
                                 <field name="product_qty" class="ms-auto me-1 fs-6"/>
-                                <field name="product_uom_id" class="small"/>
+                                <field name="product_uom_id" class="small" groups="uom.group_uom"/>
                             </div>
                             <div class="d-flex text-muted">
                                 <field name="product_id"/>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -375,7 +375,7 @@
                         </div>
                         <footer>
                             <h5>
-                                <field name="product_id"/>, <field name="qty_production" class="ms-1"/> <field name="product_uom_id"/><t t-if="record.finished_lot_id.value">, </t> <field t-if="record.finished_lot_id.value" name="finished_lot_id" class="ms-1"/>
+                                <field name="product_id"/>, <field name="qty_production" class="ms-1"/> <field name="product_uom_id" groups="uom.group_uom"/><t t-if="record.finished_lot_id.value">, </t> <field t-if="record.finished_lot_id.value" name="finished_lot_id" class="ms-1"/>
                             </h5>
                             <div class="o_kanban_workorder_status d-flex ms-auto" t-if="record.state.raw_value == 'progress'">
                                 <span t-if="record.working_state.raw_value != 'blocked' and record.working_user_ids.raw_value.length > 0"><i class="fa fa-play fs-6" role="img" aria-label="Run" title="Run"/></span>

--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -117,7 +117,7 @@
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value d-flex gap-1">
                                 <field name="mrp_product_qty" widget="statinfo" nolabel="1" class="mr4"/>
-                                <field name="uom_name"/>
+                                <field name="uom_name" groups="uom.group_uom"/>
                             </span>
                             <span class="o_stat_text">Manufactured</span>
                         </div>
@@ -148,7 +148,7 @@
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value d-flex gap-1">
                                 <field name="mrp_product_qty" widget="statinfo" nolabel="1" class="mr4"/>
-                                <field name="uom_name"/>
+                                <field name="uom_name" groups="uom.group_uom"/>
                             </span>
                             <span class="o_stat_text">Manufactured</span>
                         </div>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -72,7 +72,7 @@
                                             <field name="price_subtotal_incl" widget="monetary" class="ms-auto me-3"/>
                                         </div>
                                         <div class="text-muted">
-                                            Quantity: <field name="qty"/> <field name="product_uom_id"/>
+                                            Quantity: <field name="qty"/> <field name="product_uom_id" groups="uom.group_uom"/>
                                         </div>
                                         <div class="text-muted">
                                             Unit price: <field name="price_unit" widget="monetary"/>

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -112,7 +112,7 @@
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value d-flex gap-1">
                                 <field name="purchased_product_qty" widget="statinfo" nolabel="1" class="oe_inline"/>
-                                <field name="uom_name"  class="oe_inline"/>
+                                <field name="uom_name"  class="oe_inline" groups="uom.group_uom"/>
                             </span>
                             <span class="o_stat_text">Purchased</span>
                         </div>
@@ -133,7 +133,7 @@
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value d-flex gap-1">
                                 <field name="purchased_product_qty" widget="statinfo" nolabel="1" class="oe_inline"/>
-                                <field name="uom_name"  class="oe_inline"/>
+                                <field name="uom_name"  class="oe_inline" groups="uom.group_uom"/>
                             </span>
                             <span class="o_stat_text">Purchased</span>
                         </div>

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -58,7 +58,7 @@
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value d-flex gap-1">
                             <field name="sales_count" widget="statinfo" nolabel="1" class="oe_inline"/>
-                            <field name="uom_name" class="oe_inline"/>
+                            <field name="uom_name" class="oe_inline" groups="uom.group_uom"/>
                         </span>
                         <span class="o_stat_text">Sold</span>
                     </div>
@@ -82,7 +82,7 @@
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value d-flex gap-1">
                             <field name="sales_count" widget="statinfo" nolabel="1" class="oe_inline"/>
-                            <field name="uom_name" class="oe_inline"/>
+                            <field name="uom_name" class="oe_inline" groups="uom.group_uom"/>
                         </span>
                         <span class="o_stat_text">Sold</span>
                     </div>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -177,7 +177,7 @@
                 </xpath>
                 <xpath expr="//field[@name='product_properties']" position="before">
                     <div groups="stock.group_stock_user" t-if="record.show_on_hand_qty_status_button.raw_value">
-                        On hand: <field name="qty_available"/> <field name="uom_id"/>
+                        On hand: <field name="qty_available"/> <field name="uom_id" groups="uom.group_uom"/>
                     </div>
                 </xpath>
             </field>
@@ -303,7 +303,7 @@
                                 <div class="o_field_widget o_stat_info">
                                         <span class="o_stat_value d-flex gap-1">
                                             <field name="qty_available" nolabel="1" class="oe_inline"/>
-                                            <field name="uom_name" class="oe_inline"/>
+                                            <field name="uom_name" class="oe_inline" groups="uom.group_uom"/>
                                         </span>
                                         <span class="o_stat_text">On Hand</span>
                                 </div>
@@ -316,7 +316,7 @@
                                 <div class="o_field_widget o_stat_info">
                                     <span class="o_stat_value d-flex gap-1">
                                         <field name="virtual_available" class="oe_inline"/>
-                                        <field name="uom_name" class="oe_inline"/>
+                                        <field name="uom_name" class="oe_inline" groups="uom.group_uom"/>
                                     </span>
                                     <span class="o_stat_text">Forecasted</span>
                                 </div>
@@ -424,7 +424,7 @@
                                 <div class="o_field_widget o_stat_info">
                                     <span class="o_stat_value d-flex gap-1">
                                         <field name="qty_available" nolabel="1" class="oe_inline"/>
-                                        <field name="uom_name" class="oe_inline"/>
+                                        <field name="uom_name" class="oe_inline" groups="uom.group_uom"/>
                                     </span>
                                     <span class="o_stat_text">On Hand</span>
                                 </div>
@@ -437,7 +437,7 @@
                                 <div class="o_field_widget o_stat_info">
                                     <span class="o_stat_value d-flex gap-1">
                                         <field name="virtual_available" nolabel="1" class="oe_inline"/>
-                                        <field name="uom_name" class="oe_inline"/>
+                                        <field name="uom_name" class="oe_inline" groups="uom.group_uom"/>
                                     </span>
                                     <span class="o_stat_text">Forecasted</span>
                                 </div>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Should not show product uom when the feature "Units of Measure" is not activated
![截图 2024-12-07 15-08-59](https://github.com/user-attachments/assets/18cd3746-2e14-4c26-8e5c-334008de5f44)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
