### PR TITLE
[IMP] mail: make Recipients required when invite to follow

### DIFF
--- a/addons/mail/wizard/mail_wizard_invite.py
+++ b/addons/mail/wizard/mail_wizard_invite.py
@@ -15,7 +15,7 @@ class MailWizardInvite(models.TransientModel):
 
     res_model = fields.Char('Related Document Model', required=True, help='Model of the followed resource')
     res_id = fields.Integer('Related Document ID', help='Id of the followed resource')
-    partner_ids = fields.Many2many('res.partner', string='Recipients')
+    partner_ids = fields.Many2many('res.partner', string='Recipients', required=True)
     message = fields.Html('Message')
     notify = fields.Boolean('Notify Recipients', default=False)
 


### PR DESCRIPTION
* Currently 'Recipients' can be empty when hitting button 'Add and Close' when open 'Add Followers' wizard
* After this commit, 'Recipients' will be required

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
