### PR TITLE
[FIX] point_of_sale: avoid clipping long product names

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
@@ -28,7 +28,8 @@
 
     &.no-image {
         -webkit-line-clamp: 7;
-        aspect-ratio: 4 / 3;
+        min-height: 4rem;
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
**Problem**:
When product images are hidden in the Point of Sale (PoS) interface, long product names are clipped.
Following the commit:
https://github.com/odoo/odoo/commit/1bc90a18807c43206c4620d7faad2579a3a61fc9#diff-15a6744dfd3306e9ae2ff1236ed670da656f52c81619823fb331967dbc790487R25
the product article container's size was fixed using `aspect-ratio: 4 / 3;`. This approach is not suitable for long product names, leading to truncation.

**Solution**:
Revert the `aspect-ratio: 4 / 3;` style back to `min-height: 4rem` to prevent clipping and allow proper display of long product names.

**After fix**
![image](https://github.com/user-attachments/assets/aabed740-f6db-4656-92ac-5efa63c54a3e)

**Steps to reproduce**:
1. Go to the Point of Sale (PoS) settings.
2. Disable the display of product images.
3. Open the PoS interface.
4. Observe that long product names are clipped and improperly aligned.

opw-4389643