### PR TITLE
[IMP] website: introduce custom icons for `s_accordion`

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -347,6 +347,7 @@
             'website/static/src/js/editor/snippets.options.js',
             'website/static/src/js/editor/shared_options/pricelist.js',
             'website/static/src/snippets/s_alert/options.js',
+            'website/static/src/snippets/s_accordion/options.js',
             'website/static/src/snippets/s_facebook_page/options.js',
             'website/static/src/snippets/s_image/options.js',
             'website/static/src/snippets/s_image_gallery/options.js',

--- a/addons/website/static/src/snippets/s_accordion/000.scss
+++ b/addons/website/static/src/snippets/s_accordion/000.scss
@@ -20,6 +20,81 @@
         }
     }
 
+    .o_icons_side_to_bottom {
+        --accordion-btn-icon-transform: rotate(0deg);
+
+        .accordion-button.collapsed {
+            &.o_icons_position_reversed:after {
+                transform: rotate(-90deg);
+            }
+
+            &:after {
+                transform: rotate(90deg);
+            }
+        }
+    }
+
+    .o_custom_icons_wrap {
+        width: $accordion-icon-width;
+        height: $accordion-icon-width;
+    }
+
+    .o_icons_plus_to_minus {
+        .o_custom_icons_wrap {
+            &:before, &:after {
+                content: '';
+                position: absolute;
+                inset: 0;
+                height: 2px;
+                display: block;
+                margin: auto map-get($spacers, 1);
+                background: currentColor;
+                transition: $accordion-icon-transition;
+            }
+        }
+
+        .accordion-button.collapsed .o_custom_icons_wrap:after {
+            transform: rotate(90deg);
+        }
+    }
+
+    .o_custom_icons {
+        .accordion-button:after {
+            display: none;
+        }
+
+        &.o_transition .o_custom_icons_wrap > span {
+            transition: opacity nth($transition-base, 2) nth($transition-base, 3), transform nth($transition-base, 2) nth($transition-base, 3);
+        }
+
+        .accordion-button {
+            &.collapsed .o_custom_icon_active, &:not(.collapsed) .o_custom_icon_inactive {
+                opacity: 0;
+            }
+        }
+
+        &.o_transition_scale .accordion-button {
+            &.collapsed .o_custom_icon_active, &:not(.collapsed) .o_custom_icon_inactive {
+                transform: scale(0);
+                opacity: 1;
+            }
+        }
+
+        &.o_transition_translate .accordion-button {
+            &.collapsed .o_custom_icon_active, &:not(.collapsed) .o_custom_icon_inactive {
+                opacity: 1;
+            }
+
+            &.collapsed .o_custom_icon_active {
+                transform: translateY(-100%);
+            }
+
+            &:not(.collapsed) .o_custom_icon_inactive {
+                transform: translateY(100%);
+            }
+        }
+    }
+
     .s_accordion_highlight {
         .accordion-item {
             border: 0;

--- a/addons/website/static/src/snippets/s_accordion/options.js
+++ b/addons/website/static/src/snippets/s_accordion/options.js
@@ -1,0 +1,94 @@
+import { MediaDialog } from "@web_editor/components/media_dialog/media_dialog";
+import options from "@web_editor/js/editor/snippets.options";
+
+options.registry.Accordion = options.Class.extend({
+
+    //--------------------------------------------------------------------------
+    // Options
+    //--------------------------------------------------------------------------
+
+    /**
+     * Allows to select a font awesome icon with media dialog.
+     */
+    async defineCustomIcon(previewMode, widgetValue, params) {
+        const media = document.createElement("i");
+        media.className = params.customActiveIcon === "true" ? this.$target[0].dataset.activeCustomIcon : this.$target[0].dataset.inactiveCustomIcon;
+        this.call("dialog", "add", MediaDialog, {
+            noImages: true,
+            noDocuments: true,
+            noVideos: true,
+            media,
+            save: icon => {
+                const customClass = icon.className;
+                const activeIconsEls = this.$target[0].querySelectorAll(".o_custom_icon_active i");
+                const inactiveIconsEls = this.$target[0].querySelectorAll(".o_custom_icon_inactive i");
+                const iconsEls = params.customActiveIcon === "true" ? activeIconsEls : inactiveIconsEls;
+                iconsEls.forEach(iconEl => {
+                    iconEl.removeAttribute("class");
+                    iconEl.classList.add(...customClass.split(" "));
+                });
+                if (iconsEls === activeIconsEls) {
+                    this.$target[0].dataset.activeCustomIcon = customClass;
+                } else {
+                    this.$target[0].dataset.inactiveCustomIcon = customClass;
+                }
+            }
+        });
+    },
+    /**
+     * Allows to add the necessary HTML structure for custom icons
+     */
+    customIcon(previewMode, widgetValue, params) {
+        const accordionButtonEls = this.$target[0].querySelectorAll(".accordion-button");
+        const activeCustomIcon = this.$target[0].dataset.activeCustomIcon || "fa fa-arrow-up";
+        const inactiveCustomIcon = this.$target[0].dataset.inactiveCustomIcon || "fa fa-arrow-down";
+
+        if (widgetValue) {
+            if (widgetValue === "custom") {
+                this.$target[0].dataset.activeCustomIcon = activeCustomIcon;
+                this.$target[0].dataset.inactiveCustomIcon = inactiveCustomIcon;
+            }
+            accordionButtonEls.forEach(item => {
+                let el = item.querySelector(".o_custom_icons_wrap");
+                if (!el) {
+                    el = document.createElement("span");
+                    el.className = "o_custom_icons_wrap position-relative d-block flex-shrink-0 overflow-hidden";
+                    item.appendChild(el);
+                }
+
+                while (el.firstChild) {
+                    el.removeChild(el.firstChild);
+                }
+                if (!params.selectIcons) {
+                    return;
+                }
+                const customIconsClasses = "position-absolute top-0 end-0 bottom-0 start-0 d-flex align-items-center justify-content-center";
+                const customIconActiveEl = document.createElement("span");
+                customIconActiveEl.className = customIconsClasses;
+                customIconActiveEl.classList.add('o_custom_icon_active');
+                const customIconActiveIEl = document.createElement("i");
+                customIconActiveIEl.className = activeCustomIcon;
+                customIconActiveEl.appendChild(customIconActiveIEl);
+                el.appendChild(customIconActiveEl);
+                const customIconInactiveEl = document.createElement("span");
+                customIconInactiveEl.className = customIconsClasses;
+                customIconInactiveEl.classList.add('o_custom_icon_inactive');
+                const customIconInactiveIEl = document.createElement("i");
+                customIconInactiveIEl.className = inactiveCustomIcon;
+                customIconInactiveEl.appendChild(customIconInactiveIEl);
+                el.appendChild(customIconInactiveEl);
+            });
+        } else {
+            accordionButtonEls.forEach(item => {
+                const customIconWrapEl = item.querySelector(".o_custom_icons_wrap");
+                if (customIconWrapEl) {
+                    customIconWrapEl.remove();
+                }
+            });
+        }
+        if (widgetValue !== "custom" && !previewMode) {
+            delete this.$target[0].dataset.activeCustomIcon;
+            delete this.$target[0].dataset.inactiveCustomIcon;
+        }
+    },
+});

--- a/addons/website/views/snippets/s_accordion.xml
+++ b/addons/website/views/snippets/s_accordion.xml
@@ -36,7 +36,7 @@
 
 <template id="s_accordion_options" inherit_id="website.snippet_options">
     <xpath expr="." position="inside">
-        <div data-selector=".s_accordion" data-target=".accordion">
+        <div data-js="Accordion" data-selector=".s_accordion" data-target=".accordion">
             <we-select string="Style">
                 <we-button title="Boxed" data-name="accordion_style_boxed_opt" data-select-class="">Boxed</we-button>
                 <we-button title="Highlight Active" data-select-class="s_accordion_highlight">Highlight Active</we-button>
@@ -48,8 +48,30 @@
                 data-select-style="0"
                 data-apply-to=".accordion-item"
                 />
-            <we-button-group string="Icon Position" data-apply-to=".accordion-header">
-                <we-button title="Left" data-select-class="justify-content-end flex-row-reverse"
+            <we-select string="Icons">
+                <we-button title="Default" data-custom-icon="" data-select-class="">Default</we-button>
+                <we-button title="Side / bottom" data-custom-icon="" data-select-class="o_icons_side_to_bottom">Side / bottom</we-button>
+                <we-button title="Plus / minus" data-custom-icon="plusToMinus" data-select-class="o_custom_icons o_icons_plus_to_minus">Plus / minus</we-button>
+                <we-button title="Custom" data-custom-icon="custom" data-select-icons="true" data-select-class="o_custom_icons" data-name="accordion_icons_custom_opt">Custom</we-button>
+            </we-select>
+            <we-row string="Active" class="o_we_sublevel_1">
+                <we-button data-dependencies="accordion_icons_custom_opt" data-define-custom-icon="true" data-custom-active-icon="true" data-no-preview="true">
+                    <i class="fa fa-fw fa-refresh me-1"/> Replace Icon
+                </we-button>
+            </we-row>
+            <we-row string="Inactive" class="o_we_sublevel_1">
+                <we-button data-dependencies="accordion_icons_custom_opt" data-define-custom-icon="true" data-custom-active-icon="false" data-no-preview="true">
+                    <i class="fa fa-fw fa-refresh me-1"/> Replace Icon
+                </we-button>
+            </we-row>
+            <we-select string="Transition" data-dependencies="accordion_icons_custom_opt" class="o_we_sublevel_1">
+                <we-button title="None" data-select-class="">None</we-button>
+                <we-button title="Fade" data-select-class="o_transition o_transition_fade">Fade</we-button>
+                <we-button title="Scale" data-select-class="o_transition o_transition_scale">Scale</we-button>
+                <we-button title="Translate" data-select-class="o_transition o_transition_translate">Translate</we-button>
+            </we-select>
+            <we-button-group string="Position" data-apply-to=".accordion-header" class="o_we_sublevel_1">
+                <we-button title="Left" data-select-class="justify-content-end flex-row-reverse o_icons_position_reversed"
                     data-img="/website/static/src/img/snippets_options/pos_left.svg"/>
                 <we-button title="Right" data-select-class="justify-content-between"
                     data-img="/website/static/src/img/snippets_options/pos_right.svg"/>


### PR DESCRIPTION
This commit introduces a new option that allows the user to change the icons in the `s_accordion` snippet.
He can now choose between different presets, and can also select custom icons from the Font Awesome library and change the transition between them.

task-4377631

![Capture d’écran 2024-12-09 à 16 14 27](https://github.com/user-attachments/assets/43778d38-db70-4e6a-b05e-9851394ddb0d)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
