### PR TITLE
[FIX] mail: error while creating sub-thread

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -119,7 +119,7 @@ const threadPatch = {
             name,
         });
         this.store.insert(data, { html: true });
-        this.store.Thread.get(sub_channel).open();
+        this.store.Thread.get({ model: "discuss.channel", id: sub_channel }).open();
     },
     /**
      * @param {*} param0

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -606,7 +606,7 @@ export class DiscussChannel extends models.ServerModel {
         );
         return {
             data: store.get_result(),
-            sub_channel: mailDataHelpers.Store.one_id(subChannels),
+            sub_channel: subChannels[0].id,
         };
     }
 


### PR DESCRIPTION
Following the changes introduced in https://github.com/odoo/odoo/pull/184344, 
the sub-channel values now return only the ID. Performing a get operation on the model requires both the ID and the model name. This commit address this issue.

Error:
![image](https://github.com/user-attachments/assets/2760caed-fc71-4183-8994-14dbc02aa531)

