### PR TITLE
[FIX] discuss: compare call participants by the correct name field

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
@@ -60,10 +60,11 @@ export class DiscussSidebarCallParticipants extends Component {
     get sessions() {
         const sessions = [...this.props.thread.rtcSessions];
         return sessions.sort((s1, s2) => {
+            const persona1 = s1.channelMember.persona;
+            const persona2 = s2.channelMember.persona;
             return (
-                s1.channelMember?.persona?.nameOrDisplayName?.localeCompare(
-                    s2.channelMember?.persona?.nameOrDisplayName
-                ) ?? 1
+                persona1?.name?.localeCompare(persona2?.name) ||
+                s1.channelMember.id - s2.channelMember.id
             );
         });
     }

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -28,13 +28,12 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCallParticipants.participant">
-        <t t-set="channelMember" t-value="session.channelMember"/>
-        <div class="d-flex text-reset overflow-hidden align-items-center" t-att-class="{ 'justify-content-center bg-inherit': compact, 'me-2': !compact and props.compact === undefined }">
+        <div class="o-mail-DiscussSidebarCallParticipants-participant d-flex text-reset overflow-hidden align-items-center" t-att-class="{ 'justify-content-center bg-inherit': compact, 'me-2': !compact and props.compact === undefined }">
             <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:24px;height:24px">
-                <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle o_object_fit_cover" t-att-src="channelMember.persona.avatarUrl" t-att-class="{'o-isTalking': !session.isMute and session.isTalking}" alt="Participant avatar"/>
+                <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle o_object_fit_cover" t-att-src="session.channelMember.persona.avatarUrl" t-att-class="{'o-isTalking': !session.isMute and session.isTalking}" alt="Participant avatar"/>
             </div>
-            <span t-if="!compact" class="o-mail-DiscussSidebarCallParticipants-name mx-1 text-truncate fw-bolder smaller user-select-none" t-att-title="channelMember.persona.name" t-att-class="{ 'o-isTalking': !session.isMute and session.isTalking }">
-                <t t-esc="channelMember.persona.name"/>
+            <span t-if="!compact" class="o-mail-DiscussSidebarCallParticipants-name mx-1 text-truncate fw-bolder smaller user-select-none" t-att-title="session.channelMember.persona.name" t-att-class="{ 'o-isTalking': !session.isMute and session.isTalking }">
+                <t t-esc="session.channelMember.persona.name"/>
             </span>
             <div t-if="!compact" class="flex-grow-1"/>
             <div class="o-mail-DiscussSidebarCallParticipants-status" t-att-class="{ 'position-absolute bg-inherit p-0 rounded-circle o-compact d-flex smaller start-0 text-start': compact, 'ms-1 d-flex align-items-center justify-content-center': !compact }">

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -430,3 +430,49 @@ test("show call participants in discuss sidebar", async () => {
         ],
     });
 });
+
+test("Sort call participants in side bar by name", async () => {
+    mockGetMedia();
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    pyEnv["discuss.channel.rtc.session"].create([
+        {
+            channel_member_id: pyEnv["discuss.channel.member"].create({
+                channel_id: channelId,
+                partner_id: pyEnv["res.partner"].create({ name: "CCC" }),
+            }),
+            channel_id: channelId,
+        },
+        {
+            channel_member_id: pyEnv["discuss.channel.member"].create({
+                channel_id: channelId,
+                partner_id: pyEnv["res.partner"].create({ name: "AAA" }),
+            }),
+            channel_id: channelId,
+        },
+        {
+            channel_member_id: pyEnv["discuss.channel.member"].create({
+                channel_id: channelId,
+                partner_id: pyEnv["res.partner"].create({ name: "BBB" }),
+            }),
+            channel_id: channelId,
+        },
+    ]);
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-DiscussSidebarCallParticipants", {
+        contains: [
+            ".o-mail-DiscussSidebarCallParticipants-participant:nth-child(1):contains('AAA')",
+        ],
+    });
+    await contains(" .o-mail-DiscussSidebarCallParticipants", {
+        contains: [
+            ".o-mail-DiscussSidebarCallParticipants-participant:nth-child(2):contains('BBB')",
+        ],
+    });
+    await contains(" .o-mail-DiscussSidebarCallParticipants", {
+        contains: [
+            ".o-mail-DiscussSidebarCallParticipants-participant:nth-child(3):contains('CCC')",
+        ],
+    });
+});


### PR DESCRIPTION
Before this commit, and since [1], the call participants in the side bar were sorted by `nameOrDisplayName` which is not available and should be using `name`.

[1]: https://github.com/odoo/odoo/pull/174965

