### PR TITLE
[FIX] mail: subchannel hierarchy marker display in rtl

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -113,4 +113,6 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
 
 .o-mail-DiscussSidebarSubchannel svg {
     color: var(--mail-DiscussSidebarSubchannel-svgColor, $gray-300);
+    left: 26px;
+    transform: scaleX(1) #{"/* rtl:scaleX(-1) */"};
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -124,11 +124,11 @@
     <t t-name="mail.DiscussSidebarSubchannel.main">
         <li class="o-mail-DiscussSidebarSubchannel d-flex align-items-center flex-grow-1 position-relative" t-att-class="{ 'p-0': !store.discuss.isSidebarCompact }" t-ref="root">
             <t t-if="!store.discuss.isSidebarCompact">
-                <svg t-if="props.isFirst" class="position-absolute me-1" style="left: 26px; top: -6px;" xmlns="http://www.w3.org/2000/svg" width="10" height="20" viewBox="0 0 10 20">
+                <svg t-if="props.isFirst" class="position-absolute me-1" style="top: -6px;" xmlns="http://www.w3.org/2000/svg" width="10" height="20" viewBox="0 0 10 20">
                     <line x1="0" y1="3" x2="0" y2="100%" stroke="currentColor" stroke-width="3"/>
                     <line x1="0" y1="100%" x2="100%" y2="100%" stroke="currentColor" stroke-width="3"/>
                 </svg>
-                <svg t-else="" class="position-absolute me-1" style="left: 26px; top: -20px;" xmlns="http://www.w3.org/2000/svg" width="10" height="34" viewBox="0 0 10 34">
+                <svg t-else="" class="position-absolute me-1" style="top: -20px;" xmlns="http://www.w3.org/2000/svg" width="10" height="34" viewBox="0 0 10 34">
                     <line x1="0" y1="3" x2="0" y2="100%" stroke="currentColor" stroke-width="3"/>
                     <line x1="0" y1="100%" x2="100%" y2="100%" stroke="currentColor" stroke-width="3"/>
                 </svg>


### PR DESCRIPTION
The SVG used for the subchannel hierarchy marker was positioned using inline styles. However, `rtlcss` does not process inline CSS rules.

This commit moves the positioning rules to SCSS files to ensure proper handling of RTL layouts.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
