### PR TITLE
[FIX] base_automation: avoid templates clear_cache

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -421,26 +421,43 @@ class BaseAutomation(models.Model):
                 ),
             }}
 
+    def _has_trigger_onchange(self):
+        return any(
+            automation.active and automation.trigger == 'on_change' and automation.on_change_field_ids
+            for automation in self
+        )
+
     @api.model_create_multi
     def create(self, vals_list):
         base_automations = super(BaseAutomation, self).create(vals_list)
         self._update_cron()
         self._update_registry()
+        if base_automations._has_trigger_onchange():
+            # Invalidate templates cache to update on_change attributes if needed
+            self.env.registry.clear_cache('templates')
         return base_automations
 
-    def write(self, vals):
+    def write(self, vals: dict):
+        clear_templates = self._has_trigger_onchange()
         res = super(BaseAutomation, self).write(vals)
         if set(vals).intersection(self.CRITICAL_FIELDS):
             self._update_cron()
             self._update_registry()
+            if clear_templates or self._has_trigger_onchange():
+                # Invalidate templates cache to update on_change attributes if needed
+                self.env.registry.clear_cache('templates')
         elif set(vals).intersection(self.RANGE_FIELDS):
             self._update_cron()
         return res
 
     def unlink(self):
+        clear_templates = self._has_trigger_onchange()
         res = super(BaseAutomation, self).unlink()
         self._update_cron()
         self._update_registry()
+        if clear_templates:
+            # Invalidate templates cache to update on_change attributes if needed
+            self.env.registry.clear_cache('templates')
         return res
 
     def copy(self, default=None):
@@ -894,8 +911,6 @@ class BaseAutomation(models.Model):
                 method = make_onchange(automation_rule.id)
                 for field in automation_rule.on_change_field_ids:
                     Model._onchange_methods[field.name].append(method)
-                if automation_rule.on_change_field_ids:
-                    self.env.registry.clear_cache('templates')
 
             if automation_rule.model_id.is_mail_thread and automation_rule.trigger in MAIL_TRIGGERS:
                 patch(Model, "message_post", make_message_post())


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/152498, we invalidate the 'templates' orm cache when we load the registry if there is an onchange trigger automation exists. Every time that a worker takes its first request or that the registry is reloaded, it will then invalidate this long-term (we try anyway) cache, reducing its efficiency depending on worker recycling.
