### PR TITLE
[FIX] sale_management: test reload template translations w/out demo data

### DIFF
--- a/addons/sale_management/tests/common.py
+++ b/addons/sale_management/tests/common.py
@@ -9,6 +9,9 @@ class SaleManagementCommon(SaleCommon):
     def setUpClass(cls):
         super().setUpClass()
 
+        # Ensure user has access to sale order templates
+        cls.env.user.groups_id += cls.env.ref('sale_management.group_sale_order_template')
+
         cls.empty_order_template = cls.env['sale.order.template'].create({
             'name': "Test Quotation Template",
         })


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Run `test_reload_template_translations` without demo data.

Issue
-----
> AssertionError: sale_order_template_id was not found in the view

Cause
-----
The `sale_order_template_id` field requires the user to have the `sale_management.group_sale_order_template` group, which they don't have by default without demo data.

Solution
--------
Add the group to the current user before running the test.

---

Runbot: https://runbot.odoo.com/web#id=109475&view_type=form&model=runbot.build.error&menu_id=405&cids=1

opw-4260006