### PR TITLE
[FIX] mail: re-add body as invisible

### DIFF
--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -41,6 +41,7 @@
                         <notebook>
                             <page string="Body" name="body">
                                 <field name="body_content"/>
+                                <field name="body_html" attrs="{'invisible': 1}"/>
                             </page>
                             <page string="Advanced" name="advanced" groups="base.group_no_one">
                                 <group>


### PR DESCRIPTION
In d636c1f49ce1e680565663c272cd50e09b8662c6 we replace
body with the body content.

However the original field should not be removed entirely as it
could break any override of the view.

task-4333657