### PR TITLE
[FIX] hr_holidays: fix activity when time off officer is not set

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1541,7 +1541,7 @@ Attempting to double-book your time off won't magically make your vacation 2x be
     def _get_responsible_for_approval(self):
         self.ensure_one()
 
-        responsible = self.env.user
+        responsible = self.env['res.users']
 
         if self.holiday_type != 'employee':
             return responsible
@@ -1586,7 +1586,7 @@ Attempting to double-book your time off won't magically make your vacation 2x be
                             leave_type=holiday.holiday_status_id.name,
                         )
                         to_do_confirm_activity |= holiday
-                    user_ids = holiday.sudo()._get_responsible_for_approval().ids or self.env.user.ids
+                    user_ids = holiday.sudo()._get_responsible_for_approval().ids
                     for user_id in user_ids:
                         date_deadline = (
                             (holiday.date_from -

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -293,7 +293,7 @@ class TestCompanyLeave(TransactionCase):
         })
         company_leave._compute_date_from_to()
 
-        with self.assertQueryCount(__system__=1855):  # 770 community
+        with self.assertQueryCount(__system__=1856):  # 770 community
             # Original query count: 1987
             # Without tracking/activity context keys: 5154
             company_leave.action_validate()

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1200,3 +1200,53 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
         with self.assertRaises(UserError):
             self.holidays_type_2.requires_allocation = 'yes'
+
+    def test_activity_update_with_time_off_officer(self):
+        """ Test activity creation flow when approval settings involve Time Off Officer and Employee's Approver. """
+        # Case 1: Approved by Time Off Officer but no Time Off Officer is set
+        self.holidays_type_1.responsible_ids = False    # No Time Off Officer set
+
+        test_holiday_1 = self.env['hr.leave'].create({
+            'name': 'Test leave',
+            'employee_id': self.employee_emp_id,
+            'holiday_status_id': self.holidays_type_1.id,
+            'date_from': (datetime.today() - timedelta(days=1)),
+            'date_to': datetime.today(),
+            'number_of_days': 1,
+        })
+
+        activities = test_holiday_1.activity_ids
+        self.assertFalse(activities, "No activity should be created if no Time Off Officer is set for approval.")
+
+        self.holidays_type_2.responsible_ids = [Command.link(self.user_employee.id)]
+        test_holiday_2 = self.env['hr.leave'].create({
+            'name': 'Test leave',
+            'employee_id': self.employee_hruser_id,
+            'holiday_status_id': self.holidays_type_2.id,
+            'date_from': (datetime.today() - timedelta(days=1)),
+            'date_to': datetime.today(),
+            'number_of_days': 1,
+        })
+
+        activities = test_holiday_2.activity_ids
+        self.assertEqual(len(activities), 1, "One activity should be created for the Employee's Approver.")
+        self.assertEqual(activities.activity_type_id, self.env.ref('hr_holidays.mail_act_leave_approval'), "The activity type should be for leave approval by the Employee's Approver.")
+        self.assertEqual(activities.user_id.id, self.user_employee_id, "The activity should be assigned to the Employee's Approver.")
+
+        # Case 2: Approved by Time Off Officer and Employee's Approver, but no Time Off Officer is set
+        self.holidays_type_4.responsible_ids = False     # No Time Off Officer set
+
+        test_holiday_3 = self.env['hr.leave'].create({
+            'name': 'Test leave',
+            'employee_id': self.employee_hrmanager_id,
+            'holiday_status_id': self.holidays_type_4.id,
+            'date_from': datetime.today(),
+            'date_to': (datetime.today() + timedelta(days=1)),
+            'number_of_days': 1,
+            'state': 'confirm',
+        })
+
+        activities = test_holiday_3.activity_ids
+        self.assertEqual(len(activities), 1, "One activity should be created for the Employee's Approver.")
+        self.assertEqual(activities.activity_type_id, self.env.ref('hr_holidays.mail_act_leave_approval'), "The activity type should be for leave approval by the Employee's Approver.")
+        self.assertEqual(activities.user_id, self.employee_hrmanager.leave_manager_id, "The activity should be assigned to the Employee's Approver.")


### PR DESCRIPTION
Steps:
- Install the hr_holiday module
- Configure Time Off Type with validation set to `Approved by Time Off Officer` or `Both`
- Create a Time Off request without setting a Time Off Officer.

---

Description of the issue/feature this PR addresses: 
When the validation type is set to `hr` or `both` and no Time Off Officer is configured, an activity is incorrectly generated upon creating a Time Off request.

---

Fix:
This PR resolves the issue by ensuring the responsible user is set to empty when validation is `hr` or `Both` and no Time Off Officer is configured.

task-4351688
