### PR TITLE
[IMP] sale_purchase{,_stock},stock_dropshipping: dropship address fixes

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/models/purchase.py
+++ b/addons/mrp_subcontracting_dropshipping/models/purchase.py
@@ -15,7 +15,8 @@ class PurchaseOrder(models.Model):
         dropship_subcontract_pos = self.filtered(lambda po: po.default_location_dest_id_is_subcontracting_loc)
         for order in dropship_subcontract_pos:
             subcontractor_ids = order.picking_type_id.default_location_dest_id.subcontractor_ids
-            order.dest_address_id = subcontractor_ids if len(subcontractor_ids) == 1 else False
+            if len(subcontractor_ids) == 1:
+                order.dest_address_id = subcontractor_ids
         super(PurchaseOrder, self - dropship_subcontract_pos)._compute_dest_address_id()
 
     @api.onchange('picking_type_id')

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -71,7 +71,7 @@
             </xpath>
             <xpath expr="//div[@name='reminder']" position="after">
                 <field name="picking_type_id" domain="[('code','=','incoming'), '|', ('warehouse_id', '=', False), ('warehouse_id.company_id', '=', company_id)]" options="{'no_create': True}" readonly="state in ['cancel', 'done', 'purchase']"/>
-                <field name="dest_address_id" invisible="default_location_dest_id_usage != 'customer'" readonly="state in ['cancel', 'done', 'purchase']" required="default_location_dest_id_usage == 'customer'"/>
+                <field name="dest_address_id" invisible="default_location_dest_id_usage != 'customer'" readonly="state == 'done'" required="default_location_dest_id_usage == 'customer'"/>
             </xpath>
         </field>
     </record>

--- a/addons/sale_purchase/models/purchase_order.py
+++ b/addons/sale_purchase/models/purchase_order.py
@@ -11,11 +11,22 @@ class PurchaseOrder(models.Model):
         "Number of Source Sale",
         compute='_compute_sale_order_count',
         groups='sales_team.group_sale_salesman')
+    has_sale_order = fields.Boolean(
+        "Technical field for whether the purchase order has associated sale orders",
+        compute='_compute_sale_order_count')
 
     @api.depends('order_line.sale_order_id')
     def _compute_sale_order_count(self):
         for purchase in self:
             purchase.sale_order_count = len(purchase._get_sale_orders())
+            purchase.has_sale_order = bool(purchase.sale_order_count)
+
+    @api.depends('order_line.sale_order_id.partner_shipping_id')
+    def _compute_dest_address_id(self):
+        po_with_address = self.filtered(lambda po: len(po._get_sale_orders().partner_shipping_id) == 1)
+        for order in po_with_address:
+            order.dest_address_id = order._get_sale_orders().partner_shipping_id
+        super(PurchaseOrder, self - po_with_address)._compute_dest_address_id()
 
     def action_view_sale_orders(self):
         self.ensure_one()

--- a/addons/sale_purchase_stock/__manifest__.py
+++ b/addons/sale_purchase_stock/__manifest__.py
@@ -10,6 +10,9 @@
 Add relation information between Sale Orders and Purchase Orders if Make to Order (MTO) is activated on one sold product.
 """,
     'depends': ['sale_stock', 'purchase_stock', 'sale_purchase'],
+    'data': [
+        'views/purchase_order_views.xml',
+    ],
     'installable': True,
     'auto_install': True,
     'author': 'Odoo S.A.',

--- a/addons/sale_purchase_stock/views/purchase_order_views.xml
+++ b/addons/sale_purchase_stock/views/purchase_order_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="purchase_order_form_sale_purchase_stock" model="ir.ui.view">
+            <field name="name">purchase.order.form.sale.purchase.stock</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase_stock.purchase_order_view_form_inherit"/>
+            <field name="arch" type="xml">
+                <field name="dest_address_id" position="attributes">
+                    <attribute name="readonly">state == 'done' or has_sale_order</attribute>
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -92,7 +92,7 @@ class StockLot(models.Model):
             if lot.delivery_count > 0:
                 last_delivery = max(lot.delivery_ids, key=lambda d: d.date_done)
                 if last_delivery.is_dropship:
-                    lot.last_delivery_partner_id = last_delivery.sale_id.partner_id
+                    lot.last_delivery_partner_id = last_delivery.sale_id.partner_shipping_id
 
     def _get_outgoing_domain(self):
         res = super()._get_outgoing_domain()


### PR DESCRIPTION
If a dropship purchase order was created automatically through a sale order, the delivery address field must be readonly. If the sale order's shipping address changes, the associated purchase order's must also change to reflect this. Similarly, the delivery address for the lot must be the delivery address rather than the client company's own address (which can differ with the customer addresses option enabled) if the delivery is a dropship.

Task ID: [4291198](https://www.odoo.com/odoo/project/966/tasks/4291198)