### PR TITLE
[FIX] web: configuration layout: preview misaligned on mobile

### DIFF
--- a/addons/web/static/src/scss/base_document_layout.scss
+++ b/addons/web/static/src/scss/base_document_layout.scss
@@ -4,14 +4,12 @@
     .o_content{
         height: inherit;
         .o_form_renderer {
-            padding: 0;
             height: 100%;
             .o_group {
-                --gutter-x: 0px;
                 display: flex;
+                width: auto !important;
                 .o_document_layout_company {
                     flex: 5;
-                    padding: 24px 0 0 32px;
 
                     img {
                         max-height: 100px;
@@ -28,8 +26,6 @@
                     }
                 }
                 .o_preview {
-                    padding: 0;
-
                     .preview_document_layout {
                         .o_preview_iframe {
                             padding: 0;

--- a/addons/web/static/src/scss/base_document_layout.scss
+++ b/addons/web/static/src/scss/base_document_layout.scss
@@ -9,7 +9,6 @@
             .o_group {
                 --gutter-x: 0px;
                 display: flex;
-                height: inherit;
                 .o_document_layout_company {
                     flex: 5;
                     padding: 24px 0 0 32px;
@@ -29,11 +28,9 @@
                     }
                 }
                 .o_preview {
-                    height: inherit;
                     padding: 0;
-                    .preview_document_layout {
-                        height: inherit;
 
+                    .preview_document_layout {
                         .o_preview_iframe {
                             padding: 0;
                         }


### PR DESCRIPTION
Before this commit, the preview was on the rigth and you had to scroll
to see the preview of the document.

Now, the preview is below on mobile.

Task-4377734




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
