### PR TITLE
[FIX] stock_picking_batch: test_stock_picking_batch_sm_to_sml_sync tour

### DIFF
--- a/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
+++ b/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
@@ -2,7 +2,7 @@
 
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add('test_stock_picking_batch_sm_to_sml_synchronization', {
+registry.category("web_tour.tours").add("test_stock_picking_batch_sm_to_sml_synchronization", {
     steps: () => [
         {
             trigger: ".btn-primary[name=action_confirm]",
@@ -13,95 +13,91 @@ registry.category("web_tour.tours").add('test_stock_picking_batch_sm_to_sml_sync
             run: "click",
         },
         {
-            trigger: "h4:contains('Transfers')",
+            content: "Check the modal 'Open: Transfers' is open",
+            trigger: ".modal h4:contains(open: transfers)",
+        },
+        {
+            content: "Click in cell to start edition",
+            trigger: ".modal:contains(open: transfers) .o_data_row > td:contains('Product A')",
             run: "click",
         },
         {
-            trigger: ".o_data_row > td:contains('Product A')",
+            trigger: ".modal:contains(open: transfers) .o_list_number > div[name=quantity] input",
+            run: "edit 7",
+        },
+        {
+            trigger: ".modal:contains(open: transfers) .fa-list",
             run: "click",
         },
         {
-            trigger: ".o_list_number > div[name=quantity] input",
-            run: 'edit 7',
-        },
-        {
-            trigger: ".fa-list",
+            trigger: ".modal:contains(open: stock move) h4:contains('Stock move')",
             run: "click",
         },
         {
-            trigger: "h4:contains('Stock move')",
-            run: "click",
+            trigger:
+                ".modal:contains(open: stock move) .o_field_pick_from > span:contains('WH/Stock/Shelf A')",
         },
         {
-            trigger: ".o_field_pick_from > span:contains('WH/Stock/Shelf A')",
-            run: "click",
-        },
-        {
-            trigger: ".o_list_footer .o_list_number > span:contains('7')",
-            run: "click",
+            trigger:
+                ".modal:contains(open: stock move) .o_list_footer .o_list_number > span:contains(7)",
         },
         {
             content: "Click Save",
-            trigger: ".modal:not(.o_inactive_modal) .o_form_button_save",
+            trigger: ".modal:contains(open: stock move) .o_form_button_save",
             run: "click",
         },
         {
-            trigger: ".o_data_row > td:contains('Product A')",
+            content: "Click in cell to start edition",
+            trigger: ".modal:contains(open: transfers) .o_data_row > td:contains('Product A')",
             run: "click",
         },
         {
-            trigger: ".o_list_number[name=quantity] input",
-            run: 'edit 21',
+            trigger: ".modal:contains(open: transfers) .o_list_number[name=quantity] input",
+            run: "edit 21",
         },
         {
-            trigger: ".fa-list",
+            trigger: ".modal:contains(open: transfers) .fa-list",
             run: "click",
         },
         {
-            trigger: "h4:contains('Stock move')",
+            content: "Click in cell to start edition",
+            trigger:
+                ".modal:contains(open: stock move) .o_field_pick_from > span:contains('WH/Stock/Shelf A')",
             run: "click",
         },
         {
-            trigger: ".o_field_pick_from > span:contains('WH/Stock/Shelf A')",
-            run: "click",
-        },
-        {
-            trigger: ".modal:not(.o_inactive_modal) .o_list_number[name=quantity] input",
-            run: 'edit 27',
+            trigger: ".modal:contains(open: stock move) .o_list_number[name=quantity] input",
+            run: "edit 27",
         },
         {
             content: "Click Save",
-            trigger: ".modal:not(.o_inactive_modal) .o_form_button_save",
+            trigger: ".modal:contains(open: stock move) .o_form_button_save:contains(save)",
             run: "click",
         },
         {
-            trigger: ".o_data_row > td:contains('47')",
+            content: "Click in cell to start edition",
+            trigger: ".modal:contains(open: transfers) .o_data_row > td:contains(47)",
             run: "click",
         },
         {
-            trigger: ".o_field_widget[name=quantity] input",
-            run: 'edit 7',
+            trigger: ".modal:contains(open: transfers) .o_field_widget[name=quantity] input",
+            run: "edit 7",
         },
         {
-            trigger: ".fa-list",
+            trigger: ".modal:contains(open: transfers) .fa-list",
             run: "click",
         },
         {
-            trigger: ".o_data_row > td:contains('7')",
-            run: "click",
+            trigger: ".modal:contains(open: stock move) .o_data_row > td:contains(7)",
         },
         {
             content: "Click Save",
-            trigger: ".modal:not(.o_inactive_modal) .o_form_button_save",
+            trigger: ".modal:contains(open: stock move) .o_form_button_save",
             run: "click",
         },
         {
-            trigger: ".modal .o_form_button_save",
+            trigger: ".modal:contains(open: transfers) .o_form_button_save",
             run: "click",
         },
-        {
-            content: "wait for save completion",
-            trigger: ".o_form_readonly, .o_form_saved",
-        },
-    ]
+    ],
 });


### PR DESCRIPTION
In the test_stock_picking_batch_sm_to_sml_synchronization tour, it is imperative to be exhaustive about whether we are in a modal or not. The trigger targets an element that is not in a modal when it should be. In this commit, we stipulate each modal for each trigger. This not only makes the tour more understandable but also avoids any ambiguity.

runbot-error-id~109487

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
