### PR TITLE
[FIX] delivery: avoid carrier UserError in batch picking validation

### DIFF
--- a/addons/delivery/i18n/delivery.pot
+++ b/addons/delivery/i18n/delivery.pot
@@ -485,6 +485,20 @@ msgid "Estimated cost"
 msgstr ""
 
 #. module: delivery
+#. odoo-python
+#: code:addons/delivery/models/stock_picking.py:0
+#, python-format
+msgid "Exception occurred with respect to carrier on the transfer"
+msgstr ""
+
+#. module: delivery
+#. odoo-python
+#: code:addons/delivery/models/stock_picking.py:0
+#, python-format
+msgid "Exception:"
+msgstr ""
+
+#. module: delivery
 #: model:ir.model.fields,help:delivery.field_sale_order__carrier_id
 msgid "Fill this field if you plan to invoice the shipping based on picking."
 msgstr ""
@@ -639,6 +653,13 @@ msgstr ""
 #. module: delivery
 #: model_terms:ir.actions.act_window,help:delivery.action_delivery_zip_prefix_list
 msgid "Manage delivery zip prefixes"
+msgstr ""
+
+#. module: delivery
+#. odoo-python
+#: code:addons/delivery/models/stock_picking.py:0
+#, python-format
+msgid "Manual actions might be needed."
 msgstr ""
 
 #. module: delivery

--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -3,8 +3,10 @@
 
 import json
 from collections import defaultdict
+from datetime import date
+from markupsafe import Markup
 
-from odoo import models, fields, api, _
+from odoo import models, fields, api, _, SUPERUSER_ID
 from odoo.exceptions import UserError
 from odoo.tools.sql import column_exists, create_column
 
@@ -189,11 +191,42 @@ class StockPicking(models.Model):
         for picking in self:
             picking.weight = sum(move.weight for move in picking.move_ids if move.state != 'cancel')
 
+    def _carrier_exception_note(self, exception):
+        self.ensure_one()
+        line_1 = _("Exception occurred with respect to carrier on the transfer")
+        line_2 = _("Manual actions might be needed.")
+        line_3 = _("Exception:")
+        return Markup('<div> {line_1} <a href="#" data-oe-model="stock.picking" data-oe-id="{picking_id}"> {picking_name}</a>. {line_2}<div class="mt16"><p>{line_3} {exception}</p></div></div>').format(line_1=line_1, line_2=line_2, line_3=line_3, picking_id=self.id, picking_name=self.name, exception=exception)
+
     def _send_confirmation_email(self):
+        # The carrier's API processes validity checks and parcels generation one picking at a time.
+        # However, since a UserError of any of the picking will cause a rollback of the entire batch
+        # on Odoo's side and since pickings that were already processed on the carrier's side must
+        # stay validated, UserErrors might need to be replaced by activity warnings.
+
+        processed_carrier_picking = False
+
         for pick in self:
-            if pick.carrier_id and pick.carrier_id.integration_level == 'rate_and_ship' and pick.picking_type_code != 'incoming' and not pick.carrier_tracking_ref and pick.picking_type_id.print_label:
-                pick.sudo().send_to_shipper()
-            pick._check_carrier_details_compliance()
+            try:
+                if pick.carrier_id and pick.carrier_id.integration_level == 'rate_and_ship' and pick.picking_type_code != 'incoming' and not pick.carrier_tracking_ref and pick.picking_type_id.print_label:
+                    pick.sudo().send_to_shipper()
+                pick._check_carrier_details_compliance()
+                if pick.carrier_id:
+                    processed_carrier_picking = True
+            except (UserError) as e:
+                if processed_carrier_picking:
+                    # We can not raise a UserError at this point
+                    exception_message = str(e)
+                    pick.message_post(body=exception_message, message_type='notification')
+                    pick.sudo().activity_schedule(
+                        'mail.mail_activity_data_warning',
+                        date.today(),
+                        note=pick._carrier_exception_note(exception_message),
+                        user_id=pick.user_id.id or self.env.user.id or SUPERUSER_ID,
+                        )
+                else:
+                    raise e
+
         return super(StockPicking, self)._send_confirmation_email()
 
     def _pre_put_in_pack_hook(self, move_line_ids):

--- a/addons/delivery/tests/test_carrier_propagation.py
+++ b/addons/delivery/tests/test_carrier_propagation.py
@@ -1,3 +1,7 @@
+from unittest.mock import patch, DEFAULT
+
+from odoo import Command
+from odoo.exceptions import UserError
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
@@ -123,3 +127,70 @@ class TestCarrierPropagation(TransactionCase):
                 self.normal_delivery,
                 move_pack.picking_id.carrier_id,
         )
