### PR TITLE
[FIX] point_of_sale: compute price and taxes with smallest precision

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1211,7 +1211,8 @@ class PosGlobalState extends PosModel {
         const company = this.company;
         var round_tax = company.tax_calculation_rounding_method != 'round_globally';
 
-        var initial_currency_rounding = currency_rounding;
+        var product_rounding = Math.pow(10, -this.dp['Product Price']);
+        var initial_currency_rounding = Math.min(product_rounding, currency_rounding)
         if(!round_tax)
             currency_rounding = currency_rounding * 0.00001;
 

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -256,3 +256,23 @@ odoo.define('point_of_sale.tour.limitedProductPricelistLoading', function (requi
 
     Tour.register('limitedProductPricelistLoading', { test: true, url: '/pos/ui' }, getSteps());
 });
+
+odoo.define('point_of_sale.tour.ProductPricePrecisionTaxTour', function (require) {
+    'use strict';
+
+    const { ProductScreen } = require('point_of_sale.tour.ProductScreenTourMethods');
+    const { getSteps, startSteps } = require('point_of_sale.tour.utils');
+    var Tour = require('web_tour.tour');
+
+    startSteps();
+
+    ProductScreen.do.confirmOpeningPopup();
+    ProductScreen.do.clickHomeCategory();
+
+    ProductScreen.do.clickDisplayedProduct('Test Product');
+    ProductScreen.do.clickDisplayedProduct('Test Product');
+
+    ProductScreen.check.selectedOrderlineHas('Test Product', '2.0', '5.00');
+
+    Tour.register('ProductPricePrecisionTaxTour', { test: true, url: '/pos/ui' }, getSteps());
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1123,3 +1123,28 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CashRoundingPayment', login="accountman")
+
+    def test_product_price_precision_tax(self):
+        """ This tests the behavior of taxes when the decimal accuracy of the
+        currency and the product price are different """
+        tax = self.env['account.tax'].create({
+            'name': 'Tax 15%',
+            'amount': 10,
+            'price_include': False,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+        })
+
+        # Set the allowed number of digits for the price_unit
+        decimal_precision = self.env['decimal.precision'].search([('name', '=', 'Product Price')], limit=1)
+        decimal_precision.digits = 4
+
+        self.product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'taxes_id': [(6, 0, [tax.id])],
+            'list_price': 2.2727,
+            'available_in_pos': True,
+        })
+
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ProductPricePrecisionTaxTour', login="accountman")


### PR DESCRIPTION
Currently there is inconsistencies in product price and tax amounts computed when the product price precision and the currency precision are different.

Steps to reproduce:
-------------------
* Go in developer mode
* Open Settings App
* Select **Technical** > **Daabase structure** > **Decimal Accuracy**
* Change the decimal accuracy of `Product Price` to 4 digits
* Inside the POS app, create a product
  * Price: 2.2727
  * Tax: 10% (price excluded)
  * > Observation: Price 2.50 (tax included)
* Open shop session
* Add the product create 2 times
> Observation: Total $ 5.01. The amount is incorrect because `2 * 2.2727 * 1.1 = 4.99994`

Why the fix:
------------
This behavior is observed because, when computing all prices and taxes, we will start by rounding the base amount regarding the currency precision then compute taxes with the amount.

In our example we would do:
- Qty * base price -> 4.5454
- Round with currency accuracy -> 4.55 = (*)
- Compute tax -> 0.455
- Round tax with currency -> 0.46
- Total: 5.01 (rounded with currency)
- Price without tax (*) + rounded with currency: 4.55

What we would do now:
- Qty * base price -> 4.5454
- Round with smallest accuracy -> 4.5454 = (*)
- Compute tax -> 0.45454
- Round tax with currency -> 0.45
- Total: 4.9954
- Total rounded with currency: 5.00
- Price without tax (*) + rounded with currency: 4.55

opw-4285495