### PR TITLE
[IMP] mail: avoid MemoryError when filtering `template_category`

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -7,6 +7,7 @@ import logging
 from ast import literal_eval
 
 from odoo import _, api, fields, models, tools, Command
+from odoo.osv import expression
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools import is_html_empty
 from odoo.tools.safe_eval import safe_eval, time
@@ -131,19 +132,37 @@ class MailTemplate(models.Model):
 
     @api.model
     def _search_template_category(self, operator, value):
-        if operator in ['in', 'not in'] and isinstance(value, list):
-            value_templates = self.env['mail.template'].search([]).filtered(
-                lambda t: t.template_category in value
-            )
-            return [('id', operator, value_templates.ids)]
+        if operator not in ['in', 'not in', '=', '!=']:
+            raise NotImplementedError(_('Operation not supported'))
 
-        if operator in ['=', '!='] and isinstance(value, str):
-            value_templates = self.env['mail.template'].search([]).filtered(
-                lambda t: t.template_category == value
-            )
-            return [('id', 'in' if operator == "=" else 'not in', value_templates.ids)]
+        value = [value] if isinstance(value, str) else value
+        operator = 'in' if operator in ("in", "=") else 'not in'
 
-        raise NotImplementedError(_('Operation not supported'))
+        templates_with_xmlid = self.env['ir.model.data']._search([
+            ('model', '=', 'mail.template'),
+            ('module', '!=', '__export__')
+        ]).subselect('res_id')
+
+        domain = []
+        if 'hidden_template' in value:
+            domain.append(['|', ('active', '=', False), '&', ('description', '=', False), ('id', 'in', templates_with_xmlid)])
+
+        if 'base_template' in value:
+            domain.append(['&', ('description', '!=', False), ('id', 'in', templates_with_xmlid)])
+
+        if 'custom_template' in value:
+            domain.append([('template_category', 'not in', ['base_template', 'hidden_template'])])
+
+        if operator == 'not in':
+            for dom in domain:
+                dom.insert(0, "!")
+
+        if len(domain) > 1:
+            domain = (expression.OR if operator == 'in' else expression.AND)(domain)
+        else:
+            domain = domain[0]
+
+        return domain
 
     # ------------------------------------------------------------
     # CRUD

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -435,3 +435,99 @@ class TestTemplateConfigRestrictEditor(MailCommon):
 
         self.env['ir.config_parameter'].set_param('mail.restrict.template.rendering', False)
         self.assertTrue(self.user_employee.has_group('mail.group_mail_template_editor'))
+
+
+@tagged("mail_template", "-at_install", "post_install")
+class TestSearchTemplateCategory(MailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.mail_template = cls.env['mail.template'].with_context(active_test=False)
+        cls.model_data = cls.env['ir.model.data']
+
+        cls.existing = cls.mail_template.search([])
+
+        # Create templates
+        # 2 Hidden templates
+        cls.hidden_templates = cls.mail_template.create([
+            {'name': 'Hidden Template 1', 'active': False},
+            {'name': 'Hidden Template 2', 'description': ''},
+        ])
+        last = cls.hidden_templates[-1]
+        cls.model_data.create({
+            'name': f'mail_template_{last.id}',
+            'module': 'test_module',
+            'model': 'mail.template',
+            'res_id': last.id
+        })
+
+        # 5 Custom templates
+        cls.custom_templates = cls.mail_template.create([
+            {'name': f'Custom Template {i + 1}', 'description': f'Desc {i + 1}'}
+            for i in range(4)
+        ])
+        cls.custom_templates |= cls.mail_template.create({'name': 'Custom Template empty', 'description': ''})
+
+        # 4 Base templates with XML ID
+        cls.base_templates = cls.mail_template.create([
+            {'name': f'Base Template {i + 1}', 'description': f'Desc Base {i + 1}'}
+            for i in range(4)
+        ])
+
+        for template in cls.base_templates:
+            cls.model_data.create({
+                'name': f'mail_template_{template.id}',
+                'module': 'test_module',
+                'model': 'mail.template',
+                'res_id': template.id
+            })
+
+    def test_search_template_category(self):
+
+        # Search by hidden templates
+        hidden_domain = [('template_category', 'in', ['hidden_template'])]
+        hidden_templates = self.mail_template.search(hidden_domain) - self.existing
+        self.assertEqual(len(hidden_templates), len(self.hidden_templates), "Hidden templates count mismatch")
+        self.assertEqual(set(hidden_templates.mapped('template_category')), {'hidden_template'}, "Computed field doesn't match 'hidden_template'")
+
+        # Search by base templates
+        base_domain = [('template_category', 'in', ['base_template'])]
+        base_templates = self.mail_template.search(base_domain) - self.existing
+        self.assertEqual(len(base_templates), len(self.base_templates), "Base templates count mismatch")
+        self.assertEqual(set(base_templates.mapped('template_category')), {'base_template'}, "Computed field doesn't match 'base_template'")
+
+        # Search by custom templates
+        custom_domain = [('template_category', 'in', ['custom_template'])]
+        custom_templates = self.mail_template.search(custom_domain) - self.existing
+        self.assertEqual(len(custom_templates), len(self.custom_templates), "Custom templates count mismatch")
+        self.assertEqual(set(custom_templates.mapped('template_category')), {'custom_template'}, "Computed field doesn't match 'custom_template'")
+
+        # Combined search
+        combined_domain = [('template_category', 'in', ['hidden_template', 'base_template', 'custom_template'])]
+        combined_templates = self.mail_template.search(combined_domain) - self.existing
+        total_templates = len(self.hidden_templates) + len(self.base_templates) + len(self.custom_templates)
+        self.assertEqual(len(combined_templates), total_templates, "Combined templates count mismatch")
+
+        # Search with '=' operator
+        hidden_domain = [('template_category', '=', 'hidden_template')]
+        hidden_templates = self.mail_template.search(hidden_domain) - self.existing
+        self.assertEqual(len(hidden_templates), len(self.hidden_templates), "Hidden templates count mismatch")
+
+        # Search with '!=' operator
+        not_in_domain = [('template_category', '!=', 'hidden_template')]
+        not_in_templates = self.mail_template.search(not_in_domain) - self.existing
+        expected_templates = len(self.base_templates) + len(self.custom_templates)
+        self.assertEqual(len(not_in_templates), expected_templates, "Not in templates count mismatch")
+
+        # Search with 'not in' operator
+        not_in_domain = [('template_category', 'not in', ['hidden_template'])]
+        not_in_templates = self.mail_template.search(not_in_domain) - self.existing
+        expected_templates = len(self.base_templates) + len(self.custom_templates)
+        self.assertEqual(len(not_in_templates), expected_templates, "Not in templates count mismatch")
+
+        # Search with 'not in' operator
+        not_in_domain = [('template_category', 'not in', ['hidden_template', 'base_template'])]
+        not_in_templates = self.mail_template.search(not_in_domain) - self.existing
+        expected_templates = len(self.custom_templates)
+        self.assertEqual(len(not_in_templates), expected_templates, "Not in multi templates count mismatch")


### PR DESCRIPTION
Before this commit, databases with thousands of mail templates could trigger a MemoryError when opening the mail template list. This issue occurred because the default filter on base templates required processing all records batch by batch in Python.

With this commit, the computation is rewritten to use domain / SQL, eliminating the Python overhead.
