### PR TITLE
[FIX] mail: no chat window crop on safari mobile

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -1,6 +1,5 @@
 .o-mail-ChatWindow {
     width: $o-mail-ChatWindow-width;
-    aspect-ratio: 9 / 15;
 
     z-index: 999; // messaging menu is dropdown (1000)
     &.o-mobile {
@@ -8,6 +7,7 @@
     }
     &:not(.o-mobile) {
         --border-opacity: .15;
+        aspect-ratio: 9 / 15;
     }
     outline: none;
 }


### PR DESCRIPTION
Chat window have their style improved recently [1]: their size and aspect-ratio have changed. The aspect-ratio is intended for desktop use. In mobile, it should take whole height and width of screen.

This works well in almost all browsers: `w-100 h-100` seems to take precedence over explicit aspect-ratio. On Safari however, it seems to comply with given aspect-ratio even if this means cropping the content. This is unintentional and makes chat windows barely useable.

Steps to reproduce:

- Open a chat window with a relatively long conversation name on safari browser in small screen => The header content on the left is cropped.

This commit fixes the issue by putting the `aspect-ratio` in a non-mobile rule. That way `w-100 h-100` will be used correctly in Safari browser as in all other browsers.

[1]: https://github.com/odoo/odoo/pull/188665


Before / After
<img width="233" alt="Screenshot 2024-12-09 at 11 46 10" src="https://github.com/user-attachments/assets/b60a306d-1357-41cc-874e-da0529e40b4c"> <img width="233" alt="Screenshot 2024-12-09 at 11 46 32" src="https://github.com/user-attachments/assets/efd5a75a-73a8-4f79-b273-56516bd4996e">

