### PR TITLE
[IMP] crm,*: add new chatbot script step to create lead and forward 

### DIFF
--- a/addons/crm_livechat/models/__init__.py
+++ b/addons/crm_livechat/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import chatbot_script

--- a/addons/crm_livechat/models/chatbot_script_step.py
+++ b/addons/crm_livechat/models/chatbot_script_step.py
@@ -1,23 +1,35 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, models, fields
+from ast import literal_eval
+
+from odoo import models, fields
+from odoo.osv import expression
 
 
 class ChatbotScriptStep(models.Model):
     _inherit = 'chatbot.script.step'
 
     step_type = fields.Selection(
-        selection_add=[('create_lead', 'Create Lead')], ondelete={'create_lead': 'cascade'})
+        selection_add=[
+            ("create_lead", "Create Lead"),
+            ("create_lead_and_forward", "Create Lead & Forward"),
+        ],
+        ondelete={"create_lead": "cascade", "create_lead_and_forward": "cascade"},
+    )
     crm_team_id = fields.Many2one(
-        'crm.team', string='Sales Team', ondelete='set null',
+        'crm.team', string='Sales Team', ondelete='set null', index="btree_not_null",
         help="Used in combination with 'create_lead' step type in order to automatically "
              "assign the created lead/opportunity to the defined team")
 
