### PR TITLE
[FIX] hr: only generate default avatar if possible

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -406,7 +406,8 @@ class HrEmployeePrivate(models.Model):
         # Sudo in case HR officer doesn't have the Contact Creation group
         employees.filtered(lambda e: not e.work_contact_id).sudo()._create_work_contacts()
         for employee_sudo in employees.sudo():
-            if not employee_sudo.image_1920:
+            # creating 'svg/xml' attachments requires specific rights
+            if not employee_sudo.image_1920 and self.env['ir.ui.view'].sudo(False).check_access_rights('write', raise_exception=False):
                 employee_sudo.image_1920 = employee_sudo._avatar_generate_svg()
                 employee_sudo.work_contact_id.image_1920 = employee_sudo.image_1920
         if self.env.context.get('salary_simulation'):


### PR DESCRIPTION
Steps
-----
- Have a user with 'Employees' Administator rights and no 'Administration' rights.
- Create a new employee.
- When viewing the Kanban views of employees, the image for the newly created employee appears corrupted (the text 'binary file' appears instead of the image).

Cause
-----
When we create a new employee, `_avatar_generate_svg` is called https://github.com/odoo/odoo/blob/717f3a1ab25613c02c2d0b28fa8dd73f4e6c75e0/addons/hr/models/hr_employee.py#L497-L498 that returns a svg/xml base-64 encoded. However, only users with write rights to `ir.ui.view` are able to create svg/xml attachments. https://github.com/odoo/odoo/blob/717f3a1ab25613c02c2d0b28fa8dd73f4e6c75e0/odoo/addons/base/models/ir_attachment.py#L368-L371 Else, the attachment has a text mimetype forced, leading to it being incorrectly displayed.

Change
-----
A default image is not generated at employee creation if the user doesn't have sufficient rights.

opw-4311251