### PR TITLE
[FIX] account_peppol: Fix deduction of the demo edi mode

### DIFF
--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -224,3 +224,10 @@ class ResCompany(models.Model):
     def write(self, vals):
         self._sanitize_peppol_endpoint_in_values(vals)
         return super().write(vals)
+
+    def _get_peppol_edi_mode(self):
+        self.ensure_one()
+        config_param = self.env['ir.config_parameter'].sudo().get_param('account_peppol.edi.mode')
+        # by design, we can only have zero or one proxy user per company with type Peppol
+        peppol_user = self.sudo().account_edi_proxy_client_ids.filtered(lambda u: u.proxy_type == 'peppol')
+        return peppol_user.edi_mode or config_param or 'prod'

--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -99,12 +99,8 @@ class ResConfigSettings(models.TransientModel):
 
     @api.depends('is_account_peppol_eligible', 'account_peppol_edi_user')
     def _compute_account_peppol_edi_mode(self):
-        edi_mode = self.env['ir.config_parameter'].sudo().get_param('account_peppol.edi.mode')
         for config in self:
-            if config.account_peppol_edi_user:
-                config.account_peppol_edi_mode = config.account_peppol_edi_user.edi_mode
-            else:
-                config.account_peppol_edi_mode = edi_mode or 'prod'
+            config.account_peppol_edi_mode = config.company_id._get_peppol_edi_mode()
 
     def _inverse_account_peppol_edi_mode(self):
         for config in self:

--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -83,8 +83,7 @@ class ResPartner(models.Model):
     def _get_participant_info(self, edi_identification):
         hash_participant = md5(edi_identification.lower().encode()).hexdigest()
         endpoint_participant = parse.quote_plus(f"iso6523-actorid-upis::{edi_identification}")
-        peppol_user = self.env.company.sudo().account_edi_proxy_client_ids.filtered(lambda user: user.proxy_type == 'peppol')
-        edi_mode = peppol_user and peppol_user.edi_mode or self.env['ir.config_parameter'].sudo().get_param('account_peppol.edi.mode')
+        edi_mode = self.env.company._get_peppol_edi_mode()
         sml_zone = 'acc.edelivery' if edi_mode == 'test' else 'edelivery'
         smp_url = f"http://B-{hash_participant}.iso6523-actorid-upis.{sml_zone}.tech.ec.europa.eu/{endpoint_participant}"
 

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -136,36 +136,9 @@ def handle_demo(func, self, *args, **kwargs):
     """ This decorator is used on methods that should be mocked in demo mode.
 
     First handle the decision: "Are we in demo mode?", and conditionally decide which function to
-    execute. Whether we are in demo mode depends on the edi_mode of the EDI user, but the EDI user
-    is accessible in different ways depending on the model the function is called from and in some
-    contexts it might not yet exist, in which case demo mode should instead depend on the content
-    of the "account_peppol.edi.mode" config param.
+    execute.
     """
-    def get_demo_mode_account_edi_proxy_client_user(self, args, kwargs):
-        if self.id:
-            return self.edi_mode == 'demo' and self.proxy_type == 'peppol'
-        demo_param = self.env['ir.config_parameter'].get_param('account_peppol.edi.mode') == 'demo'
-        if len(args) > 1 and 'proxy_type' in args[1]:
-            return demo_param and args[1]['proxy_type'] == 'peppol'
-        return demo_param
-
-    def get_demo_mode_res_config_settings(self, args, kwargs):
-        if self.account_peppol_edi_user:
-            return self.account_peppol_edi_user.edi_mode == 'demo'
-        return self.account_peppol_edi_mode == 'demo'
-
-    def get_demo_mode_res_partner(self, args, kwargs):
-        peppol_user = self.env.company.sudo().account_edi_proxy_client_ids.filtered(lambda user: user.proxy_type == 'peppol')
-        if peppol_user:
-            return peppol_user.edi_mode == 'demo'
-        return False
-
-    get_demo_mode = {
-        'account_edi_proxy_client.user': get_demo_mode_account_edi_proxy_client_user,
-        'res.config.settings': get_demo_mode_res_config_settings,
-        'res.partner': get_demo_mode_res_partner,
-    }
-    demo_mode = get_demo_mode.get(self._name) and get_demo_mode[self._name](self, args, kwargs) or False
+    demo_mode = self.env.company._get_peppol_edi_mode() == 'demo'
 
     if not demo_mode or tools.config['test_enable'] or modules.module.current_test:
         return func(self, *args, **kwargs)


### PR DESCRIPTION
Previously, when no EDI proxy user existed, in some case when the handle_demo ran, it was erronously deducing that the EDI mode was not demo, while it was. This commit fixes and simplifies the deduction of the EDI mode: We check the company in the env, if there is a related Peppol proxy user we take his mode, else we fallback on the dedicated system parameter.

task-no
