### PR TITLE
[FIX] stock: remove to reorder filter

### DIFF
--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -203,7 +203,6 @@
         <field name="state">code</field>
         <field name="code">
             action = model.with_context(
-                search_default_filter_to_reorder=True,
                 search_default_filter_not_snoozed=True,
                 default_trigger='manual',
                 searchpanel_default_trigger='manual'

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -873,9 +873,6 @@ stepUtils.autoExpandMoreButtons(),
     trigger: ".o_control_panel_navigation .btn .fa-search",
     run: "click",
 }, {
-    trigger: ".o_searchview_facet:contains('To Reorder') .o_facet_remove",
-    run: "click",
-}, {
     isActive: ["desktop"],
     trigger: "td:contains('the_flow.component2')",
     run: "click",


### PR DESCRIPTION
The filter to replenish use the `qty_to_order` field. However when adding a filter multiple function are called. `web_search_read`, `search_panel_select_range, `search_panel_select_multi_range`

However they all use the search domain and in the default search there is the `to replenish` filter with [('qty_to_order', '>', 0)] And each time they trigger while it's not needed to recompute them.

We think about storing the qty_to_order_computed but it's not optimal to store a value that needs to be updated everyday, just to cache it.

Instead we will remove the default filter. It's a good trade off since it's only needed when people create their orderpoints automatic themself. In general, it's not needed since the automatic rr are deleted and created on missing quantity. For people that create the automatic rr they can still use the filter and move it default but it could continue the performance issue

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
