### PR TITLE
[FIX] l10n_din5008_purchase: Display correct Incoterm code in templates

### DIFF
--- a/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
+++ b/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
@@ -29,7 +29,7 @@
                     </tr>
                     <tr t-if="o.incoterm_id">
                         <td>Incoterm:</td>
-                        <td><t t-out="o.incoterm_id"/></td>
+                        <td><t t-out="o.incoterm_id.code"/></td>
                     </tr>
                 </table>
             </div>
@@ -83,7 +83,7 @@
                 </tr>
                 <tr t-if="o.incoterm_id">
                     <td>Incoterm:</td>
-                    <td><t t-out="o.incoterm_id"/></td>
+                    <td><t t-out="o.incoterm_id.code"/></td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
Fixed an issue where the Incoterm was incorrectly
displayed as the full object representation `account.incoterm(1,)` instead of its human-readable code.

opw-4342104


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
