### PR TITLE
[FIX] bus, mail: fix wrong super call

### DIFF
--- a/addons/bus/tests/test_bus_presence.py
+++ b/addons/bus/tests/test_bus_presence.py
@@ -23,3 +23,11 @@ class TestBusPresence(HttpCase):
         self.env["bus.presence"]._gc_bus_presence()
         presence = self.env["bus.presence"].search([("user_id", "=", user.id)])
         self.assertFalse(presence)
+
+    def test_im_status_invalidation(self):
+        bob_user = new_test_user(self.env, login="bob_user")
+        self.assertEqual(bob_user.im_status, "offline")
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="user_id", identity_value=bob_user.id
+        )
+        self.assertEqual(bob_user.im_status, "online")

--- a/addons/mail/models/bus_presence.py
+++ b/addons/mail/models/bus_presence.py
@@ -26,5 +26,5 @@ class BusPresence(models.Model):
         return {"guest_id": self.guest_id.id} if self.guest_id else super()._get_identity_data()
 
     def _invalidate_im_status(self, fnames=None, flush=True):
-        super().invalidate_recordset(fnames, flush)
+        super()._invalidate_im_status()
         self.guest_id.invalidate_recordset(["im_status"])


### PR DESCRIPTION
The mail module override of `_invalidate_im_status` is calling the wrong super method. This PR fixes the issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
