### PR TITLE
[FIX] web_editor: fix copying translation from custom blocks

### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -128,10 +128,10 @@ class IrUiView(models.Model):
             custom_snippet_name = custom_snippet_el.get('data-name')
             custom_snippet_view = self.search([('name', '=', custom_snippet_name)], limit=1)
             if custom_snippet_view:
-                self._copy_field_terms_translations(custom_snippet_view, 'arch_db', record, html_field)
+                self._copy_field_terms_translations(custom_snippet_view, 'arch_db', record, html_field, overwrite=False)
 
     @api.model
-    def _copy_field_terms_translations(self, record_from, name_field_from, record_to, name_field_to):
+    def _copy_field_terms_translations(self, record_from, name_field_from, record_to, name_field_to, overwrite=True):
         """ Copy the terms translation from a record/field ``Model1.Field1``
         to a (possibly) completely different record/field ``Model2.Field2``.
 
@@ -172,7 +172,8 @@ class IrUiView(models.Model):
             record_from[name_field_from],
             {lang: record_from.with_context(prefetch_langs=True, lang=lang)[name_field_from] for lang in langs if lang != lang_env}
         )
-        existing_translation_dictionary.update(extra_translation_dictionary)
+        if overwrite or not any(translated_value != key for key in extra_translation_dictionary.keys() for translated_value in existing_translation_dictionary[key].values()): 
+            existing_translation_dictionary.update(extra_translation_dictionary)
         translation_dictionary = existing_translation_dictionary
 
         # The `en_US` jsonb value should always be set, even if english is not


### PR DESCRIPTION
**Problem**:

When a custom block is used on a web page, its translation is copied from the corresponding saved custom block. This feature was introduced to allow users to save a custom block along with its translation, enabling reuse of the translated block on other pages.

However, this copying process occurs every time the page is saved during editing. As a result, if users manually translate the block generated by a custom block, their translations are overwritten whenever the page is edited, since the custom block itself does not contain a translation.

**Solution**:
A check was added before copying the translation of the custom block. If the block already have translation don't copy it.

**Steps to reproduce**:
1. Open any webpage.
2. Add a text block and add some text.
3. Save the block as a custom block.
4. Use this custom block in another page.
5. Translate the generated block.
6. Edit anything of this page and save. (Translation is done)

opw-4358012



