### PR TITLE
[FIX] stock_account: prevent change of valuation logic of a done SML

### DIFF
--- a/addons/stock_account/i18n/stock_account.pot
+++ b/addons/stock_account/i18n/stock_account.pot
@@ -776,6 +776,16 @@ msgstr ""
 
 #. module: stock_account
 #. odoo-python
+#: code:addons/stock_account/models/stock_move_line.py:0
+msgid ""
+"The stock valuation of a move is based on the type of the source and "
+"destination locations. As the move is already processed, you cannot modify "
+"the locations in a way that changes the valuation logic defined during the "
+"initial processing."
+msgstr ""
+
+#. module: stock_account
+#. odoo-python
 #: code:addons/stock_account/wizard/stock_valuation_layer_revaluation.py:0
 msgid ""
 "The value of a stock valuation layer cannot be negative. Landed cost could "

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -5,6 +5,7 @@
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
+from odoo.exceptions import ValidationError
 from odoo.tests import Form, tagged
 from odoo.tests.common import TransactionCase
 
@@ -334,6 +335,27 @@ class TestStockValuationStandard(TestStockValuationCommon):
             self.assertEqual(product.value_svl, 0.0)
         finally:
             self.env.user.company_id = old_company
+
+    def test_change_qty_and_locations_of_done_sml(self):
+        sub_stock_loc = self.stock_location.child_ids[0]
+
+        move_in = self._make_in_move(self.product1, 25)
+        self.assertEqual(self.product1.value_svl, 250)
+        self.assertEqual(self.product1.qty_available, 25)
+
+        move_in.move_line_ids.write({
+            'location_dest_id': sub_stock_loc.id,
+            'quantity': 30,
+        })
+        self.assertEqual(self.product1.value_svl, 300)
+        self.assertEqual(self.product1.qty_available, 30)
+
+        sub_loc_quant = self.product1.stock_quant_ids.filtered(lambda q: q.location_id == sub_stock_loc)
+        self.assertEqual(sub_loc_quant.quantity, 30)
+
+        with self.assertRaises(ValidationError):
+            move_in.move_line_ids.location_id = self.stock_location
+
 
 class TestStockValuationAVCO(TestStockValuationCommon):
     @classmethod


### PR DESCRIPTION
For now, a user chan change the locations of a done SML, making it
valuable while it was not (or the opposite), which leads to a broken
stock valuation.

To reproduce the issue:
1. In the Settins, enable
   - Automatic Accounting
   - Storage Locations
2. Create a product category C
   - Method: FIFO
   - Valo: Auto
3. Create a product P
   - Inventory tracked
   - Category P
   - Cost $1
4. Update its quantity
   - 10 x P at WH/Stock
5. Inventory > Reporting > Moves History, open SML related to P
6. Update the SML:
   - From: WH/Stock
   - To: WH/Stock/Shelf 1
   - Quantity: 100
7. Inventory > Reporting > Locations, look for P
   - There are two lines
     - -100 at WH/Stock
     - 100 at WH/Stock/Shelf 1
   - And, therefore, the total on hand is 0, which makes sense
8. Inventory > Reporting > Valuation, look for P

Error: There are two lines, one that adds $10 to the valuation (from
step 4) and a second one that adds $90. This is incorrect, the SML
is now an internal move and should not add any value to the stock.
In fact, the first line should even be cancelled

Letting the user changes a done SML can be convenient, but he should
not be able to change the locations as he wants since the code does
not handle all cases.

OPW-4275417