### PR TITLE
[FIX] survey: fix final leaderboard screen

### DIFF
--- a/addons/survey/static/src/js/survey_session_leaderboard.js
+++ b/addons/survey/static/src/js/survey_session_leaderboard.js
@@ -301,7 +301,7 @@ publicWidget.registry.SurveySessionLeaderboard = publicWidget.Widget.extend({
                     false);
 
                 var maxUpdatedScore = parseInt($(this).data('maxUpdatedScore'));
-                var baseRatio = updatedScore / maxUpdatedScore;
+                var baseRatio = maxUpdatedScore ? updatedScore / maxUpdatedScore : 1;
                 var questionScore = parseInt($(this).data('questionScore'));
                 var questionRatio = questionScore /
                     (updatedScore && updatedScore !== 0 ? updatedScore : 1);

--- a/addons/survey/static/src/js/survey_session_manage.js
+++ b/addons/survey/static/src/js/survey_session_manage.js
@@ -238,7 +238,7 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
             if ($(ev.currentTarget).data('showResults')) {
                 document.location = `/survey/results/${encodeURIComponent(self.surveyId)}`;
             } else {
-                window.history.back();
+                document.location.reload();
             }
         });
     },

--- a/addons/survey/static/tests/tours/survey_tour_session_manage.js
+++ b/addons/survey/static/tests/tours/survey_tour_session_manage.js
@@ -333,6 +333,6 @@ registry.category("web_tour.tours").add('test_survey_session_manage_tour', {
 }, {
     trigger: '.o_survey_session_close:has("i.fa-close")'
 }, {
-    trigger: 'button[name="action_start_session"]',
-    isCheck: true // check that we can start another session
+    content: "A final thank you message is displayed (the session is closed)",
+    trigger: 'h1:contains("Thank you!")',
 }])});

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -153,17 +153,17 @@
                         </div>
                     </div>
                 </div>
-                <div class="o_survey_session_leaderboard w-100 flex-column flex-grow-1" style="display: none;">
+                <div class="o_survey_session_leaderboard w-100 flex-column flex-grow-1 min-vw-75" style="display: none; max-height: 80vh;">
                     <!--Set question to false to avoid background miss match when no question are displayed.-->
                     <t t-set="question" t-value="False"/>
-                    <div class="d-flex">
-                        <h1 class="o_survey_session_leaderboard_title flex-grow-1">
+                    <div class="d-flex flex-wrap">
+                        <h1 class="o_survey_session_leaderboard_title flex-grow-1 me-4 ms-1">
                             <span t-if="is_last_question">Final Leaderboard</span>
                             <span t-else="">Leaderboard</span>
                         </h1>
-                        <div t-att-class="'o_survey_leaderboard_buttons fw-bold %s' % 'd-none' if not is_last_question else ''">
-                            <a href="#" role="button" class="o_survey_session_close btn btn-primary me-4"><i class="fa fa-close"/> Close</a>
-                            <a href="#" role="button" class="o_survey_session_close btn btn-primary" t-att-data-show-results="True"><i class="fa fa-bar-chart"/> Results</a>
+                        <div t-att-class="'o_survey_leaderboard_buttons fw-bold %s' % 'd-none' if not is_last_question else 'ms-2'">
+                            <a href="#" role="button" class="o_survey_session_close btn btn-primary mt-1"><i class="fa fa-close"/> Close</a>
+                            <a href="#" role="button" class="o_survey_session_close btn btn-primary mt-1" t-att-data-show-results="True"><i class="fa fa-bar-chart"/> Results</a>
                         </div>
                     </div>
                     <div class="justify-content-center d-flex flex-column flex-grow-1 mt-5 mb-5 pb-5 o_survey_session_leaderboard_container"/>


### PR DESCRIPTION
[FIX] survey: fix final leaderboard layout

- Install survey
- Create a survey “Live Session”
- Add a “Single Line Text Box” and check “Save as user nickname”
- Add a second question (ex.: multiple choice with 1 correct, score: 1)
- Click on “Create Live Session”
- Join the session with another browser
- Answer the question correctly
- On the survey manager, go to the end of the survey (Final leaderboard)

The stats only occupies a small portion of the width and the button are very close to the title.

We solve the problem by enlarging the stats like the previous result screens to get a layout similar as in v16.0.

[FIX] documents: fix close buttons

- Install survey
- Create a survey “Live Session”
- Add a “Single Line Text Box” and check “Save as user nickname”
- Add a second question (ex.: multiple choice with 1 correct, score: 1)
- Click on “Create Live Session”
- Join the session with another browser
- Answer the question correctly
- On the survey manager, go to the end of the survey (Final leaderboard)
- Click on the "Close" button

Nothing happens while it should close the session and get back to the survey form.

Actually, the code was closing the session but failed to get back to the survey as it was using "window.history.back()" and the button "create session" launches the session in a new tab that has no history as all the survey happens on the same URL. We solve the problem by reloading the page instead. As the session is closed, the page then displays "Thank you".

We change slightly the tour as it expects that at the end, the close button leads to the survey back-end form (as it checks the presence of the button "Create Session" which is the action "action_start_session"). But as the session is started in a new tab, we have decided that it is better to display the final "Thank you" screen rather than returning to the back-end survey form as this is meant to be displayed in public.

[FIX] documents: fix infinite line when max score is 0

How to reproduce:
- Create a live survey
- Add a “Single Line Text Box” and check “Save as user nickname”
- Add a second question (ex.: multiple choice with 1 correct, score: 1)
- Click on “Create Live Session”
- Join the session with another browser
- Answer the wrong answer to the question

At the end of the survey, the score bar size is very big (multiple time of the screen width).

We solve the problem by avoiding dividing by 0.

Task-4381603