### PR TITLE
[FIX] sale_timesheet: fix traceback when opening invoices from tasks in portal

### DIFF
--- a/addons/sale_timesheet/controllers/portal.py
+++ b/addons/sale_timesheet/controllers/portal.py
@@ -47,7 +47,7 @@ class PortalProjectAccount(PortalAccount, ProjectCustomerPortal):
 
         # content according to pager and archive selected
         invoices = values['invoices'](pager['offset'])
-        request.session['my_invoices_history'] = invoices.ids[:100]
+        request.session['my_invoices_history'] = [i['invoice'].id for i in invoices[:100]]
 
         values.update({
             'invoices': invoices,


### PR DESCRIPTION
Currently a traceback occurs when the user opens an invoices from the tasks in the portal.

To reproduce this issue:

1) Install sale, timesheet
2) Open a sale order having a project or create a confirmed SO with product type as service 
3) Create multiple invoices for that SO
4) Now open the related tasks of that SO having invoices from the portal 
5) Click on `invoices` from side panel

Error:- 
```
AttributeError: 'list' object has no attribute 'ids'
```

This error is occurring from the below line
https://github.com/odoo/odoo/blob/88c0f9d953d077510961243080dcab2cc1920c27/addons/sale_timesheet/controllers/portal.py#L43-L50

Clearly, we get invoices as a list of dict in values from the below line.
 https://github.com/odoo/odoo/blob/88c0f9d953d077510961243080dcab2cc1920c27/addons/account/controllers/portal.py#L126-L133

Initially, we get the recordsets of invoices in `values['invoices']`. But because of the recent changes from the below commit, we get a list of recordset values, from which we can access the value of invoice ID.

https://github.com/odoo/odoo/pull/174812/files#diff-3b907221102acd53c211a3a6b50b00543dcbbc865d50ef4451bea465f7300cbaR107-R112

We can resolve this issue by looping in invoices and access the invoice id. similarly like this
https://github.com/odoo/odoo/blob/48629b94dac45dad0766fbaeef0f71934a5adcc4/addons/account/controllers/portal.py#L90

sentry-6117277208

