### PR TITLE
[IMP] web: allow specifying class on datetime input

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_input.js
+++ b/addons/web/static/src/core/datetime/datetime_input.js
@@ -16,6 +16,7 @@ import { DateTimePicker } from "./datetime_picker";
 const dateTimeInputOwnProps = {
     format: { type: String, optional: true },
     id: { type: String, optional: true },
+    class: { type: String, optional: true },
     onChange: { type: Function, optional: true },
     onApply: { type: Function, optional: true },
     placeholder: { type: String, optional: true },

--- a/addons/web/static/src/core/datetime/datetime_input.xml
+++ b/addons/web/static/src/core/datetime/datetime_input.xml
@@ -6,6 +6,7 @@
             t-ref="start-date"
             t-att-id="props.id"
             class="o_datetime_input o_input cursor-pointer"
+            t-att-class="props.class"
             autocomplete="off"
             t-att-placeholder="props.placeholder"
         />

--- a/addons/web/static/tests/core/components/datetime/datetime_input.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_input.test.js
@@ -38,6 +38,7 @@ describe("DateTimeInput (date)", () => {
             props: {
                 value: DateTime.fromFormat("09/01/1997", "dd/MM/yyyy"),
                 type: "date",
+                class: "custom_class",
             },
         });
 
@@ -45,6 +46,7 @@ describe("DateTimeInput (date)", () => {
         assertDateTimePicker(false);
 
         expect(".o_datetime_input").toHaveValue("09/01/1997");
+        expect(".o_datetime_input").toHaveClass("custom_class");
 
         await click(".o_datetime_input");
         await animationFrame();


### PR DESCRIPTION
In order for a DateTimeInput to be focusable in a custom Dropdown component, we need it to have the class `o-navigable`.

This commit adds the ability to pass CSS classes to the DateTimeInput component.

[task-4284292](https://www.odoo.com/odoo/project.task/4284292)

Related to https://github.com/odoo/enterprise/pull/74992