### PR TITLE
[FIX] mass_mailing: error'd mails no longer count as "sent"

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -335,10 +335,11 @@ class MassMailing(models.Model):
             }
             total = (values['expected'] - values['canceled']) or 1
             total_no_error = (values['expected'] - values['canceled'] - values['bounced'] - values['failed']) or 1
+            total_sent = (values['expected'] - values['canceled'] - values['failed']) or 1
             values['received_ratio'] = float_round(100.0 * values['delivered'] / total, precision_digits=2)
             values['opened_ratio'] = float_round(100.0 * values['opened'] / total_no_error, precision_digits=2)
             values['replied_ratio'] = float_round(100.0 * values['replied'] / total_no_error, precision_digits=2)
-            values['bounced_ratio'] = float_round(100.0 * values['bounced'] / total, precision_digits=2)
+            values['bounced_ratio'] = float_round(100.0 * values['bounced'] / total_sent, precision_digits=2)
             mailing.update(values)
 
     @api.depends('schedule_date', 'state')

--- a/addons/test_mass_mailing/tests/test_mailing_statistics.py
+++ b/addons/test_mass_mailing/tests/test_mailing_statistics.py
@@ -51,7 +51,7 @@ class TestMailingStatistics(TestMassMailCommon):
 
         # check mailing statistics
         self.assertEqual(mailing.bounced, 1)
-        self.assertEqual(mailing.bounced_ratio, 8.33)
+        self.assertEqual(mailing.bounced_ratio, 9.09)
         self.assertEqual(mailing.canceled, 1)
         self.assertEqual(mailing.expected, 13)
         self.assertEqual(mailing.clicked, 3)


### PR DESCRIPTION
Currently, mailing traces that have error'd due to an exception during sending still count as 'sent' for the purposes of calculating email bounce rates.

This makes it so that error'd email traces (those that have encountered an exception during the sending process) no longer count as sent for the purposes of calculating email bounce rates (the rate of emails whose delivery was attempted, but were rejected by the destination email server.

task-4380451
