### PR TITLE
[IMP] l10n_mx: Set default Base Tax Received Account

### DIFF
--- a/addons/l10n_mx/models/template_mx.py
+++ b/addons/l10n_mx/models/template_mx.py
@@ -18,7 +18,6 @@ class AccountChartTemplate(models.AbstractModel):
             'property_stock_account_input_categ_id': 'cuenta205_06_01',
             'property_stock_account_output_categ_id': 'cuenta107_05_01',
             'property_stock_valuation_account_id': 'cuenta115_01',
-            'property_cash_basis_base_account_id': 'cuenta801_01_99',
         }
 
     @template('mx', 'res.company')
@@ -39,6 +38,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'tax_cash_basis_journal_id': 'cbmx',
                 'account_sale_tax_id': 'tax12',
                 'account_purchase_tax_id': 'tax14',
+                'account_cash_basis_base_account_id': 'cuenta801_01_99',
             },
         }
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- In Mexico, failing to assign an appropriate account for cash basis movements can be considered illegal. Therefore, it's essential to set a default one for Mexican companies.

Current behavior before PR:
- When the 'Cash Basis' (`tax_exigibility`) setting is enabled (via Settings → Accounting → Taxes), no 'Base Tax Received Account' (`account_cash_basis_base_account_id`) is set by default for companies using the 'Mexico' fiscal localization.

Desired behavior after PR is merged:
- For companies with Mexican fiscal localization, set the default *Base Tax Received Account* to the account with code `899.01.99`. This account, already defined in the [l10n_mx data](https://github.com/odoo/odoo/blob/17.0/addons/l10n_mx/data/template/account.account-mx.csv#L47), is specified by the SAT (_Servicio de Administración Tributaria_, Mexico's primary tax authority) for miscellaneous or generic adjustments (see their [official documentation](http://omawww.sat.gob.mx/fichas_tematicas/buzon_tributario/Documents/codigo_agrupador.pdf#page=22)).

opw-[4393526](https://www.odoo.com/odoo/project.task/4393526)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
