### PR TITLE
[IMP] account_accountant: bank reconcile draft

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -547,8 +547,8 @@ class AccountJournal(models.Model):
             return
         bills_field_list = [
             "account_move.journal_id",
-            "(CASE WHEN account_move.move_type IN ('out_refund', 'in_refund') THEN -1 ELSE 1 END) * account_move.amount_residual AS amount_total",
-            "(CASE WHEN account_move.move_type IN ('in_invoice', 'in_refund', 'in_receipt') THEN -1 ELSE 1 END) * account_move.amount_residual_signed AS amount_total_company",
+            "(CASE WHEN account_move.move_type IN ('out_refund', 'in_refund') THEN -1 ELSE 1 END) * account_move.amount_total AS amount_total",
+            "(CASE WHEN account_move.move_type IN ('in_invoice', 'in_refund', 'in_receipt') THEN -1 ELSE 1 END) * account_move.amount_total_signed AS amount_total_company",
             "account_move.currency_id AS currency",
             "account_move.move_type",
             "account_move.invoice_date",

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1233,7 +1233,7 @@ class AccountMoveLine(models.Model):
         return True
 
     def _check_reconciliation(self):
-        for line in self:
+        for line in self.filtered(lambda x: x.parent_state == 'posted'):
             if line.matched_debit_ids or line.matched_credit_ids:
                 raise UserError(_("You cannot do this modification on a reconciled journal entry. "
                                   "You can just change some non legal fields or you must unreconcile first.\n"
@@ -1501,6 +1501,8 @@ class AccountMoveLine(models.Model):
 
         line_to_write = self
         vals = self._sanitize_vals(vals)
+        lines_to_unreconcile = self.env['account.move.line']
+        st_lines_to_unreconcile = self.env['account.bank.statement.line']
         for line in self:
             if not any(self.env['account.move']._field_will_change(line, vals, field_name) for field_name in vals):
                 line_to_write -= line
@@ -1517,9 +1519,19 @@ class AccountMoveLine(models.Model):
             if line.parent_state == 'posted' and any(self.env['account.move']._field_will_change(line, vals, field_name) for field_name in protected_fields['tax']):
                 line._check_tax_lock_date()
 
-            # Check the reconciliation.
-            if any(self.env['account.move']._field_will_change(line, vals, field_name) for field_name in protected_fields['reconciliation']):
-                line._check_reconciliation()
+            # Break the reconciliation.
+            if any(self.env['account.move']._field_will_change(line, vals, field_name) for field_name in protected_fields['reconciliation']) and (line.matched_debit_ids or line.matched_credit_ids):
+                lines_to_unreconcile += line
+                st_lines_to_unreconcile += (line.matched_debit_ids.debit_move_id + line.matched_credit_ids.credit_move_id).statement_line_id
+
+        lines_to_unreconcile.remove_move_reconcile()
+        for st_line in st_lines_to_unreconcile:
+            try:
+                st_line.move_id._check_fiscal_lock_dates()
+                st_line.move_id.line_ids._check_tax_lock_date()
+            except UserError:
+                st_lines_to_unreconcile -= st_line
+        st_lines_to_unreconcile.action_undo_reconciliation()
 
         move_container = {'records': self.move_id}
         with self.move_id._check_balanced(move_container),\
@@ -2043,6 +2055,7 @@ class AccountMoveLine(models.Model):
                         credit_aml._get_reconciliation_aml_field_value('date', shadowed_aml_values),
                     ),
                 )
+                res['exchange_values']['to_post'] = debit_aml.parent_state == 'posted' and credit_aml.parent_state == 'posted'
 
         # ==== Create partials ====
 
@@ -2186,8 +2199,8 @@ class AccountMoveLine(models.Model):
 
         if any(aml.reconciled for aml in self):
             raise UserError(_("You are trying to reconcile some entries that are already reconciled."))
-        if any(aml.parent_state != 'posted' for aml in self):
-            raise UserError(_("You can only reconcile posted entries."))
+        if any(aml.parent_state == 'cancel' for aml in self):
+            raise UserError(_("You can not reconcile cancelled entries."))
         accounts = self.mapped(lambda x: x._get_reconciliation_aml_field_value('account_id', shadowed_aml_values))
         if len(accounts) > 1:
             raise UserError(_(
@@ -2363,6 +2376,7 @@ class AccountMoveLine(models.Model):
                 'aml': aml,
                 'amount_residual': aml.amount_residual,
                 'amount_residual_currency': aml.amount_residual_currency,
+                'parent_state': aml.parent_state,
             }
             for aml in all_amls
         }
@@ -2381,13 +2395,15 @@ class AccountMoveLine(models.Model):
             for results in plan_results:
                 partials_values_list.append(results['partial_values'])
                 if results.get('exchange_values') and results['exchange_values']['move_values']['line_ids']:
-                    exchange_diff_values_list.append(results['exchange_values'])
                     exchange_diff_partial_index.append(partial_index)
                     partial_index += 1
+                    exchange_diff_values_list.append(results['exchange_values'])
 
         # ==== Create the partials ====
         # Link the newly created partials to the plan. There are needed later for caba exchange entries.
         partials = self.env['account.partial.reconcile'].create(partials_values_list)
+        if self._context.get('add_caba_vals'):
+            partials._set_draft_caba_move_vals()
         start_range = 0
         for plan_results, plan in zip(all_plan_results, plan_list):
             size = len(plan_results)
@@ -2408,6 +2424,7 @@ class AccountMoveLine(models.Model):
             for plan in plan_list:
                 if is_cash_basis_needed(plan['amls']):
                     plan['partials']._create_tax_cash_basis_moves()
+                    plan['partials']._set_draft_caba_move_vals()
 
         # ==== Prepare full reconcile creation ====
         # First, we need to find all sub-set of amls that are candidates for a full.
@@ -2489,6 +2506,7 @@ class AccountMoveLine(models.Model):
                     company=involved_amls.company_id,
                     exchange_date=exchange_max_date,
                 )
