### PR TITLE
[REF] hw_posbox_homepage: move all update tools to update page

### DIFF
--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -31,6 +31,7 @@ export class Homepage extends Component {
         this.store = useStore();
         this.state = useState({ data: {}, loading: true, waitRestart: false });
         this.store.advanced = localStorage.getItem("showAdvanced") === "true";
+        this.store.dev = new URLSearchParams(window.location.search).has("debug");
 
         onWillStart(async () => {
             await this.loadInitialData();

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/HandlerDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/HandlerDialog.js
@@ -57,34 +57,6 @@ export class HandlerDialog extends Component {
         }
     }
 
-    async loadIotHandlers() {
-        try {
-            const data = await this.store.rpc({
-                url: "/hw_posbox_homepage/load_iot_handlers",
-            });
-
-            if (data.status === "success") {
-                this.state.waitRestart = true;
-            }
-        } catch {
-            console.warn("Error while saving data");
-        }
-    }
-
-    async clearIotHandlers() {
-        try {
-            const data = await this.store.rpc({
-                url: "/hw_posbox_homepage/clear_iot_handlers",
-            });
-
-            if (data.status === "success") {
-                this.state.waitRestart = true;
-            }
-        } catch {
-            console.warn("Error while saving data");
-        }
-    }
-
     static template = xml`
         <LoadingFullScreen t-if="this.state.waitRestart">
             <t t-set-slot="body">
@@ -168,17 +140,6 @@ export class HandlerDialog extends Component {
                                 <option value="error">Error</option>
                             </select>
                             <input t-else="" type="text" class="form-control" aria-label="Text input with dropdown button" disabled="true" placeholder="Logger uninitialised" />
-                        </div>
-                    </div>
-                    <div>
-                        <h5>Debug</h5>
-                        <div class="d-flex gap-2">
-                            <button class="btn btn-primary btn-sm" t-on-click="loadIotHandlers">
-                                Load IOT Handlers
-                            </button>
-                            <button class="btn btn-primary btn-sm" t-on-click="clearIotHandlers">
-                                Clear IOT Handlers
-                            </button>
                         </div>
                     </div>
                 </t>

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/UpdateDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/UpdateDialog.js
@@ -4,7 +4,7 @@ import useStore from "../../hooks/useStore.js";
 import { BootstrapDialog } from "./BootstrapDialog.js";
 import { LoadingFullScreen } from "../LoadingFullScreen.js";
 
-const { Component, xml, useState, markup } = owl;
+const { Component, xml, useState } = owl;
 
 export class UpdateDialog extends Component {
     static props = {};
@@ -14,10 +14,11 @@ export class UpdateDialog extends Component {
         this.store = useStore();
         this.state = useState({
             initialization: true,
-            commitHtml: "",
             loading: false,
             waitRestart: false,
-            upgradeData: [],
+            odooIsUpToDate: false,
+            imageIsUpToDate: false,
+            currentCommitHash: "",
         });
     }
 
@@ -25,71 +26,122 @@ export class UpdateDialog extends Component {
         this.state.initialization = [];
     }
 
-    async getUpgradeData() {
+    async getVersionInfo() {
         try {
             const data = await this.store.rpc({
-                url: "/hw_posbox_homepage/upgrade",
+                url: "/hw_posbox_homepage/version_info",
             });
 
-            this.state.upgradeData = data;
-            this.state.commitHtml = markup(data.commit);
+            this.state.odooIsUpToDate = data.odooIsUpToDate;
+            this.state.imageIsUpToDate = data.imageIsUpToDate;
+            this.state.currentCommitHash = data.currentCommitHash;
             this.state.initialization = false;
         } catch {
-            console.warn("Error while fetching data");
+            console.warn("Error while fetching version info");
         }
     }
 
-    async upgradeIotBox() {
-        console.warn("Not implemented yet");
+    async updateGitTree() {
+        this.state.waitRestart = true;
+        try {
+            const data = await this.store.rpc({
+                url: "/hw_posbox_homepage/update_git_tree",
+                method: "POST",
+            });
+            if (data.status === "success") {
+                this.state.isUpToDate = true;
+            }
+        } catch {
+            console.warn("Error while updating IoT Box.");
+        }
+    }
+
+    async forceUpdateIotHandlers() {
+        this.state.waitRestart = true;
+        try {
+            await this.store.rpc({
+                url: "/hw_posbox_homepage/load_iot_handlers",
+            });
+        } catch {
+            console.warn("Error while downloading handlers from db.");
+        }
+    }
+
+    get everythingIsUpToDate() {
+        return this.state.odooIsUpToDate && this.state.imageIsUpToDate;
     }
 
     static template = xml`
         <LoadingFullScreen t-if="this.state.waitRestart">
             <t t-set-slot="body">
-                Upgrading your device, please wait...
+                Updating your device, please wait...
             </t>
         </LoadingFullScreen>
 
-        <BootstrapDialog identifier="'update-configuration'" btnName="'Update'" onOpen.bind="getUpgradeData" onClose.bind="onClose">
+        <BootstrapDialog identifier="'update-configuration'" btnName="'Update'" onOpen.bind="getVersionInfo" onClose.bind="onClose">
             <t t-set-slot="header">
-                Upgrade IoTBox
+                <div>
+                    Update
+                    <a href="https://www.odoo.com/documentation/18.0/applications/general/iot/config/updating_iot.html" class="fa fa-question-circle text-decoration-none text-dark" target="_blank"></a>
+                </div>
             </t>
             <t t-set-slot="body">
                 <div t-if="this.state.initialization" class="position-absolute top-0 start-0 bg-white h-100 w-100 justify-content-center align-items-center d-flex flex-column gap-3 always-on-top">
                     <div class="spinner-border" role="status">
                         <span class="visually-hidden">Loading...</span>
                     </div>
-                    <p>Currently fetching upgrade data...</p>
+                    <p>Currently fetching update data...</p>
                 </div>
 
-                <div class="alert alert-warning fs-6" role="alert">
-                    This tool will help you perform an upgrade of the IoTBox's software over the internet.
-                    However the preferred method to upgrade the IoTBox is to flash the sd-card with the latest image.
-                    The upgrade procedure is explained into to the IoTBox manual.<br/><br/>
-                    Usefull links:
-                    <ul>
-                        <li>
-                            <a href="https://nightly.odoo.com/master/iotbox/iotbox-latest.zip">Download the latest image</a>
-                        </li>
-                        <li>
-                            <a href="https://www.odoo.com/documentation/18.0/applications/productivity/iot.html">IoTBox manual</a>
-                        </li>
-                    </ul>
+                <div class="mb-3">
+                    <h6>Operating System Update</h6>
+                    <div t-if="this.state.imageIsUpToDate" class="text-success px-2 small">
+                        Operating system is up to date
+                    </div>
+                    <div t-else="" class="alert alert-warning small mb-0">
+                        A new version of the operating system is available, see:
+                        <a href="https://www.odoo.com/documentation/18.0/applications/general/iot/config/updating_iot.html#flashing-the-sd-card-on-iot-box" target="_blank" class="alert-link">
+                            Flashing the SD Card on IoT Box
+                        </a>
+                    </div>
+                    <div t-if="this.store.dev" class="alert alert-light small">
+                        <a href="https://nightly.odoo.com/master/iotbox/" target="_blank" class="alert-link">
+                            Current: <t t-esc="this.store.base.version"/>
+                        </a>
+                    </div>
                 </div>
 
-                <div class="bg-light rounded p-2 fs-6">
-                    <h6>Commit details:</h6>
-                    <pre t-out="this.state.commitHtml" />
+                <div class="mb-3">
+                    <h6>IoT Box Update</h6>
+                    <div t-if="this.state.odooIsUpToDate" class="text-success px-2 small">
+                        IoT Box is up to date.
+                    </div>
+                    <div t-else="" class="d-flex justify-content-between align-items-center alert alert-warning small">
+                        A new version of the IoT Box is available
+                        <button class="btn btn-primary btn-sm" t-on-click="updateGitTree">Update</button>
+                    </div>
+                    <div t-if="this.store.dev" class="alert alert-light small">
+                        Current: 
+                        <a t-att-href="'https://github.com/odoo/odoo/commit/' + this.state.currentCommitHash" target="_blank" class="alert-link">
+                            <t t-esc="this.state.currentCommitHash"/>
+                        </a>
+                    </div>
                 </div>
 
-                <div class="w-100 mt-3 d-flex justify-content-center">
-                    <button class="btn btn-primary btn-sm" t-on-click="upgradeIotBox">
-                        Upgrade to <t t-esc="this.state.upgradeData.flashToVersion" />
+                <h6>Drivers Update</h6>
+                <div class="d-flex gap-2">
+                    <button class="btn btn-secondary btn-sm" t-on-click="forceUpdateIotHandlers">
+                        Force Drivers Update
                     </button>
                 </div>
             </t>
             <t t-set-slot="footer">
-                <button type="button" class="btn btn-primary btn-sm" data-bs-dismiss="modal">Close</button>
+                <button 
+                    type="button"
+                    t-att-class="'btn btn-sm ' + (this.everythingIsUpToDate ? 'btn-primary' : 'btn-secondary')"
+                    data-bs-dismiss="modal">
+                    Close
+                </button>
             </t>
         </BootstrapDialog>
     `;


### PR DESCRIPTION
Update core code could be updated from "Update" page and IoT Handlers from "Log Levels" page.

Now, all update tools are moved to update page.

Task: 4395958

![image](https://github.com/user-attachments/assets/6fc03aab-8b03-4a2b-a9dd-370ddbab4424)
![image](https://github.com/user-attachments/assets/629dd21a-a7ce-4afc-9116-8ae6e650db3b)
![image](https://github.com/user-attachments/assets/3015c617-a82a-4e1d-aa3c-9140b2ee59cf)
