### PR TITLE
[FIX] point_of_sale: serial/lot numbers not appearing in the dropdown list

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -748,7 +748,7 @@ export class PosStore extends WithLazyGetterTrap {
                 const newPackLotLines = [{ lot_name: code.code }];
                 pack_lot_ids = { modifiedPackLotLines, newPackLotLines };
             } else {
-                pack_lot_ids = await this.editLots(values.product_tmpl_id, packLotLinesToEdit);
+                pack_lot_ids = await this.editLots(values.product_id, packLotLinesToEdit);
             }
 
             if (!pack_lot_ids) {


### PR DESCRIPTION
Steps:
- Add a quantity for a product tracked by unique serial numbers or lots.
- Open the POS.
- Click on that product.
- The Lot/Serial Number selection popup will appear.

Issue:
- The dropdown in the popup does not display any serial/lot numbers to select.

Fix:
- The dropdown now correctly displays the corresponding lot/serial numbers for that product.

Task - 4395292
