### PR TITLE
[FIX] web: control panel duplicate layout buttons

### DIFF
--- a/addons/web/static/src/search/layout.js
+++ b/addons/web/static/src/search/layout.js
@@ -30,6 +30,9 @@ export class Layout extends Component {
     }
     get controlPanelSlots() {
         const slots = { ...this.props.slots };
+        if (this.env.inDialog) {
+            delete slots["layout-buttons"];
+        }
         delete slots.default;
         return slots;
     }

--- a/addons/web/static/tests/search/control_panel.test.js
+++ b/addons/web/static/tests/search/control_panel.test.js
@@ -3,7 +3,9 @@ import { click, press, queryAll } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { reactive } from "@odoo/owl";
 import {
+    contains,
     defineModels,
+    fields,
     getService,
     models,
     mountWithCleanup,
@@ -160,6 +162,34 @@ test("view switcher hotkey cycles through views", async () => {
     await press(["alt", "shift", "v"]);
     await animationFrame();
     expect(`.o_list_view`).toHaveCount(1);
+});
+
+test.tags`desktop`("control panel layout buttons in dialog", async () => {
+    onRpc("has_group", () => true);
+    Foo._fields.char = fields.Char();
+    Foo._records = [
+        {
+            char: "a",
+        },
+        {
+            char: "b",
+        },
+    ];
+    Foo._views["list,false"] = `<list editable="top"><field name="char"/></list>`;
+
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction({
+        res_model: "foo",
+        type: "ir.actions.act_window",
+        target: "new",
+        views: [[false, "list"]],
+    });
+    expect(`.o_list_view`).toHaveCount(1);
+    await contains(".o_data_cell").click();
+    expect(".modal-footer .o_list_buttons button").toHaveCount(2);
+    expect(".o_control_panel .o_list_buttons button").toHaveCount(0, {
+        message: "layout buttons are not replicated in the control panel when inside a dialog",
+    });
 });
 
 test.tags("mobile");


### PR DESCRIPTION
This commit fixes a bug where the control panel would display layout buttons in dialog even though they would already be present inside the dialog footer.

task-4381250