### PR TITLE
[FIX] point_of_sale: validate orders to be shipped later (blackbox)

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1411,7 +1411,7 @@ class PosOrderLine(models.Model):
             group_id = line._get_procurement_group()
             if not group_id:
                 group_id = self.env['procurement.group'].create(line._prepare_procurement_group_vals())
-                line.order_id.procurement_group_id = group_id
+                line.order_id.with_context(backend_recomputation=True).write({'procurement_group_id': group_id})
 
             values = line._prepare_procurement_values(group_id=group_id)
             product_qty = line.qty


### PR DESCRIPTION
Currently, when using `pos_blackbox_be`, if you make an order to be shipped later, you cannot validate your order.

Steps to reproduce:
-------------------
* Install `pos_blackbox_be`
* Set up the blackbox on the pos store
* Configure the shop to allow shipping later
* Open shop
* Make an order
* Select customer and ship for a later date
* Select payment method and try to validate
> Observation: Error message: Modifying registered orders in not allowed

Why the fix:
------------
The error is trigerred by a write operation on a `pos.order` record.

The field that is being modified is not in the list of white listed fields https://github.com/odoo/enterprise/blob/ade74c4ebecc1d78fe9cd4a4301b332cb79fc6db/pos_blackbox_be/models/pos_order.py#L89-L97

By passing `backend_recomputation=True` in the context we bypass the check of whitelisted fields. It allows to fix without having to modifying the blackbox code.

opw-4369744
