### PR TITLE
[IMP] mail: simplify mail template selector in full mail composer

### DIFF
--- a/addons/mail/static/src/chatter/web/mail_composer_save_template_form.js
+++ b/addons/mail/static/src/chatter/web/mail_composer_save_template_form.js
@@ -1,0 +1,30 @@
+import { formView } from "@web/views/form/form_view";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+
+
+export class MailComposerSaveTemplateFormController extends formView.Controller {
+    /** @override */
+    setup() {
+        super.setup();
+        this.actionService = useService("action");
+    }
+
+    /** @override */
+    async afterExecuteActionButton(clickParams) {
+        if (clickParams.special !== "cancel") {
+            return await super.afterExecuteActionButton(...arguments);
+        }
+        await this.actionService.doActionButton({
+            type: "object",
+            name: "cancel_save_template",
+            resId: this.model.root.resId,
+            resModel: this.model.root.resModel,
+        });
+    }
+}
+
+registry.category("views").add("mail_composer_save_template_form", {
+    ...formView,
+    Controller: MailComposerSaveTemplateFormController,
+});

--- a/addons/mail/static/src/core/web/mail_composer_template_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_template_selector.js
@@ -1,12 +1,10 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { sprintf } from "@web/core/utils/strings";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { user } from "@web/core/user";
 import { useService } from "@web/core/utils/hooks";
 
 import { Component, useState, onWillStart } from "@odoo/owl";
