### PR TITLE
[FIX] calendar: hide document smart btn on res_id pointing nowhere

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -107,7 +107,7 @@
                 </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <button string="Document" icon="fa-bars" type="object" name="action_open_calendar_event" attrs="{'invisible': ['|', ('res_model', '=', False), ('res_id', '=', False)]}"/>
+                        <button string="Document" icon="fa-bars" type="object" name="action_open_calendar_event" attrs="{'invisible': ['|', '|', ('res_model', '=', False), ('res_id', '=', False), ('res_id', '=', 0)]}"/>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="res_model" invisible="1" />


### PR DESCRIPTION
This commits backports the behavior of the following version, where document smart button is hidden on res_id being Falsy. See (ref.1)

Reproduce
---
-  -i contacts,calendar
- Open a contact, click on Meetings smart button
- Add a meeting -> Edit -> Save   (if you din'g click Edit, but save, no bug)
- Open created meeting, click on Document smart button -> BUG: no effect

(ref.1)
-----
774a3fad0eb1f7bf721a5b1251fe4a111b8c6204
[REF] base,all: Update modifier syntax: view migration

opw-4176381
