### PR TITLE
[FIX] base_import: fix access error during import

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -317,6 +317,8 @@ class Import(models.TransientModel):
             definition_record_field = field['definition_record_field']
 
             target_model = Model.env[Model._fields[definition_record].comodel_name]
+            if not target_model.has_access('read'):  # ignore if you cannot read target_model at all
+                continue
             # Do not take into account the definition of archived parents,
             # we do not import archived records most of the time.
             definition_records = target_model.search_fetch(


### PR DESCRIPTION
We try to import a model, `get_fields_tree` is called recursively to fetch all available fields importable. Since
https://github.com/odoo/odoo/issues/174366, it also includes Property of Properties Field, but the code to do that, search directly on the definition model which can be inaccessible for the current record leading to an AccessError. Filtered out Properties where the definition is inaccessible to avoid the issue.