### PR TITLE
[FIX] resource : Re-compute period duration for attendances

### DIFF
--- a/addons/resource/models/resource_calendar_attendance.py
+++ b/addons/resource/models/resource_calendar_attendance.py
@@ -73,7 +73,7 @@ class ResourceCalendarAttendance(models.Model):
         for attendance in self:
             attendance.duration_hours = (attendance.hour_to - attendance.hour_from) if attendance.day_period != 'lunch' else 0
 
-    @api.depends('day_period', 'duration_hours')
+    @api.depends('day_period', 'duration_hours', 'calendar_id.hours_per_day')
     def _compute_duration_days(self):
         for attendance in self:
             if attendance.day_period == 'lunch':


### PR DESCRIPTION
### Steps to reproduce:
	- Create a working schedule that is flexible
	- Assign this working schedule to an Employee
	- Create a time off type and set the request unit to be 'half day'
	- Create an allocation for the created time off type for the employee with the flexible working schedule
	- Create a leave for the mentioned employee with the created time off type for 1 day
	- Notice the duration of the leave is 2 days not 1

### Cause:
When creating a working schedule we compute the duration of the periods and since 'attendance.calendar_id.hours_per_day' won't have a value each period will be 1 day.
https://github.com/odoo/odoo/blob/18.0/addons/resource/models/resource_calendar_attendance.py#L82

So, when getting the duration of the leave where its request_unit is not 'day' the duration will be the summation of the periods' duration of the working schedule for the employee which in this case will be 1 for each period -each day has 2 periods with the value of 1-

### Fix:
Since 'calendar_id.hours_per_day' will be equal zero at first we should re-compute the duration of periods when this field gets a value.

opw-4309551