### PR TITLE
[REF] mail: split thread display name from channel name

### DIFF
--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -123,6 +123,7 @@ class TestImLivechatMessage(HttpCase, MailCommon):
                 ),
                 "mail.thread": self._filter_threads_fields(
                     {
+                        "display_name": "test1 Ernest Employee",
                         "id": channel_livechat_1.id,
                         "model": "discuss.channel",
                         "module_icon": "/mail/static/description/icon.png",
@@ -227,6 +228,7 @@ class TestImLivechatMessage(HttpCase, MailCommon):
                                 ),
                                 "mail.thread": self._filter_threads_fields(
                                     {
+                                        "display_name": "Chell Gladys Ernest Employee",
                                         "id": channel.id,
                                         "model": "discuss.channel",
                                         "module_icon": "/mail/static/description/icon.png",

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1008,11 +1008,7 @@ class MailMessage(models.Model):
             }
         record_fields = [
             # sudo: mail.thread - if mentionned in a non accessible thread, name is allowed
-            Store.Attr(
-                "name",
-                lambda record: record.sudo().display_name,
-                predicate=lambda record: record._name != "discuss.channel",
-            ),
+            Store.Attr("display_name", sudo=True),
             Store.Attr(
                 "module_icon",
                 lambda record: modules.module.get_module_icon(self.env[record._name]._original_module),

--- a/addons/mail/static/src/chatter/web/scheduled_message_model.js
+++ b/addons/mail/static/src/chatter/web/scheduled_message_model.js
@@ -45,7 +45,9 @@ export class ScheduledMessage extends Record {
     }
 
     get isSubjectThreadName() {
-        return this.thread.name?.trim().toLowerCase() === this.subject?.trim().toLowerCase();
+        return (
+            this.thread.display_name?.trim().toLowerCase() === this.subject?.trim().toLowerCase()
+        );
     }
 
     /**

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -379,27 +379,23 @@ export class Composer extends Component {
                 return {
                     ...props,
                     optionTemplate: "mail.Composer.suggestionThread",
-                    options: suggestions.map((suggestion) => {
-                        return {
-                            label: suggestion.parent_channel_id
-                                ? `${suggestion.parent_channel_id.displayName} > ${suggestion.displayName}`
-                                : suggestion.displayName,
-                            thread: suggestion,
-                            classList: "o-mail-Composer-suggestion",
-                        };
-                    }),
+                    options: suggestions.map((suggestion) => ({
+                        label: suggestion.parent_channel_id
+                            ? `${suggestion.parent_channel_id.displayName} > ${suggestion.displayName}`
+                            : suggestion.displayName,
+                        thread: suggestion,
+                        classList: "o-mail-Composer-suggestion",
+                    })),
                 };
             case "ChannelCommand":
                 return {
                     ...props,
                     optionTemplate: "mail.Composer.suggestionChannelCommand",
-                    options: suggestions.map((suggestion) => {
-                        return {
-                            label: suggestion.name,
-                            help: suggestion.help,
-                            classList: "o-mail-Composer-suggestion",
-                        };
-                    }),
+                    options: suggestions.map((suggestion) => ({
+                        label: suggestion.name,
+                        help: suggestion.help,
+                        classList: "o-mail-Composer-suggestion",
+                    })),
                 };
             case "mail.canned.response":
                 return {
@@ -407,14 +403,12 @@ export class Composer extends Component {
                     autoSelectFirst: false,
                     hint: _t("Tab to select"),
                     optionTemplate: "mail.Composer.suggestionCannedResponse",
-                    options: suggestions.map((suggestion) => {
-                        return {
-                            cannedResponse: suggestion,
-                            source: suggestion.source,
-                            label: suggestion.substitution,
-                            classList: "o-mail-Composer-suggestion",
-                        };
-                    }),
+                    options: suggestions.map((suggestion) => ({
+                        cannedResponse: suggestion,
+                        source: suggestion.source,
+                        label: suggestion.substitution,
+                        classList: "o-mail-Composer-suggestion",
+                    })),
                 };
             default:
                 return props;

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -243,17 +243,17 @@ export class Message extends Record {
     }
 
     get isSubjectSimilarToThreadName() {
-        if (!this.subject || !this.thread || !this.thread.name) {
+        if (!this.subject || !this.thread || !this.thread.display_name) {
             return false;
         }
         const regexPrefix = /^((re|fw|fwd)\s*:\s*)*/i;
-        const cleanedThreadName = this.thread.name.replace(regexPrefix, "");
+        const cleanedThreadName = this.thread.display_name.replace(regexPrefix, "");
         const cleanedSubject = this.subject.replace(regexPrefix, "");
         return cleanedSubject === cleanedThreadName;
     }
 
     get isSubjectDefault() {
-        const name = this.thread?.name;
+        const name = this.thread?.display_name;
         const threadName = name ? name.trim().toLowerCase() : "";
         const defaultSubject = this.default_subject ? this.default_subject.toLowerCase() : "";
         const candidates = new Set([defaultSubject, threadName]);
@@ -454,7 +454,9 @@ export class Message extends Record {
         const thread = this.thread;
         await thread.selfFollower.remove();
         this.store.env.services.notification.add(
-            _t('You are no longer following "%(thread_name)s".', { thread_name: thread.name }),
+            _t('You are no longer following "%(thread_name)s".', {
+                thread_name: thread.display_name,
+            }),
             { type: "success" }
         );
     }

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -113,6 +113,8 @@ export class Thread extends Record {
     custom_channel_name;
     /** @type {string} */
     description;
+    /** @type {string} */
+    display_name;
     displayToSelf = Record.attr(false, {
         compute() {
             return (
@@ -206,8 +208,6 @@ export class Thread extends Record {
         inverse: "threadAsNeedaction",
         sort: (message1, message2) => message1.id - message2.id,
     });
-    /** @type {string} */
-    name;
     /** @type {'open' | 'folded' | 'closed'} */
     state;
     status = "new";
@@ -292,9 +292,7 @@ export class Thread extends Record {
         const attachments = this.attachments.filter(
             (attachment) => (attachment.isPdf || attachment.isImage) && !attachment.uploading
         );
-        attachments.sort((a1, a2) => {
-            return a2.id - a1.id;
-        });
+        attachments.sort((a1, a2) => a2.id - a1.id);
         return attachments;
     }
 
@@ -326,7 +324,7 @@ export class Thread extends Record {
     }
 
     get displayName() {
-        return this.name;
+        return this.display_name;
     }
 
     computeIsDisplayed() {

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -119,7 +119,7 @@
     <button class="btn btn-secondary flex-grow-1 p-2"
         t-att-class="{
             'active o-active shadow-none': mailbox.eq(store.discuss.thread),
-        }" t-on-click="mailbox.setAsDiscussThread" t-esc="mailbox.name"
+        }" t-on-click="mailbox.setAsDiscussThread" t-esc="mailbox.display_name"
     />
 </t>
 

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -14,7 +14,7 @@
             <t t-call="mail.Mailbox.main"/>
             <t t-set-slot="content">
                 <div class="overflow-hidden" t-ref="floating">
-                    <span class="text-muted user-select-none" t-esc="mailbox.name"/>
+                    <span class="text-muted user-select-none" t-esc="mailbox.display_name"/>
                 </div>
             </t>
         </Dropdown>
@@ -36,7 +36,7 @@
         >
             <ThreadIcon className="'bg-inherit ' + (store.discuss.isSidebarCompact ? '' : 'mx-2')" thread="mailbox"/>
             <t t-if="!store.discuss.isSidebarCompact">
-                <div class="me-2 text-truncate small" style="line-height: 1.65;" t-esc="mailbox.name"/>
+                <div class="me-2 text-truncate small" style="line-height: 1.65;" t-esc="mailbox.display_name"/>
                 <div t-attf-class="flex-grow-1 {{ mailbox.counter === 0 ? 'me-3': '' }}"/>
             </t>
             <span

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -32,19 +32,19 @@ const StorePatch = {
     onStarted() {
         super.onStarted(...arguments);
         this.inbox = {
+            display_name: _t("Inbox"),
             id: "inbox",
             model: "mail.box",
-            name: _t("Inbox"),
         };
         this.starred = {
+            display_name: _t("Starred"),
             id: "starred",
             model: "mail.box",
-            name: _t("Starred"),
         };
         this.history = {
+            display_name: _t("History"),
             id: "history",
             model: "mail.box",
-            name: _t("History"),
         };
         try {
             // useful for synchronizing activity data between multiple tabs

--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -47,6 +47,7 @@ declare module "models" {
         readonly lastSelfMessageSeenByEveryone: Message,
         member_count: number | undefined,
         readonly membersThatCanSeen: ChannelMember[],
+        name: string,
         newMessageBannerText: string,
         onClickUnreadMessagesBanner(): void,
         onlineMembers: ChannelMember[],

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -116,6 +116,8 @@ const threadPatch = {
             },
         });
         this.member_count = undefined;
+        /** @type {string} name: only for channel. For generic thread, @see display_name */
+        this.name = undefined;
         this.onlineMembers = Record.many("discuss.channel.member", {
             /** @this {import("models").Thread} */
             compute() {
@@ -202,6 +204,9 @@ const threadPatch = {
             return formatList(
                 this.channel_member_ids.map((channelMember) => channelMember.persona.name)
             );
+        }
+        if (this.model === "discuss.channel" && this.name) {
+            return this.name;
         }
         return super.displayName;
     },

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -122,10 +122,10 @@ export class MailMessage extends models.ServerModel {
             const [data] = this._read_format(message.id, fields, false);
             const thread = message.model && this.env[message.model].browse(message.res_id)[0];
             if (thread) {
-                const thread_data = { module_icon: "/base/static/description/icon.png" };
-                if (message.model !== "discuss.channel") {
-                    thread_data.name = thread.name ?? thread.display_name;
-                }
+                const thread_data = {
+                    display_name: thread.name ?? thread.display_name,
+                    module_icon: "/base/static/description/icon.png",
+                };
                 if (for_current_user && add_followers) {
                     thread_data.selfFollower = mailDataHelpers.Store.one(
                         MailFollowers.browse(

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -120,6 +120,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 ),
                                 "mail.thread": self._filter_threads_fields(
                                     {
+                                        "display_name": "Channel",
                                         "id": channel.id,
                                         "model": "discuss.channel",
                                         "module_icon": "/mail/static/description/icon.png",

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -1721,10 +1721,25 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         return {}
 
     def _expected_result_for_thread(self, channel):
-        return {
+        common_data = {
             "id": channel.id,
             "model": "discuss.channel",
             "module_icon": "/mail/static/description/icon.png",
             "rating_avg": 0.0,
             "rating_count": 0,
         }
+        if channel == self.channel_general:
+            return {**common_data, "display_name": "general"}
+        if channel == self.channel_channel_public_1:
+            return {**common_data, "display_name": "public channel 1"}
+        if channel == self.channel_channel_public_2:
+            return {**common_data, "display_name": "public channel 2"}
+        if channel == self.channel_channel_group_1:
+            return {**common_data, "display_name": "group restricted channel 1"}
+        if channel == self.channel_channel_group_2:
+            return {**common_data, "display_name": "group restricted channel 2"}
+        if channel == self.channel_livechat_1:
+            return {**common_data, "display_name": "test1 Ernest Employee"}
+        if channel == self.channel_livechat_2:
+            return {**common_data, "display_name": "anon 2 Ernest Employee"}
+        return {}

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -919,10 +919,10 @@ class UnfollowFromInboxTest(MailCommon, HttpCase):
             ],
             "mail.thread": self._filter_threads_fields(
                 {
+                    "display_name": "Test",
                     "id": test_record.id,
                     "model": "mail.test.simple",
                     "module_icon": "/base/static/description/icon.png",
-                    "name": "Test",
                     "selfFollower": False,
                 },
             ),

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1426,10 +1426,10 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                             ],
                             "mail.thread": self._filter_threads_fields(
                                 {
+                                    "display_name": "Test",
                                     "id": record.id,
                                     "model": "mail.test.simple",
                                     "module_icon": "/base/static/description/icon.png",
-                                    "name": "Test",
                                     "selfFollower": follower_1.id,
                                 },
                             ),
@@ -1529,10 +1529,10 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                             ],
                             "mail.thread": self._filter_threads_fields(
                                 {
+                                    "display_name": "Test",
                                     "id": record.id,
                                     "model": "mail.test.simple",
                                     "module_icon": "/base/static/description/icon.png",
-                                    "name": "Test",
                                     "selfFollower": follower_2.id,
                                 },
                             ),


### PR DESCRIPTION
There should be no mix-match between name fields.

- `name` = field on channel
- `display_name` = field on thread

The generic `display_name` can then be returned also for channels without conflicting with the actual `name` field.

https://github.com/odoo/enterprise/pull/75449