### PR TITLE
[FIX] website_sale: display the correct variant tags

### DIFF
--- a/addons/website_sale/controllers/variant.py
+++ b/addons/website_sale/controllers/variant.py
@@ -40,7 +40,8 @@ class WebsiteSaleVariantController(Controller):
         if product and request.website.is_view_active('website_sale.product_tags'):
             combination_info['product_tags'] = request.env['ir.ui.view']._render_template(
                 'website_sale.product_tags', values={
-                    'all_product_tags': product.all_product_tag_ids.filtered('visible_on_ecommerce')
+                    'product_tag_ids': product.product_tag_ids.filtered('visible_on_ecommerce'),
+                    'additional_product_tag_ids': product.additional_product_tag_ids.filtered('visible_on_ecommerce'),
                 }
             )
         return combination_info

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -213,7 +213,7 @@
             <div class="o_wsale_product_information position-relative d-flex flex-column flex-grow-1 flex-shrink-1">
                 <div class="o_wsale_product_information_text">
                     <h6 class="o_wsale_products_item_title mb-2 text-break">
-                        <a class="text-primary text-decoration-none text-primary-emphasis" itemprop="name" t-att-href="product_href" t-att-content="product.name" t-field="product.name" />
+                        <a class="text-primary text-decoration-none" itemprop="name" t-att-href="product_href" t-att-content="product.name" t-field="product.name" />
                         <a t-if="not product.website_published" role="button" t-att-href="product_href" class="btn btn-sm btn-danger" title="This product is unpublished.">
                             Unpublished
                         </a>

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -261,10 +261,10 @@
                                         </td>
                                     </tr>
                                 </t>
-                                <t t-if="is_view_active('website_sale.product_tags') and any([product.all_product_tag_ids for product in products])">
+                                <t t-if="is_view_active('website_sale.product_tags') and product.product_tag_ids or product.additional_product_tag_ids">
                                     <tr class="clickable" data-bs-toggle="collapse" data-bs-target=".o_ws_tags">
                                         <th class="text-start" t-att-colspan="len(products) + 1">
-                                            <i class="fa fa-chevron-circle-down o_product_comparison_collpase" role="img" aria-label="Collapse" title="Collapse"></i><span>Tags</span>
+                                            <i class="fa fa-chevron-circle-down o_product_comparison_collapse" role="img" aria-label="Collapse" title="Collapse"></i><span>Tags</span>
                                         </th>
                                     </tr>
                                     <tr class="collapse show o_ws_tags">
@@ -272,10 +272,9 @@
                                         <td t-foreach="products" t-as="product">
                                             <div class="d-flex justify-content-center">
                                                 <t t-call="website_sale.product_tags">
-                                                    <t t-set="all_product_tags" t-value="product.all_product_tag_ids"/>
+                                                    <t t-set="all_product_tags" t-value="product.product_tag_ids + product.additional_product_tag_ids"/>
                                                 </t>
                                             </div>
-
                                         </td>
                                     </tr>
                                 </t>


### PR DESCRIPTION
Steps to reproduce:
------------------

- Set a product tags for a specific variant
- Go to the shop
- All the tags of all product variant are displayed

Issue:
-----

While displaying the tags the tags does not take into account the current product. This results in the display of all the tags of all variant instead of the tags of the specific one.

Fix:
----



task-4357477

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
