### PR TITLE
[IMP] point_of_sale, pos_restaurant: Different UX improvements

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
@@ -12,8 +12,8 @@
                     t-on-click="() => this.pos.selectPreset()">
                     <span t-esc="currentOrder.preset_id?.name" />
                 </button>
-                <button class="button mobile-more-button btn btn-light btn-lg flex-fill" t-if="props.onClickMore" t-on-click="props.onClickMore">
-                    <span>Actions</span>
+                <button class="button mobile-more-button btn btn-light btn-lg ms-auto" t-if="props.onClickMore" t-on-click="props.onClickMore">
+                    <i class="fa fa-ellipsis-v" aria-hidden="true" />
                 </button>
             </div>
             <div t-if="props.showActionButton" class="validation d-flex gap-2">

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -15,8 +15,8 @@
             t-on-click="() => this.pos.selectPreset()">
             <span t-esc="currentOrder.preset_id?.name" />
         </button>
-        <button class="btn btn-light btn-lg flex-shrink-0 ms-auto" t-if="!props.showRemainingButtons and !ui.isSmall and props.onClickMore" t-on-click="props.onClickMore">
-            Actions
+        <button class="btn btn-light btn-lg flex-shrink-0 ms-auto more-btn" t-if="!props.showRemainingButtons and !ui.isSmall and props.onClickMore" t-on-click="props.onClickMore">
+            <i class="fa fa-ellipsis-v" aria-hidden="true" />
         </button>
         <!-- All these buttons will only be displayed in a dialog -->
         <t t-if="props.showRemainingButtons">

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/search_bar/search_bar.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/search_bar/search_bar.xml
@@ -3,7 +3,7 @@
 
     <t t-name="point_of_sale.SearchBar">
         <div class="pos-search-bar d-flex align-items-center flex-grow-1 rounded">
-            <div class="search position-relative h-100 d-flex flex-grow-1">
+            <div class="search position-relative h-100 d-flex">
                 <div class="input-group">
                     <input class="form-control bg-view border-light ps-2 ps-5" t-ref="autofocus"
                     t-model="state.searchInput" t-on-keydown="onSearchInputKeydown" t-on-keyup="onSearchInputKeyup" type="text" t-att-placeholder="props.placeholder" />

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.scss
@@ -18,6 +18,9 @@
     }
 }
 
