### PR TITLE
[IMP] pos_restaurant: limit the floorplan view on mobile

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.scss
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.scss
@@ -15,13 +15,14 @@
             transition: 150ms;
         }
     }
-    &.floor-grid {
-        background-image:
-            linear-gradient(0, #D3D3D3 14%, transparent 14%),
-            linear-gradient(90deg, transparent 90%, #D3D3D3 70%);
-        background-size: 10px 10px;
-    }
 }
+
+.floor-grid {
+    background-image: linear-gradient(0, #D3D3D3 14%, transparent 14%),
+    linear-gradient(90deg, transparent 90%, #D3D3D3 70%);
+    background-size: 10px 10px;
+}
+
 .floor-picture {
     height: 50px;
     width: 50px;

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
@@ -98,9 +98,9 @@
                 </div>
             </div>
             <t t-set="isKanban" t-value="pos.floorPlanStyle == 'kanban'"/>
-            <div t-ref="floor-map-scroll" class="overflow-auto flex-grow-1 flex-shrink-1 flex-basis-0 w-auto" t-attf-style="background: {{activeFloor?.background_color}}"> 
+            <div t-ref="floor-map-scroll" class="overflow-auto flex-grow-1 flex-shrink-1 flex-basis-0 w-auto" t-att-class="{'floor-grid': pos.isEditMode}" t-attf-style="background-color: {{activeFloor?.background_color}}">
                 <div t-on-click="onClickFloorMap" t-on-touchstart="_onPinchStart" t-on-touchmove="_onPinchMove" t-on-touchend="_onPinchEnd"
-                    t-attf-class="floor-map position-relative w-100 h-100 {{ pos.isEditMode ? 'floor-grid' : ''}}"
+                    t-attf-class="floor-map position-relative w-100 h-100"
                     t-ref="floor-map-ref"
                     t-attf-style="
                         -webkit-touch-callout: none;
@@ -142,8 +142,8 @@
                                                     `
                                                         width: ${table.width}px;
                                                         height: ${table.height}px;
-                                                        top: ${table.getY()}px;
-                                                        left: ${table.getX()}px;
+                                                        top: ${table.getY() +  state.floorMapOffset.y}px;
+                                                        left: ${table.getX() + state.floorMapOffset.x}px;
                                                     `
                                                 }}
                                             "

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -575,4 +575,17 @@ patch(PosStore.prototype, {
             this.tableSelectorState = false;
         }
     },
+    storeFloorScrollPosition(floorId, position) {
+        if (!floorId) {
+            return;
+        }
+        this.floorScrollPositions = this.floorScrollPositions || {};
+        this.floorScrollPositions[floorId] = position;
+    },
+    getFloorScrollPositions(floorId) {
+        if (!floorId || !this.floorScrollPositions) {
+            return;
+        }
+        return this.floorScrollPositions[floorId];
+    },
 });


### PR DESCRIPTION
Previously, on mobile, the first table of the floor plan may not  be visible without scrolling. 
This commit minimizes the scrolling area on mobile to ensure the first table is visible.
(The floor plan area remains unchanged in edit mode)

task-4383744
