### PR TITLE
[FIX] test_http: correct device test route

### DIFF
--- a/odoo/addons/test_http/tests/test_device.py
+++ b/odoo/addons/test_http/tests/test_device.py
@@ -276,7 +276,8 @@ class TestDevice(TestHttpBase):
         session = self.authenticate(self.user_admin.login, self.user_admin.login)
         session._trace_disable = True
         odoo.http.root.session_store.save(session)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw')
+        res = self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
+        self.assertEqual(res.status_code, 200)
         devices, logs = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 0)
         self.assertEqual(len(logs), 0)


### PR DESCRIPTION
The `test_detection_no_trace_mechanism` test checks that no trace is created with the flag in the session. Commit 7aa53005688291a6c903ba759f76574cd35bff77 renamed the routes in `test_http`. This test does not fail, because even if the route does not exist, no trace is created. It is necessary to correct the route so that the test covers the use of the flag in the session.