### PR TITLE
[FIX] core: give fallback value of UTC if there is no tz in employee

### DIFF
--- a/odoo/_monkeypatches/pytz.py
+++ b/odoo/_monkeypatches/pytz.py
@@ -124,8 +124,8 @@ original_pytz_timezone = pytz.timezone
 
 def patch_pytz():
     def timezone(name):
-        if name not in pytz.all_timezones_set and name in _tz_mapping:
+        if name and name not in pytz.all_timezones_set and name in _tz_mapping:
             name = _tz_mapping[name]
-        return original_pytz_timezone(name)
+        return original_pytz_timezone(name or 'UTC')
 
     pytz.timezone = timezone


### PR DESCRIPTION
Currently a traceback occurrs from multiple places when there is no tz for employee and used in the `pytz.timezone` method.

https://github.com/odoo/enterprise/blob/517983ae9deec37795eb11522134a1f5ade31e9b/hr_payroll/wizard/hr_payroll_payslips_by_employees.py#L131

For instance, if there is no tz in resource_calendar_id, it leads to a traceback.

Error: 
```
AttributeError: 'bool' object has no attribute 'upper'
  File "odoo/http.py", line 2364, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1892, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1955, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1922, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2169, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 329, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 727, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 517, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 70, in web_save
    self.write(vals)
  File "home/odoo/src/enterprise/18.0/hr_payroll/models/hr_contract.py", line 429, in write
    res = super().write(vals)
  File "addons/hr_work_entry_contract/models/hr_contract.py", line 453, in write
    contract._recompute_work_entries(date_from, date_to)
  File "home/odoo/src/enterprise/18.0/hr_payroll/models/hr_contract.py", line 441, in _recompute_work_entries
    self._recompute_payslips(date_from, date_to)
  File "home/odoo/src/enterprise/18.0/hr_payroll/models/hr_contract.py", line 453, in _recompute_payslips
    all_payslips.action_refresh_from_work_entries()
  File "home/odoo/src/enterprise/18.0/hr_payroll/models/hr_payslip.py", line 601, in action_refresh_from_work_entries
    payslips._compute_worked_days_line_ids()
  File "home/odoo/src/enterprise/18.0/hr_payroll/models/hr_payslip.py", line 1141, in _compute_worked_days_line_ids
    slip_tz = pytz.timezone(slip.contract_id.resource_calendar_id.tz)
  File "odoo/_monkeypatches/pytz.py", line 129, in timezone
    return original_pytz_timezone(name)
  File "__init__.py", line 183, in timezone
    if zone.upper() == 'UTC':
```

To resolve this issue we can give a default value of `UTC` is there is no name. which makes the code more robust.

sentry-6134147853, 6119911834
