### PR TITLE
[FIX] web_editor: remove <br> after dynamic placeholder

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -375,7 +375,7 @@ export const editorCommands = {
 
         currentNode = lastChildNode || currentNode;
         if (
-            !isUnbreakable(currentNode) &&
+            (currentNode.tagName === 'T' || !isUnbreakable(currentNode)) &&
             currentNode.nodeName !== 'BR' &&
             currentNode.nextSibling &&
             currentNode.nextSibling.nodeName === 'BR' &&

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insertHTML.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insertHTML.test.js
@@ -111,6 +111,22 @@ describe('insert HTML', () => {
                 contentAfter: '<p>abcdefgh</p><p><br>[]</p>',
             });
         });
+        it("should remove <br> when inserting <t> tag", async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: `<p>[]<br></p>`,
+                contentBeforeEdit: `<p placeholder="Type &quot;/&quot; for commands" class="oe-hint oe-command-temporary-hint">[]<br></p>`,
+                stepFunction: async (editor) => {
+                    await editor.execCommand(
+                        "insert",
+                        parseHTML(
+                            `<t t-out="object. or '''abcd'''" contenteditable="false" data-oe-t-inline="true"></t>`
+                        )
+                    );
+                },
+                contentAfterEdit: `<p><t t-out="object. or '''abcd'''" contenteditable="false" data-oe-t-inline="true"></t>[]</p>`,
+                contentAfter: `<p><t t-out="object. or '''abcd'''" data-oe-t-inline="true"></t>[]</p>`,
+            });
+        });
     });
     describe('not collapsed selection', () => {
         it('should delete selection and insert html in its place', async () => {


### PR DESCRIPTION
### Steps to reproduce:

- Create a new email template.
- Add an "Applies to" condition.
- Insert a dynamic placeholder.
- Inspect the HTML, and notice that the `<br>` element added for the empty `<p>` is still present.

### Description of the issue/feature this PR addresses:

When inserting a dynamic placeholder, the `insert` in `editorCommand` checks if the current node is unbreakable. Since the `<t>` tag is categorized as an unbreakable node, the `<br>` element (as the last child of the parent element and next sibling of the `<t>` tag) remains in the DOM.

### Desired behavior after PR is merged:

The `<br>` element is now removed when executing dynamic placeholder.

task-4251326