### PR TITLE
[FIX] mail: less visible non-self message reaction in dark theme

### DIFF
--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -12,7 +12,7 @@
     <t t-name="mail.MessageReactionList.button">
         <button class="position-relative o-mail-MessageReaction btn d-flex p-0 border rounded-2 mb-1 fs-5 px-1 gap-1 align-items-center" t-on-click="() => this.onClickReaction(props.reaction)" t-on-contextmenu="onContextMenu" t-on-mouseenter="loadEmoji" t-ref="reactionButton" t-att-class="{
             'o-selfReacted border-primary text-primary fw-bold': hasSelfReacted(props.reaction),
-            'bg-view': !hasSelfReacted(props.reaction),
+            'bg-view border-secondary': !hasSelfReacted(props.reaction),
             'ms-1': env.inChatWindow and env.alignedRight,
             'me-1': !(env.inChatWindow and env.alignedRight),
         }">


### PR DESCRIPTION
When message has emoji reactions, they have slightly different visual whether the current user has reacted or not: When the user has reacted, this is highlighted.

This works great in white them, but in dark theme the non-self reacted visual was more highlighted, which goes against the intend of highlighting self-reactions more. The problem is that non-self reactions are too distracting in dark theme, which isn't the case in white theme, This comes from borders being too visible.

The color of default `border` is too much in dark theme. This commit fixes the issue by using `border-secondary`, which has reduced opacity in dark theme. In white theme, this is unchanged.

Before
<img width="868" alt="Screenshot 2024-12-09 at 13 03 23" src="https://github.com/user-attachments/assets/963f6b65-a280-4be9-b15f-8a1cdbd562a5">

After
<img width="864" alt="Screenshot 2024-12-09 at 13 03 31" src="https://github.com/user-attachments/assets/5c43b705-d750-4370-af5b-2f3ab3dac51e">