### PR TITLE
[FIX] mrp: correct color logic for consumed quantities' display

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -398,8 +398,8 @@
                                     <!-- Button are used in state draft to doesn't have the name of the column "Reserved"-->
                                     <field name="forecast_availability" column_invisible="parent.state in ['done', 'cancel']" string="Forecast" widget="forecast_widget" optional="hide"/>
                                     <field name="quantity" string="Quantity"
-                                        decoration-success="product_uom_qty - quantity &gt; 0.0001"
-                                        decoration-warning="quantity - product_uom_qty &gt; 0.0001"
+                                        decoration-success="not is_done and (quantity - should_consume_qty == 0)"
+                                        decoration-warning="not is_done and (quantity - should_consume_qty &gt; 0.0001)"
                                         column_invisible="parent.state == 'draft'"
                                         readonly="has_tracking != 'none'"
                                         force_save="1" widget="mrp_consumed"/>


### PR DESCRIPTION
**Steps to reproduce:**
- Create a storable product `P1` with the following BoM:
    - Qty: 1 unit
    - Components:
        - C1, C2, C3: 3 units
- Create a MO to produce one unit of `P1`;
  - Confirm the order;
  - Update the product's `Quantity` to 1 at least;
    *The quantities of `To Consume` and `Quantity` columns in the `Components` tab of the notebook are automatically set to 3.*
- Update the field `Quantity` of components to:
    - **C1**: 1 unit
    - **C2**: 3 units
    - **C3**: 4 units

___
**Issue:**
On a Manufacturing Order, if a component's quantity is:
- **C1**: less than the <ins>total needed</ins> value &rarr; highlights in green;
- **C2**: equal to the value &rarr; highlights in black;
- **C3**: higher than the value &rarr; highlights in orange.

![Capture d’écran 2024-12-30 à 17 49 56](https://github.com/user-attachments/assets/e4fe7488-de04-4749-9930-85f11f71532a)

___
**Expected:**
On a Manufacturing Order, if a component's quantity is:
- **C1**: less -> black;
- **C2**: equal -> green;
- **C3**: higher -> orange.

___
**Cause:**
Text decorations are based on a wrong logic by getting the quantities from wrong field. This field has been changed during an apocalypse.
https://github.com/odoo/odoo/blob/c43297435cfcaf560d5c952ac3c4a383a6f1dc28/addons/mrp/views/mrp_production_views.xml#L405-L406

___
**Fix:**
Reset good field to check quantities, inspired by Odoo 16 using the computed `should_consume_qty` value to check the consumption status:
https://github.com/odoo/odoo/blob/67c78b38e794333eae55758ad4610515df5c49d2/addons/mrp/views/mrp_production_views.xml#L342-L343

![Capture d’écran 2024-12-30 à 17 49 26](https://github.com/user-attachments/assets/f30bd7fc-0140-4c16-abaf-540f4c1bc12d)

___
**Forward:**
To forward up to master.
Odoo 17 :
```
<field name="quantity" string="Quantity"
    decoration-success="product_uom_qty - quantity &gt; -0.0001 and product_uom_qty - quantity &lt; 0.0001"
    decoration-warning="quantity - product_uom_qty &gt; 0.0001"

```

___
opw-4393156
opw-4391582
opw-4391600

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
