### PR TITLE
[IMP] web: add companies infos to the evaluation context

### DIFF
--- a/addons/web/models/__init__.py
+++ b/addons/web/models/__init__.py
@@ -8,6 +8,7 @@ from . import ir_ui_menu
 from . import ir_ui_view
 from . import models
 from . import base_document_layout
+from . import res_company
 from . import res_config_settings
 from . import res_partner
 from . import res_users

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -154,7 +154,6 @@ class IrHttp(models.AbstractModel):
                     'disallowed_ancestor_companies': {comp.id: comp._get_session_info(all_companies_in_hierarchy_sudo) for comp in disallowed_ancestor_companies_sudo},
                 },
                 "show_effect": True,
-                "display_switch_company_menu": user.has_group('base.group_multi_company') and len(user_companies) > 1,
             })
         return session_info
 

--- a/addons/web/models/res_company.py
+++ b/addons/web/models/res_company.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    def _get_session_info(self, allowed_companies):
+        '''
+        Args:
+            allowed_companies: The companies allowed to the user when creating the session_info.
+                               These can be the user companies, or the user companies with the ancestors.
+
+        Returns:
+            A dictionary of the company values to be added to the session_info
+
+        '''
+        self.ensure_one()
+        return {
+            'id': self.id,
+            'name': self.name,
+            'sequence': self.sequence,
+            'child_ids': (self.child_ids & allowed_companies).ids,
+            'parent_id': self.parent_id.id,
+        }

--- a/addons/web/static/src/core/py_js/py_interpreter.js
+++ b/addons/web/static/src/core/py_js/py_interpreter.js
@@ -315,14 +315,7 @@ const SET = {
         );
     },
     union(...args) {
-        return applyFunc(
-            "union",
-            (iterable) => {
-                return new Set([...this, ...iterable]);
-            },
-            this,
-            ...args
-        );
+        return applyFunc("union", (iterable) => new Set([...this, ...iterable]), this, ...args);
     },
 };
 
@@ -339,7 +332,7 @@ function methods(_class) {
     return Object.getOwnPropertyNames(_class.prototype).map((prop) => _class.prototype[prop]);
 }
 
