### PR TITLE
[FIX] point_of_sale: prevent overlapping of subtotal labels in the POS interface

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -20,7 +20,7 @@
                     <t t-foreach="taxTotals.subtotals" t-as="subtotal" t-key="subtotal.name">
                         <div class="d-flex">
                             <span t-if="showTaxGroupLabels" class="me-2" style="visibility: hidden;">A</span>
-                            <span class="fw-bolder" t-out="subtotal.name"/>
+                            <span class="fw-bolder text-nowrap mw-100" t-out="subtotal.name"/>
                             <span t-esc="props.formatCurrency(subtotal.base_amount_currency)" class="ms-auto"/>
                         </div>
 


### PR DESCRIPTION
In this commit:
===
- Added `text-nowrap` and `mw-100` classes to ensure labels like "Untaxed Amount" do not overlap with other elements.
- This issue is only reproduce in odoo online.

task-4402429

Before this commit:
![IMG_2662](https://github.com/user-attachments/assets/ed80cdeb-0c0d-47b5-bcc2-e25b656602c0)

After this commit:
![IMG_2663](https://github.com/user-attachments/assets/bb93cced-d36c-48d5-ad89-7afced364b15)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
