### PR TITLE
[IMP] mail: backport messaging menu style improvements

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -229,18 +229,6 @@ msgstr ""
 
 #. module: mail
 #. odoo-javascript
-#: code:addons/mail/static/src/core/web/messaging_menu_patch.js:0
-msgid "%s has a request"
-msgstr ""
-
-#. module: mail
-#. odoo-javascript
-#: code:addons/mail/static/src/core/web/messaging_menu_patch.js:0
-msgid "%s has a suggestion"
-msgstr ""
-
-#. module: mail
-#. odoo-javascript
 #: code:addons/mail/static/src/discuss/typing/common/typing.js:0
 msgid "%s is typing..."
 msgstr ""
@@ -598,6 +586,13 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/mail/static/src/discuss/call/common/call_invitation.xml:0
 msgid "Accept"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/discuss/call/common/call_action_list.xml:0
+#: code:addons/mail/static/src/discuss/call/common/call_invitation.xml:0
+msgid "Accept with camera"
 msgstr ""
 
 #. module: mail
@@ -1151,6 +1146,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/mail/static/src/core/common/failure_model.js:0
 msgid "An error occurred when sending an email"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/core/common/failure_model.js:0
+msgid "An error occurred when sending an email on “%(record_name)s”"
 msgstr ""
 
 #. module: mail
@@ -2144,7 +2145,7 @@ msgstr ""
 #. module: mail
 #. odoo-javascript
 #: code:addons/mail/static/src/core/web/messaging_menu_patch.js:0
-msgid "Come here often? Install Odoo on your device!"
+msgid "Come here often? Install the app for quick and easy access!"
 msgstr ""
 
 #. module: mail
@@ -3171,6 +3172,12 @@ msgid "Download:"
 msgstr ""
 
 #. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/core/common/mail_attachment_dropzone.xml:0
+msgid "Drop Files here"
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_activity__date_deadline
 #: model:ir.model.fields,field_description:mail.field_mail_activity_schedule__date_deadline
 msgid "Due Date"
@@ -3352,6 +3359,12 @@ msgid "Email Domain"
 msgstr ""
 
 #. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/core/web/messaging_menu_patch.js:0
+msgid "Email Failure: %(modelName)s"
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,field_description:mail.field_res_company__email_primary_color
 #: model:ir.model.fields,field_description:mail.field_res_config_settings__email_primary_color
 msgid "Email Header Color"
@@ -3510,14 +3523,14 @@ msgid "Employee Only"
 msgstr ""
 
 #. module: mail
-#: model:ir.model.fields,field_description:mail.field_ir_model_fields__tracking
-msgid "Enable Ordered Tracking"
+#. odoo-javascript
+#: code:addons/mail/static/src/core/web/messaging_menu_patch.xml:0
+msgid "Enable"
 msgstr ""
 
 #. module: mail
-#. odoo-javascript
-#: code:addons/mail/static/src/core/web/messaging_menu_patch.js:0
-msgid "Enable desktop notifications to chat"
+#: model:ir.model.fields,field_description:mail.field_ir_model_fields__tracking
+msgid "Enable Ordered Tracking"
 msgstr ""
 
 #. module: mail
@@ -3675,12 +3688,6 @@ msgstr ""
 #. module: mail
 #. odoo-python
 #: code:addons/mail/models/mail_render_mixin.py:0
-msgid "Failed to render inline_template template: %(template_txt)s)"
-msgstr ""
-
-#. module: mail
-#. odoo-python
-#: code:addons/mail/models/mail_render_mixin.py:0
 msgid "Failed to render inline_template template: %(template_txt)s"
 msgstr ""
 
@@ -3714,6 +3721,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_mail__failure_type
 #: model:ir.model.fields,field_description:mail.field_mail_notification__failure_type
 msgid "Failure type"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/core/web/messaging_menu_patch.js:0
+msgid "Failure: %(modelName)s"
 msgstr ""
 
 #. module: mail
@@ -4633,6 +4646,12 @@ msgid "Incoming Mail Servers"
 msgstr ""
 
 #. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/discuss/call/common/call_invitation.xml:0
+msgid "Incoming Video Call..."
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,help:mail.field_mail_activity__automated
 msgid ""
 "Indicates this activity has been created automatically and not by any user."
@@ -4677,6 +4696,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/mail/static/src/core/web/messaging_menu_patch.xml:0
 msgid "Install"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/core/web/messaging_menu_patch.js:0
+msgid "Install Odoo"
 msgstr ""
 
 #. module: mail
@@ -7325,6 +7350,12 @@ msgid "Preview"
 msgstr ""
 
 #. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/discuss/call/common/call_invitation.xml:0
+msgid "Preview my camera"
+msgstr ""
+
+#. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_template_preview_view_form
 msgid "Preview of"
 msgstr ""
@@ -8654,6 +8685,12 @@ msgstr ""
 
 #. module: mail
 #. odoo-javascript
+#: code:addons/mail/static/src/discuss/call/common/thread_actions.js:0
+msgid "Start a Video Call"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
 #: code:addons/mail/static/src/core/public_web/discuss_app_model.js:0
 #: code:addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml:0
 msgid "Start a conversation"
@@ -8702,6 +8739,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/mail/static/src/views/fields/statusbar_duration/statusbar_duration_field.js:0
 msgid "Status with time"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/core/web/messaging_menu_patch.js:0
