### PR TITLE
[FIX] mrp: raise User Error when linking 2 WOs from different MOs

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -6632,6 +6632,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/mrp/models/mrp_workorder.py:0
 #, python-format
+msgid "You cannot link work orders from one manufacturing order to another."
+msgstr ""
+
+#. module: mrp
+#. odoo-python
+#: code:addons/mrp/models/mrp_workorder.py:0
+#, python-format
 msgid ""
 "You cannot change the workcenter of a work order that is in progress or "
 "done."


### PR DESCRIPTION
Steps to reproduce the issue:
- Create a storable product “P1” with the following BoM:
    -Operation: OP1
- Create a MO to produce one unit of P1.
- Duplicate this MO.
- Confirm both MOs.
- Plan both MOs.
- Navigate to the Work Orders Planning page:
    - Move the work order of the second MO to the next day.
     - Block the work order of the first MO by the work order of the second MO.
- Go back to the MO list:
    - Unplan both MOs.
    - Attempt to replan the first MO.

Problem:
A validation error is triggered:
“The operation cannot be completed:
Create/update: a mandatory field is not set.
 Model: Production Order (mrp.production)
 Field: Start (date_start)"

When trying to plan the work order, we’ll checks if it is blocked by
another work order and skips planning if this is the case. Since the
work order is blocked by one from another MO, it remains unplanned:
https://github.com/odoo/odoo/blob/17.0/addons/mrp/models/mrp_production.py#L1510-L1512
As a result, the work order remains unplanned and does not have a
"leave_id" set. Consequently, the calculation for the "date_start" and
"date_finished" on the MO fails because the min function returns False.
This leads to an attempt to write a False value to the MO’s "date_start"
field:
https://github.com/odoo/odoo/blob/17.0/addons/mrp/models/mrp_production.py#L1518-L1521

opw-4393415