### PR TITLE
[FIX] hr_expense: remove dead code in ´product.product.expense.form´

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -558,12 +558,6 @@
                         <div class="oe_title px-3">
                             <label for="name" string="Product Name"/>
                             <h1><field name="name" placeholder="e.g. Lunch"/></h1>
-                            <div name="options" groups="base.group_user" invisible="1">
-                                <div>
-                                    <field name="can_be_expensed"/>
-                                    <label for="can_be_expensed"/>
-                                </div>
-                            </div>
                         </div>
                         <group name="product_details">
                             <group>


### PR DESCRIPTION
This element is never displayed and seems not necessary anymore. Probably an old duplicate of ´product_template_form_view´ based on ´product.template´

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
