### PR TITLE
[FIX] pos_restaurant: prevent multiple order send

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
@@ -1,5 +1,6 @@
 import { patch } from "@web/core/utils/patch";
 import { ActionpadWidget } from "@point_of_sale/app/screens/product_screen/action_pad/action_pad";
+import { useState } from "@odoo/owl";
 import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
 /**
  * @props partner
@@ -8,6 +9,9 @@ import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_sc
 patch(ActionpadWidget.prototype, {
     setup() {
         super.setup();
+        this.uiState = useState({
+            clicked: false,
+        });
     },
     get swapButton() {
         return (
@@ -32,8 +36,15 @@ patch(ActionpadWidget.prototype, {
             altlight: !this.hasChangesToPrint && this.currentOrder?.hasSkippedChanges(),
         };
     },
-    submitOrder() {
-        this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
+    async submitOrder() {
+        if (!this.uiState.clicked) {
+            this.uiState.clicked = true;
+            try {
+                await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
+            } finally {
+                this.uiState.clicked = false;
+            }
+        }
     },
     hasQuantity(order) {
         if (!order) {

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.js
@@ -1,5 +1,6 @@
 import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
 import { patch } from "@web/core/utils/patch";
+import { useState } from "@odoo/owl";
 
 patch(ProductScreen.prototype, {
     /**
@@ -7,6 +8,9 @@ patch(ProductScreen.prototype, {
      */
     setup() {
         super.setup(...arguments);
+        this.uiState = useState({
+            clicked: false,
+        });
     },
     get selectedOrderlineQuantity() {
         const order = this.pos.get_order();
@@ -36,8 +40,15 @@ patch(ProductScreen.prototype, {
         return this.pos.categoryCount.slice(0, 3);
     },
     async submitOrder() {
-        await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
-        this.pos.addPendingOrder([this.currentOrder.id]);
+        if (!this.uiState.clicked) {
+            this.uiState.clicked = true;
+            try {
+                await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
+                this.pos.addPendingOrder([this.currentOrder.id]);
+            } finally {
+                this.uiState.clicked = false;
+            }
+        }
     },
     get primaryReviewButton() {
         return (


### PR DESCRIPTION
before this commit and since commit 42b207f, the pos_restaurant does not lock the state of the order button anymore. This has as an effect that if the order submitting takes a lot of time (which e.g. happens when a preparation printer is configured) the user could press the order button multiple times.

This situation can happen both intentionally or unintentionally.

The end result is a disturbed flow for users, where orders are sent multiple times in preparation and therefore need to be manually checked by the staff regularly risking wrong extra order preparation otherwise.

This commit reverts the changes adding back the state locking the order button while it's being processed.

opw-4242269