### PR TITLE
[FIX] pos_online_payment: correctly download the invoice

### DIFF
--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -230,13 +230,13 @@ patch(PaymentScreen.prototype, {
         }
 
         if (isInvoiceRequested) {
-            if (!this.currentOrder.account_move) {
+            if (!orderJSON[0].account_move) {
                 this.dialog.add(AlertDialog, {
                     title: _t("Invoice could not be generated"),
                     body: _t("The invoice could not be generated."),
                 });
             } else {
-                await this.invoiceService.downloadPdf(this.currentOrder.account_move);
+                await this.invoiceService.downloadPdf(orderJSON[0].account_move);
             }
         }
 


### PR DESCRIPTION
Before this commit, it wasn't possible to download the invoice of an order paid with online payment. This was because the account move of the order was not loaded, even though it could have its ID, which is sufficient.

opw-4357927

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
