### PR TITLE
[FIX] point_of_sale: correctly sync pos payments

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -100,11 +100,12 @@ class PosOrder(models.Model):
             })
             pos_order = pos_order.with_company(pos_order.company_id)
         else:
-            # Save line before to avoid exception if a line is deleted
+            # Save lines and payments first to avoid exceptions if they are deleted
             # when vals change the state to 'paid'
-            if order.get('lines'):
-                pos_order.write({'lines': order.get('lines')})
-                order['lines'] = []
+            for field in ['lines', 'payment_ids']:
+                if order.get(field):
+                    pos_order.write({field: order.get(field)})
+                    order[field] = []
 
             pos_order.write(order)
 

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -17,7 +17,7 @@ class PosPayment(models.Model):
     _inherit = ['pos.load.mixin']
 
     name = fields.Char(string='Label', readonly=True)
-    pos_order_id = fields.Many2one('pos.order', string='Order', required=True, index=True)
+    pos_order_id = fields.Many2one('pos.order', string='Order', required=True, index=True, ondelete='cascade')
     amount = fields.Monetary(string='Amount', required=True, currency_field='currency_id', readonly=True, help="Total amount of the payment.")
     payment_method_id = fields.Many2one('pos.payment.method', string='Payment Method', required=True)
     payment_date = fields.Datetime(string='Date', required=True, readonly=True, default=lambda self: fields.Datetime.now())

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -283,3 +283,62 @@ registry.category("web_tour.tours").add("CrmTeamTour", {
             ProductScreen.back(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PoSPaymentSyncTour1", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.totalAmountIs("2.20"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.emptyPaymentlines("2.20"),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickBack(),
+            ProductScreen.isShown(),
+            ProductScreen.clickOrderButton(),
+            ProductScreen.orderlinesHaveNoChange(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PoSPaymentSyncTour2", {
+    test: true,
+    steps: () =>
+        [
+            FloorScreen.clickTable("5"),
+            PaymentScreen.isShown(),
+            PaymentScreen.clickBack(),
+            ProductScreen.isShown(),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.totalAmountIs("4.40"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentlineDelButton("Bank", "2.20"),
+            PaymentScreen.emptyPaymentlines("4.40"),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickBack(),
+            ProductScreen.isShown(),
+            ProductScreen.clickOrderButton(),
+            ProductScreen.orderlinesHaveNoChange(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PoSPaymentSyncTour3", {
+    test: true,
+    steps: () =>
+        [
+            FloorScreen.clickTable("5"),
+            PaymentScreen.isShown(),
+            PaymentScreen.clickBack(),
+            ProductScreen.isShown(),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.totalAmountIs("6.60"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.remainingIs("2.2"),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickBack(),
+            ProductScreen.isShown(),
+            ProductScreen.clickOrderButton(),
+            ProductScreen.orderlinesHaveNoChange(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -309,3 +309,18 @@ class TestFrontend(TestFrontendCommon):
         self.start_pos_tour('CrmTeamTour')
         order = self.env['pos.order'].search([], limit=1)
         self.assertEqual(order.crm_team_id.id, sale_team.id)
+
+    def test_14_pos_payment_sync(self):
+        self.pos_config.write({'printer_ids': False})
+        self.pos_config.with_user(self.pos_user).open_ui()
+        def assert_payment(lines_count, amount):
+            self.assertEqual(len(order.payment_ids), lines_count)
+            self.assertEqual(round(sum(payment.amount for payment in order.payment_ids), 2), amount)
+        self.start_pos_tour('PoSPaymentSyncTour1')
+        order = self.pos_config.current_session_id.order_ids
+        self.assertEqual(len(order), 1)
+        assert_payment(1, 2.2)
+        self.start_pos_tour('PoSPaymentSyncTour2')
+        assert_payment(1, 4.4)
+        self.start_pos_tour('PoSPaymentSyncTour3')
+        assert_payment(2, 6.6)


### PR DESCRIPTION
Before this commit, if you added a payment line to an order and synced it to the server, then added some items and removed the payment line to add a new one, the payment line wasn't removed from the backend. This caused the order to have different payment lines from what the user validated. This commit ensures that payment lines are correctly synced and updated in the backend.

opw-4257663

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
