### PR TITLE
[FIX] im_livechat: chatbot rules with same regex url

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -83,18 +83,16 @@ class LivechatController(http.Controller):
         # extract url
         url = request.httprequest.headers.get('Referer')
         # find the first matching rule for the given country and url
-        matching_rule = request.env['im_livechat.channel.rule'].sudo().match_rule(channel_id, url, country_id)
-        if matching_rule and (not matching_rule.chatbot_script_id or matching_rule.chatbot_script_id.script_step_ids):
+        if matching_rule := request.env['im_livechat.channel.rule'].sudo().match_rule(channel_id, url, country_id):
             matching_rule = matching_rule.with_context(lang=request.env['chatbot.script']._get_chatbot_language())
             rule = {
-                'action': matching_rule.action,
-                'auto_popup_timer': matching_rule.auto_popup_timer,
-                'regex_url': matching_rule.regex_url,
+                "action": matching_rule.action,
+                "auto_popup_timer": matching_rule.auto_popup_timer,
+                "regex_url": matching_rule.regex_url,
+                "chatbotScript": matching_rule.chatbot_script_id._format_for_frontend()
+                if matching_rule.chatbot_script_id
+                else None,
             }
-            if matching_rule.chatbot_script_id.active and (not matching_rule.chatbot_only_if_no_operator or
-               (not operator_available and matching_rule.chatbot_only_if_no_operator)) and matching_rule.chatbot_script_id.script_step_ids:
-                chatbot_script = matching_rule.chatbot_script_id
-                rule.update({'chatbotScript': chatbot_script._format_for_frontend()})
         store = Store()
         request.env["res.users"]._init_store_data(store)
         return {

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -386,8 +386,15 @@ class ImLivechatChannelRule(models.Model):
             for rule in rules:
                 # url might not be set because it comes from referer, in that
                 # case match the first rule with no regex_url
-                if re.search(rule.regex_url or '', url or ''):
-                    return rule
+                if not re.search(rule.regex_url or "", url or ""):
+                    continue
+                if rule.chatbot_script_id and (
+                    not rule.chatbot_script_id.active or not rule.chatbot_script_id.script_step_ids
+                ):
+                    continue
+                if rule.chatbot_only_if_no_operator and rule.channel_id.available_operator_ids:
+                    continue
+                return rule
             return False
         # first, search the country specific rules (the first match is returned)
         if country_id: # don't include the country in the research if geoIP is not installed

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -1,8 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.addons.im_livechat.tests import chatbot_common
 from odoo.exceptions import ValidationError
-from odoo.tests.common import tagged
+from odoo.tests.common import tagged, new_test_user
 
 @tagged("post_install", "-at_install")
 class ChatbotCase(chatbot_common.ChatbotCase):
@@ -108,3 +109,71 @@ class ChatbotCase(chatbot_common.ChatbotCase):
         welcome_steps = self.chatbot_script._get_welcome_steps()
         self.assertEqual(len(welcome_steps), 1)
         self.assertEqual(welcome_steps, self.chatbot_script.script_step_ids[0])
+
+    def test_chatbot_multiple_rules_on_same_url(self):
+        bob_user = new_test_user(
+            self.env, login="bob_user", groups="im_livechat.im_livechat_group_user,base.group_user"
+        )
+        chatbot_no_operator = self.env["chatbot.script"].create(
+            {
+                "title": "Chatbot operators not available",
+                "script_step_ids": [
+                    Command.create(
+                        {
+                            "step_type": "text",
+                            "message": "I'm shown because there is no operator available",
+                        }
+                    )
+                ],
+            }
+        )
+        chatbot_operator = self.env["chatbot.script"].create(
+            {
+                "title": "Chatbot operators available",
+                "script_step_ids": [
+                    Command.create(
+                        {
+                            "step_type": "text",
+                            "message": "I'm shown because there is an operator available",
+                        }
+                    )
+                ],
+            }
+        )
+        self.livechat_channel.user_ids += bob_user
+        self.livechat_channel.rule_ids = self.env["im_livechat.channel.rule"].create(
+            [
+                {
+                    "channel_id": self.livechat_channel.id,
+                    "chatbot_script_id": chatbot_no_operator.id,
+                    "chatbot_only_if_no_operator": True,
+                    "regex_url": "/",
+                    "sequence": 1,
+                },
+                {
+                    "channel_id": self.livechat_channel.id,
+                    "chatbot_script_id": chatbot_operator.id,
+                    "regex_url": "/",
+                    "sequence": 2,
+                },
+            ]
+        )
+        self.assertFalse(self.livechat_channel.available_operator_ids)
+        self.assertEqual(
+            self.env["im_livechat.channel.rule"]
+            .match_rule(self.livechat_channel.id, "/")
+            .chatbot_script_id,
+            chatbot_no_operator,
+        )
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="user_id", identity_value=bob_user.id
+        )
+        # Force the recomputation of `available_operator_ids` after bob becomes online
+        self.livechat_channel.invalidate_recordset(["available_operator_ids"])
+        self.assertTrue(self.livechat_channel.available_operator_ids)
+        self.assertEqual(
+            self.env["im_livechat.channel.rule"]
+            .match_rule(self.livechat_channel.id, "/")
+            .chatbot_script_id,
+            chatbot_operator,
+        )


### PR DESCRIPTION
Before this PR, chatbot rules with the same target URL could be ignored, leading to missing chat bot in some cases.

Steps to reproduce:
- Setup chatbot A on url "/".
- Setup chatbot B on url "/". Only enable it if there aren't any available operators.
- Ensure no operator is connected.
- Go to the "/" URL as a visitor.
- No chat bot is present.

This occurs because the first rule is returned then discarded since there aren't any operators. We should instead ensure that the second one is used a fallback. This PR corrects the `match_rule` method to do so.

opw-4352046