### PR TITLE
[FIX] pos_restaurant: avoid error on refund without tables

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -124,9 +124,11 @@ patch(TicketScreen.prototype, {
     async onDoRefund() {
         const order = this.getSelectedOrder();
         if (this.pos.config.module_pos_restaurant && order && !this.pos.selectedTable) {
-            await this.pos.setTable(
-                order.table ? order.table : this.pos.models["restaurant.table"].getAll()[0]
-            );
+            const tableModel = this.pos.models["restaurant.table"];
+            const table = order.table_id || tableModel.getFirst();
+            if (table) {
+                await this.pos.setTable(table);
+            }
         }
         await super.onDoRefund(...arguments);
     },

--- a/addons/pos_restaurant/static/tests/tours/refund_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/refund_tour.js
@@ -8,6 +8,7 @@ import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_
 import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
+import * as Utils from "@point_of_sale/../tests/tours/utils/common";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("RefundStayCurrentTableTour", {
@@ -82,5 +83,25 @@ registry.category("web_tour.tours").add("RefundQtyTour", {
             TicketScreen.selectFilter("Paid"),
             TicketScreen.selectOrder("-0001"),
             TicketScreen.refundedNoteContains("2.00 Refunded"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("RefundNoTable", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            Chrome.newOrder(),
+            ProductScreen.clickDisplayedProduct("Coca-Cola", true, "1.0"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.selectFilter("Paid"),
+            TicketScreen.selectOrder("-0001"),
+            Utils.selectButton("Refund"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
         ].flat(),
 });

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -328,3 +328,8 @@ class TestFrontend(TestFrontendCommon):
     def test_15_pos_refund_qty(self):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('RefundQtyTour')
+
+    def test_refund_no_tables(self):
+        self.pos_config.floor_ids.unlink()
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('RefundNoTable')


### PR DESCRIPTION
### Steps to reproduce:
- Create a new POS from the settings (tick the "is bar/restaurant" option)
- Remove the Floors & Tables Map
- Open a session with this POS
- Create a new order with the + button at the top
- Select a product, pay for it and click on "New Order"
- Click on the menu at the top right, then Orders
- Change the status to "Paid" to find the order
- Refund it
- An error pops up

### Cause:
When doing a refund, Odoo tries to fill the table field of the new order, when there are no table selected it gets all tables and returns the first one. So when there are no tables, the `setTable` method has its `table` field to `undefined` and raises an error when it tries to read its values.

### Solution:
Do not call `setTable` when there are no tables.