### PR TITLE
[FIX] web: export all: correct group counts

### DIFF
--- a/addons/test_import_export/models/models_export.py
+++ b/addons/test_import_export/models/models_export.py
@@ -23,5 +23,7 @@ class ExportAggregatorO2M(models.Model):
     _name = 'export.aggregator.one2many'
     _description = 'Export Aggregator One2Many'
 
+    name = fields.Char()
     parent_id = fields.Many2one('export.aggregator')
     value = fields.Integer()
+    active = fields.Boolean(default=True)


### PR DESCRIPTION
Before this commit, exporting all records in a grouped list view generated wrong group counts in the sheet, because archived records where taken into account (even though they weren't exported). The issue comes from [1], which we kind of revert.

[1] https://github.com/odoo/odoo/pull/166097

task~4375142

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
