### PR TITLE
[FIX] web: form: avoid custom div to wrap

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -478,7 +478,7 @@
     & .o_form_renderer:not(.o_kanban_quick_create_form) .o_inner_group {
         @include media-breakpoint-up(sm) {
             .o_cell:first-child:last-child,
-            .o_cell:not(.o_wrap_label):not(.o_wrap_input) {
+            .o_cell:not(.o_wrap_label):not(.o_wrap_input):not(.o_cell_custom) {
                 grid-column: span 2;
             }
         }

--- a/addons/web/static/src/views/form/form_group/form_group.xml
+++ b/addons/web/static/src/views/form/form_group/form_group.xml
@@ -25,7 +25,7 @@
 
                 <t t-else="">
                     <div
-                        class="o_cell"
+                        class="o_cell o_cell_custom"
                         t-attf-style="{{ cell.itemSpan > 1 ? 'grid-column: span ' + cell.itemSpan + ';' : '' }}"
                         t-attf-class="{{ cell.subType === 'label' ? 'o_wrap_label text-break text-900' : null }}"
                         t-if="cell.isVisible">


### PR DESCRIPTION
Since the removal of the `d-contents` in form view when we have a custom div and not a field into an inner group it will wrap to the next line.

This commit fixes this problem using a class to identify when we have a custom div and so excluding the CSS rules.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
