### PR TITLE
[FIX] hr_expense: handle undefined main attachment

### DIFF
--- a/addons/hr_expense/static/src/views/expense_line_widget.js
+++ b/addons/hr_expense/static/src/views/expense_line_widget.js
@@ -19,7 +19,7 @@ export class ExpenseLinesListRenderer extends ListRenderer {
     async onCellClicked(record, column, ev) {
         const attachmentChecksum = record.data.message_main_attachment_checksum;
 
-        if (attachmentChecksum && this.sheetThread.mainAttachment.checksum !== attachmentChecksum) {
+        if (attachmentChecksum && this.sheetThread.mainAttachment?.checksum !== attachmentChecksum) {
             this.sheetThread.update({ mainAttachment: this.sheetThread.attachments.find((attachment) => attachment.checksum === attachmentChecksum) });
         }
         super.onCellClicked(record, column, ev);


### PR DESCRIPTION
A temporary issue may occur when the attachment of an expense report is deleted.

Steps to reproduce:
- Create an expense and add an attachment.
- Create the report.
- On the report, delete the attachment.
- Try to click on the expense line.

An error "TypeError: Cannot read properties of  undefined (reading 'checksum')" is raised. The problem is resolved as soon as the page is reloaded.

This fix ensures the case is handled when one clicks before the page is reloaded.

opw-4355488