### PR TITLE
[FIX] bus, mail: display a warning when the bus connection is unstable

### DIFF
--- a/addons/bus/__manifest__.py
+++ b/addons/bus/__manifest__.py
@@ -13,6 +13,7 @@
         'web.assets_backend': [
             'bus/static/src/*.js',
             'bus/static/src/services/**/*.js',
+            'bus/static/src/components/**/*',
             'bus/static/src/workers/websocket_worker.js',
             'bus/static/src/workers/websocket_worker_utils.js',
         ],

--- a/addons/bus/i18n/bus.pot
+++ b/addons/bus/i18n/bus.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-26 08:55+0000\n"
-"PO-Revision-Date: 2024-09-26 08:55+0000\n"
+"POT-Creation-Date: 2024-12-19 09:52+0000\n"
+"PO-Revision-Date: 2024-12-19 09:52+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -122,6 +122,12 @@ msgstr ""
 #. module: bus
 #: model:ir.model.fields.selection,name:bus.selection__bus_presence__status__online
 msgid "Online"
+msgstr ""
+
+#. module: bus
+#. odoo-javascript
+#: code:addons/bus/static/src/components/bus_connection_alert.xml:0
+msgid "Real-time connection lost..."
 msgstr ""
 
 #. module: bus

--- a/addons/bus/static/src/@types/services.d.ts
+++ b/addons/bus/static/src/@types/services.d.ts
@@ -1,0 +1,13 @@
+declare module "services" {
+    import { multiTabService } from "@bus/multi_tab_service";
+    import { busMonitoringservice } from "@bus/services/bus_monitoring_service";
+    import { busService } from "@bus/services/bus_service";
+    import { presenceService } from "@bus/services/presence_service";
+
+    export interface Services {
+        bus_service: typeof busService,
+        multi_tab: typeof multiTabService,
+        presence_service: typeof presenceService,
+        "bus.monitoring_service": typeof busMonitoringservice,
+    }
+}

--- a/addons/bus/static/src/components/bus_connection_alert.js
+++ b/addons/bus/static/src/components/bus_connection_alert.js
@@ -1,0 +1,26 @@
+import { Component, useState } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+
+/**
+ * @typedef {Object} Props
+ * @extends {Component<Props, Env>}
+ */
+export class BusConnectionAlert extends Component {
+    static template = "bus.BusConnectionAlert";
+    static props = {};
+
+    setup() {
+        this.busMonitoring = useState(useService("bus.monitoring_service"));
+    }
+
+    /**
+     * Determine if a border should be shown around the screen in addition to
+     * the failure message when an issue is detected.
+     */
+    get showBorderOnFailure() {
+        return false;
+    }
+}
+
+registry.category("main_components").add("bus.connection_alert", { Component: BusConnectionAlert });

