### PR TITLE
[IMP] osv/expression: optimize SQL query for one2many domain by replacing NOT IN with NOT EXISTS

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1683,9 +1683,9 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner".id
             FROM "res_partner"
-            WHERE ("res_partner"."id" IN (
-                SELECT "partner_id" FROM "res_partner_bank" WHERE "partner_id" IS NOT NULL
-            ))
+            WHERE EXISTS (
+                SELECT 1 FROM "res_partner_bank" AS "comodel_alias" WHERE "comodel_alias".partner_id = "res_partner".id
+            )
             ORDER BY "res_partner"."id"
         ''']):
             self.Partner.search([('bank_ids', '!=', False)], order='id')
@@ -1693,9 +1693,9 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner".id
             FROM "res_partner"
-            WHERE ("res_partner"."id" NOT IN (
-                SELECT "partner_id" FROM "res_partner_bank" WHERE "partner_id" IS NOT NULL
-            ))
+            WHERE NOT EXISTS (
+                SELECT 1 FROM "res_partner_bank" AS "comodel_alias" WHERE "comodel_alias".partner_id = "res_partner".id
+            )
             ORDER BY "res_partner"."id"
         ''']):
             self.Partner.search([('bank_ids', '=', False)], order='id')

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -806,9 +806,12 @@ class expression(object):
                 else:
                     if inverse_field.store and not (inverse_is_int and domain):
                         # rewrite condition to match records with/without lines
-                        op1 = 'inselect' if operator in NEGATIVE_TERM_OPERATORS else 'not inselect'
-                        subquery = f'SELECT "{inverse_field.name}" FROM "{comodel._table}" WHERE "{inverse_field.name}" IS NOT NULL'
-                        push(('id', op1, (subquery, [])), model, alias, internal=True)
+                        exists = 'EXISTS' if operator in NEGATIVE_TERM_OPERATORS else 'NOT EXISTS'
+                        push_result(f"""
+                            {exists} (
+                                SELECT 1 FROM "{comodel._table}" AS "comodel_alias" WHERE "comodel_alias".{inverse_field.name} = "{alias}".id
+                            )
+                        """, [])
                     else:
                         comodel_domain = [(inverse_field.name, '!=', False)]
                         if inverse_is_int and domain:


### PR DESCRIPTION
This change replaces the NOT IN condition with a NOT EXISTS subquery, which is expected to improve performance by stopping the search as soon as a matching record is found. This enhancement ensures more efficient querying, particularly in high-volume environments.

Currently, with the domain `[('matched_debit_ids', '=', False)]`, the generated SQL is `("account_move_line"."id" not in (SELECT "credit_move_id" FROM "account_partial_reconcile" WHERE "credit_move_id" IS NOT NULL))`. After the improvement, the generated SQL is `NOT EXISTS (SELECT 1 FROM "account_partial_reconcile" WHERE "credit_move_id" = "account_move_line".id LIMIT 1)`.

Similar, with the domain `[('matched_debit_ids', '!=', False)]`, the generated SQL is `("account_move_line"."id" in (SELECT "credit_move_id" FROM "account_partial_reconcile" WHERE "credit_move_id" IS NOT NULL))`. After the improvement, the generated SQL is `EXISTS (SELECT 1 FROM "account_partial_reconcile" WHERE "credit_move_id" = "account_move_line".id LIMIT 1)`.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
