### PR TITLE
[FIX] web_editor: properly show toolbar when overflow

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3132,7 +3132,10 @@ export class OdooEditor extends EventTarget {
         // Hide toolbar if it overflows the scroll container.
         const distToScrollContainer = Math.min(toolbarTop - scrollContainerRect.top,
                                                 scrollContainerRect.bottom - toolbarBottom);
-        this.toolbar.classList.toggle('d-none', distToScrollContainer < OFFSET / 2);
+        const isToolbarOverflow = distToScrollContainer < OFFSET / 2;
+        if (isToolbarOverflow) {
+            this.toolbar.style.top = `${(Math.max(selRect.top, scrollContainerRect.top) + OFFSET)}px`
+        }
     }
 
     // PASTING / DROPPING


### PR DESCRIPTION
**Problem**:
After this commit:
https://github.com/odoo/odoo/commit/cf8f0ff7ba4bb33425003399bc4e5b33d3d5629a the toolbar is hidden when it overflows (`this.toolbar.classList.toggle('d-none', distToScrollContainer < OFFSET / 2);`). This behavior is not suitable for selections containing elements with a height that exceeds the viewport, as the toolbar becomes inaccessible.

**Solution**:
Ensure the toolbar is always visible, even when overflowing. In such cases, reposition the toolbar to align with the top of the selection, providing consistent accessibility.

**Picture before fix**
***top***
![image](https://github.com/user-attachments/assets/f3f40ab5-b1f2-4492-9711-7d16a23c9b41)
***bottom***
![image](https://github.com/user-attachments/assets/028a9bd2-1b13-421c-b4ee-12bf71273872)

**Picture after fix**
***top***
![image](https://github.com/user-attachments/assets/e52f71a9-937e-4dd1-9f89-73960a71fe8f)
***bottom***
![image](https://github.com/user-attachments/assets/b7fe05ce-0367-4b66-8feb-31ab4cc40ac0)


**Steps to reproduce**:
1. Add an image to the editor that overflows the viewport.
2. Select the image.
3. Observe that the toolbar does not appear.

opw-4398551

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
