### PR TITLE
[FIX] html_editor: toolbar and link popover dark mode

### DIFF
--- a/addons/html_editor/__manifest__.py
+++ b/addons/html_editor/__manifest__.py
@@ -21,8 +21,9 @@ This addon provides an extensible, maintainable editor.
         ],
         'web.assets_backend': [
             'html_editor/static/src/**/*',
-            ('remove', 'html_editor/static/src/components/history_dialog/history_dialog.dark.scss'),
             ('include', 'html_editor.assets_media_dialog'),
+            ('remove', 'html_editor/static/src/components/history_dialog/history_dialog.dark.scss'),
+            ('remove', 'html_editor/static/src/main/toolbar/toolbar.dark.scss'),
         ],
         'html_editor.assets_media_dialog': [
             # Bundle to use the media dialog in the backend and the frontend
@@ -32,6 +33,7 @@ This addon provides an extensible, maintainable editor.
         ],
         "web.assets_web_dark": [
             'html_editor/static/src/components/history_dialog/history_dialog.dark.scss',
+            'html_editor/static/src/main/toolbar/toolbar.dark.scss',
         ],
         'web.assets_unit_tests': [
             'html_editor/static/tests/**/*',

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -21,7 +21,7 @@
                             <select name="link_type" class="form-select form-select-sm" t-att-class="{'mb-1': state.type !==  ''}" t-on-change="(ev)=>this.state.type = ev.target.value">
                                 <t t-foreach="this.colorsData" t-as="colorData" t-key="colorData.type">
                                     <t t-if="colorData.type !== 'custom'">
-                                        <option t-att-value="colorData.type" t-att-selected="state.type === colorData.type" t-attf-class="o_btn_preview dropdown-item">
+                                        <option t-att-value="colorData.type" t-att-selected="state.type === colorData.type" t-attf-class="o_btn_preview">
                                             <span t-esc="colorData.label"/>
                                         </option>
                                     </t>
@@ -47,7 +47,7 @@
                         </div>
                     </div>
 
-                    <div t-if="!this.ui.isSmall" class="col o_link_dialog_preview" style="max-width: 125px;border-left: 1px solid #DEE2E6;">
+                    <div t-if="!this.ui.isSmall" class="col o_link_dialog_preview" style="max-width: 125px;border-left: 1px solid var(--border-color);">
                         <div class="text-center p-2">
                             <label>Preview</label>
                             <div style="max-width: 100px; max-height: 200px;" class="text-truncate">

--- a/addons/html_editor/static/src/main/toolbar/toolbar.dark.scss
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.dark.scss
@@ -1,0 +1,8 @@
+.o-we-toolbar {
+    background-color: $gray-200;
+    border-bottom: 1px solid $gray-300;
+
+    .o-we-toolbar-vertical-seperator:not(:first-child) {
+        border-left: 1px solid $gray-300;
+    }
+}

--- a/addons/html_editor/static/src/main/toolbar/toolbar.scss
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.scss
@@ -9,6 +9,7 @@
     height: 40px;
     padding: 0 2px;
     border-bottom: 1px solid lightgrey;
+    background-color: #fff;
     
 
     .btn-group {

--- a/addons/html_editor/static/src/main/toolbar/toolbar.xml
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.xml
@@ -1,6 +1,6 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.Toolbar">
-        <div class="o-we-toolbar bg-white d-flex align-items-center m-0" t-on-pointerdown.prevent="" style="overflow-x: auto; overflow-y:hidden"  t-att-class="props.class">
+        <div class="o-we-toolbar d-flex align-items-center m-0" t-on-pointerdown.prevent="" style="overflow-x: auto; overflow-y:hidden"  t-att-class="props.class">
             <t t-foreach="this.getFilteredButtonGroups()" t-as="buttonGroup" t-key="buttonGroup.id">
                 <span class="o-we-toolbar-vertical-seperator"></span>
                 <div class="btn-group" t-att-name="buttonGroup.id">


### PR DESCRIPTION
Description of the issue this PR addresses:

This PR changes the background color of toolbar and link popover dropdown for a smoother UI.

task-4356656

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