+                exchange_diff_values['to_post'] = all([aml.parent_state == 'posted' for aml in exchange_lines_to_fix])
 
                 # Exchange difference for cash basis entries.
                 # If we are fully reversing the entry, no need to fix anything since the journal entry
@@ -2586,8 +2604,8 @@ class AccountMoveLine(models.Model):
             'always_tax_exigible': True,
         }
         to_reconcile = []
-
         for line, amounts in zip(self, amounts_list):
+
             move_vals['date'] = max(move_vals['date'], line.date)
 
             if 'amount_residual' in amounts:
@@ -2653,6 +2671,10 @@ class AccountMoveLine(models.Model):
                                             See the '_prepare_exchange_difference_move_vals' method.
         :return: An account.move recordset.
         """
+        # early return to prevent endless recursive computation of reconcile plan
+        if not exchange_diff_values_list:
+            return self.env['account.move']
+
         exchange_move_values_list = []
         journal_ids = set()
         for exchange_diff_values in exchange_diff_values_list:
@@ -2666,9 +2688,6 @@ class AccountMoveLine(models.Model):
                 ))
 
             journal_ids.add(move_vals['journal_id'])
-
-        if not exchange_move_values_list:
-            return self.env['account.move']
 
         # ==== Check the config ====
         journals = self.env['account.journal'].browse(list(journal_ids))
@@ -2684,9 +2703,8 @@ class AccountMoveLine(models.Model):
                     " automatically the booking of accounting entries related to differences between exchange rates."
                 ))
 
-        # ==== Create the move ====
+        # ==== Create the moves ====
         exchange_moves = self.env['account.move'].create(exchange_move_values_list)
-        exchange_moves._post(soft=False)
 
         # ==== Reconcile ====
         reconciliation_plan = []
@@ -2695,9 +2713,16 @@ class AccountMoveLine(models.Model):
                 exchange_diff_line = exchange_move.line_ids[sequence]
                 reconciliation_plan.append((source_line + exchange_diff_line))
 
-        self\
-            .with_context(no_exchange_difference=True)\
-            ._reconcile_plan(reconciliation_plan)
+        self.with_context(no_exchange_difference=True)._reconcile_plan(reconciliation_plan)
+
+        # ==== See if the exchange moves need to be posted or not ====
+        exchange_moves_to_post = self.env['account.move']
+        for exchange_move, vals in zip(exchange_moves, exchange_diff_values_list):
+            if vals['to_post']:
+                exchange_moves_to_post |= exchange_move
+
+        if exchange_moves_to_post:
+            exchange_moves_to_post._post(soft=False)
 
         return exchange_moves
 

--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -4,7 +4,7 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.tools import frozendict
 
 from datetime import date
-
+import json
 
 class AccountPartialReconcile(models.Model):
     _name = 'account.partial.reconcile'
@@ -21,6 +21,10 @@ class AccountPartialReconcile(models.Model):
         comodel_name='account.full.reconcile',
         string="Full Reconcile", copy=False, index='btree_not_null')
     exchange_move_id = fields.Many2one(comodel_name='account.move', index='btree_not_null')
+
+    # this field will be used upon the posting of the invoice, to know if we can keep the partial or if the
+    # user has to re-do entirely the reconciliaion (in  case fundamental values changed for the cash basis)
+    draft_caba_move_vals = fields.Json(string="Values that created the draft cash-basis entry")
 
     # ==== Currency fields ====
     company_currency_id = fields.Many2one(
@@ -106,14 +110,16 @@ class AccountPartialReconcile(models.Model):
         if not self:
             return True
 
-        # Retrieve the matching number to unlink.
-        full_to_unlink = self.full_reconcile_id
-        all_reconciled = self.debit_move_id + self.credit_move_id
-
         # Retrieve the CABA entries to reverse.
         moves_to_reverse = self.env['account.move'].search([('tax_cash_basis_rec_id', 'in', self.ids)])
         # Same for the exchange difference entries.
         moves_to_reverse += self.exchange_move_id
+
+        # Retrieve the matching number to unlink
+        full_to_unlink = self.full_reconcile_id
+
+        # if the move is draft and can be removed, there is no need to update the matching number
+        all_reconciled = self.debit_move_id + self.credit_move_id
 
         # Unlink partials before doing anything else to avoid 'Record has already been deleted' due to the recursion.
         res = super().unlink()
@@ -121,14 +127,18 @@ class AccountPartialReconcile(models.Model):
         # Remove the matching numbers before reversing the moves to avoid trying to remove the full twice.
         full_to_unlink.unlink()
 
-        # Reverse CABA entries.
+        # Reverse or unlink CABA/exchange move entries.
         if moves_to_reverse:
+            not_draft_moves = moves_to_reverse.filtered(lambda m: m.state != 'draft')
+            draft_moves = moves_to_reverse.filtered(lambda m: m.state == 'draft')
             default_values_list = [{
                 'date': move._get_accounting_date(move.date, move._affect_tax_report()),
                 'ref': move.env._('Reversal of: %s', move.name),
-            } for move in moves_to_reverse]
-            moves_to_reverse._reverse_moves(default_values_list, cancel=True)
+            } for move in not_draft_moves]
+            not_draft_moves._reverse_moves(default_values_list, cancel=True)
+            draft_moves.unlink()
 
+        all_reconciled = all_reconciled.exists()
         self._update_matching_number(all_reconciled)
         return res
 
@@ -307,6 +317,7 @@ class AccountPartialReconcile(models.Model):
                     'partial': partial,
                     'percentage': percentage,
                     'payment_rate': payment_rate,
+                    'both_move_posted': partial.debit_move_id.move_id.state == 'posted' and partial.credit_move_id.move_id.state == 'posted',
                 }
 
                 # Add partials.
@@ -490,7 +501,8 @@ class AccountPartialReconcile(models.Model):
         tax_cash_basis_values_per_move = self._collect_tax_cash_basis_values()
         today = fields.Date.context_today(self)
 
-        moves_to_create = []
+        moves_to_create_and_post = []
+        moves_to_create_in_draft = []
         to_reconcile_after = []
         for move_values in tax_cash_basis_values_per_move.values():
             move = move_values['move']
@@ -520,7 +532,6 @@ class AccountPartialReconcile(models.Model):
                 partial_lines_to_create = {}
 
                 for caba_treatment, line in move_values['to_process_lines']:
-
                     # ==========================================================================
                     # Compute the balance of the current line on the cash basis entry.
                     # This balance is a percentage representing the part of the journal entry
@@ -601,7 +612,7 @@ class AccountPartialReconcile(models.Model):
                         counterpart_line_vals['sequence'] = sequence + 1
 
                         if tax_line.account_id.reconcile:
-                            move_index = len(moves_to_create)
+                            move_index = len(moves_to_create_and_post) + len(moves_to_create_in_draft)
                             to_reconcile_after.append((tax_line, move_index, counterpart_line_vals['sequence']))
 
                     else:
@@ -614,16 +625,17 @@ class AccountPartialReconcile(models.Model):
 
                     move_vals['line_ids'] += [(0, 0, counterpart_line_vals), (0, 0, line_vals)]
 
-                moves_to_create.append(move_vals)
+                if partial_values['both_move_posted']:
+                    moves_to_create_and_post.append(move_vals)
+                else:
+                    moves_to_create_in_draft.append(move_vals)
 
-        moves = self.env['account.move']\
-            .with_context(
-                skip_invoice_sync=True,
-                skip_invoice_line_sync=True,
-                skip_account_move_synchronization=True,
-            )\
-            .create(moves_to_create)
-        moves._post(soft=False)
+        moves = self.env['account.move'].with_context(
+            skip_invoice_sync=True,
+            skip_invoice_line_sync=True,
+            skip_account_move_synchronization=True,
+        ).create(moves_to_create_and_post + moves_to_create_in_draft)
+        moves[:len(moves_to_create_and_post)]._post(soft=False)
 
         # Reconcile the tax lines being on a reconcile tax basis transfer account.
         reconciliation_plan = []
@@ -643,6 +655,26 @@ class AccountPartialReconcile(models.Model):
 
             reconciliation_plan.append((counterpart_line + lines))
 
-        self.env['account.move.line']._reconcile_plan(reconciliation_plan)
-
+        # passing add_caba_vals in the context to make sure that any exchange diff that would be created for
+        # this cash basis move would set the field draft_caba_move_vals accordingly on the partial
+        self.env['account.move.line'].with_context(add_caba_vals=True)._reconcile_plan(reconciliation_plan)
         return moves
+
+    def _get_draft_caba_move_vals(self):
+        self.ensure_one()
+        debit_vals = self.debit_move_id.move_id._collect_tax_cash_basis_values() or {}
+        credit_vals = self.credit_move_id.move_id._collect_tax_cash_basis_values() or {}
+        if not debit_vals and not credit_vals:
+            return False
+        return json.dumps({
+            'debit_caba_lines': [(aml_type, aml.id) for aml_type, aml in debit_vals.get('to_process_lines', [])],
+            'debit_total_balance': debit_vals.get('total_balance'),
+            'debit_total_amount_currency': debit_vals.get('total_amount_currency'),
+            'credit_caba_lines': [(aml_type, aml.id) for aml_type, aml in credit_vals.get('to_process_lines', [])],
+            'credit_total_balance': credit_vals.get('total_balance'),
+            'credit_total_amount_currency': credit_vals.get('total_amount_currency'),
+        })
+
+    def _set_draft_caba_move_vals(self):
+        for partial in self:
+            partial.draft_caba_move_vals = partial._get_draft_caba_move_vals()

--- a/addons/account/tests/test_account_move_date_algorithm.py
+++ b/addons/account/tests/test_account_move_date_algorithm.py
@@ -177,6 +177,7 @@ class TestAccountMoveDateAlgorithm(AccountTestInvoicingCommon):
         amls = (invoice + refund).line_ids.filtered(lambda x: x.account_id.account_type == 'asset_receivable')
         amls.reconcile()
         exchange_move = amls.matched_debit_ids.exchange_move_id
+        self.assertEqual(exchange_move.state, 'posted')
 
         self._set_lock_date('2017-01-31')
         (invoice + refund).line_ids.remove_move_reconcile()

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -698,6 +698,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
             },
         ]
         self.assertRecordValues(caba_move.line_ids, expected_values)
+        self.assertEqual(caba_move.state, 'posted')
         # unreconcile
         debit_aml = move.line_ids.filtered('debit')
         debit_aml.remove_move_reconcile()
@@ -709,6 +710,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
                 'credit': value['debit'],
             })
         self.assertRecordValues(reversed_caba_move.line_ids, expected_values)
+        self.assertEqual(reversed_caba_move.state, 'posted')
 
     def _get_cache_count(self, model_name='account.move', field_name='name'):
         model = self.env[model_name]

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1578,9 +1578,6 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         move.action_post()
         self.assertFalse(move.payment_ids)  # don't auto reconcile payments
 
-        # Reconcile manually, the move is now fully paid
-        (move.line_ids[-1] | payment.move_id.line_ids.filtered(lambda line: line.account_id == move.line_ids[-1].account_id)).reconcile()
-
         # If the move is already fully paid, we should alert the user
         with self.assertRaisesRegex(UserError, r"You can't register a payment because there is nothing left"):
             action_register_payment = move.action_force_register_payment()
@@ -2302,7 +2299,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         move = move_form.save()
         self.assertEqual(move.invoice_date.strftime('%Y-%m-%d'), '2022-05-06')
 
-    def _assert_payment_move_state(self, move_type, amount, counterpart_values_list, payment_state):
+    def _assert_payment_move_state(self, move_type, amount, counterpart_values_list, payment_state, post_move=True):
         def assert_partial(line1, line2):
             partial = self.env['account.partial.reconcile'].search(expression.OR([
                 [('debit_move_id', '=', line1.id), ('credit_move_id', '=', line2.id)],
@@ -2343,7 +2340,8 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                     }),
                 ]
             move = self.env['account.move'].create(move_vals)
-            move.action_post()
+            if post_move:
+                move.action_post()
             return move
 
         def create_payment(move, amount):
@@ -2485,6 +2483,69 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 payment_state=payment_state,
             ):
                 self._assert_payment_move_state(move_type, amount, counterpart_values_list, payment_state)
+
+    def test_payment_move_state_draft(self):
+        for move_type, amount, counterpart_values_list, payment_state, *extra in (
+            ('out_invoice', 1000.0, [('out_refund', 1000.0)], 'reversed'),
+            ('out_invoice', 1000.0, [('out_refund', 500.0), ('out_refund', 500.0)], 'reversed'),
+            ('out_invoice', 1000.0, [('out_refund', 500.0), ('entry', -500.0)], 'reversed'),
+            ('out_receipt', 1000.0, [('out_refund', 1000.0)], 'reversed'),
+            ('out_receipt', 1000.0, [('out_refund', 500.0), ('out_refund', 500.0)], 'reversed'),
+            ('out_refund', 1000.0, [('entry', 1000.0)], 'reversed'),
+            ('in_invoice', 1000.0, [('in_refund', 1000.0)], 'reversed'),
+            ('in_invoice', 1000.0, [('in_refund', 500.0), ('in_refund', 500.0)], 'reversed'),
+            ('in_invoice', 1000.0, [('in_refund', 500.0), ('entry', 500.0)], 'reversed'),
+            ('in_receipt', 1000.0, [('in_refund', 1000.0)], 'reversed'),
+            ('in_receipt', 1000.0, [('in_refund', 500.0), ('in_refund', 500.0)], 'reversed'),
+            ('in_refund', 1000.0, [('entry', -1000.0)], 'reversed'),
+            ('entry', 1000.0, [('entry', -1000.0)], 'not_paid'),
+            ('out_invoice', 1000.0, [('payment', 500.0)], 'partial'),
+            ('out_invoice', 1000.0, [('payment', 1000.0)], 'in_payment'),
+            ('out_invoice', 1000.0, [('statement_line', 500.0)], 'partial'),
+            ('out_invoice', 1000.0, [('statement_line', 1000.0)], 'paid'),
+            ('out_receipt', 1000.0, [('payment', 500.0)], 'partial'),
+            ('out_receipt', 1000.0, [('payment', 1000.0)], 'in_payment'),
+            ('out_receipt', 1000.0, [('statement_line', 500.0)], 'partial'),
+            ('out_receipt', 1000.0, [('statement_line', 1000.0)], 'paid'),
+            ('out_refund', 1000.0, [('payment', 500.0)], 'partial'),
+            ('out_refund', 1000.0, [('payment', 1000.0)], 'in_payment'),
+            ('out_refund', 1000.0, [('statement_line', -500.0)], 'partial'),
+            ('out_refund', 1000.0, [('statement_line', -1000.0)], 'paid'),
+            ('in_invoice', 1000.0, [('payment', 500.0)], 'partial'),
+            ('in_invoice', 1000.0, [('payment', 1000.0)], 'in_payment'),
+            ('in_invoice', 1000.0, [('statement_line', -500.0)], 'partial'),
+            ('in_invoice', 1000.0, [('statement_line', -1000.0)], 'paid'),
+            ('in_receipt', 1000.0, [('payment', 500.0)], 'partial'),
+            ('in_receipt', 1000.0, [('payment', 1000.0)], 'in_payment'),
+            ('in_receipt', 1000.0, [('statement_line', -500.0)], 'partial'),
+            ('in_receipt', 1000.0, [('statement_line', -1000.0)], 'paid'),
+            ('in_refund', 1000.0, [('payment', 500.0)], 'partial'),
+            ('in_refund', 1000.0, [('payment', 1000.0)], 'in_payment'),
+            ('in_refund', 1000.0, [('statement_line', 500.0)], 'partial'),
+            ('in_refund', 1000.0, [('statement_line', 1000.0)], 'paid'),
+            ('entry', 1000.0, [('payment', 500.0)], 'not_paid'),
+            ('entry', 1000.0, [('payment', 1000.0)], 'not_paid'),
+            ('entry', 1000.0, [('statement_line', 500.0)], 'not_paid'),
+            ('entry', 1000.0, [('statement_line', 1000.0)], 'not_paid'),
+            ('out_invoice', 1000.0, [('out_refund', 500.0), ('payment', 500.0)], 'in_payment'),
+            ('out_invoice', 1000.0, [('out_refund', 500.0), ('payment', 400.0)], 'partial'),
+            ('out_invoice', 1000.0, [('out_refund', 500.0), ('statement_line', 500.0)], 'paid'),
+            ('out_invoice', 1000.0, [('out_refund', 500.0), ('statement_line', 400.0)], 'partial'),
+            ('out_invoice', 1000.0, [('entry', -1000.0)], 'paid'),
+            ('in_invoice', 1000.0, [('in_refund', 500.0), ('payment', 500.0)], 'in_payment'),
+            ('in_invoice', 1000.0, [('in_refund', 500.0), ('payment', 400.0)], 'partial'),
+            ('in_invoice', 1000.0, [('in_refund', 500.0), ('statement_line', -500.0)], 'paid'),
+            ('in_invoice', 1000.0, [('in_refund', 500.0), ('statement_line', -400.0)], 'partial'),
+            ('in_invoice', 1000.0, [('entry', 1000.0)], 'paid'),
+            ('out_invoice', 0.0, [], 'not_paid'),
+        ):
+            with self.subTest(
+                move_type=move_type,
+                amount=amount,
+                counterpart_values_list=counterpart_values_list,
+                payment_state=payment_state,
+            ):
+                self._assert_payment_move_state(move_type, amount, counterpart_values_list, payment_state, post_move=False)
 
     def test_onchange_journal_currency(self):
         """

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4007,6 +4007,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
 
                 # Date of the exchange move should be the end of the month/year of the payment
                 self.assertEqual(exchange_move.date, fields.Date.to_date(expected_date))
+                self.assertEqual(exchange_move.state, 'posted')
 
                 line_receivable.remove_move_reconcile()
 

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -412,7 +412,6 @@
                     <field name="move_type" column_invisible="True"/>
                     <field name="is_same_currency" column_invisible="True"/>
                     <field name="is_account_reconcile" column_invisible="True"/>
-                    <field name="currency_id" groups="!base.group_multi_currency" column_invisible="True"/>
                     <field name="parent_state" column_invisible="True"/>
                     <groupby name="partner_id">
                         <button name="edit" type="edit" icon="fa-edit" title="Edit"/>

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -1186,7 +1186,6 @@ class AccountPaymentRegister(models.TransientModel):
                     .filtered_domain([
                         ('account_id', '=', account.id),
                         ('reconciled', '=', False),
-                        ('parent_state', '=', 'posted'),
                     ])\
                     .reconcile()
             lines.move_id.matched_payment_ids += payment


### PR DESCRIPTION
Since users cannot view draft invoices/bills on the bank recon screen, duplicates may be created. To avoid this, and to simplify the process for users who might pay on draft bills, we allow the reconciliation of bank statement lines with draft invoices & bills.

Task-4286245

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
