### PR TITLE
[FIX] base: append suffix to duplicated server action name

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -1020,6 +1020,12 @@ class IrActionsServer(models.Model):
             result[action.id] = expr
         return result
 
+    def copy_data(self, default=None):
+        default = default or {}
+        if not default.get('name'):
+            default['name'] = _('%s (copy)', self.name)
+        return super().copy_data(default=default)
+
 class IrActionsTodo(models.Model):
     """
     Configuration Wizards


### PR DESCRIPTION
Before this commit:
When a user duplicates a server action, the new action retains the exact same name as the original.

After this commit:
Duplicated server actions are assigned a name with the suffix "(copy)" to differentiate them from the original action.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
