### PR TITLE
[IMP] stock: sync sequence prefix with sequence code

### DIFF
--- a/addons/l10n_it_stock_ddt/__init__.py
+++ b/addons/l10n_it_stock_ddt/__init__.py
@@ -8,7 +8,7 @@ def _create_picking_seq(env):
         wh = ptype.warehouse_id
         ptype.l10n_it_ddt_sequence_id = env['ir.sequence'].create({
         'name': wh.name + ' ' + ' Sequence ' + ' ' + ptype.sequence_code,
-        'prefix': wh.code + '/' + ptype.sequence_code + '/DDT', 'padding': 5,
+        'prefix': ptype.sequence_code + 'DDT', 'padding': 5,
         'company_id': wh.company_id.id,
         'implementation': 'no_gap',
     }).id

--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -212,9 +212,9 @@ class StockWarehouse(models.Model):
     def _get_sequence_values(self, name=False, code=False):
         values = super(StockWarehouse, self)._get_sequence_values(name=name, code=code)
         values.update({
-            'pbm_type_id': {'name': _('%(name)s Sequence picking before manufacturing', name=self.name), 'prefix': self.code + '/' + (self.pbm_type_id.sequence_code or 'PC') + '/', 'padding': 5, 'company_id': self.company_id.id},
-            'sam_type_id': {'name': _('%(name)s Sequence stock after manufacturing', name=self.name), 'prefix': self.code + '/' + (self.sam_type_id.sequence_code or 'SFP') + '/', 'padding': 5, 'company_id': self.company_id.id},
-            'manu_type_id': {'name': _('%(name)s Sequence production', name=self.name), 'prefix': self.code + '/' + (self.manu_type_id.sequence_code or 'MO') + '/', 'padding': 5, 'company_id': self.company_id.id},
+            'pbm_type_id': {'name': _('%(name)s Sequence picking before manufacturing', name=self.name), 'prefix': self.code + '/PC/', 'padding': 5, 'company_id': self.company_id.id},
+            'sam_type_id': {'name': _('%(name)s Sequence stock after manufacturing', name=self.name), 'prefix': self.code + '/SFP/', 'padding': 5, 'company_id': self.company_id.id},
+            'manu_type_id': {'name': _('%(name)s Sequence production', name=self.name), 'prefix': self.code + '/MO/', 'padding': 5, 'company_id': self.company_id.id},
         })
         return values
 
@@ -229,7 +229,6 @@ class StockWarehouse(models.Model):
                 'default_location_src_id': self.lot_stock_id.id,
                 'default_location_dest_id': self.pbm_loc_id.id,
                 'sequence': next_sequence + 1,
-                'sequence_code': 'PC',
                 'company_id': self.company_id.id,
             },
             'sam_type_id': {
@@ -240,7 +239,6 @@ class StockWarehouse(models.Model):
                 'default_location_src_id': self.sam_loc_id.id,
                 'default_location_dest_id': self.lot_stock_id.id,
                 'sequence': next_sequence + 3,
-                'sequence_code': 'SFP',
                 'company_id': self.company_id.id,
             },
             'manu_type_id': {
@@ -249,7 +247,6 @@ class StockWarehouse(models.Model):
                 'use_create_lots': True,
                 'use_existing_lots': True,
                 'sequence': next_sequence + 2,
-                'sequence_code': 'MO',
                 'company_id': self.company_id.id,
             },
         })

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -3703,14 +3703,14 @@ class TestMrpOrder(TestMrpCommon):
         picking_type_1 = self.env['stock.picking.type'].create({
             'name': 'new_picking_type_1',
             'code': 'mrp_operation',
-            'sequence_code': 'PT1',
+            'sequence_code': 'BWH/PT1/',
             'default_location_src_id': stock_location_1.id,
             'default_location_dest_id': stock_location_1.id,
             'warehouse_id': self.warehouse_1.id,
         })
         picking_type_2 = picking_type_1.copy({
             'name': 'new_picking_type_2',
-            'sequence_code': 'PT2',
+            'sequence_code': 'BWH/PT2/',
             'default_location_src_id': stock_location_2.id,
             'default_location_dest_id': stock_location_2.id,
         })

