### PR TITLE
[FIX] point_of_sale: prevent empty receipt page print

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.scss
@@ -20,14 +20,10 @@
     body {
         background-color: transparent;
     }
-    body * {
-        visibility: hidden;
-    }
     .pos, .pos * {
         position: static !important;
     }
     .render-container .pos-receipt * {
-        visibility: visible;
         background-color: transparent !important;
         color: black !important;
     }
@@ -49,9 +45,8 @@
         top: 0;
         left: 0;
     }
-    .o-main-components-container > *:not(.render-container-parent) {
-        display: none !important;
-    }
+    body > *:not(.o-main-components-container),
+    .o-main-components-container > *:not(.render-container-parent),
     .render-container-parent > *:not(.render-container) {
         display: none !important;
     }


### PR DESCRIPTION
Before this commit, printing a receipt would result in an empty page at the end. This commit ensures that the receipt is printed correctly without any additional empty pages.

opw-4389871

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
