### PR TITLE
[IMP] hr: remove ssnid and change identification_id label per country

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -92,9 +92,8 @@ class HrEmployee(models.Model):
     birthday = fields.Date('Birthday', groups="hr.group_hr_user", tracking=True)
     birthday_public_display = fields.Boolean('Show to all employees', groups="hr.group_hr_user", default=False)
     birthday_public_display_string = fields.Char("Public Date of Birth", compute="_compute_birthday_public_display_string", default="hidden")
-    ssnid = fields.Char('SSN No', help='Social Security Number', groups="hr.group_hr_user", tracking=True)
-    sinid = fields.Char('SIN No', help='Social Insurance Number', groups="hr.group_hr_user", tracking=True)
     identification_id = fields.Char(string='Identification No', groups="hr.group_hr_user", tracking=True)
+    identification_id_label = fields.Char(compute='_compute_identification_id_label', groups="hr.group_hr_user")
     passport_id = fields.Char('Passport No', groups="hr.group_hr_user", tracking=True)
     bank_account_id = fields.Many2one(
         'res.partner.bank', 'Bank Account',
@@ -237,6 +236,17 @@ class HrEmployee(models.Model):
     @api.depends('name', 'user_id.avatar_128', 'image_128')
     def _compute_avatar_128(self):
         super()._compute_avatar_128()
+
+    def _compute_identification_id_label(self):
+        for employee in self:
+            label = _('Identification No')
+            if self.env.company.country_code == 'BE':
+                label += ' (NISS)'
+            elif self.env.company.country_code == 'US':
+                label += ' (SSN)'
+            elif self.env.company.country_code == 'LU':
+                label = _('Matricule')
+            employee.identification_id_label = label
 
     def _compute_avatar(self, avatar_field, image_field):
         employee_wo_user_and_image = self.env['hr.employee']
@@ -466,9 +476,9 @@ class HrEmployee(models.Model):
                 if not (re.match(r'^[A-Za-z0-9]+$', employee.barcode) and len(employee.barcode) <= 18):
                     raise ValidationError(_("The Badge ID must be alphanumeric without any accents and no longer than 18 characters."))
 
-    @api.constrains('ssnid')
-    def _check_ssnid(self):
-        # By default, an Social Security Number is always valid, but each localization
+    @api.constrains('identification_id')
+    def _check_identification_id(self):
+        # By default, it is always valid, but each localization
         # may want to add its own constraints
         pass
 

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -49,7 +49,7 @@ HR_WRITABLE_FIELDS = [
     'employee_country_id',
     'gender',
     'identification_id',
-    'ssnid',
+    'identification_id_label',
     'job_title',
     'km_home_work',
     'distance_home_work',
@@ -120,7 +120,7 @@ class ResUsers(models.Model):
     employee_bank_account_id = fields.Many2one(related='employee_id.bank_account_id', string="Employee's Bank Account Number", related_sudo=False, readonly=False)
     employee_country_id = fields.Many2one(related='employee_id.country_id', string="Employee's Country", readonly=False, related_sudo=False)
     identification_id = fields.Char(related='employee_id.identification_id', readonly=False, related_sudo=False)
-    ssnid = fields.Char(related='employee_id.ssnid', readonly=False, related_sudo=False)
+    identification_id_label = fields.Char(related='employee_id.identification_id_label', readonly=False, related_sudo=False)
     passport_id = fields.Char(related='employee_id.passport_id', readonly=False, related_sudo=False)
     gender = fields.Selection(related='employee_id.gender', readonly=False, related_sudo=False)
     birthday = fields.Date(related='employee_id.birthday', readonly=False, related_sudo=False)

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -165,8 +165,10 @@
                                     </group>
                                     <group string="Citizenship">
                                         <field name="country_id" options='{"no_open": True, "no_create": True}'/>
-                                        <field name="identification_id"/>
-                                        <field name="ssnid"/>
+                                        <div class="o_cell o_wrap_label">
+                                            <field name="identification_id_label" nolabel="1" class="o_form_label"/>
+                                        </div>
+                                        <field name="identification_id" nolabel="1"/>
                                         <field name="passport_id"/>
                                         <field name="gender"/>
                                         <label for="birthday"/>

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -155,7 +155,6 @@
                             <group string="Citizenship">
                                 <field name="employee_country_id" options='{"no_open": True, "no_create": True}' readonly="not can_edit"/>
                                 <field name="identification_id" readonly="not can_edit"/>
-                                <field name="ssnid" readonly="not can_edit"/>
                                 <field name="passport_id" readonly="not can_edit"/>
                                 <field name="gender" readonly="not can_edit"/>
                                 <label for="birthday"/>


### PR DESCRIPTION
SSNID is usually not used and could be removed from the standard version. Only when needed in a loca, it is added back. If possible, use the identification_id
 instead.

Task: 4384436
