### PR TITLE
[FIX] l10n_hu_edi: Fix HU invoice generation with multi-currency

### DIFF
--- a/addons/l10n_hu_edi/tests/common.py
+++ b/addons/l10n_hu_edi/tests/common.py
@@ -132,13 +132,14 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
             'l10n_hu_edi_signature_key': 'some_key',
             'l10n_hu_edi_replacement_key': 'abcdefghijklmnop',
         })
+    
+    def _create_simple_move(self, move_type='out_invoice', currency=None):
+        journal = self.company_data['default_journal_sale'] if move_type in self.env['account.move'].get_sale_types() else self.company_data['default_journal_purchase']
 
-    def create_invoice_simple(self):
-        """ Create a really basic invoice - just one line. """
         return self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'journal_id': self.company_data['default_journal_sale'].id,
-            'currency_id': self.env.ref('base.HUF').id,
+            'move_type': move_type,
+            'journal_id': journal.id,
+            'currency_id': (currency or self.env.ref('base.HUF')).id,
             'partner_id': self.partner_company.id,
             'invoice_date': self.today,
             'delivery_date': self.today,
@@ -151,6 +152,22 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
                 })
             ]
         })
+
+    def create_invoice_simple(self, currency=None):
+        """ Create a really basic invoice - just one line. """
+        return self._create_simple_move(move_type='out_invoice', currency=currency)
+    
+    def create_bill_simple(self, currency=None):
+        """ Create a really basic bill - just one line. """
+        return self._create_simple_move(move_type='in_invoice', currency=currency)
+    
+    def create_credit_note_simple(self, currency=None):
+        """ Create a really basic credit note - just one line. """
+        return self._create_simple_move(move_type='out_refund', currency=currency)
+    
+    def create_refund_simple(self, currency=None):
+        """ Create a really basic bill refund - just one line. """
+        return self._create_simple_move(move_type='in_refund', currency=currency)
 
     def create_advance_invoice(self):
         """ Create a sale order and an advance invoice. """

--- a/addons/l10n_hu_edi/tests/test_invoice_xml.py
+++ b/addons/l10n_hu_edi/tests/test_invoice_xml.py
@@ -122,3 +122,18 @@ class L10nHuEdiTestInvoiceXml(L10nHuEdiTestCommon):
                     self.get_xml_tree_from_string(invoice_xml),
                     self.get_xml_tree_from_string(expected_xml_file.read()),
                 )
+
+    def test_multi_currency_tax_sign(self):
+        currency_eur = self.env.ref('base.EUR')
+
+        out_invoice = self.create_invoice_simple(currency=currency_eur)
+        in_invoice = self.create_bill_simple(currency=currency_eur)
+        out_refund = self.create_credit_note_simple(currency=currency_eur)
+        in_refund = self.create_refund_simple(currency=currency_eur)
+
+        expected_value = tools.float_round(10000 * self.tax_vat.amount / (100 * currency_eur.rate), self.currency.decimal_places)
+
+        self.assertEqual(out_invoice._l10n_hu_get_invoice_totals_for_report()['total_vat_amount_in_huf'], expected_value)
+        self.assertEqual(in_invoice._l10n_hu_get_invoice_totals_for_report()['total_vat_amount_in_huf'], expected_value)
+        self.assertEqual(out_refund._l10n_hu_get_invoice_totals_for_report()['total_vat_amount_in_huf'], -expected_value)
+        self.assertEqual(in_refund._l10n_hu_get_invoice_totals_for_report()['total_vat_amount_in_huf'], -expected_value)

--- a/addons/l10n_hu_edi/views/report_invoice.xml
+++ b/addons/l10n_hu_edi/views/report_invoice.xml
@@ -107,7 +107,7 @@
         <xpath expr="//tr[hasclass('o_total')]" position="after">
             <tr t-if="o.currency_id.name != 'HUF'">
                 <td><strong>Total VAT amount in HUF</strong></td>
-                <td class="text-end">
+                <td class="text-end text-nowrap">
                     <span t-out="tax_totals['formatted_total_vat_amount_in_huf']"/>
                 </td>
             </tr>


### PR DESCRIPTION
Problem
---------
1 - Open Odoo 18.0
2 - install l10n_hu_edi
3 - switch to "HU Company"
4 - create an outgoing normal invoice with other than HUF currency
5 - put items, taxes, select partner, etc.
6 - print the invoice
-> KeyError: 'formatted_total_vat_amount_in_huf'

The issue occurs because, in multi-currency, the method
`_l10n_hu_get_invoice_totals_for_report` is expected to add
`total_vat_amount_in_huf` to the tax dictionary as required by the 
invoice template.

However, currently, the said method only adds `total_vat_amount_in_huf`
for credit notes / refunds, in other cases, it stops early and does not
add the required key-value pair in the dictionary.

Solution
---------
Make sure the method always adds `total_vat_amount_in_huf` to the tax
dictionary, while making sure that it only reverses the tax values when
it is rendering a credit note / refund like before.

task-4391659

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
