### PR TITLE
[FIX] payment_worldline: don't truncate PAYIDs

### DIFF
--- a/addons/payment_worldline/models/payment_transaction.py
+++ b/addons/payment_worldline/models/payment_transaction.py
@@ -268,7 +268,7 @@ class PaymentTransaction(models.Model):
 
         # Update the provider reference.
         payment_data = notification_data['payment']
-        self.provider_reference = payment_data.get('id', '').rstrip('_0')
+        self.provider_reference = payment_data.get('id', '').removesuffix('_0')
 
         # Update the payment method.
         payment_output = payment_data.get('paymentOutput', {})

--- a/addons/payment_worldline/tests/common.py
+++ b/addons/payment_worldline/tests/common.py
@@ -35,7 +35,7 @@ class WorldlineCommon(AccountTestInvoicingCommon, PaymentCommon):
                         'token': 'whateverToken'
                     },
                 },
-                'id': '123456789_0',
+                'id': '1234567890_0',
                 'status': 'CAPTURED',
             },
         }

--- a/addons/payment_worldline/tests/test_worldline.py
+++ b/addons/payment_worldline/tests/test_worldline.py
@@ -40,7 +40,7 @@ class WorldlineTest(WorldlineCommon, PaymentHttpCommon):
         self._webhook_notification_flow(self.notification_data)
         self.assertFalse(tx.token_id, "No token should be created.")
         self.assertEqual(tx.state, 'done')
-        self.assertEqual(tx.provider_reference, '123456789')
+        self.assertEqual(tx.provider_reference, '1234567890')
 
     @mute_logger('odoo.addons.payment_worldline.controllers.main')
     def test_webhook_notification_creates_token(self):


### PR DESCRIPTION
Fixup of #185951

When removing the trailing _0 in transaction IDs from the API response, any trailing 0 in the PAYID gets truncated as well, due to the use of `rstrip()`.

A series of consecutive transactions are then saved with the following provider_reference values:

8390248265
8390248266
8390248267
8390248268
8390248269
839024827
8390248271

which leads to mismatching reconciliations of payouts for the truncated ones, and may cause collisions of PAYIDs with older transactions.