### PR TITLE
[FIX] sale_project_stock: fixed default setting of picking type opened through topbar

### DIFF
--- a/addons/sale_project_stock/models/__init__.py
+++ b/addons/sale_project_stock/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import project_project
 from . import sale_order_line
 from . import stock_move
 from . import stock_picking

--- a/addons/sale_project_stock/models/project_project.py
+++ b/addons/sale_project_stock/models/project_project.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ProjectProject(models.Model):
+    _inherit = 'project.project'
+
+    def _get_picking_action(self, action_name, picking_type=None):
+        result = super()._get_picking_action(action_name, picking_type)
+
+        if picking_type and (property_warehouse := self.env.user.property_warehouse_id):
+            if picking_type == 'outgoing':
+                result['context']['default_picking_type_id'] = property_warehouse.out_type_id.id
+            elif picking_type == 'incoming':
+                result['context']['default_picking_type_id'] = property_warehouse.in_type_id.id
+
+        return result


### PR DESCRIPTION
Steps to reproduce:

- Set default Warehouse in the profile.
- From Project topbar open either "From WH" or "To WH".
- Create a new stock picking

Issue:

- The stock picking type is not set by default

Reason:

- Non existence of supplied values.

Solution:

- Supply default picking type if user has a default warehouse.

task-4207753