### PR TITLE
[FIX] l10n_vn: use correct company field

### DIFF
--- a/addons/l10n_vn/migrations/17.0.2.0.2/post-migration.py
+++ b/addons/l10n_vn/migrations/17.0.2.0.2/post-migration.py
@@ -1,22 +1,22 @@
 from odoo import api, SUPERUSER_ID
 from odoo.osv import expression
+from odoo.release import version
+from odoo.tools import parse_version
 
 FIXED_ACCOUNTS_TYPE = {
     'asset_prepayments': ['242'],
     'expense_depreciation': ['6274', '6414', '6424'],
 }
 
-
 def _fix_accounts_type(env):
     for correct_account_type, accounts_code in FIXED_ACCOUNTS_TYPE.items():
         domains_per_company = []
         for company in env['res.company'].with_context(active_test=False).search([('chart_template', '=', 'vn')]):
-            doamin = expression.AND([
-                [('company_id', '=', company.id), ('account_type', '!=', correct_account_type)],
-                expression.OR([
-                    [('code', 'like', f'{code}%')] for code in accounts_code
-                ])
-            ])
+            if parse_version(version) > parse_version("saas~17.5"):
+                company_domain = [('company_ids', 'in', company.ids), ('account_type', '!=', correct_account_type)]
+            else:
+                company_domain = [('company_id', '=', company.id), ('account_type', '!=', correct_account_type)]
+            doamin = expression.AND([company_domain, expression.OR([[('code', 'like', f'{code}%')] for code in accounts_code])])
             domains_per_company.append(doamin)
         accounts = env['account.account'].search(expression.OR(domains_per_company))
         accounts.account_type = correct_account_type


### PR DESCRIPTION
- The post-migration script _fix_accounts_type attempted to use the field company_id, which no longer exists in the account.account model in the 18 version. This caused a traceback ValueError: Invalid field during the database 
  upgrade.

[reference](odoo@854c3b2#diff-19ef5a530c506fdee93fe0d113e61946b87fae7dd2d360558da69c0014f766b2R102)

tbg-1602
upg-2387888