### PR TITLE
[IMP] stock, mrp: picking code handling and display improvements

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -19,10 +19,9 @@ class StockMoveLine(models.Model):
     def _compute_picking_type_id(self):
         line_to_remove = self.env['stock.move.line']
         for line in self:
-            if not line.production_id:
-                continue
-            line.picking_type_id = line.production_id.picking_type_id
-            line_to_remove |= line
+            if production_id := line.production_id or line.move_id.production_id:
+                line.picking_type_id = production_id.picking_type_id
+                line_to_remove |= line
         return super(StockMoveLine, self - line_to_remove)._compute_picking_type_id()
 
     def _search_picking_type_id(self, operator, value):

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -4,6 +4,7 @@
 from ast import literal_eval
 
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 from odoo.osv import expression
 
 
@@ -70,6 +71,12 @@ class StockPickingType(models.Model):
         for picking_type in self:
             if picking_type.code == 'mrp_operation':
                 picking_type.use_existing_lots = True
+
+    @api.constrains('default_location_dest_id')
+    def _check_default_location(self):
+        for record in self:
+            if record.code == 'mrp_operation' and record.default_location_dest_id.scrap_location:
+                raise ValidationError(_("You cannot set a scrap location as the destination location for a manufacturing type operation."))
 
     def _get_mo_count(self):
         mrp_picking_types = self.filtered(lambda picking: picking.code == 'mrp_operation')

--- a/addons/mrp/views/stock_move_views.xml
+++ b/addons/mrp/views/stock_move_views.xml
@@ -74,6 +74,17 @@
             </field>
         </record>
 
+        <record id="view_move_line_tree" model="ir.ui.view">
+            <field name="name">stock.move.line.list</field>
+            <field name="model">stock.move.line</field>
+            <field name="inherit_id" ref="stock.view_move_line_tree"/>
+            <field name="arch" type="xml">
+                <field name="reference" position="attributes">
+                    <attribute name="decoration-primary">picking_code == 'mrp_operation'</attribute>
+                </field>
+            </field>
+        </record>
+
     <menuitem id="menu_mrp_traceability"
           name="Lots/Serial Numbers"
           parent="menu_mrp_bom"

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -80,6 +80,7 @@ class StockMoveLine(models.Model):
     state = fields.Selection(related='move_id.state', store=True)
     is_inventory = fields.Boolean(related='move_id.is_inventory')
     is_locked = fields.Boolean(related='move_id.is_locked', readonly=True)
+    is_scrap = fields.Boolean(related='move_id.scrapped')
     consume_line_ids = fields.Many2many('stock.move.line', 'stock_move_line_consume_rel', 'consume_line_id', 'produce_line_id')
     produce_line_ids = fields.Many2many('stock.move.line', 'stock_move_line_consume_rel', 'produce_line_id', 'consume_line_id')
     reference = fields.Char(related='move_id.reference', readonly=False)

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.addons.stock.models.stock_move import PROCUREMENT_PRIORITIES
 from odoo.addons.web.controllers.utils import clean_action
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import UserError
 from odoo.fields import Domain
 from odoo.osv import expression
 from odoo.tools import format_datetime, format_date, groupby, SQL
@@ -413,12 +413,6 @@ class StockPickingType(models.Model):
                         "to avoid issues and/or repeated reference values or assign the existing reference sequence to this operation type.")
                 }
             }
-
-    @api.constrains('default_location_dest_id')
-    def _check_default_location(self):
-        for record in self:
-            if record.code == 'mrp_operation' and record.default_location_dest_id.scrap_location:
-                raise ValidationError(_("You cannot set a scrap location as the destination location for a manufacturing type operation."))
 
     @api.model
     def action_redirect_to_barcode_installation(self):

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -8,17 +8,22 @@
                 <field name="location_usage" column_invisible="True"/>
                 <field name="location_dest_usage" column_invisible="True"/>
                 <field name="date"/>
-                <field name="reference" string="Reference"
-                       column_invisible="context.get('no_reference', False)"/>
+                <field name="reference" string="Reference" class="fw-bolder"
+                       column_invisible="context.get('no_reference', False)"
+                       decoration-muted="1"
+                       decoration-info="picking_code == 'outgoing'"
+                       decoration-success="picking_code == 'incoming'"
+                       decoration-warning="is_inventory"
+                       decoration-danger="is_scrap"/>
                 <field name="product_id"/>
                 <field name="lot_id" optional="show" groups="stock.group_production_lot"/>
                 <field name="package_id" optional="hide" groups="stock.group_tracking_lot"/>
                 <field name="result_package_id" optional="hide" groups="stock.group_tracking_lot"/>
-                <field name="location_id"/>
-                <field name="location_dest_id"/>
+                <field name="location_id" decoration-muted="location_usage not in ('internal', 'transit')"/>
+                <field name="location_dest_id" decoration-muted="location_dest_usage not in ('internal', 'transit')"/>
                 <field name="picking_partner_id" optional="hide"/>
                 <field name="company_id" optional="hide" groups="base.group_multi_company" force_save="1"/>
-                <field name="quantity" string="Quantity"
+                <field name="quantity" string="Quantity" class="fw-bolder"
                     decoration-danger="(location_usage in ('internal','transit')) and (location_dest_usage not in ('internal','transit'))"
                     decoration-success="(location_usage not in ('internal','transit')) and (location_dest_usage in ('internal','transit'))"/>
                 <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" widget="many2one_uom" groups="uom.group_uom"/>


### PR DESCRIPTION
In the `stock.move.line` list view, references should be bolded and coloured by type, quantities should be bolded, and locations should be muted if they aren't internal.

Task ID: [4385357](https://www.odoo.com/odoo/project/966/tasks/4385357)