### PR TITLE
[FIX] point_of_sale: fix access to currency in pos_order.js

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -119,7 +119,7 @@ export class PosOrder extends Base {
      * @returns See '_get_tax_totals_summary' in account_tax.py for the full details.
      */
     get taxTotals() {
-        const currency = this.config_id.currency_id;
+        const currency = this.config.currency_id;
         const company = this.company_id;
         const extraValues = { currency_id: currency };
         const orderLines = this.lines;


### PR DESCRIPTION
Config should not be accessed directly from the order since it can came from another config that isn't loaded in all session.

For example with shared order between config, when an order is created on config A and loaded on config B, the config A link will not be available on config B.

runbot err: 109601, 109616

