### PR TITLE
[FIX] account: x2many button on payment view

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -447,6 +447,15 @@ class AccountPayment(models.Model):
     def _get_method_codes_needing_bank_account(self):
         return []
 
+    def action_open_business_doc(self):
+        return {
+            'name': _("Payment"),
+            'type': 'ir.actions.act_window',
+            'views': [(False, 'form')],
+            'res_model': 'account.payment',
+            'res_id': self.id,
+        }
+
     @api.depends('payment_method_code')
     def _compute_show_require_partner_bank(self):
         """ Computes if the destination bank account must be displayed in the payment form view. By default, it


### PR DESCRIPTION
In the payment view, he `x2many_buttons` widget on `duplicate_payment_ids`
calls the `action_open_business_doc`, but this method is not implemented
on `account.payment`. This was not not a problem before 01b87f1230beac0568f4e3b1b76e547909506892
since a payment was always linked to a move, therefore we were calling
the method from `account.move`.

With this commit, we implement the `action_open_business_doc` in
`account.payment`.

Step:

- Create a payment and confirm
- Duplicate it
- Click on the 'Same payment' hyperlink
-> Error: "The method 'action_open_business_doc' does not exist on the
   model 'account.payment'"

opw-4363907
