### PR TITLE
[IMP] web, *:  convert type edit to open

### DIFF
--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -184,7 +184,7 @@
                             <div groups="account.group_account_manager" class="row o_kanban_card_manage_settings">
                                 <field name="show_on_dashboard" widget="boolean_favorite" class="col-6"/>
                                 <div class="col-6 text-end">
-                                    <a class="dropdown-item" t-if="widget.editable" type="edit">Configuration</a>
+                                    <a class="dropdown-item" t-if="widget.editable" type="open">Configuration</a>
                                 </div>
                             </div>
                         </div>

--- a/addons/base_import_module/views/ir_module_views.xml
+++ b/addons/base_import_module/views/ir_module_views.xml
@@ -21,7 +21,7 @@
                     <attribute name="type">object</attribute>
                     <attribute name="name">more_info</attribute>
                 </xpath>
-                <xpath expr="//footer/a[@type='edit']" position="attributes">
+                <xpath expr="//footer/a[@type='open']" position="attributes">
                     <attribute name="context">{'module_type': module_type, 'module_name':name}</attribute>
                     <attribute name="type">object</attribute>
                     <attribute name="name">more_info</attribute>

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -189,7 +189,7 @@
                                                 </t>
                                             </div>
                                             <t t-if="!read_only_mode">
-                                                <a type="edit" t-attf-class="oe_kanban_action text-black">
+                                                <a type="open" t-attf-class="oe_kanban_action text-black">
                                                     <t t-call="level_content"/>
                                                 </a>
                                             </t>

--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -178,7 +178,7 @@
                             </div>
                             <footer>
                                 <button t-if="!installed and !selection_mode and !to_buy" type="object" class="btn btn-sm btn-primary ms-auto" name="button_immediate_install">Install</button>
-                                <button t-if="installed and is_disabled and !selection_mode" type="edit" class="btn btn-sm btn-secondary ms-auto">Activate</button>
+                                <button t-if="installed and is_disabled and !selection_mode" type="open" class="btn btn-sm btn-secondary ms-auto">Activate</button>
                                 <button t-if="!installed and to_buy" href="https://odoo.com/pricing?utm_source=db&amp;utm_medium=module" target="_blank" class="btn btn-sm btn-primary ms-auto">Upgrade</button>
                             </footer>
                         </main>

--- a/addons/web/static/src/views/kanban/kanban_compiler.js
+++ b/addons/web/static/src/views/kanban/kanban_compiler.js
@@ -19,7 +19,6 @@ import { toInterpolatedStringExpression, ViewCompiler } from "@web/views/view_co
 const ACTION_TYPES = ["action", "object"];
 const SPECIAL_TYPES = [
     ...ACTION_TYPES,
-    "edit",
     "open",
     "delete",
     "url",

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -304,12 +304,8 @@ export class KanbanRecord extends Component {
         const { archInfo, openRecord, deleteRecord, record, archiveRecord } = this.props;
         const { type } = params;
         switch (type) {
-            // deprecated, records are always in edit mode in form views now, use "open" instead
-            case "edit": {
-                return openRecord(record, { mode: "edit" });
-            }
             case "open": {
-                return openRecord(record);
+                return openRecord(record, { mode: "edit" });
             }
             case "archive": {
                 return archiveRecord(record, true);

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -5261,7 +5261,7 @@ test("clicking on a link triggers correct event", async () => {
             <kanban>
                 <templates>
                     <t t-name="card">
-                        <a type="edit">Edit</a>
+                        <a type="open">Edit</a>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -269,7 +269,7 @@
                                     </div>
                                 </div>
                                 <t t-else="">
-                                    <button class="position-absolute top-0 start-0 h-100 w-100 opacity-0" role="button" type="edit" t-if="record.url.value"/>
+                                    <button class="position-absolute top-0 start-0 h-100 w-100 opacity-0" role="button" type="open" t-if="record.url.value"/>
                                 </t>
                             </div>
                             <div class="o_theme_preview_bottom mt-2 mb-3 px-2">

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1603,7 +1603,7 @@ actual arch.
             if special not in ('cancel', 'save', 'add'):
                 self._raise_view_error(_("Invalid special '%(value)s' in button", value=special), node)
         elif type_:
-            if type_ == 'edit': # list_renderer, used in kanban view
+            if type_ != 'action' and type_ != 'object':
                 return
             elif not name:
                 self._raise_view_error(_("Button must have a name"), node)

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -180,7 +180,7 @@
                                 <button type="object" class="btn btn-primary btn-sm" name="button_immediate_install" invisible="state != 'uninstalled'" t-if="! record.to_buy.raw_value" groups="base.group_system">Activate</button>
                                 <div t-if="installed" class="d-flex align-items-center text-muted float-start">Installed</div>
                                 <a t-att-href="record.website.raw_value" target="_blank" invisible="website in (False, '')" class="btn btn-sm btn-secondary float-end o-hidden-ios" role="button">Learn More</a>
-                                <a type="edit" class="btn btn-secondary btn-sm float-end" role="button" invisible="website != ''">Module Info</a>
+                                <a type="open" class="btn btn-secondary btn-sm float-end" role="button" invisible="website != ''">Module Info</a>
                                 <a href="https://odoo.com/pricing?utm_source=db&amp;utm_medium=module#hosting=on_premise" target="_blank" class="btn btn-info btn-sm" invisible="state not in ('uninstalled', 'uninstallable')" t-if="record.to_buy.raw_value" role="button" groups="base.group_system">Upgrade</a>
                                 <button invisible="state != 'to remove'" type="object" class="btn btn-sm btn-primary" name="button_uninstall_cancel" groups="base.group_system">Cancel Uninstall</button>
                                 <button invisible="state != 'to install'" type="object" class="btn btn-sm btn-primary" name="button_install_cancel" groups="base.group_system">Cancel Install</button>


### PR DESCRIPTION
* = { account, base_import_module, hr_holdidays, payment, website, base}

**Before this commit:**
Historically, buttons with type="edit" opened the record in form view in edit
mode, and those with type="open" opened them in readonly. Since v16, form views
are always in edition, so those two types are redundant.

**After this commit:**
Support of `type="edit"` has been removed from the codebase.

Enterprise: https://github.com/odoo/enterprise/pull/75346

Task-4367373

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
