### PR TITLE
[IMP] account: default cash rounding with ir.default

### DIFF
--- a/addons/account/data/account_data.xml
+++ b/addons/account/data/account_data.xml
@@ -137,6 +137,38 @@
             <field name="payment_type">outbound</field>
         </record>
 
+        <!-- Cash Rounding Method -->
+        <record id="cash_rounding_1_0" model="account.cash.rounding">
+            <field name="name">Rounding to 1</field>
+            <field name="rounding">1.0</field>
+            <field name="strategy">biggest_tax</field>
+        </record>
+        <record id="cash_rounding_0_1" model="account.cash.rounding">
+            <field name="name">Rounding to 0.1</field>
+            <field name="rounding">0.1</field>
+            <field name="strategy">biggest_tax</field>
+        </record>
+        <record id="cash_rounding_0_01" model="account.cash.rounding">
+            <field name="name">Rounding to 0.01</field>
+            <field name="rounding">0.01</field>
+            <field name="strategy">biggest_tax</field>
+        </record>
+        <record id="cash_rounding_0_05" model="account.cash.rounding">
+            <field name="name">Rounding to 0.05</field>
+            <field name="rounding">0.05</field>
+            <field name="strategy">biggest_tax</field>
+        </record>
+        <record id="cash_rounding_0_001" model="account.cash.rounding">
+            <field name="name">Rounding to 0.001</field>
+            <field name="rounding">0.001</field>
+            <field name="strategy">biggest_tax</field>
+        </record>
+
+        <!-- By default, set rounding exceptions for IDR, INR, and CHF -->
+        <function model="ir.default" name="set" eval="('account.move', 'invoice_cash_rounding_id', obj().env.ref('account.cash_rounding_1_0').id, False, False, 'currency=IDR')"/>
+        <function model="ir.default" name="set" eval="('account.move', 'invoice_cash_rounding_id', obj().env.ref('account.cash_rounding_1_0').id, False, False, 'currency=INR')"/>
+        <function model="ir.default" name="set" eval="('account.move', 'invoice_cash_rounding_id', obj().env.ref('account.cash_rounding_0_05').id, False, False, 'currency=CHF')"/>
+
         <!-- Partner Trust Property -->
         <function model="ir.default" name="set" eval="('res.partner', 'trust', 'normal')"/>
 

--- a/addons/account/views/account_cash_rounding_view.xml
+++ b/addons/account/views/account_cash_rounding_view.xml
@@ -24,7 +24,8 @@
                         </div>
                         <group>
                             <group>
-                                <field name="rounding"/>
+                                <field name="id"/>
+                                <field name="rounding" options="{'digits': [false, 5]}"/>
                                 <field name="strategy"/>
                                 <field name="profit_account_id" options="{'no_create': True}" invisible="strategy != 'add_invoice_line'" required="strategy == 'add_invoice_line'"
                                     groups="account.group_account_invoice,account.group_account_readonly" domain="[('account_type', 'not in', ('asset_receivable', 'liability_payable'))]"/>
@@ -53,8 +54,9 @@
             <field name="model">account.cash.rounding</field>
             <field name="arch" type="xml">
                 <list string="Rounding List">
+                    <field name="id" optional="hide"/>
                     <field name="name"/>
-                    <field name="rounding"/>
+                    <field name="rounding" options="{'digits': [false, 5]}"/>
                     <field name="rounding_method"/>
                 </list>
             </field>

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -218,6 +218,7 @@
                             <group id="invoice_send_settings"
                                    string="Customer Invoices"
                                    groups="account.group_account_invoice,account.group_account_readonly">
+                                <field name="default_cash_rounding_id"/>
                                 <field name="invoice_sending_method"/>
                                 <field name="invoice_edi_format" invisible="not display_invoice_edi_format"/>
                                 <field name="invoice_template_pdf_report_id"


### PR DESCRIPTION
This commit implements a way for user to manually set a default value for the `invoice_cash_rounding_id` field in moves, and apply by default a standard `account.cash.rounding` record based on the found `ir.default` record or the ISO-4217 standard for every available currency.

It adds 5 new `account.cash.rounding` record included on the data of the `account` module. They're set with the 'biggest_tax' strategy so that the user doesn't need to add required account data on the fields.

We use the `ir.default` object to store the "preferred" default value of the move rounding field. The rounding field will also be computed to make sure it gets filled with the default value. An override on `default_get` is needed so that the default `ir.default` behavior does not interferre with the compute and making sure the rounding field gets computed correctly.

To set a preferred `ir.default` on the cash rounding field, the user must create a new record on "User-Defined Defaults" menu, select the cash rounding, fill the JSON value with the rounding record ID, and fill either the  condition string with "currency=<currency_name>" (e.g. "currency=USD").

By default, 3 `ir.default` record are created when installing `account` module as an exception to the ISO-4217 standard in Odoo for the currency of IDR, INR, and CHF.

An options for digits is added on the rounding field in the `account.cash.rounding` list and form view, to make sure the additional decimal points are shown (previously it's set to hide anything smaller than 2 digits behind the decimal separator)

In this version (master), an preferred default cash rounding field will be saved on the partner of the move, and will be used in the computation of the move's cash rounding field as a preferred value.

task-id: 4338116