### PR TITLE
[FIX] point_of_sale: display company on receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -7,7 +7,7 @@
         <div class="d-flex flex-column align-items-center">
             <div class="pos-receipt-contact">
                 <!-- contact address -->
-                <div t-if="props.data.company.partner_id?.[1]" t-esc="props.data.company.partner_id[1]" />
+                <div t-if="props.data.company.name" t-esc="props.data.company.name" />
                 <t t-if="props.data.company.phone">
                     <div>Tel:<t t-esc="props.data.company.phone" /></div>
                 </t>


### PR DESCRIPTION
**Steps to reproduce:**
- Make a POS order
- Process to payment
- Check receipt

**Issue:**
The company name is not displayed on the receipt as it was in previous versions.

opw-4349203



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
