### PR TITLE
[FIX] website_*: allow website designers to access mailing lists (ro)

### DIFF
--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -12,6 +12,7 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
     'category': 'Website/Website',
     'depends': ['website', 'mass_mailing', 'google_recaptcha'],
     'data': [
+        'security/ir.model.access.csv',
         'data/ir_model_data.xml',
         'views/snippets/s_popup.xml',
         'views/snippets_templates.xml',

--- a/addons/website_mass_mailing/security/ir.model.access.csv
+++ b/addons/website_mass_mailing/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mailing_list_website_designer,access_mailing_list_website_designer,mass_mailing.model_mailing_list,website.group_website_designer,1,0,0,0


### PR DESCRIPTION
*: mass_mailing

Users with website_designer permissions but without access to the email marketing app (mass_mailing.group_mass_mailing_user) encountered an access error when editing pages with "Newsletter" blocks.

This commit fixes the issue by granting read-only access to the mailing.list model for the website_designer group. This ensures they can edit pages containing "Newsletter" blocks without exposing full email marketing functionality or compromising security.

Steps to reproduce:

- Install the website and mass_mailing modules.
- Remove the "Email Marketing: User" access rights from a user in Settings > Users.
- Open the Website Editor.
- Add a "Newsletter" block to a page.
- Observe: An access error is triggered.

opw-4201455

