### PR TITLE
[PERF] stock: reduce number of queries when writing on smls

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -722,7 +722,7 @@ class StockMoveLine(models.Model):
         lots = self.env['stock.lot'].create(lot_vals)
         for key, mls in key_to_mls.items():
             lot = lots[key_to_index[key]].with_prefetch(lots._ids)   # With prefetch to reconstruct the ones broke by accessing by index
-            mls.write({'lot_id': lot.id})
+            mls.with_prefetch(self._prefetch_ids).write({'lot_id': lot.id})
 
     def _reservation_is_updatable(self, quantity, reserved_quant):
         # To remove in master


### PR DESCRIPTION
Currently when we validate a transfer with products tracked by serial number, we may run into a bottleneck when the `quality_mrp` module is installed. That's because there's 1 move_line by Serial Number and inside `_create_assign_production_lot` those move_lines are grouped by `(company_id, product_id, lot_name)`. As we are tracking by Serial Number, each of these group key will be unique. Also, the mls are grouped in key_to_mls using `__union__` which calls `browse` to produce a recordset, effectively setting the `_prefetch_ids` of the results to `_ids`. Therefore, in the sml `write` override in quality_mrp when there's a condition on `self.sudo().check_ids`, the `_prefetch_ids` of self will only be the id in self, leading to 1 SELECT query by SML, i.e. 1 SELECT query by serial number.

This wouldn't be that much of an issue if `quality_check.move_line_id` was properly indexed but that's not the case.

So this commit first adds a missing `btree_not_null` index on `quality_check.move_line_id` to change the query plan from Seq Scan to Index Scan. Then we manually set the `_prefetch_ids` in `_create_and_assign_production_lot` to reduce the number of queries.

#### speedup

In a 17 database with 750 000 quality checks, on hot cache, adding the index makes a single query go from ~50ms to 0.250ms.

When doing a transfer of 1000 serial numbers, setting the `_prefetch_ids` reduce the number of queries from 1000 to 1. This query takes around 120ms on hot cache without the index.

Both with the index and the `_prefetch_ids`, the total time of the `_create_and_assign_production_lot` method when validating a transer of 1000 serial numbers goes from 50ms * 1000 = 50s -> 2ms * 1 = 2ms.

opw-4285293

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
