### PR TITLE
[IMP] stock_picking_batch: move some logic to dedicated function so it is overridable

### DIFF
--- a/addons/stock_picking_batch/models/stock_move_line.py
+++ b/addons/stock_picking_batch/models/stock_move_line.py
@@ -138,30 +138,48 @@ class StockMoveLine(models.Model):
         if remaining_lines:
             remaining_lines._auto_wave_lines_into_new_waves(nearest_parent_locations=lines_nearest_parent_locations)
 
+    def _check_potential_line_for_wave(self, **kwargs):
+        wave = kwargs.get('wave')
+        waves_nearest_parent_locations = kwargs.get('waves_nearest_parent_locations')
+        nearest_parent_locations = kwargs.get('nearest_parent_locations')
+        picking_type = self.picking_type_id
+        return self.company_id != wave.company_id \
+                        or (picking_type.batch_group_by_partner and self.move_id.partner_id != wave.picking_ids.partner_id) \
+                        or (picking_type.batch_group_by_destination and self.move_id.partner_id.country_id != wave.picking_ids.partner_id.country_id) \
+                        or (picking_type.batch_group_by_src_loc and self.location_id != wave.picking_ids.location_id) \
+                        or (picking_type.batch_group_by_dest_loc and self.location_dest_id != wave.picking_ids.location_dest_id) \
+                        or (picking_type.wave_group_by_product and self.product_id != wave.move_line_ids.product_id) \
+                        or (picking_type.wave_group_by_category and self.product_id.categ_id != wave.move_line_ids.product_id.categ_id) \
+                        or (picking_type.wave_group_by_location and waves_nearest_parent_locations[wave] != nearest_parent_locations[self].id)
+
+    def _get_possible_wave_batch_picking_domain(self):
+        picking_type = self.picking_type_id        
+        domain = [
+            ('picking_type_id', '=', picking_type.id),
+            ('company_id', 'in', self.mapped('company_id').ids),
+            ('is_wave', '=', True)
+        ]
+        if picking_type.batch_auto_confirm:
+            domain = expression.AND([domain, [('state', 'not in', ['done', 'cancel'])]])
+        else:
+            domain = expression.AND([domain, [('state', '=', 'draft')]])
+        if picking_type.batch_group_by_partner:
+            domain = expression.AND([domain, [('picking_ids.partner_id', 'in', self.move_id.partner_id.ids)]])
+        if picking_type.batch_group_by_destination:
+            domain = expression.AND([domain, [('picking_ids.partner_id.country_id', 'in', self.move_id.partner_id.country_id.ids)]])
+        if picking_type.batch_group_by_src_loc:
+            domain = expression.AND([domain, [('picking_ids.location_id', 'in', self.location_id.ids)]])
+        if picking_type.batch_group_by_dest_loc:
+            domain = expression.AND([domain, [('picking_ids.location_dest_id', 'in', self.location_dest_id.ids)]])
+        return domain
+
     def _auto_wave_lines_into_existing_waves(self, nearest_parent_locations=False):
         """ Try to add move lines to existing waves if possible, return move lines of which no appropriate waves were found to link to
          :param nearest_parent_locations (defaultdict): the key is the move line and the value is the nearest parent location in the wave locations list"""
         remaining_lines = OrderedSet()
         for (picking_type, lines) in self.grouped(lambda l: l.picking_type_id).items():
             if lines:
-                domain = [
-                    ('picking_type_id', '=', picking_type.id),
-                    ('company_id', 'in', lines.mapped('company_id').ids),
-                    ('is_wave', '=', True)
-                ]
-                if picking_type.batch_auto_confirm:
-                    domain = expression.AND([domain, [('state', 'not in', ['done', 'cancel'])]])
-                else:
-                    domain = expression.AND([domain, [('state', '=', 'draft')]])
-                if picking_type.batch_group_by_partner:
-                    domain = expression.AND([domain, [('picking_ids.partner_id', 'in', lines.move_id.partner_id.ids)]])
-                if picking_type.batch_group_by_destination:
-                    domain = expression.AND([domain, [('picking_ids.partner_id.country_id', 'in', lines.move_id.partner_id.country_id.ids)]])
-                if picking_type.batch_group_by_src_loc:
-                    domain = expression.AND([domain, [('picking_ids.location_id', 'in', lines.location_id.ids)]])
-                if picking_type.batch_group_by_dest_loc:
-                    domain = expression.AND([domain, [('picking_ids.location_dest_id', 'in', lines.location_dest_id.ids)]])
-
+                domain = lines._get_possible_wave_batch_picking_domain()
                 potential_waves = self.env['stock.picking.batch'].search(domain)
                 wave_to_new_lines = defaultdict(set)
 
