### PR TITLE
[18.0][FIX] mail: catch `imaplib.IMAP4.abort` errors when closing IMAP connection

### DIFF
--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -253,7 +253,7 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
                         try:
                             imap_server.close()
                             imap_server.logout()
-                        except OSError:
+                        except (OSError, IMAP4.abort):
                             _logger.warning('Failed to properly finish imap connection: %s.', server.name, exc_info=True)
             elif connection_type == 'pop':
                 try:


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

This error could be raised if oAuth session has expired before Odoo gets a chance to close the IMAP connection:

```
<class 'imaplib.IMAP4.abort'>: \"socket error: [Errno 32] Broken pipe\" while evaluating\n'model._fetch_mails()
```

We get this error from time to time when fetching emails from a Gmail account configured with Google oAuth.

### Current behavior before PR:

Fetchmail scheduled action hangs when this happens, and no email are fetched anymore (dangling connection still in worker process, until this worker is recycled? Is it possible?).

### Desired behavior after PR is merged:

Catch properly the exception and have a scheduled action terminating nicely.

We did this patch on v14, but we are not entirely sure it is fixing the encountered issue as this happened randomly, and very rarely.
But I guess it is anyway a good thing to catch such errors to get a WARNING log, like it has been done by catching `OSError` for timeout issues.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