-const allowedFns = new Set([
+export const allowedFns = new Set([
     BUILTINS.time.strftime,
     BUILTINS.set,
     BUILTINS.bool,

--- a/addons/web/static/src/model/relational_model/datapoint.js
+++ b/addons/web/static/src/model/relational_model/datapoint.js
@@ -77,8 +77,8 @@ export class DataPoint extends Reactive {
         return this.config.context;
     }
 
-    get currentCompanyId() {
-        return this.config.currentCompanyId;
+    get companies() {
+        return this.config.companies;
     }
 
     // -------------------------------------------------------------------------

--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -221,6 +221,7 @@ export class DynamicGroupList extends DynamicList {
             resModel: this.config.resModel,
             fields: this.config.fields,
             activeFields: this.config.activeFields,
+            companies: this.config.companies,
         };
         const context = {
             ...this.context,

--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -19,7 +19,7 @@ export class DynamicList extends DataPoint {
             this.handleField = DEFAULT_HANDLE_FIELD;
         }
         this.isDomainSelected = false;
-        this.evalContext = this.context;
+        this.evalContext = { ...this.context, companies: this.config.companies };
     }
 
     // -------------------------------------------------------------------------
@@ -263,16 +263,16 @@ export class DynamicList extends DataPoint {
         if (!Object.keys(changes).length || record === this._recordToDiscard) {
             return;
         }
-        const validSelection = this.selection.filter((record) => {
-            return Object.keys(changes).every((fieldName) => {
+        const validSelection = this.selection.filter((record) =>
+            Object.keys(changes).every((fieldName) => {
                 if (record._isReadonly(fieldName)) {
                     return false;
                 } else if (record._isRequired(fieldName) && !changes[fieldName]) {
                     return false;
                 }
                 return true;
-            });
-        });
+            })
+        );
         const canProceed = await this.model.hooks.onWillSaveMulti(record, changes, validSelection);
         if (canProceed === false) {
             return false;

--- a/addons/web/static/src/model/relational_model/dynamic_record_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_record_list.js
@@ -123,7 +123,7 @@ export class DynamicRecordList extends DynamicList {
                 resId: data.id || false,
                 resIds: data.id ? [data.id] : [],
                 isMonoRecord: true,
-                currentCompanyId: this.currentCompanyId,
+                companies: this.companies,
                 mode,
             },
             data,

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -549,7 +549,7 @@ export class Record extends DataPoint {
             resIds: data.map((r) => r.id),
             orderBy: orderBys?.[fieldName] || defaultOrderBy || [],
             limit: limit || Number.MAX_SAFE_INTEGER,
-            currentCompanyId: this.currentCompanyId,
+            companies: this.companies,
             context: {}, // will be set afterwards, see "_updateContext" in "_setEvalContext"
         };
         const options = {

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -45,7 +45,7 @@ import { FetchRecordError } from "./errors";
  * @property {Object} activeFields
  * @property {object} context
  * @property {boolean} isMonoRecord
- * @property {number} currentCompanyId
+ * @property {object} companies
  * @property {boolean} isRoot
  * @property {Array} [domain]
  * @property {Array} [groupBy]
@@ -120,7 +120,7 @@ export class RelationalModel extends Model {
         /** @type {Config} */
         this.config = {
             isMonoRecord: false,
-            currentCompanyId: company.currentCompany.id,
+            companies: company.evalContext,
             context: {},
             ...params.config,
             isRoot: true,
@@ -329,7 +329,7 @@ export class RelationalModel extends Model {
             ...config,
             context: {
                 ...config.context,
-                current_company_id: config.currentCompanyId,
+                current_company_id: config.companies.active_id,
             },
         });
         if (config.offset && !records.length) {
@@ -377,6 +377,7 @@ export class RelationalModel extends Model {
             resModel: config.resModel,
             fields: config.fields,
             activeFields: config.activeFields,
+            companies: config.companies,
         };
         let groupRecordConfig;
         const groupRecordResIds = [];
@@ -385,6 +386,7 @@ export class RelationalModel extends Model {
                 ...this.groupByInfo[firstGroupByName],
                 resModel: config.fields[firstGroupByName].relation,
                 context: {},
+                companies: config.companies,
             };
         }
         const proms = [];
@@ -547,9 +549,7 @@ export class RelationalModel extends Model {
 
             return records;
         } else {
-            return resIds.map((resId) => {
-                return { id: resId };
-            });
+            return resIds.map((resId) => ({ id: resId }));
         }
     }
 

--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -743,7 +743,7 @@ export class StaticList extends DataPoint {
             resIds: resId ? [resId] : [],
             mode: params.mode || "readonly",
             isMonoRecord: true,
-            currentCompanyId: this.currentCompanyId,
+            companies: this.companies,
         };
         const { CREATE, UPDATE } = x2ManyCommands;
         const options = {

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -326,9 +326,10 @@ export function getBasicEvalContext(config) {
     const { uid, allowed_company_ids } = config.context;
     return {
         context: config.context,
+        companies: config.companies,
         uid,
         allowed_company_ids,
-        current_company_id: config.currentCompanyId,
+        current_company_id: config.companies.active_id,
     };
 }
 

--- a/addons/web/static/src/views/form/form_label.js
+++ b/addons/web/static/src/views/form/form_label.js
@@ -1,8 +1,8 @@
 import { fieldVisualFeedback } from "@web/views/fields/field";
-import { session } from "@web/session";
 import { getTooltipInfo } from "@web/views/fields/field_tooltip";
 import { _t } from "@web/core/l10n/translation";
 import { Component } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
 
 export class FormLabel extends Component {
     static template = "web.FormLabel";
@@ -16,6 +16,9 @@ export class FormLabel extends Component {
         notMuttedLabel: { type: Boolean, optional: true },
     };
 
+    setup() {
+        this.company = useService("company");
+    }
     get className() {
         const { invalid, empty, readonly } = fieldVisualFeedback(
             this.props.fieldInfo.field,
@@ -43,7 +46,7 @@ export class FormLabel extends Component {
     get tooltipHelp() {
         const field = this.props.record.fields[this.props.fieldName];
         let help = this.props.fieldInfo.help || field.help || "";
-        if (field.company_dependent && session.display_switch_company_menu) {
+        if (field.company_dependent && this.company.isMultiCompany) {
             help += (help ? "\n\n" : "") + _t("Values set here are company-specific.");
         }
         return help;

--- a/addons/web/static/src/views/form/setting/setting.js
+++ b/addons/web/static/src/views/form/setting/setting.js
@@ -1,7 +1,7 @@
-import { session } from "@web/session";
 import { Component } from "@odoo/owl";
 import { FormLabel } from "../form_label";
 import { DocumentationLink } from "@web/views/widgets/documentation_link/documentation_link";
+import { useService } from "@web/core/utils/hooks";
 
 export class Setting extends Component {
     static template = "web.Setting";
@@ -26,6 +26,7 @@ export class Setting extends Component {
     };
 
     setup() {
+        this.company = useService("company");
         if (this.props.fieldName) {
             this.fieldType = this.props.record.fields[this.props.fieldName].type;
             if (this.props.fieldInfo.readonly === "True") {
@@ -47,9 +48,7 @@ export class Setting extends Component {
     }
 
     get displayCompanyDependentIcon() {
-        return (
-            this.labelString && this.props.companyDependent && session.display_switch_company_menu
-        );
+        return this.labelString && this.props.companyDependent && this.company.isMultiCompany;
     }
 
     get labelString() {

--- a/addons/web/static/src/webclient/company_service.js
+++ b/addons/web/static/src/webclient/company_service.js
@@ -136,6 +136,10 @@ export const companyService = {
                 return allowedCompanies[activeCompanyIds[0]];
             },
 
+            get isMultiCompany() {
+                return Object.values(allowedCompanies).length > 1;
+            },
+
             getCompany(companyId) {
                 return allowedCompaniesWithAncestors[companyId];
             },

--- a/addons/web/static/tests/_framework/mock_session.hoot.js
+++ b/addons/web/static/tests/_framework/mock_session.hoot.js
@@ -32,7 +32,6 @@ const makeSession = ({
     },
     can_insert_in_spreadsheet: true,
     db,
-    display_switch_company_menu: false,
     home_action_id: false,
     is_admin: true,
     is_internal_user: true,

--- a/addons/web/static/tests/legacy/helpers/mock_services.js
+++ b/addons/web/static/tests/legacy/helpers/mock_services.js
@@ -263,6 +263,13 @@ export const fakeCompanyService = {
             currentCompany: {},
             setCompanies: () => {},
             getCompany: () => {},
+            evalContext: {
+                multi_company: false,
+                allowed_ids: [],
+                active_ids: [],
+                active_id: undefined,
+                has: () => {},
+            },
         };
     },
 };

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -59,7 +59,6 @@ import { cookie } from "@web/core/browser/cookie";
 import { registry } from "@web/core/registry";
 import { SIZES } from "@web/core/ui/ui_service";
 import { useBus, useService } from "@web/core/utils/hooks";
-import { session } from "@web/session";
 import { CharField } from "@web/views/fields/char/char_field";
 import { DateTimeField } from "@web/views/fields/datetime/datetime_field";
 import { Field } from "@web/views/fields/field";
@@ -10437,7 +10436,11 @@ test(`company_dependent field in form view, in multi company group`, async () =>
         help: "this is a tooltip",
     });
 
-    patchWithCleanup(session, { display_switch_company_menu: true });
+    serverState.companies = [
+        { id: 1, name: "Company 1", sequence: 1, parent_id: false, child_ids: [] },
+        { id: 2, name: "Company 2", sequence: 2, parent_id: false, child_ids: [] },
+        { id: 3, name: "Company 3", sequence: 3, parent_id: false, child_ids: [] },
+    ];
     await mountView({
         resModel: "partner",
         type: "form",
@@ -10470,7 +10473,10 @@ test(`company_dependent field in form view, not in multi company group`, async (
         help: "this is a tooltip",
     });
 
-    patchWithCleanup(session, { display_switch_company_menu: false });
+    serverState.companies = [
+        { id: 1, name: "Company 1", sequence: 1, parent_id: false, child_ids: [] },
+    ];
+
     await mountView({
         resModel: "partner",
         type: "form",
@@ -11253,9 +11259,11 @@ test(`setting : boolean field`, async () => {
 });
 
 test(`setting : char field`, async () => {
-    patchWithCleanup(session, {
-        display_switch_company_menu: true,
-    });
+    serverState.companies = [
+        { id: 1, name: "Company 1", sequence: 1, parent_id: false, child_ids: [] },
+        { id: 2, name: "Company 2", sequence: 2, parent_id: false, child_ids: [] },
+        { id: 3, name: "Company 3", sequence: 3, parent_id: false, child_ids: [] },
+    ];
 
     await mountView({
         resModel: "partner",

--- a/addons/web/static/tests/webclient/company_service.test.js
+++ b/addons/web/static/tests/webclient/company_service.test.js
@@ -70,3 +70,64 @@ test("extract allowed company ids from cookies", async () => {
     expect(getService("company").activeCompanyIds).toEqual([3, 1]);
     expect(getService("company").currentCompany.id).toBe(3);
 });
+
+test("company evalContext", async () => {
+    serverState.companies = [
+        {
+            id: 1,
+            name: "Company 1",
+            sequence: 1,
+            parent_id: false,
+            child_ids: [],
+            country_code: "BE",
+        },
+        {
+            id: 2,
+            name: "Company 2",
+            sequence: 2,
+            parent_id: false,
+            child_ids: [],
+            country_code: "PE",
+        },
+        {
+            id: 3,
+            name: "Company 3",
+            sequence: 3,
+            parent_id: false,
+            child_ids: [],
+            country_code: "AR",
+        },
+    ];
+    cookie.set("cids", "3-1");
+    await makeMockEnv();
+
+    const companyEvalContext = getService("company").evalContext;
+
+    expect(companyEvalContext.allowed_ids).toEqual([1, 2, 3]);
+    expect(companyEvalContext.active_ids).toEqual([3, 1]);
+    expect(companyEvalContext.active_id).toBe(3);
+    expect(companyEvalContext.multi_company).toBe(true);
+
+    // check if the active_id has as contry_code AR
+    expect(companyEvalContext.has(companyEvalContext.active_id, "country_code", "AR")).toBe(true);
+    // check if the active_id has as contry_code PE
+    expect(companyEvalContext.has(companyEvalContext.active_id, "country_code", "PE")).toBe(false);
+
+    // check if one of the active_ids has as contry_code AR
+    expect(companyEvalContext.has(companyEvalContext.active_ids, "country_code", "AR")).toBe(true);
+    // check if one of the active_ids has as contry_code BE
+    expect(companyEvalContext.has(companyEvalContext.active_ids, "country_code", "BE")).toBe(true);
+    // check if one of the active_ids has as contry_code PE
+    expect(companyEvalContext.has(companyEvalContext.active_ids, "country_code", "PE")).toBe(false);
+
+    // check if one of the allowed_ids has as contry_code AR
+    expect(companyEvalContext.has(companyEvalContext.allowed_ids, "country_code", "PE")).toBe(true);
+    // check if one of the allowed_ids has as contry_code BR
+    expect(companyEvalContext.has(companyEvalContext.allowed_ids, "country_code", "BR")).toBe(
+        false
+    );
+
+    // If the company don't exist in the list, return always false
+    expect(companyEvalContext.has(false, "country_code", "AR")).toBe(false);
+    expect(companyEvalContext.has(4, "country_code", "AR")).toBe(false);
+});

--- a/odoo/tools/view_validation.py
+++ b/odoo/tools/view_validation.py
@@ -24,6 +24,7 @@ IGNORED_IN_EXPRESSION = {
     'self',
     'uid',
     'context',
+    'companies',
     'context_today',
     'allowed_company_ids',
     'current_company_id',


### PR DESCRIPTION
This commit adds a new object with the information of the companies, to
the evaluation context of Python expressions.

The object contains:
- multi_company: A boolean indicating whether the user has access to multiple companies.
- allowed_ids : The list of company IDs the user is allowed to connect to.
- active_ids: The list of company IDs the user is connected to (selected in the company switcher dropdown).
- active_id: The ID of the main company selected (the one highlighted in the company switcher dropdown and displayed in the navbar of the webclient).
- has(id|ids, 'property', value) : returns a boolean indicating whether there's a company with id in `ids` for which `field` matches the given `value`. Note that the properties of the companies are those sent by the server in the session info. If a new property is needed, the company function `_get_session_info` can be overridden. For example, the following code will add the `company_code` property:
    ```py
    def _get_session_info(self, allowed_company_ids):
        res = super()._get_session_info(allowed_company_ids)
        res.update({
            'country_code': self.country_id.code
        })
        return res
    ```

Some usage examples:

- In this case, the field 'foo' will be visible if the user has access
        to more than one company:
    ```xml
        <field name="foo" invisible="not companies.multi_company"/>
    ```
- In this case, the filed 'foo' will be visible if the user has
        activated one company with the country code 'PE':
    ```xml
        <field name="foo" invisible="not companies.has(companies.active_ids, 'country_code', 'PE')"/>
    ```
- In this case, the field 'float_field' will be visible if the main
        company (the one show on the top bar), has the country code 'PE':
    ```xml
        <field name="float_field" invisible="not companies.has(companies.active_id, 'country_code', 'PE')"/>
    ```

- In this case, the field 'child_ids' will be visible if the company of
        the current record has the country code 'PE'. Note that, to
        evaluate correctly this expression, the 'company_id' field
        should be in the view:
    ```xml
        <field name="child_ids" invisible="not companies.has(company_id, 'country_code', 'PE')"/>
    ```

part-of task-id 4250356