### PR TITLE
[FIX] account: prevent error when opening a preview of an invoice

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -597,7 +597,7 @@
                         <!-- Preview (only customer invoices) -->
                         <button name="preview_invoice" type="object" string="Preview" data-hotkey="o"
                                 title="Preview invoice"
-                                attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice', 'out_refund')), ('state', '==', 'cancel')]}"/>
+                                attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice', 'out_refund')), ('state', 'in', ('draft', 'cancel'))]}"/>
                         <!-- Reverse -->
                         <button name="%(action_view_account_move_reversal)d" string="Reverse Entry"
                                 type="action" groups="account.group_account_invoice" data-hotkey="z"


### PR DESCRIPTION
Currently, an error occurs when opening a preview of an invoice without an invoice date.

Step to produce:

- Install the ```l10n_ec_edi``` module.
- Change a current company to 'EC Company', which has an 'Ecuador' country.
- Create a new invoice, add a customer name, payment terms and invoice line, save the record,
- Click on the 'Preview' button (ensure that the invoice has no date).

```TypeError: unsupported operand type(s) for -: 'bool' and 'datetime.date'```

An error occurs when the system attempts to calculate payment term days at [1], with using an invoice date, but it is not available.

Link [1]: 
https://github.com/odoo/enterprise/blob/028e3f0304fdc01f8bab7718223fb3d61b26cee2/l10n_ec_edi/models/account_move.py#L440

To resolve this issue, Hide a ```PREVIEW``` button on the draft invoice as done in 17.4 and later [2].

Link [2]: https://github.com/odoo/odoo/blob/f0a680dec52b323bdb462d7a7c2ddffd30febd02/addons/account/views/account_move_views.xml#L716

Sentry-6015854429

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
