### PR TITLE
[FIX] ir_cron: Allow any user to run cron

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -714,7 +714,7 @@ class ir_cron(models.Model):
         :return: a pair ``(cron, progress)``, where the progress has
             been injected inside the cron's context
         """
-        progress = self.env['ir.cron.progress'].create([{
+        progress = self.env['ir.cron.progress'].sudo().create([{
             'cron_id': self.id,
             'remaining': 0,
             'done': 0,
@@ -735,7 +735,7 @@ class ir_cron(models.Model):
             return
         if done < 0 or remaining < 0:
             raise ValueError("`done` and `remaining` must be positive integers.")
-        self.env['ir.cron.progress'].browse(progress_id).write({
+        self.env['ir.cron.progress'].sudo().browse(progress_id).write({
             'remaining': remaining,
             'done': done,
         })


### PR DESCRIPTION
Step to reproduce:
 - Set any non-admin user as the cron scheduler
 - The cron won't run as the permission required to create the ir.cron.progress are admin

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
