### PR TITLE
[IMP] core: remove some openerp remains

### DIFF
--- a/odoo/__init__.py
+++ b/odoo/__init__.py
@@ -2,7 +2,7 @@
 # ruff: noqa: E402, F401
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-""" OpenERP core library."""
+""" Odoo core library."""
 
 # ----------------------------------------------------------
 # odoo must be a namespace package for odoo.addons to become one too

--- a/odoo/addons/base/models/decimal_precision.py
+++ b/odoo/addons/base/models/decimal_precision.py
@@ -71,4 +71,3 @@ class DecimalPrecision(models.Model):
 dp = sys.modules['odoo.addons.base.models.decimal_precision']
 odoo.addons.decimal_precision = dp
 sys.modules['odoo.addons.decimal_precision'] = dp
-sys.modules['openerp.addons.decimal_precision'] = dp

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -25,7 +25,7 @@ _logger = logging.getLogger(__name__)
 
 
 class IrAttachment(models.Model):
-    """Attachments are used to link binary files or url to any openerp document.
+    """Attachments are used to link binary files or url to any Odoo document.
 
     External attachment storage
     ---------------------------

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -154,7 +154,7 @@ class IrCron(models.Model):
         except BadModuleState:
             _logger.warning('Skipping database %s because of modules to install/upgrade/remove.', db_name)
         except psycopg2.errors.UndefinedTable:
-            # The table ir_cron does not exist; this is probably not an OpenERP database.
+            # The table ir_cron does not exist; this is probably not an Odoo database.
             _logger.warning('Tried to poll an undefined table on database %s.', db_name)
         except psycopg2.ProgrammingError as e:
             raise

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -319,7 +319,7 @@ class ResUsersLog(models.Model):
 
 
 class ResUsers(models.Model):
-    """ User class. A res.users record models an OpenERP user and is different
+    """ User class. A res.users record models an Odoo user and is different
         from an employee.
 
         res.users class now inherits from res.partner. The partner model is

--- a/odoo/addons/base/tests/test_cli.py
+++ b/odoo/addons/base/tests/test_cli.py
@@ -115,7 +115,6 @@ class TestCommand(BaseCase):
         self.assertEqual(shell.stdout.read().splitlines(), [
             Like("No environment set..."),
             Like("odoo: <module 'odoo' from '/.../odoo/__init__.py'>"),
-            Like("openerp: <module 'odoo' from '/.../odoo/__init__.py'>"),
             ">>> Hello from Python!",
             '>>> '
         ])

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -407,7 +407,7 @@ class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
         # more intuitive that the union returns all the records, and that
         # a domain like ('parent_id', 'not in', [0]) will return all
         # the records. For instance, if you perform a search for the companies
-        # that don't have OpenERP has a parent company, you expect to find,
+        # that don't have OpenERP as a parent company, you expect to find,
         # among others, the companies that don't have parent company.
         #
 

--- a/odoo/addons/test_inherit/tests/test_inherit.py
+++ b/odoo/addons/test_inherit/tests/test_inherit.py
@@ -24,7 +24,7 @@ class test_inherits(common.TransactionCase):
         # This test checks if the new added column of a parent model
         # is accessible from the child model. This test has been written
         # to verify the purpose of the inheritance computing of the class
-        # in the openerp.osv.orm._build_model.
+        # in the odoo.osv.orm._build_model.
         mother = self.env['test.inherit.mother']
         daughter = self.env['test_inherit_daughter']
 

--- a/odoo/cli/shell.py
+++ b/odoo/cli/shell.py
@@ -127,7 +127,6 @@ class Shell(Command):
 
     def shell(self, dbname):
         local_vars = {
-            'openerp': odoo,
             'odoo': odoo,
         }
         if dbname:

--- a/odoo/import_xml.rng
+++ b/odoo/import_xml.rng
@@ -306,11 +306,10 @@
         </rng:element>
     </rng:define>
 
-    <rng:define name="odoo_openerp_data">
+    <rng:define name="odoo_data">
         <rng:element>
             <rng:choice>
                 <rng:name>odoo</rng:name>
-                <rng:name>openerp</rng:name>
                 <rng:name>data</rng:name>
             </rng:choice>
             <rng:optional><rng:attribute name="noupdate" /></rng:optional>
@@ -319,7 +318,7 @@
             <rng:zeroOrMore>
                 <rng:choice>
                     <rng:text/>
