### PR TITLE
 [IMP] tests: accept test-file as test-tags

### DIFF
--- a/odoo/addons/base/tests/test_configmanager.py
+++ b/odoo/addons/base/tests/test_configmanager.py
@@ -289,6 +289,7 @@ class TestConfigManager(TransactionCase):
         self.assertEqual(capture.output, [
             "WARNING:odoo.tools.config:option addons_path, no such directory '/tmp/odoo', skipped",
             "WARNING:odoo.tools.config:option upgrade_path, no such directory '/tmp/upgrade', skipped",
+            "WARNING:odoo.tools.config:test file '/tmp/file-file' cannot be found",
         ])
 
     @unittest.skipIf(not IS_POSIX, 'this test is POSIX only')
@@ -447,6 +448,7 @@ class TestConfigManager(TransactionCase):
                 self.config._parse_config(file.read().split())
         self.assertEqual(capture.output, [
             "WARNING:odoo.tools.config:option --without-demo: since 19.0, invalid boolean value: 'rigolo', assume True",
+            "WARNING:odoo.tools.config:test file '/tmp/file-file' cannot be found",
         ])
 
         self.assertConfigEqual({
@@ -605,7 +607,7 @@ class TestConfigManager(TransactionCase):
             (['--stop'], True),
             (['--test-enable'], True),
             (['--test-tags', 'tag'], True),
-            (['--test-file', 'file'], True),
+            (['--test-file', __file__], True),
         ]:
             with self.subTest(args=args):
                 _, options = self.parse_reset(args)

--- a/odoo/addons/base/tests/test_tests_tags.py
+++ b/odoo/addons/base/tests/test_tests_tags.py
@@ -165,7 +165,7 @@ class TestSelector(TransactionCase):
         self.assertEqual(set(), tags.exclude)
 
         tags = TagsSelector('/module/tests/test_file.py')  # all standard test of a module
-        self.assertEqual({('standard', None, None, None, 'module.tests.test_file'), }, tags.include)
+        self.assertEqual({('standard', None, None, None, '/module/tests/test_file.py'), }, tags.include)
         self.assertEqual(set(), tags.exclude)
 
         tags = TagsSelector('*/module')  # all tests of a module

--- a/odoo/tests/tag_selector.py
+++ b/odoo/tests/tag_selector.py
@@ -29,11 +29,11 @@ class TagsSelector(object):
             elif not tag or tag == '*':
                 # '*' indicates all tests (instead of 'standard' tests only)
                 tag = None
-            module_path = None
+            file_path = None
             if module and (module.endswith('.py')):
-                module_path = module[:-3].replace('/', '.')
+                file_path = f"/{module}"
                 module = None
-            test_filter = (tag, module, klass, method, module_path)
+            test_filter = (tag, module, klass, method, file_path)
 
             if is_include:
                 self.include.add(test_filter)
@@ -55,14 +55,15 @@ class TagsSelector(object):
         test_class = test.test_class
         test_tags = test.test_tags | {test_module}  # module as test_tags deprecated, keep for retrocompatibility,
         test_method = test._testMethodName
+        test_module_path = test.__module__.removeprefix('odoo.addons').replace('.', '/') + '.py'
 
         def _is_matching(test_filter):
-            (tag, module, klass, method, module_path) = test_filter
+            (tag, module, klass, method, file_path) = test_filter
             if tag and tag not in test_tags:
                 return False
-            elif module_path and not test.__module__.endswith(module_path):
+            elif file_path and not file_path.endswith(test_module_path):
                 return False
-            elif not module_path and module and module != test_module:
+            elif not file_path and module and module != test_module:
                 return False
             elif klass and klass != test_class:
                 return False

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -623,10 +623,21 @@ class configmanager:
         if 'all' in self['dev_mode']:
             self._runtime_options['dev_mode'] = self['dev_mode'] + ['reload', 'qweb', 'xml']
 
+        if test_file := self['test_file']:
+            if not os.path.isfile(test_file):
+                self._log(logging.WARNING, f'test file {test_file!r} cannot be found')
+            elif not test_file.endswith('.py'):
+                self._log(logging.WARNING, f'test file {test_file!r} is not a python file')
+            else:
+                self._log(logging.INFO, 'Transforming --test-file into --test-tags')
+                test_tags = (self['test_tags'] or '').split(',')
+                test_tags.append(os.path.abspath(self['test_file']))
+                self._runtime_options['test_tags'] = ','.join(test_tags)
+                self._runtime_options['test_enable'] = True
         if self['test_enable'] and not self['test_tags']:
             self._runtime_options['test_tags'] = "+standard"
         self._runtime_options['test_enable'] = bool(self['test_tags'])
-        if self['test_enable'] or self['test_file']:
+        if self._runtime_options['test_enable']:
             self._runtime_options['stop_after_init'] = True
 
     def _warn_deprecated_options(self):


### PR DESCRIPTION
The current test-file option is run outside of the tests-suites, leading
to potential issues:
- dedicated code to run the test-file leading to potential error and
more maintenance
- at-install tests are run post-install
- tests order is not the same
- possible to run a test of a module that is not installed
- no warning if no test is run (outside addons path)

This proposes to convert test-file into a test-tag.

A first version was transforming the test-file into a path relative to
the root of the containing addons path. Unfortunately this was not the
easier way to do since we would like to do so in post_process_args but
we don't have an initialized sys path at this point.

The new solution doesnt make this transformation but supports absolute
paths as module path in the tag selector.