+    def _compute_is_forward_operator(self):
+        super()._compute_is_forward_operator()
+        self.filtered(lambda s: s.step_type == "create_lead_and_forward").is_forward_operator = True
+
     def _chatbot_crm_prepare_lead_values(self, discuss_channel, description):
         return {
+            "company_id": self.crm_team_id.company_id.id,
             'description': description + discuss_channel._get_channel_history(),
-            'name': _("%s's New Lead", self.chatbot_script_id.title),
+            "name": self.env._("%s's New Lead", self.chatbot_script_id.title),
             'source_id': self.chatbot_script_id.source_id.id,
             'team_id': self.crm_team_id.id,
             'type': 'lead' if self.crm_team_id.use_leads else 'opportunity',
@@ -26,12 +38,11 @@ class ChatbotScriptStep(models.Model):
 
     def _process_step(self, discuss_channel):
         self.ensure_one()
-
+        if self.step_type == "create_lead_and_forward":
+            return self._process_step_create_lead_and_forward(discuss_channel)
         posted_message = super()._process_step(discuss_channel)
-
         if self.step_type == 'create_lead':
             self._process_step_create_lead(discuss_channel)
-
         return posted_message
 
     def _process_step_create_lead(self, discuss_channel):
@@ -44,7 +55,6 @@ class ChatbotScriptStep(models.Model):
         The whole conversation history will be saved into the lead's description for reference.
         This also allows having a question of type 'free_input_multi' to let the visitor explain
         their interest / needs before creating the lead. """
-
         customer_values = self._chatbot_prepare_customer_values(
             discuss_channel, create_partner=False, update_partner=True)
         if self.env.user._is_public():
@@ -58,8 +68,49 @@ class ChatbotScriptStep(models.Model):
                 'partner_id': partner.id,
                 'company_id': partner.company_id.id,
             }
-
         create_values.update(self._chatbot_crm_prepare_lead_values(
             discuss_channel, customer_values['description']))
+        return self.env["crm.lead"].create(create_values)
 
-        self.env['crm.lead'].create(create_values)
+    def _process_step_create_lead_and_forward(self, discuss_channel):
+        lead = self._process_step_create_lead(discuss_channel)
+        teams = lead.team_id
+        if not teams:
+            possible_teams = self.env["crm.team"].search(
+                expression.AND(
+                    [
+                        [("assignment_optout", "=", False)],
+                        expression.OR(
+                            [[("use_leads", "=", True)], [("use_opportunities", "=", True)]]
+                        ),
+                    ]
+                )
+            )
+            teams = possible_teams.filtered(
+                lambda team: team.assignment_max
+                and lead.filtered_domain(literal_eval(team.assignment_domain or "[]"))
+            )
+        assignable_user_ids = [
+            member.user_id.id
+            for member in teams.crm_team_member_ids
+            if not member.assignment_optout
+            and member._get_assignment_quota() > 0
+            and lead.filtered_domain(literal_eval(member.assignment_domain or "[]"))
+        ]
+        # sudo: im_livechat.channel - getting available operators is acceptable
+        users = discuss_channel.livechat_channel_id.sudo()._get_available_operators_by_livechat_channel(
+            self.env["res.users"].browse(assignable_user_ids)
+        )[discuss_channel.livechat_channel_id]
+        message = self._process_step_forward_operator(discuss_channel, users=users)
+        operator_partner = discuss_channel.livechat_operator_id
+        if operator_partner != self.chatbot_script_id.operator_partner_id:
+            user = next(user for user in users if user.partner_id == operator_partner)
+            lead.user_id = user
+            lead.team_id = next(team for team in teams if user in team.crm_team_member_ids.user_id)
+            msg = self.env._("Created a new lead: %s", lead._get_html_link())
+            user._bus_send_transient_message(discuss_channel, msg)
+            # Call flush_recordset() now (as sudo), otherwise flush_all() is called at the end of
+            # the request with a non-sudo env, which fails (as public user) to compute some crm.lead
+            # fields having dependencies on assigned user_id.
+            lead.flush_recordset()
+        return message

--- a/addons/crm_livechat/tests/chatbot_common.py
+++ b/addons/crm_livechat/tests/chatbot_common.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.addons.im_livechat.tests.chatbot_common import ChatbotCase
 from odoo.addons.mail.tests.common import mail_new_test_user
 
@@ -9,37 +9,25 @@ class CrmChatbotCase(ChatbotCase):
 
     @classmethod
     def setUpClass(cls):
-        super(CrmChatbotCase, cls).setUpClass()
-
-        cls.company_id = cls.env['res.company'].create({
-            'name': 'Test Company',
-            'country_id': cls.env.ref('base.be').id,
-        })
-
-        cls.user_public = mail_new_test_user(
-            cls.env, login='user_public', groups='base.group_public', name='Public User')
-        cls.user_portal = mail_new_test_user(
-            cls.env, login='user_portal', groups='base.group_portal', name='Portal User',
-            company_id=cls.company_id.id, email='portal@example.com')
-        # update company_id on partner since the user's company is not propagated
-        cls.user_portal.partner_id.write({'company_id': cls.company_id.id})
-
-        cls.sale_team = cls.env['crm.team'].create({
-            'name': 'Test Sale Team 1',
-            'company_id': cls.company_id.id,
-        })
-
-        cls.sale_team_with_lead = cls.env['crm.team'].create({
-            'name': 'Test Sale Team 2',
-            'use_leads': True,
-            'company_id': cls.company_id.id,
-        })
-
+        super().setUpClass()
+        cls._create_portal_user()
+        teams_data = [
+            {
+                "company_id": cls.company_admin.id,
+                "crm_team_member_ids": [Command.create({"user_id": cls.user_employee.id})],
+                "name": "Test Sale Team 1",
+            },
+            {
+                "company_id": cls.company_admin.id,
+                "name": "Test Sale Team 2",
+                "use_leads": True,
+            },
+        ]
+        cls.sale_team, cls.sale_team_with_lead = cls.env["crm.team"].create(teams_data)
         cls.step_dispatch_create_lead = cls.env['chatbot.script.answer'].sudo().create({
             'name': 'Create a lead',
             'script_step_id': cls.step_dispatch.id,
         })
-
         [
             cls.step_create_lead_email,
             cls.step_create_lead_phone,

--- a/addons/crm_livechat/tests/test_chatbot_lead.py
+++ b/addons/crm_livechat/tests/test_chatbot_lead.py
@@ -1,15 +1,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.addons.crm_livechat.tests import chatbot_common
-from odoo.tests.common import tagged, users
+from odoo.tests.common import tagged
 
 
 @tagged("post_install", "-at_install")
 class CrmChatbotCase(chatbot_common.CrmChatbotCase):
 
-    @users('user_public')
-    def test_chatbot_lead_public_user(self):
-        self._chatbot_create_lead(self.user_public)
+    def test_chatbot_create_lead_public_user(self):
+        self._play_session_with_lead()
 
         created_lead = self.env['crm.lead'].sudo().search([], limit=1, order='id desc')
         self.assertEqual(created_lead.name, "Testing Bot's New Lead")
@@ -19,10 +19,73 @@ class CrmChatbotCase(chatbot_common.CrmChatbotCase):
         self.assertEqual(created_lead.team_id, self.sale_team)
         self.assertEqual(created_lead.type, 'opportunity')
 
-    @users('user_portal')
-    def test_chatbot_lead_portal_user(self):
+    def test_chatbot_create_lead_and_forward_public_user(self):
+        """Test create_lead_and_forward properly creates a lead, assigns it to an available sales
+        team member, and forwards the discussion to that member."""
+        self.step_create_lead.sudo().step_type = "create_lead_and_forward"
+        discuss_channel = self._play_session_with_lead()
+        not_available_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
+        self.assertEqual(not_available_lead.name, "Testing Bot's New Lead")
+        self.assertEqual(not_available_lead.email_from, "test2@example.com")
+        self.assertEqual(not_available_lead.phone, "123456")
+        self.assertEqual(not_available_lead.team_id, self.sale_team)
+        self.assertEqual(not_available_lead.type, "opportunity")
+        chatbot_partner = self.chatbot_script.operator_partner_id
+        # sales team member is not available
+        self.assertFalse(not_available_lead.user_id)
+        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
+        # sales team member is available
+        self.env["bus.presence"].create({"user_id": self.user_employee.id, "status": "online"})
+        discuss_channel = self._play_session_with_lead()
+        assigned_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
+        self.assertEqual(assigned_lead.user_id, self.user_employee)
+        self.assertEqual(discuss_channel.livechat_operator_id, self.partner_employee)
+        # sales team member quota is reached (lead already assigned before)
+        discuss_channel = self._play_session_with_lead()
+        quota_reached_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
+        self.assertFalse(quota_reached_lead.user_id)
+        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
+        assigned_lead.unlink()
+        # sales team member opt out
+        self.sale_team.crm_team_member_ids.assignment_optout = True
+        discuss_channel = self._play_session_with_lead()
+        optout_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
+        self.assertFalse(optout_lead.user_id)
+        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
+        self.sale_team.crm_team_member_ids.assignment_optout = False
+        # sales team member invalid domain (probability of lead is 5.39)
+        self.sale_team.crm_team_member_ids.assignment_domain = "[('probability', '>=', 20)]"
+        discuss_channel = self._play_session_with_lead()
+        non_matching_domain_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
+        self.assertFalse(non_matching_domain_lead.user_id)
+        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
+        self.sale_team.crm_team_member_ids.assignment_domain = False
+        # auto-assign team
+        self.step_create_lead.crm_team_id = False
+        discuss_channel = self._play_session_with_lead()
+        auto_team_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
+        self.assertEqual(auto_team_lead.user_id, self.user_employee)
+        self.assertEqual(auto_team_lead.team_id, self.sale_team)
+        self.assertEqual(discuss_channel.livechat_operator_id, self.partner_employee)
+        auto_team_lead.unlink()
+        # sales team opt out
+        self.sale_team.assignment_optout = True
+        discuss_channel = self._play_session_with_lead()
+        team_optout_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
+        self.assertFalse(team_optout_lead.user_id)
+        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
+        self.sale_team.assignment_optout = False
+        # sales team invalid domain (probability of lead is 5.39)
+        self.sale_team.assignment_domain = "[('probability', '>=', 20)]"
+        discuss_channel = self._play_session_with_lead()
+        team_non_matching_domain_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
+        self.assertFalse(team_non_matching_domain_lead.user_id)
+        self.assertEqual(discuss_channel.livechat_operator_id, chatbot_partner)
+
+    def test_chatbot_create_lead_portal_user(self):
+        self.authenticate(self.user_portal.login, self.user_portal.login)
         self.step_create_lead.write({'crm_team_id': self.sale_team_with_lead})
-        self._chatbot_create_lead(self.user_portal)
+        self._play_session_with_lead()
 
         created_lead = self.env['crm.lead'].sudo().search([], limit=1, order='id desc')
         self.assertEqual(created_lead.name, "Testing Bot's New Lead")
@@ -32,26 +95,21 @@ class CrmChatbotCase(chatbot_common.CrmChatbotCase):
         self.assertEqual(created_lead.team_id, self.sale_team_with_lead)
         self.assertEqual(created_lead.type, 'lead')
 
-    def _chatbot_create_lead(self, user):
+    def _play_session_with_lead(self):
         data = self.make_jsonrpc_request("/im_livechat/get_session", {
             'anonymous_name': 'Test Visitor',
             'channel_id': self.livechat_channel.id,
             'chatbot_script_id': self.chatbot_script.id,
-            'user_id': user.id,
         })
         discuss_channel = (
             self.env["discuss.channel"].sudo().browse(data["discuss.channel"][0]["id"])
         )
-
         self._post_answer_and_trigger_next_step(
-            discuss_channel,
-            self.step_dispatch_create_lead.name,
-            chatbot_script_answer=self.step_dispatch_create_lead
+            discuss_channel, chatbot_script_answer=self.step_dispatch_create_lead
         )
         self.assertEqual(discuss_channel.chatbot_current_step_id, self.step_create_lead_email)
-        self._post_answer_and_trigger_next_step(discuss_channel, 'test2@example.com')
-
+        self._post_answer_and_trigger_next_step(discuss_channel, email="test2@example.com")
         self.assertEqual(discuss_channel.chatbot_current_step_id, self.step_create_lead_phone)
         self._post_answer_and_trigger_next_step(discuss_channel, '123456')
-
         self.assertEqual(discuss_channel.chatbot_current_step_id, self.step_create_lead)
+        return discuss_channel

--- a/addons/crm_livechat/views/chatbot_script_step_views.xml
+++ b/addons/crm_livechat/views/chatbot_script_step_views.xml
@@ -7,8 +7,11 @@
         <field name="inherit_id" ref="im_livechat.chatbot_script_step_view_form"/>
         <field name="arch" type="xml">
             <field name="step_type" position="after">
-                <field name="crm_team_id" invisible="step_type != 'create_lead'"
-                    options="{'no_open': True}"/>
+                <field
+                    name="crm_team_id"
+                    invisible="step_type not in ['create_lead', 'create_lead_and_forward']"
+                    options="{'no_open': True}"
+                />
             </field>
         </field>
     </record>

--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -46,12 +46,13 @@ class LivechatChatbotScriptController(http.Controller):
         # sudo: chatbot.script.step - visitor can access current step of the script
         if current_step := discuss_channel.sudo().chatbot_current_step_id:
             chatbot = current_step.chatbot_script_id
-            user_messages = discuss_channel.message_ids.filtered(
-                lambda message: message.author_id != chatbot.operator_partner_id
-            )
-            user_answer = request.env['mail.message'].sudo()
-            if user_messages:
-                user_answer = user_messages.sorted(lambda message: message.id)[-1]
+            domain = [
+                ("author_id", "!=", chatbot.operator_partner_id.id),
+                ("model", "=", "discuss.channel"),
+                ("res_id", "=", channel_id),
+            ]
+            # sudo: mail.message - accessing last message to process answer is allowed
+            user_answer = self.env["mail.message"].sudo().search(domain, order="id desc", limit=1)
             next_step = current_step._process_answer(discuss_channel, user_answer.body)
         elif chatbot_script_id:  # when restarting, we don't have a "current step" -> set "next" as first step of the script
             chatbot = request.env['chatbot.script'].sudo().browse(chatbot_script_id).with_context(lang=chatbot_language)
@@ -60,7 +61,8 @@ class LivechatChatbotScriptController(http.Controller):
 
         if not next_step:
             return None
-
+        # sudo: discuss.channel - updating current step on the channel is allowed
+        discuss_channel.sudo().chatbot_current_step_id = next_step.id
         posted_message = next_step._process_step(discuss_channel)
         store = Store(posted_message, for_current_user=True)
         store.add(next_step)
@@ -103,14 +105,16 @@ class LivechatChatbotScriptController(http.Controller):
 
         # sudo: chatbot.script - visitor can access chatbot script of their channel
         chatbot = discuss_channel.sudo().chatbot_current_step_id.chatbot_script_id
-        user_messages = discuss_channel.message_ids.filtered(
-            lambda message: message.author_id != chatbot.operator_partner_id
-        )
-
-        if user_messages:
-            user_answer = user_messages.sorted(lambda message: message.id)[-1]
-            result = chatbot._validate_email(user_answer.body, discuss_channel)
-
+        domain = [
+            ("author_id", "!=", chatbot.operator_partner_id.id),
+            ("model", "=", "discuss.channel"),
+            ("res_id", "=", channel_id),
+        ]
+        # sudo: mail.message - accessing last message to validate email is allowed
+        last_user_message = self.env["mail.message"].sudo().search(domain, order="id desc", limit=1)
+        result = {}
+        if last_user_message:
+            result = chatbot._validate_email(last_user_message.body, discuss_channel)
             if posted_message := result.pop("posted_message"):
                 result["data"] = Store(posted_message, for_current_user=True).get_result()
         return result

--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -108,7 +108,7 @@ class LivechatController(http.Controller):
 
     @http.route('/im_livechat/get_session', methods=["POST"], type="jsonrpc", auth='public')
     @add_guest_to_context
-    def get_session(self, channel_id, anonymous_name, previous_operator_id=None, chatbot_script_id=None, persisted=True, **kwargs):
+    def get_session(self, channel_id, anonymous_name, previous_operator_id=None, chatbot_script_id=None, persisted=True):
         store = Store()
         user_id = None
         country_id = None

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -329,11 +329,7 @@ class ChatbotScriptStep(models.Model):
         Those will have a dedicated processing method with specific docstrings.
 
         Returns the mail.message posted by the chatbot's operator_partner_id. """
-
         self.ensure_one()
-        # sudo: discuss.channel - updating current step on the channel is allowed
-        discuss_channel.sudo().chatbot_current_step_id = self.id
-
         if self.step_type == 'forward_operator':
             return self._process_step_forward_operator(discuss_channel)
         return discuss_channel._chatbot_post_message(self.chatbot_script_id, plaintext2html(self.message))
@@ -346,8 +342,9 @@ class ChatbotScriptStep(models.Model):
         The script will continue normally, which allows to add extra steps when it's the case
         (e.g: ask for the visitor's email and create a lead).
 
-        When specific available users are not provided, the currently available users of the
-        livechat channel are used as candidates.
+        :param discuss_channel: channel on which to execute the step
+        :param users: recordset of candidate operators, if not provided the currently available
+            users of the livechat channel are used as candidates instead.
         """
 
         human_operator = False

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -156,9 +156,11 @@ class DiscussChannel(models.Model):
         """
         Converting message body back to plaintext for correct data formatting in HTML field.
         """
-        return Markup('').join(
-            Markup('%s: %s<br/>') % (message.author_id.name or self.anonymous_name, html2plaintext(message.body))
-            for message in self.message_ids.sorted('id')
+        return Markup("").join(
+            Markup("%s: %s<br/>")
+            % (message.author_id.name or self.anonymous_name, html2plaintext(message.body))
+            # sudo: discuss.channel: can read all previous messages when converting to lead
+            for message in self.sudo().message_ids.sorted("id")
         )
 
     # =======================

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -216,7 +216,6 @@ export class LivechatService {
                     ? this.thread.chatbot?.script.id
                     : this.rule.chatbotScript?.id,
                 previous_operator_id: expirableStorage.getItem(OPERATOR_STORAGE_KEY),
-                temporary_id: this.thread?.id,
                 persisted: persist,
             },
             { shadow: true }

--- a/addons/im_livechat/static/tests/embed/livechat_service.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service.test.js
@@ -110,7 +110,6 @@ test("Only necessary requests are made when creating a new chat", async () => {
             channel_id: livechatChannelId,
             anonymous_name: "Visitor",
             previous_operator_id: operatorPartnerId,
-            temporary_id: -1,
             persisted: true,
         })}`,
         `/mail/data - ${JSON.stringify({

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -143,13 +143,29 @@ class ChatbotCase(MailCommon, common.HttpCase):
             })]
         })
 
-    @classmethod
-    def _post_answer_and_trigger_next_step(cls, discuss_channel, answer, chatbot_script_answer=False):
-        mail_message = discuss_channel.message_post(body=answer)
+    def _post_answer_and_trigger_next_step(
+        self, discuss_channel, body=None, email=None, chatbot_script_answer=None
+    ):
+        data = self.make_jsonrpc_request(
+            "/mail/message/post",
+            {
+                "thread_model": "discuss.channel",
+                "thread_id": discuss_channel.id,
+                "post_data": {"body": body or email or chatbot_script_answer.name},
+            },
+        )
+        if email:
+            self.make_jsonrpc_request(
+                "/chatbot/step/validate_email", {"channel_id": discuss_channel.id}
+            )
         if chatbot_script_answer:
-            cls.env['chatbot.message'].search([
-                ('mail_message_id', '=', mail_message.id)
-            ], limit=1).user_script_answer_id = chatbot_script_answer.id
-
-        next_step = discuss_channel.chatbot_current_step_id._process_answer(discuss_channel, mail_message.body)
-        next_step._process_step(discuss_channel)
+            message = self.env["mail.message"].browse(data["mail.message"][0]["id"])
+            self.make_jsonrpc_request(
+                "/chatbot/answer/save",
+                {
+                    "channel_id": discuss_channel.id,
+                    "message_id": message.id,
+                    "selected_answer_id": chatbot_script_answer.id,
+                },
+            )
+        self.make_jsonrpc_request("/chatbot/step/trigger", {"channel_id": discuss_channel.id})

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -36,7 +36,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     'anonymous_name': 'Visitor 22',
                     'previous_operator_id': operator.partner_id.id,
                     'channel_id': self.livechat_channel.id,
-                    'country_id': belgium.id,
                 },
             )
         channel_info = data["discuss.channel"][0]
@@ -88,7 +87,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         data = self.make_jsonrpc_request('/im_livechat/get_session', {
             'anonymous_name': 'whatever',
             'previous_operator_id': operator.partner_id.id,
-            'user_id': test_user.id,
             'channel_id': self.livechat_channel.id,
         })
         channel_info = data["discuss.channel"][0]
@@ -180,7 +178,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         data = self.make_jsonrpc_request('/im_livechat/get_session', {
             'anonymous_name': 'whatever',
             'previous_operator_id': operator.partner_id.id,
-            'user_id': operator.id,
             'channel_id': self.livechat_channel.id,
         })
         channel_info = data["discuss.channel"][0]

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -65,7 +65,6 @@ class TestImLivechatMessage(HttpCase, MailCommon):
                 {
                     "anonymous_name": "anon 1",
                     "previous_operator_id": self.users[0].partner_id.id,
-                    "country_id": self.env.ref("base.in").id,
                     "channel_id": im_livechat_channel.id,
                 },
             )["discuss.channel"][0]["id"]
@@ -168,7 +167,6 @@ class TestImLivechatMessage(HttpCase, MailCommon):
                 {
                     "anonymous_name": "anon 1",
                     "previous_operator_id": self.users[0].partner_id.id,
-                    "country_id": self.env.ref("base.in").id,
                     "channel_id": im_livechat_channel.id,
                 },
             )["discuss.channel"][0]["id"]

--- a/addons/website_livechat/controllers/main.py
+++ b/addons/website_livechat/controllers/main.py
@@ -65,9 +65,9 @@ class WebsiteLivechat(LivechatController):
         return _('Visitor #%d', visitor_sudo.id) if visitor_sudo else super()._get_guest_name()
 
     @http.route()
-    def get_session(self, channel_id, anonymous_name, previous_operator_id=None, chatbot_script_id=None, persisted=True, **kwargs):
+    def get_session(self, channel_id, anonymous_name, previous_operator_id=None, chatbot_script_id=None, persisted=True):
         """ Override to use visitor name instead of 'Visitor' whenever a visitor start a livechat session. """
         visitor_sudo = request.env['website.visitor']._get_visitor_from_request()
         if visitor_sudo:
             anonymous_name = _('Visitor #%s', visitor_sudo.id)
-        return super(WebsiteLivechat, self).get_session(channel_id, anonymous_name, previous_operator_id=previous_operator_id, chatbot_script_id=chatbot_script_id, persisted=persisted, **kwargs)
+        return super().get_session(channel_id, anonymous_name, previous_operator_id=previous_operator_id, chatbot_script_id=chatbot_script_id, persisted=persisted)


### PR DESCRIPTION
\* = im_livechat, crm_livechat

This commit introduces a new chatbot script step 'create lead & forward'.

On selection, the chatbot will:

1. Create a new lead.
2. Assign the lead and forward the conversation to a salesperson based on the assignment rules configured for the selected sales team, provided a salesperson is available.

task-4354325
