### PR TITLE
[FIX] base: allow automated actions to link m2m fields

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -31942,13 +31942,6 @@ msgid "many2many"
 msgstr ""
 
 #. module: base
-#. odoo-python
-#: code:addons/base/models/ir_actions.py:0
-#, python-format
-msgid "many2many fields cannot be evaluated by reference"
-msgstr ""
-
-#. module: base
 #: model:ir.model.fields.selection,name:base.selection__ir_model_fields__ttype__many2one
 msgid "many2one"
 msgstr ""


### PR DESCRIPTION
Versions
--------
- 16.0 (fix issue)
- 17.0+ (skip useless constraint)

Commit 3871ae2c6c45 enabled automated m2m CRUD in 17.0+

Steps
-----
1. Create an automated action on a Model with tags (e.g. Contact);
2. set trigger to On Creation;
3. in data to write, have evaluation type to Value;
4. fill in the value (e.g. 1);
5. create a record that would trigger the automation.

Issue
-----
> ValueError: Wrong value for res.partner.category_id: 1

Cause
-----
In the `eval_value` method, the `many2many` type doesn't get covered.

Solution
--------
1. Have `eval_value` handle `many2many` values (linking them to relevant record, and existing as a single expression per column).
2. Undo 09a6df204f2a which disallowed writing by reference for many2many fields. This change makes writing by reference possible as well, and allows you to select the desired record, instead of having to manually fill in its ID.

opw-4054461