--- a/addons/mrp_subcontracting/models/stock_warehouse.py
+++ b/addons/mrp_subcontracting/models/stock_warehouse.py
@@ -135,7 +135,6 @@ class StockWarehouse(models.Model):
                 'code': 'mrp_operation',
                 'use_create_components_lots': True,
                 'sequence': next_sequence + 2,
-                'sequence_code': 'SBC',
                 'company_id': self.company_id.id,
             },
             'subcontracting_resupply_type_id': {
@@ -145,7 +144,6 @@ class StockWarehouse(models.Model):
                 'use_existing_lots': True,
                 'default_location_dest_id': self._get_subcontracting_location().id,
                 'sequence': next_sequence + 3,
-                'sequence_code': 'RES',
                 'print_label': True,
                 'company_id': self.company_id.id,
             }
@@ -158,13 +156,13 @@ class StockWarehouse(models.Model):
         values.update({
             'subcontracting_type_id': {
                 'name': _('%(name)s Sequence subcontracting', name=self.name),
-                'prefix': self.code + '/' + (self.subcontracting_type_id.sequence_code or (('SBC' + str(count)) if count else 'SBC')) + '/',
+                'prefix': self.code + '/' + ('SBC' + str(count) if count else 'SBC') + '/',
                 'padding': 5,
                 'company_id': self.company_id.id
             },
             'subcontracting_resupply_type_id': {
                 'name': _('%(name)s Sequence Resupply Subcontractor', name=self.name),
-                'prefix': self.code + '/' + (self.subcontracting_resupply_type_id.sequence_code or (('RES' + str(count)) if count else 'RES')) + '/',
+                'prefix': self.code + '/' + ('RES' + str(count) if count else 'RES') + '/',
                 'padding': 5,
                 'company_id': self.company_id.id
             },

--- a/addons/mrp_subcontracting_dropshipping/models/res_company.py
+++ b/addons/mrp_subcontracting_dropshipping/models/res_company.py
@@ -36,7 +36,6 @@ class ResCompany(models.Model):
                 'code': 'dropship',
                 'default_location_src_id': self.env.ref('stock.stock_location_suppliers').id,
                 'default_location_dest_id': company.subcontracting_location_id.id,
-                'sequence_code': 'DSC',
                 'use_existing_lots': False,
             })
         if pick_type_vals:

--- a/addons/point_of_sale/models/stock_warehouse.py
+++ b/addons/point_of_sale/models/stock_warehouse.py
@@ -13,7 +13,7 @@ class StockWarehouse(models.Model):
         sequence_values.update({
             'pos_type_id': {
                 'name': _('%(name)s Picking POS', name=self.name),
-                'prefix': self.code + '/' + (self.pos_type_id.sequence_code or 'POS') + '/',
+                'prefix': self.code + '/POS/',
                 'padding': 5,
                 'company_id': self.company_id.id,
             }
@@ -36,7 +36,6 @@ class StockWarehouse(models.Model):
                 'default_location_src_id': self.lot_stock_id.id,
                 'default_location_dest_id': self.env.ref('stock.stock_location_customers').id,
                 'sequence': max_sequence + 1,
-                'sequence_code': 'POS',
                 'company_id': self.company_id.id,
             }
         })

--- a/addons/repair/data/repair_data.xml
+++ b/addons/repair/data/repair_data.xml
@@ -14,7 +14,7 @@
         <field name="default_location_dest_id" model="stock.location" search="[('usage', '=', 'production'), ('company_id', '=', obj().env.ref('base.main_company').id)]"/>
         <field name="default_remove_location_dest_id" model="stock.location" search="[('usage', '=', 'inventory'), ('company_id', '=', obj().env.ref('base.main_company').id)]"/>
         <field name="default_recycle_location_dest_id" ref="stock.stock_location_stock"/>