+
+    def test_carrier_picking_batch_validation(self):
+        """
+        Create 2 delivery orders with carriers. Make them respectively
+        valid and invalid on the carrier side. Validate the pickings in batch
+        Since the pickings are processed unbatched on the carrier side the
+        "UserError" of the invalid picking can not be raised and should be
+        replaced by a warning activity.
+        """
+        self.warehouse.delivery_steps = "ship_only"
+        alien = self.env['res.users'].create({
+            'login': 'Mars Man',
+            'name': 'Spleton',
+            'email': 'alien@mars.com',
+        })
+        super_product_2 = self.ProductProduct.create({
+            'name': 'Super Product 2',
+            'invoice_policy': 'delivery',
+        })
+        sale_orders = self.env['sale.order'].create([
+            {
+                'partner_id': self.partner_propagation.id,
+                'order_line': [
+                    Command.create({
+                        'product_id': self.super_product.id
+                    }),
+                ]
+            },
+            {
+                'partner_id': self.partner_propagation.id,
+                'order_line': [
+                    Command.create({
+                        'product_id': super_product_2.id
+                    }),
+                ]
+            },
+        ])
+        for so in sale_orders:
+            delivery_wizard = Form(self.env['choose.delivery.carrier'].with_context({
+                'default_order_id': so.id,
+                'default_carrier_id': self.normal_delivery.id,
+            }))
+            choose_delivery_carrier = delivery_wizard.save()
+            choose_delivery_carrier.button_confirm()
+
+        def fail_send_to_shipper(pick):
+            # side effect to throw an error for a given picking but resolve the normal call for the other
+            def _throw_error_on_chosen_picking(self):
+                if self == pick:
+                    raise UserError("Something went wrong, parcel not returned from Sendcloud: {'weight': ['The weight must be less than 10.001 kg']}")
+                else:
+                    return DEFAULT
+            return _throw_error_on_chosen_picking
+
+        sale_orders.action_confirm()
+        for i in range(0, len(sale_orders)):
+            # check that a delivery was created for the associated carrier
+            self.assertEqual(sale_orders[i].picking_ids.carrier_id.id, sale_orders[i].carrier_id.id)
+        pickings = sale_orders.picking_ids
+        pickings.action_assign()
+        pickings.action_set_quantities_to_reservation()
+        picking_class = 'odoo.addons.delivery.models.stock_picking.StockPicking'
+        with patch(picking_class + '.send_to_shipper', new=fail_send_to_shipper(pickings[1])):
+            pickings.with_user(alien).button_validate()
+        # both pickings should be validated but and activity should have been created for the invalid picking
+        self.assertEqual(pickings.mapped('state'), ['done', 'done'])
+        self.assertTrue(self.env['mail.activity'].search([('res_model', '=', 'stock.picking'), ('res_id', '=', pickings[1].id), ('user_id', '=', alien.id)], limit=1))


### PR DESCRIPTION
### Issue:

Certain carrier's API processes validity checks and parcels generation one picking at a time so that on our end we are forced to send requests one at a time at the end of the the `_action_done`: https://github.com/odoo/odoo/blob/e4f68fc6eb2a666a07b6627b9dc0ec575b79d1e3/addons/stock/models/stock_picking.py#L918 https://github.com/odoo/odoo/blob/e4f68fc6eb2a666a07b6627b9dc0ec575b79d1e3/addons/delivery/models/stock_picking.py#L192-L196 However, since a UserError of any of the picking will cause a rollback of the entire batch on Odoo's side, pikcings might end up being processed on the carrier side but non validated on Odoo's side during batch validation.

### Steps to reproduce:

- Configure sendcloud shipping method + website + payment providers
- In your sendcloud configuration select sendcloud shipping product to not be able to handle products with a weight exceeding 10 kg e.g; bpost @home (0-10kg).
- Create 2 storable products with respective weigth 1 and 100 kg.
- Publish them on the website for sale.
- Open a private window, make an order via the website for the 1kg product by filling your cart and use sendcloud as carrier.
- Repeat the operation with the other product to generate a seconde SO.
- Back to your main window > Inventory Overview > Delivery Orders
- Select both deliveries > Action > Validate (in batch)

#### > While the first delivery order was processed on carrier side (can be checked on sendcloud's website)
#### > the UserError of the second DO rollbacked its validation in Odoo.

### Fix:

As such, and since the carrier requests needs to happen after we have validated the pickings in Odoo, we should avoid any rollback of the transaction once any requests has already been successfully treated on the carrier side.

### Note:

It is not possible restructure the code to use `senf.env.cr.savepoint` in a loop in order to reset the validation of pickings that are not valid on the carrier side because savepoints can't be used more than 64 times before the server crashes and hence can't be used in record loops.

enterprise: https://github.com/odoo/enterprise/pull/75502

opw-4357325
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
