### PR TITLE
[FIX] l10n_jo_edi: neutralise

### DIFF
--- a/addons/l10n_jo_edi/data/neutralize.sql
+++ b/addons/l10n_jo_edi/data/neutralize.sql
@@ -1,0 +1,4 @@
+UPDATE res_company
+   SET l10n_jo_edi_secret_key = 'dummy_secret',
+       l10n_jo_edi_client_identifier = 'dummy_id';
+


### PR DESCRIPTION
This commit adds the missing neutralization necessary for the
l10n_jo_edi module introduced in 18.0 in [1] and then backported to 17.0
in [2]

The purpose of the standard neutralization framework is to allow us to
create database copies that will not interact with external systems in
ways that could impact the production database (or if it is not possible
to prevent the interactions, make sure that they are benign or won't
result in actual changes), or impact the customers of the operator of
the production database.

This is mainly useful to allow safe support investigation on database
duplicates.

[1] https://github.com/odoo/odoo/pull/182983
[2] https://github.com/odoo/odoo/pull/176625
