### PR TITLE
[FIX] hr_recruitment: never set Subject as candidate name

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -603,6 +603,7 @@ class Applicant(models.Model):
         })
         defaults = {
             'candidate_id': candidate.id,
+            'partner_name': partner_name,
         }
         job_platform = self.env['hr.job.platform'].search([('email', '=', email_from_normalized)], limit=1)
         if msg.get('from') and not job_platform:

--- a/addons/hr_recruitment/tests/test_recruitment_process.py
+++ b/addons/hr_recruitment/tests/test_recruitment_process.py
@@ -47,7 +47,7 @@ class TestRecruitmentProcess(TestHrCommon):
             ('name', '=', 'resume.pdf'),
             ('res_model', '=', self.env['hr.applicant']._name),
             ('res_id', '=', applicant.id)])
-        self.assertEqual(applicant.partner_name, 'Application for the post of Jr.application Programmer.', 'Applicant name does not match.')
+        self.assertEqual(applicant.partner_name, 'Mr. Richard Anderson', 'Applicant name does not match.')
         self.assertEqual(applicant.stage_id, self.env.ref('hr_recruitment.stage_job0'),
             "Stage should be 'New' and is '%s'." % (applicant.stage_id.name))
         self.assertTrue(resume_ids, 'Resume is not attached.')


### PR DESCRIPTION
Emails sent by some job platforms (e.g. Indeed) result in applicants with a display name like:

[Action required] New application for Developer, San Francisco, CA

This makes it hard for recruiters to efficiently use the recruitment app. These emails don't use `hr.job.platform`, because the platform (e.g. Indeed) sends out the email under an application-specific `From: `, e.g.

`"Joren Van Onder" <jov2ueneo87n_g88@indeedemail.com>`

So the `hr.job.platform` mechanism isn't needed.

Before this commit, when an application like this was received, the name on the hr.applicant (computed field based on candidate_id) would become the email subject name. This is the default behavior of `mail.thread`: it fills `_rec_name` with the subject if not set [1]. To fix it, always force partner_name in `hr.applicant`s `message_new()` (this already was being done if an `hr.job.platform` matched).

[1] https://github.com/odoo/odoo/blob/f4990442904a23a387f21822b91d096f5eb987fc/addons/mail/models/mail_thread.py#L1412-L1422

opw-4383191
