### PR TITLE
[FIX] base: not showing email for widget contact

### DIFF
--- a/odoo/addons/base/views/ir_qweb_widget_templates.xml
+++ b/odoo/addons/base/views/ir_qweb_widget_templates.xml
@@ -37,7 +37,7 @@
             <div t-if="phone and 'phone' in fields"><i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-phone fa-fw' role="img" aria-label="Phone" title="Phone"/> <span class="o_force_ltr" itemprop="telephone" t-esc="phone"/></div>
             <div t-if="mobile and 'mobile' in fields"><i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-mobile fa-fw' role="img" aria-label="Mobile" title="Mobile"/> <span class="o_force_ltr" itemprop="telephone" t-esc="mobile"/></div>
             <!-- Prevent issue with iOS Safari parsing of schema data without telephone itemprops -->
-            <div t-elif="not (phone and 'phone' in fields)" itemprop="telephone"/>
+            <div t-if="not (phone and 'phone' in fields or mobile and 'mobile' in fields)" itemprop="telephone"/>
             <div t-if="website and 'website' in fields">
                 <i t-if="not options.get('no_marker')" class='fa fa-globe' role="img" aria-label="Website" title="Website"/>
                 <a t-att-href="website and '%s%s' % ('http://' if '://' not in website else '',website)"><span itemprop="website" t-esc="website"/></a>


### PR DESCRIPTION
* Close https://github.com/odoo/odoo/issues/190009
* Since https://github.com/odoo/odoo/pull/187143 , when using widget contact with email field or any fields that come after phone (see the order in ir_qweb_widget_templates.xml) it all gone
* This commit fix by using t-if not t-elif anymore

After the fix we still get the desired behavior when user has no phone or mobile

![2024-12-11_10-56](https://github.com/user-attachments/assets/9a97638e-78aa-4a23-9572-f217856e757d)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
