### PR TITLE
[FIX] web_editor: raise NotFound instead of of ValueError for unsupported file

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -634,7 +634,7 @@ class Web_Editor(http.Controller):
         try:
             with file_open(shape_path, 'r', filter_ext=('.svg',)) as file:
                 return file.read()
-        except FileNotFoundError:
+        except (FileNotFoundError, ValueError):
             raise werkzeug.exceptions.NotFound()
 
     def _update_svg_colors(self, options, svg):


### PR DESCRIPTION
Currently a ValueError occurs when users access URLs like '/web_editor/shape/image/jpeg'.

Error:
```
ValueError: Unsupported file: util/static/shapes/index
  File "odoo/http.py", line 2364, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1892, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1955, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1922, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2082, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 329, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 727, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/html_editor/controllers/main.py", line 499, in shape
    svg = self._get_shape_svg(module, 'shapes', filename)
  File "addons/html_editor/controllers/main.py", line 84, in _get_shape_svg
    with file_open(shape_path, 'r', filter_ext=('.svg',)) as file:
  File "odoo/tools/misc.py", line 247, in file_open
    path = file_path(name, filter_ext=filter_ext, env=env)
  File "odoo/tools/misc.py", line 210, in file_path
    raise ValueError("Unsupported file: " + file_path)
```

This ValueError was raised from the odoo/tools/misc.py at line [1] because the
file extension was not a match with the normalise path of the file path.

This commit will handle the ValueError at the time of opening the file;
now it shows not found instead of an error.

https://github.com/odoo/odoo/blob/231952114ae730bb8d4671f4a61f738e8b6dd5b8/odoo/tools/misc.py#L177-L178


sentry-6073086305