### PR TITLE
[FIX] account: allow accountants to create products

### DIFF
--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -22,6 +22,7 @@ access_account_fiscal_position_account,account.fiscal.position all,model_account
 
 access_product_product_account_user,product.product.account.user,product.model_product_product,group_account_readonly,1,0,0,0
 access_product_product_account_manager,product.product.account.manager,product.model_product_product,account.group_account_manager,1,1,1,1
+access_product_template_account_manager,product.template.account.manager,product.model_product_template,account.group_account_manager,1,1,1,1
 
 access_account_bank_statement_group_readonly,account.bank.statement.group.invoice,model_account_bank_statement,account.group_account_readonly,1,0,0,0
 access_account_bank_statement_group_invoice,account.bank.statement.group.invoice,model_account_bank_statement,account.group_account_invoice,1,0,0,0

--- a/addons/account/tests/test_product.py
+++ b/addons/account/tests/test_product.py
@@ -16,6 +16,11 @@ class TestProduct(AccountTestInvoicingCommon):
             login="internal_user",
             groups="base.group_user",
         )
+        cls.account_manager_user = new_test_user(
+            cls.env,
+            login="account_manager_user",
+            groups="account.group_account_manager",
+        )
 
     def test_internal_user_can_read_product_with_tax_and_tags(self):
         """Internal users need read access to products, no matter their taxes."""
@@ -52,3 +57,10 @@ class TestProduct(AccountTestInvoicingCommon):
             'taxes_id': self.company_data['company'].account_sale_tax_id.ids,
             'supplier_taxes_id': self.company_data['company'].account_purchase_tax_id.ids,
         }])
+
+    def test_account_manager_user_can_create_product(self):
+        """Test that a user with group_account_manager can create a product."""
+        product = self.env['product.product'].with_user(self.account_manager_user).create({
+            'name': 'Test Accountant', 'type': 'product', 'list_price': 50.0,
+        })
+        self.assertTrue(product)


### PR DESCRIPTION
**Issue:**
Accountants cannot create products through Customer Invoice or Vendor Bill product lines.

![image](https://github.com/user-attachments/assets/fde7d8de-354f-46fa-861d-bfe55dcabfbd)

**Expected:**
Accountants should be allowed to manage the products database.

**Steps to reproduce:**
- Activate Invoicing app;
- Configure a branch to the company;
- Create a user with an accounting `Accountant` role and set the branch company as only entry in Allowed Companies and as Default Company;

![Capture d’écran 2024-12-10 à 18 04 55](https://github.com/user-attachments/assets/bc0fae3f-cff4-4e73-9eb9-f86d5285ba6d)

- Log in as that new user;
- Try create a new product through a Customer Invoice or a Vendor Bill.

**Cause:**
The `Accountant` role itself has no right on products.

**Fix:**
Reset a previously removed (february 2023 (saas-16.2) odoo/odoo@512574861691f425ec6a17f20fe4b586bb88a299) access right on `product_template` for group `group_account_manager`.

![Capture d’écran 2024-12-10 à 18 14 38](https://github.com/user-attachments/assets/8902ceee-6b97-4522-8505-3f72a0260226)

**Note:**
This PR replaces https://github.com/odoo/enterprise/pull/75453 after discussion with reviewer.


opw-4293151

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