--- a/addons/bus/static/src/components/bus_connection_alert.scss
+++ b/addons/bus/static/src/components/bus_connection_alert.scss
@@ -1,0 +1,58 @@
+$o-bus-ConnectionAlert-color: mix($white, $warning, 40%);
+
+.o-bus-ConnectionAlert {
+    z-index: 1056;
+
+    &.o-bus-ConnectionAlert-border {
+        animation: o-bus-ConnectionAlert-borderAnimation ease-in-out .5s forwards;
+        border: 5px solid $o-bus-ConnectionAlert-color;
+    }
+}
+
+.o-bus-ConnectionAlert-failure {
+    width: fit-content;
+    animation: o-bus-ConnectionAlert-failureAnimation ease-in-out .5s forwards;
+    padding: map-get($spacers, 1) * 1.5;
+}
+
+.o-bus-ConnectionAlert-icon {
+    animation: o-bus-ConnectionAlert-iconAnimation .5s;
+    animation-direction: alternate;
+    animation-timing-function: cubic-bezier(.5, 0.95, 0, .5);
+    animation-iteration-count: 9;
+}
+
+.o-bus-ConnectionAlert-label {
+    color: $black;
+}
+
+@keyframes o-bus-ConnectionAlert-iconAnimation {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes o-bus-ConnectionAlert-borderAnimation {
+    from {
+        border-color: rgba($o-bus-ConnectionAlert-color, 0);
+
+    }
+
+    to {
+        border-color: $o-bus-ConnectionAlert-color;
+    }
+}
+
+@keyframes o-bus-ConnectionAlert-failureAnimation {
+    from {
+        background-color: rgba($o-bus-ConnectionAlert-color, .5);
+    }
+
+    to {
+        background-color: $o-bus-ConnectionAlert-color;
+    }
+}

--- a/addons/bus/static/src/components/bus_connection_alert.xml
+++ b/addons/bus/static/src/components/bus_connection_alert.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="bus.BusConnectionAlert">
+        <div t-if="busMonitoring.isConnectionLost" class="o-bus-ConnectionAlert position-absolute top-0 bottom-0 end-0 start-0 pe-none" t-att-class="{'o-bus-ConnectionAlert-border': showBorderOnFailure}">
+            <div class="o-bus-ConnectionAlert-failure small d-flex align-items-baseline m-0 position-absolute bottom-0 end-0 rounded-3 rounded-bottom-0 rounded-end-0 z-1" role="alert">
+                <i class="o-bus-ConnectionAlert-icon fa fa-warning me-1 text-warning"/>
+                <span class="o-bus-ConnectionAlert-label ms-1 lh-1 fw-bold">Real-time connection lost...</span>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/bus/static/src/services/bus_monitoring_service.js
+++ b/addons/bus/static/src/services/bus_monitoring_service.js
@@ -1,0 +1,67 @@
+import { WORKER_STATE } from "@bus/workers/websocket_worker";
+import { reactive } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
+import { registry } from "@web/core/registry";
+
+/**
+ * Detect lost connections to the bus. A connection is considered as lost if it
+ * couldn't be established after a reconnect attempt.
+ */
+export class BusMonitoringService {
+    isConnectionLost = false;
+
+    constructor(env, services) {
+        const reactiveThis = reactive(this);
+        reactiveThis.setup(env, services);
+        return reactiveThis;
+    }
+
+    /**
+     * @param {import("@web/env").OdooEnv} env
+     * @param {Partial<import("services").Services>} services
+     */
+    setup(env, { bus_service }) {
+        bus_service.addEventListener("worker_state_updated", ({ detail }) =>
+            this.workerStateOnChange(detail)
+        );
+        browser.addEventListener("offline", () => (this.isReconnecting = false));
+    }
+
+    /**
+     * Handle state changes for the WebSocket worker.
+     *
+     * @param {WORKER_STATE[keyof WORKER_STATE]} state
+     */
+    workerStateOnChange(state) {
+        if (!navigator.onLine) {
+            return;
+        }
+        switch (state) {
+            case WORKER_STATE.CONNECTING: {
+                this.isReconnecting = true;
+                break;
+            }
+            case WORKER_STATE.CONNECTED: {
+                this.isReconnecting = false;
+                this.isConnectionLost = false;
+                break;
+            }
+            case WORKER_STATE.DISCONNECTED: {
+                if (this.isReconnecting) {
+                    this.isConnectionLost = true;
+                    this.isReconnecting = false;
+                }
+                break;
+            }
+        }
+    }
+}
+
+export const busMonitoringservice = {
+    dependencies: ["bus_service"],
+    start(env, services) {
+        return new BusMonitoringService(env, services);
+    },
+};
+
+registry.category("services").add("bus.monitoring_service", busMonitoringservice);

--- a/addons/bus/static/src/services/bus_service.js
+++ b/addons/bus/static/src/services/bus_service.js
@@ -8,16 +8,10 @@ import { EventBus } from "@odoo/owl";
 import { user } from "@web/core/user";
 
 // List of worker events that should not be broadcasted.
-const INTERNAL_EVENTS = new Set([
-    "initialized",
-    "outdated",
-    "log_debug",
-    "notification",
-    "update_state",
-]);
+const INTERNAL_EVENTS = new Set(["initialized", "outdated", "log_debug", "notification"]);
 // Slightly delay the reconnection when coming back online as the network is not
 // ready yet and the exponential backoff would delay the reconnection by a lot.
-const BACK_ONLINE_RECONNECT_DELAY = 5000;
+export const BACK_ONLINE_RECONNECT_DELAY = 5000;
 /**
  * Communicate with a SharedWorker in order to provide a single websocket
  * connection shared across multiple tabs.
@@ -26,6 +20,7 @@ const BACK_ONLINE_RECONNECT_DELAY = 5000;
  *  @emits disconnect
  *  @emits reconnect
  *  @emits reconnecting
+ *  @emits worker_state_updated
  */
 export const busService = {
     dependencies: ["bus.parameters", "localization", "multi_tab", "notification"],
@@ -91,7 +86,7 @@ export const busService = {
                     connectionInitializedDeferred.resolve();
                     break;
                 }
-                case "update_state":
+                case "worker_state_updated":
                     workerState = data;
                     break;
                 case "log_debug":
@@ -202,25 +197,35 @@ export const busService = {
                 send("leave");
             }
         });
