### PR TITLE
[FIX] point_of_sale: correctly show the changes

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -856,8 +856,8 @@ export class PosOrder extends Base {
         const dueAmount = this.get_due();
         const changeAmount = this.get_change();
         return (
-            floatIsZero(changeAmount, this.currency.rounding) &&
-            (floatIsZero(dueAmount, this.currency.rounding) || dueAmount > 0.0)
+            floatIsZero(changeAmount, this.currency.decimal_places) &&
+            (floatIsZero(dueAmount, this.currency.decimal_places) || dueAmount > 0.0)
         );
     }
 


### PR DESCRIPTION
Before this commit, rounding was passed to the floatIsZero function, while the decimal places should have been passed. This caused the changes to not be displayed correctly in some cases.

opw-4393181

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
