### PR TITLE
[IMP] point_of_sale: remove kiosk warning message

### DIFF
--- a/addons/l10n_in_pos/views/res_config_settings_views.xml
+++ b/addons/l10n_in_pos/views/res_config_settings_views.xml
@@ -5,10 +5,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='available_payment_terminal']" position="attributes">
-                <attribute name="invisible">not is_kiosk_mode or country_code == 'IN'</attribute>
-            </xpath>
-            <xpath expr="//div[@id='available_payment_terminal']" position="after">
+            <xpath expr="//setting[@id='payment_methods_new']" position="before">
                 <div class="o_notification_alert alert alert-warning" role="alert" invisible="not is_kiosk_mode or country_code != 'IN'">
                     <span>Please note that the kiosk for INR currency only works with Razorpay terminal</span>
                 </div>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -67,9 +67,6 @@
                             </setting>
                         </block>
                         <block title="Payment" id="pos_payment_section">
-                            <div id="available_payment_terminal" class="o_notification_alert alert alert-warning" role="alert" invisible="not is_kiosk_mode">
-                                <span>Please note that the kiosk only works with Adyen &amp; Stripe terminals</span>
-                            </div>
                             <setting id="payment_methods_new" string="Payment Methods" help="Payment methods available" documentation="/applications/sales/point_of_sale/payment_methods.html">
                                 <field name="pos_payment_method_ids"
                                     colspan="4"


### PR DESCRIPTION
The corresponding enterprise PR adds support for
IoT payment methods, so the message about
only supporting Adyen and Stripe is out of date.
This commit removes that message.

task-4128846

Enterprise PR: https://github.com/odoo/enterprise/pull/72683

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
