### PR TITLE
[FIX] mail: fix non-deterministic crash popout test

### DIFF
--- a/addons/mail/static/src/core/common/mail_popout_service.js
+++ b/addons/mail/static/src/core/common/mail_popout_service.js
@@ -17,7 +17,7 @@ export const mailPopoutService = {
          * - destroy the current app mounted on the window
          */
         function reset() {
-            if (externalWindow) {
+            if (externalWindow?.document) {
                 externalWindow.document.head.innerHTML = "";
                 externalWindow.document.write(window.document.head.outerHTML);
                 externalWindow.document.body = externalWindow.document.createElement("body");

--- a/addons/test_mail/static/tests/attachment_view.test.js
+++ b/addons/test_mail/static/tests/attachment_view.test.js
@@ -26,6 +26,9 @@ beforeEach(() => {
         closed: false,
         get document() {
             const doc = popoutIframe.contentDocument;
+            if (!doc) {
+                return undefined;
+            }
             const originalWrite = doc.write;
             doc.write = (content) => {
                 // This avoids duplicating the test script in the popoutWindow


### PR DESCRIPTION
Before this commit, the following unit test may crash non-deterministically:

"Attachment view / chatter popout across multiple records test"

With the following error:

```
Cannot read properties of null (reading 'write')
```

This happens because `iframe.contentDocument` could be `null`, which happens when the iframe of popout is closed before it had time to load content. The `reset()` function of popout service assumes that the document has been loaded, which is not necessarily true.

runbot-106785