### PR TITLE
[FIX] hr_expense: correct mapping of expense alias domain in settings

### DIFF
--- a/addons/hr_expense/models/res_config_settings.py
+++ b/addons/hr_expense/models/res_config_settings.py
@@ -11,6 +11,11 @@ class ResConfigSettings(models.TransientModel):
         compute='_compute_hr_expense_alias_prefix',
         store=True,
         readonly=False)
+    hr_expense_alias_domain_id = fields.Many2one(
+        comodel_name='mail.alias.domain',
+        compute='_compute_hr_expense_alias_domain_id',
+        inverse='_inverse_hr_expense_alias_domain_id',
+        readonly=False)
     hr_expense_use_mailgateway = fields.Boolean(string='Let your employees record expenses by email',
                                              config_parameter='hr_expense.use_mailgateway')
     module_hr_payroll_expense = fields.Boolean(string='Reimburse Expenses in Payslip')
@@ -30,6 +35,7 @@ class ResConfigSettings(models.TransientModel):
         expense_alias = self.env.ref('hr_expense.mail_alias_expense', raise_if_not_found=False)
         res.update(
             hr_expense_alias_prefix=expense_alias.alias_name if expense_alias else False,
+            hr_expense_alias_domain_id=expense_alias.alias_domain_id if expense_alias else False,
         )
         return res
 
@@ -57,3 +63,13 @@ class ResConfigSettings(models.TransientModel):
     @api.depends('hr_expense_use_mailgateway')
     def _compute_hr_expense_alias_prefix(self):
         self.filtered(lambda w: not w.hr_expense_use_mailgateway).hr_expense_alias_prefix = False
+
+    @api.depends('hr_expense_use_mailgateway')
+    def _compute_hr_expense_alias_domain_id(self):
+        self.filtered(lambda w: not w.hr_expense_use_mailgateway).hr_expense_alias_domain_id = False
+
+    def _inverse_hr_expense_alias_domain_id(self):
+        expense_alias = self.env.ref('hr_expense.mail_alias_expense', raise_if_not_found=False)
+        for record in self:
+            if expense_alias and expense_alias.alias_domain_id != record.hr_expense_alias_domain_id:
+                expense_alias.alias_domain_id = record.hr_expense_alias_domain_id

--- a/addons/hr_expense/views/res_config_settings_views.xml
+++ b/addons/hr_expense/views/res_config_settings_views.xml
@@ -19,7 +19,7 @@
                                         <label for="hr_expense_alias_prefix" string="Alias" class="o_light_label"/>
                                         <field name="hr_expense_alias_prefix" class="oe_inline ps-2"/>
                                         <span>@</span>
-                                        <field name="alias_domain_id" class="oe_inline" placeholder="e.g. domain.com"
+                                        <field name="hr_expense_alias_domain_id" class="oe_inline" placeholder="e.g. domain.com"
                                                options="{'no_create': True, 'no_open': True}"/>
                                     </div>
                                 </div>


### PR DESCRIPTION
**Steps to reproduce:**
- Install hr_expense
- Create 2 alias domains
- Go to "Settings / Technical / Email / Aliases"
- Check the values for Expense model
- Go to Expenses settings
- Change the prefix and the domain of the alias
- Save
- Go to "Settings / Technical / Email / Aliases"
- Check the values for Expense model again

**Issue:**
The prefix has correctly been modified but not the domain. The domain from Expenses settings and the domain of the Expense alias are different.

**Cause:**
The domain field in Expenses settings is in fact the Email Domain (alias_domain_id) of the company, which makes no sense to combine the prefix and the domain from 2 different sources.

**Solution:**
Add a non-stored computed field to map the domain displayed in Expenses settings with the domain of the Expense alias.
Not great in stable, but there is no other way if we want to keep the option.

opw-4293936




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
