### PR TITLE
[FIX] l10n_in: auto capitalize GST Number

### DIFF
--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -55,6 +55,10 @@ class ResCompany(models.Model):
             else:
                 record.l10n_in_pan_type = False
 
+    @api.onchange('vat')
+    def onchange_vat(self):
+        self.partner_id.onchange_vat()
+
     @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)

--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -77,6 +77,7 @@ class ResPartner(models.Model):
     @api.onchange('vat')
     def onchange_vat(self):
         if self.vat and self.check_vat_in(self.vat):
+            self.vat = self.vat.upper()
             state_id = self.env['res.country.state'].search([('l10n_in_tin', '=', self.vat[:2])], limit=1)
             if state_id:
                 self.state_id = state_id


### PR DESCRIPTION
If the GST Number is not in the capital at the time of pushing GSTR-1 data, giving the error that `GSTN is invalid`.

To fix the issue, Auto capitalize GSTN on data input.

> Task-4397069

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
