### PR TITLE
[FIX] sale: disabled price edition

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -549,6 +549,7 @@ class SaleOrderLine(models.Model):
                 or (line.product_id.expense_policy == 'cost' and line.is_expense)
             ):
                 continue
+            line = line.with_context(sale_write_from_compute=True)
             if not line.product_uom or not line.product_id:
                 line.price_unit = 0.0
                 line.technical_price_unit = 0.0
@@ -1177,6 +1178,12 @@ class SaleOrderLine(models.Model):
             if vals.get('display_type') or self.default_get(['display_type']).get('display_type'):
                 vals['product_uom_qty'] = 0.0
 
+            if 'technical_price_unit' in vals and 'price_unit' not in vals:
+                # price_unit field was set as readonly in the view (but technical_price_unit not)
+                # the field is not sent by the client and expected to be recomputed, but isn't
+                # because technical_price_unit is set.
+                vals.pop('technical_price_unit')
+
         lines = super().create(vals_list)
         for line in lines:
             linked_line = line._get_linked_line()
@@ -1206,6 +1213,16 @@ class SaleOrderLine(models.Model):
             precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
             self.filtered(
                 lambda r: r.state == 'sale' and float_compare(r.product_uom_qty, values['product_uom_qty'], precision_digits=precision) != 0)._update_line_quantity(values)
+
+        if (
+            'technical_price_unit' in values
+            and 'price_unit' not in values
+            and not self.env.context.get('sale_write_from_compute')
+        ):
+            # price_unit field was set as readonly in the view (but technical_price_unit not)
+            # the field is not sent by the client and expected to be recomputed, but isn't
+            # because technical_price_unit is set.
+            values.pop('technical_price_unit')
 
         # Prevent writing on a locked SO.
         protected_fields = self._get_protected_fields()


### PR DESCRIPTION
The new `technical_price_unit` logic was introduced to reduce/prevent unexpected price recomputations when the price is manually updated on sale order lines.

Nevertheless, if the price_unit field is made readonly (through studio or any custom view ...), the price would stop being sent to the server by the client, resulting in zero-priced amounts because the presence of the technical price discarded the price recomputation, leading to the default 0 value.

This commit makes sure that in this situation, the technical price sent by the client is dropped, ensuring that the price is correctly computed.

opw-4319211

