### PR TITLE
[FIX] account_peppol: Fix unhandled requests exception

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import contextlib
+import logging
 import requests
 from lxml import etree
 from hashlib import md5
@@ -12,6 +13,8 @@ from odoo.addons.account_peppol.tools.demo_utils import handle_demo
 from odoo.tools.sql import column_exists, create_column
 
 TIMEOUT = 10
+_logger = logging.getLogger(__name__)
+
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
@@ -90,9 +93,9 @@ class ResPartner(models.Model):
 
         try:
             response = requests.get(smp_url, timeout=TIMEOUT)
-        except requests.exceptions.ConnectionError:
-            return None
-        if response.status_code != 200:
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            _logger.debug(e)
             return None
         return etree.fromstring(response.content)
 


### PR DESCRIPTION
In some rare case, the following call:https://github.com/odoo/odoo/blob/2b15cdecfacdc777b5db1ee151012681c3760899/addons/account_peppol/models/res_partner.py#L89 fails. 
The call is try-catched but we didn't handle all possible requests exception, only the Connection Error.
We therefore instead catch the more general RequestException that will catch all ConnectionError, Timeout, HTTPError, ...
We also add a logging to help debugging.

task-no