-import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
@@ -20,8 +18,12 @@ export class MailComposerTemplateSelector extends Component {
     setup() {
         this.action = useService("action");
         this.orm = useService("orm");
-        this.state = useState({});
-        this.limit = 7;
+        this.limit = 80;
+
+        const { context } = this.props.record.evalContext;
+        this.state = useState({
+            hideMailTemplateManagementOptions: context?.hide_mail_template_management_options,
+        });
 
         onWillStart(() => {
             this.fetchTemplates();
@@ -54,50 +56,6 @@ export class MailComposerTemplateSelector extends Component {
         });
     }
 
-    /**
-     * @param {Object} template
-     * @param {integer} template.id
-     * @param {string} template.display_name
-     */
-    async onDeleteTemplate(template) {
-        this.env.services.dialog.add(ConfirmationDialog, {
-            body: sprintf(_t('Are you sure you want to delete "%(template_name)s" for all users?\nOnce done, there is no going back!'), {
-                template_name: template.display_name,
-            }),
-            confirmLabel: _t("Delete Template"),
-            confirm: async () => {
-                await this.orm.unlink("mail.template", [template.id]);
-                this.state.templates = this.state.templates.filter(current => {
-                    return current.id !== template.id;
-                });
-            },
-            cancelLabel: _t("No, keep it"),
-            cancel: () => {},
-            title: _t("Delete Email Template"),
-        });
-    }
-
-    /**
-     * @param {Object} template
-     * @param {integer} template.id
-     * @param {string} template.display_name
-     */
-    async onOverwriteTemplate(template) {
-        this.env.services.dialog.add(ConfirmationDialog, {
-            body: sprintf(_t('Are your sure you want to update "%(template_name)s"?'), {
-                template_name: template.display_name,
-            }),
-            confirmLabel: _t("Update Template"),
-            confirm: async () => {
-                await this.orm.write("mail.template", [template.id], {
-                    subject: this.props.record.data.subject,
-                    body_html: this.props.record.data.body,
-                });
-            },
-            cancel: () => {},
-        });
-    }
-
     async onSaveTemplate() {
         if (!(await this.props.record.save())) {
             return;
@@ -110,48 +68,27 @@ export class MailComposerTemplateSelector extends Component {
         });
     }
 
+    async onManageTemplateBtnClick() {
+        const action = await this.action.loadAction("mail.action_email_template_tree_all");
+        action.context = {
+            search_default_my_templates: 1,
+            search_default_model: this.props.record.data.model,
+            default_model: this.props.record.data.model,
+            default_user_id: user.userId,
+        };
+        this.action.doAction(action);
+    }
+
     onSelectTemplateSearchMoreBtnClick() {
         this.env.services.dialog.add(SelectCreateDialog, {
             resModel: "mail.template",
-            title: _t("Insert Templates"),
+            title: _t("Select a Template"),
             multiSelect: false,
             noCreate: true,
             domain: [["model", "=", this.props.record.data.render_model]],
             onSelected: async templateIds => {
                 await this.props.record.update({
                     template_id: templateIds
-                });
-            },
-        });
-    }
-
-    onDeleteTemplateSearchMoreBtnClick() {
-        this.env.services.dialog.add(SelectCreateDialog, {
-            resModel: "mail.template",
-            title: _t("Delete Template"),
-            multiSelect: true,
-            noCreate: true,
-            domain: [["model", "=", this.props.record.data.render_model]],
-            onSelected: async templateIds => {
-                await this.orm.unlink("mail.template", templateIds);
-                this.state.templates = this.state.templates.filter(current => {
-                    return !templateIds.includes(current.id);
-                });
-            },
-        });
-    }
-
-    onOverwriteTemplateSearchMoreBtnClick() {
-        this.env.services.dialog.add(SelectCreateDialog, {
-            resModel: "mail.template",
-            title: _t("Overwrite Template"),
-            multiSelect: false,
-            noCreate: true,
-            domain: [["model", "=", this.props.record.data.render_model]],
-            onSelected: async templateIds => {
-                await this.orm.write("mail.template", templateIds, {
-                    subject: this.props.record.data.subject,
-                    body_html: this.props.record.data.body,
                 });
             },
         });

--- a/addons/mail/static/src/core/web/mail_composer_template_selector.scss
+++ b/addons/mail/static/src/core/web/mail_composer_template_selector.scss
@@ -1,0 +1,5 @@
+@include media-breakpoint-up(xl) {
+    .mail-composer-template-dropdown {
+        max-height: 50vh;
+    }
+}

--- a/addons/mail/static/src/core/web/mail_composer_template_selector.xml
+++ b/addons/mail/static/src/core/web/mail_composer_template_selector.xml
@@ -1,66 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates>
     <t t-name="mail.MailComposerTemplateSelector">
-        <Dropdown t-if="props.record.data.can_edit_body" menuClass="'mail-composer-template-dropdown'">
+        <Dropdown t-if="props.record.data.can_edit_body" menuClass="'mail-composer-template-dropdown d-flex flex-column'">
             <button class="btn btn-light w-auto mail-composer-template-dropdown-btn" data-hotkey="t">
                 <i class="fa fa-fw fa-ellipsis-v"/>
             </button>
             <t t-set-slot="content">
-                <div class="px-3 pb-1 text-muted">Insert Template</div>
-                <t t-foreach="state.templates" t-as="template" t-key="template_index">
-                    <DropdownItem onSelected="() => this.onLoadTemplate(template)">
-                        <t t-if="template.display_name" t-out="template.display_name"/>
-                        <span t-else="" class="fst-italic">Untitled</span>
+                <div class="px-3 pb-1 text-muted">Select a Template</div>
+                <div t-if="state.templates.length > 0" class="mail-composer-template-list overflow-y-auto">
+                    <t t-foreach="state.templates" t-as="template" t-key="template_index">
+                        <DropdownItem class="'px-3'" onSelected="() => this.onLoadTemplate(template)">
+                            <t t-if="template.display_name" t-out="template.display_name"/>
+                            <span t-else="" class="fst-italic">Untitled</span>
+                        </DropdownItem>
+                    </t>
+                    <DropdownItem class="'px-3'"
+                        t-if="state.templates.length >= this.limit"
+                        onSelected="() => this.onSelectTemplateSearchMoreBtnClick()">
+                        <a href="#">Search More...</a>
                     </DropdownItem>
-                </t>
-                <div t-if="state.templates.length === 0" class="fst-italic px-3">
+                </div>
+                <div t-else="" class="fst-italic px-3">
                     No saved templates
                 </div>
-                <DropdownItem t-if="state.templates.length >= this.limit" onSelected="() => this.onSelectTemplateSearchMoreBtnClick()">
-                    <a href="#">Search More...</a>
-                </DropdownItem>
-                <div class="dropdown-divider"/>
-                <Dropdown>
-                    <div>Save as Template</div>
-                    <t t-set-slot="content">
-                        <div class="px-3 pb-1 text-muted">Overwrite Template</div>
-                        <t t-foreach="state.templates" t-as="template" t-key="template_index">
-                            <DropdownItem onSelected="() => this.onOverwriteTemplate(template)">
-                                <t t-if="template.display_name" t-out="template.display_name"/>
-                                <span t-else="" class="fst-italic">Untitled</span>
-                            </DropdownItem>
-                        </t>
-                        <div t-if="state.templates.length === 0" class="fst-italic px-3">
-                            No saved templates
-                        </div>
-                        <DropdownItem t-if="state.templates.length >= this.limit" onSelected="() => this.onOverwriteTemplateSearchMoreBtnClick()">
-                            <a href="#">Search More...</a>
-                        </DropdownItem>
-                        <div class="dropdown-divider"/>
-                        <DropdownItem onSelected="() => this.onSaveTemplate()">
-                            Save as Template
-                        </DropdownItem>
-                    </t>
-                </Dropdown>
-                <div class="dropdown-divider"/>
-                <Dropdown>
-                    <div>Delete Template</div>
-                    <t t-set-slot="content">
-                        <div class="px-3 pb-1 text-muted">Delete Template</div>
-                        <t t-foreach="state.templates" t-as="template" t-key="template_index">
-                            <DropdownItem onSelected="() => this.onDeleteTemplate(template)">
-                                <t t-if="template.display_name" t-out="template.display_name"/>
-                                <span t-else="" class="fst-italic">Untitled</span>
-                            </DropdownItem>
-                        </t>
-                        <div t-if="state.templates.length === 0" class="fst-italic px-3">
-                            No saved templates
-                        </div>
-                        <DropdownItem t-if="state.templates.length >= this.limit" onSelected="() => this.onDeleteTemplateSearchMoreBtnClick()">
-                            <a href="#">Search More...</a>
-                        </DropdownItem>
-                    </t>
-                </Dropdown>
+                <t t-if="!this.state.hideMailTemplateManagementOptions">
+                    <div class="dropdown-divider"/>
+                    <DropdownItem class="'px-3'" onSelected="() => this.onSaveTemplate()">
+                        Save as Template
+                    </DropdownItem>
+                    <div class="dropdown-divider"/>
+                    <a href="#" class="px-3" t-on-click="() => this.onManageTemplateBtnClick()">
+                        Manage Templates
+                    </a>
+                </t>
             </t>
         </Dropdown>
     </t>

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -121,13 +121,14 @@
                 <search string="Templates">
                     <field name="name" filter_domain="['|', '|', ('name','ilike',self), ('subject','ilike',self), ('email_to','ilike',self)]" string="Templates"/>
                     <field name="lang"/>
+                    <field name="model" filter_domain="[('model', '=', raw_value)]"/>
                     <field name="model_id"/>
                     <filter name="my_templates" string="My Templates" domain="[('user_id', '=', uid)]"/>
                     <filter name="base_templates" string="Base Templates" domain="[('template_category', '=', 'base_template')]"/>
                     <filter name="custom_templates" string="Custom Templates" domain="[('template_category', '=', 'custom_template')]"/>
                     <group expand="0" string="Group by...">
                         <filter string="SMTP Server" name="smtpserver" domain="[]" context="{'group_by':'mail_server_id'}"/>
-                        <filter string="Model" name="model" domain="[]" context="{'group_by':'model_id'}"/>
+                        <filter string="Model" name="group_by_model_id" domain="[]" context="{'group_by':'model_id'}"/>
                     </group>
                 </search>
             </field>

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -810,7 +810,7 @@ class MailComposeMessage(models.TransientModel):
             raise UserError(_('Template creation from composer requires a valid model.'))
         model_id = self.env['ir.model']._get_id(self.model)
         values = {
-            'name': self.template_name or self.subject,
+            'name': self.template_name,
             'subject': self.subject,
             'body_html': self.body,
             'model_id': model_id,

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -91,14 +91,14 @@
             <field name="name">mail.compose.message.view.form.template.save</field>
             <field name="model">mail.compose.message</field>
             <field name="arch" type="xml">
-                <form string="Templates">
+                <form js_class="mail_composer_save_template_form" string="Templates">
                     <group>
-                        <field name="template_name" placeholder="e.g: Send order confirmation"/>
+                        <field name="template_name" placeholder="e.g: Send order confirmation" required="1"/>
                         <field name="model" invisible="1"/>
                     </group>
                     <footer>
-                        <button name="create_mail_template" type="object" class="btn btn-primary" string="Save"/>
-                        <button name="cancel_save_template" type="object" class="btn btn-secondary" string="Cancel"/>
+                        <button name="create_mail_template" type="object" class="btn btn-primary" string="Save Template"/>
+                        <button class="btn btn-secondary" string="Cancel" special="cancel"/>
                     </footer>
                 </form>
             </field>

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -472,6 +472,7 @@ class PurchaseOrder(models.Model):
             'default_composition_mode': 'comment',
             'default_email_layout_xmlid': "mail.mail_notification_layout_with_responsible_signature",
             'force_email': True,
+            'hide_mail_template_management_options': True,
             'mark_rfq_as_sent': True,
         })
 

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -988,6 +988,7 @@ class SaleOrder(models.Model):
             'default_res_ids': self.ids,
             'default_composition_mode': 'comment',
             'default_email_layout_xmlid': 'mail.mail_notification_layout_with_responsible_signature',
+            'hide_mail_template_management_options': True,
             'proforma': self.env.context.get('proforma', False),
         }
 


### PR DESCRIPTION
Currently, users can overwrite or delete templates directly from the template selector in the full mail composer. However, managing templates this way can lead to accidental overwrites or deletions, especially when users rely solely on template names to make selection. This is particularly problematic when multiple templates share the same name, as there is no preview available to confirm their choice.

To address this issue, we will remove the overwrite and delete options from the template selector. Instead, we will provide a link to the mail template list view. From there, they can preview, edit, or delete templates as needed. This approach significantly reduces the risk of accidental overwrites or deletions.

task-4365019

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
