### PR TITLE
[FIX] web: prevent error when split an expense

### DIFF
--- a/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
+++ b/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
@@ -36,7 +36,7 @@
                     </group>
                     <field name="split_possible" invisible="1"/>
                     <footer>
-                        <button name="action_split_expense" attrs="{'invisible': [ ('split_possible', '=', True)]}" string="Split Expense" type="object" class="oe_highlight disabled"  data-hotkey="q"/>
+                        <button name="action_split_expense" attrs="{'invisible': [ ('split_possible', '=', True)]}" string="Split Expense" type="object" class="oe_highlight" disabled="disabled" data-hotkey="q"/>
                         <button name="action_split_expense" string="Split Expense" attrs="{'invisible': [('split_possible', '=', False)]}" type="object" class="oe_highlight"  data-hotkey="q"/>
                         <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z"/>
                     </footer>

--- a/addons/web/static/src/views/view_compiler.js
+++ b/addons/web/static/src/views/view_compiler.js
@@ -18,7 +18,7 @@ import { toStringExpression, BUTTON_CLICK_PARAMS } from "./utils";
 
 import { xml } from "@odoo/owl";
 
-const BUTTON_STRING_PROPS = ["string", "size", "title", "icon", "id"];
+const BUTTON_STRING_PROPS = ["string", "size", "title", "icon", "id", "disabled"];
 const INTERP_REGEXP = /(\{\{|#\{)(.*?)(\}{1,2})/g;
 
 /**

--- a/addons/web/static/tests/views/form/form_compiler_tests.js
+++ b/addons/web/static/tests/views/form/form_compiler_tests.js
@@ -426,6 +426,25 @@ QUnit.module("Form Renderer", (hooks) => {
         assert.containsOnce(target, "button[id=action_button]");
     });
 
+    QUnit.test("compile a button with disabled", async (assert) => {
+        serverData.views = {
+            "partner,1,form": /*xml*/ `
+                <form>
+                    <button string="ActionButton" class="demo" name="action_button" type="object" disabled="disabled"/>
+                </form>`,
+        };
+
+        await makeView({
+            serverData,
+            resModel: "partner",
+            type: "form",
+            resId: 1,
+        });
+
+        const button = target.querySelector(".demo");
+        assert.ok(button.hasAttribute("disabled"), "The button should have the 'disabled' attribute");
+    });
+
     QUnit.test("invisible is correctly computed with another t-if", (assert) => {
         patchWithCleanup(FormCompiler.prototype, {
             setup() {


### PR DESCRIPTION
Currently, an error occurs when users press the data-hotkey 'ALT + Q' to split expense and any expense is not available in the split expense line.

Step to produce:

- Install the ```hr_expense``` module.
- Create an expense, add a category, and click on the `Split Expense` button.
- Delete all expenses from the split expense line, and press the data-hotkey `ALT + Q` to click on the `Split Expense` button to split expenses.

```IndexError: tuple index out of range```

This occurs because the system attempts to access the first expense from the split expense line [1], but expenses are not available.

Link [1]: https://github.com/odoo/odoo/blob/280b762e7cd1b3d9a578bbae60cbb9b137ee5ce5/addons/hr_expense/wizard/hr_expense_split_wizard.py#L36

To resolve this issue, Disable a 'Split Expense' button after simply adding a  `disabled` attribute on it.

Sentry-6015854429

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
