### PR TITLE
[FIX] web_tour: clear tour recorder state at the end

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -16,6 +16,7 @@ import {
     TourRecorder,
 } from "@web_tour/tour_service/tour_recorder/tour_recorder";
 import { redirect } from "@web/core/utils/urls";
+import { tourRecorderState } from "@web_tour/tour_service/tour_recorder/tour_recorder_state";
 
 const StepSchema = {
     id: { type: [String], optional: true },
@@ -229,6 +230,7 @@ export const tourService = {
                         onClose: () => {
                             remove();
                             browser.localStorage.removeItem(TOUR_RECORDER_ACTIVE_LOCAL_STORAGE_KEY);
+                            tourRecorderState.clear();
                         },
                     },
                     { sequence: 99999 }
@@ -267,6 +269,7 @@ export const tourService = {
                         onClose: () => {
                             remove();
                             browser.localStorage.removeItem(TOUR_RECORDER_ACTIVE_LOCAL_STORAGE_KEY);
+                            tourRecorderState.clear();
                         },
                     },
                     { sequence: 99999 }

--- a/addons/web_tour/static/tests/tour_recorder.test.js
+++ b/addons/web_tour/static/tests/tour_recorder.test.js
@@ -456,4 +456,11 @@ test("Check Tour Recorder State", async () => {
         { trigger: ".o_child_1", run: "click" },
         { trigger: ".o_child_2", run: "click" },
     ]);
+
+    await click(".o_button_record");
+    await animationFrame();
+    await click(".o_tour_recorder_close_button");
+    await animationFrame();
+    expect(tourRecorderState.getCurrentTourRecorder()).toEqual([]);
+    expect(tourRecorderState.isRecording()).toBe("0");
 });


### PR DESCRIPTION
When closing the tour recorder, the state should be clear. Because if not, when leaving and coming back later, the tour recorder would be still recording.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
