### PR TITLE
[IMP] account: Add EDI information when batch sending invoices

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -17661,6 +17661,12 @@ msgstr ""
 
 #. module: account
 #. odoo-python
+#: code:addons/account/wizard/account_move_send_batch_wizard.py:0
+msgid "by %s"
+msgstr ""
+
+#. module: account
+#. odoo-python
 #: code:addons/account/controllers/portal.py:0
 #: model:ir.model.fields.selection,name:account.selection__res_partner__invoice_sending_method__email
 msgid "by Email"

--- a/addons/account/static/src/components/account_batch_sending_summary/account_batch_sending_summary.xml
+++ b/addons/account/static/src/components/account_batch_sending_summary/account_batch_sending_summary.xml
@@ -3,8 +3,8 @@
 
     <t t-name="account.BatchSendingSummary">
         <p>You are about to send</p>
-        <ul t-foreach="this.data" t-as="summary_entry" t-key="summary_entry">
-            <li>
+        <ul>
+            <li t-foreach="this.data" t-as="summary_entry" t-key="summary_entry">
                 <t t-out="summary_entry_value.count"/> invoice(s)
                 <t t-out="summary_entry_value.label"/>
                 <t t-if="summary_entry_value.extra" t-out="summary_entry_value.extra"/>


### PR DESCRIPTION
Problem
---------
The Send&Print has been reworked in 9e769e1b11f22890e5245859053bc8dd31e42634.

However, there is currently no information about which EDIs are going to be triggered along side the sending of the invoice; meaning that the user will not know that the EDI process will be executed too, which is confusing.

Objective
---------
Add to the preview of the list of stuff to be sent in batch the amount of invoices that will be sent using the default EDI.

Solution
---------
Update the `summary_data` computation to encompass for EDI counting adding the results to the dictionary that will be displayed by the batch Send&Print custom JS Component and custom template.

task-4306204

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