-        <field name="sequence_code">RO</field>
+        <field name="sequence_code">WH/RO/</field>
         <field name="warehouse_id" ref="stock.warehouse0"/>
     </record>
 

--- a/addons/repair/models/stock_warehouse.py
+++ b/addons/repair/models/stock_warehouse.py
@@ -17,7 +17,7 @@ class StockWarehouse(models.Model):
         values.update({
             'repair_type_id': {
                 'name': _('%(name)s Sequence repair', name=self.name),
-                'prefix': self.code + '/' + (self.repair_type_id.sequence_code or 'RO') + '/',
+                'prefix': self.code + '/RO/',
                 'padding': 5,
                 'company_id': self.company_id.id
                 },
@@ -37,7 +37,6 @@ class StockWarehouse(models.Model):
                 'default_remove_location_dest_id': scrap_location_id,
                 'default_recycle_location_dest_id': self.lot_stock_id.id,
                 'sequence': next_sequence + 1,
-                'sequence_code': 'RO',
                 'company_id': self.company_id.id,
                 'use_create_lots': True,
                 'use_existing_lots': True,

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -192,6 +192,8 @@ class StockPickingType(models.Model):
                     raise UserError(_("Changing the company of this record is forbidden at this point, you should rather archive it and create a new one."))
         if 'sequence_code' in vals:
             for picking_type in self:
+                if vals.get('sequence_id') is False:  # revert the sequence_id
+                    vals['sequence_id'] = picking_type.sequence_id.id
                 if picking_type.warehouse_id:
                     picking_type.sequence_id.sudo().write({
                         'name': _('%(warehouse)s Sequence %(code)s', warehouse=picking_type.warehouse_id.name, code=vals['sequence_code']),

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -29,7 +29,7 @@ class StockPickingType(models.Model):
     sequence_id = fields.Many2one(
         'ir.sequence', 'Reference Sequence',
         check_company=True, copy=False)
-    sequence_code = fields.Char('Sequence Prefix', required=True)
+    sequence_code = fields.Char('Sequence Prefix', related='sequence_id.prefix', readonly=False)
     default_location_src_id = fields.Many2one(
         'stock.location', 'Source Location', compute='_compute_default_location_src_id',
         check_company=True, store=True, readonly=False, precompute=True, required=True,
@@ -164,13 +164,13 @@ class StockPickingType(models.Model):
                     wh = self.env['stock.warehouse'].browse(vals['warehouse_id'])
                     vals['sequence_id'] = self.env['ir.sequence'].sudo().create({
                         'name': _('%(warehouse)s Sequence %(code)s', warehouse=wh.name, code=vals['sequence_code']),
-                        'prefix': wh.code + '/' + vals['sequence_code'] + '/', 'padding': 5,
+                        'padding': 5,
                         'company_id': wh.company_id.id,
                     }).id
                 else:
                     vals['sequence_id'] = self.env['ir.sequence'].sudo().create({
                         'name': _('Sequence %(code)s', code=vals['sequence_code']),
-                        'prefix': vals['sequence_code'], 'padding': 5,
+                        'padding': 5,
                         'company_id': vals.get('company_id') or self.env.company.id,
                     }).id
         return super().create(vals_list)
@@ -195,13 +195,13 @@ class StockPickingType(models.Model):
                 if picking_type.warehouse_id:
                     picking_type.sequence_id.sudo().write({
                         'name': _('%(warehouse)s Sequence %(code)s', warehouse=picking_type.warehouse_id.name, code=vals['sequence_code']),
-                        'prefix': picking_type.warehouse_id.code + '/' + vals['sequence_code'] + '/', 'padding': 5,
+                        'padding': 5,
                         'company_id': picking_type.warehouse_id.company_id.id,
                     })
                 else:
                     picking_type.sequence_id.sudo().write({
                         'name': _('Sequence %(code)s', code=vals['sequence_code']),
-                        'prefix': vals['sequence_code'], 'padding': 5,
+                        'padding': 5,
                         'company_id': picking_type.env.company.id,
                     })
         if 'reservation_method' in vals:

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -982,14 +982,12 @@ class StockWarehouse(models.Model):
                 'code': 'incoming',
                 'use_existing_lots': False,
                 'sequence': max_sequence + 1,
-                'sequence_code': 'IN',
                 'company_id': self.company_id.id,
             }, 'out_type_id': {
                 'name': _('Delivery Orders'),
                 'code': 'outgoing',
                 'use_create_lots': False,
                 'sequence': max_sequence + 7,
-                'sequence_code': 'OUT',
                 'print_label': True,
                 'company_id': self.company_id.id,
             }, 'pack_type_id': {
@@ -1000,7 +998,6 @@ class StockWarehouse(models.Model):
                 'default_location_src_id': self.wh_pack_stock_loc_id.id,
                 'default_location_dest_id': output_loc.id,
                 'sequence': max_sequence + 6,
-                'sequence_code': 'PACK',
                 'company_id': self.company_id.id,
             }, 'pick_type_id': {
                 'name': _('Pick'),
@@ -1009,7 +1006,6 @@ class StockWarehouse(models.Model):
                 'use_existing_lots': True,
                 'default_location_src_id': self.lot_stock_id.id,
                 'sequence': max_sequence + 5,
-                'sequence_code': 'PICK',
                 'company_id': self.company_id.id,
             }, 'qc_type_id': {
                 'name': _('Quality Control'),
@@ -1019,7 +1015,6 @@ class StockWarehouse(models.Model):
                 'default_location_src_id': self.wh_input_stock_loc_id.id,
                 'default_location_dest_id': self.wh_qc_stock_loc_id.id,
                 'sequence': max_sequence + 2,
-                'sequence_code': 'QC',
                 'company_id': self.company_id.id,
             }, 'store_type_id': {
                 'name': _('Storage'),
@@ -1028,7 +1023,6 @@ class StockWarehouse(models.Model):
                 'use_existing_lots': True,
                 'default_location_dest_id': self.lot_stock_id.id,
                 'sequence': max_sequence + 3,
-                'sequence_code': 'STOR',
                 'company_id': self.company_id.id,
             }, 'int_type_id': {
                 'name': _('Internal Transfers'),
@@ -1039,7 +1033,6 @@ class StockWarehouse(models.Model):
                 'default_location_dest_id': self.lot_stock_id.id,
                 'active': self.env.user.has_group('stock.group_stock_multi_locations'),
                 'sequence': max_sequence + 4,
-                'sequence_code': 'INT',
                 'company_id': self.company_id.id,
             }, 'xdock_type_id': {
                 'name': _('Cross Dock'),
@@ -1049,7 +1042,6 @@ class StockWarehouse(models.Model):
                 'default_location_src_id': self.wh_input_stock_loc_id.id,
                 'default_location_dest_id': self.wh_output_stock_loc_id.id,
                 'sequence': max_sequence + 8,
-                'sequence_code': 'XD',
                 'company_id': self.company_id.id,
             }
         }, max_sequence + 9
@@ -1063,42 +1055,42 @@ class StockWarehouse(models.Model):
         return {
             'in_type_id': {
                 'name': _('%(name)s Sequence in', name=name),
-                'prefix': code + '/' + (self.in_type_id.sequence_code or 'IN') + '/', 'padding': 5,
+                'prefix': code + '/IN/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
             'out_type_id': {
                 'name': _('%(name)s Sequence out', name=name),
-                'prefix': code + '/' + (self.out_type_id.sequence_code or 'OUT') + '/', 'padding': 5,
+                'prefix': code + '/OUT/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
             'pack_type_id': {
                 'name': _('%(name)s Sequence packing', name=name),
-                'prefix': code + '/' + (self.pack_type_id.sequence_code or 'PACK') + '/', 'padding': 5,
+                'prefix': code + '/PACK/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
             'pick_type_id': {
                 'name': _('%(name)s Sequence picking', name=name),
-                'prefix': code + '/' + (self.pick_type_id.sequence_code or 'PICK') + '/', 'padding': 5,
+                'prefix': code + '/PICK/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
             'qc_type_id': {
                 'name': _('%(name)s Sequence quality control', name=name),
-                'prefix': code + '/' + (self.qc_type_id.sequence_code or 'QC') + '/', 'padding': 5,
+                'prefix': code + '/QC/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
             'store_type_id': {
                 'name': _('%(name)s Sequence storage', name=name),
-                'prefix': code + '/' + (self.store_type_id.sequence_code or 'STOR') + '/', 'padding': 5,
+                'prefix': code + '/STOR/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
             'int_type_id': {
                 'name': _('%(name)s Sequence internal', name=name),
-                'prefix': code + '/' + (self.int_type_id.sequence_code or 'INT') + '/', 'padding': 5,
+                'prefix': code + '/INT/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
             'xdock_type_id': {
                 'name': _('%(name)s Sequence cross dock', name=name),
-                'prefix': code + '/' + (self.xdock_type_id.sequence_code or 'XD') + '/', 'padding': 5,
+                'prefix': code + '/XD/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
         }

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -90,7 +90,7 @@
                                     <field name="hide_reservation_method" invisible="1"/>
                                     <field name="show_picking_type" invisible="1"/>
                                     <field name="sequence_id" groups="base.group_no_one"/>
-                                    <field name="sequence_code"/>
+                                    <field name="sequence_code" required="1"/>
                                     <field name="warehouse_id" groups="stock.group_stock_multi_warehouses" force_save="1"/>
                                     <field name="reservation_method" invisible="hide_reservation_method" widget="radio"/>
                                     <span invisible="code == 'incoming' or reservation_method != 'by_date'"/>

--- a/addons/stock_dropshipping/models/res_company.py
+++ b/addons/stock_dropshipping/models/res_company.py
@@ -52,7 +52,6 @@ class ResCompany(models.Model):
                 'code': 'dropship',
                 'default_location_src_id': self.env.ref('stock.stock_location_suppliers').id,
                 'default_location_dest_id': self.env.ref('stock.stock_location_customers').id,
-                'sequence_code': 'DS',
                 'use_existing_lots': False,
             })
         if dropship_vals:


### PR DESCRIPTION
In This PR:
---------------
1. Prefix Sync
    
    - The prefix displayed on operation types now directly reflects the prefix of 
      their reference sequence.
    - This avoids inconsistencies and eliminates the need for manual updates when
      the sequence prefix changes.

2. Simplify Prefix For Default Operation Types

    Before: Prefix = `WH Code + (Dynamic Sequence Code or Default Code)`
    After: Prefix = `WH Code + Default Code`
    - The prefix for picking types is now consistently generated using the warehouse
      code and default code only.
    - Dynamic sequence codes no longer affect the prefix as changes are handled directly
      through the reference sequence.

3. Italy Stock DDT Prefix Alignment

    Before: Prefix = `WH Code + Sequence Code + DDT`
    After: Prefix = `Sequence Code + DDT`
    
    Since the sequence code already includes the warehouse code, there's no need to
    manually prepend it. This ensures the DDT sequence remains aligned with the
    operation sequence.

4. Auto-Recovery for Missing Sequences

    - If a picking type still has a sequence_code but its reference sequence was
      removed, it is now restored automatically.
    - This ensures the prefix stays consistent and avoids broken configurations.

Impact:
---------
Users can now view the `actual sequence prefix` used on pickings, rather than just the code used to generate it.
This provides better clarity and improves the user experience by making the real sequence prefix directly visible and accessible.

task-4344313