### PR TITLE
[IMP] website_event_exhibitor: add the sponsor inside the ticket

### DIFF
--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -44,6 +44,7 @@ class EventSponsor(models.Model):
         sanitize_overridable=True,
         sanitize_attributes=False, sanitize_form=True, translate=html_translate,
         readonly=False, store=True)
+    show_on_ticket = fields.Boolean("Show on ticket", default=True)
     # contact information
     partner_id = fields.Many2one('res.partner', 'Partner', required=True, auto_join=True)
     partner_name = fields.Char('Name', related='partner_id.name')

--- a/addons/website_event_exhibitor/report/website_event_exhibitor_templates.xml
+++ b/addons/website_event_exhibitor/report/website_event_exhibitor_templates.xml
@@ -3,7 +3,7 @@
     <template id="event_report_full_page_ticket_layout_inherit_exhibitor" inherit_id="event.event_report_full_page_ticket_layout">
         <xpath expr="//div[hasclass('o_event_full_page_ticket_powered_by')]" position="before">
             <div t-if="not responsive_html" class="o_event_full_page_ticket_sponsors_container text-center mb-2">
-                <t t-foreach="event.sponsor_ids.filtered(lambda sponsor: sponsor.image_128 and sponsor.website_published)[:10]"
+                <t t-foreach="event.sponsor_ids.filtered(lambda sponsor: sponsor.image_128 and sponsor.show_on_ticket)[:10]"
                     t-as="sponsor">
                     <div class="o_event_full_page_ticket_sponsor_card d-inline-block">
                         <div class="h-100 p-2 pb-0">

--- a/addons/website_event_exhibitor/views/event_sponsor_views.xml
+++ b/addons/website_event_exhibitor/views/event_sponsor_views.xml
@@ -103,7 +103,7 @@
                             <field name="exhibitor_type" required="1"/>
                             <!-- Use website_published because is_published already used and widget conflicts -->
                             <field name="website_published" widget="boolean_toggle"
-                                string="Display in footer"
+                                string="Display on website footer"
                                 invisible="exhibitor_type != 'sponsor'"/>
                             <label for="hour_from" string="Opening Hours"
                                 invisible="exhibitor_type == 'sponsor'"/>
@@ -113,6 +113,7 @@
                                 <field name="hour_to" widget="float_time" nolabel="1" class="oe_inline"/>
                                 <field name="event_date_tz" nolabel="1" class="oe_inline"/>
                             </div>
+                            <field name="show_on_ticket"/>
                         </group>
                     </group>
                     <notebook>
@@ -155,6 +156,7 @@
                 <field name="sponsor_type_id"/>
                 <field name="is_published" optional="show"/>
                 <field name="exhibitor_type"/>
+                <field name="show_on_ticket" optional="hide"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
Purpose
========
Improve the design of the tickets by showing only wanted sponsors inside the tickets.

This commit adds the feature by adding the boolean field inside the event.sponsor model, and when this field is checked in, the sponsor will be shown inside the ticket as per their ranking: Gold>Silver>Bronze.

Task-4247628
