### PR TITLE
[FIX] analytic: missing context in analytic_distribution widget

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
@@ -43,7 +43,7 @@
                         <tr t-foreach="state.formattedData" t-as="line" t-key="line.id" t-att-id="line_index" t-att-name="'line_' + line_index">
                             <Record t-props="recordProps(line)" t-slot-scope="data">
                                 <td t-foreach="Object.keys(data.record.fields).filter((f) => f.startsWith('x_plan'))" t-as="field" t-key="field">
-                                    <Field id="field" name="field" record="data.record" domain="data.record.fields[field].domain" canOpen="false" canCreate="false" canCreateEdit="false" canQuickCreate="false"/>
+                                    <Field id="field" name="field" record="data.record" context="data.record.fields[field].context" domain="data.record.fields[field].domain" canOpen="false" canCreate="false" canCreateEdit="false" canQuickCreate="false"/>
                                 </td>
                                 <td class="numeric_column_width">
                                     <Field id="'percentage'" name="'percentage'" record="data.record"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Previously, the `context` attribute set in the `analytic_distribution` field was not usable in the related `AnalyticDistribution` widget. For example:
```xml
<field name="analytic_distribution" widget="analytic_distribution"
       groups="analytic.group_analytic_accounting"
       optional="show"
       options="{'product_field': 'product_id', 'account_field': 'account_id', 'force_applicability': 'optional'}"
       context="{'context_key': 'context_value'}" <!-- not usable in the widget -->
/>
```

Current behavior before PR:
The `context` was neither extracted nor propagated to relevant methods, causing issues in operations dependent on it.

Desired behavior after PR is merged:
This fix ensures that the `context` is properly handled and propagated throughout the component, enabling its use in ORM interactions and improving the widget's functionality.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
