### PR TITLE
[IMP] mail: minimize notification email layout

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -421,6 +421,7 @@ class AccountMoveSend(models.AbstractModel):
             .with_context(
                 no_new_invoice=True,
                 mail_notify_author=author_id in partner_ids,
+                email_notification_allow_footer=True,
             ).message_post(
                 message_type='comment',
                 **kwargs,

--- a/addons/mail/data/mail_templates_email_layouts.xml
+++ b/addons/mail/data/mail_templates_email_layouts.xml
@@ -8,17 +8,21 @@
 </head>
 <body style="font-family:Verdana, Arial,sans-serif; color: #454748;">
 <t t-set="subtype_internal" t-value="subtype and subtype.internal"/>
+<t t-set="show_header" t-value="email_notification_force_header or (
+    email_notification_allow_header and has_button_access)"/>
+<t t-set="show_footer" t-value="email_notification_force_footer or (
+    email_notification_allow_footer and show_header and author_user._is_internal())"/>
 <!-- HEADER -->
 <t t-call="mail.notification_preview"/>
 <div style="max-width: 900px; width: 100%;">
-<div t-if="has_button_access" itemscope="itemscope" itemtype="http://schema.org/EmailMessage">
+<div t-if="show_header and has_button_access" itemscope="itemscope" itemtype="http://schema.org/EmailMessage">
     <div itemprop="potentialAction" itemscope="itemscope" itemtype="http://schema.org/ViewAction">
         <link itemprop="target" t-att-href="button_access['url']"/>
         <link itemprop="url" t-att-href="button_access['url']"/>
         <meta itemprop="name" t-att-content="button_access['title']"/>
     </div>
 </div>
-<div t-if="subtitles or has_button_access or not is_discussion"
+<div t-if="show_header and (subtitles or has_button_access or not is_discussion)"
         summary="o_mail_notification" style="padding: 0px;">
     <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="width: 100%; margin-top: 5px;">
         <tbody>
@@ -51,9 +55,6 @@
                 <td valign="center">
                     <hr width="100%"
                         style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0;margin: 10px 0px;"/>
-                    <p t-if="subtype_internal" style="background-color: #f2dede; padding: 5px; margin-bottom: 16px; font-size: 13px;">
-                        <strong>Internal communication</strong>: Replying will post an internal note. Followers won't receive any email notification.
-                    </p>
                 </td>
             </tr>
         </tbody>
@@ -70,7 +71,7 @@
     <div t-if="email_add_signature and not is_html_empty(signature)" t-out="signature" style="font-size: 13px;"/>
 </t>
 <!-- FOOTER -->
-<div style="margin-top:16px;">
+<div t-if="show_footer" style="margin-top:16px;">
     <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 4px 0px;"/>
     <b t-out="company.name" style="font-size:11px;"/><br/>
     <p style="color: #999999; margin-top:2px; font-size:11px;">
@@ -81,7 +82,7 @@
         <a t-if="company.website" t-att-href="'%s' % company.website" style="text-decoration:none; color: #999999;" t-out="company.website"/>
     </p>
 </div>
-<div style="color: #555555; font-size:11px;">
+<div t-if="show_footer" style="color: #555555; font-size:11px;">
     Powered by <a target="_blank" href="https://www.odoo.com?utm_source=db&amp;utm_medium=email"
                   t-att-style="'color: ' + (company.email_secondary_color or '#875A7B') + ';'">Odoo</a>
     <span id="mail_unfollow">

--- a/addons/mail/data/mail_templates_invite.xml
+++ b/addons/mail/data/mail_templates_invite.xml
@@ -22,7 +22,6 @@
                     </div>
                 </div>
             </xpath>
-            <xpath expr="//tr[td/p[@t-if='subtype_internal']]" position="replace"/>
             <xpath expr="//span[@id='mail_unfollow']" position="replace"/>
             <xpath expr="//div[@style='margin-top:16px;']/hr" position="before">
                 <span id="mail_unfollow" style="font-size: 13px;">

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -476,6 +476,7 @@ class PurchaseOrder(models.Model):
             'default_template_id': template_id,
             'default_composition_mode': 'comment',
             'default_email_layout_xmlid': "mail.mail_notification_layout_with_responsible_signature",
+            'email_notification_allow_footer': True,
             'force_email': True,
             'mark_rfq_as_sent': True,
         })

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1003,6 +1003,7 @@ class SaleOrder(models.Model):
             'default_res_ids': self.ids,
             'default_composition_mode': 'comment',
             'default_email_layout_xmlid': 'mail.mail_notification_layout_with_responsible_signature',
+            'email_notification_allow_footer': True,
             'proforma': self.env.context.get('proforma', False),
         }
 

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1749,10 +1749,6 @@ class SaleOrder(models.Model):
                 format_amount(self.env, self.amount_total, self.currency_id, lang_code=lang_code),
             )
 
-        if self.validity_date and self.state in ['draft', 'sent']:
-            formatted_date = format_date(self.env, self.validity_date, lang_code=lang_code)
-            subtitles.append(_("Expires on %(date)s", date=formatted_date))
-
         render_context['subtitles'] = subtitles
         return render_context
 

--- a/addons/test_mail/tests/test_ir_actions.py
+++ b/addons/test_mail/tests/test_ir_actions.py
@@ -176,4 +176,4 @@ class TestServerActionsEmail(MailCommon, TestServerActionsBase):
                 'subject': 'About Test NoMailThread',
             }
         )
-        self.assertIn('Powered by', mail.body_html, 'Body should contain the notification layout')
+        self.assertNotIn('Powered by', mail.body_html, 'Body should contain the notification layout')

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -998,8 +998,13 @@ class UnfollowFromEmailTest(MailCommon, HttpCase):
     def _post_message_and_get_unfollow_urls(self, record, partner_ids):
         """ Post a message on the record for the partners and extract the unfollow URLs. """
         with self.mock_mail_gateway():
-            record.message_post(body='test message', subtype_id=self.env.ref('mail.mt_comment').id,
-                                partner_ids=partner_ids.ids)
+            record.with_user(self.user_admin).with_context(
+                email_notification_force_header=True,
+                email_notification_force_footer=True
+            ).message_post(
+                body='test message',
+                subtype_id=self.env.ref('mail.mt_comment').id,
+                partner_ids=partner_ids.ids)
         self.assertEqual(len(self._mails), len(partner_ids))
         mail_by_email = {parse_contact_from_email(email_to)[1]: mail
                          for mail in self._mails


### PR DESCRIPTION
Email notifications typically include:
1) A header with elements such as an access button, title, or subtitle.
2) A footer with sender information and a "Powered by Odoo" link.

While these elements provide valuable context, they can clutter email threads, especially in interleaved responses.

This commit introduces a dynamic mechanism to streamline email notifications by conditionally hiding the header and footer based on predefined criteria:

By default,
- The header will be displayed only if it contains an access button.
- The footer will be displayed if it contains an access button and the email is sent from an internal user and if the email is a notification  about an invoice, a Purchase order (PO) or a Sales order (SO).

To ensure flexibility, new context variables are introduced:
- `email_notification_allow_header`, `email_notification_allow_footer`: Enable or disable the conditional hiding mechanism.
- `email_notification_force_header`, `email_notification_force_footer`: Force the display of the header and footer regardless of conditions.

Additionally, the ribbon indicating that an email is internal has been removed to further simplify the layout.

These updates reduce email size, improve readability in threaded conversations, and ensure that critical information is highlighted without unnecessary clutter.

Task-4128966