### PR TITLE
[FIX] account: Wrong order of rows need to be write and created new when sync dynamic line

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2308,8 +2308,9 @@ class AccountMove(models.Model):
         }
 
         while to_delete and to_create:
-            key, values = to_create.popitem()
-            line_id = to_delete.pop()
+            key = next(iter(to_create)) if len(to_create) > 1 else to_create
+            values = to_create.pop(key)
+            line_id = to_delete.pop(0)
             self.env['account.move.line'].browse(line_id).write(
                 {**key, **values, 'display_type': line_type}
             )


### PR DESCRIPTION
1. Create Payment terms with line 1: after 15 days, line 2: after 45 day
1. Create invoice and save.
2. Assign payment term

Move line payment term wrong

Reason: The last line of the needed terms data goes first.

Video Issue:


https://github.com/user-attachments/assets/9cfa352f-da9e-4dc9-b861-7e12edd377e4




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
