### PR TITLE
[FIX] tools: handle self closing t tags in html fields

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -266,6 +266,11 @@ def html_normalize(src, filter_callback=None, output_method="html"):
     if filter_callback:
         doc = filter_callback(doc)
 
+    if output_method == 'xml':
+        for t_tag in doc.xpath("//t"):
+            if not t_tag.text and not len(t_tag):
+                t_tag.text = ""
+
     src = html.tostring(doc, encoding='unicode', method=output_method)
 
     # this is ugly, but lxml/etree tostring want to put everything in a


### PR DESCRIPTION
Steps to reproduce
-----
1. On a fresh database, install Calendar
2. Go to Email Templates > "Calendar : Event update" ** The content of the mail has a blue background **

Cause
-----
Since commit 24731938f75358fd3c72b91465b72ab80d62d208, the `body_html` of the `mail.template` is stored in a xhtml format while it was previously saved in HTML.
This means self-closing t tags, which were previously saved as `<t></t>`, are now saved as <t .../> in database. Since self closing t tags are not valid HTML, they get turned into opening t tags when viewed as HTML and the `data-oe-t-inline` attribute that prevents the blue background color styling to be applied are not present on these t tags.

Solution
-----
In case `output_format` is xml, transform the self closing t tags into empty elements which will be valid html.

opw-4348482
