### PR TITLE
[FIX] web: ribbon overlap

### DIFF
--- a/addons/web/static/src/views/widgets/ribbon/ribbon.scss
+++ b/addons/web/static/src/views/widgets/ribbon/ribbon.scss
@@ -66,7 +66,3 @@
         }
     }
 }
-
-.o_form_sheet .ribbon {
-   --Ribbon-z-index: 1;
-}


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/179284 makes the form view status bar sticky
https://github.com/odoo/odoo/pull/172102 gives the ribbon a z-index

together they make the ribbon overlap the sticky status bar.
![2024-12-11_16-31](https://github.com/user-attachments/assets/752bf74f-64c3-47bc-bc84-9dc338020e26)

After
![2024-12-11_16-34](https://github.com/user-attachments/assets/8f8c354f-f78b-4902-ba27-4016988f6221)



reported by AVW
