### PR TITLE
[FIX] html_editor: backspace in list after formatting crashes page

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -551,7 +551,7 @@ export class ListPlugin extends Plugin {
             }
             toMove = li.lastChild;
         }
-        if (p && isVisible(p)) {
+        if (p && p.hasChildNodes()) {
             cursors.update(callbacksForCursorUpdate.after(ul, p));
             ul.after(p);
         }

--- a/addons/html_editor/static/tests/list/delete_backward.test.js
+++ b/addons/html_editor/static/tests/list/delete_backward.test.js
@@ -1,7 +1,8 @@
 import { test, describe } from "@odoo/hoot";
 import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
-import { deleteBackward } from "../_helpers/user_actions";
+import { deleteBackward, insertText } from "../_helpers/user_actions";
+import { execCommand } from "../_helpers/userCommands";
 
 describe("Selection collapsed", () => {
     // Note: All tests on ordered lists should be duplicated
@@ -323,6 +324,18 @@ describe("Selection collapsed", () => {
                     contentBefore: "<p><br></p><ol><li>[]<br></li></ol>",
                     stepFunction: deleteBackward,
                     contentAfter: "<p><br></p><p>[]<br></p>",
+                });
+            });
+
+            test("should outdent list item with strong tag", async () => {
+                await testEditor({
+                    contentBefore: `<ol><li>abcd</li><li>[]<br></li></ol>`,
+                    stepFunction: async (editor) => {
+                        execCommand(editor, "formatBold");
+                        deleteBackward(editor);
+                        await insertText(editor, "abcd");
+                    },
+                    contentAfter: `<ol><li>abcd</li></ol><p><strong>abcd[]</strong></p>`,
                 });
             });
         });


### PR DESCRIPTION
### Steps to reproduce:

- Open the To-Do app.
- Create a list (e.g., using /list).
- Write some text and press Enter.
- Press Ctrl + B to bold the text.
- Press Backspace.
- Observe that the cursor moves to the previous list instead of creating a <p> tag, causing the page to crash.

### Description of the issue/feature this PR addresses:

- The `<p>` tag contains content `<p><strong>​</strong></p>`.
- The `isVisible` function returns false for this content, causing the `<p>` tag to not be inserted into the DOM.
- When cursor is restored, traceback occurs because selection is not in editor.

### Desired behavior after PR is merged:

- Backspace now converts the `<li>` element into a `<p>` tag without traceback.

task-4397159