-                    <rng:ref name="odoo_openerp_data"/>
+                    <rng:ref name="odoo_data"/>
                     <rng:ref name="menuitem" />
                     <rng:ref name="record" />
                     <rng:ref name="template" />
@@ -333,6 +332,6 @@
     </rng:define>
 
     <rng:start>
-        <rng:ref name="odoo_openerp_data"/>
+        <rng:ref name="odoo_data"/>
     </rng:start>
 </rng:grammar>

--- a/odoo/modules/__init__.py
+++ b/odoo/modules/__init__.py
@@ -18,7 +18,7 @@ from .module import (
     get_resource_from_path,
     initialize_sys_path,
     get_manifest,
-    load_openerp_module,
+    load_odoo_module,
 )
 
 from . import registry

--- a/odoo/modules/db.py
+++ b/odoo/modules/db.py
@@ -168,7 +168,7 @@ def has_unaccent(cr: BaseCursor) -> FunctionStatus:
     """ Test whether the database has function 'unaccent' and return its status.
 
     The unaccent is supposed to be provided by the PostgreSQL unaccent contrib
-    module but any similar function will be picked by OpenERP.
+    module but any similar function will be picked by Odoo.
 
     :rtype: FunctionStatus
     """

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -23,7 +23,7 @@ from odoo.tools.misc import SENTINEL
 from . import db as modules_db
 from .graph import Graph
 from .migration import MigrationManager
-from .module import adapt_version, initialize_sys_path, load_openerp_module
+from .module import adapt_version, initialize_sys_path, load_odoo_module
 from .registry import Registry
 
 if typing.TYPE_CHECKING:
