### PR TITLE
[FIX] html_editor: outdent list item with empty nodes

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -6,7 +6,6 @@ import {
     isEmptyBlock,
     isProtected,
     isProtecting,
-    isVisible,
     paragraphRelatedElements,
 } from "@html_editor/utils/dom_info";
 import {
@@ -15,6 +14,7 @@ import {
     getAdjacents,
     selectElements,
     ancestors,
+    childNodes,
 } from "@html_editor/utils/dom_traversal";
 import { childNodeIndex } from "@html_editor/utils/position";
 import { leftLeafOnlyNotBlockPath } from "@html_editor/utils/dom_state";
@@ -525,38 +525,37 @@ export class ListPlugin extends Plugin {
         cursors.restore();
     }
 
+    /**
+     * @param {HTMLLIElement} li
+     */
     outdentTopLevelLI(li) {
         const cursors = this.dependencies.selection.preserveSelection();
         const ul = li.parentNode;
         const dir = ul.getAttribute("dir");
-        let p;
-        let toMove = li.lastChild;
-        while (toMove) {
-            if (isBlock(toMove)) {
-                if (p && isVisible(p)) {
-                    cursors.update(callbacksForCursorUpdate.after(ul, p));
-                    ul.after(p);
-                }
-                p = undefined;
-                cursors.update(callbacksForCursorUpdate.after(ul, toMove));
-                ul.after(toMove);
-            } else {
-                p = p || this.document.createElement("P");
-                if (dir) {
-                    p.setAttribute("dir", dir);
-                    p.style.setProperty("text-align", ul.style.getPropertyValue("text-align"));
-                }
-                cursors.update(callbacksForCursorUpdate.prepend(p, toMove));
-                p.prepend(toMove);
+        const textAlign = ul.style.getPropertyValue("text-align");
+        wrapInlinesInBlocks(li, cursors);
+        if (!li.hasChildNodes()) {
+            // Outdenting an empty LI produces an empty P
+            const p = this.document.createElement("p");
+            p.append(this.document.createElement("br"));
+            li.append(p);
+            cursors.remapNode(li, p);
+        }
+        // Move LI's children to after UL
+        for (const block of childNodes(li).reverse()) {
+            if (dir && !block.getAttribute("dir")) {
+                block.setAttribute("dir", dir);
             }
-            toMove = li.lastChild;
+            if (textAlign && !block.style.getPropertyValue("text-align")) {
+                block.style.setProperty("text-align", textAlign);
+            }
+            cursors.update(callbacksForCursorUpdate.after(ul, block));
+            ul.after(block);
         }
-        if (p && isVisible(p)) {
-            cursors.update(callbacksForCursorUpdate.after(ul, p));
-            ul.after(p);
-        }
+        // Remove LI
         cursors.update(callbacksForCursorUpdate.remove(li));
         li.remove();
+        // Remove UL if left empty
         if (!ul.firstElementChild) {
             cursors.update(callbacksForCursorUpdate.remove(ul));
             ul.remove();

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -74,12 +74,15 @@ export function wrapInlinesInBlocks(element, cursors = { update: () => {} }) {
         node.remove();
     };
 
+    const children = childNodes(element);
+    const visibleNodes = new Set(children.filter(isVisible));
+
     let currentBlock;
     let shouldBreakLine = true;
-    for (const node of [...element.childNodes]) {
+    for (const node of children) {
         if (isBlock(node)) {
             shouldBreakLine = true;
-        } else if (!isVisible(node)) {
+        } else if (!visibleNodes.has(node)) {
             removeNode(node, cursors);
         } else if (node.nodeName === "BR") {
             if (shouldBreakLine) {

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -276,6 +276,12 @@ describe("wrapInlinesInBlocks", () => {
             `)
         );
     });
+    test("should wrap inlines in P, preserving space", async () => {
+        const div = document.createElement("div");
+        div.innerHTML = "<span>abc</span> <span>def</span>";
+        wrapInlinesInBlocks(div);
+        expect(div.innerHTML).toBe("<p><span>abc</span> <span>def</span></p>");
+    });
 });
 
 describe("fillEmpty", () => {


### PR DESCRIPTION
[FIX] html_editor: space removal by  wrapInlinesInBlocks <- fix required for the following one
[FIX] html_editor: outdent list item with empty nodes

task-4398327
