### PR TITLE
[FIX] stock_landed_costs: round down in cost split

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -267,15 +267,16 @@ class StockLandedCost(models.Model):
                             value = (line.price_unit / total_line)
 
                         if rounding:
-                            value = tools.float_round(value, precision_rounding=rounding, rounding_method='UP')
-                            fnc = min if line.price_unit > 0 else max
-                            value = fnc(value, line.price_unit - value_split)
+                            value = tools.float_round(value, precision_rounding=rounding, rounding_method='HALF-UP')
                             value_split += value
 
                         if valuation.id not in towrite_dict:
                             towrite_dict[valuation.id] = value
                         else:
                             towrite_dict[valuation.id] += value
+                rounding_diff = cost.currency_id.round(line.price_unit - value_split)
+                if not cost.currency_id.is_zero(rounding_diff):
+                    towrite_dict[max(towrite_dict.keys())] += rounding_diff
         for key, value in towrite_dict.items():
             AdjustementLines.browse(key).write({'additional_landed_cost': value})
         return True
@@ -300,16 +301,15 @@ class StockLandedCost(models.Model):
     def _check_sum(self):
         """ Check if each cost line its valuation lines sum to the correct amount
         and if the overall total amount is correct also """
-        prec_digits = self.env.company.currency_id.decimal_places
         for landed_cost in self:
             total_amount = sum(landed_cost.valuation_adjustment_lines.mapped('additional_landed_cost'))
-            if not tools.float_is_zero(total_amount - landed_cost.amount_total, precision_digits=prec_digits):
+            if not landed_cost.currency_id.is_zero(total_amount - landed_cost.amount_total):
                 return False
 
             val_to_cost_lines = defaultdict(lambda: 0.0)
             for val_line in landed_cost.valuation_adjustment_lines:
                 val_to_cost_lines[val_line.cost_line_id] += val_line.additional_landed_cost
-            if any(not tools.float_is_zero(cost_line.price_unit - val_amount, precision_digits=prec_digits)
+            if any(not landed_cost.currency_id.is_zero(cost_line.price_unit - val_amount)
                    for cost_line, val_amount in val_to_cost_lines.items()):
                 return False
         return True

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_rounding.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_rounding.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.addons.stock_landed_costs.tests.common import TestStockLandedCostsCommon
+from odoo.fields import Date
 from odoo.tests import tagged, Form
 
 
@@ -283,3 +285,45 @@ class TestStockLandedCostsRounding(TestStockLandedCostsCommon):
         deliveries.button_validate()
 
         self.assertEqual(self.product_a.value_svl, 0)
+
+    def test_lc_cost_split_cumulative_rounding_diff(self):
+        """ Ensure that the sum total difference of all rounding operations during the splitting of
+        an LC cost allots a sensible value to each cost line.
+        I.e., we don't end up with one line which bears the brunt of this difference.
+        """
+        product = self.env['product.product'].create({
+            'name': 'product',
+            'type': 'product',
+            'standard_price': 10,
+            'categ_id': self.categ_real_time.id,
+        })
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_qty': 1,
+            }) for _ in range(6)],
+        })
+        purchase_order.button_confirm()
+        purchase_order.picking_ids.button_validate()
+        purchase_order.action_create_invoice()
+        bill = purchase_order.invoice_ids
+        bill.invoice_date = Date.today()
+        with Form(bill) as bill_form:
+            with bill_form.invoice_line_ids.new() as inv_line:
+                inv_line.product_id = self.landed_cost
+                inv_line.price_unit = 6.85
+                inv_line.is_landed_costs_line = True
+        bill.action_post()
+        action = bill.button_create_landed_costs()
+        lc = Form(self.env[action['res_model']].browse(action['res_id'])).save()
+        lc.picking_ids = [Command.link(purchase_order.picking_ids.id)]
+        lc.cost_lines.split_method = 'equal'
+        lc.button_validate()
+        line_costs = lc.valuation_adjustment_lines.mapped('additional_landed_cost')
+        for line_cost, expected_cost in zip(line_costs, [1.14, 1.14, 1.14, 1.14, 1.14, 1.15]):
+            self.assertAlmostEqual(
+                line_cost,
+                expected_cost,
+                delta=lc.currency_id.rounding * 0.1
+            )


### PR DESCRIPTION
**Current behavior:**
The rounding applied during the cost split of a landed cost's
cost computation can yield undesirable/unexpected results.

**Expected behavior:**
Sensible rounding.

**Steps to reproduce:**
1. Create some product with arbitrary cost, with avg and
real_time costing and valuation, respectively

2. Create a purchase order with 6 lines, all for that product

3. Confirm order & receive products, create bill and add a
landed cost line with cost=6.85

4. Post bill and create the landed cost:
* link to the receipt
* set split method to `equal`

5. Validate the LC, see that the val adjustment lines are
rounded unexpectedly- *specifically all the lines are rounded up
(beyond the per-adjustment-line value) which means the final
adjustment line cost-split share will reflect the cumulative
rounding loss of every adjustment line rounded prior*
E.g.,
<pre>
[ 1.15, 1.15, 1.15, 1.15, 1.15, 1.11 ]
                                  ^
</pre>

**Cause of the issue:**
We currently use `rounding_method='UP'`.

**Fix:**
Round HALF-UP. This will minimize the difference between the
true, unrounded split-value and the post-rounding value.

Semi-related fix: try to use consistent `ResCurrency.round()`
methods between `compute_landed_cost()` and `_check_sum()`.

opw-4200916