### PR TITLE
[FIX] product,*: Change product.product order

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -627,7 +627,7 @@
             <field name="model">product.product</field>
             <field eval="50" name="priority"/>
             <field name="arch" type="xml">
-                <list string="Product Variants">
+                <list string="Product Variants" default_order="is_favorite desc, default_code, name, id">
                     <field name="default_code"/>
                     <field name="name"/>
                     <field name="product_template_attribute_value_ids" widget="many2many_tags"
@@ -643,7 +643,7 @@
             <field name="name">product.product.expense.categories.list.view</field>
             <field name="model">product.product</field>
             <field name="arch" type="xml">
-                <list class="o_expense_categories">
+                <list class="o_expense_categories" default_order="is_favorite desc, default_code, name, id">
                     <field name="name" readonly="1"/>
                     <field name="currency_id" column_invisible="True"/>
                     <field name="default_code" optional="show" string="Reference" readonly="1"/>

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -17,7 +17,7 @@ class ProductProduct(models.Model):
     _description = "Product Variant"
     _inherits = {'product.template': 'product_tmpl_id'}
     _inherit = ['mail.thread', 'mail.activity.mixin']
-    _order = 'is_favorite desc, default_code, name, id'
+    _order = 'default_code, name, id'
     _check_company_domain = models.check_company_domain_parent_of
 
     # price_extra: catalog extra value only, sum of variant extra attributes
@@ -107,6 +107,9 @@ class ProductProduct(models.Model):
     # Ensure there is at most one active variant for each combination.
     # There could be no variant for a combination if using dynamic attributes.
     _combination_unique = models.UniqueIndex("(product_tmpl_id, combination_indices) WHERE active IS TRUE")
+
+    is_favorite = fields.Boolean(related='product_tmpl_id.is_favorite', readonly=True, store=True)
+    _is_favorite_index = models.Index("(is_favorite) WHERE is_favorite IS TRUE")
 
     @api.depends('image_variant_1920', 'image_variant_1024')
     def _compute_can_image_variant_1024_be_zoomed(self):

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -170,6 +170,7 @@ class ProductTemplate(models.Model):
     product_tooltip = fields.Char(compute='_compute_product_tooltip')
 
     is_favorite = fields.Boolean(string="Favorite")
+    _is_favorite_index = models.Index("(is_favorite) WHERE is_favorite IS TRUE")
 
     product_tag_ids = fields.Many2many(
         string="Tags", comodel_name='product.tag', relation='product_tag_product_template_rel'

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -426,7 +426,7 @@
             <field name="model">product.product</field>
             <field eval="7" name="priority"/>
             <field name="arch" type="xml">
-                <list string="Product Variants" multi_edit="1" duplicate="false" sample="1">
+                <list string="Product Variants" multi_edit="1" duplicate="false" sample="1" default_order="is_favorite desc, default_code, name, id">
                 <header>
                     <button string="Print Labels" type="object" name="action_open_label_layout"/>
                 </header>
@@ -465,7 +465,7 @@
             <field name="name">product.product.view.list.tag</field>
             <field name="model">product.product</field>
             <field name="arch" type="xml">
-                <list string="Product Variants" editable="bottom">
+                <list string="Product Variants" editable="bottom" default_order="is_favorite desc, default_code, name, id">
                     <field name="name" readonly="1"/>
                     <field name="default_code" readonly="1" optional="show"/>
                     <field name="product_template_variant_value_ids"
@@ -554,7 +554,7 @@
             <field name="name">Product Kanban</field>
             <field name="model">product.product</field>
             <field name="arch" type="xml">
-                <kanban sample="1">
+                <kanban sample="1" default_order="is_favorite desc, default_code, name, id">
                     <field name="activity_state"/>
                     <field name="color"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
@@ -643,7 +643,7 @@ action = {
         <field name="name">product.view.kanban.catalog</field>
         <field name="model">product.product</field>
         <field name="arch" type="xml">
-            <kanban records_draggable="0" js_class="product_kanban_catalog">
+            <kanban records_draggable="0" js_class="product_kanban_catalog" default_order="is_favorite desc, default_code, name, id">
                 <field name="id"/>
                 <templates>
                     <t t-name="menu">

--- a/addons/product_margin/views/product_product_views.xml
+++ b/addons/product_margin/views/product_product_views.xml
@@ -63,7 +63,7 @@
             <field name="model">product.product</field>
             <field name="priority" eval="50"/>
             <field name="arch" type="xml">
-                <list string="Product Margins">
+                <list string="Product Margins" default_order="is_favorite desc, default_code, name, id">
                     <field name="name"/>
                     <field name="default_code"/>
                     <field name="sale_avg_price"/>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -537,7 +537,7 @@
             <field name="model">product.product</field>
             <field name="priority" eval="100"/>
             <field name="arch" type="xml">
-                <list sample="1" js_class="stock_report_list_view" duplicate="0">
+                <list sample="1" js_class="stock_report_list_view" duplicate="0" default_order="is_favorite desc, default_code, name, id">
                     <header>
                         <button name="%(action_inventory_at_date)d" invisible="((context.get('inventory_mode') and not context.get('inventory_report_mode')) or context.get('no_at_date'))" string="Inventory at Date" type="action" class="btn-primary ms-1" display="always"/>
                     </header>


### PR DESCRIPTION
For performance reasons:
- the is_favorite field is moved from the model's _order to the related tree & kanban views
- on product.product it is now a stored related to product.template

From nim-odoo survey on a database containing more than 1 million products
- stored related field & index: improvement in all cases (2500ms => 500 ms)
- limit order & adapt views: name search will be fast (~2 ms)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
