### PR TITLE
[FIX] l10n_in_edi: `igst` on intra and refund claimable for overseas

### DIFF
--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -498,7 +498,7 @@ class AccountEdiFormat(models.Model):
                 "TaxSch": "GST",
                 "SupTyp": self._l10n_in_get_supply_type(invoice, tax_details_by_code),
                 "RegRev": tax_details_by_code.get("is_reverse_charge") and "Y" or "N",
-                "IgstOnIntra": is_intra_state and tax_details_by_code.get("igst") and "Y" or "N"},
+                "IgstOnIntra": is_intra_state and tax_details_by_code.get("igst_amount") and "Y" or "N"},
             "DocDtls": {
                 "Typ": invoice.move_type == "out_refund" and "CRN" or "INV",
                 "No": invoice.name,
@@ -546,7 +546,7 @@ class AccountEdiFormat(models.Model):
         if is_overseas:
             json_payload.update({
                 "ExpDtls": {
-                    "RefClm": tax_details_by_code.get("igst") and "Y" or "N",
+                    "RefClm": tax_details_by_code.get("igst_amount") and "Y" or "N",
                     "ForCur": invoice.currency_id.name,
                     "CntCode": saler_buyer.get("buyer_details").country_id.code or "",
                 }

--- a/addons/l10n_in_edi/tests/test_edi_json.py
+++ b/addons/l10n_in_edi/tests/test_edi_json.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
 
@@ -129,6 +130,46 @@ class TestEdiJson(AccountTestInvoicingCommon):
             "invoice_cash_rounding_id": rounding.id,
         })
         cls.invoice_cash_rounding.action_post()
+        cls.sez_partner = cls.env['res.partner'].create({
+            'name': 'SEZ Partner',
+            'vat': '36AAAAA1234AAZA',
+            'l10n_in_gst_treatment': 'special_economic_zone',
+            'street': 'Block no. 402',
+            'city': 'Some city',
+            'zip': '500002',
+            'state_id': cls.env.ref('base.state_in_ts').id,
+            'country_id': cls.env.ref('base.in').id,
+        })
+        cls.invoice_with_intra_igst = cls.init_invoice(
+            "out_invoice", partner=cls.sez_partner, post=False, products=cls.product_a
+        )
+        igst_18 = cls.env.ref(f'l10n_in.{cls.company_data["company"].id}_igst_sale_18')
+        cls.invoice_with_intra_igst.write({
+            'invoice_line_ids': [
+                Command.update(line_id, {'tax_ids': [Command.clear(), Command.set(igst_18.ids)]}) 
+                for line_id in cls.invoice_with_intra_igst.invoice_line_ids.ids
+            ]
+        })
+        cls.invoice_with_intra_igst.action_post()
+        cls.overseas = cls.env['res.partner'].create({
+            'name': 'Overseas',
+            'vat': False,
+            'l10n_in_gst_treatment': 'overseas',
+            'street': 'Block no. 402',
+            'city': 'Some city',
+            'zip': '999999',
+            'country_id': cls.env.ref('base.us').id,
+        })
+        cls.invoice_with_export = cls.init_invoice(
+            "out_invoice", partner=cls.overseas, post=False, products=cls.product_a
+        )
+        cls.invoice_with_export.write({
+            'invoice_line_ids': [
+                Command.update(line_id, {'tax_ids': [Command.clear(), Command.set(igst_18.ids)]}) 
+                for line_id in cls.invoice_with_export.invoice_line_ids.ids
+            ]
+        })
+        cls.invoice_with_export.action_post()
 
     def test_edi_json(self):
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice)
@@ -288,3 +329,80 @@ class TestEdiJson(AccountTestInvoicingCommon):
                 "StCesVal": 0.0, "RndOffAmt": 0.41, "TotInvVal": 2000.00
             }})
         self.assertDictEqual(json_value, expected_copy_rounding, "Indian EDI with cash rounding sent json value is not matched")
+
+        json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_with_intra_igst)
+        expected_with_intra_igst = {
+            'Version': '1.1',
+            'TranDtls': {'TaxSch': 'GST', 'SupTyp': 'SEZWP', 'RegRev': 'N', 'IgstOnIntra': 'Y'},
+            'DocDtls': {'Typ': 'INV', 'No': 'INV/2019/00010', 'Dt': '01/01/2019'},
+            'SellerDtls': expected['SellerDtls'],
+            'BuyerDtls': {
+                'Addr1': 'Block no. 402',
+                'Loc': 'Some city',
+                'Pin': 500002,
+                'Stcd': '36',
+                'POS': '36',
+                'LglNm': 'SEZ Partner',
+                'GSTIN': '36AAAAA1234AAZA'
+            },
+            'ItemList': [{
+                'SlNo': '1',
+                'PrdDesc': 'product_a',
+                'IsServc': 'N',
+                'HsnCd': '01111',
+                'Qty': 1.0,
+                'Unit': 'UNT',
+                'UnitPrice': 1000.0,
+                'TotAmt': 1000.0,
+                'Discount': 0.0,
+                'AssAmt': 1000.0,
+                'GstRt': 18.0,
+                'IgstAmt': 180.0,
+                'CgstAmt': 0.0,
+                'SgstAmt': 0.0,
+                'CesRt': 0.0,
+                'CesAmt': 0.0,
+                'CesNonAdvlAmt': 0.0,
+                'StateCesRt': 0.0,
+                'StateCesAmt': 0.0,
+                'StateCesNonAdvlAmt': 0.0,
+                'OthChrg': 0.0,
+                'TotItemVal': 1180.0
+            }],
+            'ValDtls': {
+                'AssVal': 1000.0,
+                'CgstVal': 0.0,
+                'SgstVal': 0.0,
+                'IgstVal': 180.0,
+                'CesVal': 0.0,
+                'StCesVal': 0.0,
+                'RndOffAmt': 0.0,
+                'TotInvVal': 1180.0
+            }
+        }
+        self.assertDictEqual(
+            json_value,
+            expected_with_intra_igst,
+            "Indian EDI with Intra IGST sent json value is not matched"
+        )
+        json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_with_export)
+        expected_with_overseas = expected_with_intra_igst.copy()
+        expected_with_overseas.update({
+            'TranDtls': {'TaxSch': 'GST', 'SupTyp': 'EXPWP', 'RegRev': 'N', 'IgstOnIntra': 'N'},
+            'BuyerDtls': {
+                'Addr1': 'Block no. 402',
+                'Loc': 'Some city',
+                'Pin': 999999,
+                'Stcd': '96',
+                'POS': '96',
+                'LglNm': 'Overseas',
+                'GSTIN': 'URP'
+            },
+            'DocDtls': {'Dt': '01/01/2019', 'No': 'INV/2019/00011', 'Typ': 'INV'},
+            'ExpDtls': {'CntCode': 'US', 'ForCur': 'INR', 'RefClm': 'Y'}
+        })
+        self.assertDictEqual(
+            json_value,
+            expected_with_overseas,
+            "Indian EDI with Overseas sent json value is not matched"
+        )


### PR DESCRIPTION
In this commit we fix to two things:
1. For SEZ(intra state) with payment of `IGST`, the `IGST` on Intra used to be sent `False`
for E-Invoice

2. For Overseas export, refund claimable is also used to be sent as `False` with same
situation payable of `IGST` in case of export

In this commit resolve the above issues

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