+.input-page-number {
+    width: 50px;
+}
 .order-row:hover {
     color: white;
     background-color:  $primary !important;

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -21,7 +21,17 @@
                             </button>
                         </div>
                         <div class="item d-flex align-items-center justify-content-end">
-                            <span class="page me-2"><t t-esc="getPageNumber()" /></span>
+                            <div class="align-items-center d-flex me-1">
+                                <div>
+                                    <span t-if="!this.state.nbrByPageEdit" t-on-click="() => this.state.nbrByPageEdit = true" t-esc="currentPage" />
+                                    <input t-else=""
+                                        class="border-0 text-end input-page-number"
+                                        t-on-focusout="() => this.state.nbrByPageEdit = false"
+                                        t-on-change="handleInputChange"
+                                        t-att-placeholder="this.state.nbrByPage" />
+                                </div>
+                                / <span t-esc="this.pos.ticketScreenState.totalCount" />
+                            </div>
                             <div class="page-controls d-flex align-items-center gap-1">
                                 <button class="previous btn btn-light" t-on-click="() => this.onPrevPage()">
                                     <i class="fa fa-fw fa-caret-left" role="img" aria-label="Previous Order List" title="Previous Order List"></i>

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -25,7 +25,7 @@ import {
 import { PartnerList } from "../screens/partner_list/partner_list";
 import { ScaleScreen } from "../screens/scale_screen/scale_screen";
 import { computeComboItems } from "../models/utils/compute_combo_items";
-import { changesToOrder, getOrderChanges } from "../models/utils/order_change";
+import { getOrderChanges } from "../models/utils/order_change";
 import { getTaxesAfterFiscalPosition, getTaxesValues } from "../models/utils/tax_utils";
 import { QRPopup } from "@point_of_sale/app/components/popups/qr_code_popup/qr_code_popup";
 import { ActionScreen } from "@point_of_sale/app/screens/action_screen";
@@ -1492,25 +1492,17 @@ export class PosStore extends WithLazyGetterTrap {
     async sendOrderInPreparation(order, cancelled = false) {
         if (this.printers_category_ids_set.size) {
             try {
-                const changes = changesToOrder(
-                    order,
+                const isPrintSuccessful = await order.printChanges(
                     false,
                     this.orderPreparationCategories,
-                    cancelled
+                    cancelled,
+                    this.unwatched.printers
                 );
-                if (changes.cancelled.length > 0 || changes.new.length > 0) {
-                    const isPrintSuccessful = await order.printChanges(
-                        false,
-                        this.orderPreparationCategories,
-                        cancelled,
-                        this.unwatched.printers
-                    );
-                    if (!isPrintSuccessful) {
-                        this.dialog.add(AlertDialog, {
-                            title: _t("Printing failed"),
-                            body: _t("Failed in printing the changes in the order"),
-                        });
-                    }
+                if (!isPrintSuccessful) {
+                    this.dialog.add(AlertDialog, {
+                        title: _t("Printing failed"),
+                        body: _t("Failed in printing the changes in the order"),
+                    });
                 }
             } catch (e) {
                 console.info("Failed in printing the changes in the order", e);

--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -36,7 +36,8 @@
             </t>
             <t t-if="changes.new.length > 0">
                 <div class="pos-receipt-title">
-                    NEW
+                    <t t-if="!reprint">NEW</t>
+                    <t t-else="">REPRINT</t>
                     <t t-esc='changes.time.hours'/>:<t t-esc='changes.time.minutes'/>
                 </div>
                 <br />

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -219,7 +219,7 @@ export function clickControlButtonMore() {
         {
             isActive: ["desktop"],
             content: "click Actions button",
-            trigger: controlButtonTrigger("Actions"),
+            trigger: ".more-btn",
             run: "click",
         },
     ];

--- a/addons/pos_restaurant/static/src/app/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/app/components/navbar/navbar.xml
@@ -15,7 +15,7 @@
             <attribute name="t-if">!pos.config.module_pos_restaurant</attribute>
         </xpath>
         <xpath expr="//div[hasclass('pos-leftheader')]/OrderTabs" position="after">
-            <span t-if="pos.config.module_pos_restaurant and pos.getOrder()" t-esc="pos.getOrder().getName()" class="ps-1 text-wrap fw-bolder fst-italic"/>
+            <span t-if="pos.config.module_pos_restaurant and pos.getOrder()" t-esc="pos.getOrder().getName()" class="ps-1 me-2 text-wrap fw-bolder fst-italic"/>
         </xpath>
         <xpath expr="//button[hasclass('register-label')]" position="before">
             <button t-if="pos.config.module_pos_restaurant" class="table-button btn btn-lg lh-lg" t-att-class="{'fw-bolder text-primary': mainButton === 'table' and !this.ui.isSmall, 'btn-primary text-white': mainButton === 'table' and this.ui.isSmall, 'text-muted': this.pos.getOrder()?.isFilledDirectSale}" t-on-click="() => this.onClickPlanButton()">

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
@@ -34,9 +34,16 @@
                     </div>
                 </button>
                 <button
+                    class="h-100 button btn btn-light btn-lg d-flex flex-row align-items-center justify-content-center"
+                    t-on-click="() => this.submitOrder()"
+                    t-elif="this.pos.unwatched.printers.length"
+                >
+                    <i class="fa fa-print" aria-hidden="true"></i>
+                </button>
+                <button
                     class="h-100 button btn btn-light btn-lg d-flex flex-row align-items-center justify-content-center w-50"
                     t-on-click="() => this.pos.showDefault()"
-                    t-elif="!this.currentOrder.isDirectSale and !this.displayCategoryCount.length and !this.currentOrder.isEmpty()"
+                    t-if="!this.currentOrder.isDirectSale and !this.displayCategoryCount.length and !this.currentOrder.isEmpty()"
                 >
                     <span>New</span>
                 </button>


### PR DESCRIPTION
Point of sale:
- Adding margin left on preset time on product screen.
- Replacing ActionPad button "action" by 3 vertical dots
- Allow to reprint the last prepration ticket
- Adding number of orders by pages on ticket screen.
- Removing seconds on the time of the order.
- Resizing search bar on ticket screen.

Preparation display:
- Adding zoom parameter on the navbar
- Removing waiter name.
- Adding order floating name.
- Adding preset name and time on orders.

taskId: 4398826
