### PR TITLE
[FIX] website: fix missing active class in mega-menus

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -778,6 +778,7 @@ publicWidget.registry.MegaMenuDropdown = publicWidget.Widget.extend({
             }
         }
 
+        this._updateActiveMenuLinks();
         return this._super(...arguments);
     },
 
@@ -812,6 +813,41 @@ publicWidget.registry.MegaMenuDropdown = publicWidget.Widget.extend({
         Dropdown.getOrCreateInstance(previousMegaMenuToggleEl).hide();
         megaMenuToggleEl.insertAdjacentElement("afterend", megaMenuEl);
         this.options.wysiwyg?.odooEditor.observerActive("moveMegaMenu");
+    },
+
+    /**
+     * @private
+     */
+    _updateActiveMenuLinks() {
+        // Prevent having several active links in the menu.
+        if (this.el.querySelector(".navbar #top_menu a.nav-link.active")) {
+            return;
+        }
+        const currentHrefWithoutHash = `${window.location.origin}${window.location.pathname}`;
+        // Check and update the active state of menu items based on the current
+        // page
+        const megaMenuEls = this.el.querySelectorAll(".o_mega_menu");
+        let matchingLink = null;
+        megaMenuEls.forEach((megaMenuEl, position) => {
+            const linkEls = Array.from(megaMenuEl.querySelectorAll(`a:not([href="#"])`));
+            matchingLink = linkEls.find((linkEl) => {
+                const url = new URL(linkEl.href);
+                return `${url.origin}${url.pathname}` === currentHrefWithoutHash;
+            });
+            if (matchingLink) {
+                const megaMenuToggleEl = megaMenuEl
+                    .closest(".nav-item")
+                    .querySelector(".o_mega_menu_toggle");
+                // Target the corresponding link in the mobile navigation. Since the
+                // mega-menu for mobile is dynamically rendered, it is not
+                // accessible at this moment.
+                const mobileMegaMenuToggleEl = this.el.querySelectorAll(
+                    "#top_menu_collapse_mobile .top_menu .o_mega_menu_toggle"
+                )[position];
+                megaMenuToggleEl.classList.add("active");
+                mobileMegaMenuToggleEl.classList.add("active");
+            }
+        });
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1346,9 +1346,12 @@ $-transition-duration: 200ms;
             border-top: 1px solid map-get($grays, '200');
         }
         > a.dropdown-toggle {
-            background-color: map-get($grays, '200');
             color: inherit; // Useful when the toggle is active
             pointer-events: none; // hack to prevent clicking on it because dropdown always opened
+            
+            &:not(.active) {
+                background-color: map-get($grays, '200');
+            }
         }
         > ul, > .o_mega_menu { // remove dropdown-menu default style as it is nested in another one
             position: static;

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -120,6 +120,87 @@ registerWebsitePreviewTour('edit_megamenu', {
         trigger: ':iframe .o_mega_menu h4:contains("New Menu Item")',
     },
 ]);
+registerWebsitePreviewTour("megamenu_active_nav_link", {
+    url: "/",
+    edition: true,
+}, () => [
+       // Add a megamenu item to the top menu.
+    {
+        content: "Click on a menu item",
+        trigger: ":iframe .top_menu .nav-item a",
+        run: "click",
+    },
+    {
+        content: "Click on 'Link' to open Link Dialog",
+        trigger: ":iframe .o_edit_menu_popover a.js_edit_menu",
+        run: "click",
+    },
+    {
+        trigger: ".o_website_dialog",
+    },
+    {
+        content: "Trigger the link dialog (click 'Add Mega Menu Item')",
+        trigger: ".modal-body a:eq(1)",
+        run: "click",
+    },
+    {
+        content: "Write a label for the new menu item",
+        trigger: ".modal-dialog .o_website_dialog input",
+        run: "edit MegaTron",
+    },
+    {
+        content: "Confirm the mega menu label",
+        trigger: ".modal .modal-footer .btn-primary:contains(ok)",
+        run: "click",
+    },
+    {
+        trigger: `.oe_menu_editor [data-is-mega-menu="true"] .js_menu_label:contains("MegaTron")`,
+    },
+    {
+        content: "Save the website menu with a new mega menu",
+        trigger: ".modal-footer .btn-primary",
+        run: "click",
+    },
+    {
+        trigger: "#oe_snippets.o_loaded",
+    },
+    {
+        content: "Check for the new mega menu",
+        trigger: `:iframe .top_menu:has(.nav-item a.o_mega_menu_toggle:contains("Megatron"))`,
+    },
+    {
+        trigger: ".o_website_preview.editor_enable.editor_has_snippets:not(.o_is_blocked)"
+    },
+    clickOnExtraMenuItem({}, true),
+    toggleMegaMenu({}),
+    {
+        content: "Select the last menu link of the first column",
+        trigger: ":iframe .s_mega_menu_odoo_menu .row > div:first-child .nav > :nth-child(6)",
+        run: "click",
+    },
+    {
+        content: "Edit link",
+        trigger: "#create-link",
+        run: "click",
+    },
+    {
+        content: "Change the link",
+        trigger: "#o_link_dialog_url_input",
+        run: "edit /new_page"
+    },
+    ...clickOnSave(),
+    clickOnExtraMenuItem({}, true),
+    toggleMegaMenu(),
+    {
+        content: "Click on the last menu link of the first column",
+        trigger: ":iframe .s_mega_menu_odoo_menu .row > div:first-child .nav > :nth-child(6)",
+        run: "click",
+    },
+    {
+        content: "Check if the new mega menu is active",
+        trigger: `:iframe .top_menu:has(.nav-item a.o_mega_menu_toggle.active:contains("MegaTron"))`,
+    },
+])
 registerWebsitePreviewTour('edit_megamenu_big_icons_subtitles', {
     url: '/',
     edition: true,

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -459,6 +459,9 @@ class TestUi(odoo.tests.HttpCase):
     def test_16_website_edit_megamenu(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'edit_megamenu', login='admin')
 
+    def test_website_megamenu_active_nav_link(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'megamenu_active_nav_link', login='admin')
+
     def test_17_website_edit_menus(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'edit_menus', login='admin')
 


### PR DESCRIPTION
The active CSS class was not applied to parent items of the mega menu or their child items, resulting in the corresponding menu item not being highlighted in the navigation bar.

This commit ensures that the active class is correctly applied to mega menu items, providing consistent highlighting behavior similar to regular pages.

Steps to reproduce:

- Open the Website Editor.
- Navigate to Site > Menu Editor.
- Add a Mega Menu and save the changes.
- Edit the page.
- Open the Mega Menu.
- Change any link to /contactus-thank-you.
- Save the changes.
- Visit /contactus-thank-you.
- Observe that the Mega Menu title does not appear as active

opw-4383641

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
