### PR TITLE
[FIX] html_editor: collaboration selection test failing

### DIFF
--- a/addons/html_editor/static/tests/odoo_collaboration.test.js
+++ b/addons/html_editor/static/tests/odoo_collaboration.test.js
@@ -13,6 +13,7 @@ import { patch } from "@web/core/utils/patch";
 import { getContent, getSelection, setSelection } from "./_helpers/selection";
 import { insertText } from "./_helpers/user_actions";
 import { animationFrame, advanceTime } from "@odoo/hoot-mock";
+import { waitUntil } from "@odoo/hoot-dom";
 
 /**
  * @typedef PeerPool
@@ -1171,7 +1172,13 @@ describe("Selection", () => {
             peers.p2.plugins.collaborationSelection.selectionInfos.get("p1").selection.anchorOffset
         ).toBe(1);
         peers.p1.plugins.delete.delete("backward", "character");
-        advanceTime(100);
+        await waitUntil(() => {
+            const selectionInAvatarPlugin =
+                peers.p2.plugins.collaborationSelectionAvatar.selectionInfos.get("p1").selection.anchorOffset == 0;
+            const selectionInCollabSelectionPlugin =
+                peers.p2.plugins.collaborationSelection.selectionInfos.get("p1").selection.anchorOffset == 0;
+            return selectionInAvatarPlugin && selectionInCollabSelectionPlugin;
+        });
         expect(
             peers.p2.plugins.collaborationSelectionAvatar.selectionInfos.get("p1").selection
                 .anchorOffset


### PR DESCRIPTION
The test introduced in [1] is failing undeterministically.

Since the selection update somtimes takes more time than what is expected, we change it waituntil the selection is correct.

109367

[1]: https://github.com/odoo/odoo/pull/179742