@@ -206,7 +206,7 @@ def load_module_graph(
             if package.name != 'base':
                 env.flush_all()
 
-        load_openerp_module(package.name)
+        load_odoo_module(package.name)
 
         if new_install:
             py_module = sys.modules['odoo.addons.%s' % (module_name,)]

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -45,7 +45,7 @@ __all__ = [
     "get_modules_with_version",
     "get_resource_from_path",
     "initialize_sys_path",
-    "load_openerp_module",
+    "load_odoo_module",
 ]
 
 MANIFEST_NAMES = ['__manifest__.py']
@@ -104,7 +104,7 @@ TYPED_FIELD_DEFINITION_RE = re.compile(r'''
 _logger = logging.getLogger(__name__)
 
 current_test: bool = False
-"""Indicates whteher we are in a test mode"""
+"""Indicates whether we are in a test mode"""
 
 
 class UpgradeHook:
@@ -359,8 +359,8 @@ def _get_manifest_cached(module, mod_path=None):
     return load_manifest(module, mod_path)
 
 
-def load_openerp_module(module_name: str) -> None:
-    """ Load an OpenERP module, if not already loaded.
+def load_odoo_module(module_name: str) -> None:
+    """ Load an Odoo module, if not already loaded.
 
     This loads the module and register all of its models, thanks to either
     the MetaModel metaclass, or the explicit instantiation of the model.

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -240,7 +240,7 @@ def init_logger():
         except Exception:
             sys.stderr.write("ERROR: couldn't create the logfile directory. Logging to the standard output.\n")
 
-    # Check that handler.stream has a fileno() method: when running OpenERP
+    # Check that handler.stream has a fileno() method: when running Odoo
     # behind Apache with mod_wsgi, handler.stream will have type mod_wsgi.Log,
     # which has no fileno() method. (mod_wsgi.Log is what is being bound to
     # sys.stderr when the logging.StreamHandler is being constructed above.)

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -29,7 +29,7 @@ an infix notation, and the available operators, and possible left and
 right operands differ with those of the previous level. Here is a
 possible term::
 
-    ('company_id.name', '=', 'OpenERP')
+    ('company_id.name', '=', 'Odoo')
 
 The left and right operand don't have the same possible values. The
 left operand is field name (related to the model for which the domain
@@ -42,10 +42,10 @@ operator can be used, and thus the right operand should be a list.
 
 Note: the non-uniform syntax could have been more uniform, but this
 would hide an important limitation of the domain syntax. Say that the
-term representation was ['=', 'company_id.name', 'OpenERP']. Used in a
+term representation was ['=', 'company_id.name', 'Odoo']. Used in a
 complete domain, this would look like::
 
-    ['!', ['=', 'company_id.name', 'OpenERP']]
+    ['!', ['=', 'company_id.name', 'Odoo']]
 
 and you would be tempted to believe something like this would be
 possible::
@@ -106,7 +106,7 @@ You can check unaccent is working:
 
     > psql9 <database> -c"select unaccent('hélène')"
 
-Finally, to instruct OpenERP to really use the unaccent function, you have to
+Finally, to instruct Odoo to really use the unaccent function, you have to
 start the server specifying the ``--unaccent`` flag.
 
 """

--- a/odoo/service/__init__.py
+++ b/odoo/service/__init__.py
@@ -8,7 +8,7 @@ from . import server
 #.apidoc title: RPC Services
 
 """ Classes of this module implement the network protocols that the
-    OpenERP server uses to communicate with remote clients.
+    Odoo server uses to communicate with remote clients.
 
     Some classes are mostly utilities, whose API need not be visible to
     the average user/developer. Study them only if you are about to

--- a/odoo/service/common.py
+++ b/odoo/service/common.py
@@ -35,13 +35,13 @@ def exp_version():
     return RPC_VERSION_1
 
 def exp_about(extended=False):
-    """Return information about the OpenERP Server.
+    """Return information about the Odoo Server.
 
     @param extended: if True then return version info
     @return string if extended is False else tuple
     """
 
-    info = _('See http://openerp.com')
+    info = _('See https://odoo.com')
 
     if extended:
         return info, odoo.release.version

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1248,7 +1248,7 @@ server_phoenix = False
 def load_server_wide_modules():
     for m in config['server_wide_modules']:
         try:
-            odoo.modules.module.load_openerp_module(m)
+            odoo.modules.module.load_odoo_module(m)
         except Exception:
             msg = ''
             if m == 'web':
@@ -1258,7 +1258,7 @@ Maybe you forgot to add those addons in your addons_path configuration."""
             _logger.exception('Failed to load server-wide module `%s`.%s', m, msg)
 
 def _reexec(updated_modules=None):
-    """reexecute openerp-server process with (nearly) the same arguments"""
+    """reexecute odoo-server process with (nearly) the same arguments"""
     if osutil.is_running_as_nt_service():
         subprocess.call('net stop {0} && net start {0}'.format(nt_service_name), shell=True)
     exe = os.path.basename(sys.executable)

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -2,7 +2,7 @@
 
 
 """
-The PostgreSQL connector is a connectivity layer between the OpenERP code and
+The PostgreSQL connector is a connectivity layer between the Odoo code and
 the database, *not* a database abstraction toolkit. Database abstraction is what
 the ORM does, in fact.
 """

--- a/odoo/tools/cloc.py
+++ b/odoo/tools/cloc.py
@@ -12,7 +12,6 @@ from odoo.tools.config import config
 VERSION = 1
 DEFAULT_EXCLUDE = [
     "__manifest__.py",
-    "__openerp__.py",
     "tests/**/*",
     "static/lib/**/*",
     "static/tests/**/*",

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -184,7 +184,7 @@ class configmanager:
         group.add_option("-c", "--config", dest="config", type='path', file_loadable=False,
                          help="specify alternate config file")
         group.add_option("-s", "--save", action="store_true", dest="save", my_default=False, file_loadable=False,
-                         help="save configuration to ~/.odoorc (or to ~/.openerp_serverrc if it exists)")
+                         help="save configuration to ~/.odoorc")
         group.add_option("-i", "--init", dest="init", type='comma', metavar="MODULE,...", my_default=[], file_loadable=False,
                          help="install one or more modules (comma-separated list, use \"all\" for all modules), requires -d")
         group.add_option("-u", "--update", dest="update", type='comma',  metavar="MODULE,...", my_default=[], file_loadable=False,
@@ -460,14 +460,10 @@ class configmanager:
 
         if rcfilepath := os.getenv('ODOO_RC'):
             pass
-        elif rcfilepath := os.getenv('OPENERP_SERVER'):
-            self._warn("Since ages ago, the OPENERP_SERVER environment variable has been replaced by ODOO_RC", DeprecationWarning)
         elif os.name == 'nt':
             rcfilepath = os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])), 'odoo.conf')
         elif os.path.isfile(rcfilepath := os.path.expanduser('~/.odoorc')):
             pass
-        elif os.path.isfile(rcfilepath := os.path.expanduser('~/.openerp_serverrc')):
-            self._warn("Since ages ago, the ~/.openerp_serverrc file has been replaced by ~/.odoorc", DeprecationWarning)
         else:
             rcfilepath = '~/.odoorc'
         self._default_options['config'] = self._normalize(rcfilepath)
@@ -501,7 +497,7 @@ class configmanager:
         """ Parse the configuration file (if any) and the command-line
         arguments.
 
-        This method initializes odoo.tools.config and openerp.conf (the
+        This method initializes odoo.tools.config and odoo.conf (the
         former should be removed in the future) with library-wide
         configuration values.
 

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -590,9 +590,9 @@ form: module.record_id""" % (xml_id,)
         }
 
     def parse(self, de):
-        assert de.tag in self.DATA_ROOTS, "Root xml tag must be <openerp>, <odoo> or <data>."
+        assert de.tag in self.DATA_ROOTS, "Root xml tag must be <odoo> or <data>."
         self._tag_root(de)
-    DATA_ROOTS = ['odoo', 'data', 'openerp']
+    DATA_ROOTS = ['odoo', 'data']
 
 def convert_file(env, module, filename, idref, mode='update', noupdate=False, kind=None, pathname=None):
     if pathname is None:

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -96,7 +96,7 @@ def float_round(value, precision_digits=None, precision_rounding=None, rounding_
     # To correct this, we add a very small epsilon value, scaled to the
     # the order of magnitude of the value, to tip the tie-break in the right
     # direction.
-    # Credit: discussion with OpenERP community members on bug 882036
+    # Credit: discussion with Odoo community members on bug 882036
     epsilon_magnitude = math.log2(abs(normalized_value))
     # `2**(epsilon_magnitude - 52)` would be the minimal size, but we increase it to be
     # more tolerant of inaccuracies accumulated after multiple floating point operations

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -469,7 +469,7 @@ def get_iso_codes(lang: str) -> str:
 
 
 def scan_languages() -> list[tuple[str, str]]:
-    """ Returns all languages supported by OpenERP for translation
+    """ Returns all languages supported by Odoo for translation
 
     :returns: a list of (lang_code, lang_name) pairs
     :rtype: [(str, unicode)]

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -6,7 +6,7 @@ safe_eval module - methods intended to provide more restricted alternatives to
                    evaluate simple and/or untrusted code.
 
 Methods in this module are typically used as alternatives to eval() to parse
-OpenERP domain strings, conditions and expressions, mostly based on locals
+Odoo domain strings, conditions and expressions, mostly based on locals
 condition/math builtins.
 """
 
@@ -346,7 +346,7 @@ def safe_eval(expr, globals_dict=None, locals_dict=None, mode="eval", nocopy=Fal
     objects directly provided in context.
 
     This can be used to e.g. evaluate
-    an OpenERP domain expression from an untrusted source.
+    an Odoo domain expression from an untrusted source.
 
     :param filename: optional pseudo-filename for the compiled expression,
                      displayed for example in traceback frames

--- a/setup/odoo-wsgi.example.py
+++ b/setup/odoo-wsgi.example.py
@@ -6,11 +6,11 @@
 #
 # For generic wsgi handlers a global application is defined.
 # For uwsgi this should work:
-#   $ uwsgi_python --http :9090 --pythonpath . --wsgi-file openerp-wsgi.py
+#   $ uwsgi_python --http :9090 --pythonpath . --wsgi-file odoo-wsgi.py
 #
 # For gunicorn additional globals need to be defined in the Gunicorn section.
 # Then the following command should run:
-#   $ gunicorn odoo:service.wsgi_server.application -c openerp-wsgi.py
+#   $ gunicorn odoo:service.wsgi_server.application -c odoo-wsgi.py
 
 import odoo
 
@@ -20,7 +20,7 @@ import odoo
 
 conf = odoo.tools.config
 
-# Path to the OpenERP Addons repository (comma-separated for
+# Path to the Odoo Addons repository (comma-separated for
 # multiple locations)
 #conf['addons_path'] = './odoo/addons,./addons'
 
@@ -41,7 +41,7 @@ odoo.service.server.load_server_wide_modules()
 #----------------------------------------------------------
 # Gunicorn
 #----------------------------------------------------------
-# Standard OpenERP XML-RPC port is 8069
+# Standard Odoo XML-RPC port is 8069
 bind = '127.0.0.1:8069'
 pidfile = '.gunicorn.pid'
 workers = 4


### PR DESCRIPTION
Continuation of https://github.com/odoo/odoo/commit/298ecdb77422ae726c9650d1c242d97621ed799b, that removed `__openerp__.py` from manifest names.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr