### PR TITLE
[FIX] web: fix favorite management tour

### DIFF
--- a/addons/web/static/tests/tours/favorite_management_tour.js
+++ b/addons/web/static/tests/tours/favorite_management_tour.js
@@ -2,12 +2,8 @@ import { queryAll } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_favorite_management", {
-    url: "/odoo",
+    url: "/odoo/apps",
     steps: () => [
-        {
-            trigger: ".o_app[data-menu-xmlid='base\\.menu_management']",
-            run: "click",
-        },
         {
             trigger: ".o_facet_remove",
             run: "click",
@@ -60,7 +56,7 @@ registry.category("web_tour.tours").add("test_favorite_management", {
             trigger: ".o_facet_values:contains('Apps2')",
         },
         {
-            trigger: ".o_kanban_header:contains(Account Charts):contains(112)",
+            trigger: ".o_kanban_header:contains(Account Charts)",
         },
         {
             trigger: ".o_searchview_dropdown_toggler",

--- a/addons/web/tests/test_favorite.py
+++ b/addons/web/tests/test_favorite.py
@@ -3,4 +3,4 @@ from odoo.tests.common import HttpCase, tagged
 @tagged('post_install', '-at_install')
 class TestFavorite(HttpCase):
     def test_favorite_management(self):
-        self.start_tour("/odoo", "test_favorite_management", login="admin")
+        self.start_tour("/odoo/apps", "test_favorite_management", login="admin")


### PR DESCRIPTION
This commit solves two issues with the favorite management tour:
- first one is that the tour would only work in enterprise since it used the home menu to access apps
- second issue is that the tour would check the exact amount of account charts apps which is not reliable in all cases
