### PR TITLE
[FIX] web: search_bar quick search uses Dropdown

### DIFF
--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -115,14 +115,8 @@ export class QuickReactionMenu extends Component {
             // Bypass nested dropdown behavior to allow initial focus.
             onEnabled: null,
             hotkeys: {
-                arrowright(index, items) {
-                    const target = index === items.length - 1 ? items[0] : items[index + 1];
-                    target.setActive();
-                },
-                arrowleft(index, items) {
-                    const target = index === 0 ? items.at(-1) : items[index - 1];
-                    target.setActive();
-                },
+                arrowright: (navigator) => navigator.next(),
+                arrowleft: (navigator) => navigator.previous(),
                 // Disable up and down navigation as it does not make sense for horizontal menu.
                 arrowdown: null,
                 arrowup: null,

--- a/addons/project/static/tests/tours/project_burndown_chart_tour.js
+++ b/addons/project/static/tests/tours/project_burndown_chart_tour.js
@@ -32,7 +32,7 @@ registry.category("web_tour.tours").add('burndown_chart_tour', {
     run: `edit Burndown`,
 }, {
     content: 'Validate search',
-    trigger: '.o_searchview_autocomplete .o_menu_item:contains("Project")',
+    trigger: '.o_searchview_autocomplete .o-dropdown-item:contains("Project")',
     run: "click",
 }, {
     content: 'Remove the group by "Date: Month > Stage"',

--- a/addons/stock/static/tests/tours/stock_report_tests.js
+++ b/addons/stock/static/tests/tours/stock_report_tests.js
@@ -36,11 +36,11 @@ registry.category("web_tour.tours").add('test_multiple_warehouses_filter', {
             run: 'edit warehouse',
         },
         {
-            trigger: '.o_menu_item.dropdown-item:contains("Search Warehouse for:") a.o_expand > i',
+            trigger: '.o-dropdown-item:contains("Search Warehouse for:") a.o_expand > i',
             run: 'click',
         },
         {
-            trigger: '.o_menu_item.dropdown-item.o_indent:contains("Warehouse A") a',
+            trigger: '.o-dropdown-item.o_indent:contains("Warehouse A") a',
             run: 'click',
         },
         {
@@ -48,11 +48,11 @@ registry.category("web_tour.tours").add('test_multiple_warehouses_filter', {
             run: 'edit warehouse',
         },
         {
-            trigger: '.o_menu_item.dropdown-item:contains("Search Warehouse for:") a.o_expand > i',
+            trigger: '.o-dropdown-item:contains("Search Warehouse for:") a.o_expand > i',
             run: 'click',
         },
         {
-            trigger: '.o_menu_item.dropdown-item.o_indent:contains("Warehouse B") a',
+            trigger: '.o-dropdown-item.o_indent:contains("Warehouse B") a',
             run: 'click',
         },
         // Go to product page

--- a/addons/test_mail/static/tests/tours/mail_activity_view_tour.js
+++ b/addons/test_mail/static/tests/tours/mail_activity_view_tour.js
@@ -51,7 +51,7 @@ registry.category("web_tour.tours").add("mail_activity_view", {
             run: "edit Test Activity View"
         },
         {
-            trigger: ".o_menu_item.focus",
+            trigger: ".o_searchview_autocomplete .o-dropdown-item.focus",
             content: "Validate search",
             run: "click",
         },

--- a/addons/web/static/src/core/dropdown/_behaviours/dropdown_nesting.js
+++ b/addons/web/static/src/core/dropdown/_behaviours/dropdown_nesting.js
@@ -123,21 +123,21 @@ export function useDropdownNesting(state) {
             },
             hotkeys: {
                 escape: () => current.close(),
-                arrowleft: (index, items) => {
+                arrowleft: (navigator) => {
                     if (
                         localization.direction === "rtl" &&
-                        items[index]?.target.classList.contains("o-dropdown")
+                        navigator.activeItem?.target.classList.contains("o-dropdown")
                     ) {
-                        items[index]?.select();
+                        navigator.activeItem?.select();
                     } else if (current.parent) {
                         current.close();
                     }
                 },
-                arrowright: (index, items) => {
+                arrowright: (navigator) => {
                     if (localization.direction === "rtl" && current.parent) {
                         current.close();
-                    } else if (items[index]?.target.classList.contains("o-dropdown")) {
-                        items[index]?.select();
+                    } else if (navigator.activeItem?.target.classList.contains("o-dropdown")) {
+                        navigator.activeItem?.select();
                     }
                 },
             },

--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -97,6 +97,9 @@ export class Dropdown extends Component {
         },
         manual: { type: Boolean, optional: true },
 
+        /** When true, do not add optional styling css classes on the target*/
+        noClasses: { type: Boolean, optional: true },
+
         /**
          * Override the internal navigation hook options
          * @type {import("@web/core/navigation/navigation").NavigationOptions}
@@ -108,6 +111,7 @@ export class Dropdown extends Component {
         holdOnHover: false,
         menuClass: "",
         state: undefined,
+        noClasses: false,
         navigationOptions: {},
     };
 
@@ -239,22 +243,30 @@ export class Dropdown extends Component {
         }
 
         target.ariaExpanded = false;
-        target.classList.add("o-dropdown");
+        const optionalClasses = [];
+        const requiredClasses = [];
+        optionalClasses.push("o-dropdown");
 
         if (this.hasParent) {
-            target.classList.add("o-dropdown--has-parent");
+            requiredClasses.push("o-dropdown--has-parent");
         }
 
         const tagName = target.tagName.toLowerCase();
         if (!["input", "textarea", "table", "thead", "tbody", "tr", "th", "td"].includes(tagName)) {
-            target.classList.add("dropdown-toggle");
+            optionalClasses.push("dropdown-toggle");
             if (this.hasParent) {
-                target.classList.add("o-dropdown-item", "o-navigable", "dropdown-item");
+                optionalClasses.push("o-dropdown-item", "dropdown-item");
+                requiredClasses.push("o-navigable");
 
                 if (!target.classList.contains("o-dropdown--no-caret")) {
-                    target.classList.add("o-dropdown-caret");
+                    requiredClasses.push("o-dropdown-caret");
                 }
             }
+        }
+
+        target.classList.add(...requiredClasses);
+        if (!this.props.noClasses) {
+            target.classList.add(...optionalClasses);
         }
 
         this.defaultDirection = this.position.split("-")[0];
@@ -272,7 +284,7 @@ export class Dropdown extends Component {
     }
 
     setTargetDirectionClass(direction) {
-        if (!this.target) {
+        if (!this.target || this.props.noClasses) {
             return;
         }
         const directionClasses = {

--- a/addons/web/static/src/core/navigation/navigation.js
+++ b/addons/web/static/src/core/navigation/navigation.js
@@ -7,7 +7,7 @@ import { throttleForAnimation } from "@web/core/utils/timing";
 export const ACTIVE_ELEMENT_CLASS = "focus";
 const throttledFocus = throttleForAnimation((el) => el?.focus());
 
-export class NavigationItem {
+class NavigationItem {
     /**@type {number} */
     index = -1;
 
@@ -80,7 +80,7 @@ export class NavigationItem {
     }
 }
 
-export class Navigator {
+class Navigator {
     /**@type {NavigationItem|undefined}*/
     activeItem = undefined;
 
@@ -104,6 +104,7 @@ export class Navigator {
         this.containerRef = containerRef;
         this._hotkeyService = hotkeyService;
 
+        /**@private*/
         this._options = deepMerge(
             {
                 shouldFocusChildInput: true,

--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -8,9 +8,13 @@ import { fuzzyTest } from "@web/core/utils/search";
 import { _t } from "@web/core/l10n/translation";
 import { SearchBarMenu } from "../search_bar_menu/search_bar_menu";
 
-import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, useRef, useState } from "@odoo/owl";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { hasTouch } from "@web/core/browser/feature_detection";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { ACTIVE_ELEMENT_CLASS } from "@web/core/navigation/navigation";
+
 const parsers = registry.category("parsers");
 
 const CHAR_FIELDS = ["char", "html", "many2many", "many2one", "one2many", "text", "properties"];
@@ -23,6 +27,8 @@ export class SearchBar extends Component {
     static template = "web.SearchBar";
     static components = {
         SearchBarMenu,
+        Dropdown,
+        DropdownItem,
     };
     static props = {
         autofocus: { type: Boolean, optional: true },
@@ -55,7 +61,6 @@ export class SearchBar extends Component {
         // core state
         this.state = useState({
             expanded: [],
-            focusedIndex: 0,
             query: "",
             subItemsLimits: {},
         });
@@ -63,6 +68,9 @@ export class SearchBar extends Component {
         // derived state
         this.items = useState([]);
         this.subItems = {};
+
+        this.inputDropdownState = useDropdownState();
+        this.inputDropdownNavOptions = this.getInputDropdownNavOptions();
 
         this.searchBarDropdownState = useDropdownState();
 
@@ -80,9 +88,6 @@ export class SearchBar extends Component {
         });
 
         useBus(this.env.searchModel, "update", this.render);
-
-        useExternalListener(window, "click", this.onWindowClick);
-        useExternalListener(window, "keydown", this.onWindowKeydown);
     }
 
     /**
@@ -96,7 +101,6 @@ export class SearchBar extends Component {
     /**
      * @param {Object} [options={}]
      * @param {number[]} [options.expanded]
-     * @param {number} [options.focusedIndex]
      * @param {string} [options.query]
      * @param {Object[]} [options.subItems]
      * @returns {Object[]}
@@ -104,8 +108,6 @@ export class SearchBar extends Component {
     async computeState(options = {}) {
         const query = "query" in options ? options.query : this.state.query;
         const expanded = "expanded" in options ? options.expanded : this.state.expanded;
-        const focusedIndex =
-            "focusedIndex" in options ? options.focusedIndex : this.state.focusedIndex;
         const subItems = "subItems" in options ? options.subItems : this.subItems;
 
         const tasks = [];
@@ -132,7 +134,6 @@ export class SearchBar extends Component {
 
         this.state.expanded = expanded;
         this.state.query = query;
-        this.state.focusedIndex = focusedIndex;
         this.subItems = subItems;
 
         this.inputRef.el.value = query;
@@ -397,7 +398,7 @@ export class SearchBar extends Component {
 
     resetState(options = { focus: true }) {
         this.state.subItemsLimits = {};
-        this.computeState({ expanded: [], focusedIndex: 0, query: "", subItems: [] });
+        this.computeState({ expanded: [], query: "", subItems: [] });
         if (options.focus) {
             this.inputRef.el.focus();
         }
@@ -435,6 +436,7 @@ export class SearchBar extends Component {
         if (item.loadMore) {
             item.loadMore();
         } else {
+            this.inputDropdownState.close();
             this.resetState();
         }
     }
@@ -491,17 +493,24 @@ export class SearchBar extends Component {
     onFacetKeydown(facet, facetIndex, ev) {
         switch (ev.key) {
             case "ArrowLeft": {
+                ev.preventDefault();
+                ev.stopPropagation();
                 if (facetIndex === 0) {
                     this.inputRef.el.focus();
+                    const inputLength = this.inputRef.el.value.length;
+                    this.inputRef.el.setSelectionRange(inputLength, inputLength);
                 } else {
                     this.focusFacet(facetIndex - 1);
                 }
                 break;
             }
             case "ArrowRight": {
+                ev.preventDefault();
+                ev.stopPropagation();
                 const facets = this.root.el.getElementsByClassName("o_searchview_facet");
                 if (facetIndex === facets.length - 1) {
                     this.inputRef.el.focus();
+                    this.inputRef.el.setSelectionRange(0, 0);
                 } else {
                     this.focusFacet(facetIndex + 1);
                 }
@@ -522,121 +531,53 @@ export class SearchBar extends Component {
     }
 
     /**
-     * @param {number} index
-     */
-    onItemMousemove(focusedIndex) {
-        this.state.focusedIndex = focusedIndex;
-        this.inputRef.el.focus();
-    }
-
-    /**
      * @param {KeyboardEvent} ev
      */
     onSearchKeydown(ev) {
-        if (ev.isComposing) {
+        if (ev.isComposing || this.inputDropdownState.isOpen) {
             // This case happens with an IME for example: we let it handle all key events.
             return;
         }
-        const focusedItem = this.items[this.state.focusedIndex];
-        let focusedIndex;
         switch (ev.key) {
             case "ArrowDown":
                 ev.preventDefault();
-                if (this.items.length) {
-                    if (this.state.focusedIndex >= this.items.length - 1) {
-                        focusedIndex = 0;
-                    } else {
-                        focusedIndex = this.state.focusedIndex + 1;
-                    }
-                } else {
-                    this.env.searchModel.trigger("focus-view");
-                }
-                break;
-            case "ArrowUp":
-                ev.preventDefault();
-                if (this.items.length) {
-                    if (
-                        this.state.focusedIndex === 0 ||
-                        this.state.focusedIndex > this.items.length - 1
-                    ) {
-                        focusedIndex = this.items.length - 1;
-                    } else {
-                        focusedIndex = this.state.focusedIndex - 1;
-                    }
-                }
+                this.env.searchModel.trigger("focus-view");
                 break;
             case "ArrowLeft":
-                if (focusedItem && focusedItem.isParent && focusedItem.isExpanded) {
-                    ev.preventDefault();
-                    this.toggleItem(focusedItem, false);
-                } else if (focusedItem && focusedItem.isChild) {
-                    ev.preventDefault();
-                    focusedIndex = this.items.findIndex(
-                        (item) => item.isParent && item.searchItemId === focusedItem.searchItemId
-                    );
-                } else if (focusedItem && focusedItem.isFieldProperty) {
-                    ev.preventDefault();
-                    focusedIndex = this.items.findIndex(
-                        (item) => item.isParent && item.searchItemId === focusedItem.propertyItemId
-                    );
-                } else if (ev.target.selectionStart === 0) {
+                if (ev.target.selectionStart === 0) {
                     // focus rightmost facet if any.
                     this.focusFacet();
-                } else {
-                    // do nothing and navigate inside text
                 }
                 break;
             case "ArrowRight":
                 if (ev.target.selectionStart === this.state.query.length) {
-                    if (focusedItem && focusedItem.isParent) {
-                        ev.preventDefault();
-                        if (focusedItem.isExpanded) {
-                            focusedIndex = this.state.focusedIndex + 1;
-                        } else {
-                            this.toggleItem(focusedItem, true);
-                        }
-                    } else if (ev.target.selectionStart === this.state.query.length) {
-                        // Priority 3: focus leftmost facet if any.
-                        this.focusFacet(0);
-                    }
+                    // focus leftmost facet if any.
+                    this.focusFacet(0);
                 }
                 break;
-            case "Backspace":
-                if (!this.state.query.length) {
-                    const facets = this.env.searchModel.facets;
-                    if (facets.length) {
-                        this.removeFacet(facets[facets.length - 1]);
-                    }
+            case "Backspace": {
+                const facets = this.env.searchModel.facets;
+                if (facets.length) {
+                    this.removeFacet(facets[facets.length - 1]);
                 }
                 break;
+            }
             case "Enter":
-                if (!this.state.query.length) {
-                    this.env.searchModel.search(); /** @todo keep this thing ?*/
-                    break;
-                } else if (focusedItem) {
-                    ev.preventDefault(); // keep the focus inside the search bar
-                    this.selectItem(focusedItem);
-                }
-                break;
-            case "Tab":
-                if (this.state.query.length && focusedItem) {
-                    ev.preventDefault(); // keep the focus inside the search bar
-                    this.selectItem(focusedItem);
-                }
+                this.env.searchModel.search(); /** @todo keep this thing ?*/
                 break;
             case "Escape":
                 this.resetState();
                 break;
         }
-
-        if (focusedIndex !== undefined) {
-            this.state.focusedIndex = focusedIndex;
-        }
     }
 
     onSearchClick() {
-        if (!hasTouch() && !this.inputRef.el.value.length) {
-            this.searchBarDropdownState.open();
+        if (!hasTouch()) {
+            if (!this.inputRef.el.value.length) {
+                this.searchBarDropdownState.open();
+            } else {
+                this.inputDropdownState.open();
+            }
         }
     }
 
@@ -649,18 +590,27 @@ export class SearchBar extends Component {
         }
         const query = ev.target.value;
         if (query.trim()) {
-            this.computeState({ query, expanded: [], focusedIndex: 0, subItems: [] });
+            this.inputDropdownState.open();
+            this.computeState({ query, expanded: [], subItems: [] });
         } else if (this.items.length) {
+            this.inputDropdownState.close();
             this.resetState();
         }
     }
 
     onClickSearchIcon() {
-        const focusedItem = this.items[this.state.focusedIndex];
         if (!this.state.query.length) {
             this.env.searchModel.search();
-        } else if (focusedItem) {
-            this.selectItem(focusedItem);
+        } else {
+            const els = [
+                ...this.root.el.ownerDocument.querySelectorAll(
+                    ".o_searchview_autocomplete .o-dropdown-item"
+                ),
+            ];
+            const index = els.findIndex((el) => el.classList.contains(ACTIVE_ELEMENT_CLASS));
+            if (this.items[index]) {
+                this.selectItem(this.items[index]);
+            }
         }
     }
 
@@ -669,20 +619,71 @@ export class SearchBar extends Component {
     }
 
     /**
-     * @param {MouseEvent} ev
+     * @returns {import("@web/core/navigation/navigation").NavigationOptions}
      */
-    onWindowClick(ev) {
-        if (this.items.length && !this.root.el.contains(ev.target)) {
-            this.resetState({ focus: false });
-        }
+    getInputDropdownNavOptions() {
+        return {
+            virtualFocus: true,
+            hotkeys: {
+                arrowright: {
+                    bypassEditableProtection: true,
+                    isAvailable: (navigator) => {
+                        const focusedItem = this.items[navigator.activeItemIndex];
+                        return (
+                            focusedItem &&
+                            this.inputRef.el.selectionStart === this.state.query.length
+                        );
+                    },
+                    callback: (navigator) => {
+                        const focusedItem = this.items[navigator.activeItemIndex];
+                        if (focusedItem.isParent) {
+                            if (focusedItem.isExpanded) {
+                                navigator.next();
+                            } else {
+                                this.toggleItem(focusedItem, true);
+                            }
+                        } else {
+                            this.focusFacet(0);
+                        }
+                    },
+                },
+                arrowleft: {
+                    bypassEditableProtection: true,
+                    isAvailable: (navigator) => {
+                        const focusedItem = this.items[navigator.activeItemIndex];
+                        return (
+                            this.inputRef.el.selectionStart === 0 ||
+                            (focusedItem &&
+                                ((focusedItem.isParent && focusedItem.isExpanded) ||
+                                    focusedItem.isChild ||
+                                    focusedItem.isFieldProperty))
+                        );
+                    },
+                    callback: (navigator) => {
+                        const focusedItem = this.items[navigator.activeItemIndex];
+                        const findIndex = (id) =>
+                            this.items.findIndex(
+                                (item) => item.isParent && item.searchItemId === id
+                            );
+                        if (focusedItem && focusedItem.isParent && focusedItem.isExpanded) {
+                            this.toggleItem(focusedItem, false);
+                        } else if (focusedItem && focusedItem.isChild) {
+                            navigator.items[findIndex(focusedItem.searchItemId)]?.setActive();
+                        } else if (focusedItem && focusedItem.isFieldProperty) {
+                            navigator.items[findIndex(focusedItem.propertyItemId)]?.setActive();
+                        } else if (this.inputRef.el.selectionStart === 0) {
+                            this.focusFacet();
+                        }
+                    },
+                },
+            },
+            onEnabled: (items) => items[0]?.setActive(),
+        };
     }
 
-    /**
-     * @param {KeyboardEvent} ev
-     */
-    onWindowKeydown(ev) {
-        if (this.items.length && ev.key === "Escape") {
-            this.resetState();
+    onInputDropdownChanged(isOpen) {
+        if (!isOpen) {
+            this.resetState({ focus: false });
         }
     }
 }

--- a/addons/web/static/src/search/search_bar/search_bar.scss
+++ b/addons/web/static/src/search/search_bar/search_bar.scss
@@ -25,3 +25,26 @@
         }
     }
 }
+
+.o_searchview_autocomplete {
+    .o-dropdown-item {
+        align-items: center;
+        display: flex;
+        padding-left: 25px;
+
+        &.o_indent {
+            padding-left: 50px;
+        }
+
+        a {
+            color: inherit;
+
+            &.o_expand {
+                display: flex;
+                justify-content: center;
+                width: 25px;
+                @include o-position-absolute($left: 0);
+            }
+        }
+    }
+}

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -58,71 +58,75 @@
         </t>
     </t>
 
-    <t t-name="web.SearchBar.Input">
-        <input type="text"
-            class="o_searchview_input o_input d-print-none flex-grow-1 w-auto border-0"
-            accesskey="Q"
-            placeholder="Search..."
-            role="searchbox"
-            t-ref="autofocus"
-            t-on-keydown="onSearchKeydown"
-            t-on-click="onSearchClick"
-            t-on-input="onSearchInput"
-        />
-    </t>
-
-    <t t-name="web.SearchBar.Items">
-        <ul class="o-dropdown--menu dropdown-menu o_searchview_autocomplete show" role="menu">
-            <t t-foreach="items" t-as="item" t-key="item.id">
-                <li class="o_menu_item dropdown-item"
-                    t-att-class="{ o_indent: item.isChild, focus: item_index === state.focusedIndex}"
-                    t-att-id="item.id"
-                    t-on-click="() => this.selectItem(item)"
-                    t-on-mousemove="() => this.onItemMousemove(item_index)"
-                    >
-                    <t t-if="item.isParent">
-                        <a t-att-class="{ o_expand: true, 'ms-4': item.isFieldProperty}"
-                            href="#"
-                            t-on-click.stop.prevent="() => this.toggleItem(item, !item.isExpanded)"
-                            >
-                            <i t-attf-class="fa fa-caret-{{ item.isExpanded ? 'down' : 'right' }}"/>
-                        </a>
-                    </t>
-                    <a href="#" t-on-click.prevent="" t-att-class="{'ps-3 pe-2 text-truncate': item.isFieldProperty }" t-att-title="item.title">
-                        <t t-if="item.isAddCustomFilterButton"><span class="text-action">Add Custom Filter</span></t>
-                        <t t-elif="item.loadMore"><span class="text-action"><t t-esc="item.label"/></span></t>
-                        <t t-elif="item.isChild">
-                            <t t-esc="item.label"/>
-                        </t>
-                        <t t-elif="!item.isFieldProperty" > Search </t> <b t-esc="item.searchItemDescription"/> <t t-if="item.preposition"> <t t-esc="item.preposition"/>: <b class="fst-italic text-primary" t-esc="item.label"/> </t>
+    <t t-name="web.SearchBar.QuickSearchItems">
+        <t t-foreach="items" t-as="item" t-key="item.id">
+            <DropdownItem
+                class="{ o_indent: item.isChild }"
+                attrs="{ id: item.id }"
+                onSelected="() => this.selectItem(item)"
+                closingMode="'none'"
+            >
+                <t t-if="item.isParent">
+                    <a t-att-class="{ o_expand: true, 'ms-4': item.isFieldProperty}"
+                        href="#"
+                        t-on-click.stop.prevent="() => this.toggleItem(item, !item.isExpanded)"
+                        >
+                        <i t-attf-class="fa fa-caret-{{ item.isExpanded ? 'down' : 'right' }}"/>
                     </a>
-                </li>
-            </t>
-        </ul>
+                </t>
+                <a href="#" t-on-click.prevent="" t-att-class="{'ps-3 pe-2 text-truncate': item.isFieldProperty }" t-att-title="item.title">
+                    <t t-if="item.isAddCustomFilterButton"><span class="text-action">Add Custom Filter</span></t>
+                    <t t-elif="item.loadMore"><span class="text-action"><t t-esc="item.label"/></span></t>
+                    <t t-elif="item.isChild">
+                        <t t-esc="item.label"/>
+                    </t>
+                    <t t-elif="!item.isFieldProperty" > Search </t> <b t-esc="item.searchItemDescription"/> <t t-if="item.preposition"> <t t-esc="item.preposition"/>: <b class="fst-italic text-primary" t-esc="item.label"/> </t>
+                </a>
+            </DropdownItem>
+        </t>
     </t>
 
     <t t-name="web.SearchBar">
         <div t-if="visibilityState.showSearchBar" class="o_cp_searchview d-flex input-group mt-1 mt-md-0" role="search" t-ref="root">
-            <div class="o_searchview form-control d-print-contents d-flex align-items-center py-1 border-end-0"
-                 role="search" aria-autocomplete="list">
-                <button class="d-print-none btn border-0 p-0"
-                    role="button"
-                    aria-label="Search..."
-                    title="Search..."
-                    t-on-click="this.onClickSearchIcon"
-                >
-                    <i class="o_searchview_icon oi oi-search me-2"
-                        role="img"
-                    />
-                </button>
-                <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 mw-100">
-                    <t t-call="web.SearchBar.Facets"/>
-                    <t t-call="web.SearchBar.Input"/>
-                    <t t-if="items.length">
-                        <t t-call="web.SearchBar.Items"/>
-                    </t>
+            <Dropdown
+                state="inputDropdownState"
+                manual="true"
+                noClasses="true"
+                position="'bottom-fit'"
+                menuClass="'o_searchview_autocomplete'"
+                navigationOptions="inputDropdownNavOptions"
+                onStateChanged.bind="onInputDropdownChanged"
+            >
+                <div class="o_searchview form-control d-print-contents d-flex align-items-center py-1 border-end-0"
+                    role="search" aria-autocomplete="list">
+                    <button class="d-print-none btn border-0 p-0"
+                        role="button"
+                        aria-label="Search..."
+                        title="Search..."
+                        t-on-click="this.onClickSearchIcon"
+                    >
+                        <i class="o_searchview_icon oi oi-search me-2"
+                            role="img"
+                        />
+                    </button>
+                    <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 mw-100">
+                        <t t-call="web.SearchBar.Facets"/>
+                        <input type="text"
+                            class="o_searchview_input o_input d-print-none flex-grow-1 w-auto border-0"
+                            accesskey="Q"
+                            placeholder="Search..."
+                            role="searchbox"
+                            t-ref="autofocus"
+                            t-on-keydown="onSearchKeydown"
+                            t-on-click="onSearchClick"
+                            t-on-input="onSearchInput"
+                        />
+                    </div>
                 </div>
-            </div>
+                <t t-set-slot="content">
+                    <t t-call="web.SearchBar.QuickSearchItems"/>
+                </t>
+            </Dropdown>
             <SearchBarMenu dropdownState="searchBarDropdownState">
                 <t t-slot="search-bar-additional-menu"/>
             </SearchBarMenu>

--- a/addons/web/static/src/search/search_panel/search_view.scss
+++ b/addons/web/static/src/search/search_panel/search_view.scss
@@ -18,32 +18,6 @@
     .o_searchview_input {
         appearance: none;
     }
-
-    .o_searchview_autocomplete {
-        @include o-position-absolute(calc(100% + #{$border-width * 3}), 0);
-        width: 100%;
-
-        .o_menu_item {
-            align-items: center;
-            display: flex;
-            padding-left: 25px;
-
-            &.o_indent {
-                padding-left: 50px;
-            }
-
-            a {
-                color: inherit;
-
-                &.o_expand {
-                    display: flex;
-                    justify-content: center;
-                    width: 25px;
-                    @include o-position-absolute($left: 0);
-                }
-            }
-        }
-    }
 }
 
 .o_search_options {

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
@@ -164,25 +164,27 @@ export class SwitchCompanyMenu extends Component {
         this.containerRef = useChildRef();
         this.navigationOptions = {
             hotkeys: {
-                space: (index, items) => {
-                    if (!items[index]) {
+                space: (navigator) => {
+                    const navItem = navigator.activeItem;
+                    if (!navItem) {
                         return;
                     }
-                    if (items[index].el.classList.contains("o_switch_company_item")) {
-                        const companyId = parseInt(items[index].el.dataset.companyId);
+                    if (navItem.el.classList.contains("o_switch_company_item")) {
+                        const companyId = parseInt(navItem.el.dataset.companyId);
                         this.companySelector.switchCompany("toggle", companyId);
                     }
                 },
-                enter: (index, items) => {
-                    if (!items[index]) {
+                enter: (navigator) => {
+                    const navItem = navigator.activeItem;
+                    if (!navItem) {
                         return;
                     }
-                    if (items[index].el.classList.contains("o_switch_company_item")) {
-                        const companyId = parseInt(items[index].el.dataset.companyId);
+                    if (navItem.el.classList.contains("o_switch_company_item")) {
+                        const companyId = parseInt(navItem.el.dataset.companyId);
                         this.companySelector.switchCompany("loginto", companyId);
                         this.dropdown.close();
                     } else {
-                        items[index].select();
+                        navItem.select();
                     }
                 },
             },

--- a/addons/web/static/tests/core/navigation_hook.test.js
+++ b/addons/web/static/tests/core/navigation_hook.test.js
@@ -86,13 +86,15 @@ test("hotkey override options", async () => {
     class Parent extends BasicHookParent {
         navOptions = {
             hotkeys: {
-                arrowleft: (index, items) => {
-                    expect.step(index);
-                    items[(index + 2) % items.length].setActive();
+                arrowleft: (navigator) => {
+                    expect.step(navigator.activeItemIndex);
+                    navigator.items[
+                        (navigator.activeItemIndex + 2) % navigator.items.length
+                    ].setActive();
                 },
-                escape: (index, items) => {
+                escape: (navigator) => {
                     expect.step("escape");
-                    items[0].setActive();
+                    navigator.items[0].setActive();
                 },
             },
         };

--- a/addons/web/static/tests/views/fields/many2many_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_field.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { queryAllTexts } from "@odoo/hoot-dom";
+import { press, queryAllTexts } from "@odoo/hoot-dom";
 import { Deferred, animationFrame, runAllTimers } from "@odoo/hoot-mock";
 
 import {
@@ -1233,6 +1233,8 @@ test("many2many with a domain", async () => {
     await contains(".o_field_x2many_list_row_add a").click();
     expect(".modal .o_data_row").toHaveCount(1);
     await contains(`.modal .o_searchview input`).edit("s");
+    await press("enter");
+    await animationFrame();
 
     expect(".modal .o_data_row").toHaveCount(0);
 });


### PR DESCRIPTION
This PR makes it so the search_bar quick search uses the Dropdown component, this fixes issues where the menu would sometimes be under overlays such as modals.

The navigation hook had to be adapted to better work with inputs, allowing to control when a hotkey press should be ignored or not.

Task ID: 4251342
Enterprise PR: https://github.com/odoo/enterprise/pull/75491

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