@@ -187,14 +205,7 @@ class StockMoveLine(models.Model):
                 for line in lines:
                     wave_found = False
                     for wave in potential_waves:
-                        if line.company_id != wave.company_id \
-                        or (picking_type.batch_group_by_partner and line.move_id.partner_id != wave.picking_ids.partner_id) \
-                        or (picking_type.batch_group_by_destination and line.move_id.partner_id.country_id != wave.picking_ids.partner_id.country_id) \
-                        or (picking_type.batch_group_by_src_loc and line.location_id != wave.picking_ids.location_id) \
-                        or (picking_type.batch_group_by_dest_loc and line.location_dest_id != wave.picking_ids.location_dest_id) \
-                        or (picking_type.wave_group_by_product and line.product_id != wave.move_line_ids.product_id) \
-                        or (picking_type.wave_group_by_category and line.product_id.categ_id != wave.move_line_ids.product_id.categ_id) \
-                        or (picking_type.wave_group_by_location and waves_nearest_parent_locations[wave] != nearest_parent_locations[line].id):
+                        if line._check_potential_line_for_wave(wave=wave, waves_nearest_parent_locations=waves_nearest_parent_locations, nearest_parent_locations=nearest_parent_locations):
                             continue
 
                         wave_new_move_ids = wave_to_new_moves[wave]
@@ -227,35 +238,55 @@ class StockMoveLine(models.Model):
                     lines._add_to_wave(wave)
         return list(remaining_lines)
 
+    def _get_potential_lines_domain(self):
+        picking_type = self.picking_type_id
+        domain = [
+            ('id', 'in', self.ids),
+            ('company_id', 'in', self.company_id.ids),
+            ('picking_id.state', '=', 'assigned'),
+            ('picking_type_id', '=', picking_type.id),
+            '|',
+            ('batch_id', '=', False),
+            ('batch_id.is_wave', '=', False)
+        ]
+        if picking_type.batch_group_by_partner:
+            domain = expression.AND([domain, [('move_id.partner_id', 'in', self.move_id.partner_id.ids)]])
+        if picking_type.batch_group_by_destination:
+            domain = expression.AND([domain, [('move_id.partner_id.country_id', 'in', self.move_id.partner_id.country_id.ids)]])
+        if picking_type.batch_group_by_src_loc:
+            domain = expression.AND([domain, [('location_id', 'in', self.location_id.ids)]])
+        if picking_type.batch_group_by_dest_loc:
+            domain = expression.AND([domain, [('location_dest_id', 'in', self.location_dest_id.ids)]])
+        if picking_type.wave_group_by_product:
+            domain = expression.AND([domain, [('product_id', 'in', self.product_id.ids)]])
+        if picking_type.wave_group_by_category:
+            domain = expression.AND([domain, [('product_id.categ_id', 'in', self.product_id.categ_id.ids)]])
+        if picking_type.wave_group_by_location:
+            domain = expression.AND([domain, [('location_id', 'child_of', picking_type.wave_location_ids.ids)]])
+        return domain
+    
+    def _check_potential_line_for_line(self, **kwargs):
+        potential_line = kwargs.get('potential_line')
+        lines_nearest_parent_locations = kwargs.get('lines_nearest_parent_locations')
+        nearest_parent_locations = kwargs.get('nearest_parent_locations')
+        picking_type = self.picking_type_id
+
+        return self.id == potential_line.id \
+                    or self.company_id != potential_line.company_id \
+                    or (picking_type.batch_group_by_partner and self.move_id.partner_id != potential_line.move_id.partner_id) \
+                    or (picking_type.batch_group_by_destination and self.move_id.partner_id.country_id != potential_line.move_id.partner_id.country_id) \
+                    or (picking_type.batch_group_by_src_loc and self.location_id != potential_line.location_id) \
+                    or (picking_type.batch_group_by_dest_loc and self.location_dest_id != potential_line.location_dest_id) \
+                    or (picking_type.wave_group_by_product and self.product_id != potential_line.product_id) \
+                    or (picking_type.wave_group_by_category and self.product_id.categ_id != potential_line.product_id.categ_id) \
+                    or (picking_type.wave_group_by_location and lines_nearest_parent_locations[potential_line] != nearest_parent_locations[self].id)
+
     def _auto_wave_lines_into_new_waves(self, nearest_parent_locations=False):
         """ Create new waves for the move lines that could not be added to existing waves. """
         picking_types = self.picking_type_id
         for picking_type in picking_types:
             lines = self.filtered(lambda l: l.picking_type_id == picking_type)
