### PR TITLE
[IMP] mail: make discuss sidebar less distracting

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss_sidebar.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.scss
@@ -29,6 +29,18 @@
     padding-top: map-get($spacers, 1) / 2;
     padding-bottom: map-get($spacers, 1) / 2;
 
+    .o-mail-DiscussSidebar.o-compact & {
+        opacity: 75%;
+
+        &.o-unread {
+            opacity: 87.5%;
+        }
+
+        &.o-active, &:hover {
+            opacity: 100%;
+        }
+    }
+
     &.o-active, &:hover {
         background-color: var(--mail-DiscussSidebar-itemActiveBgColor, mix($o-view-background-color, $o-action, 90%)) !important;
         outline-color: var(--mail-DiscussSidebar-itemActiveOutlineColor, rgba($o-action, .15)) !important;

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -29,6 +29,7 @@
                 'o-active': mailbox.eq(store.discuss.thread),
                 'mx-2 justify-content-center position-relative': store.discuss.isSidebarCompact,
                 'mx-3 py-0': !store.discuss.isSidebarCompact,
+                'o-unread': mailbox.counter,
             }"
             t-att-data-mailbox-id="mailbox.id"
             t-on-click="(ev) => this.openThread(ev)"


### PR DESCRIPTION
Discuss sidebar items are too catchy, which is distracting when the core part of Discuss app is the conversation itself. As much as possible, conversation should be very visible while other elements are slightly less visible.

This problem is even more pronunced when the sidebar is compact, because the avatars in sidebar are next to avatars of conversation, which is even more distracting.

This commit fixes the issue by reducing opacity slightly on non-active sidebar items. Conversation that are unread and unactive have an in-between opacity so they are more visible than other read and non-active conversations but still have reduced opacity so that this is less distracting than the conversation itself.

Before
<img width="1278" alt="Screenshot 2024-12-09 at 14 33 48" src="https://github.com/user-attachments/assets/b6f9feb6-ffc0-42b7-9102-a6850fc71334">


After
<img width="1277" alt="Screenshot 2024-12-09 at 14 36 12" src="https://github.com/user-attachments/assets/28394bff-18f2-403d-8b4b-1c6f80f01cb8">
