### PR TITLE
[FIX] stock: store qty to order

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2277,6 +2277,8 @@ Please change the quantity done or the rounding precision of your unit of measur
                 orderpoints_context_by_company[orderpoint.company_id].setdefault(orderpoint.id, [])
                 orderpoints_context_by_company[orderpoint.company_id][orderpoint.id].append(move.origin)
         for company, orderpoints in orderpoints_by_company.items():
+            orderpoints = orderpoints.with_company(company)
+            orderpoints._compute_qty_to_order_computed()
             orderpoints.with_context(origins=orderpoints_context_by_company[company])._procure_orderpoint_confirm(
                 company_id=company, raise_user_error=False)
 

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -81,7 +81,7 @@ class StockWarehouseOrderpoint(models.Model):
     qty_on_hand = fields.Float('On Hand', readonly=True, compute='_compute_qty', digits='Product Unit of Measure')
     qty_forecast = fields.Float('Forecast', readonly=True, compute='_compute_qty', digits='Product Unit of Measure')
     qty_to_order = fields.Float('To Order', compute='_compute_qty_to_order', inverse='_inverse_qty_to_order', search='_search_qty_to_order', digits='Product Unit of Measure')
-    qty_to_order_computed = fields.Float('To Order Computed', compute='_compute_qty_to_order_computed', digits='Product Unit of Measure')
+    qty_to_order_computed = fields.Float('To Order Computed', compute='_compute_qty_to_order_computed', digits='Product Unit of Measure', store=True)
     qty_to_order_manual = fields.Float('To Order Manual', digits='Product Unit of Measure')
 
     days_to_order = fields.Float(compute='_compute_days_to_order', help="Numbers of days  in advance that replenishments demands are created.")

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -688,6 +688,7 @@ class ProcurementGroup(models.Model):
         # Minimum stock rules
         domain = self._get_orderpoint_domain(company_id=company_id)
         orderpoints = self.env['stock.warehouse.orderpoint'].search(domain)
+        orderpoints._compute_qty_to_order_computed()
         if use_new_cursor:
             self._cr.commit()
         orderpoints.sudo()._procure_orderpoint_confirm(use_new_cursor=use_new_cursor, company_id=company_id, raise_user_error=False)


### PR DESCRIPTION
The filter to replenish use the `qty_to_order` field. However when adding a filter multiple function are called. `web_search_read`, `search_panel_select_range, `search_panel_select_multi_range`

However they all use the search domain and in the default search there is the `to replenish` filter with [('qty_to_order', '>', 0)] And each time they trigger while it's not needed to recompute them.

The idea is to compute this quantity when the report is open or when the orderpoint is needed for a procurement (on automatic).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
