### PR TITLE
[FIX] l10n_in_withholding check for active_ids first

### DIFF
--- a/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.py
+++ b/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.py
@@ -15,10 +15,10 @@ class L10nInWithholdWizard(models.TransientModel):
         result = super().default_get(fields_list)
         active_model = self._context.get('active_model')
         active_ids = self._context.get('active_ids')
-        if len(active_ids) > 1:
-            raise UserError(_("You can only create a withhold for only one record at a time."))
         if active_model not in ('account.move', 'account.payment') or not active_ids:
             raise UserError(_("TDS must be created from an Invoice or a Payment."))
+        if len(active_ids) > 1:
+            raise UserError(_("You can only create a withhold for only one record at a time."))
         active_record = self.env[active_model].browse(active_ids)
         result['reference'] = _("TDS of %s", active_record.name)
         if active_model == 'account.move':


### PR DESCRIPTION
We need to first check if active_ids exist and get usererror if there are no active_ids present.

[Link to Runbot Error builds](https://runbot.odoo.com/web#id=74407&menu_id=424&cids=1&action=573&model=runbot.build.error&view_type=form)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
