### PR TITLE
[FIX] purchase: prevent deletion of product in use

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -33,7 +33,7 @@ class PurchaseOrderLine(models.Model):
     taxes_id = fields.Many2many('account.tax', string='Taxes', context={'active_test': False})
     product_uom = fields.Many2one('uom.uom', string='Unit of Measure', domain="[('category_id', '=', product_uom_category_id)]")
     product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id')
-    product_id = fields.Many2one('product.product', string='Product', domain=[('purchase_ok', '=', True)], change_default=True, index='btree_not_null')
+    product_id = fields.Many2one('product.product', string='Product', domain=[('purchase_ok', '=', True)], change_default=True, index='btree_not_null', ondelete='restrict')
     product_type = fields.Selection(related='product_id.type', readonly=True)
     price_unit = fields.Float(
         string='Unit Price', required=True, digits='Product Price', aggregator='avg',


### PR DESCRIPTION
This error occurs when a product is used in a purchase order, but the product is subsequently removed or deleted from the product list, and then an attempt is made to access it in the forecast report.

Steps to reproduce:
---
- Install ``purchase_stock`` module
- Create a new purchase order and create a new product in the purchase order line(eg: Test)
- Now go to products and delete the product(eg: Test)
- Now in the purchase order line click on the ``Forecast Report`` button

Traceback: 
---
``ValueError: Expected singleton: product.product()``

This commit resolves the error by adding the ``ondelete`` constraint to the ``product_id`` field. This ensures that a product in use cannot be deleted.

sentry-6121903860

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
