### PR TITLE
[IMP] {website_}mail_group: improve views' UX

### DIFF
--- a/addons/mail/models/mail_alias.py
+++ b/addons/mail/models/mail_alias.py
@@ -504,8 +504,7 @@ Please try again later or contact %(company_name)s instead."""
         }, minimal_qcontext=True)
 
     def _alias_bounce_incoming_email(self, message, message_dict, set_invalid=True):
-        """Set alias status to invalid and create bounce message to the sender
-        and the alias responsible.
+        """Set alias status to invalid and create bounce message to the sender.
 
         This method must be called when a message received on the alias has
         caused an error due to the mis-configuration of the alias.
@@ -526,6 +525,4 @@ Please try again later or contact %(company_name)s instead."""
         self.env['mail.thread']._routing_create_bounce_email(
             message_dict['email_from'], body, message,
             references=message_dict['message_id'],
-            # add the alias creator as recipient if set
-            recipient_ids=self.create_uid.partner_id.ids if self.create_uid.active else [],
         )

--- a/addons/mail_group/__manifest__.py
+++ b/addons/mail_group/__manifest__.py
@@ -21,6 +21,7 @@ Manage your mailing lists from Odoo.
         'security/ir.model.access.csv',
         'security/mail_group_security.xml',
         'wizard/mail_group_message_reject_views.xml',
+        'views/mail_compose_message_views.xml',
         'views/mail_group_member_views.xml',
         'views/mail_group_message_views.xml',
         'views/mail_group_moderation_views.xml',

--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -61,7 +61,7 @@ class MailGroup(models.Model):
     member_count = fields.Integer('Members Count', compute='_compute_member_count')
     # Moderation
     is_moderator = fields.Boolean(string='Moderator', help='Current user is a moderator of the group', compute='_compute_is_moderator')
-    moderation = fields.Boolean(string='Moderate this group')
+    moderation = fields.Boolean(string='Moderate')
     moderation_rule_count = fields.Integer(string='Moderated emails count', compute='_compute_moderation_rule_count')
     moderation_rule_ids = fields.One2many('mail.group.moderation', 'mail_group_id', string='Moderated Emails')
     moderator_ids = fields.Many2many('res.users', 'mail_group_moderator_rel', string='Moderators',
@@ -71,7 +71,7 @@ class MailGroup(models.Model):
         help='People receive an automatic notification about their message being waiting for moderation.')
     moderation_notify_msg = fields.Html(string='Notification message')
     moderation_guidelines = fields.Boolean(
-        string='Send guidelines to new subscribers',
+        string='Send guidelines to new members',
         help='Newcomers on this moderated group will automatically receive the guidelines.')
     moderation_guidelines_msg = fields.Html(string='Guidelines')
     # ACLs

--- a/addons/mail_group/static/src/css/mail_group.scss
+++ b/addons/mail_group/static/src/css/mail_group.scss
@@ -6,6 +6,11 @@
     background-image: url(/mail_group/static/src/img/mail_group_portal.jpg);
 }
 
