### PR TITLE
[FIX] website: prevent traceback when adding a tab containing a form

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -1385,7 +1385,11 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                     const inputsInDependencyContainer = dependencyContainerEl.querySelectorAll('.s_website_form_input');
                     for (const el of inputsInDependencyContainer) {
                         const button = document.createElement('we-button');
-                        button.textContent = el.labels[0].textContent;
+                        button.textContent = inputsInDependencyContainer.length === 1
+                            ? el.value
+                            : dependencyContainerEl
+                                .querySelector(`label[for="${el.id}"]`)
+                                .textContent;
                         button.dataset.selectDataAttribute = el.value;
                         selectOptEl.append(button);
                     }


### PR DESCRIPTION
Since [1], a fix was introduced to display the actual value of a relational field instead of its ID. However, another issue occurs when a form is inside a tab (Tabs snippet) and a new tab is added. During this process, the currently active tab is cloned, including its field IDs. Although a method exists to update the IDs after cloning, the form rendering is triggered beforehand.

This causes the labels property of input elements—which is expected to return a NodeList of associated <label> elements—to fail because the cloned input IDs are not unique.

This commit resolves the issue by using querySelector to target the associated label elements directly.

Steps to reproduce:

- Open the Website editor.
- Drag & Drop a Tabs snippet.
- In the first tab, drag & Drop a Form snippet.
- Set the first field as a radio buttons.
- Make the second field's visibility depend on the first field.
- Add a new tab by clicking the "+" icon in the right panel.
- Observe that a traceback occurs.

A second issue related to [1] has been resolved for cases where there is
only a single checkbox. In this scenario, the value displayed in the
visibility condition dropdown menu should be "Yes".

opw-4345340

[1]: https://github.com/odoo/odoo/commit/4b37f22cece5424d6992c6bafe619c9a457d184b

