### PR TITLE
[FIX] point_of_sale: allow cashiers to close sessions without accounting's Administrator access rights

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -346,7 +346,7 @@ class PosSession(models.Model):
                 # Set the uninvoiced orders' state to 'done'
                 self.env['pos.order'].search([('session_id', '=', self.id), ('state', '=', 'paid')]).write({'state': 'done'})
             else:
-                self.move_id.sudo().unlink()
+                self.move_id.with_context(force_delete=True).sudo().unlink()
             self.sudo().with_company(self.company_id)._reconcile_account_move_lines(data)
         else:
             self.sudo()._post_statement_difference(self.cash_register_difference, False)


### PR DESCRIPTION
Because an exception raised by the `_unlink_forbid_parts_of_chain` method when attempting to delete journal entries.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
