### PR TITLE
[IMP] website_sale: attribute filters revamp

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -24,6 +24,9 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
         'mousemove .o_wsale_filmstip_wrapper': '_onMouseMove',
         'click .o_wsale_filmstip_wrapper' : '_onClickHandler',
         'submit': '_onClickConfirmOrder',
+        'input .o_wsale_attribute_search_bar': '_searchAttributeValues',
+        'click .o_wsale_variant_pills_shop': '_onClickPillsAttribute',
+        'click .o_wsale_view_more_btn': '_onToggleViewMoreLabel',
     }),
 
     /**
@@ -350,6 +353,46 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
         }
     },
     /**
+     * Search attribute values based on the input text.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _searchAttributeValues(ev) {
+        const input = ev.target;
+        const searchValue = input.value.toLowerCase();
+
+        document.querySelectorAll(`#${input.dataset.containerId} .form-check`).forEach(item =>{
+            const labelText = item.querySelector('.form-check-label').textContent.toLowerCase();
+            item.style.display = labelText.includes(searchValue) ? '' : 'none'
+        });
+    },
+    /**
+     * Highlight selected pill
+     *
+     * @private
+     * @param {MouseEvent} ev
+     */
+    _onClickPillsAttribute(ev) {
+        if (ev.target.tagName === "LABEL" || ev.target.tagName === "INPUT") {
+            return;
+        }
+        const checkbox = ev.target.closest('.o_wsale_variant_pills_shop').querySelector("input");
+        checkbox.click();
+    },
+    /**
+     * Toggle the button text between "View More" and "View Less"
+     *
+     * @private
+     * @param {MouseEvent} ev
+     */
+    _onToggleViewMoreLabel(ev) {
+        const button = ev.target;
+        const isExpanded = button.getAttribute('aria-expanded') === 'true';
+
+        button.innerHTML = isExpanded ? "View Less" : "View More";
+    },
+    /**
      * When the quantity is changed, we need to query the new price of the product.
      * Based on the pricelist, the price might change when quantity exceeds a certain amount.
      *
@@ -421,9 +464,9 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
             const url = new URL(form.action);
             const searchParams = url.searchParams;
             // Aggregate all attribute values belonging to the same attribute into a single
-            // `attribute_value` search param.
+            // `attribute_values` search param.
             for (const entry of attributeValues.entries()) {
-                searchParams.append('attribute_value', `${entry[0]}-${[...entry[1]].join(',')}`);
+                searchParams.append('attribute_values', `${entry[0]}-${[...entry[1]].join(',')}`);
             }
             // Aggregate all tags into a single `tags` search param.
             if (tags.size) {

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1274,3 +1274,28 @@ a.no-decoration {
 body.modal-open:has(.js_sale.o_wsale_product_page) {
     overflow: hidden;
 }
+
+.o_wsale_variant_pills_shop {
+    padding: $spacer/2 $spacer;
+    border: none;
+    cursor: pointer;
+
+    &.btn.active {
+        background-color: map-get($theme-colors, 'primary');
+    }
+    &:not(.active) {
+        color: map-get($grays, '600');
+        background-color: map-get($grays, '200');
+    }
+    &:hover{
+        background-color: map-get($theme-colors, 'primary');
+        color: white;
+    }
+
+    input {
+        -moz-appearance: none;
+        -webkit-appearance: none;
+        appearance: none;
+        opacity: 0;
+    }
+}

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -459,7 +459,7 @@
                                     class="py-3 border-bottom"
                                 >
                                     <a
-                                        t-att-href="keep(attribute_value=0, tags=0, min_price=0, max_price=0)"
+                                        t-att-href="keep(attribute_values=0, tags=0, min_price=0, max_price=0)"
                                         t-attf-class="btn btn-{{navClass}} d-flex align-items-center py-1"
                                         title="Clear Filters"
                                     >
@@ -832,7 +832,7 @@
     <template id="website_sale.products_categories_top" active="True" name="Categories in top-nav"/>
     <template id="website_sale.products_attributes_top" active="False" name="Attributes in top-nav"/>
 
-    <template id="o_wsale_offcanvas_color_attribute" name="Color type attribute in filter">
+    <template id="website_sale.filter_color_attributes" name="Color attributes in Filter">
         <t t-foreach="a.value_ids" t-as="v">
             <t t-set="img_style"
                t-value="'background:url(/web/image/product.attribute.value/%s/image); background-size:cover;' % v.id if v.image else ''"
@@ -851,6 +851,278 @@
                 />
             </label>
         </t>
+    </template>
+
+    <template id="website_sale.filter_select_attributes" name="Select attributes in Filter">
+        <select class="form-select css_attribute_select" name="attribute_value">
+            <option value="" selected="true">All <t t-out="a.name"/></option>
+            <t t-foreach="a.value_ids" t-as="v">
+                <option
+                    t-att-value="'%s-%s' % (a.id,v.id)"
+                    t-out="v.name"
+                    t-att-selected="v.id in attrib_set"
+                />
+            </t>
+        </select>
+    </template>
+
+    <template
+        id="website_sale.filter_radio_and_multi_attributes"
+        name="Radio and Multi attributes in Filter"
+    >
+        <t
+            t-set="sorted_values"
+            t-value="sorted(a.value_ids, key=lambda v: v.id not in attrib_set)"
+        />
+        <t t-if="len(sorted_values) &lt;= 20">
+            <div
+                t-foreach="sorted_values[:8]"
+                t-as="v"
+                t-attf-class="{{'list-group-item border-0 ps-0 pb-0' if isMobile else ''}}"
+            >
+                <div class="form-check mb-1">
+                    <input
+                        type="checkbox"
+                        name="attribute_value"
+                        class="form-check-input"
+                        t-att-id="'%s-%s' % (a.id,v.id)"
+                        t-att-value="'%s-%s' % (a.id,v.id)"
+                        t-att-checked="v.id in attrib_set"
+                    />
+                    <label
+                        class="form-check-label fw-normal"
+                        t-att-for="'%s-%s' % (a.id,v.id)"
+                        t-field="v.name"
+                    />
+                </div>
+            </div>
+            <t t-if="len(sorted_values) &gt; 8">
+                <div
+                    t-attf-id="o_wsale_remaining_values_{{a.id}}"
+                    class="accordion-collapse collapse"
+                    t-attf-aria-labelledby="o_wsale_view_more_{{a.id}}_header"
+                >
+                    <div
+                        t-foreach="sorted_values[8:]"
+                        t-as="v"
+                        t-attf-class="{{'list-group-item border-0 ps-0 pb-0' if isMobile else ''}}"
+                    >
+                        <div class="form-check mb-1">
+                            <input
+                                type="checkbox"
+                                name="attribute_value"
+                                class="form-check-input"
+                                t-att-id="'%s-%s' % (a.id,v.id)"
+                                t-att-value="'%s-%s' % (a.id,v.id)"
+                                t-att-checked="v.id in attrib_set"
+                            />
+                            <label
+                                class="form-check-label fw-normal"
+                                t-att-for="'%s-%s' % (a.id,v.id)"
+                                t-field="v.name"
+                            />
+                        </div>
+                    </div>
+                </div>
+                <div
+                    t-attf-id="o_wsale_view_more_{{a.id}}_header"
+                    t-attf-class="accordion-header {{'mb-0' if isMobile else ''}}"
+                >
+                    <button
+                        type="button"
+                        class="o_wsale_view_more_btn btn btn-link px-0 collapsed"
+                        data-bs-toggle="collapse"
+                        t-attf-data-bs-target="#o_wsale_remaining_values_{{a.id}}"
+                        t-attf-aria-controls="o_wsale_remaining_values_{{a.id}}"
+                        aria-expanded="false"
+                    >
+                        View More
+                    </button>
+                </div>
+            </t>
+        </t>
+        <t t-elif="len(sorted_values) &gt; 20">
+            <div t-attf-class="{{'my-3' if isMobile else 'mb-3'}}">
+                <input
+                    type="text"
+                    class="o_wsale_attribute_search_bar form-control"
+                    t-att-placeholder="'Search %s (%s)' % (a.name, len(a.value_ids))"
+                    t-att-data-container-id="'searchable-values-%s' % a.id"
+                />
+            </div>
+            <div
+                t-attf-id="searchable-values-{{ a.id }}"
+                class="overflow-auto"
+                t-attf-style="max-height:{{'290px' if isMobile else '220px'}};"
+            >
+                <t t-foreach="sorted_values" t-as="v">
+                    <div
+                        t-attf-class="form-check mb-1 {{'list-group-item border-0 ms-3 pb-0' if isMobile else 'ms-1'}}"
+                    >
+                        <input
+                            type="checkbox"
+                            name="attribute_value"
+                            class="form-check-input"
+                            t-att-id="'%s-%s' % (a.id,v.id)"
+                            t-att-value="'%s-%s' % (a.id,v.id)"
+                            t-att-checked="v.id in attrib_set"
+                        />
+                        <label
+                            class="form-check-label fw-normal"
+                            t-att-for="'%s-%s' % (a.id,v.id)"
+                            t-field="v.name"
+                        />
+                    </div>
+                </t>
+            </div>
+        </t>
+    </template>
+
+    <template id="website_sale.filter_pills_attributes" name="Pills attributes in Filter">
+        <t t-foreach="a.value_ids" t-as="v">
+            <div
+                t-attf-class="o_wsale_variant_pills_shop form-check btn btn-primary mb-1 {{'active' if v.id in attrib_set else ''}}"
+            >
+                <input
+                    type="checkbox"
+                    name="attribute_value"
+                    class="form-check-input"
+                    t-att-id="'%s-%s' % (a.id,v.id)"
+                    t-att-value="'%s-%s' % (a.id,v.id)"
+                    t-att-checked="v.id in attrib_set"
+                />
+                <label
+                    class="form-check-label fw-normal"
+                    t-att-for="'%s-%s' % (a.id,v.id)"
+                    t-field="v.name"
+                />
+            </div>
+        </t>
+    </template>
+
+    <template
+        id="website_sale.product_attribute_filters_form"
+        name="Product Attribute Filters Form"
+    >
+        <form
+            t-attf-class="js_attributes {{('accordion accordion-flush d-flex flex-column ' + ('border-bottom' if attributes else '')) if isMobile else 'position-relative mb-2'}}"
+            method="get"
+            t-att-action="keep(attribute_values=0, tags=0)"
+        >
+            <t
+                t-set="visible_attributes"
+                t-value="len([a for a in attributes if a.value_ids and len(a.value_ids) &gt; 1])"
+            />
+
+            <t t-foreach="attributes" t-as="a">
+                <t t-cache="a,attrib_set,visible_attributes,isMobile">
+                    <t t-set="_status" t-value="'inactive'"/>
+                    <t t-foreach="a.value_ids" t-as="v" t-if="v.id in attrib_set" t-set="_status" t-value="'active'"/>
+                    <div
+                        t-if="a.value_ids and len(a.value_ids) &gt; 1"
+                        t-attf-class="accordion-item {{('border-top-0 ' + ('order-1' if _status == 'active' else 'order-2')) if isMobile else 'nav-item mb-1 rounded-0'}}"
+                    >
+                        <h2
+                            t-if="isMobile"
+                            class="accordion-header mb-0"
+                            t-attf-id="o_wsale_offcanvas_attribute_{{a.id}}_header"
+                        >
+                            <button
+                                t-attf-class="o_wsale_offcanvas_title accordion-button rounded-0 {{'collapsed' if not attrib_values and visible_attributes &gt;= 4 else ''}}"
+                                type="button"
+                                t-att-data-status="_status"
+                                data-bs-toggle="collapse"
+                                t-attf-data-bs-target="#o_wsale_offcanvas_attribute_{{a.id}}"
+                                t-att-aria-expanded="(_status == 'active' or visible_attributes &lt; 4) and 'True' or 'False'"
+                                t-attf-aria-controls="o_wsale_offcanvas_attribute_{{a.id}}"
+                            >
+                                <b t-out="a.name"/>
+                            </button>
+                        </h2>
+                        <h6 t-else="" class="mb-3">
+                            <b class="d-none d-lg-block" t-field="a.name"/>
+                        </h6>
+                        <div
+                            t-attf-id="{{'o_wsale_offcanvas_attribute_' + str(a.id) if isMobile else 'o_products_attributes_' + str(a.id)}}"
+                            t-attf-class="{{'accordion-collapse collapse ' + ('show' if _status == 'active' or visible_attributes &lt; 4 else '') if isMobile else ''}}"
+                        >
+                            <div t-attf-class="{{'accordion-body pt-0' if isMobile else ''}}">
+                                <div
+                                    t-if="a.display_type == 'select'"
+                                    t-attf-class="{{'my-2' if isMobile else 'mb-3'}}"
+                                >
+                                    <t t-call="website_sale.filter_select_attributes"/>
+                                </div>
+                                <div
+                                    t-elif="a.display_type == 'color'"
+                                    t-attf-class="{{'pt-1 pb-3' if isMobile else 'mb-3'}}"
+                                >
+                                    <t t-call="website_sale.filter_color_attributes"/>
+                                </div>
+                                <div
+                                    t-elif="a.display_type in ('radio', 'multi')"
+                                    t-attf-class="{{'list-group list-group-flush' if isMobile else 'flex-column mb-3'}}"
+                                >
+                                    <t t-call="website_sale.filter_radio_and_multi_attributes">
+                                        <t t-set="isMobile" t-value="isMobile"/>
+                                    </t>
+                                </div>
+                                <div
+                                    t-elif="a.display_type == 'pills'"
+                                    t-attf-class="btn-group-toggle {{'my-2' if isMobile else 'mb-3'}}"
+                                    data-bs-toggle="buttons"
+                                >
+                                    <t t-call="website_sale.filter_pills_attributes"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </t>
+            </t>
+            <t t-if="isMobile">
+                <t t-if="opt_wsale_filter_tags and (opt_wsale_attributes or opt_wsale_attributes_top)">
+                    <t t-set="_status" t-value="'inactive'"/>
+                    <t t-foreach="all_tags" t-as="v" t-if="v.id in tags" t-set="_status" t-value="'active'"/>
+                    <div t-if="all_tags">
+                        <h2 class="accordion-header mb-0" t-attf-id="o_wsale_offcanvas_tags_header">
+                            <button
+                                t-attf-class="o_wsale_offcanvas_title accordion-button border-top rounded-0 {{not tags and 'collapsed'}}"
+                                type="button"
+                                t-att-data-status="_status"
+                                data-bs-toggle="collapse"
+                                t-attf-data-bs-target="#o_wsale_offcanvas_tags"
+                                t-att-aria-expanded="_status == 'active' and 'True' or 'False'"
+                                t-attf-aria-controls="o_wsale_offcanvas_tags"
+                            >
+                                <b>Tags</b>
+                            </button>
+                        </h2>
+                        <div
+                            t-attf-id="o_wsale_offcanvas_tags"
+                            t-attf-class="accordion-collapse collapse {{(_status == 'active') and 'show'}}"
+                            t-att-aria-expanded="(_status == 'active') and 'True' or 'False'"
+                            t-attf-aria-labelledby="o_wsale_offcanvas_tags_header"
+                        >
+                            <div class="accordion-body pt-0">
+                                <div class="list-group list-group-flush">
+                                    <t t-call="website_sale.filter_products_tags_list">
+                                        <t t-set="all_tags" t-value="all_tags"/>
+                                    </t>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </t>
+            </t>
+            <t t-else="">
+                <t
+                    t-if="opt_wsale_filter_tags and opt_wsale_attributes"
+                    t-call="website_sale.filter_products_tags"
+                >
+                    <t t-set="all_tags" t-value="all_tags"/>
+                </t>
+            </t>
+        </form>
     </template>
 
     <!-- OffCanvas Nav -->
@@ -933,92 +1205,9 @@
                         </div>
                     </div>
                 </div>
-
-                <form
-                    t-if="opt_wsale_attributes or opt_wsale_attributes_top"
-                    t-attf-class="js_attributes accordion accordion-flush d-flex flex-column {{len(attributes) > 0 and 'border-bottom'}}"
-                    method="get"
-                    t-att-action="keep(attribute_value=0, tags=0)"
-                >
-                    <t t-foreach="attributes" t-as="a">
-                        <t t-cache="a,attrib_set">
-                            <t t-set="_status" t-value="'inactive'"/>
-                            <t t-foreach="a.value_ids" t-as="v" t-if="v.id in attrib_set" t-set="_status" t-value="'active'"/>
-
-                            <div t-if="a.value_ids and len(a.value_ids) &gt; 1"
-                                 t-attf-class="accordion-item border-top-0 {{(_status == 'active') and 'order-1' or 'order-2'}}">
-                                <h2 class="accordion-header mb-0" t-attf-id="o_wsale_offcanvas_attribute_{{a.id}}_header">
-                                    <button t-attf-class="o_wsale_offcanvas_title accordion-button rounded-0 {{ not attrib_values and 'collapsed'}}"
-                                            type="button"
-                                            t-att-data-status="_status"
-                                            data-bs-toggle="collapse"
-                                            t-attf-data-bs-target="#o_wsale_offcanvas_attribute_{{a.id}}"
-                                            t-att-aria-expanded="_status == 'active' and 'True' or 'False'"
-                                            t-attf-aria-controls="o_wsale_offcanvas_attribute_{{a.id}}">
-                                            <b t-out="a.name"/>
-                                    </button>
-                                </h2>
-                                <div t-attf-id="o_wsale_offcanvas_attribute_{{a.id}}"
-                                     t-attf-class="accordion-collapse collapse {{ (_status == 'active') and 'show'}}"
-                                     t-att-aria-expanded="(_status == 'active') and 'True' or 'False'"
-                                     t-attf-aria-labelledby="o_wsale_offcanvas_attribute_{{a.id}}_header">
-
-                                    <div class="accordion-body pt-0">
-                                        <div t-if="a.display_type == 'color'" class="pt-1 pb-3">
-                                            <t t-call="website_sale.o_wsale_offcanvas_color_attribute"/>
-                                        </div>
-                                        <div t-else=""
-                                             class="list-group list-group-flush">
-                                            <div t-foreach="a.value_ids" t-as="v" class="list-group-item border-0 ps-0 pb-0">
-                                                <div class="form-check mb-1">
-                                                    <input type="checkbox"
-                                                           name="attribute_value"
-                                                           class="form-check-input"
-                                                           t-att-id="'%s-%s' % (a.id,v.id)"
-                                                           t-att-value="'%s-%s' % (a.id,v.id)"
-                                                           t-att-checked="'checked' if v.id in attrib_set else None"/>
-                                                    <label class="form-check-label fw-normal" t-att-for="'%s-%s' % (a.id,v.id)" t-field="v.name"/>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </t>
-                    </t>
-                    <t t-if="opt_wsale_filter_tags and (opt_wsale_attributes or opt_wsale_attributes_top)">
-                        <t t-set="_status" t-value="'inactive'"/>
-                        <t t-foreach="all_tags" t-as="v" t-if="v.id in tags" t-set="_status" t-value="'active'"/>
-                        <div t-if="all_tags">
-                            <h2 class="accordion-header mb-0" t-attf-id="o_wsale_offcanvas_tags_header">
-                                <button t-attf-class="o_wsale_offcanvas_title accordion-button border-top rounded-0 {{ not tags and 'collapsed'}}"
-                                        type="button"
-                                        t-att-data-status="_status"
-                                        data-bs-toggle="collapse"
-                                        t-attf-data-bs-target="#o_wsale_offcanvas_tags"
-                                        t-att-aria-expanded="_status == 'active' and 'True' or 'False'"
-                                        t-attf-aria-controls="o_wsale_offcanvas_tags"
-                                >
-                                    <b>Tags</b>
-                                </button>
-                            </h2>
-                            <div t-attf-id="o_wsale_offcanvas_tags"
-                                 t-attf-class="accordion-collapse collapse {{ (_status == 'active') and 'show'}}"
-                                 t-att-aria-expanded="(_status == 'active') and 'True' or 'False'"
-                                 t-attf-aria-labelledby="o_wsale_offcanvas_tags_header"
-                            >
-                                <div class="accordion-body pt-0">
-                                    <div class="list-group list-group-flush">
-                                        <t t-call="website_sale.filter_products_tags_list">
-                                            <t t-set="all_tags" t-value="all_tags"/>
-                                        </t>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </t>
-                </form>
-
+                <t t-call="website_sale.product_attribute_filters_form">
+                    <t t-set="isMobile" t-value="True"/>
+                </t>
                 <t t-if="opt_wsale_filter_price and (opt_wsale_attributes or opt_wsale_attributes_top)"
                    t-call="website_sale.filter_products_price">
                     <t
@@ -1032,7 +1221,7 @@
             <div class="offcanvas-body d-flex justify-content-between flex-grow-0 border-top overflow-hidden">
                 <a t-attf-class="btn btn-{{navClass}} d-flex py-1 mb-2 {{(not attrib_values and not isFilteringByPrice and not tags) and 'disabled' }}"
                    t-att-aria-disabled="(not attrib_values and not isFilteringByPrice and not tags) and 'true' or 'false'"
-                   t-att-href="keep(attribute_value=0, tags=0, min_price=0, max_price=0)"
+                   t-att-href="keep(attribute_values=0, tags=0, min_price=0, max_price=0)"
                    title="Clear Filters">
                     Clear Filters
                 </a>
@@ -1315,52 +1504,9 @@
         <xpath expr="//div[contains(@t-attf-class, 'products_attributes_filters')]" position="inside">
             <div t-if="attributes or all_tags" id="wsale_products_attributes_collapse"
                  class=" position-relative">
-                <form
-                    class="js_attributes position-relative mb-2"
-                    method="get"
-                    t-att-action="keep(attribute_value=0, tags=0)"
-                >
-                    <t t-foreach="attributes" t-as="a">
-                        <t t-cache="a,attrib_set">
-                            <div class="accordion-item nav-item mb-1 rounded-0" t-if="a.value_ids and len(a.value_ids) &gt; 1">
-                                <h6 class="mb-3">
-                                    <b class="d-none d-lg-block" t-field="a.name"/>
-                                </h6>
-                                <div t-attf-id="o_products_attributes_{{a.id}}" class="">
-                                    <t t-if="a.display_type == 'select'">
-                                        <select class="form-select css_attribute_select mb-2" name="attribute_value">
-                                            <option value="" selected="true">All <t t-out="a.name"/></option>
-                                            <t t-foreach="a.value_ids" t-as="v">
-                                                <option t-att-value="'%s-%s' % (a.id,v.id)" t-esc="v.name" t-att-selected="v.id in attrib_set" />
-                                            </t>
-                                        </select>
-                                    </t>
-                                    <div t-elif="a.display_type == 'color'" class="mb-3">
-                                        <t t-call="website_sale.o_wsale_offcanvas_color_attribute"/>
-                                    </div>
-                                    <div t-elif="a.display_type in ('radio', 'pills', 'multi')" class="flex-column mb-3">
-                                        <t t-foreach="a.value_ids" t-as="v">
-                                            <div class="form-check mb-1">
-                                                <input type="checkbox"
-                                                       name="attribute_value"
-                                                       class="form-check-input"
-                                                       t-att-id="'%s-%s' % (a.id,v.id)"
-                                                       t-att-value="'%s-%s' % (a.id,v.id)"
-                                                       t-att-checked="'checked' if v.id in attrib_set else None"/>
-                                                <label class="form-check-label fw-normal" t-att-for="'%s-%s' % (a.id,v.id)" t-field="v.name"/>
-                                            </div>
-                                        </t>
-                                    </div>
-                                </div>
-                            </div>
-                        </t>
-                    </t>
-                    <t t-if="opt_wsale_filter_tags and opt_wsale_attributes"
-                       t-call="website_sale.filter_products_tags"
-                    >
-                        <t t-set="all_tags" t-value="all_tags"/>
-                    </t>
-                </form>
+                 <t t-call="website_sale.product_attribute_filters_form">
+                    <t t-set="isMobile" t-value="False"/>
+                </t>
             </div>
         </xpath>
     </template>
@@ -1368,39 +1514,40 @@
     <template
         id="products_attributes_collapsible"
         name="Collapsed Attributes &amp; Variants filters"
-        inherit_id="website_sale.products_attributes"
+        inherit_id="website_sale.product_attribute_filters_form"
     >
         <xpath expr="//form" position="attributes">
-            <attribute
-                name="class"
-                add="wsale_accordion_collapsible accordion accordion-flush"
-                remove="mb-2"
-                separator=" "
-            />
+            <t t-if="not isMobile">
+                <attribute
+                    name="t-attf-class"
+                    add="wsale_accordion_collapsible accordion accordion-flush"
+                    remove="mb-2"
+                    separator=" "
+                />
+            </t>
         </xpath>
-        <xpath expr="//div[hasclass('accordion-item')]//h6" position="replace">
-            <h6 class="accordion-header">
+        <xpath expr="//div[contains(@t-attf-class, 'accordion-item')]//h6" position="replace">
+            <h6 t-if="not isMobile" class="accordion-header">
                 <button
-                    class="accordion-button px-0 bg-transparent shadow-none"
+                    t-attf-class="accordion-button px-0 bg-transparent shadow-none
+                        {{'collapsed' if visible_attributes &gt;= 4 else ''}}"
                     type="button"
                     data-bs-toggle="collapse"
                     t-attf-data-bs-target="#o_products_attributes_{{a.id}}"
                     t-attf-aria-controls="o_products_attributes_{{a.id}}"
-                    aria-expanded="true"
+                    t-att-aria-expanded="'false' if visible_attributes &gt;= 4 else 'true'"
                 >
                     <b t-field="a.name"/>
                 </button>
             </h6>
         </xpath>
-        <xpath expr="//div[@t-attf-id='o_products_attributes_{{a.id}}']" position="attributes">
-            <attribute name="class" add="accordion-collapse collapse show" separator=" "/>
+        <xpath expr="//div[contains(@t-attf-id, 'o_products_attributes_')]" position="attributes">
+            <attribute
+                name="t-attf-class"
+                add="accordion-collapse collapse {{'' if visible_attributes &gt;= 4 else 'show'}}"
+                separator=" "
+            />
             <attribute name="data-bs-parent" add="wsale_products_attributes_collapse"/>
-        </xpath>
-        <xpath expr="//select" position="attributes">
-            <attribute name="class" add="mb-3" remove="mb-2" separator=" "/>
-        </xpath>
-        <xpath expr="//div[hasclass('flex-column')]" position="attributes">
-            <attribute name="class" add="mb-3" separator=" "/>
         </xpath>
     </template>
 
@@ -1534,7 +1681,7 @@
                         <div class="col d-flex align-items-center order-1 order-lg-0">
                             <ol class="o_wsale_breadcrumb breadcrumb p-0 mb-4 m-lg-0">
                                 <li class="o_not_editable breadcrumb-item d-none d-lg-inline-block">
-                                    <a t-att-href="shop_path">
+                                    <a t-att-href="keep(shop_path)">
                                         <i class="oi oi-chevron-left d-lg-none me-1" role="presentation"/>All Products
                                     </a>
                                 </li>
@@ -1545,13 +1692,13 @@
                                 >
                                     <a
                                         class="py-2 py-lg-0"
-                                        t-attf-href="{{shop_path}}/category/{{slug(category)}}"
+                                        t-att-href="keep('%s/category/%s' % (shop_path, slug(category)))"
                                     >
                                         <i class="oi oi-chevron-left d-lg-none me-1" role="presentation"/><t t-out="category.name"/>
                                     </a>
                                 </li>
                                 <li t-else="" class="o_not_editable breadcrumb-item d-lg-none">
-                                    <a class="py-2 py-lg-0" t-att-href="shop_path">
+                                    <a class="py-2 py-lg-0" t-att-href="keep(shop_path)">
                                         <i class="oi oi-chevron-left me-1" role="presentation"/>All Products
                                     </a>
                                 </li>


### PR DESCRIPTION
Post this commit:
- Store selected attribute values in the session to restore them when navigating
  back to the /shop page from the product form.  
- Automatically collapse filter sections when four or more attributes are
  present in a filter.  
- Refine Checkbox/Radio filters:  
  - Display up to 8 values (+ the selected ones) initially.  
  - Add a 'View More' button to display all values beyond the initial 8.  
  - Introduce a search bar for filters with over 20 values, replacing the
    'View More' button with a scrollable list and an indicator of the number of
    values available.  
- Display attribute values as pills for attributes of the 'pills' display type,
  allowing multi-select functionality on the /shop page.  


task-4244913

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
