### PR TITLE
[17.0][IMP] hr_holidays_attendance: remove dead code

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave_type.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_type.py
@@ -48,11 +48,6 @@ class HRLeaveType(models.Model):
                     leave_data[1]['overtime_deductible'] = False
         return res
 
-    def _get_days_request(self, date=None):
-        res = super()._get_days_request(date)
-        res[1]['overtime_deductible'] = self.overtime_deductible
-        return res
-
     @api.depends('company_id.hr_attendance_overtime')
     def _compute_hr_attendance_overtime(self):
         # If no company is linked to the time off type, use the current company's setting


### PR DESCRIPTION
during refactoring of `hr_holidays` for 17.0 (commit https://github.com/odoo/odoo/commit/8f87e102a95412aa7dd1b0ce07365d9d3bbdba6a), the `_get_days_request` function has been removed in the `hr_holidays` module, but it is still overridden in `hr_holidays_attendance`
