### PR TITLE
[FIX] mrp: correct color logic for consumed quantities' display

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -339,8 +339,8 @@
                                     <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart text-danger" attrs="{'column_invisible': [('parent.state', '!=', 'draft')], 'invisible': [('forecast_availability', '&gt;=', 0)]}"/>
                                     <field name="forecast_availability" string="Reserved" attrs="{'column_invisible': [('parent.state', 'in', ('draft', 'done'))]}" widget="forecast_widget"/>
                                     <field name="quantity_done" string="Consumed"
-                                        decoration-success="not is_done and (quantity_done - should_consume_qty == 0)"
-                                        decoration-warning="not is_done and (quantity_done - should_consume_qty &gt; 0.0001)"
+                                        decoration-success="not is_done and quantity_done - product_uom_qty &lt; 0.0001 and quantity_done - product_uom_qty &gt; -0.0001" 
+                                        decoration-warning="quantity_done - product_uom_qty &gt; 0.0001"
                                         attrs="{'column_invisible': [('parent.state', '=', 'draft')], 'readonly': [('has_tracking', '!=','none')]}"
                                         force_save="1" widget="mrp_consumed"/>
                                     <field name="manual_consumption" invisible="1" force_save="1"/>


### PR DESCRIPTION
**Issue:**
On confirming a new Manufacturing Order, if a component's quantity is:
- less or equal to the needed value, the displayed text is colored in green;
- higher than the value, the text is colored in orange.

![Capture d’écran 2024-12-10 à 09 13 39](https://github.com/user-attachments/assets/b03cd559-c639-4007-abcb-d6992904c747)

**Expected:**
On confirming a new Manufacturing Order, if a component's quantity is:
- less than the exact needed value, the displayed text should be black;
- equal to the needed value, the text should be colored in green;
- higher than the value, the text should be in orange.

![image](https://github.com/user-attachments/assets/99e52724-e35a-4892-ab1b-795ea5ccf3df)

**Steps to reproduce:**
- Activate Manufaturing app;
- Navigate to Manufacturing Orders and create a new one with any product having a BoM;
- Confirm the order and watch the "Consumed" column's content.

**Cause:**
Text decoration are based on a too restrictive computation logic. This might be due to very small computation errors.

**Fix:**
Setup text success decoration on a restricted range of very small values to apply as if exactly equal to 0.
![Capture d’écran 2024-12-10 à 08 48 11](https://github.com/user-attachments/assets/78e8e760-abb7-4e09-b8ca-f3463d413e1a)

**Forward:**
To forward up to master.
Odoo 17 :
```
<field name="quantity" string="Quantity"
    decoration-success="product_uom_qty - quantity &gt; -0.0001 and product_uom_qty - quantity &lt; 0.0001"
    decoration-warning="quantity - product_uom_qty &gt; 0.0001"

```


opw-4393156

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