+.o_mg_mail_group_default_image {
+    background: url(/mail_group/static/src/img/fa_envelope_square.svg) no-repeat center center;
+    opacity: 0.5;
+}
+
 .o_mg_ribbon {
     right: 0;
     width: 120px;

--- a/addons/mail_group/static/src/img/fa_envelope_square.svg
+++ b/addons/mail_group/static/src/img/fa_envelope_square.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 448 512"><!--!Font Awesome Free 6.7.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+    <path d="M64 32C28.7 32 0 60.7 0 96L0 416c0 35.3 28.7 64 64 64l320 0c35.3 0 64-28.7 64-64l0-320c0-35.3-28.7-64-64-64L64 32zM218 271.7L64.2 172.4C66 156.4 79.5 144 96 144l256 0c16.5 0 30 12.4 31.8 28.4L230 271.7c-1.8 1.2-3.9 1.8-6 1.8s-4.2-.6-6-1.8zm29.4 26.9L384 210.4 384 336c0 17.7-14.3 32-32 32L96 368c-17.7 0-32-14.3-32-32l0-125.6 136.6 88.2c7 4.5 15.1 6.9 23.4 6.9s16.4-2.4 23.4-6.9z"/>
+</svg>

--- a/addons/mail_group/static/src/interactions/mail_group_message.js
+++ b/addons/mail_group/static/src/interactions/mail_group_message.js
@@ -23,12 +23,14 @@ export class MailGroupMessage extends Interaction {
 
         // By default hide the mention of the previous email for which we reply
         // And add a button "Read more" to show the mention of the parent email
-        const quoted = this.el.querySelector(".card-body *[data-o-mail-quote]");
-        const readMore = document.createElement("button");
-        readMore.classList.add("btn btn-light btn-sm ms-1");
-        readMore.innerText = ". . .";
-        quoted.insertBefore(readMore);
-        readMore.addEventListener("click", () => quoted.classList.toggle("visible"));
+        const quoted = this.el.querySelectorAll(".card-body *[data-o-mail-quote]");
+        if (quoted.length > 0)  {
+            const readMore = document.createElement("button");
+            readMore.classList.add("btn", "btn-light", "btn-sm", "ms-1");
+            readMore.innerText = ". . .";
+            quoted[0].before(readMore);
+            readMore.addEventListener("click", () => quoted.forEach((node) => node.classList.toggle("visible")));
+        }
     }
 
     /**

--- a/addons/mail_group/views/mail_compose_message_views.xml
+++ b/addons/mail_group/views/mail_compose_message_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="mail_compose_message_action_mail_group" model="ir.actions.act_window">
+        <field name="name">Send email</field>
+        <field name="res_model">mail.compose.message</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="context">{
+            'default_composition_mode': 'mass_mail',
+            'default_model': 'mail.group.member',
+            'default_res_ids': active_ids
+        }</field>
+        <field name="binding_model_id" ref="model_mail_group_member"/>
+        <field name="binding_view_types">list</field>
+    </record>
+</odoo>

--- a/addons/mail_group/views/mail_group_member_views.xml
+++ b/addons/mail_group/views/mail_group_member_views.xml
@@ -5,6 +5,9 @@
         <field name="model">mail.group.member</field>
         <field name="arch" type="xml">
             <list editable="top" sample="1">
+                <header>
+                    <button name="%(mail_group.mail_compose_message_action_mail_group)d" type="action" string="Email" />
+                </header>
                 <field name="email"
                     force_save="1"
                     required="1"

--- a/addons/mail_group/views/mail_group_views.xml
+++ b/addons/mail_group/views/mail_group_views.xml
@@ -5,10 +5,10 @@
         <field name="model">mail.group</field>
         <field name="arch" type="xml">
             <list sample="1">
-                <field name="name"/>
-                <field name="alias_email" string="Alias"/>
-                <field name="moderation" string="Moderated"/>
-                <field name="member_count" string="Members"/>
+                <field name="name" width="100%"/>
+                <field name="member_count" string="#Members" width="100%"/>
+                <field name="mail_group_message_count" string="#Messages" width="100%"/>
+                <field name="mail_group_message_moderation_count" string="#To Review" width="100%"/>
             </list>
         </field>
     </record>
@@ -23,17 +23,28 @@
                         <aside>
                             <field name="image_128" widget="image" alt="Group"/>
                         </aside>
-                        <main>
+                        <main class="ms-2 d-flex flex-column">
                             <widget name="web_ribbon" title="Closed" bg_color="text-bg-danger" invisible="not is_closed"/>
                             <span class="fw-bold fs-5">#<field name="name"/></span>
-                            <field class="text-truncate text-nowrap" name="description"/>
-                            <span>
-                                <field name="member_count" class="me-1"/>
-                                <t t-if="record.member_count.raw_value > 1">Members</t>
-                                <t t-else="">Member</t>
-                            </span>
-                            <button type="object" invisible="is_member or is_closed" class="btn btn-primary ms-auto" name="action_join">Join</button>
-                            <button type="object" invisible="not is_member" class="btn btn-secondary ms-auto" name="action_leave">Leave</button>
+                            <field class="text-truncate text-nowrap d-block" name="description"/>
+                            <div class="d-flex flex-row mt-2">
+                                <a class="text-truncate"
+                                   t-if="record.mail_group_message_moderation_count.raw_value"
+                                   name="%(mail_group.mail_group_message_action)d"
+                                   type="action"
+                                   context="{'search_default_mail_group_id': id, 'search_default_moderation_status': 'pending_moderation'}">
+                                    <field name="mail_group_message_moderation_count"/>
+                                    messages to review
+                                </a>
+                                <div class="text-end ms-auto">
+                                    <button type="object" invisible="is_member or is_closed" class="btn btn-primary ms-auto"
+                                            name="action_join">Join
+                                    </button>
+                                    <button type="object" invisible="not is_member" class="btn btn-secondary ms-auto"
+                                            name="action_leave">Leave
+                                    </button>
+                                </div>
+                            </div>
                         </main>
                     </t>
                 </templates>
@@ -50,12 +61,6 @@
                         string="Join" invisible="is_member or is_closed"/>
                     <button type="object" invisible="not is_member"
                         class="btn btn-secondary" name="action_leave" string="Leave"/>
-                    <button name="action_send_guidelines" type="object" class="btn btn-secondary"
-                        string="Send Guidelines" invisible="is_closed"/>
-                    <button name="action_close" type="object" class="btn btn-secondary"
-                        string="Close" invisible="is_closed"/>
-                    <button name="action_open" type="object" class="btn btn-secondary"
-                        string="Re-Open" invisible="not is_closed"/>
                 </header>
                 <sheet>
                     <widget name="web_ribbon" title="Closed" bg_color="text-bg-danger" invisible="not is_closed"/>
@@ -82,13 +87,13 @@
                                 class="oe_stat_button"
                                 icon="fa-commenting-o"
                                 help="Emails waiting an action for this group"
-                                invisible="not moderation">
+                                invisible="not (moderation and mail_group_message_moderation_count != 0)">
                             <field name="mail_group_message_moderation_count" widget="statinfo" string="To Review"/>
                         </button>
                         <button name="%(mail_group.mail_group_moderation_action)d"
                                 type="action"
                                 context="{'search_default_mail_group_id': id}"
-                                invisible="not moderation"
+                                invisible="not (moderation and moderation_rule_count != 0)"
                                 class="oe_stat_button"
                                 icon="fa-gavel"
                                 help="Moderated emails in this group">
@@ -96,7 +101,7 @@
                         </button>
                     </div>
                     <field name="image_128" widget="image" class="oe_avatar" options="{'size': [90, 90]}"/>
-                    <div class="oe_title">
+                    <div class="oe_title mb24">
                         <label for="name" string="Group Name"/>
                         <h1>
                             <field name="name" class="oe_inline" default_focus="1" placeholder='e.g. "Newsletter"'/>
@@ -119,13 +124,13 @@
                                             invisible="alias_domain_id"/>
                                 </div>
                             </div>
-                            <field name="description"/>
+                            <field name="description" placeholder='e.g. "This group is about ..."'/>
                             <field name="moderation"/>
                             <td class="o_td_label">
                                 <label for="moderator_ids" string="Moderators" invisible="not moderation"/>
-                                <label for="moderator_ids" string="Responsible Users" invisible="moderation"/>
+                                <label for="moderator_ids" string="Responsibles" invisible="moderation"/>
                             </td>
-                            <field name="moderator_ids" widget="many2many_tags" class="oe_inline" nolabel="1"/>
+                            <field name="moderator_ids" widget="many2many_avatar_user" class="oe_inline" nolabel="1" placeholder="Select users"/>
                             <field name="is_moderator" invisible="1"/>
                             <field name="can_manage_group" invisible="1"/>
                             <field name="is_member" invisible="1"/>
@@ -134,9 +139,12 @@
                     <notebook>
                         <page name="privacy" string="Privacy">
                             <group>
-                                <field name="access_mode" widget="radio"/>
-                                <field name="access_group_id" invisible="access_mode != 'groups'" required="access_mode == 'groups'"/>
-                                <field name="alias_contact" invisible="1"/>
+                                <group>
+                                    <field name="access_mode" widget="radio"/>
+                                    <field name="access_group_id" invisible="access_mode != 'groups'"
+                                           required="access_mode == 'groups'"/>
+                                    <field name="alias_contact" invisible="1"/>
+                                </group>
                             </group>
                         </page>
                         <page name="moderation" string="Notify Members" invisible="not moderation">
@@ -148,7 +156,7 @@
                         <page name="guidelines" string="Guidelines">
                             <group>
                                 <field name="moderation_guidelines"/>
-                                <field required="moderation_guidelines" name="moderation_guidelines_msg"/>
+                                <field required="moderation_guidelines" name="moderation_guidelines_msg" placeholder='e.g."Please be polite and ..."'/>
                             </group>
                         </page>
                     </notebook>

--- a/addons/mail_group/views/portal_templates.xml
+++ b/addons/mail_group/views/portal_templates.xml
@@ -22,40 +22,42 @@
                 <div t-if="'unsubscribe' in request.params" class="offset-lg-9 col-lg-3 alert alert-info" role="status">
                     <h5>Need to unsubscribe? <br/>It's right here! <span class="oi fa-2x oi-arrow-down float-end" role="img" aria-label="" title="Read this !"/></h5>
                 </div>
-                <div class="row mb-4" t-foreach="mail_groups" t-as="group_data">
+                <t t-foreach="mail_groups" t-as="group_data">
                     <t t-set="group" t-value="group_data['group']"/>
                     <t t-set="is_member" t-value="group_data['is_member']"/>
-                    <div class="col-lg-5">
-                        <img t-if="group.image_128" t-attf-src="/web/image/mail.group/#{group.id}/image_128" class="o_image_64_cover float-start me-3" alt="Group"/>
-                        <div t-else="" class="o_image_64_cover float-start me-3 d-lg-block d-md-none"/>
-                        <div class="d-flex flex-row">
-                            <strong><a t-attf-href="/groups/#{ slug(group) }" t-esc="group.name"/></strong>
-                            <div t-if="group.alias_email and not group.is_closed"
-                                class="d-flex align-items-center ms-3">
-                                <i class="fa fa-envelope-o me-1" role="img" aria-label="Alias" title="Alias"/>
-                                <a class="text-break" t-attf-href="mailto:#{group.alias_email}" t-field="group.alias_email"/>
+                    <div class="row mb-4 o_mail_group" t-att-data-id="group.id">
+                        <div class="col-lg-5">
+                            <img t-if="group.image_128" t-attf-src="/web/image/mail.group/#{group.id}/image_128" class="o_image_64_cover float-start me-3" alt="Group"/>
+                            <div t-else="" class="o_image_64_cover o_mg_mail_group_default_image float-start me-3 d-lg-block d-md-none"/>
+                            <div class="d-flex flex-row">
+                                <strong><a t-attf-href="/groups/#{ slug(group) }" t-esc="group.name"/></strong>
+                                <div t-if="group.alias_email and not group.is_closed"
+                                    class="d-flex align-items-center ms-3">
+                                    <i class="fa fa-envelope-o me-1" role="img" aria-label="Alias" title="Alias"/>
+                                    <a class="text-break" t-attf-href="mailto:#{group.alias_email}" t-field="group.alias_email"/>
+                                </div>
                             </div>
+                            <div t-field="group.description" class="text-muted d-flex"/>
                         </div>
-                        <div t-field="group.description" class="text-muted d-flex"/>
-                    </div>
-                    <div class="col-lg-3">
-                        <i class="fa fa-fw fa-user" role="img" aria-label="Recipients" title="Recipients"/> <t t-esc="group.member_count"/> members<br />
-                        <t t-if="not group.is_closed">
-                            <i class="fa fa-fw fa-envelope-o" role="img" aria-label="Traffic" title="Traffic"/> <t t-esc="group.mail_group_message_last_month_count"/> messages / month
-                        </t>
-                    </div>
-                    <div class="col-lg-4">
-                        <t t-set="force_unsubscribe" t-value="'unsubscribe' in request.params"/>
-                        <div t-if="not group.is_closed" class="o_mail_group" t-att-data-id="group.id" t-att-data-is-member="force_unsubscribe or is_member">
-                            <div class="input-group o_mg_subscribe_form">
-                                <input type="email" name="email" class="o_mg_subscribe_email form-control" t-att-value="email" placeholder="your email..." t-att-readonly="int(bool(email))"/>
-                               <button t-if="force_unsubscribe or is_member" href="#" class="btn btn-outline-primary o_mg_subscribe_btn">Unsubscribe</button>
-                               <button t-else="" href="#" class="btn btn-primary o_mg_subscribe_btn">Subscribe</button>
+                        <div class="col-lg-3">
+                            <i class="fa fa-fw fa-user" role="img" aria-label="Recipients" title="Recipients"/> <span class="o_mg_members_count" t-out="group.member_count"/> members<br />
+                            <t t-if="group.mail_group_message_last_month_count and not group.is_closed">
+                                <i class="fa fa-fw fa-envelope-o" role="img" aria-label="Traffic" title="Traffic"/> <t t-esc="group.mail_group_message_last_month_count"/> messages / month
+                            </t>
+                        </div>
+                        <div class="col-lg-4">
+                            <t t-set="force_unsubscribe" t-value="'unsubscribe' in request.params"/>
+                            <div t-if="not group.is_closed" class="o_mg_subscribe_form d-flex justify-content-end" t-att-data-is-member="force_unsubscribe or is_member">
+                                <button href="#" t-attf-class="{{ 'd-none' if not (force_unsubscribe or is_member) else '' }} btn btn-outline-primary o_mg_subscribe_btn o_mg_unsubscribe_btn">Unsubscribe</button>
+                                <div t-attf-class="{{ 'd-none' if force_unsubscribe or is_member else '' }} {{ 'input-group' if not int(bool(email)) else '' }} o_mg_email_input_group">
+                                    <input type="email" name="email" t-attf-class="o_mg_subscribe_email form-control {{ 'd-none' if int(bool(email)) else '' }}" t-att-value="email" placeholder="your email..." t-att-readonly="int(bool(email))"/>
+                                    <button href="#" class="btn btn-primary o_mg_subscribe_btn">Subscribe</button>
+                                </div>
                             </div>
+                            <div t-else="" class="ms-2 float-end text-center text-muted">Closed</div>
                         </div>
-                        <div t-else="" class="ms-2 o_mg_subscribe_btn float-end text-center text-muted">Closed</div>
                     </div>
-                </div>
+                </t>
             </div>
             <div t-else="" class="container mt32">
                 <div class="alert alert-primary text-center">
@@ -160,7 +162,7 @@
 
     <template id="messages_short">
         <div>
-            <ul class="list-unstyled">
+            <ul t-if="messages" class="list-unstyled">
                 <li t-foreach="messages" t-as="message" class="d-flex mt-3">
                     <div class="flex-grow-1 o_mg_message mw-100">
                         <div class="card">
@@ -196,6 +198,13 @@
                     </div>
                 </li>
             </ul>
+            <p t-else="" class="text-center h4 mt-5">
+                Oops, there are no messages here.
+                <t t-if="group.alias_email">
+                    <br/>
+                    Get the conversation started by sending an email to <a t-attf-href="mailto:{{ group.alias_email }}" t-out="group.alias_email"></a>!
+                </t>
+            </p>
             <p t-if="messages and (msg_more_count or 0) > 0 and parent_message">
                 <button class="btn btn-link o_mg_read_more"
                     t-attf-data-href="/groups/#{slug(group)}/#{slug(parent_message)}/get_replies"

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -597,7 +597,7 @@ class TestMailgateway(MailGatewayCommon):
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.addons.mail.models.mail_mail', 'odoo.models', 'odoo.sql_db')
     def test_message_process_alias_config_invalid_defaults(self):
         """Sending a mail to a misconfigured alias must change its status to
-        invalid and notify sender and alias creator."""
+        invalid and notify sender."""
         test_model_track = self.env['ir.model']._get('mail.test.track')
         container_custom = self.env['mail.test.container'].create({})
         alias_valid = self.env['mail.alias'].with_user(self.user_admin).create({
@@ -637,9 +637,6 @@ class TestMailgateway(MailGatewayCommon):
             alias._alias_bounce_incoming_email(message, message_dict)
 
         self.assertEqual(alias_valid.alias_status, 'invalid')
-        self.assertSentEmail(f'"MAILER-DAEMON" <{self.alias_bounce}@{self.alias_domain}>',
-                             [self.user_admin.email_formatted],
-                             subject='Re: Invalid')
         # Not sent to self.email_from because a return path is present in MAIL_TEMPLATE
         self.assertSentEmail(f'"MAILER-DAEMON" <{self.alias_bounce}@{self.alias_domain}>',
                              ['whatever-2a840@postmaster.twitter.com'],

--- a/addons/website_mail_group/static/src/snippets/s_group/mail_group.js
+++ b/addons/website_mail_group/static/src/snippets/s_group/mail_group.js
@@ -2,7 +2,6 @@ import { MailGroup } from "@mail_group/interactions/mail_group";
 import { patch } from "@web/core/utils/patch";
 import { patchDynamicContent } from "@web/public/utils";
 
-import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 
 patch(MailGroup.prototype, {
@@ -25,7 +24,7 @@ patch(MailGroup.prototype, {
         // for the first time, we make a RPC call to setup the widget properly
         const email = (new URL(document.location.href)).searchParams.get('email');
         const response = await rpc('/group/is_member', {
-            'group_id': this.mailgroupId,
+            'group_id': this.mailGroupId,
             'email': email,
             'token': this.token,
         });
@@ -39,17 +38,19 @@ patch(MailGroup.prototype, {
         const userEmail = response.email;
         this.isMember = response.is_member;
 
+        const inputGroup = this.el.querySelector(".o_mg_email_input_group")
+
         if (userEmail && userEmail.length) {
-            const emailInputEl = this.el.querySelector(".o_mg_subscribe_email");
+            inputGroup.classList.remove("input-group")
+            inputGroup.classList.add("d-flex", "justify-content-end");
+            const emailInputEl = inputGroup.querySelector(".o_mg_subscribe_email");
             emailInputEl.value = userEmail;
-            emailInputEl.setAttribute("readonly", 1);
+            emailInputEl.classList.add("d-none");
         }
 
         if (this.isMember) {
-            const buttonEl = this.el.querySelector(".o_mg_subscribe_btn");
-            buttonEl.innerText = _t('Unsubscribe');
-            buttonEl.classList.remove("btn-primary");
-            buttonEl.classList.add("btn-outline-primary");
+            this.el.querySelector(".o_mg_unsubscribe_btn").classList.remove("d-none");
+            inputGroup.classList.add("d-none");
         }
 
         this.el.dataset.isMember = this.isMember;

--- a/addons/website_mail_group/static/src/snippets/s_group/options.js
+++ b/addons/website_mail_group/static/src/snippets/s_group/options.js
@@ -26,17 +26,18 @@ options.registry.Group = options.Class.extend({
             this.$target[0].dataset.id = this.mailGroups[0][0];
         } else {
             const widget = this._requestUserValueWidgets('create_mail_group_opt')[0];
-            widget.$el.click();
+            widget.el.click();
         }
     },
 
     cleanForSave: function () {
         // TODO: this should probably be done by the public widget, not the
         // option code, not important enough to try and fix in stable though.
-        const emailInput = this.$target.find('.o_mg_subscribe_email');
-        emailInput.val('');
-        emailInput.removeAttr('readonly');
-        this.$target.find('.o_mg_subscribe_btn').text(_t('Subscribe'));
+        const emailInput = this.$target[0].querySelector(".o_mg_subscribe_email");
+        emailInput.value = "";
+        emailInput.classList.remove("d-none");
+        this.$target[0].querySelector(".o_mg_unsubscribe_btn").classList.add("d-none");
+        this.$target[0].querySelector(".o_mg_email_input_group").classList.add("input-group");
     },
 
     //--------------------------------------------------------------------------
@@ -62,7 +63,7 @@ options.registry.Group = options.Class.extend({
 
         const groupId = await this.orm.create("mail.group", [{ name: name }]);
 
-        this.$target.attr("data-id", groupId);
+        this.$target[0].setAttribute("data-id", groupId);
         return this._rerenderXML();
     },
 

--- a/addons/website_mail_group/views/mail_group_views.xml
+++ b/addons/website_mail_group/views/mail_group_views.xml
@@ -6,7 +6,8 @@
         <field name="inherit_id" ref="mail_group.mail_group_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
-                <button type="object" class="oe_stat_button" icon="fa-globe" name="action_go_to_website">
+                <button type="object" class="oe_stat_button" name="action_go_to_website">
+                    <i class="fa fa-fw o_button_icon fa-globe text-success" title="Mail group accessible on website"/>
                     <div class="o_form_field o_stat_info">
                         <span class="o_stat_text">Go to <br/>Website</span>
                     </div>

--- a/addons/website_mail_group/views/snippets/s_group.xml
+++ b/addons/website_mail_group/views/snippets/s_group.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="s_group" name="Discussion Group">
-        <div class="s_group o_mail_group"
-             data-id="0" data-object="mail.group" data-follow="off">
-            <div class="input-group o_mg_subscribe_form">
-                <input class="o_mg_subscribe_email form-control" type="email" name="email" placeholder="your email..."/>
-                <button href="#" class="btn btn-primary o_mg_subscribe_btn">Subscribe</button>
+        <div class="s_group o_mail_group" data-object="mail.group" data-follow="off">
+            <div class="o_mg_subscribe_form">
+                <div class="d-flex justify-content-end">
+                    <button href="#" t-attf-class="d-none btn btn-outline-primary o_mg_subscribe_btn o_mg_unsubscribe_btn">Unsubscribe</button>
+                </div>
+                <div t-attf-class="o_mg_email_input_group input-group">
+                    <input type="email" name="email" t-attf-class="o_mg_subscribe_email form-control" t-att-value="email" placeholder="your email..."/>
+                    <button href="#" class="btn btn-primary o_mg_subscribe_btn">Subscribe</button>
+                </div>
             </div>
         </div>
     </template>


### PR DESCRIPTION
[IMP] {website_}mail_group: improve views' UX

This PR aims to give users a better experience by editing some labels, changing widgets or fields' appearance, adding mass mailing for mail groups and hiding some URLs if the pages do not yet displayed any data.

task-4306166

____________________________________________________________________________________________________

[IMP] mail: remove alias creators of bounce mails recipients

The bounce mails are sent to the mail.alias creators. This PR aims prevent this because users do not have to be spammed because they created mail.alias. 

task-4306166

____________________________________________________________________________________________________

[FIX] mail_group: fix quoted elements display issue.

Problem 1:
The js selects only the first element with the html data-o-mail-quote attribute but there may be more than one. Thus, some elements were not displayed when user clicked on the "read more" button. Now, they are all displayed when the user clicks on
this one.

Problem 2:
The js selects an element with the html data-o-mail-quote attribute and try to use js attributes of the returned object but this one can be null. Then the error occurs. From now, we use its attributes if its is not null.

Problem 3:
The add method of classList contains spaces. Now, the list of classes is split by commas.

Task-4306166