### PR TITLE
[IMP] orm: domain complement char inequality

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -219,6 +219,7 @@ class AccountBankStatement(models.Model):
         previous = self.env['account.bank.statement'].search(
             [
                 ('first_line_index', '<', self.first_line_index),
+                ('first_line_index', '!=', False),
                 ('journal_id', '=', self.journal_id.id),
             ],
             limit=1,

--- a/odoo/addons/test_new_api/tests/test_domain.py
+++ b/odoo/addons/test_new_api/tests/test_domain.py
@@ -357,6 +357,16 @@ class TestDomainComplement(TransactionExpressionCase):
         self._search(Model, [('number2', '<', 1)])
         self._search(Model, [('number2', '<=', 1)])
 
+    def test_inequalities_char(self):
+        Model = self.env['test_new_api.empty_char']
+        Model.create([{}])
+        Model.create([{'name': n} for n in (False, '', 'hello', 'world')])
+        self._search(Model, [('name', '>', 'a')])
+        self._search(Model, [('name', '>', 'z')])
+        self._search(Model, [('name', '<', 'k')])
+        self._search(Model, [('name', '<=', 'k')])
+        self._search(Model, [('name', '<', '')])
+
 
 class TestDomainOptimize(TransactionCase):
     number_domain = Domain('number', '>', 5)

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1263,7 +1263,7 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
         # operator: inequality
         if operator in ('>', '<', '>=', '<='):
             can_be_null = False
-            if (null_value := self.falsy_value) is not None and not isinstance(null_value, str):  # TODO remove check on str
+            if (null_value := self.falsy_value) is not None:
                 value = self.convert_to_cache(value, model) or null_value
                 can_be_null = (
                     null_value < value if operator == '<' else


### PR DESCRIPTION
Make string comparison complementary. Strings have a `falsy_value` which is already used for equality checks. We use it now for inequality checks just as it is already done for numbers.

task-4017289


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
