### PR TITLE
[FIX] hr_gamification: allow badge granting through badge card

### DIFF
--- a/addons/hr_gamification/wizard/gamification_badge_user_wizard.py
+++ b/addons/hr_gamification/wizard/gamification_badge_user_wizard.py
@@ -20,7 +20,7 @@ class GamificationBadgeUserWizard(models.TransientModel):
             'user_id': self.user_id.id,
             'sender_id': self.env.uid,
             'badge_id': self.badge_id.id,
-            'employee_id': self.employee_id.id,
+            'employee_id': self.user_id.employee_id.id,
             'comment': self.comment,
         }
 


### PR DESCRIPTION
**Issue:**
Badges granted to employees don't display the link to access employee card.
https://github.com/user-attachments/assets/d8de916d-4f24-4ebb-b312-4e17d4c79bbb

**Expected:**
Magic button on badges cards should lead to the rewarded employee if any.

**Steps to reproduce:**
- Activate Employees and Gamification apps;
- Configure an employee;
- Configure a badge to grant through `Employees / Configuration / Challenges / Badges`;
- Grant the badge and select the employee;
- See all counters increase but the magic button's one.

**Cause:**
The employee_id is not set on the `GamificationBadgeUserWizard` during creation state so `values` never contain an employee_id if retrieved on `self`.

**Fix:**
Retrieve the user's employee id through the selected user entity.
https://github.com/user-attachments/assets/a0076e85-cd66-421a-992f-2c89afb07ad8


opw-4366690

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
