### PR TITLE
[FIX] hr_timesheet: resolve error portal user click time spent on subtasks

### DIFF
--- a/addons/hr_timesheet/models/project_task.py
+++ b/addons/hr_timesheet/models/project_task.py
@@ -174,6 +174,8 @@ class Task(models.Model):
         graph_view_id = self.env.ref("hr_timesheet.view_hr_timesheet_line_graph_by_employee").id
         new_views = []
         for view in action['views']:
+            if (not is_internal_user or self.env.context.get('is_project_sharing')) and view[1] not in ['tree', 'kanban', 'form']:
+                continue
             if not is_internal_user:
                 if view[1] == 'tree':
                     tree_view_id = self.env['ir.model.data']._xmlid_to_res_id('hr_timesheet.hr_timesheet_line_portal_tree')

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -34,6 +34,7 @@
                     <attribute name="edit">0</attribute>
                     <attribute name="create">0</attribute>
                     <attribute name="delete">0</attribute>
+                    <attribute name="js_class"></attribute>
                 </xpath>
                 <xpath expr="//field[@name='task_id']" position="attributes">
                     <attribute name="options">{'no_create_edit': True, 'no_open': True}</attribute>

--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -90,7 +90,7 @@
                                 <label class="fw-bold" for="effective_hours" string="Time Spent"/>
                             </span>
                             <field name="effective_hours" widget="timesheet_uom" nolabel="1"/>
-                            <button name="action_view_subtask_timesheet" type="object" class="ps-0 border-0 oe_inline oe_link mb-2 o_td_label float-start" invisible="subtask_effective_hours == 0.0">
+                            <button name="action_view_subtask_timesheet" type="object" class="ps-0 border-0 oe_inline oe_link mb-2 o_td_label float-start" invisible="subtask_effective_hours == 0.0" context="{'is_project_sharing': True}">
                                 <span class="text-nowrap">Time Spent on Sub-tasks:</span>
                             </button>
                             <field name="subtask_effective_hours" class="mt-2" widget="timesheet_uom"


### PR DESCRIPTION
- saas-17.4

### Steps to reproduce:
- Install the hr_timesheet module.
- Create a portal user.
- Create a project, task, and sub-task (with timesheet entries).
- Share the project with the portal user.
- Log in as the portal user.
- Open the shared project and navigate to the task.
- Click on the Time Spent on Sub-tasks action.

### Issue:
Traceback error

### Cause:
Tries to load timesheet timer header.

### Solution:
Remove the timesheet header from the portal list view. The timesheet header is not displayed to internal users, so we can remove it for portal users.


task-4369891


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
