### PR TITLE
[FIX] stock: correct error message when checking lot_id

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -638,7 +638,7 @@ class StockQuant(models.Model):
     def check_lot_id(self):
         for quant in self:
             if quant.lot_id.product_id and quant.lot_id.product_id != quant.product_id:
-                raise ValidationError(_('The Lot/Serial number (%s) is linked to another product.', quant.location_id.name))
+                raise ValidationError(_('The Lot/Serial number (%s) is linked to another product.', quant.lot_id.name))
 
     @api.model
     def _get_removal_strategy(self, product_id, location_id):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- On the error message when we check the lot and it's linked to another product it displays the location_id instead of the lot_id which isn't correct.

Current behavior before PR:

- Incorrect displayed value in the error message.

Desired behavior after PR is merged:

- Replace the location name with the lot name.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
