### PR TITLE
[FIX] fields: access error when filtering active record on compute_sudo

### DIFF
--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -137,27 +137,6 @@ class TestMailComposerForm(TestMailComposer):
         self.assertEqual(message.partner_ids, partner_private + partner_classic)
         self.assertEqual(message.subject, f'{test_record.name}')
 
-    @mute_logger('odoo.addons.base.models.ir_rule', 'odoo.addons.mail.models.mail_mail')
-    @users('employee')
-    def test_composer_default_recipients_private_norights(self):
-        """ Test usage of a private partner in composer when not having the
-        rights to see them, as default value """
-        self.user_employee.write({'company_ids': [
-            (3, self.other_company.id),
-        ]})
-        with self.assertRaises(AccessError):
-            _name = self.partner_private.with_env(self.env).name
-
-        partner_classic = self.partner_classic.with_env(self.env)
-        test_record = self.test_record.with_env(self.env)
-
-        with self.assertRaises(AccessError):
-            _form = Form(self.env['mail.compose.message'].with_context({
-                'default_partner_ids': (self.partner_private + partner_classic).ids,
-                'default_model': test_record._name,
-                'default_res_ids': test_record.ids,
-            }))
-
     @mute_logger('odoo.addons.mail.models.mail_mail')
     @users('employee')
     def test_composer_template_recipients_private(self):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -4246,7 +4246,13 @@ class _RelationalMulti(_Relational):
             Comodel._active_name
             and self.context.get('active_test', record.env.context.get('active_test', True))
         ):
-            corecords = corecords.filtered(Comodel._active_name).with_prefetch(prefetch_ids)
+            try:
+                corecords = corecords.filtered(Comodel._active_name)
+            except AccessError:
+                if not self.compute_sudo:
+                    raise
+                corecords = corecords.sudo().with_context(prefetch_fields=False).filtered(Comodel._active_name).with_env(record.env)
+            corecords = corecords.with_prefetch(prefetch_ids)
         return corecords
 
     def convert_to_record_multi(self, values, records):
@@ -4259,7 +4265,13 @@ class _RelationalMulti(_Relational):
             Comodel._active_name
             and self.context.get('active_test', records.env.context.get('active_test', True))
         ):
-            corecords = corecords.filtered(Comodel._active_name).with_prefetch(prefetch_ids)
+            try:
+                corecords = corecords.filtered(Comodel._active_name)
+            except AccessError:
+                if not self.compute_sudo:
+                    raise
+                corecords = corecords.sudo().with_context(prefetch_fields=False).filtered(Comodel._active_name).with_env(records.env)
+            corecords = corecords.with_prefetch(prefetch_ids)
         return corecords
 
     def convert_to_read(self, value, record, use_display_name=True):


### PR DESCRIPTION
Given a x2many field computed with `compute_sudo=True`, it is possible that the value computed value returns records that the user cannot read, which is fine because the user can only see the id of the record an it's name, but nothing more.
However, trying to read that field with the field's getter will call `convert_to_record`, which will filter the active records or not depending on the context key `active_test`, because the cache is shared between the different contexts. This is done performing a `filtered` on the records, which requires read access on the returned records.

To reproduce:
* Create a company branch
* Create a new user with access only to that company branch
* Try to read `parent_ids` of that new branch.

It is particularly important to have access at least to the ids of the companies because one can have access to records belonging to the parent company without having access to the company itself (i.e. accounting accounts, journals, taxes, analytic accounts, products, ...)

