### PR TITLE
[FIX] account: update the payment_reference when reordering moves

### DIFF
--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -151,6 +151,8 @@ class ReSequenceWizard(models.TransientModel):
             if self.ordering == 'date':
                 raise UserError(_('You can not reorder sequence by date when the journal is locked with a hash.'))
         moves_to_rename = self.env['account.move'].browse(int(k) for k in new_values.keys())
+        moves_to_reset_payment_reference = moves_to_rename.filtered(lambda l: l.payment_reference == l._get_invoice_computed_reference())
+        moves_to_reset_payment_reference.payment_reference = False
         moves_to_rename.name = '/'
         moves_to_rename.flush_recordset(["name"])
         # If the db is not forcibly updated, the temporary renaming could only happen in cache and still trigger the constraint


### PR DESCRIPTION
During the resequencing process, default `payment_reference`s that got generated when the move was posted don't get updated with the new name.