### PR TITLE
[FIX] web_editor: Fix setTag in commands

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -496,10 +496,10 @@ export const editorCommands = {
         }
         const isContextBlock = container => ['TD', 'DIV', 'LI'].includes(container.nodeName);
         if (!startContainer.isConnected || isContextBlock(startContainer)) {
-            startContainer = startContainerChild.parentNode;
+            startContainer = startContainerChild?.parentNode || startContainer;
         }
         if (!endContainer.isConnected || isContextBlock(endContainer)) {
-            endContainer = endContainerChild.parentNode;
+            endContainer = endContainerChild?.parentNode || endContainer;
         }
         const newRange = new Range();
         newRange.setStart(startContainer, startOffset);


### PR DESCRIPTION
Steps to reproduce

- Create a new report with studio
- Chose "External Business header/footer"
- Try to add a /heading1 below the header
- Crash

```
UncaughtPromiseError > TypeError
Uncaught Promise > Cannot read properties of null (reading 'parentNode')
TypeError: Cannot read properties of null (reading 'parentNode')
```

As `startContainerChild` and `endContainerChild` refers to a dom element that can be changed in the for loop, we can declare both of them after.

opw-4368425