### PR TITLE
[IMP] product: optimize product _name_search by combining default_code and barcode conditions in a single query

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -495,9 +495,7 @@ class ProductProduct(models.Model):
             positive_operators = ['=', 'ilike', '=ilike', 'like', '=like']
             product_ids = []
             if operator in positive_operators:
-                product_ids = list(self._search([('default_code', '=', name)] + args, limit=limit, access_rights_uid=name_get_uid))
-                if not product_ids:
-                    product_ids = list(self._search([('barcode', '=', name)] + args, limit=limit, access_rights_uid=name_get_uid))
+                product_ids = list(self._search(['|', ('default_code', '=', name), ('barcode', '=', name)] + args, limit=limit, access_rights_uid=name_get_uid))
             if not product_ids and operator not in expression.NEGATIVE_TERM_OPERATORS:
                 # Do not merge the 2 next lines into one single search, SQL search performance would be abysmal
                 # on a database with thousands of matching products, due to the huge merge+unique needed for the


### PR DESCRIPTION
Since both default_code and barcode are usually unique fields, combining the conditions into one query ensures the search is faster and more resource-efficient.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