-        browser.addEventListener("online", () => {
-            backOnlineTimeout = browser.setTimeout(() => {
-                if (this.isActive) {
-                    send("start");
-                }
-            }, BACK_ONLINE_RECONNECT_DELAY);
-        });
-        browser.addEventListener("offline", () => {
-            clearTimeout(backOnlineTimeout);
-            send("stop");
-        });
+        browser.addEventListener(
+            "online",
+            () => {
+                backOnlineTimeout = browser.setTimeout(() => {
+                    if (isActive) {
+                        send("start");
+                    }
+                }, BACK_ONLINE_RECONNECT_DELAY);
+            },
+            { capture: true }
+        );
+        browser.addEventListener(
+            "offline",
+            () => {
+                clearTimeout(backOnlineTimeout);
+                send("stop");
+            },
+            {
+                capture: true,
+            }
+        );
 
         return {
             addEventListener: bus.addEventListener.bind(bus),
             addChannel: async (channel) => {
                 if (!worker) {
                     startWorker();
-                    await connectionInitializedDeferred;
                 }
+                await connectionInitializedDeferred;
                 send("add_channel", channel);
                 send("start");
                 isActive = true;
@@ -233,8 +238,8 @@ export const busService = {
             start: async () => {
                 if (!worker) {
                     startWorker();
-                    await connectionInitializedDeferred;
                 }
+                await connectionInitializedDeferred;
                 send("start");
                 isActive = true;
             },

--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -5,7 +5,7 @@ import { debounce, Deferred } from "@bus/workers/websocket_worker_utils";
 /**
  * Type of events that can be sent from the worker to its clients.
  *
- * @typedef { 'connect' | 'reconnect' | 'disconnect' | 'reconnecting' | 'notification' | 'initialized' | 'outdated'|'update_state' | 'log_debug' } WorkerEvent
+ * @typedef { 'connect' | 'reconnect' | 'disconnect' | 'reconnecting' | 'notification' | 'initialized' | 'outdated'| 'worker_state_updated' | 'log_debug' } WorkerEvent
  */
 
 /**
@@ -243,8 +243,8 @@ export class WebsocketWorker {
         if (this.newestStartTs && this.newestStartTs > startTs) {
             this.debugModeByClient.set(client, debug);
             this.isDebug = [...this.debugModeByClient.values()].some(Boolean);
-            this.sendToClient(client, "initialized");
             this.sendToClient(client, "update_state", this.state);
+            this.sendToClient(client, "initialized");
             return;
         }
         this.newestStartTs = startTs;
@@ -265,8 +265,8 @@ export class WebsocketWorker {
             }
             this.channelsByClient.forEach((_, key) => this.channelsByClient.set(key, []));
         }
-        this.sendToClient(client, "initialized");
         this.sendToClient(client, "update_state", this.state);
+        this.sendToClient(client, "initialized");
         if (!this.active) {
             this.sendToClient(client, "outdated");
         }
@@ -514,6 +514,6 @@ export class WebsocketWorker {
      */
     _updateState(newState) {
         this.state = newState;
-        this.broadcast("update_state", newState);
+        this.broadcast("worker_state_updated", newState);
     }
 }

--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -441,6 +441,13 @@ export class WebsocketWorker {
         }
     }
 
+    _removeWebsocketListeners() {
+        this.websocket?.removeEventListener("open", this._onWebsocketOpen);
+        this.websocket?.removeEventListener("message", this._onWebsocketMessage);
+        this.websocket?.removeEventListener("error", this._onWebsocketError);
+        this.websocket?.removeEventListener("close", this._onWebsocketClose);
+    }
+
     /**
      * Start the worker by opening a websocket connection.
      */
@@ -449,12 +456,7 @@ export class WebsocketWorker {
         if (!this.active || this._isWebsocketConnected() || this._isWebsocketConnecting()) {
             return;
         }
-        if (this.websocket) {
-            this.websocket.removeEventListener("open", this._onWebsocketOpen);
-            this.websocket.removeEventListener("message", this._onWebsocketMessage);
-            this.websocket.removeEventListener("error", this._onWebsocketError);
-            this.websocket.removeEventListener("close", this._onWebsocketClose);
-        }
+        this._removeWebsocketListeners();
         if (this._isWebsocketClosing()) {
             // close event was not triggered and will never be, broadcast the
             // disconnect event for consistency sake.
@@ -478,9 +480,8 @@ export class WebsocketWorker {
         this.connectRetryDelay = this.INITIAL_RECONNECT_DELAY;
         this.isReconnecting = false;
         this.lastChannelSubscription = null;
-        if (this.websocket) {
-            this.websocket.close();
-        }
+        this.websocket?.close();
+        this._removeWebsocketListeners();
     }
 
     /**

--- a/addons/bus/static/tests/bus_connection_alert.test.js
+++ b/addons/bus/static/tests/bus_connection_alert.test.js
@@ -1,0 +1,42 @@
+import {
+    defineBusModels,
+    lockBusServiceStart,
+    lockWebsocketConnect,
+} from "@bus/../tests/bus_test_helpers";
+import { WEBSOCKET_CLOSE_CODES } from "@bus/workers/websocket_worker";
+import { describe, expect, test } from "@odoo/hoot";
+import { queryFirst, runAllTimers, waitFor, waitUntil } from "@odoo/hoot-dom";
+import {
+    asyncStep,
+    MockServer,
+    mountWithCleanup,
+    waitForSteps,
+} from "@web/../tests/web_test_helpers";
+import { WebClient } from "@web/webclient/webclient";
+
+defineBusModels();
+describe.current.tags("desktop");
+
+test("show warning when bus connection encounters issues", async () => {
+    const unlockBus = lockBusServiceStart();
+    const { env } = await mountWithCleanup(WebClient);
+    env.services.bus_service.addEventListener("connect", () => asyncStep("connect"));
+    env.services.bus_service.addEventListener("reconnecting", () => asyncStep("reconnecting"));
+    env.services.bus_service.addEventListener("reconnect", () => asyncStep("reconnect"));
+    unlockBus();
+    await env.services.bus_service.start();
+    await waitForSteps(["connect"]);
+    const unlockWebsocket = lockWebsocketConnect();
+    MockServer.current.env["bus.bus"]._simulateDisconnection(
+        WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE
+    );
+    await waitForSteps(["reconnecting"]);
+    const alert = await waitFor(".o-bus-ConnectionAlert");
+    expect(alert).toHaveText("Real-time connection lost...");
+    await runAllTimers();
+    expect(alert).toHaveText("Real-time connection lost...");
+    unlockWebsocket();
+    await waitForSteps(["reconnect"]);
+    await runAllTimers();
+    await waitUntil(() => !queryFirst(".o-bus-ConnectionAlert"));
+});

--- a/addons/bus/static/tests/bus_monitoring_service.test.js
+++ b/addons/bus/static/tests/bus_monitoring_service.test.js
@@ -1,0 +1,96 @@
+import {
+    defineBusModels,
+    lockBusServiceStart,
+    lockWebsocketConnect,
+} from "@bus/../tests/bus_test_helpers";
+import { busMonitoringservice } from "@bus/services/bus_monitoring_service";
+import { WEBSOCKET_CLOSE_CODES } from "@bus/workers/websocket_worker";
+import { describe, expect, test } from "@odoo/hoot";
+import { runAllTimers } from "@odoo/hoot-dom";
+import {
+    asyncStep,
+    makeMockEnv,
+    MockServer,
+    patchWithCleanup,
+    waitForSteps,
+} from "@web/../tests/web_test_helpers";
+import { browser } from "@web/core/browser/browser";
+
+defineBusModels();
+describe.current.tags("desktop");
+
+function stepConnectionStateChanges() {
+    patchWithCleanup(busMonitoringservice, {
+        start() {
+            const api = super.start(...arguments);
+            Object.defineProperty(api, "isConnectionLost", {
+                get() {
+                    return this._isConnectionLost;
+                },
+                set(value) {
+                    if (value === this._isConnectionLost) {
+                        return;
+                    }
+                    this._isConnectionLost = value;
+                    asyncStep(`isConnectionLost - ${value}`);
+                },
+                configurable: true,
+                enumerable: true,
+            });
+            return api;
+        },
+    });
+}
+
+test("connection considered as lost after failed reconnect attempt", async () => {
+    stepConnectionStateChanges();
+    const unlockBus = lockBusServiceStart();
+    const env = await makeMockEnv();
+    env.services.bus_service.addEventListener("connect", () => asyncStep("connect"));
+    env.services.bus_service.addEventListener("reconnect", () => asyncStep("reconnect"));
+    unlockBus();
+    await env.services.bus_service.start();
+    await waitForSteps(["isConnectionLost - false", "connect"]);
+    const unlockWebsocket = lockWebsocketConnect();
+    MockServer.current.env["bus.bus"]._simulateDisconnection(
+        WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE
+    );
+    await waitForSteps([`isConnectionLost - true`]);
+    unlockWebsocket();
+    await waitForSteps([`isConnectionLost - false`]);
+});
+
+test("brief disconect not considered lost", async () => {
+    stepConnectionStateChanges();
+    const unlockBus = lockBusServiceStart();
+    const env = await makeMockEnv();
+    env.services.bus_service.addEventListener("connect", () => asyncStep("connect"));
+    env.services.bus_service.addEventListener("reconnect", () => asyncStep("reconnect"));
+    unlockBus();
+    await env.services.bus_service.start();
+    await waitForSteps(["isConnectionLost - false", "connect"]);
+    MockServer.current.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.SESSION_EXPIRED);
+    await waitForSteps(["reconnect"]); // Only reconnect step, which means the monitoring state didn't change.
+});
+
+test("computer sleep doesn't mark connection as lost", async () => {
+    stepConnectionStateChanges();
+    const unlockBus = lockBusServiceStart();
+    const env = await makeMockEnv();
+    env.services.bus_service.addEventListener("connect", () => asyncStep("connect"));
+    env.services.bus_service.addEventListener("disconnect", () => asyncStep("disconnect"));
+    env.services.bus_service.addEventListener("reconnect", () => asyncStep("reconnect"));
+    unlockBus();
+    await env.services.bus_service.start();
+    await waitForSteps(["isConnectionLost - false", "connect"]);
+    patchWithCleanup(navigator, { onLine: false });
+    browser.dispatchEvent(new Event("offline")); // Offline event is triggered when the computer goes to sleep.
+    const unlockWebsocket = lockWebsocketConnect();
+    await waitForSteps(["disconnect"]);
+    patchWithCleanup(navigator, { onLine: true });
+    browser.dispatchEvent(new Event("online")); // Online event is triggered when the computer wakes up.
+    unlockWebsocket();
+    await runAllTimers();
+    await waitForSteps(["connect"]);
+    expect(env.services["bus.monitoring_service"].isConnectionLost).toBe(false);
+});

--- a/addons/bus/static/tests/legacy/websocket_worker_tests.js
+++ b/addons/bus/static/tests/legacy/websocket_worker_tests.js
@@ -10,10 +10,9 @@ QUnit.module("Websocket Worker");
 QUnit.test("connect event is broadcasted after calling start", async function (assert) {
     const worker = patchWebsocketWorkerWithCleanup({
         broadcast(type) {
-            if (type === "update_state") {
-                return;
+            if (type !== "worker_state_updated") {
+                assert.step(`broadcast ${type}`);
             }
-            assert.step(`broadcast ${type}`);
         },
     });
     worker._start();
@@ -25,10 +24,9 @@ QUnit.test("connect event is broadcasted after calling start", async function (a
 QUnit.test("disconnect event is broadcasted", async function (assert) {
     const worker = patchWebsocketWorkerWithCleanup({
         broadcast(type) {
-            if (type === "update_state") {
-                return;
+            if (type !== "worker_state_updated") {
+                assert.step(`broadcast ${type}`);
             }
-            assert.step(`broadcast ${type}`);
         },
     });
     worker._start();
@@ -48,10 +46,9 @@ QUnit.test("reconnecting/reconnect event is broadcasted", async function (assert
     });
     const worker = patchWebsocketWorkerWithCleanup({
         broadcast(type) {
-            if (type === "update_state") {
-                return;
+            if (type !== "worker_state_updated") {
+                assert.step(`broadcast ${type}`);
             }
-            assert.step(`broadcast ${type}`);
         },
     });
     worker._start();

--- a/addons/bus/static/tests/mock_server/bus_mock_server.js
+++ b/addons/bus/static/tests/mock_server/bus_mock_server.js
@@ -1,0 +1,7 @@
+import { serializeDateTime } from "@web/core/l10n/dates";
+import { registry } from "@web/core/registry";
+
+registry.category("mock_rpc").add("/bus/get_autovacuum_info", () => ({
+    lastcall: serializeDateTime(luxon.DateTime.now().minus({ days: 1 }).toUTC()),
+    nextcall: serializeDateTime(luxon.DateTime.now().plus({ days: 1 }).toUTC()),
+}));

--- a/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
+++ b/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
@@ -96,4 +96,14 @@ export class BusBus extends models.Model {
         }
         this.wsWorker.broadcast("notification", values);
     }
+
+    /**
+     * Close the current websocket with the given reason and code.
+     *
+     * @param {number} closeCode the code to close the connection with.
+     * @param {string} [reason] the reason to close the connection with.
+     */
+    _simulateDisconnection(closeCode, reason) {
+        this.wsWorker.websocket.close(closeCode, reason);
+    }
 }

--- a/addons/bus/static/tests/mock_websocket.js
+++ b/addons/bus/static/tests/mock_websocket.js
@@ -75,7 +75,7 @@ export function patchWebsocketWorkerWithCleanup(params = {}) {
     patchWithCleanup(websocketWorker || WebsocketWorker.prototype, params);
     websocketWorker = websocketWorker || new WebsocketWorker();
     websocketWorker.INITIAL_RECONNECT_DELAY = 0;
-    websocketWorker.RECONNECT_JITTER = 0;
+    websocketWorker.RECONNECT_JITTER = 5;
     patchWithCleanup(browser, {
         SharedWorker: function () {
             const sharedWorker = new SharedWorkerMock(websocketWorker);

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -890,7 +890,7 @@ class WebsocketConnectionHandler:
     # Latest version of the websocket worker. This version should be incremented
     # every time `websocket_worker.js` is modified to force the browser to fetch
     # the new worker bundle.
-    _VERSION = "18.0-2"
+    _VERSION = "18.0-3"
 
     @classmethod
     def websocket_allowed(cls, request):

--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -22,6 +22,7 @@ export class ChatHub extends Component {
         super.setup();
         this.store = useState(useService("mail.store"));
         this.ui = useState(useService("ui"));
+        this.busMonitoring = useState(useService("bus.monitoring_service"));
         this.bubblesHover = useHover("bubbles");
         this.moreHover = useHover(["more-button", "more-menu*"], {
             onHover: () => (this.more.isOpen = true),

--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -5,6 +5,10 @@
     margin-bottom: $o-mail-ChatHub-bubblesMargin;
     margin-left: $o-mail-ChatHub-bubblesMargin;
     z-index:  $o-mail-NavigableList-zIndex - 1;
+
+    &.o-liftUp {
+        transform: translateY(-25px);
+    }
 }
 
 .o-mail-ChatHub-bubbleBtn {

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -8,7 +8,7 @@
                 <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.opened.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2))"/>
             </t>
         </t>
-        <div t-if="isShown" class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto' }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
+        <div t-if="isShown" class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto', 'o-liftUp': busMonitoring.hasConnectionIssues }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
             <div class="d-flex flex-column align-content-start justify-content-end align-items-center gap-1">
                 <t t-if="store.chatHub.compact">
                     <t t-call="mail.ChatHub.compactButton"/>

--- a/addons/mail/static/src/discuss/web/bus_connection_alert_patch.js
+++ b/addons/mail/static/src/discuss/web/bus_connection_alert_patch.js
@@ -1,0 +1,15 @@
+import { patch } from "@web/core/utils/patch";
+import { BusConnectionAlert } from "@bus/components/bus_connection_alert";
+import { useState } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+patch(BusConnectionAlert.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.store = useState(useService("mail.store"));
+    },
+
+    get showBorderOnFailure() {
+        return super.showBorderOnFailure || this.store.discuss.isActive;
+    },
+});

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -201,6 +201,7 @@
             'web/static/src/views/form/button_box/*.scss',
 
             'bus/static/src/**/*.js',
+            ('remove', 'bus/static/src/components/**/*'),
 
             'html_editor/static/src/**/*',
 


### PR DESCRIPTION
Gevent server issues can be difficult to detect as there is no visible
hint in the UI to inform the user when something is wrong. This delays
the detection of issues even more since symptoms are not easily linked
to bus malfunctioning.

This PR introduces the `bus_monitoring_service`, a utility designed to
detect unstable or lost bus connections. It displays a small warning
in the UI to promptly alert users of potential connection problems.

A connection is considered lost if it could reconnect after a disconnection.

task-4403259

enterprise: https://github.com/odoo/enterprise/pull/75675

<img width="1280" alt="Screenshot 2024-12-12 at 16 52 45" src="https://github.com/user-attachments/assets/959308c0-a7ee-44cf-86e8-c460dbd93b8d" />
<img width="1281" alt="Screenshot 2024-12-12 at 16 52 55" src="https://github.com/user-attachments/assets/18692c36-54b6-4d43-a0c5-d98dd4c66ec7" />
