### PR TITLE
[FIX] hr_expense: prevent error when split an expense

### DIFF
--- a/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
+++ b/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
@@ -40,7 +40,8 @@
                     </group>
                     <field name="split_possible" invisible="1"/>
                     <footer>
-                        <button name="action_split_expense" string="Split Expense" type="object" class="oe_highlight"  data-hotkey="q"/>
+                        <button name="action_split_expense" invisible="split_possible" string="Split Expense" type="object" class="oe_highlight disabled"  data-hotkey="q"/>
+                        <button name="action_split_expense" string="Split Expense" invisible="not split_possible" type="object" class="oe_highlight"  data-hotkey="q"/>
                         <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>


### PR DESCRIPTION
Currently, an error occurs when clicking on the 'Split Expense' button without any available expenses to split.

Step to produce:

- Install the ```hr_expense``` module.
- Create an expense, add a category, and click on 'Split Expense' button.
- Delete all expenses from the split expense line, and click on 'Split Expense'.

```IndexError: tuple index out of range```

This occurs because the system attempts to access the first expense from the split expense line [1], but expenses are not available.

Link [1]: https://github.com/odoo/odoo/blob/280b762e7cd1b3d9a578bbae60cbb9b137ee5ce5/addons/hr_expense/wizard/hr_expense_split_wizard.py#L36

To resolve this issue, Disable the 'Split Expense' button when no expenses are available in the split expense line or split is not possible.

Sentry-6015854429


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
