### PR TITLE
[FIX] sale_stock: Fix deliver more test

### DIFF
--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1145,6 +1145,7 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
 
         so = self._get_new_sale_order(product=self.product_a)
         so.action_confirm()
+        so.order_line[0].product_uom_qty = 0
 
         picking = so.picking_ids
         self.env['stock.move'].create({


### PR DESCRIPTION
The Issue:
Before this commit, the second sale order was not being created due to the product type being set to 'product'. And, another test override the product_b variable with another product with the same name but a different type. As a result, the _should_bypass_reservation function returned False, triggering a recompute of the state and setting it to assigned, which was not the intended behavior in the originally created test.

The Fix:
To address this, we explicitly set the product type to 'consumable', as this reflects the expected product data in a fresh database with only the sale_stock module installed.

runbot-70732
