### PR TITLE
[FIX] core: _search_display_name without _rec_name

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1814,6 +1814,20 @@ class TestMany2one(TransactionCase):
         ''']):
             self.Partner.search([('company_id', 'not like', "blablabla")])
 
+    def test_name_search_undefined(self):
+        """Check that if the _rec_name is not defined, we do not restrict anything.
+
+        This way the model continues to work in the web interface inside many2one fields.
+        """
+        PartnerClass = self.env.registry['res.partner']
+        with (
+            patch.object(PartnerClass, '_rec_name', ''),
+            patch.object(PartnerClass, '_rec_names_search', []),
+            mute_logger('odoo.models'),
+        ):
+            self.assertGreater(len(self.Partner.name_search()), 0)
+            self.assertGreater(len(self.Partner.name_search('test')), 0)
+
 
 class TestOne2many(TransactionCase):
     def setUp(self):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1782,7 +1782,8 @@ class BaseModel(metaclass=MetaModel):
         search_fnames = self._rec_names_search or ([self._rec_name] if self._rec_name else [])
         if not search_fnames:
             _logger.warning("Cannot search on display_name, no _rec_name or _rec_names_search defined on %s", self._name)
-            return expression.FALSE_DOMAIN
+            # do not restrain anything
+            return expression.TRUE_DOMAIN
         if operator.endswith('like') and not value and '=' not in operator:
             # optimize out the default criterion of ``like ''`` that matches everything
             # return all when operator is positive


### PR DESCRIPTION
We already display a warning message, but we need to explicitely not restrict the search. The `name_search` method is called when trying to populate many2one fields and we want to be able to select items even when name searching is not defined.

task-3484032


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
