### PR TITLE
[IMP] hr: added filter of activity plans on the employee

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -213,6 +213,7 @@ class HrEmployee(models.Model):
     activity_user_id = fields.Many2one(groups="hr.group_hr_user")
     activity_type_id = fields.Many2one(groups="hr.group_hr_user")
     activity_type_icon = fields.Char(groups="hr.group_hr_user")
+    activity_plans_ids = fields.Many2many(groups="hr.group_hr_user")
     activity_date_deadline = fields.Date(groups="hr.group_hr_user")
     my_activity_date_deadline = fields.Date(groups="hr.group_hr_user")
     activity_summary = fields.Char(groups="hr.group_hr_user")

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -33,6 +33,8 @@
                         domain="[('my_activity_date_deadline', '=', 'today')]"/>
                     <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                         domain="[('my_activity_date_deadline', '&gt;', 'today')]"/>
+                    <filter string="Ongoing Activity Plan" name="filter_ongoing_activity_plan"
+                         domain="[('activity_plans_ids', '!=', False)]"/>
                     <separator/>
                     <filter name="my_team" string="My Team" domain="[('parent_id.user_id', '=', uid)]"/>
                     <filter name="my_department" string="My Department" domain="[('member_of_department', '=', True)]"/>

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -69,6 +69,7 @@ class MailActivity(models.Model):
     activity_category = fields.Selection(related='activity_type_id.category', readonly=True)
     activity_decoration = fields.Selection(related='activity_type_id.decoration_type', readonly=True)
     icon = fields.Char('Icon', related='activity_type_id.icon', readonly=True)
+    activity_plan_id = fields.Many2one('mail.activity.plan', string='Plan', ondelete='set null', copy=False)
     summary = fields.Char('Summary')
     note = fields.Html('Note', sanitize_style=True)
     date_deadline = fields.Date('Due Date', index=True, required=True, default=fields.Date.context_today)

--- a/addons/mail/tests/common_activity.py
+++ b/addons/mail/tests/common_activity.py
@@ -93,6 +93,7 @@ class ActivityScheduleCase(MailCommon):
         self.assertEqual(len(activities), expected_number_of_activity)
 
         for activity, template, expected_deadline in zip(activities, plan.template_ids, expected_deadlines):
+            self.assertEqual(activity.activity_plan_id, template.plan_id)
             self.assertEqual(activity.activity_type_id, template.activity_type_id)
             self.assertEqual(activity.date_deadline, expected_deadline)
             self.assertEqual(activity.note, template.note)

--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -337,11 +337,12 @@ class MailActivitySchedule(models.TransientModel):
                 date_deadline = template._get_date_deadline(self.plan_date)
                 record.activity_schedule(
                     activity_type_id=template.activity_type_id.id,
+                    activity_plan_id=template.plan_id.id,
                     automated=False,
+                    date_deadline=date_deadline,
                     summary=template.summary,
                     note=template.note,
                     user_id=responsible.id,
-                    date_deadline=date_deadline
                 )
                 activity_descriptions.append(
                     _('%(activity)s, assigned to %(name)s, due on the %(deadline)s',


### PR DESCRIPTION
In this PR,
- The 'Ongoing Activity Plan' group has been added to the employee search view.
- When you create plans using the 'Launch Plan' button, you will be redirected to the employee view with the default group-by setting applied.
Activities created will follow the naming format: 'Activity Plan Name - Summary'


Task-4327533
