### PR TITLE
[FIX] web: fix query count for no demo runbot

### DIFF
--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -37,8 +37,8 @@ class TestPerfSessionInfo(common.HttpCase):
     def test_load_web_menus_perf(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
-        # cold orm/fields cache (only web: 10, all module: 38)
-        with self.assertQueryCount(38):
+        # cold orm/fields cache (only web: 10, all module: 40 - no demo)
+        with self.assertQueryCount(40):
             self.env['ir.ui.menu'].load_web_menus(False)
 
         # cold fields cache - warm orm cache (only web: 0, all module: 1)
@@ -49,8 +49,8 @@ class TestPerfSessionInfo(common.HttpCase):
     def test_load_menus_perf(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
-        # cold orm/fields cache (only web: 10, all module: 38)
-        with self.assertQueryCount(38):
+        # cold orm/fields cache (only web: 10, all module: 40 - no demo)
+        with self.assertQueryCount(40):
             self.env['ir.ui.menu'].load_menus(False)
 
         # cold fields cache - warm orm cache (only web: 0, all module: 1)


### PR DESCRIPTION
Without demo load menu perf test fails, 40 > 38 queries. It is due that some override of `_load_menus_blacklist` relies on some data or fallback are used.

