### PR TITLE
[FIX] website: fix gradient color for mobile navbar

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -340,6 +340,10 @@ $-seen-urls: ();
     @include o-add-gradient('menu-gradient');
 }
 
+.navbar-light .o_navbar_mobile {
+    @include o-add-gradient('menu-gradient');
+}
+
 // TODO this should be reviewed. While it allowed to choose a color for the
 // navbar text, there is no :hover effect, the active item is not visible and
 // the selector is probably too specific and should rather be about extending


### PR DESCRIPTION
Since commits [1] and [2], the gradient background colors for headers in the mobile version were not applied. This commit resolves the issue.

Steps to reproduce:

- Open the Website Editor.
- Click on the header.
- Change the background color of the header and select a custom gradient.
- Exit edit mode.
- Click on the mobile icon to view the mobile version.
- Click the hamburger icon.
- Observe that the gradient background is not applied.

opw-4329423

[1]: https://github.com/odoo/odoo/commit/2dc3b28e570492b0484d185eb656e74df9c59d68
[2]: https://github.com/odoo/odoo/commit/bc13176de8d66bbdc1c536017b1f046c5fd31a86
