### PR TITLE
[IMP] l10n_sa, l10n_sa_edi: Improved Report Spacing

### DIFF
--- a/addons/l10n_sa/__manifest__.py
+++ b/addons/l10n_sa/__manifest__.py
@@ -23,6 +23,7 @@ Odoo Arabic localization for most Saudi Arabia.
         'data/account_tax_template_data.xml',
         'data/account_fiscal_position_template_data.xml',
         'data/account_chart_template_configure_data.xml',
+        'data/report_paperformat_data.xml',
         'views/view_move_form.xml',
         'views/report_invoice.xml',
     ],

--- a/addons/l10n_sa/data/report_paperformat_data.xml
+++ b/addons/l10n_sa/data/report_paperformat_data.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="paperformat_l10n_sa_a4" model="report.paperformat">
+            <field name="name">Saudi Arabia A4</field>
+            <field name="orientation">Portrait</field>
+            <field name="margin_bottom">32</field>
+            <field name="header_spacing">45</field>
+            <field name="margin_top">50</field>
+        </record>
+    </data>
+    <data>
+        <function model="res.company" name="write">
+            <value model="res.company" search="[
+                ('partner_id.country_id', '=', ref('base.sa'))]"/>
+            <value eval="{'paperformat_id': ref('l10n_sa.paperformat_l10n_sa_a4')}"/>
+        </function>
+    </data>
+</odoo>

--- a/addons/l10n_sa/demo/demo_company.xml
+++ b/addons/l10n_sa/demo/demo_company.xml
@@ -17,6 +17,7 @@
         <field name="name">SA Company</field>
         <field name="vat">310175397400003</field>
         <field name="partner_id" ref="partner_demo_company_sa"/>
+        <field name="paperformat_id" ref="l10n_sa.paperformat_l10n_sa_a4"></field>
     </record>
 
     <function model="res.company" name="_onchange_country_id">

--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -34,9 +34,7 @@
             </t>
         </xpath>
         <xpath expr="//th[@name='th_total']//span[2]" position="attributes">
-            <span>
-                 <attribute name="class">d-none</attribute>
-            </span>
+            <attribute name="class">d-none</attribute>
         </xpath>
         <xpath expr="//th[@name='th_total']//span[2]" position="after">
             <span>
@@ -52,9 +50,7 @@
             </span>
         </xpath>
         <xpath expr="//th[@name='th_subtotal']//span[2]" position="attributes">
-            <span>
-                <attribute name="class">d-none</attribute>
-            </span>
+            <attribute name="class">d-none</attribute>
         </xpath>
         <xpath expr="//th[@name='th_subtotal']//span[2]" position="after">
             <span>
@@ -62,9 +58,7 @@
             </span>
         </xpath>
         <xpath expr="//th[@name='th_subtotal']//span" position="attributes">
-            <span>
-                <attribute name="class">d-none</attribute>
-            </span>
+            <attribute name="class">d-none</attribute>
         </xpath>
         <xpath expr="//th[@name='th_subtotal']//span" position="after">
             <span>
@@ -113,6 +107,9 @@
         </xpath>
         <xpath expr="//div[@name='invoice_date']//span[@t-field='o.invoice_date']" position="attributes">
             <attribute name="t-if">not o.l10n_sa_confirmation_datetime</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('clearfix')]" position="attributes">
+            <attribute name="class">clearfix pt-2 pb-2</attribute>
         </xpath>
     </template>
 </odoo>

--- a/addons/l10n_sa_edi/views/report_invoice.xml
+++ b/addons/l10n_sa_edi/views/report_invoice.xml
@@ -7,21 +7,28 @@
             <!--    Add Currency Exchange rate if different currency than SAR    -->
             <xpath expr="//div[hasclass('clearfix')]" position="after">
                 <table t-if="o.company_id.country_id.code == 'SA' and o.currency_id != o.company_id.currency_id"
-                     id="sar_amounts" t-att-style="'ltr' if lang != 'ar_001' else 'rtl'" class="row clearfix ms-auto my-3 table table-sm table-borderless">
+                    id="sar_amounts" style="page-break-inside: avoid;" class="clearfix mx-auto mt-3 table-sm table-borderless">
+                    <t t-set="curr_date" t-value="o.invoice_date or datetime.datetime.today()"></t>
                     <t t-set="sar_rate"
-                       t-value="o.env['res.currency']._get_conversion_rate(o.currency_id, o.company_id.currency_id, o.company_id, o.invoice_date)"/>
+                    t-value="o.env['res.currency']._get_conversion_rate(o.currency_id, o.company_id.currency_id, o.company_id, curr_date)"/>
                     <tr>
-                        <td style="width: 25%"><strong>Exchange Rate</strong></td>
-                        <td style="width: 25%"><strong>Subtotal (SAR)</strong></td>
-                        <td style="width: 25%"><strong>VAT Amount (SAR)</strong></td>
-                        <td style="width: 25%"><strong>Total (SAR)</strong></td>
+                        <td class="w-25 text-start" dir="rtl"><strong>سعر الصرف</strong></td>
+                        <td class="w-25 text-start" dir="rtl"><strong>الإجمالي الفرعي بالريال السعودي</strong></td>
+                        <td class="w-25 text-start" dir="rtl"><strong>مبلغ ضريبة القيمة المضافة بالريال السعودي</strong></td>
+                        <td class="w-25 text-start" dir="rtl"><strong>الإجمالي بالريال السعودي</strong></td>
+                    </tr>
+                    <tr>
+                        <td class="w-25"><span class="fw-bold">Exchange Rate</span></td>
+                        <td class="w-25"><span class="fw-bold">Subtotal</span></td>
+                        <td class="w-25"><span class="fw-bold">VAT Amount</span></td>
+                        <td class="w-25"><span class="fw-bold">Total</span></td>
                     </tr>
                     <tr>
                         <td><p class="m-0" t-esc="sar_rate" t-options='{"widget": "float", "precision": 5}'/></td>
                         <td><p class="m-0" t-esc="o.amount_untaxed_signed"
                             t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></td>
                         <td><p class="m-0"
-                            t-esc="o.currency_id._convert(o.amount_tax, o.company_id.currency_id, o.company_id, o.invoice_date)"
+                            t-esc="o.currency_id._convert(o.amount_tax, o.company_id.currency_id, o.company_id, curr_date)"
                             t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></td>
                         <td><p class="m-0" t-esc="o.amount_total_signed"
                             t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></td>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Task ID: 4342267

Current behavior before PR:
-Error When printing draft invoice due to unset invoice_date.

-Report spacing between header & body in second page overlaps due to paperformat spacing.
Due to the long address format of saudi arabia, the default paperformat header spacing and margin top are not enough to show the full address without overlapping the second and onward pages.

-English labels on the exchange rate table in l10n_sa_edi are translated and not shown together with the arabic labels.

-Remove unnecessary spans in xpaths

Desired behavior after PR is merged:
-Fix printing draft invoice with invoice_date as today's date

-Fix report spacing header by adding a new A4 paperformat for l10n_sa which is set as the saudi arabia companies default paper format.

-Fix exchange rate table to show both arabic and english labels and remove unnecessary translations (no longer used)

-Remove unnecessary spans in xpath.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
