### PR TITLE
[FIX] website: prevent font from reverting after custom font upload

### DIFF
--- a/addons/website/static/src/xml/website.editor.xml
+++ b/addons/website/static/src/xml/website.editor.xml
@@ -138,7 +138,8 @@
     </t>
     <t t-name="website.add_font_btn">
         <we-button href="#" class="o_we_add_font_btn"
-                   t-att-data-variable="variable">
+                   t-att-data-variable="variable"
+                   data-no-bundle-reload="true">
             Add a Custom Font
         </we-button>
     </t>

--- a/addons/website/static/tests/tours/font_family.js
+++ b/addons/website/static/tests/tours/font_family.js
@@ -1,0 +1,58 @@
+/** @odoo-module **/
+import wTourUtils from "@website/js/tours/tour_utils";
+import { patch } from "@web/core/utils/patch";
+
+wTourUtils.registerWebsitePreviewTour("website_font_family", {
+    test: true,
+    url: "/",
+    edition: true,
+}, () => [
+    ...wTourUtils.goToTheme(),
+    {
+        content: "Click on the heading font family selector",
+        trigger: "we-select[data-variable='headings-font']",
+        run: "click",
+    },
+    {
+        content: "Click on the 'Arvo' font we-button from the font selection list.",
+        trigger: "we-selection-items we-button[data-font-family='Arvo']",
+        run: "click",
+    },
+    {
+        content: "Verify that the 'Arvo' font family is correctly applied to the heading.",
+        trigger: "we-toggler[style*='font-family: Arvo;']",
+    },
+    {
+        content: "Open the heading font family selector",
+        trigger: "we-toggler[style*='font-family: Arvo;']",
+        run: "click",
+    },
+    {
+        trigger: "we-select[data-variable='headings-font']",
+        // This is a workaround to prevent the _reloadBundles method from being called.
+        // It addresses the issue where selecting a we-button with data-no-bundle-reload,
+        // such as o_we_add_font_btn.
+        run: function () {
+            const options = odoo.loader.modules.get("@web_editor/js/editor/snippets.options")[Symbol.for("default")];
+            patch(options.Class.prototype, {
+                async _refreshBundles() {
+                    console.error("The font family selector value get reload to its default.");
+                }
+            })
+        },
+    },
+    {
+        content: "Click on the 'Add a custom font' button",
+        trigger: "we-select[data-variable='headings-font'] .o_we_add_font_btn",
+        run: "click",
+    },
+    {
+        content: "Wait for the modal to open and then refresh",
+        trigger: "button.btn-secondary",
+        run: "click",
+    },
+    {
+        content: "Check that 'Arvo' font family is still applied and not reverted",
+        trigger: "we-toggler[style*='font-family: Arvo;']",
+    },
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -696,3 +696,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_snippet_visibility_option(self):
         self.start_tour("/", "snippet_visibility_option", login="admin")
+
+    def test_website_font_family(self):
+        self.start_tour("/", "website_font_family", login="admin")


### PR DESCRIPTION
Steps to reproduce:

1. Go to Website -> Edit -> Theme section.
2. Choose a predefined font family for the paragraph, such as "Arvo".
4. Return to the font family dropdown and click on "Add a Custom Font".
Notice that the selected font reverts to the "default/system" font.

Issue:
The issue occurs because when a predefined "we-button" is selected from the dropdown menu(we-button with value i.e. data attributes defined), its value is passed to widgetValue. However, when the "Add a Custom Font" button is clicked(which does not have value i.e. data attributes are not defined), the "we-button" value changes to an empty string, which is then passed into widgetValue. As a result, it triggers refreshBundle with the empty string and resets to the default value.

Solution:
This PR ensures that `_refreshBundles` is not triggered until the widgetValue has a valid (non-empty) value. This prevents the font from being reverted to the default.

task-4373983