### PR TITLE
[FIX] pos_viva_wallet: add webhook fallback

### DIFF
--- a/addons/pos_viva_wallet/models/pos_payment_method.py
+++ b/addons/pos_viva_wallet/models/pos_payment_method.py
@@ -84,15 +84,14 @@ class PosPaymentMethod(models.Model):
             _logger.exception('Failed to call https://%s/api/messages/config/token endpoint', endpoint)
         return resp.json().get('Key')
 
-    def _call_viva_wallet(self, endpoint, action, data=None):
-        session = get_viva_wallet_session()
+    def _call_viva_wallet(self, endpoint, action, data=None, should_retry=True):
+        session = get_viva_wallet_session(should_retry)
         session.headers.update({'Authorization': f"Bearer {self.viva_wallet_bearer_token}"})
         endpoint = f"{self._viva_wallet_api_get_endpoint()}/ecr/v1/{endpoint}"
         try:
             resp = session.request(action, endpoint, json=data, timeout=TIMEOUT)
         except requests.exceptions.RequestException as e:
             return {'error': _("There are some issues between us and Viva Wallet, try again later.%s)", e)}
-
         if resp.text and resp.json().get('detail') == 'Could not validate credentials':
             session.headers.update(self._bearer_token(session))
             resp = session.request(action, endpoint, json=data, timeout=TIMEOUT)
@@ -139,19 +138,26 @@ class PosPaymentMethod(models.Model):
 
     def viva_wallet_send_payment_request(self, data):
         if not self.env.user.has_group('point_of_sale.group_pos_user'):
-            raise AccessError(_("Only 'group_pos_user' are allowed to fetch token from Viva Wallet"))
+            raise AccessError(_("Only 'group_pos_user' are allowed to send a Viva Wallet payment request"))
 
         endpoint = "transactions:sale"
         return self._call_viva_wallet(endpoint, 'post', data)
 
     def viva_wallet_send_payment_cancel(self, data):
         if not self.env.user.has_group('point_of_sale.group_pos_user'):
-            raise AccessError(_("Only 'group_pos_user' are allowed to fetch token from Viva Wallet"))
+            raise AccessError(_("Only 'group_pos_user' are allowed to cancel a Viva Wallet payment"))
 
         session_id = data.get('sessionId')
         cash_register_id = data.get('cashRegisterId')
         endpoint = f"sessions/{session_id}?cashRegisterId={cash_register_id}"
         return self._call_viva_wallet(endpoint, 'delete')
+
+    def viva_wallet_get_payment_status(self, session_id):
+        if not self.env.user.has_group('point_of_sale.group_pos_user'):
+            raise AccessError(_("Only 'group_pos_user' are allowed to get the payment status from Viva Wallet"))
+
+        endpoint = f"sessions/{session_id}"
+        return self._call_viva_wallet(endpoint, 'get', should_retry=False)
 
     def write(self, vals):
         record = super().write(vals)
@@ -202,11 +208,12 @@ class PosPaymentMethod(models.Model):
                 raise UserError(_('It is essential to provide API key for the use of viva wallet'))
 
 
-def get_viva_wallet_session():
+def get_viva_wallet_session(should_retry=True):
     session = requests.Session()
-    session.mount('https://', requests.adapters.HTTPAdapter(max_retries=requests.adapters.Retry(
-        total=6,
-        backoff_factor=2,
-        status_forcelist=[202, 500, 502, 503, 504],
-        )))
+    if should_retry:
+        session.mount('https://', requests.adapters.HTTPAdapter(max_retries=requests.adapters.Retry(
+            total=5,
+            backoff_factor=2,
+            status_forcelist=[202, 500, 502, 503, 504],
+            )))
     return session

--- a/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
+++ b/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
@@ -7,6 +7,10 @@ import { sprintf } from "@web/core/utils/strings";
 import { roundPrecision } from "@web/core/utils/numbers";
 import { uuidv4 } from "@point_of_sale/utils";
 
+// Due to consistency issues with the webhook, we also poll
+// the status of the payment periodically as a fallback.
+const POLLING_INTERVAL_MS = 5000
+
 export class PaymentVivaWallet extends PaymentInterface {
 
     /*
@@ -112,7 +116,9 @@ export class PaymentVivaWallet extends PaymentInterface {
             "cashRegisterId": this.pos.get_cashier().name
         };
         return this._call_viva_wallet(data, 'viva_wallet_send_payment_cancel').then((data) => {
-            this._viva_wallet_handle_response(data);
+            if (data.error) {
+                this._show_error(data.error);
+            }
             return true;
         });
     }
@@ -149,6 +155,7 @@ export class PaymentVivaWallet extends PaymentInterface {
         // we use the handle_payment_response method on the payment line
         const resolver = this.paymentLineResolvers?.[line.cid];
         if (resolver) {
+            this.paymentLineResolvers[line.cid] = null;
             resolver(isPaymentSuccessful);
         } else {
             line.handle_payment_response(isPaymentSuccessful);
@@ -166,7 +173,29 @@ export class PaymentVivaWallet extends PaymentInterface {
 
     waitForPaymentConfirmation() {
         return new Promise((resolve) => {
-            this.paymentLineResolvers[this.pending_viva_wallet_line().cid] = resolve;
+            const paymentLine = this.pending_viva_wallet_line();
+            this.paymentLineResolvers[paymentLine.cid] = resolve;
+            const intervalId = setInterval(async () => {
+                if (!this.paymentLineResolvers[paymentLine.cid]) {
+                    clearInterval(intervalId);
+                    return;
+                }
+                
+                const result = await this._call_viva_wallet(
+                    paymentLine.sessionId,
+                    'viva_wallet_get_payment_status'
+                );
+                if ('success' in result && this.paymentLineResolvers[paymentLine.cid]) {
+                    clearInterval(intervalId);
+                    if (this.isPaymentSuccessful(result)) {
+                        this.handleSuccessResponse(paymentLine, result);
+                        resolve(true);
+                    } else {
+                        resolve(false);
+                    }
+                    this.paymentLineResolvers[paymentLine.cid] = null;
+                }
+            }, POLLING_INTERVAL_MS);
         });
     }
 


### PR DESCRIPTION
The Viva Wallet integration relies on Odoo
being called by Viva Wallet via a webhook.
There have been many issues of this webhook
never being called, and therefore payments
getting stuck in Odoo.

In this commit, we add a polling fallback.
Every 5 seconds we query the Viva Wallet
session, and if we get a response (success/failure) then we update the payment state in the PoS.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
