### PR TITLE
[CLA] Update Vauxoo's CLA adding emtz10

### DIFF
--- a/doc/cla/corporate/vauxoo.md
+++ b/doc/cla/corporate/vauxoo.md
@@ -74,3 +74,4 @@ German Loredo german@vauxoo.com https://github.com/xmglord
 Antonio Aguilar antonio@vauxoo.com https://github.com/antonag32
 Christihan Laurel laurel@vauxoo.com https://github.com/CLaurelB
 Andrea Manenti manenti@vauxoo.com https://github.com/maneandrea
+Eduardo Martinez eduardoms@vauxoo.com https://github.com/emtz10


### PR DESCRIPTION
Incorporate Eduardo Martinez (emtz10) as Vauxoo's contributor.

I confirm I have signed the CLA and read the PR guidelines at http://www.odoo.com/submit-pr