+msgid "Stay tuned! Enable push notifications to never miss a message."
 msgstr ""
 
 #. module: mail
@@ -9618,6 +9661,12 @@ msgid "Turn camera on"
 msgstr ""
 
 #. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/core/web/messaging_menu_patch.js:0
+msgid "Turn on notifications"
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,field_description:mail.field_res_config_settings__twilio_account_token
 msgid "Twilio Account Auth Token"
 msgstr ""
@@ -9920,12 +9969,6 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/mail/static/src/core/common/attachment_list.xml:0
 msgid "Uploading"
-msgstr ""
-
-#. module: mail
-#. odoo-javascript
-#: code:addons/mail/static/src/core/web/mail_composer_attachment_selector.js:0
-msgid "Uploading error"
 msgstr ""
 
 #. module: mail

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1127,7 +1127,7 @@ class Message(models.Model):
                     Store.one(
                         self.env[message.model].browse(message.res_id) if message.model else False,
                         as_thread=True,
-                        fields=["modelName"],
+                        fields=["modelName", "name"],
                     )
                 ),
             }

--- a/addons/mail/static/src/core/common/failure_model.js
+++ b/addons/mail/static/src/core/common/failure_model.js
@@ -63,6 +63,11 @@ export class Failure extends Record {
     }
 
     get body() {
+        if (this.notifications.length === 1 && this.lastMessage?.thread) {
+            return _t("An error occurred when sending an email on “%(record_name)s”", {
+                record_name: this.lastMessage.thread.name,
+            });
+        }
         return _t("An error occurred when sending an email");
     }
 

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -21,6 +21,8 @@
                     onClick="(isMarkAsRead) => this.onClickThread(isMarkAsRead, thread)"
                     onSwipeRight="hasTouch() and thread.isUnread ? { action: () => this.markAsRead(thread), icon: 'fa-check-circle', bgColor: 'bg-success' } : undefined"
                     onSwipeLeft="hasTouch() and thread.canUnpin ? { action: () => thread.unpin(), icon: 'fa-times-circle', bgColor: 'bg-danger' } : undefined"
+                    nameMaxLine="1"
+                    textMaxLine="2"
                 >
                     <t t-set-slot="name">
                         <div t-if="thread.parent_channel_id" class="d-flex align-items-center">

--- a/addons/mail/static/src/core/public_web/notification_item.js
+++ b/addons/mail/static/src/core/public_web/notification_item.js
@@ -44,6 +44,9 @@ export class NotificationItem extends Component {
         if (isToday(this.props.datetime)) {
             return this.props.datetime?.toLocaleString(DateTime.TIME_SIMPLE);
         }
+        if (this.props.datetime?.year === DateTime.now().year) {
+            return this.props.datetime?.toLocaleString({ month: "short", day: "numeric" });
+        }
         return this.props.datetime?.toLocaleString(DateTime.DATE_MED);
     }
 

--- a/addons/mail/static/src/core/public_web/notification_item.js
+++ b/addons/mail/static/src/core/public_web/notification_item.js
@@ -24,6 +24,8 @@ export class NotificationItem extends Component {
         "onSwipeRight?",
         "slots?",
         "isActive?",
+        "nameMaxLine?",
+        "textMaxLine?",
     ];
     static defaultProps = {
         counter: 0,
@@ -52,5 +54,14 @@ export class NotificationItem extends Component {
 
     onClick(ev) {
         this.props.onClick(ev.target === this.markAsReadRef.el);
+    }
+
+    webkitLineClamp(maxLine) {
+        return `
+            display: -webkit-box;
+            overflow: hidden;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: ${maxLine};
+        `;
     }
 }

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -61,4 +61,8 @@
     color: darken($info, 5%);
     font-size: 0.5rem;
     left: map-get($spacers, 1);
+
+    .o-mail-NotificationItem.o-small & {
+        left: map-get($spacers, 1) / 2;
+    }
 }

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -20,6 +20,8 @@
 }
 
 .o-mail-NotificationItem-avatarContainer {
+    height: 40px;
+    aspect-ratio: 1;
     margin-top: map-get($spacers, 1) / 2;
     margin-bottom: map-get($spacers, 1) / 2;
 
@@ -61,6 +63,8 @@
     color: darken($info, 5%);
     font-size: 0.5rem;
     left: map-get($spacers, 1);
+    top: 40px;
+    transform: translateY(-125%);
 
     .o-mail-NotificationItem.o-small & {
         left: map-get($spacers, 1) / 2;

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -7,9 +7,9 @@
             'o-important': props.muted === 0,
             'text-muted border-transparent': props.muted === 1,
             'opacity-50 border-transparent': props.muted === 2,
-            'py-2 o-small': ui.isSmall,
+            'p-2 o-small': ui.isSmall,
             'border-top-0': props.first,
-            'px-3 py-2': !ui.isSmall,
+            'ps-3 pe-2 py-2': !ui.isSmall,
             'o-active': props.isActive,
         }">
             <span class="o-mail-NotificationItem-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': props.muted, 'opacity-50': !props.muted }"><i class="fa fa-circle"/></span>
@@ -23,9 +23,10 @@
                         <t t-slot="name"/>
                     </span>
                     <span class="flex-grow-1"/>
-                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2 opacity-75" t-att-class="{ 'fw-bolder': !props.muted, 'text-muted': props.muted }" t-att-title="props.datetime?.toLocaleString(DateTime.DATETIME_SHORT) ?? ''">
-                        <t t-esc="dateText"/>
-                    </small>
+                    <div class="d-flex align-items-center">
+                        <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted === 2 ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter"><t t-esc="props.counter"/></span>
+                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer" title="Mark As Read" t-ref="markAsRead"/>
+                    </div>
                 </div>
                 <div class="d-flex">
                     <div class="o-mail-NotificationItem-text text-truncate opacity-75" t-att-class="{ 'fw-bold': !props.muted }">
@@ -33,10 +34,9 @@
                         <t t-if="props.body" t-esc="props.body" name="notificationBody"/>
                     </div>
                     <div class="flex-grow-1"/>
-                    <div class="d-flex align-items-center">
-                        <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted === 2 ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter"><t t-esc="props.counter"/></span>
-                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer" title="Mark As Read" t-ref="markAsRead"/>
-                    </div>
+                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2 me-1 opacity-75 flex-shrink-0 align-self-end" t-att-class="{ 'fw-bold': !props.muted }" t-att-title="props.datetime?.toLocaleString(DateTime.DATETIME_SHORT) ?? ''">
+                        <t t-esc="dateText"/>
+                    </small>
                 </div>
             </div>
             <t t-if="props.slots and props.slots.requestContent">

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -13,13 +13,13 @@
             'o-active': props.isActive,
         }">
             <span class="o-mail-NotificationItem-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': props.muted, 'opacity-50': !props.muted }"><i class="fa fa-circle"/></span>
