### PR TITLE
[FIX] read-only: check cache/registry signals in read-write mode

### DIFF
--- a/addons/web/tests/test_assets.py
+++ b/addons/web/tests/test_assets.py
@@ -159,7 +159,7 @@ class TestWebAssetsCursors(HttpCase):
             self.assertEqual(response.status_code, 200)
 
         # remove the check_signaling cursor
-        self.assertEqual(cursors[0][1], '(ro_requested)', "the first cursor used for match and check signaling should be ro")
+        self.assertEqual(cursors[0][1], '(rw_requested)', "the first cursor used for match and check signaling should be rw")
         return cursors[1:]
 
     def test_web_binary_keep_cursor_ro(self):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1483,11 +1483,13 @@ class Request:
     def _open_registry(self):
         try:
             registry = Registry(self.db)
-            cr_readonly = registry.cursor(readonly=True)
-            registry = registry.check_signaling(cr_readonly)
+            # use a RW cursor! Sequence data is not replicated and would
+            # be invalid if accessed on a readonly replica. Cfr task-4399456
+            cr_readwrite = registry.cursor(readonly=False)
+            registry = registry.check_signaling(cr_readwrite)
         except (AttributeError, psycopg2.OperationalError, psycopg2.ProgrammingError) as e:
             raise RegistryError(f"Cannot get registry {self.db}") from e
-        return registry, cr_readonly
+        return registry, cr_readwrite
 
     # =====================================================
     # Getters and setters
@@ -1858,7 +1860,7 @@ class Request:
         Prepare the user session and load the ORM before forwarding the
         request to ``_serve_ir_http``.
         """
-        cr_readonly = None
+        cr_readwrite = None
         rule = None
         args = None
         not_found = None
@@ -1866,16 +1868,16 @@ class Request:
         # reuse the same cursor for building+checking the registry and
         # for matching the controller endpoint
         try:
-            self.registry, cr_readonly = self._open_registry()
+            self.registry, cr_readwrite = self._open_registry()
             threading.current_thread().dbname = self.registry.db_name
-            self.env = odoo.api.Environment(cr_readonly, self.session.uid, self.session.context)
+            self.env = odoo.api.Environment(cr_readwrite, self.session.uid, self.session.context)
             try:
                 rule, args = self.registry['ir.http']._match(self.httprequest.path)
             except NotFound as not_found_exc:
                 not_found = not_found_exc
         finally:
-            if cr_readonly is not None:
-                cr_readonly.close()
+            if cr_readwrite is not None:
+                cr_readwrite.close()
 
         if not_found:
             # no controller endpoint matched -> fallback or 404

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -854,6 +854,8 @@ class Registry(Mapping):
                           self.registry_sequence, ' '.join('[Cache %s: %s]' % cs for cs in self.cache_sequences.items()))
 
     def get_sequences(self, cr):
+        assert cr.readonly is False, "can't use replica, sequence data is not replicated"
+
         cache_sequences_query = ', '.join([f'base_cache_signaling_{cache_name}' for cache_name in _CACHES_BY_KEY])
         cache_sequences_values_query = ',\n'.join([f'base_cache_signaling_{cache_name}.last_value' for cache_name in _CACHES_BY_KEY])
         cr.execute(f"""


### PR DESCRIPTION
The PostgreSQL streaming physical replication notably does not synchonize sequence data[^1].

For sequences that are only used to generate unique IDs (for primary keys), this is not a concern because those IDs *will be* replicated correctly.

However it's a different story for sequences that are used directly. For us it means that on read-only cursors targeting database replicas, the registry and cache generation numbers (`base_registry_signaling` and `base_cache_signaling_*`) will remain fixed and out of sync with the values on the read-write master database.

As a consequence, workers serving alternating read-write and read-only requests will keep reloading the registry or discarding caches, because they will jump between the progressing master sequences, and the fixed sequences on the replica.

For HTTP workers this causes a peformance hit and suboptimal usage of resources, as the registry will be needlessly reloaded after a "sequence jump", or caches discarded.

For Gevent workers it may be much worse, because the registry reloading will *yield* and may be started by hundreds of different greenlets, blocking as many database connections, until the connection pool is exhausted. Repeat and rinse...

Note that the problem could manifest even for a worker that only ever processes read-write requests (like Gevent), because the registry and signaling checks were explicitly done in read-only mode.

As a mitigation, this patch forces the cursor mode to "read-write" during the registry loading and signaling checks, regardless of the actual request mode. This causes some minimal extra load on the master database, but ensures that the signaling checks will always use the correct sequences. The actual request handling, which is the costly part, will still be executed in the dynamically selected cursor mode.

PS: this patch does not change the possibility of having a pure read-only server, with a replica connection used for both the read-write and read-only database connections in the config. One should however be aware that the signaling sequences will never advance, so the replica will not receive the signals.

-----
Note: in master we could overcome this limitation by defining an explicit append-only `base_signal` table, with an `id` PK column driven by a sequence, like all tables. Then, whenever we want to trigger a signal, we would simply insert a row in the table with the corresponding signal:

```sql

CREATE TABLE base_signal (
    id SERIAL PRIMARY KEY,
    signal VARCHAR
);

-- increment signal `registry`
INSERT INTO base_signal (signal) VALUES ('registry')

-- check current signal `registry`:
SELECT max(id) FROM base_signal WHERE signal = 'registry';

```

The `base_signal` table would be properly synchronized and visible on replicas, and could be trivially garbage collected by the autovacuum system. As a bonus, it would also make signaling transactional, in the sense that a transaction would be unable to trigger a signal and then rollback due to a later error. The sequence ID might advance, but the row won't be inserted.

Cfr task-4399456

[^1]: https://www.postgresql.org/docs/16/logical-replication-restrictions.html