### PR TITLE
[FIX] website_{crm,hr_recruitment,project}: sudo access model name

### DIFF
--- a/addons/website_crm/controllers/website_form.py
+++ b/addons/website_crm/controllers/website_form.py
@@ -57,7 +57,7 @@ class WebsiteForm(form.WebsiteForm):
         return super(WebsiteForm, self)._handle_website_form(model_name, **kwargs)
 
     def insert_record(self, request, model, values, custom, meta=None):
-        is_lead_model = model.model == 'crm.lead'
+        is_lead_model = model.sudo().model == 'crm.lead'
         if is_lead_model:
             values_email_normalized = tools.email_normalize(values.get('email_from'))
             visitor_sudo = request.env['website.visitor']._get_visitor_from_request(force_create=True)

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -353,7 +353,7 @@ class WebsiteHrRecruitment(WebsiteForm):
 
     def extract_data(self, model, values):
         candidate = request.env['hr.candidate']
-        if model.model == 'hr.applicant':
+        if model.sudo().model == 'hr.applicant':
             # pop the fields since there are only useful to generate a candidate record
             partner_name = values.pop('partner_name')
             partner_phone = values.pop('partner_phone', None)

--- a/addons/website_project/controllers/main.py
+++ b/addons/website_project/controllers/main.py
@@ -8,14 +8,15 @@ from odoo.addons.website.controllers import form
 
 class WebsiteForm(form.WebsiteForm):
     def insert_record(self, request, model, values, custom, meta=None):
-        if model.model == 'project.task':
+        model_name = model.sudo().model
+        if model_name == 'project.task':
             # When a task is created from the web editor, if the key 'user_ids' is not present, the user_ids is filled with the odoo bot. We set it to False to ensure it is not.
             values.setdefault('user_ids', False)
             if custom:
                 custom.replace('email_from', 'Email')
 
         res = super().insert_record(request, model, values, custom, meta=meta)
-        if model.model != 'project.task':
+        if model_name != 'project.task':
             return res
         task = request.env['project.task'].sudo().browse(res)
         default_field = model.website_form_default_field_id
@@ -28,7 +29,7 @@ class WebsiteForm(form.WebsiteForm):
 
     def extract_data(self, model, values):
         data = super().extract_data(model, values)
-        if model.model == 'project.task' and values.get('email_from'):
+        if model.sudo().model == 'project.task' and values.get('email_from'):
             partners_list = request.env['mail.thread'].sudo()._mail_find_partner_from_emails([values['email_from']])
             partner = partners_list[0] if partners_list else self.env['res.partner']
             data['record']['partner_id'] = partner.id


### PR DESCRIPTION
Versions
--------
- 18.0+

Enterprise: https://github.com/odoo/enterprise/pull/75382

Steps
-----
1. In eCommerce, enable extra step during checkout;
2. modify extra step form by adding another field;
3. save changes;
4. as a public or portal user, add item cart;
5. go to checkout;
6. upload file in extra step;
7. go to payment.

Issue
-----
Form cannot be submitted due to error.

Cause
-----
eCommerce uses the `extract_data` method from the `WebsiteForm` controller. Several other modules also have overrides that may get called on checkout via super, but don't use `sudo` to check the `model` name for their module-specific logic, leading to access errors.

This isn't always an issue, depending on the order they're called in. If the model name is read once into cache using `sudo`, access rights are no longer checked.

Commit 75b385bae0360 added an `extract_data` override to website_hr_recruitment which checks `model.model` before calling `super`, which means the `model.model` value hasn't been cached yet, and an access error is thrown when called as Public User.

Solution
--------
Add `sudo` to any `model.model` check in `WebsiteForm` overrides to make the `sudo` requirement explicit (and not rely on ORM caching behavior).


opw-4376165