-            domain = [
-                ('id', 'in', lines.ids),
-                ('company_id', 'in', self.company_id.ids),
-                ('picking_id.state', '=', 'assigned'),
-                ('picking_type_id', '=', picking_type.id),
-                '|',
-                ('batch_id', '=', False),
-                ('batch_id.is_wave', '=', False)
-            ]
-            if picking_type.batch_group_by_partner:
-                domain = expression.AND([domain, [('move_id.partner_id', 'in', lines.move_id.partner_id.ids)]])
-            if picking_type.batch_group_by_destination:
-                domain = expression.AND([domain, [('move_id.partner_id.country_id', 'in', lines.move_id.partner_id.country_id.ids)]])
-            if picking_type.batch_group_by_src_loc:
-                domain = expression.AND([domain, [('location_id', 'in', lines.location_id.ids)]])
-            if picking_type.batch_group_by_dest_loc:
-                domain = expression.AND([domain, [('location_dest_id', 'in', lines.location_dest_id.ids)]])
-            if picking_type.wave_group_by_product:
-                domain = expression.AND([domain, [('product_id', 'in', lines.product_id.ids)]])
-            if picking_type.wave_group_by_category:
-                domain = expression.AND([domain, [('product_id.categ_id', 'in', lines.product_id.categ_id.ids)]])
-            if picking_type.wave_group_by_location:
-                domain = expression.AND([domain, [('location_id', 'child_of', picking_type.wave_location_ids.ids)]])
-
+            domain = lines._get_potential_lines_domain()           
             potential_lines = self.env['stock.move.line'].search(domain)
             lines_nearest_parent_locations = defaultdict(int)
             if picking_type.wave_group_by_location:
@@ -273,15 +304,7 @@ class StockMoveLine(models.Model):
                 if line.id in matched_lines:
                     continue
                 for potential_line in potential_lines:
-                    if line.id == potential_line.id \
-                    or line.company_id != potential_line.company_id \
-                    or (picking_type.batch_group_by_partner and line.move_id.partner_id != potential_line.move_id.partner_id) \
-                    or (picking_type.batch_group_by_destination and line.move_id.partner_id.country_id != potential_line.move_id.partner_id.country_id) \
-                    or (picking_type.batch_group_by_src_loc and line.location_id != potential_line.location_id) \
-                    or (picking_type.batch_group_by_dest_loc and line.location_dest_id != potential_line.location_dest_id) \
-                    or (picking_type.wave_group_by_product and line.product_id != potential_line.product_id) \
-                    or (picking_type.wave_group_by_category and line.product_id.categ_id != potential_line.product_id.categ_id) \
-                    or (picking_type.wave_group_by_location and lines_nearest_parent_locations[potential_line] != nearest_parent_locations[line].id):
+                    if line._check_potential_line_for_line(potential_line=potential_line, lines_nearest_parent_locations=lines_nearest_parent_locations, nearest_parent_locations=nearest_parent_locations):
                         continue
 
                     line_to_lines[line].add(potential_line.id)

--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -280,11 +280,10 @@ class StockPicking(models.Model):
 
         return domain
 
-    def _get_auto_batch_description(self):
-        """ Get the description of the automatically created batch based on the grouped pickings and grouping criteria """
+    def _get_auto_batch_description_items(self):
         self.ensure_one()
         description_items = []
-        if self.picking_type_id.batch_group_by_partner and self.partner_id:
+        if self.picking_type_id.batch_group_by_partner and self.partner_id.name:
             description_items.append(self.partner_id.name)
         if self.picking_type_id.batch_group_by_destination and self.partner_id.country_id:
             description_items.append(self.partner_id.country_id.name)
@@ -292,6 +291,12 @@ class StockPicking(models.Model):
             description_items.append(self.location_id.display_name)
         if self.picking_type_id.batch_group_by_dest_loc and self.location_dest_id:
             description_items.append(self.location_dest_id.display_name)
+        return description_items
+
+    def _get_auto_batch_description(self):
+        """ Get the description of the automatically created batch based on the grouped pickings and grouping criteria """
+        self.ensure_one()
+        description_items = self._get_auto_batch_description_items()
         return ', '.join(description_items)
 
     def _package_move_lines(self, batch_pack=False, move_lines_to_pack=False):


### PR DESCRIPTION
### After this PR
Some logic such as domain for potential lines and fields for description are moved on separated function so it is overridable by custom logic (for example add some new custom group field for batch picking)

I used kwargs so other module can override the function and add some args 

There is also a fix when the shipping address doesn't have the name. i check for partner_id.name 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
