### PR TITLE
[FIX] web_editor: fix email in link widget

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -306,8 +306,8 @@ export class Link extends Component {
         var doStripDomain = this._doStripDomain();
         if (this.state.url.indexOf(location.origin) === 0 && doStripDomain) {
             this.state.url = this.state.url.slice(location.origin.length);
-        } else {
-            this.state.url = url
+        } else if (url.indexOf(location.origin) === 0 && !doStripDomain) {
+            this.state.url = url;
         }
         var allWhitespace = /\s+/gi;
         var allStartAndEndSpace = /^\s+|\s+$/gi;


### PR DESCRIPTION
**Steps to reproduce:**
- Create a new mailing
- Add a link with "Link" widget
- Enter an email
- Insert the link

**Issue:**
`http://` is prepended to the email instead of `mailto:`.

**Cause:**
Introduced by this commit:
https://github.com/odoo/odoo/commit/31dff0ed609b0e95c6097afc8d3a5daf194737f5 
As `this.state.url = url;` is executed each time the domain is not stripped, it is undoing the code adding "mailto:" to an email address.

opw-4357095




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
