### PR TITLE
[FIX] google_calendar: allow portal attendees

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -237,7 +237,10 @@ class AlarmManager(models.AbstractModel):
     def _notify_next_alarm(self, partner_ids):
         """ Sends through the bus the next alarm of given partners """
         notifications = []
-        users = self.env['res.users'].search([('partner_id', 'in', tuple(partner_ids))])
+        users = self.env['res.users'].search([
+            ('partner_id', 'in', tuple(partner_ids)),
+            ('groups_id', 'in', self.env.ref('base.group_user').ids),
+        ])
         for user in users:
             notif = self.with_user(user).with_context(allowed_company_ids=user.company_ids.ids).get_next_notif()
             notifications.append([user.partner_id, 'calendar.alarm', notif])


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
allow portal attendees to be synced by google calendar

Current behavior before PR:
There was an `AccessError` happening when:
- One portal user was invited to more than one event.
- At least one of them was going to be notified in the future.
- Google cancelled the first of those.

<details>

```
2024-12-11 10:19:02,144 31 INFO odoo odoo.addons.base.models.ir_cron: Manually starting job `Google Calendar: sincronización`.
2024-12-11 10:19:02,151 31 INFO odoo odoo.addons.google_calendar.models.res_users: Calendar Synchro - Starting synchronization for res.users(29,)
2024-12-11 10:19:02,539 31 INFO odoo odoo.addons.google_calendar.models.res_users: Calendar Synchro - Starting synchronization for res.users(15,)
2024-12-11 10:19:03,029 31 INFO odoo odoo.addons.google_calendar.models.res_users: Calendar Synchro - Starting synchronization for res.users(50,)
2024-12-11 10:19:03,414 31 INFO odoo odoo.addons.google_calendar.models.res_users: Calendar Synchro - Starting synchronization for res.users(40,)
2024-12-11 10:19:03,823 31 INFO odoo odoo.addons.google_calendar.models.res_users: Calendar Synchro - Starting synchronization for res.users(52,)
2024-12-11 10:19:04,219 31 INFO odoo odoo.addons.google_calendar.models.res_users: Calendar Synchro - Starting synchronization for res.users(10,)
2024-12-11 10:19:04,580 31 INFO odoo odoo.addons.google_calendar.models.res_users: Calendar Synchro - Starting synchronization for res.users(28,)
2024-12-11 10:19:04,936 31 INFO odoo odoo.addons.google_calendar.models.res_users: Calendar Synchro - Starting synchronization for res.users(2,)
2024-12-11 10:19:05,501 31 INFO odoo odoo.models.unlink: User #2 deleted mail.message records with IDs: [1055490, 1055487, 1055480, 1055478, 1055403]
2024-12-11 10:19:05,518 31 INFO odoo odoo.models.unlink: User #2 deleted calendar.event records with IDs: [2920874, 2920875, 2920880]
2024-12-11 10:19:05,520 31 INFO odoo odoo.models.unlink: User #2 deleted mail.followers records with IDs: [6232226, 6232227, 6232228, 6232229, 6232230, 6232231, 6232232, 6232233, 6232234, 6232235, 6232236, 6232237, 6232238, 6232239, 6232240, 6232241, 6232242, 6232243, 6232270, 6232271, 6232272, 6232283]
2024-12-11 10:19:05,544 31 INFO odoo odoo.addons.base.models.ir_model: Access Denied by ACLs for operation: read, uid: 65, model: calendar.alarm
2024-12-11 10:19:05,545 31 INFO odoo odoo.addons.base.models.ir_model: Access Denied by ACLs for operation: read, uid: 65, model: calendar.alarm
2024-12-11 10:19:05,545 31 ERROR odoo odoo.addons.google_calendar.models.res_users: [res.users(2,)] Calendar Synchro - Exception : No puede ingresar a los registros 'Event Alarm' (calendar.alarm)

Se permite esta operación para los grupos siguientes:
      - User types/Internal User

Póngase en contacto con su administrador para solicitar acceso si es necesario. !
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 997, in get
    cache_value = field_cache[record._ids[0]]
KeyError: 8

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1161, in __get__
    value = env.cache.get(record, self)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 1004, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: 'calendar.alarm(8,).alarm_type'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1187, in __get__
    recs._fetch_field(self)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3210, in _fetch_field
    self._read(fnames)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3220, in _read
    self.check_access_rights('read')
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3480, in check_access_rights
    return self.env['ir.model.access'].check(self._name, operation, raise_exception)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_model.py", line 1924, in check
    raise AccessError(msg)
odoo.exceptions.AccessError: No puede ingresar a los registros 'Event Alarm' (calendar.alarm)

Se permite esta operación para los grupos siguientes:
      - User types/Internal User

Póngase en contacto con su administrador para solicitar acceso si es necesario.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/auto/addons/google_calendar/models/res_users.py", line 100, in _sync_all_google_calendar
    user.with_user(user).sudo()._sync_google_calendar(google)
  File "/opt/odoo/auto/addons/google_calendar/models/res_users.py", line 79, in _sync_google_calendar
    synced_events = self.env['calendar.event'].with_context(write_dates=events_write_dates)._sync_google2odoo(events - recurrences, default_reminders=default_reminders)
  File "/opt/odoo/auto/addons/google_calendar/models/google_sync.py", line 185, in _sync_google2odoo
    cancelled_odoo._cancel()
  File "/opt/odoo/auto/addons/google_calendar/models/calendar.py", line 326, in _cancel
    super(Meeting, my_cancelled_records)._cancel()
  File "/opt/odoo/auto/addons/google_calendar/models/google_sync.py", line 152, in _cancel
    self.unlink()
  File "/opt/odoo/auto/addons/calendar/models/calendar_event.py", line 721, in unlink
    self.env['calendar.alarm_manager']._notify_next_alarm(partner_ids)
  File "/opt/odoo/auto/addons/calendar/models/calendar_alarm_manager.py", line 242, in _notify_next_alarm
    notif = self.with_user(user).with_context(allowed_company_ids=user.company_ids.ids).get_next_notif()
  File "/opt/odoo/auto/addons/calendar/models/calendar_alarm_manager.py", line 210, in get_next_notif
    last_found = self.do_check_alarm_for_one_date(in_date_format, meeting, max_delta, time_limit, 'notification', after=partner.calendar_last_notif_ack)
  File "/opt/odoo/auto/addons/calendar/models/calendar_alarm_manager.py", line 130, in do_check_alarm_for_one_date
    if alarm.alarm_type != alarm_type:
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1189, in __get__
    record._fetch_field(self)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3210, in _fetch_field
    self._read(fnames)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3220, in _read
    self.check_access_rights('read')
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3480, in check_access_rights
    return self.env['ir.model.access'].check(self._name, operation, raise_exception)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_model.py", line 1924, in check
    raise AccessError(msg)
odoo.exceptions.AccessError: No puede ingresar a los registros 'Event Alarm' (calendar.alarm)

Se permite esta operación para los grupos siguientes:
      - User types/Internal User

Póngase en contacto con su administrador para solicitar acceso si es necesario.
2024-12-11 10:19:05,547 31 INFO odoo odoo.addons.base.models.ir_cron: Job `Google Calendar: sincronización` done.
```

</details>

Desired behavior after PR is merged:
Google Sync works.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr


@moduon MT-8345
cc @arj-odoo 