### PR TITLE
[FIX] stock: allow dropship operation type

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -27,14 +27,15 @@ class StockRule(models.Model):
         message_dict['manufacture'] = manufacture_message
         return message_dict
 
-    def _compute_picking_type_code_domain(self):
+    @api.depends('action')
+    def _compute_picking_type_code_ids(self):
         remaining = self.browse()
         for rule in self:
             if rule.action == 'manufacture':
-                rule.picking_type_code_domain = 'mrp_operation'
+                rule.picking_type_code_ids = self.env['stock.picking.type'].search([('code', '=', 'mrp_operation')])
             else:
                 remaining |= rule
-        super(StockRule, remaining)._compute_picking_type_code_domain()
+        super(StockRule, remaining)._compute_picking_type_code_ids()
 
     def _should_auto_confirm_procurement_mo(self, p):
         return (not p.orderpoint_id and p.move_raw_ids) or (p.move_dest_ids.procure_method != 'make_to_order' and not p.move_raw_ids and not p.workorder_ids)

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -31,14 +31,14 @@ class StockRule(models.Model):
         return message_dict
 
     @api.depends('action')
-    def _compute_picking_type_code_domain(self):
+    def _compute_picking_type_code_ids(self):
         remaining = self.browse()
         for rule in self:
             if rule.action == 'buy':
-                rule.picking_type_code_domain = 'incoming'
+                rule.picking_type_code_ids = self.env['stock.picking.type'].search([('code', '=', 'incoming')])
             else:
                 remaining |= rule
-        super(StockRule, remaining)._compute_picking_type_code_domain()
+        super(StockRule, remaining)._compute_picking_type_code_ids()
 
     @api.onchange('action')
     def _onchange_action(self):

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -80,8 +80,9 @@ class StockRule(models.Model):
     picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type',
         required=True, check_company=True,
-        domain="[('code', '=?', picking_type_code_domain)]")
-    picking_type_code_domain = fields.Char(compute='_compute_picking_type_code_domain')
+        domain="[('id', 'in', picking_type_code_ids)]")
+    picking_type_code_ids = fields.Many2many(
+        'stock.picking.type', compute='_compute_picking_type_code_ids')
     delay = fields.Integer('Lead Time', default=0, help="The expected date of the created transfer will be computed based on this lead time.")
     partner_address_id = fields.Many2one(
         'res.partner', 'Partner Address',
@@ -202,8 +203,8 @@ class StockRule(models.Model):
         (self - action_rules).rule_message = None
 
     @api.depends('action')
-    def _compute_picking_type_code_domain(self):
-        self.picking_type_code_domain = False
+    def _compute_picking_type_code_ids(self):
+        self.picking_type_code_ids = self.env['stock.picking.type'].search([])
 
     def _run_push(self, move):
         """ Apply a push rule on a move.

--- a/addons/stock/views/stock_rule_views.xml
+++ b/addons/stock/views/stock_rule_views.xml
@@ -72,7 +72,7 @@
                             <group>
                                 <field name="active" invisible="1"/>
                                 <field name="company_id" invisible="1"/>
-                                <field name="picking_type_code_domain" invisible="1"/>
+                                <field name="picking_type_code_ids" invisible="1"/>
                                 <field name="action"/>
                                 <field name="picking_type_id"/>
                                 <field name="location_src_id" options="{'no_create': True}" required="action in ['pull', 'push', 'pull_push']"/>

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -21,6 +21,15 @@ class StockRule(models.Model):
             return False
         return super()._get_partner_id(values, rule)
 
+    @api.depends('action')
+    def _compute_picking_type_code_ids(self):
+        remaining = self.browse()
+        for rule in self:
+            if rule.action == 'buy':
+                rule.picking_type_code_ids = self.env['stock.picking.type'].search([('code', 'in', ['incoming', 'dropship'])])
+            else:
+                remaining |= rule
+        super(StockRule, remaining)._compute_picking_type_code_ids()
 
 class ProcurementGroup(models.Model):
     _inherit = "procurement.group"


### PR DESCRIPTION
Issue Before This Commit:
============================
- The operation type 'Dropship' was officially categorized as a "Receipt" type of operation. However, the adaptation in route functionality was incomplete. Specifically, the domain on the operation types list allowed selection of only 'Receipt' types, excluding 'Dropship' when creating custom routes.

Steps to Produce:
=====================
1. Create or edit a custom route.
2. Attempt to select the "Dropship" operation type in the operation types list.
3. Notice that only "Receipt" types are available for selection.

With This Commit:
=====================
- The domain on the operation types has been updated to allow selection of both 'Receipt' and 'Dropship' types. This ensures that custom routes can be configured correctly, addressing the limitation in functionality.

task-4353843

