### PR TITLE
[FIX] mail: remove false positive when checking message features

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -31,6 +31,7 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
+import { setElementContent } from "@web/core/utils/html";
 import { url } from "@web/core/utils/urls";
 import { useMessageActions } from "./message_actions";
 import { cookie } from "@web/core/browser/cookie";
@@ -143,7 +144,9 @@ export class Message extends Component {
                 this.shadowRoot = this.shadowBody.el.attachShadow({ mode: "open" });
                 const color = cookie.get("color_scheme") === "dark" ? "white" : "black";
                 const shadowStyle = document.createElement("style");
-                shadowStyle.innerHTML = `
+                setElementContent(
+                    shadowStyle,
+                    markup(`
                     * {
                         background-color: transparent !important;
                         color: ${color} !important;
@@ -157,7 +160,8 @@ export class Message extends Component {
                     .o-mail-Message-searchHighlight {
                         background: ${this.constructor.SHADOW_HIGHLIGHT_COLOR} !important;
                     }
-                `;
+                `)
+                );
                 if (cookie.get("color_scheme") === "dark") {
                     this.shadowRoot.appendChild(shadowStyle);
                 }
@@ -167,10 +171,13 @@ export class Message extends Component {
             () => {
                 if (this.shadowBody.el) {
                     const body = document.createElement("span");
-                    body.innerHTML = this.state.showTranslation
-                        ? this.message.translationValue
-                        : this.props.messageSearch?.highlight(this.message.body) ??
-                          this.message.body;
+                    setElementContent(
+                        body,
+                        this.state.showTranslation
+                            ? this.message.translationValue
+                            : this.props.messageSearch?.highlight(this.message.body) ??
+                                  this.message.body
+                    );
                     this.prepareMessageBody(body);
                     this.shadowRoot.appendChild(body);
                     return () => {

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -1,8 +1,10 @@
 import { Record } from "@mail/core/common/record";
 import { EMOJI_REGEX, htmlToTextContentInline } from "@mail/utils/common/format";
+import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
 
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
+import { setElementContent } from "@web/core/utils/html";
 import { omit } from "@web/core/utils/objects";
 import { url } from "@web/core/utils/urls";
 
@@ -25,8 +27,7 @@ export class Message extends Record {
     update(data) {
         super.update(data);
         if (this.isNotification && !this.notificationType) {
-            const parser = new DOMParser();
-            const htmlBody = parser.parseFromString(this.body, "text/html");
+            const htmlBody = createDocumentFragmentFromContent(this.body);
             this.notificationType = htmlBody.querySelector(".o_mail_notification")?.dataset.oeType;
         }
     }
@@ -45,7 +46,7 @@ export class Message extends Record {
                 return false;
             }
             const div = document.createElement("div");
-            div.innerHTML = this.body;
+            setElementContent(div, this.body);
             return Boolean(div.querySelector("a:not([data-oe-model])"));
         },
     });
@@ -85,7 +86,7 @@ export class Message extends Record {
     onlyEmojis = Record.attr(false, {
         compute() {
             const div = document.createElement("div");
-            div.innerHTML = this.body;
+            setElementContent(div, this.body);
             const bodyWithoutTags = div.textContent;
             const withoutEmojis = bodyWithoutTags.replace(EMOJI_REGEX, "");
             return bodyWithoutTags.length > 0 && withoutEmojis.trim().length === 0;

--- a/addons/mail/static/src/core/common/message_search_hook.js
+++ b/addons/mail/static/src/core/common/message_search_hook.js
@@ -1,4 +1,5 @@
 import { useSequential } from "@mail/utils/common/hooks";
+import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
 import { useState, onWillUnmount, markup } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { escapeRegExp } from "@web/core/utils/strings";
@@ -13,7 +14,7 @@ export function searchHighlight(searchTerm, target) {
     if (!searchTerm) {
         return target;
     }
-    const htmlDoc = new DOMParser().parseFromString(target, "text/html");
+    const htmlDoc = createDocumentFragmentFromContent(target);
     for (const term of searchTerm.split(" ")) {
         const regexp = new RegExp(`(${escapeRegExp(term)})`, "gi");
         // Special handling for '

--- a/addons/mail/static/src/discuss/core/common/message_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_patch.js
@@ -1,19 +1,20 @@
 import { Message } from "@mail/core/common/message";
+import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
 import { patch } from "@web/core/utils/patch";
 
 patch(Message.prototype, {
     /** @override */
     enterEditMode() {
-        const body = new DOMParser().parseFromString(this.props.message.body, "text/html");
+        const body = createDocumentFragmentFromContent(this.props.message.body);
         const mentionedChannelElements = body.querySelectorAll(".o_channel_redirect");
         this.props.message.mentionedChannelPromises = Array.from(mentionedChannelElements)
             .filter((el) => el.dataset.oeModel === "discuss.channel")
-            .map(async (el) => {
-                return this.store.Thread.getOrFetch({
+            .map(async (el) =>
+                this.store.Thread.getOrFetch({
                     id: el.dataset.oeId,
                     model: el.dataset.oeModel,
-                });
-            });
+                })
+            );
         return super.enterEditMode();
     },
 });

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -1,7 +1,17 @@
-import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
+import {
+    createDocumentFragmentFromContent,
+    htmlJoin,
+    htmlReplace,
+    htmlTrim
+} from "@mail/utils/common/html";
 
-import { escape, unaccent } from "@web/core/utils/strings";
+import { markup } from "@odoo/owl";
+
+import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
+import { htmlEscape, setElementContent } from "@web/core/utils/html";
+import { escapeRegExp, unaccent } from "@web/core/utils/strings";
 import { url } from "@web/core/utils/urls";
+import { setAttributes } from "@web/core/utils/xml";
 
 const urlRegexp =
     /\b(?:https?:\/\/\d{1,3}(?:\.\d{1,3}){3}|(?:https?:\/\/|(?:www\.))[-a-z0-9@:%._+~#=\u00C0-\u024F\u1E00-\u1EFF]{1,256}\.[a-z]{2,13})\b(?:[-a-z0-9@:%_+~#?&[\]^|{}`\\'$//=\u00C0-\u024F\u1E00-\u1EFF]|[.]*[-a-z0-9@:%_+~#?&[\]^|{}`\\'$//=\u00C0-\u024F\u1E00-\u1EFF]|,(?!$| )|\.(?!$| |\.)|;(?!$| ))*/gi;
@@ -26,7 +36,7 @@ const _escapeEntities = (function () {
 })();
 
 /**
- * @param rawBody {string}
+ * @param rawBody {string|ReturnType<markup>}
  * @param validRecords {Object}
  * @param validRecords.partners {Partner}
  */
@@ -35,7 +45,8 @@ export async function prettifyMessageContent(rawBody, validRecords = []) {
     // Adapted to make http(s):// not required if (and only if) www. is given. So `should.notmatch` does not match.
     // And further extended to include Latin-1 Supplement, Latin Extended-A, Latin Extended-B and Latin Extended Additional.
     const escapedAndCompactContent = escapeAndCompactTextContent(rawBody);
-    let body = escapedAndCompactContent.replace(/&nbsp;/g, " ").trim();
+    let body = htmlReplace(escapedAndCompactContent, /&nbsp;/g, " ");
+    body = htmlTrim(body);
     // This message will be received from the mail composer as html content
     // subtype but the urls will not be linkified. If the mail composer
     // takes the responsibility to linkify the urls we end up with double
@@ -53,27 +64,24 @@ export async function prettifyMessageContent(rawBody, validRecords = []) {
  * should handle it or it should be handled after/before calling parseAndTransform. So if the result
  * of this function is used in a t-raw, be very careful.
  *
- * @param {string} htmlString
+ * @param {string|ReturnType<markup>} htmlString
  * @param {function} transformFunction
- * @returns {string}
+ * @returns {ReturnType<markup>}
  */
 export function parseAndTransform(htmlString, transformFunction) {
-    const openToken = "OPEN" + Date.now();
-    const string = htmlString.replace(/&lt;/g, openToken);
     let children;
     try {
         const div = document.createElement("div");
-        div.innerHTML = string; // /!\ quotes are unescaped
+        setElementContent(div, htmlString);
         children = Array.from(div.childNodes);
     } catch {
         const div = document.createElement("div");
-        div.innerHTML = `<pre>${string}</pre>`;
+        const pre = document.createElement("pre");
+        setElementContent(pre, htmlString);
+        div.appendChild(pre);
         children = Array.from(div.childNodes);
     }
-    return _parseAndTransform(children, transformFunction).replace(
-        new RegExp(openToken, "g"),
-        "&lt;"
-    );
+    return _parseAndTransform(children, transformFunction);
 }
 
 /**
@@ -82,49 +90,59 @@ export function parseAndTransform(htmlString, transformFunction) {
  *   param node
  *   param function
  *   return string
- * @return {string}
+ * @return {ReturnType<markup>}
  */
 function _parseAndTransform(nodes, transformFunction) {
     if (!nodes) {
         return;
     }
-    return Object.values(nodes)
-        .map((node) => {
-            return transformFunction(node, function () {
+    return htmlJoin(
+        ...Object.values(nodes).map((node) =>
+            transformFunction(node, function () {
                 return _parseAndTransform(node.childNodes, transformFunction);
-            });
-        })
-        .join("");
+            })
+        )
+    );
 }
 
 /**
  * @param {string} text
- * @return {string} linkified text
+ * @return {ReturnType<markup>} linkified text
  */
 function linkify(text) {
     let curIndex = 0;
     let result = "";
     let match;
     while ((match = urlRegexp.exec(text)) !== null) {
-        result += _escapeEntities(text.slice(curIndex, match.index));
+        result = htmlJoin(result, text.slice(curIndex, match.index));
         // Decode the url first, in case it's already an encoded url
         const url = decodeURI(match[0]);
         const href = encodeURI(!/^https?:\/\//i.test(url) ? "http://" + url : url);
-        result += `<a target="_blank" rel="noreferrer noopener" href="${href}">${_escapeEntities(
-            url
-        )}</a>`;
+        result = htmlJoin(
+            result,
+            markup(
+                `<a target="_blank" rel="noreferrer noopener" href="${href}">${_escapeEntities(
+                    url
+                )}</a>`
+            )
+        );
         curIndex = match.index + match[0].length;
     }
-    return result + _escapeEntities(text.slice(curIndex));
+    return htmlJoin(result, text.slice(curIndex));
 }
 
+/**
+ * @param {Node} node
+ * @param {function} transformFunction
+ * @return {ReturnType<markup>}
+ */
 export function addLink(node, transformChildren) {
     if (node.nodeType === 3) {
         // text node
-        const linkified = linkify(node.data);
-        if (linkified !== node.data) {
+        const linkified = linkify(node.textContent);
+        if (linkified.toString() !== node.textContent) {
             const div = document.createElement("div");
-            div.innerHTML = linkified;
+            setElementContent(div, linkified);
             for (const childNode of [...div.childNodes]) {
                 node.parentNode.insertBefore(childNode, node);
             }
@@ -134,40 +152,41 @@ export function addLink(node, transformChildren) {
         return node.textContent;
     }
     if (node.tagName === "A") {
-        return node.outerHTML;
+        return markup(node.outerHTML);
     }
     transformChildren();
-    return node.outerHTML;
+    return markup(node.outerHTML);
 }
 
 /**
  * Returns an escaped conversion of a content.
  *
- * @param {string} content
- * @returns {string}
+ * @param {string|ReturnType<markup>} content
+ * @returns {ReturnType<markup>}
  */
 export function escapeAndCompactTextContent(content) {
     //Removing unwanted extra spaces from message
-    let value = escape(content).trim();
-    value = value.replace(/(\r|\n){2,}/g, "<br/><br/>");
-    value = value.replace(/(\r|\n)/g, "<br/>");
+    let value = htmlTrim(content);
+    value = htmlReplace(value, /(\r|\n){2,}/g, markup("<br/><br/>"));
+    value = htmlReplace(value, /(\r|\n)/g, markup("<br/>"));
 
     // prevent html space collapsing
-    value = value.replace(/ /g, "&nbsp;").replace(/([^>])&nbsp;([^<])/g, "$1 $2");
+    value = htmlReplace(value, / /g, markup("&nbsp;"));
+    value = htmlReplace(value, /([^>])&nbsp;([^<])/g, markup("$1 $2"));
     return value;
 }
 
 /**
- * @param body {string}
+ * @param body {string|ReturnType<markup>}
  * @param validRecords {Object}
  * @param validRecords.partners {Array}
- * @return {string}
+ * @return {ReturnType<markup>}
  */
 function generateMentionsLinks(body, { partners = [], threads = [] }) {
     const mentions = [];
     for (const partner of partners) {
         const placeholder = `@-mention-partner-${partner.id}`;
-        const text = `@${escape(partner.name)}`;
+        const text = `@${partner.name}`;
         mentions.push({
             class: "o_mail_redirect",
             id: partner.id,
@@ -175,11 +194,11 @@ function generateMentionsLinks(body, { partners = [], threads = [] }) {
             placeholder,
             text,
         });
-        body = body.replace(text, placeholder);
+        body = htmlReplace(body, text, placeholder);
     }
     for (const thread of threads) {
         const placeholder = `#-mention-channel-${thread.id}`;
-        const text = `#${escape(thread.displayName)}`;
+        const text = `#${thread.displayName}`;
         mentions.push({
             class: "o_channel_redirect",
             id: thread.id,
@@ -187,50 +206,55 @@ function generateMentionsLinks(body, { partners = [], threads = [] }) {
             placeholder,
             text,
         });
-        body = body.replace(text, placeholder);
+        body = htmlReplace(body, text, placeholder);
     }
     const baseHREF = url("/web");
     for (const mention of mentions) {
-        const href = `href='${baseHREF}#model=${mention.model}&id=${mention.id}'`;
-        const attClass = `class='${mention.class}'`;
-        const dataOeId = `data-oe-id='${mention.id}'`;
-        const dataOeModel = `data-oe-model='${mention.model}'`;
-        const target = "target='_blank'";
-        const link = `<a ${href} ${attClass} ${dataOeId} ${dataOeModel} ${target} contenteditable="false">${mention.text}</a>`;
-        body = body.replace(mention.placeholder, link);
+        const link = document.createElement("a");
+        setAttributes(link, {
+            href: `${baseHREF}#model=${mention.model}&id=${mention.id}`,
+            class: mention.class,
+            "data-oe-id": mention.id,
+            "data-oe-model": mention.model,
+            target: "_blank",
+            contenteditable: "false",
+        });
+        link.textContent = mention.text;
+        body = htmlReplace(body, mention.placeholder, markup(link.outerHTML));
     }
-    return body;
+    return htmlEscape(body);
 }
 
 /**
  * @private
- * @param {string} htmlString
- * @returns {string}
+ * @param {string|ReturnType<markup>} htmlString
+ * @returns {ReturnType<markup>}
  */
 async function _generateEmojisOnHtml(htmlString) {
     const { emojis } = await loadEmoji();
     for (const emoji of emojis) {
         for (const source of [...emoji.shortcodes, ...emoji.emoticons]) {
-            const escapedSource = escape(String(source)).replace(
-                /([.*+?=^!:${}()|[\]/\\])/g,
-                "\\$1"
-            );
-            const regexp = new RegExp("(\\s|^)(" + escapedSource + ")(?=\\s|$)", "g");
-            htmlString = htmlString.replace(regexp, "$1" + emoji.codepoints);
+            const escapedSource = htmlJoin(String(source));
+            const regexp = new RegExp("(\\s|^)(" + escapeRegExp(escapedSource) + ")(?=\\s|$)", "g");
+            htmlString = htmlReplace(htmlString, regexp, "$1" + emoji.codepoints);
         }
     }
-    return htmlString;
+    return htmlEscape(htmlString);
 }
 
+/**
+ * @param {string|ReturnType<markup>} htmlString
+ * @returns {string}
+ */
 export function htmlToTextContentInline(htmlString) {
-    const fragment = document.createDocumentFragment();
+    htmlString = htmlReplace(htmlString, /<br\s*\/?>/gi, " ");
     const div = document.createElement("div");
-    fragment.appendChild(div);
-    htmlString = htmlString.replace(/<br\s*\/?>/gi, " ");
     try {
-        div.innerHTML = htmlString;
+        setElementContent(div, htmlString);
     } catch {
-        div.innerHTML = `<pre>${htmlString}</pre>`;
+        const pre = document.createElement("pre");
+        setElementContent(pre, htmlString);
+        div.appendChild(pre);
     }
     return div.textContent
         .trim()
@@ -239,10 +263,8 @@ export function htmlToTextContentInline(htmlString) {
 }
 
 export function convertBrToLineBreak(str) {
-    return new DOMParser().parseFromString(
-        str.replaceAll("<br>", "\n").replaceAll("</br>", "\n"),
-        "text/html"
-    ).body.textContent;
+    str = htmlReplace(str, /<br\s*\/?>/gi, "\n");
+    return createDocumentFragmentFromContent(str).body.textContent;
 }
 
 export function cleanTerm(term) {

--- a/addons/mail/static/src/utils/common/html.js
+++ b/addons/mail/static/src/utils/common/html.js
@@ -1,0 +1,53 @@
+import { markup } from "@odoo/owl";
+
+import { htmlEscape, setElementContent } from "@web/core/utils/html";
+
+/**
+ * Safely creates a Document fragment from content. If content was flagged as safe HTML using
+ * `markup()` it is parsed as HTML. Otherwise it is escaped and parsed as text.
+ *
+ * @param {string|ReturnType<markup>} content
+ */
+export function createDocumentFragmentFromContent(content) {
+    const div = document.createElement("div");
+    setElementContent(div, content);
+    return new DOMParser().parseFromString(div.innerHTML, "text/html");
+}
+
+/**
+ * Applies list join on content and returns a markup result built for HTML.
+ *
+ * @param {Array<string|ReturnType<markup>>} args
+ * @returns {ReturnType<markup>}
+ */
+export function htmlJoin(...args) {
+    return markup(args.map((arg) => htmlEscape(arg)).join(""));
+}
+
+/**
+ * Applies string replace on content and returns a markup result built for HTML.
+ *
+ * @param {string|ReturnType<markup>} content
+ * @param {string | RegExp} search
+ * @param {string} replacement
+ * @returns {ReturnType<markup>}
+ */
+export function htmlReplace(content, search, replacement) {
+    content = htmlEscape(content);
+    if (typeof search === "string" || search instanceof String) {
+        search = htmlEscape(search);
+    }
+    replacement = htmlEscape(replacement);
+    return markup(content.replace(search, replacement));
+}
+
+/**
+ * Applies string trim on content and returns a markup result built for HTML.
+ *
+ * @param {string|ReturnType<markup>} content
+ * @returns {string|ReturnType<markup>}
+ */
+export function htmlTrim(content) {
+    content = htmlEscape(content);
+    return markup(content.trim());
+}

--- a/addons/mail/static/src/views/web/activity/activity_record.js
+++ b/addons/mail/static/src/views/web/activity/activity_record.js
@@ -4,12 +4,9 @@ import { Component } from "@odoo/owl";
 
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { user } from "@web/core/user";
+import { isHtmlEmpty } from "@web/core/utils/html";
 import { Field } from "@web/views/fields/field";
-import {
-    getFormattedRecord,
-    getImageSrcFromRecordInfo,
-    isHtmlEmpty,
-} from "@web/views/kanban/kanban_record";
+import { getFormattedRecord, getImageSrcFromRecordInfo } from "@web/views/kanban/kanban_record";
 import { useViewCompiler } from "@web/views/view_compiler";
 
 export class ActivityRecord extends Component {

--- a/addons/mail/static/tests/core/search_highlight.test.js
+++ b/addons/mail/static/tests/core/search_highlight.test.js
@@ -1,3 +1,4 @@
+import { HIGHLIGHT_CLASS, searchHighlight } from "@mail/core/common/message_search_hook";
 import {
     SIZES,
     click,
@@ -11,10 +12,11 @@ import {
     startServer,
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, expect, test } from "@odoo/hoot";
-import { serverState } from "@web/../tests/web_test_helpers";
 
-import { HIGHLIGHT_CLASS, searchHighlight } from "@mail/core/common/message_search_hook";
+import { describe, expect, test } from "@odoo/hoot";
+import { markup } from "@odoo/owl";
+
+import { serverState } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -22,40 +24,45 @@ defineMailModels();
 test("Search highlight", async () => {
     const testCases = [
         {
-            input: "test odoo",
+            input: markup("test odoo"),
             output: `test <span class="${HIGHLIGHT_CLASS}">odoo</span>`,
             searchTerm: "odoo",
         },
         {
-            input: '<a href="https://www.odoo.com">https://www.odoo.com</a>',
+            input: markup('<a href="https://www.odoo.com">https://www.odoo.com</a>'),
             output: `<a href="https://www.odoo.com">https://www.<span class="${HIGHLIGHT_CLASS}">odoo</span>.com</a>`,
             searchTerm: "odoo",
         },
         {
-            input: '<a href="https://www.odoo.com">Odoo</a>',
+            input: '<a href="https://www.odoo.com">https://www.odoo.com</a>',
+            output: `&lt;a href="https://www.<span class="${HIGHLIGHT_CLASS}">odoo</span>.com"&gt;https://www.<span class="${HIGHLIGHT_CLASS}">odoo</span>.com&lt;/a&gt;`,
+            searchTerm: "odoo",
+        },
+        {
+            input: markup('<a href="https://www.odoo.com">Odoo</a>'),
             output: `<a href="https://www.odoo.com"><span class="${HIGHLIGHT_CLASS}">Odoo</span></a>`,
             searchTerm: "odoo",
         },
         {
-            input: '<a href="https://www.odoo.com">Odoo</a> Odoo is a free software',
+            input: markup('<a href="https://www.odoo.com">Odoo</a> Odoo is a free software'),
             output: `<a href="https://www.odoo.com"><span class="${HIGHLIGHT_CLASS}">Odoo</span></a> <span class="${HIGHLIGHT_CLASS}">Odoo</span> is a free software`,
             searchTerm: "odoo",
         },
         {
-            input: "odoo is a free software",
+            input: markup("odoo is a free software"),
             output: `<span class="${HIGHLIGHT_CLASS}">odoo</span> is a free software`,
             searchTerm: "odoo",
         },
         {
-            input: "software ODOO is a free",
+            input: markup("software ODOO is a free"),
             output: `software <span class="${HIGHLIGHT_CLASS}">ODOO</span> is a free`,
             searchTerm: "odoo",
         },
         {
-            input: `<ul>
+            input: markup(`<ul>
                 <li>Odoo</li>
                 <li><a href="https://odoo.com">Odoo ERP</a> Best ERP</li>
-            </ul>`,
+            </ul>`),
             output: `<ul>
                 <li><span class="${HIGHLIGHT_CLASS}">Odoo</span></li>
                 <li><a href="https://odoo.com"><span class="${HIGHLIGHT_CLASS}">Odoo</span> ERP</a> Best ERP</li>
@@ -63,42 +70,42 @@ test("Search highlight", async () => {
             searchTerm: "odoo",
         },
         {
-            input: "test <strong>Odoo</strong> test",
+            input: markup("test <strong>Odoo</strong> test"),
             output: `<span class="${HIGHLIGHT_CLASS}">test</span> <strong><span class="${HIGHLIGHT_CLASS}">Odoo</span></strong> <span class="${HIGHLIGHT_CLASS}">test</span>`,
             searchTerm: "odoo test",
         },
         {
-            input: "test <br> test",
+            input: markup("test <br> test"),
             output: `<span class="${HIGHLIGHT_CLASS}">test</span> <br> <span class="${HIGHLIGHT_CLASS}">test</span>`,
             searchTerm: "odoo test",
         },
         {
-            input: "<strong>test</strong> test",
+            input: markup("<strong>test</strong> test"),
             output: `<strong><span class="${HIGHLIGHT_CLASS}">test</span></strong> <span class="${HIGHLIGHT_CLASS}">test</span>`,
             searchTerm: "test",
         },
         {
-            input: "<strong>a</strong> test",
+            input: markup("<strong>a</strong> test"),
             output: `<strong><span class="${HIGHLIGHT_CLASS}">a</span></strong> <span class="${HIGHLIGHT_CLASS}">test</span>`,
             searchTerm: "a test",
         },
         {
-            input: "&amp;amp;",
+            input: markup("&amp;amp;"),
             output: `<span class="${HIGHLIGHT_CLASS}">&amp;amp;</span>`,
             searchTerm: "&amp;",
         },
         {
-            input: "&amp;amp;",
+            input: markup("&amp;amp;"),
             output: `<span class="${HIGHLIGHT_CLASS}">&amp;</span>amp;`,
             searchTerm: "&",
         },
         {
-            input: "<strong>test</strong> hello",
+            input: markup("<strong>test</strong> hello"),
             output: `<strong><span class="${HIGHLIGHT_CLASS}">test</span></strong> <span class="${HIGHLIGHT_CLASS}">hello</span>`,
             searchTerm: "test hello",
         },
         {
-            input: "<p>&lt;strong&gt;test&lt;/strong&gt; hello</p>",
+            input: markup("<p>&lt;strong&gt;test&lt;/strong&gt; hello</p>"),
             output: `<p>&lt;strong&gt;<span class="${HIGHLIGHT_CLASS}">test</span>&lt;/strong&gt; <span class="${HIGHLIGHT_CLASS}">hello</span></p>`,
             searchTerm: "test hello",
         },

--- a/addons/mail/static/tests/discuss/search_discuss.test.js
+++ b/addons/mail/static/tests/discuss/search_discuss.test.js
@@ -253,16 +253,11 @@ test("Search a message containing round brackets", async () => {
 test("Search a message containing single quotes", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
-    pyEnv["mail.message"].create({
-        author_id: serverState.partnerId,
-        body: "I can't do it",
-        attachment_ids: [],
-        message_type: "comment",
-        model: "discuss.channel",
-        res_id: channelId,
-    });
     await start();
     await openDiscuss(channelId);
+    await insertText(".o-mail-Composer-input", "I can't do it");
+    await click(".o-mail-Composer-send:enabled");
+    await contains(".o-mail-Message");
     await click("button[title='Search Messages']");
     await insertText(".o_searchview_input", "can't");
     triggerHotkey("Enter");

--- a/addons/mail/static/tests/mail_utils.test.js
+++ b/addons/mail/static/tests/mail_utils.test.js
@@ -1,5 +1,3 @@
-import { describe, expect, test } from "@odoo/hoot";
-
 import { addLink, parseAndTransform } from "@mail/utils/common/format";
 import {
     click,
@@ -10,6 +8,9 @@ import {
     start,
     startServer,
 } from "./mail_test_helpers";
+
+import { describe, expect, test } from "@odoo/hoot";
+import { markup } from "@odoo/owl";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -47,38 +48,55 @@ test("add_link utility function", () => {
 });
 
 test("addLink: utility function and special entities", () => {
-    const testInputs = {
+    const testInputs = [
         // textContent not unescaped
-        "<p>https://example.com/?&amp;currency_id</p>":
+        [
+            markup("<p>https://example.com/?&amp;currency_id</p>"),
             '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/?&amp;currency_id">https://example.com/?&amp;currency_id</a></p>',
+        ],
         // entities not unescaped
-        "&amp; &amp;amp; &gt; &lt;": "&amp; &amp;amp; &gt; &lt;",
+        [markup("&amp; &amp;amp; &gt; &lt;"), "&amp; &amp;amp; &gt; &lt;"],
         // > and " not linkified since they are not in URL regex
-        "<p>https://example.com/&gt;</p>":
+        [
+            markup("<p>https://example.com/&gt;</p>"),
             '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/">https://example.com/</a>&gt;</p>',
-        '<p>https://example.com/"hello"&gt;</p>':
+        ],
+        [
+            markup('<p>https://example.com/"hello"&gt;</p>'),
             '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/">https://example.com/</a>"hello"&gt;</p>',
+        ],
         // & and ' linkified since they are in URL regex
-        "<p>https://example.com/&amp;hello</p>":
+        [
+            markup("<p>https://example.com/&amp;hello</p>"),
             '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/&amp;hello">https://example.com/&amp;hello</a></p>',
-        "<p>https://example.com/'yeah'</p>":
+        ],
+        [
+            markup("<p>https://example.com/'yeah'</p>"),
             '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/\'yeah\'">https://example.com/\'yeah\'</a></p>',
-        // normal character should not be escaped
-        ":'(": ":'(",
-        // special character in smileys should be escaped
-        "&lt;3": "&lt;3",
+        ],
+        [markup("<p>:'(</p>"), "<p>:'(</p>"],
+        [markup(":'("), ":&#x27;("],
+        ["<p>:'(</p>", "&lt;p&gt;:&#x27;(&lt;/p&gt;"],
+        [":'(", ":&#x27;("],
+        [markup("<3"), "&lt;3"],
+        [markup("&lt;3"), "&lt;3"],
+        ["<3", "&lt;3"],
         // Already encoded url should not be encoded twice
-        "https://odoo.com/%5B%5D": `<a target="_blank" rel="noreferrer noopener" href="https://odoo.com/%5B%5D">https://odoo.com/[]</a>`,
-    };
+        [
+            markup("https://odoo.com/%5B%5D"),
+            `<a target="_blank" rel="noreferrer noopener" href="https://odoo.com/%5B%5D">https://odoo.com/[]</a>`,
+        ],
+    ];
 
-    for (const [content, result] of Object.entries(testInputs)) {
+    for (const [content, result] of testInputs) {
         const output = parseAndTransform(content, addLink);
-        expect(output).toBe(result);
+        expect(output).toBeInstanceOf(markup().constructor);
+        expect(output.toString()).toBe(result);
     }
 });
 
 test("addLink: linkify inside text node (1 occurrence)", async () => {
-    const content = "<p>some text https://somelink.com</p>";
+    const content = markup("<p>some text https://somelink.com</p>");
     const linkified = parseAndTransform(content, addLink);
     expect(linkified.startsWith("<p>some text <a")).toBe(true);
     expect(linkified.endsWith("</a></p>")).toBe(true);
@@ -99,7 +117,9 @@ test("addLink: linkify inside text node (2 occurrences)", () => {
     // linkify may add some attributes. Since we do not care of their exact
     // stringified representation, we continue deeper assertion with query
     // selectors.
-    const content = "<p>some text https://somelink.com and again https://somelink2.com ...</p>";
+    const content = markup(
+        "<p>some text https://somelink.com and again https://somelink2.com ...</p>"
+    );
     const linkified = parseAndTransform(content, addLink);
     const fragment = document.createDocumentFragment();
     const div = document.createElement("div");

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -710,7 +710,7 @@ test("channel preview: basic rendering", async () => {
     });
     pyEnv["mail.message"].create({
         author_id: partnerId,
-        body: "<p>test</p>",
+        body: "<p>test<br/>hi</p>",
         model: "discuss.channel",
         res_id: channelId,
     });
@@ -719,7 +719,7 @@ test("channel preview: basic rendering", async () => {
     await contains(".o-mail-NotificationItem");
     await contains(".o-mail-NotificationItem img");
     await contains(".o-mail-NotificationItem-name", { text: "General" });
-    await contains(".o-mail-NotificationItem-text", { text: "Demo: test" });
+    await contains(".o-mail-NotificationItem-text", { text: "Demo: test hi" });
 });
 
 test("filtered previews", async () => {

--- a/addons/mail/static/tests/utils/html.test.js
+++ b/addons/mail/static/tests/utils/html.test.js
@@ -1,0 +1,81 @@
+import {
+    createDocumentFragmentFromContent,
+    htmlJoin,
+    htmlReplace,
+    htmlTrim,
+} from "@mail/utils/common/html";
+
+import { describe, expect, test } from "@odoo/hoot";
+import { markup } from "@odoo/owl";
+
+const Markup = markup().constructor;
+
+describe.current.tags("headless");
+
+test("createDocumentFragmentFromContent escapes text", () => {
+    const doc = createDocumentFragmentFromContent("<p>test</p>");
+    expect(doc.body.innerHTML).toEqual("&lt;p&gt;test&lt;/p&gt;");
+});
+
+test("createDocumentFragmentFromContent keeps html markup", () => {
+    const doc = createDocumentFragmentFromContent(markup("<p>test</p>"));
+    expect(doc.body.innerHTML).toEqual("<p>test</p>");
+});
+
+test("htmlJoin keeps html markup and escapes text", () => {
+    const res = htmlJoin(markup("<p>test</p>"), "<p>test</p>");
+    expect(res.toString()).toBe("<p>test</p>&lt;p&gt;test&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlReplace with text/text/text replaces with escaped text", () => {
+    const res = htmlReplace("<p>test</p>", "<p>test</p>", "<span>test</span>");
+    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlReplace with text/text/html replaces with html markup", () => {
+    const res = htmlReplace("<p>test</p>", "<p>test</p>", markup("<span>test</span>"));
+    expect(res.toString()).toBe("<span>test</span>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlReplace with text/html does not find", () => {
+    const res = htmlReplace("<p>test</p>", markup("<p>test</p>"), "never found");
+    expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlReplace with html/html/html replaces with html markup", () => {
+    const res = htmlReplace(
+        markup("<p>test</p>"),
+        markup("<p>test</p>"),
+        markup("<span>test</span>")
+    );
+    expect(res.toString()).toBe("<span>test</span>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlReplace with html/html/text replaces with escaped text", () => {
+    const res = htmlReplace(markup("<p>test</p>"), markup("<p>test</p>"), "<span>test</span>");
+    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlReplace with html/text does not find", () => {
+    const res = htmlReplace(markup("<p>test</p>"), "<p>test</p>", "never found");
+    expect(res.toString()).toBe("<p>test</p>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlTrim escapes text", () => {
+    const res = htmlTrim(" <p>test</p> ");
+    expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlTrim keeps html markup", () => {
+    const res = htmlTrim(markup(" <p>test</p> "));
+    expect(res.toString()).toBe("<p>test</p>");
+    expect(res).toBeInstanceOf(Markup);
+});

--- a/addons/web/static/src/core/utils/html.js
+++ b/addons/web/static/src/core/utils/html.js
@@ -1,0 +1,47 @@
+import { markup } from "@odoo/owl";
+
+import { escape } from "@web/core/utils/strings";
+
+const Markup = markup().constructor;
+
+/**
+ * Escapes content for HTML. Content is unchanged if it is already a Markup.
+ *
+ * @param {string|ReturnType<markup>} content
+ * @returns {ReturnType<markup>}
+ */
+export function htmlEscape(content) {
+    return content instanceof Markup ? content : markup(escape(content));
+}
+
+/**
+ * Checks if a html content is empty. If there are only formatting tags
+ * with style attributes or a void content. Famous use case is
+ * '<p style="..." class=".."><br></p>' added by some web editor(s).
+ * Note that because the use of this method is limited, we ignore the cases
+ * like there's one <img> tag in the content. In such case, even if it's the
+ * actual content, we consider it empty.
+ *
+ * @param {string|ReturnType<markup>} content
+ * @returns {boolean} true if no content found or if containing only formatting tags
+ */
+export function isHtmlEmpty(content = "") {
+    const div = document.createElement("div");
+    setElementContent(div, content);
+    return div.textContent.trim() === "";
+}
+
+/**
+ * Safely sets content on element. If content was flagged as safe HTML using `markup()` it is set as
+ * innerHTML. Otherwise it is set as text.
+ *
+ * @param {Element} element
+ * @param {string|ReturnType<markup>} content
+ */
+export function setElementContent(element, content) {
+    if (content instanceof Markup) {
+        element.innerHTML = content;
+    } else {
+        element.textContent = content;
+    }
+}

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -7,6 +7,7 @@ import { registry } from "@web/core/registry";
 import { useTooltip } from "@web/core/tooltip/tooltip_hook";
 import { user } from "@web/core/user";
 import { useService } from "@web/core/utils/hooks";
+import { isHtmlEmpty as _isHtmlEmpty } from "@web/core/utils/html";
 import { imageUrl } from "@web/core/utils/urls";
 import { useRecordObserver } from "@web/model/relational_model/utils";
 import { Field } from "@web/views/fields/field";
@@ -165,12 +166,11 @@ function isBinSize(value) {
  * like there's one <img> tag in the content. In such case, even if it's the
  * actual content, we consider it empty.
  *
- * @param {string} innerHTML
+ * @param {string|ReturnType<import("@odoo/owl").markup>} innerHTML
  * @returns {boolean} true if no content found or if containing only formatting tags
  */
 export function isHtmlEmpty(innerHTML = "") {
-    const div = Object.assign(document.createElement("div"), { innerHTML });
-    return div.innerText.trim() === "";
+    return _isHtmlEmpty(innerHTML);
 }
 
 export class KanbanRecord extends Component {

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -29,6 +29,7 @@ import {
 import { downloadReport, getReportUrl } from "./reports/utils";
 import { omit, pick, shallowEqual } from "@web/core/utils/objects";
 import { zip } from "@web/core/utils/arrays";
+import { isHtmlEmpty } from "@web/core/utils/html";
 
 class BlankComponent extends Component {
     static props = ["onMounted", "withControlPanel", "*"];
@@ -370,9 +371,7 @@ export function makeActionManager(env, router = _router) {
                 ? evaluateExpr(domain, Object.assign({}, user.context, action.context))
                 : domain;
         if (action.help) {
-            const htmlHelp = document.createElement("div");
-            htmlHelp.innerHTML = action.help;
-            if (!htmlHelp.innerText.trim()) {
+            if (isHtmlEmpty(action.help)) {
                 delete action.help;
             }
         }

--- a/addons/web/static/tests/core/utils/html.test.js
+++ b/addons/web/static/tests/core/utils/html.test.js
@@ -1,0 +1,40 @@
+import { markup } from "@odoo/owl";
+
+const Markup = markup().constructor;
+
+import { describe, expect, test } from "@odoo/hoot";
+import { htmlEscape, isHtmlEmpty, setElementContent } from "@web/core/utils/html";
+
+describe.current.tags("headless");
+
+test("htmlEscape escapes text", () => {
+    const res = htmlEscape("<p>test</p>");
+    expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlEscape keeps html markup", () => {
+    const res = htmlEscape(markup("<p>test</p>"));
+    expect(res.toString()).toBe("<p>test</p>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("isHtmlEmpty does not consider text as empty", () => {
+    expect(isHtmlEmpty("<p></p>")).toBe(false);
+});
+
+test("isHtmlEmpty considers empty html markup as empty", () => {
+    expect(isHtmlEmpty(markup("<p></p>"))).toBe(true);
+});
+
+test("setElementContent escapes text", () => {
+    const div = document.createElement("div");
+    setElementContent(div, "<p>test</p>");
+    expect(div.innerHTML).toBe("&lt;p&gt;test&lt;/p&gt;");
+});
+
+test("setElementContent keeps html markup", () => {
+    const div = document.createElement("div");
+    setElementContent(div, markup("<p>test</p>"));
+    expect(div.innerHTML).toBe("<p>test</p>");
+});


### PR DESCRIPTION
When message content is not markup(), it will not render its content as HTML but as text when using t-out.

This case was not taken into account when manually processing the content, leading to incorrectly detecting links or other features within purely text content. Those are now properly ignored.