### PR TITLE
[FIX] hw_drivers: detect Star printers again

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -96,10 +96,7 @@ class PrinterDriver(Driver):
         if (
                 any(x in device['url'] for x in protocol)
                 and device['device-make-and-model'] != 'Unknown'
-                or (
-                'direct' in device['device-class']
-                and 'serial=' in device['url']
-        )
+                or 'direct' in device['device-class']
         ):
             model = cls.get_device_model(device)
             ppd_file = ''


### PR DESCRIPTION
Our "supported" method filtering detected printers had a condition introduced in v17 which was too strict and filtering out the STAR printers, so they were never detected anymore.

This PR fixes this issue
related PR: #174436