-            <div class="o-mail-NotificationItem-avatarContainer position-relative bg-inherit flex-shrink-0" t-att-class="{ 'o-small': ui.isSmall }" style="width:40px;height:40px;">
+            <div class="o-mail-NotificationItem-avatarContainer position-relative bg-inherit flex-shrink-0 align-self-start" t-att-class="{ 'o-small': ui.isSmall }">
                 <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>
             </div>
             <div class="d-flex flex-column flex-grow-1 align-self-start overflow-auto">
                 <div class="d-flex text-nowrap">
-                    <span class="o-mail-NotificationItem-name text-truncate fw-bold" t-att-class="{ 'fw-bold': props.muted, 'fw-bolder': !props.muted }">
+                    <span class="o-mail-NotificationItem-name fw-bold" t-att-class="{ 'fw-bold': props.muted, 'fw-bolder': !props.muted }" t-att-style="props.nameMaxLine !== undefined ? webkitLineClamp(props.nameMaxLine) : ''">
                         <t t-slot="name"/>
                     </span>
                     <span class="flex-grow-1"/>
@@ -29,7 +29,7 @@
                     </div>
                 </div>
                 <div class="d-flex">
-                    <div class="o-mail-NotificationItem-text text-truncate opacity-75" t-att-class="{ 'fw-bold': !props.muted }">
+                    <div class="o-mail-NotificationItem-text opacity-75" t-att-class="{ 'fw-bold': !props.muted, 'text-truncate': props.textTruncate, 'text-start': !props.textTruncate  }" t-att-style="props.textMaxLine !== undefined ? webkitLineClamp(props.textMaxLine) : ''">
                         <t t-slot="body-icon"/>
                         <t t-if="props.body" t-esc="props.body" name="notificationBody"/>
                     </div>

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -77,8 +77,8 @@ patch(MessagingMenu.prototype, {
     },
     get installationRequest() {
         return {
-            body: _t("Come here often? Install Odoo on your device!"),
-            displayName: _t("%s has a suggestion", this.store.odoobot.name),
+            body: _t("Come here often? Install the app for quick and easy access!"),
+            displayName: _t("Install Odoo"),
             onClick: () => {
                 this.pwa.show();
             },
@@ -89,8 +89,8 @@ patch(MessagingMenu.prototype, {
     },
     get notificationRequest() {
         return {
-            body: _t("Enable desktop notifications to chat"),
-            displayName: _t("%s has a request", this.store.odoobot.name),
+            body: _t("Stay tuned! Enable push notifications to never miss a message."),
+            displayName: _t("Turn on notifications"),
             iconSrc: this.store.odoobot.avatarUrl,
             partner: this.store.odoobot,
             isShown: this.store.discuss.activeTab === "main" && this.shouldAskPushPermission,
@@ -178,5 +178,11 @@ patch(MessagingMenu.prototype, {
     },
     get shouldAskPushPermission() {
         return this.notification.permission === "prompt";
+    },
+    getFailureNotificationName(failure) {
+        if (failure.type === "email") {
+            return _t("Email Failure: %(modelName)s", { modelName: failure.modelName });
+        }
+        return _t("Failure: %(modelName)s", { modelName: failure.modelName });
     },
 });

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -72,6 +72,12 @@
                     <t t-set-slot="icon">
                         <ImStatus persona="notificationRequest.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
                     </t>
+                    <t t-set-slot="requestContent">
+                        <a t-if="ui.isSmall" class="btn fa fa-bell" />
+                        <t t-else="">
+                            <a class="btn btn-primary px-2 py-1 smaller">Enable</a>
+                        </t>
+                    </t>
                 </NotificationItem>
                 <t t-set="itemIndex" t-value="itemIndex + 1"/>
             </t>
@@ -87,7 +93,7 @@
                         onClick="(isMarkAsRead) => isMarkAsRead ? this.cancelNotifications(failure) : this.onClickFailure(failure)"
                         onSwipeRight="hasTouch() ? { action: () => this.cancelNotifications(failure), icon: 'fa-times-circle', bgColor: 'bg-warning' } : undefined"
                     >
-                        <t t-set-slot="name"><t t-esc="failure.modelName"/></t>
+                        <t t-set-slot="name"><t t-esc="getFailureNotificationName(failure)"/></t>
                     </NotificationItem>
                     <t t-set="itemIndex" t-value="itemIndex + 1"/>
                 </t>

--- a/addons/mail/static/src/discuss/call/common/call_action_list.xml
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.xml
@@ -33,7 +33,7 @@
                 </button>
                 <button t-if="props.thread.rtcInvitingSession?.isCameraOn" class="btn smaller btn-success d-flex m-1 border-0 rounded-circle shadow-none align-items-center"
                     t-att-class="{ 'p-0': isSmall, 'p-1': !isSmall }"
-                    aria-label="Acceot with camera"
+                    aria-label="Accept with camera"
                     title="Accept with camera"
                     t-att-disabled="rtc.state.hasPendingRequest"
                     t-on-click="(ev) => this.onClickToggleAudioCall(ev, { camera: true })">

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -81,7 +81,7 @@ test("counter is taking into account failure notification", async () => {
     await contains(".o-mail-MessagingMenu-counter", { text: "1" });
 });
 
-test("rendering with OdooBot has a request (default)", async () => {
+test("rendering with chat push notification default permissions", async () => {
     patchBrowserNotification("default");
     const pyEnv = await startServer();
     const [odoobot] = pyEnv["res.partner"].read(serverState.odoobotId);
@@ -95,10 +95,10 @@ test("rendering with OdooBot has a request (default)", async () => {
             serverState.odoobotId
         }/avatar_128?unique=${deserializeDateTime(odoobot.write_date).ts}']`
     );
-    await contains(".o-mail-NotificationItem", { text: "OdooBot has a request" });
+    await contains(".o-mail-NotificationItem", { text: "Turn on notifications" });
 });
 
-test("rendering without OdooBot has a request (denied)", async () => {
+test("rendering with chat push notification permissions denied", async () => {
     patchBrowserNotification("denied");
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
@@ -106,7 +106,7 @@ test("rendering without OdooBot has a request (denied)", async () => {
     await contains(".o-mail-NotificationItem", { count: 0 });
 });
 
-test("rendering without OdooBot has a request (accepted)", async () => {
+test("rendering with chat push notification permissions accepted", async () => {
     patchBrowserNotification("granted");
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
@@ -138,7 +138,7 @@ test("respond to notification prompt (granted)", async () => {
     });
 });
 
-test("no 'OdooBot has a request' in mobile app", async () => {
+test("no suggestion to enable chat push notifications in mobile app", async () => {
     patchBrowserNotification("default");
     // simulate Android Odoo App
     mockUserAgent("Chrome/0.0.0 Android (OdooMobile; Linux; Android 13; Odoo TestSuite)");
@@ -183,9 +183,9 @@ test("rendering with PWA installation request", async () => {
             serverState.odoobotId
         }/avatar_128?unique=${deserializeDateTime(odoobot.write_date).ts}']`
     );
-    await contains(".o-mail-NotificationItem-name", { text: "OdooBot has a suggestion" });
+    await contains(".o-mail-NotificationItem-name", { text: "Install Odoo" });
     await contains(".o-mail-NotificationItem-text", {
-        text: "Come here often? Install Odoo on your device!",
+        text: "Come here often? Install the app for quick and easy access!",
     });
     await click(".o-mail-NotificationItem a.btn-primary");
     await assertSteps(["show prompt"]);
@@ -330,7 +330,7 @@ test("grouped notifications by document", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-ChatWindow", { count: 0 });
     await click(".o-mail-NotificationItem", {
-        text: "Contact",
+        text: "Email Failure: Contact",
         contains: [".badge", { text: "2" }],
     });
     await contains(".o-mail-ChatWindow");
@@ -386,7 +386,7 @@ test("grouped notifications by document model", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem", {
-        text: "Contact",
+        text: "Email Failure: Contact",
         contains: [".badge", { text: "2" }],
     });
     await assertSteps(["do_action"]);
@@ -433,8 +433,10 @@ test("multiple grouped notifications by document model, sorted by the most recen
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem", { count: 2 });
-    await contains(":nth-child(1 of .o-mail-NotificationItem)", { text: "Companies" });
-    await contains(":nth-child(2 of .o-mail-NotificationItem)", { text: "Contact" });
+    await contains(":nth-child(1 of .o-mail-NotificationItem)", {
+        text: "Email Failure: Companies",
+    });
+    await contains(":nth-child(2 of .o-mail-NotificationItem)", { text: "Email Failure: Contact" });
 });
 
 test("non-failure notifications are ignored", async () => {
@@ -490,6 +492,7 @@ test("mark failure as read", async () => {
     const pyEnv = await startServer();
     const messageId = pyEnv["mail.message"].create({ message_type: "email" });
     pyEnv["discuss.channel"].create({
+        name: "General",
         message_ids: [messageId],
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, seen_message_id: messageId }),
@@ -504,17 +507,23 @@ test("mark failure as read", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await triggerEvents(".o-mail-NotificationItem", ["mouseenter"], {
         contains: [
-            [".o-mail-NotificationItem-name", { text: "Discussion Channel" }],
-            [".o-mail-NotificationItem-text", { text: "An error occurred when sending an email" }],
+            [".o-mail-NotificationItem-name", { text: "Email Failure: Discussion Channel" }],
+            [
+                ".o-mail-NotificationItem-text",
+                { text: "An error occurred when sending an email on “General”" },
+            ],
         ],
     });
     await click("[title='Mark As Read']", {
-        parent: [".o-mail-NotificationItem", { text: "Discussion Channel" }],
+        parent: [".o-mail-NotificationItem", { text: "Email Failure: Discussion Channel" }],
     });
-    await contains(".o-mail-NotificationItem", { count: 0, text: "Discussion Channel" });
+    await contains(".o-mail-NotificationItem", {
+        count: 0,
+        text: "Email Failure: Discussion Channel",
+    });
     await contains("o-mail-NotificationItem", {
         count: 0,
-        text: "An error occurred when sending an email",
+        text: "An error occurred when sending an email on “General”",
     });
 });
 
@@ -561,7 +570,9 @@ test("different discuss.channel are not grouped", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem", { count: 4 });
-    await click(":nth-child(1 of .o-mail-NotificationItem)", { text: "Discussion Channel" });
+    await click(":nth-child(1 of .o-mail-NotificationItem)", {
+        text: "Email Failure: Discussion Channel",
+    });
     await contains(".o-mail-ChatWindow");
 });
 
@@ -1079,7 +1090,7 @@ test("failure notifications are shown before channel preview", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem-text", {
-        text: "An error occurred when sending an email",
+        text: "An error occurred when sending an email on “Test”",
         before: [".o-mail-NotificationItem-text", { text: "Partner1: message" }],
     });
 });
@@ -1130,7 +1141,7 @@ test("can open messaging menu even if messaging is not initialized", async () =>
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem", { text: "OdooBot has a request" });
+    await contains(".o-mail-NotificationItem", { text: "Turn on notifications" });
 });
 
 test("can open messaging menu even if channels are not fetched", async () => {
@@ -1279,8 +1290,11 @@ test("failure is removed from messaging menu when message is deleted", async () 
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem", {
         contains: [
-            [".o-mail-NotificationItem-name", { text: "Contact" }],
-            [".o-mail-NotificationItem-text", { text: "An error occurred when sending an email" }],
+            [".o-mail-NotificationItem-name", { text: "Email Failure: Contact" }],
+            [
+                ".o-mail-NotificationItem-text",
+                { text: "An error occurred when sending an email on “Mitchell Admin”" },
+            ],
         ],
     });
     pyEnv["mail.message"].unlink([messageId]);

--- a/addons/mail/static/tests/messaging_menu/notification.test.js
+++ b/addons/mail/static/tests/messaging_menu/notification.test.js
@@ -44,15 +44,10 @@ test("basic layout", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem", {
         contains: [
-            [".o-mail-NotificationItem-name", { text: "Discussion Channel" }],
+            [".o-mail-NotificationItem-name", { text: "Email Failure: Discussion Channel" }],
             [".o-mail-NotificationItem-counter", { text: "2" }],
             [".o-mail-NotificationItem-date", { text: "Jan 1" }],
-            [
-                ".o-mail-NotificationItem-text",
-                {
-                    text: "An error occurred when sending an email",
-                },
-            ],
+            [".o-mail-NotificationItem-text", { text: "An error occurred when sending an email" }],
         ],
     });
 });
@@ -72,11 +67,16 @@ test("mark as read", async () => {
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await triggerEvents(".o-mail-NotificationItem", ["mouseenter"], { text: "Discussion Channel" });
-    await click(".o-mail-NotificationItem-markAsRead", {
-        parent: [".o-mail-NotificationItem", { text: "Discussion Channel" }],
+    await triggerEvents(".o-mail-NotificationItem", ["mouseenter"], {
+        text: "Email Failure: Discussion Channel",
     });
-    await contains(".o-mail-NotificationItem", { count: 0, text: "Discussion Channel" });
+    await click(".o-mail-NotificationItem-markAsRead", {
+        parent: [".o-mail-NotificationItem", { text: "Email Failure: Discussion Channel" }],
+    });
+    await contains(".o-mail-NotificationItem", {
+        count: 0,
+        text: "Email Failure: Discussion Channel",
+    });
 });
 
 test("open non-channel failure", async () => {

--- a/addons/mail/static/tests/messaging_menu/notification.test.js
+++ b/addons/mail/static/tests/messaging_menu/notification.test.js
@@ -46,7 +46,7 @@ test("basic layout", async () => {
         contains: [
             [".o-mail-NotificationItem-name", { text: "Discussion Channel" }],
             [".o-mail-NotificationItem-counter", { text: "2" }],
-            [".o-mail-NotificationItem-date", { text: "Jan 1, 2019" }],
+            [".o-mail-NotificationItem-date", { text: "Jan 1" }],
             [
                 ".o-mail-NotificationItem-text",
                 {

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -513,7 +513,7 @@ export class MailMessage extends models.ServerModel {
                 ),
                 thread: mailDataHelpers.Store.one(
                     message.model ? this.env[message.model].browse(message.res_id) : false,
-                    makeKwArgs({ as_thread: true, fields: ["modelName"] })
+                    makeKwArgs({ as_thread: true, fields: ["modelName", "name"] })
                 ),
             });
         }

--- a/addons/sms/i18n/sms.pot
+++ b/addons/sms/i18n/sms.pot
@@ -51,6 +51,12 @@ msgid "+1 555-555-555"
 msgstr ""
 
 #. module: sms
+#. odoo-javascript
+#: code:addons/sms/static/src/components/sms_widget/fields_sms_widget.xml:0
+msgid ", fits in"
+msgstr ""
+
+#. module: sms
 #: model_terms:ir.ui.view,arch_db:sms.iap_account_view_form
 msgid ""
 "<i class=\"fa fa-warning\"/> An error occurred with your account. Please "
@@ -165,6 +171,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/sms/static/src/core/failure_model_patch.js:0
 msgid "An error occurred when sending an SMS"
+msgstr ""
+
+#. module: sms
+#. odoo-javascript
+#: code:addons/sms/static/src/core/failure_model_patch.js:0
+msgid "An error occurred when sending an SMS on “%(record_name)s”"
 msgstr ""
 
 #. module: sms
@@ -540,34 +552,16 @@ msgid "If checked, new messages require your attention."
 msgstr ""
 
 #. module: sms
-#: model:ir.model.fields,help:sms.field_account_analytic_account__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_calendar_event__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_crm_team__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_crm_team_member__message_has_sms_error
 #: model:ir.model.fields,help:sms.field_discuss_channel__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_fleet_vehicle__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_fleet_vehicle_log_contract__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_fleet_vehicle_log_services__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_fleet_vehicle_model__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_gamification_badge__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_gamification_challenge__message_has_sms_error
+#: model:ir.model.fields,help:sms.field_extract_mixin__message_has_sms_error
 #: model:ir.model.fields,help:sms.field_iap_account__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_lunch_supplier__message_has_sms_error
 #: model:ir.model.fields,help:sms.field_mail_blacklist__message_has_sms_error
 #: model:ir.model.fields,help:sms.field_mail_thread__message_has_sms_error
 #: model:ir.model.fields,help:sms.field_mail_thread_blacklist__message_has_sms_error
 #: model:ir.model.fields,help:sms.field_mail_thread_cc__message_has_sms_error
 #: model:ir.model.fields,help:sms.field_mail_thread_main_attachment__message_has_sms_error
 #: model:ir.model.fields,help:sms.field_mail_thread_phone__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_maintenance_equipment__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_maintenance_equipment_category__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_maintenance_request__message_has_sms_error
 #: model:ir.model.fields,help:sms.field_phone_blacklist__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_product_category__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_product_pricelist__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_product_product__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_product_template__message_has_sms_error
-#: model:ir.model.fields,help:sms.field_rating_mixin__message_has_sms_error
 #: model:ir.model.fields,help:sms.field_res_partner__message_has_error
 #: model:ir.model.fields,help:sms.field_res_partner__message_has_sms_error
 #: model:ir.model.fields,help:sms.field_res_users__message_has_sms_error
@@ -899,11 +893,6 @@ msgid "Put in queue"
 msgstr ""
 
 #. module: sms
-#: model:ir.model.fields,field_description:sms.field_res_partner__rating_ids
-msgid "Ratings"
-msgstr ""
-
-#. module: sms
 #: model_terms:ir.ui.view,arch_db:sms.mail_resend_message_view_form
 msgid "Reason"
 msgstr ""
@@ -1059,37 +1048,25 @@ msgid "SMS Account Verification Code Wizard"
 msgstr ""
 
 #. module: sms
-#: model:ir.model.fields,field_description:sms.field_account_analytic_account__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_calendar_event__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_crm_team__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_crm_team_member__message_has_sms_error
 #: model:ir.model.fields,field_description:sms.field_discuss_channel__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_fleet_vehicle__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_fleet_vehicle_log_contract__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_fleet_vehicle_log_services__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_fleet_vehicle_model__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_gamification_badge__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_gamification_challenge__message_has_sms_error
+#: model:ir.model.fields,field_description:sms.field_extract_mixin__message_has_sms_error
 #: model:ir.model.fields,field_description:sms.field_iap_account__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_lunch_supplier__message_has_sms_error
 #: model:ir.model.fields,field_description:sms.field_mail_blacklist__message_has_sms_error
 #: model:ir.model.fields,field_description:sms.field_mail_thread__message_has_sms_error
 #: model:ir.model.fields,field_description:sms.field_mail_thread_blacklist__message_has_sms_error
 #: model:ir.model.fields,field_description:sms.field_mail_thread_cc__message_has_sms_error
 #: model:ir.model.fields,field_description:sms.field_mail_thread_main_attachment__message_has_sms_error
 #: model:ir.model.fields,field_description:sms.field_mail_thread_phone__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_maintenance_equipment__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_maintenance_equipment_category__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_maintenance_request__message_has_sms_error
 #: model:ir.model.fields,field_description:sms.field_phone_blacklist__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_product_category__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_product_pricelist__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_product_product__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_product_template__message_has_sms_error
-#: model:ir.model.fields,field_description:sms.field_rating_mixin__message_has_sms_error
 #: model:ir.model.fields,field_description:sms.field_res_partner__message_has_sms_error
 #: model:ir.model.fields,field_description:sms.field_res_users__message_has_sms_error
 msgid "SMS Delivery error"
+msgstr ""
+
+#. module: sms
+#. odoo-javascript
+#: code:addons/sms/static/src/messaging_menu/messaging_menu_patch.js:0
+msgid "SMS Failure: %(modelName)s"
 msgstr ""
 
 #. module: sms
@@ -1568,16 +1545,6 @@ msgid ""
 msgstr ""
 
 #. module: sms
-#: model:ir.model.fields,field_description:sms.field_res_partner__website_message_ids
-msgid "Website Messages"
-msgstr ""
-
-#. module: sms
-#: model:ir.model.fields,help:sms.field_res_partner__website_message_ids
-msgid "Website communication history"
-msgstr ""
-
-#. module: sms
 #: model:ir.model.fields,help:sms.field_ir_model__is_mail_thread_sms
 msgid "Whether this model supports messages and notifications through SMS"
 msgstr ""
@@ -1656,7 +1623,7 @@ msgstr ""
 #. module: sms
 #. odoo-javascript
 #: code:addons/sms/static/src/components/sms_widget/fields_sms_widget.xml:0
-msgid "characters, fits in"
+msgid "characters"
 msgstr ""
 
 #. module: sms

--- a/addons/sms/static/src/core/failure_model_patch.js
+++ b/addons/sms/static/src/core/failure_model_patch.js
@@ -13,6 +13,11 @@ patch(Failure.prototype, {
     },
     get body() {
         if (this.type === "sms") {
+            if (this.notifications.length === 1 && this.lastMessage?.thread) {
+                return _t("An error occurred when sending an SMS on “%(record_name)s”", {
+                    record_name: this.lastMessage.thread.name,
+                });
+            }
             return _t("An error occurred when sending an SMS");
         }
         return super.body;

--- a/addons/sms/static/src/messaging_menu/messaging_menu_patch.js
+++ b/addons/sms/static/src/messaging_menu/messaging_menu_patch.js
@@ -25,4 +25,10 @@ patch(MessagingMenu.prototype, {
         });
         this.dropdown.close();
     },
+    getFailureNotificationName(failure) {
+        if (failure.type === "sms") {
+            return _t("SMS Failure: %(modelName)s", { modelName: failure.modelName });
+        }
+        return super.getFailureNotificationName(...arguments);
+    },
 });

--- a/addons/sms/static/tests/messaging_menu/messaging_menu_patch.test.js
+++ b/addons/sms/static/tests/messaging_menu/messaging_menu_patch.test.js
@@ -32,7 +32,7 @@ test("mark as read", async () => {
     await triggerEvents(".o-mail-NotificationItem", ["mouseenter"], { text: "" });
     await contains(".o-mail-NotificationItem [title='Mark As Read']");
     await contains(".o-mail-NotificationItem-text", {
-        text: "An error occurred when sending an SMS",
+        text: "An error occurred when sending an SMS on “Mitchell Admin”",
     });
     await click(".o-mail-NotificationItem [title='Mark As Read']");
     await contains(".o-mail-NotificationItem", { count: 0 });
@@ -80,14 +80,14 @@ test("notifications grouped by notification_type", async () => {
     await contains(".o-mail-NotificationItem", { count: 2 });
     await contains(":nth-child(1 of .o-mail-NotificationItem)", {
         contains: [
-            [".o-mail-NotificationItem-name", { text: "Contact" }],
+            [".o-mail-NotificationItem-name", { text: "Email Failure: Contact" }],
             [".o-mail-NotificationItem-counter", { text: "2" }],
             [".o-mail-NotificationItem-text", { text: "An error occurred when sending an email" }],
         ],
     });
     await contains(":nth-child(2 of .o-mail-NotificationItem)", {
         contains: [
-            [".o-mail-NotificationItem-name", { text: "Contact" }],
+            [".o-mail-NotificationItem-name", { text: "SMS Failure: Contact" }],
             [".o-mail-NotificationItem-counter", { text: "2" }],
             [".o-mail-NotificationItem-text", { text: "An error occurred when sending an SMS" }],
         ],
@@ -96,7 +96,7 @@ test("notifications grouped by notification_type", async () => {
 
 test("grouped notifications by document model", async () => {
     const pyEnv = await startServer();
-    const [partnerId_1, partnerId_2 ]= pyEnv["res.partner"].create([{}, {}]);
+    const [partnerId_1, partnerId_2] = pyEnv["res.partner"].create([{}, {}]);
     const [messageId_1, messageId_2] = pyEnv["mail.message"].create([
         {
             message_type: "sms",
@@ -127,7 +127,11 @@ test("grouped notifications by document model", async () => {
             expect(action.name).toBe("SMS Failures");
             expect(action.type).toBe("ir.actions.act_window");
             expect(action.view_mode).toBe("kanban,list,form");
-            expect(action.views).toEqual([[false, "kanban"],[false, "list"],[false, "form"]]);
+            expect(action.views).toEqual([
+                [false, "kanban"],
+                [false, "list"],
+                [false, "form"],
+            ]);
             expect(action.target).toBe("current");
             expect(action.res_model).toBe("res.partner");
             expect(action.domain).toEqual([["message_has_sms_error", "=", true]]);
@@ -136,7 +140,7 @@ test("grouped notifications by document model", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem", {
-        text: "Contact",
+        text: "SMS Failure: Contact",
         contains: [".badge", { text: "2" }],
     });
     await assertSteps(["do_action"]);

--- a/addons/snailmail/i18n/snailmail.pot
+++ b/addons/snailmail/i18n/snailmail.pot
@@ -36,6 +36,13 @@ msgstr ""
 #. module: snailmail
 #. odoo-javascript
 #: code:addons/snailmail/static/src/core/failure_model_patch.js:0
+msgid ""
+"An error occurred when sending a letter with Snailmail on “%(record_name)s”"
+msgstr ""
+
+#. module: snailmail
+#. odoo-javascript
+#: code:addons/snailmail/static/src/core/failure_model_patch.js:0
 msgid "An error occurred when sending a letter with Snailmail."
 msgstr ""
 
@@ -452,6 +459,12 @@ msgstr ""
 #. module: snailmail
 #: model:ir.model.fields.selection,name:snailmail.selection__mail_notification__failure_type__sn_credit
 msgid "Snailmail Credit Error"
+msgstr ""
+
+#. module: snailmail
+#. odoo-javascript
+#: code:addons/snailmail/static/src/messaging_menu/messaging_menu_patch.js:0
+msgid "Snailmail Failure: %(modelName)s"
 msgstr ""
 
 #. module: snailmail

--- a/addons/snailmail/static/src/core/failure_model_patch.js
+++ b/addons/snailmail/static/src/core/failure_model_patch.js
@@ -13,6 +13,12 @@ patch(Failure.prototype, {
     },
     get body() {
         if (this.type === "snail") {
+            if (this.notifications.length === 1 && this.lastMessage?.thread) {
+                return _t(
+                    "An error occurred when sending a letter with Snailmail on “%(record_name)s”",
+                    { record_name: this.lastMessage.thread.name }
+                );
+            }
             return _t("An error occurred when sending a letter with Snailmail.");
         }
         return super.body;

--- a/addons/snailmail/static/src/messaging_menu/messaging_menu_patch.js
+++ b/addons/snailmail/static/src/messaging_menu/messaging_menu_patch.js
@@ -24,4 +24,10 @@ patch(MessagingMenu.prototype, {
         });
         this.dropdown.close();
     },
+    getFailureNotificationName(failure) {
+        if (failure.type === "snail") {
+            return _t("Snailmail Failure: %(modelName)s", { modelName: failure.modelName });
+        }
+        return super.getFailureNotificationName(...arguments);
+    },
 });

--- a/addons/snailmail/static/tests/messaging_menu/messaging_menu_patch.test.js
+++ b/addons/snailmail/static/tests/messaging_menu/messaging_menu_patch.test.js
@@ -31,7 +31,7 @@ test("mark as read", async () => {
     await contains(".o-mail-NotificationItem");
     await triggerEvents(".o-mail-NotificationItem", ["mouseenter"]);
     await contains(".o-mail-NotificationItem-text", {
-        text: "An error occurred when sending a letter with Snailmail.",
+        text: "An error occurred when sending a letter with Snailmail on “Mitchell Admin”",
     });
     await click(".o-mail-NotificationItem [title='Mark As Read']");
     await contains(".o-mail-NotificationItem", { count: 0 });
@@ -79,14 +79,14 @@ test("notifications grouped by notification_type", async () => {
     await contains(".o-mail-NotificationItem", { count: 2 });
     await contains(":nth-child(1 of .o-mail-NotificationItem)", {
         contains: [
-            [".o-mail-NotificationItem-name", { text: "Contact" }],
+            [".o-mail-NotificationItem-name", { text: "Email Failure: Contact" }],
             [".o-mail-NotificationItem-counter", { text: "2" }],
             [".o-mail-NotificationItem-text", { text: "An error occurred when sending an email" }],
         ],
     });
     await contains(":nth-child(2 of .o-mail-NotificationItem)", {
         contains: [
-            [".o-mail-NotificationItem-name", { text: "Contact" }],
+            [".o-mail-NotificationItem-name", { text: "Snailmail Failure: Contact" }],
             [".o-mail-NotificationItem-counter", { text: "2" }],
             [
                 ".o-mail-NotificationItem-text",
@@ -145,7 +145,7 @@ test("grouped notifications by document model", async (assert) => {
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem", { text: "Contact" });
+    await contains(".o-mail-NotificationItem", { text: "Snailmail Failure: Contact" });
     await contains(".o-mail-NotificationItem-counter", { text: "2" });
     await click(".o-mail-NotificationItem");
     assertSteps(["do_action"]);


### PR DESCRIPTION
Before
<img width="480" alt="Screenshot 2024-12-12 at 12 53 27" src="https://github.com/user-attachments/assets/31e6def5-5899-4947-b3e2-5fddd73284d1" />

After
<img width="481" alt="Screenshot 2024-12-12 at 12 58 59" src="https://github.com/user-attachments/assets/055cd267-fbc1-407b-b544-72b9cfcebb53" />
