### PR TITLE
[FIX] projects: fix analytic display in project setting

### DIFF
--- a/addons/project/static/src/scss/project_form.scss
+++ b/addons/project/static/src/scss/project_form.scss
@@ -49,3 +49,10 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+.o_mobile_min_margin {
+    margin-top:-20px;
+    @media only screen and (max-width: 650px) {
+        margin-top: 0px;
+    }
+}

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -107,9 +107,8 @@
                                         <i class="fa fa-warning pe-2" title="Warning"/><field class="d-inline" name="privacy_visibility_warning" nolabel="1"/>
                                     </span>
                                 </group>
-                                <group name="analytic">
-                                    <div class="o_horizontal_separator text-uppercase fw-bolder small mb-3" groups="analytic.group_analytic_accounting">analytic</div>
-                                    <field name="account_id" groups="analytic.group_analytic_accounting"/>
+                                <group name="analytic" string="Analytic" class="o_mobile_min_margin" groups="analytic.group_analytic_accounting">
+                                    <field name="account_id"/>
                                 </group>
                                 <group name="extra_settings">
                                 </group>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -118,7 +118,7 @@
                     </div>
                 </group>
             </xpath>
-            <xpath expr="//group[@name='analytic']//div" position="before">
+            <xpath expr="//page[@name='settings']//field[@name='privacy_visibility']" position="after">
                 <field name="reinvoiced_sale_order_id" invisible="not allow_billable or not partner_id"/>
                 <label for="sale_line_id" invisible="not allow_billable or not partner_id"/>
                 <div 


### PR DESCRIPTION
This commit's purpose is to fix the alignment of the plans and the selection fields associated to those plan in the setting of the form view of projects. The issue was caused by the extra 'div' inside the group, which was disrupting the usual display order of 'field name' - 'field selection'

Solution: adds a colspan so that the div is computed as a block of 2
elements instead of 1.

task - 4397694
