### PR TITLE
[IMP] account: automatic validation of payment with bank account

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -898,7 +898,7 @@ class AccountPayment(models.Model):
         return outstanding_account
 
     def write(self, vals):
-        if vals.get('state') == 'in_process' and not vals.get('move_id'):
+        if vals.get('state') in ('in_process', 'paid') and not vals.get('move_id'):
             self.filtered(lambda p: not p.move_id)._generate_journal_entry()
             self.move_id.action_post()
 
@@ -1047,6 +1047,7 @@ class AccountPayment(models.Model):
                     method_name=self.payment_method_line_id.name,
                     partner=payment.partner_id.display_name,
                 ))
+        self.filtered(lambda pay: pay.outstanding_account_id.account_type == 'asset_cash').state = 'paid'
         # Avoid going back one state when clicking on the confirm action in the payment list view and having paid expenses selected
         # We need to set values to each payment to avoid recomputation later
         self.filtered(lambda pay: pay.state in {False, 'draft', 'in_process'}).state = 'in_process'

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -593,3 +593,20 @@ class TestAccountPayment(AccountTestInvoicingCommon):
         invoice_2.action_post()
         register_payment_and_assert_state(invoice_2, 100.0, is_community=False)
         self.assertFalse(invoice_2.matched_payment_ids.move_id)
+
+    def test_payment_confirmation_with_bank_outstanding_account(self):
+        """ Ensures that when the outstanding account of the payment method is set to a bank,
+            the validation process of a payment is skipped therefore reaching paid status after confirmation of payment. """
+        bank_journal = self.company_data['default_journal_bank']
+        outstanding_account = bank_journal.default_account_id
+        # Sets the outstanding account to a bank
+        bank_journal.inbound_payment_method_line_ids.payment_account_id = outstanding_account
+        payment = self.env['account.payment'].create({
+            'payment_type': 'inbound',
+            'partner_type': 'customer',
+            'partner_id': self.partner_a.id,
+            'journal_id': bank_journal.id,
+            'amount': 2629,
+        })
+        payment.action_post()
+        self.assertEqual(payment.state, 'paid')


### PR DESCRIPTION
### Purpose

Since the Payment without Entry, we've added new Payment Statuses on the payment. We've already added some heuristics to automatically mark payments as validated when the payment is reconciled.

But we allow the users to set Bank accounts directly as Outstanding. It's often used by people who want to easily get their Accounting entry created, but they want to skip the reconciliation process. The problem is that, as the reconciliation is skipped, the auto-validation heuristic is never applied, and so all those payments stay "In process".

### Implementation

If the Outstanding account set on the Payment Method is of type Bank, the payment is auto-validated once created.

task-4392152