### PR TITLE
[IMP] mail,website_slides: move request_partner_id field...

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -93,7 +93,6 @@ class MailActivity(models.Model):
         default=lambda self: self.env.user,
         index=True, required=True, ondelete='cascade')
     user_tz = fields.Selection(string='Timezone', related="user_id.tz", store=True)
-    request_partner_id = fields.Many2one('res.partner', string='Requesting Partner')
     state = fields.Selection([
         ('overdue', 'Overdue'),
         ('today', 'Today'),

--- a/addons/mail/static/src/core/web/activity_model.js
+++ b/addons/mail/static/src/core/web/activity_model.js
@@ -62,9 +62,6 @@ export class Activity extends Record {
     static _insert(data, { broadcast = true } = {}) {
         /** @type {import("models").Activity} */
         const activity = this.preinsert(data);
-        if (data.request_partner_id) {
-            data.request_partner_id = data.request_partner_id[0];
-        }
         assignDefined(activity, data);
         if (broadcast) {
             this.store.activityBroadcastChannel?.postMessage({

--- a/addons/website_slides/models/__init__.py
+++ b/addons/website_slides/models/__init__.py
@@ -13,3 +13,4 @@ from . import website
 from . import res_users
 from . import res_groups
 from . import res_partner
+from . import mail_activity

--- a/addons/website_slides/models/mail_activity.py
+++ b/addons/website_slides/models/mail_activity.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+from odoo.addons.mail.tools.discuss import Store
+
+
+class MailActivity(models.Model):
+    _inherit = "mail.activity"
+
+    request_partner_id = fields.Many2one("res.partner", string="Requesting Partner")
+
+    def _to_store_defaults(self):
+        return super()._to_store_defaults() + [Store.One("request_partner_id", [])]

--- a/addons/website_slides/static/src/activity/@types/models.d.ts
+++ b/addons/website_slides/static/src/activity/@types/models.d.ts
@@ -1,0 +1,5 @@
+declare module "models" {
+    interface Activity {
+        request_partner_id: Persona,
+    }
+}

--- a/addons/website_slides/static/src/activity/activity_model_patch.js
+++ b/addons/website_slides/static/src/activity/activity_model_patch.js
@@ -1,0 +1,11 @@
+import { Activity } from "@mail/core/web/activity_model";
+import { Record } from "@mail/model/record";
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").Activity} */
+const activityPatch = {
+    setup() {
+        this.request_partner_id = Record.one("Persona");
+    },
+};
+patch(Activity.prototype, activityPatch);

--- a/addons/website_slides/static/src/activity/activity_patch.js
+++ b/addons/website_slides/static/src/activity/activity_patch.js
@@ -9,7 +9,7 @@ const ActivityPatch = {
             "slide.channel",
             "action_grant_access",
             [[this.props.activity.res_id]],
-            { partner_id: this.props.activity.request_partner_id }
+            { partner_id: this.props.activity.request_partner_id.id }
         );
         this.props.activity.remove();
         this.props.reloadParentView();
@@ -19,7 +19,7 @@ const ActivityPatch = {
             "slide.channel",
             "action_refuse_access",
             [[this.props.activity.res_id]],
-            { partner_id: this.props.activity.request_partner_id }
+            { partner_id: this.props.activity.request_partner_id.id }
         );
         this.props.activity.remove();
         this.props.reloadParentView();

--- a/addons/website_slides/static/tests/activity_patch.test.js
+++ b/addons/website_slides/static/tests/activity_patch.test.js
@@ -5,8 +5,7 @@ import {
     start,
     startServer
 } from "@mail/../tests/mail_test_helpers";
-import { describe, expect, test } from "@odoo/hoot";
-import { asyncStep, onRpc, waitForSteps } from "@web/../tests/web_test_helpers";
+import { describe, test } from "@odoo/hoot";
 import { defineWebsiteSlidesModels } from "@website_slides/../tests/website_slides_test_helpers";
 
 describe.current.tags("desktop");
@@ -22,20 +21,11 @@ test("grant course access", async () => {
         request_partner_id: partnerId,
         res_model: "slide.channel",
     });
-    onRpc("action_grant_access", (args) => {
-        expect(args.args).toHaveLength(1);
-        expect(args.args[0]).toHaveLength(1);
-        expect(args.args[0][0]).toBe(channelId);
-        expect(args.kwargs.partner_id).toBe(partnerId);
-        asyncStep("access_grant");
-        // random value returned in order for the mock server to know that this route is implemented.
-        return true;
-    });
     await start();
     await openFormView("slide.channel", channelId);
     await contains(".o-mail-Activity");
     await click("button", { text: "Grant Access" });
-    await waitForSteps(["access_grant"]);
+    await contains(".o-mail-Activity", { count: 0 });
 });
 
 test("refuse course access", async () => {
@@ -48,18 +38,9 @@ test("refuse course access", async () => {
         request_partner_id: partnerId,
         res_model: "slide.channel",
     });
-    onRpc("action_refuse_access", (args) => {
-        expect(args.args).toHaveLength(1);
-        expect(args.args[0]).toHaveLength(1);
-        expect(args.args[0][0]).toBe(channelId);
-        expect(args.kwargs.partner_id).toBe(partnerId);
-        asyncStep("access_refused");
-        // random value returned in order for the mock server to know that this route is implemented.
-        return true;
-    });
     await start();
     await openFormView("slide.channel", channelId);
     await contains(".o-mail-Activity");
     await click("button", { text: "Refuse Access" });
-    await waitForSteps(["access_refused"]);
+    await contains(".o-mail-Activity", { count: 0 });
 });

--- a/addons/website_slides/static/tests/mock_server/models/mail_activity.js
+++ b/addons/website_slides/static/tests/mock_server/models/mail_activity.js
@@ -1,0 +1,20 @@
+import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
+import { mailModels } from "@mail/../tests/mail_test_helpers";
+import { makeKwArgs } from "@web/../tests/web_test_helpers";
+
+export class MailActivity extends mailModels.MailActivity {
+    /** @param {number[]} ids */
+    _to_store(ids, store) {
+        super._to_store(...arguments);
+        for (const activity of this.browse(ids)) {
+            if (activity.request_partner_id) {
+                store.add(this.browse(activity.id), {
+                    request_partner_id: mailDataHelpers.Store.one(
+                        this.env["res.partner"].browse(activity.request_partner_id),
+                        makeKwArgs({ only_id: true })
+                    ),
+                });
+            }
+        }
+    }
+}

--- a/addons/website_slides/static/tests/mock_server/models/slide_channel.js
+++ b/addons/website_slides/static/tests/mock_server/models/slide_channel.js
@@ -1,4 +1,4 @@
-import { models } from "@web/../tests/web_test_helpers";
+import { getKwArgs, models } from "@web/../tests/web_test_helpers";
 import { DEFAULT_MAIL_VIEW_ID } from "@mail/../tests/mock_server/mock_models/constants";
 
 export class SlideChannel extends models.ServerModel {
@@ -10,4 +10,24 @@ export class SlideChannel extends models.ServerModel {
             </form>
         `,
     };
+
+    action_grant_access() {
+        const kwargs = getKwArgs(arguments, "ids", "partner_id");
+        if (kwargs.partner_id) {
+            const activities = this.env["mail.activity"].search_read([
+                ["request_partner_id", "=", kwargs.partner_id],
+            ]);
+            this.env["mail.activity"].action_feedback(activities.map(a => a.id));
+        }
+    }
+
+    action_refuse_access() {
+        const kwargs = getKwArgs(arguments, "ids", "partner_id");
+        if (kwargs.partner_id) {
+            const activities = this.env["mail.activity"].search_read([
+                ["request_partner_id", "=", kwargs.partner_id],
+            ]);
+            this.env["mail.activity"].action_feedback(activities.map(a => a.id));
+        }
+    }
 }

--- a/addons/website_slides/static/tests/website_slides_test_helpers.js
+++ b/addons/website_slides/static/tests/website_slides_test_helpers.js
@@ -1,10 +1,12 @@
 import { mailModels } from "@mail/../tests/mail_test_helpers";
 import { defineModels } from "@web/../tests/web_test_helpers";
 import { SlideChannel } from "@website_slides/../tests/mock_server/models/slide_channel";
+import { MailActivity } from "@website_slides/../tests/mock_server/models/mail_activity";
 
 export const websiteSlidesModels = {
     ...mailModels,
     SlideChannel,
+    MailActivity,
 };
 
 export function defineWebsiteSlidesModels() {


### PR DESCRIPTION
to webside_slides
This field is only used by webside_slides, so this commit moves it there.

PR upgrade: https://github.com/odoo/upgrade/pull/6898