### PR TITLE
[WIP][IMP] hr_holidays: traceback error on overview

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -81,7 +81,7 @@ class LeaveReportCalendar(models.Model):
         records = super()._fetch_query(query, fields)
         if self.env.context.get('hide_employee_name') and 'employee_id' in self.env.context.get('group_by', []):
             self.env.cache.update(records, self._fields['name'], [
-                record.name.split(':')[-1].strip()
+                (record.name.split(':')[-1].strip() if record.name else record.name)
                 for record in records.with_user(SUPERUSER_ID)
             ])
         return records


### PR DESCRIPTION
Steps to reproduce:
-login as marc demo or any other user with no time off rights 
-Navigate to the Time Off app.
-Click on "Overview."

Issue:
A traceback error is encountered.

Cause:
The leave_id is restricted based on user group, resulting in a false value. 
In the _fetch_query function, it attempts to use split() or strip() on the name which 
causes the error because these methods cannot be applied to a boolean value.

Solution:
check the validation of name before split and strip

task-4384350