### PR TITLE
[IMP] website: improve dynamic snippets & mono record snippet

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -414,11 +414,13 @@ class Website(Home):
         request.session[f'website_{view_id}_layout_mode'] = layout_mode
 
     @http.route('/website/snippet/filters', type='jsonrpc', auth='public', website=True, readonly=True)
-    def get_dynamic_filter(self, filter_id, template_key, limit=None, search_domain=None, with_sample=False, **custom_template_data):
-        dynamic_filter = request.env['website.snippet.filter'].sudo().search(
-            Domain('id', '=', filter_id) & request.website.website_domain()
-        )
-        return dynamic_filter and dynamic_filter._render(template_key, limit, search_domain, with_sample, **custom_template_data) or []
+    def get_dynamic_filter(self, filter_id, **kwargs):
+        dynamic_filter_sudo = request.env['website.snippet.filter'].sudo()
+        if filter_id:
+            dynamic_filter_sudo = dynamic_filter_sudo.search(
+                Domain('id', '=', filter_id) & request.website.website_domain()
+            )
+        return dynamic_filter_sudo._render(**kwargs) or []
 
     @http.route('/website/snippet/options_filters', type='jsonrpc', auth='user', website=True, readonly=True)
     def get_dynamic_snippet_filters(self, model_name=None, search_domain=None):
@@ -455,6 +457,9 @@ class Website(Home):
             t['rowPerSlide'] = attribs.get('data-row-per-slide')
             t['arrowPosition'] = attribs.get('data-arrow-position')
             t['extraClasses'] = attribs.get('data-extra-classes')
+            t['extraSnippetClasses'] = attribs.get('data-extra-snippet-classes')
+            t['containerClasses'] = attribs.get('data-container-classes')
+            t['contentClasses'] = attribs.get('data-content-classes')
             t['columnClasses'] = attribs.get('data-column-classes')
             t['thumb'] = attribs.get('data-thumb')
         return templates

--- a/addons/website/models/website_snippet_filter.py
+++ b/addons/website/models/website_snippet_filter.py
@@ -19,7 +19,7 @@ class WebsiteSnippetFilter(models.Model):
 
     name = fields.Char(required=True, translate=True)
     action_server_id = fields.Many2one('ir.actions.server', 'Server Action', ondelete='cascade')
-    field_names = fields.Char(help="A list of comma-separated field names", required=True)
+    field_names = fields.Char(help="A list of comma-separated field names", required=True, default='')
     filter_id = fields.Many2one('ir.filters', 'Filter', ondelete='cascade')
     limit = fields.Integer(help='The limit is the maximum number of records retrieved', required=True)
     website_id = fields.Many2one('website', string='Website', ondelete='cascade')
@@ -58,9 +58,10 @@ class WebsiteSnippetFilter(models.Model):
                 if not field_name.strip():
                     raise ValidationError(_("Empty field name in “%s”", record.field_names))
 
-    def _render(self, template_key, limit, search_domain=None, with_sample=False, **custom_template_data):
+    def _render(self, template_key, limit, search_domain=None, with_sample=False, res_model=None, res_id=None, **custom_template_data):
         """Renders the website dynamic snippet items"""
-        self.ensure_one()
+        self and self.ensure_one()
+
         assert '.dynamic_filter_template_' in template_key, _("You can only use template prefixed by dynamic_filter_template_ ")
         if search_domain is None:
             search_domain = []
@@ -68,13 +69,13 @@ class WebsiteSnippetFilter(models.Model):
         if self.website_id and self.env['website'].get_current_website() != self.website_id:
             return ''
 
-        if self.model_name.replace('.', '_') not in template_key:
+        if self.model_name and self.model_name.replace('.', '_') not in template_key:
             return ''
 
-        records = self._prepare_values(limit=limit, search_domain=search_domain)
+        records = self._prepare_values(limit=limit, search_domain=search_domain, res_model=res_model, res_id=res_id)
         is_sample = with_sample and not records
         if is_sample:
-            records = self._prepare_sample(limit)
+            records = self._prepare_sample(limit, res_model=res_model)
         content = self.env['ir.qweb'].with_context(inherit_branding=False)._render(template_key, dict(
             records=records,
             is_sample=is_sample,
@@ -82,38 +83,44 @@ class WebsiteSnippetFilter(models.Model):
         ))
         return [etree.tostring(el, encoding='unicode', method='html') for el in html.fromstring('<root>%s</root>' % str(content)).getchildren()]
 
-    def _prepare_values(self, limit=None, search_domain=None):
+    def _prepare_values(self, limit=None, search_domain=None, **options):
         """Gets the data and returns it the right format for render."""
-        self.ensure_one()
+        self and self.ensure_one()
 
+        model_name = options.get('res_model') or self.filter_id.sudo().model_id
+        res_id = options.get('res_id')
         # The "limit" field is there to prevent loading an arbitrary number of
         # records asked by the client side. This here makes sure you can always
         # load at least 16 records as it is what the editor allows.
         max_limit = max(self.limit, 16)
         limit = limit and min(limit, max_limit) or max_limit
+        single_record_filter = limit == 1 and model_name and res_id
 
-        if self.filter_id:
-            filter_sudo = self.filter_id.sudo()
-            domain = Domain(filter_sudo._get_eval_domain())
-            if 'website_id' in self.env[filter_sudo.model_id]:
-                domain &= self.env['website'].get_current_website().website_domain()
-            if 'company_id' in self.env[filter_sudo.model_id]:
-                website = self.env['website'].get_current_website()
-                domain &= Domain('company_id', 'in', [False, website.company_id.id])
-            if 'is_published' in self.env[filter_sudo.model_id]:
-                domain &= Domain('is_published', '=', True)
-            if search_domain:
-                search_domain = Domain(search_domain)
-                domain &= search_domain
+        # Either a multi-record filter is provided, or a single record is specified.
+        if self.filter_id or single_record_filter:
+            if not single_record_filter:
+                filter_sudo = self.filter_id.sudo()
+                domain = Domain(filter_sudo._get_eval_domain())
+                if 'website_id' in self.env[model_name]:
+                    domain &= self.env['website'].get_current_website().website_domain()
+                if 'company_id' in self.env[model_name]:
+                    website = self.env['website'].get_current_website()
+                    domain &= Domain('company_id', 'in', [False, website.company_id.id])
+                if 'is_published' in self.env[model_name]:
+                    domain &= Domain('is_published', '=', True)
+                if search_domain:
+                    search_domain = Domain(search_domain)
+                    domain &= search_domain
             try:
-                records = self.env[filter_sudo.model_id].sudo(False).with_context(**literal_eval(filter_sudo.context)).search(
+                records = self.env[model_name].sudo(False).with_context(**literal_eval(filter_sudo.context)).search(
                     domain,
                     order=','.join(literal_eval(filter_sudo.sort)) or None,
                     limit=limit
-                )
-                return self._filter_records_to_values(records.sudo())
+                ) if not single_record_filter else self.env[model_name].browse([res_id])
+                return self._filter_records_to_values(records.sudo(), res_model=model_name)
             except MissingError:
-                _logger.warning("The provided domain %s in 'ir.filters' generated a MissingError in '%s'", domain, self._name)
+                if not single_record_filter:
+                    _logger.warning("The provided domain %s in 'ir.filters' generated a MissingError in '%s'", domain, self._name)
                 return []
         elif self.action_server_id:
             try:
@@ -148,37 +155,42 @@ class WebsiteSnippetFilter(models.Model):
                 field_type = 'text'
         return field_name, field_widget or field_type
 
-    def _get_filter_meta_data(self):
+    def _get_filter_meta_data(self, model):
         """
         Extracts the meta data of each field
 
         @return OrderedDict containing the widget type for each field name
         """
-        model = self.env[self.model_name]
         meta_data = OrderedDict({})
-        for field_name in self.field_names.split(","):
+        field_names = self.field_names or self.with_context(model=model._name).default_get(['field_names']).get('field_names')
+        for field_name in field_names.split(","):
             field_name, field_widget = self._get_field_name_and_type(model, field_name)
             meta_data[field_name] = field_widget
         return meta_data
 
-    def _prepare_sample(self, length=6):
+    def _prepare_sample(self, length=6, **options):
         """
         Generates sample data and returns it the right format for render.
 
         @param length: Number of sample records to generate
+        @param options: Additional options:
+        - res_model (str): The name of the targeted model.
 
         @return Array of objets with a value associated to each name in field_names
         """
         if not length:
             return []
-        records = self._prepare_sample_records(length)
-        return self._filter_records_to_values(records, is_sample=True)
+        records = self._prepare_sample_records(length, **options)
+        options['is_sample'] = True
+        return self._filter_records_to_values(records, **options)
 
-    def _prepare_sample_records(self, length):
+    def _prepare_sample_records(self, length, **options):
         """
         Generates sample records.
 
         @param length: Number of sample records to generate
+        @param options: Additional options:
+        - res_model (str): The name of the targeted model.
 
         @return List of of sample records
         """
@@ -186,24 +198,23 @@ class WebsiteSnippetFilter(models.Model):
             return []
 
         sample = []
-        model = self.env[self.model_name]
+        model = self.env[(self.model_name or options.get('res_model'))]
         sample_data = self._get_hardcoded_sample(model)
         if sample_data:
             for index in range(0, length):
                 single_sample_data = sample_data[index % len(sample_data)].copy()
-                self._fill_sample(single_sample_data, index)
+                self._fill_sample(model, single_sample_data, index)
                 sample.append(model.new(single_sample_data))
         return sample
 
-    def _fill_sample(self, sample, index):
+    def _fill_sample(self, model, sample, index):
         """
         Fills the missing fields of a sample
 
         @param sample: Data structure to fill with values for each name in field_names
         @param index: Index of the sample within the dataset
         """
-        meta_data = self._get_filter_meta_data()
-        model = self.env[self.model_name]
+        meta_data = self._get_filter_meta_data(model)
         for field_name, field_widget in meta_data.items():
             if field_name not in sample and field_name in model:
                 if field_widget in ('image', 'binary'):
@@ -226,27 +237,29 @@ class WebsiteSnippetFilter(models.Model):
         """
         return [{}]
 
-    def _filter_records_to_values(self, records, is_sample=False):
+    def _filter_records_to_values(self, records, **options):
         """
         Extract the fields from the data source 'records' and put them into a dictionary of values
 
         @param records: Model records returned by the filter
-        @param is_sample: True if conversion if for sample records
+        @param options: Additional options:
+        - res_model (str): The name of the targeted model.
+        - is_sample (bool): True if conversion is for sample records.
 
         @return List of dict associating the field value to each field name
         """
-        self.ensure_one()
-        meta_data = self._get_filter_meta_data()
+        self and self.ensure_one()
+        model = self.env[self.model_name or options.get('res_model')]
+        meta_data = self._get_filter_meta_data(model)
 
         values = []
-        model = self.env[self.model_name]
         Website = self.env['website']
         for record in records:
             data = {}
             for field_name, field_widget in meta_data.items():
                 field = model._fields.get(field_name)
                 if field and field.type in ('binary', 'image'):
-                    if is_sample:
+                    if options.get('is_sample'):
                         data[field_name] = record[field_name].decode('utf8') if field_name in record else '/web/image'
                     else:
                         data[field_name] = Website.image_url(record, field_name)

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option.xml
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option.xml
@@ -3,10 +3,10 @@
 
 <t t-name="website.DynamicSnippetCarouselOption" t-inherit="website.DynamicSnippetOption">
     <xpath expr="//BuilderRow[*[@id=&quot;'template_opt'&quot;]]" position="after">
-	    <BuilderRow label.translate="Slider Speed">
+	    <BuilderRow label.translate="Slider Speed" t-if="numberOfRecords > 1">
 	        <BuilderNumberInput action="'setCarouselSliderSpeed'" default="1" unit="'s'" saveUnit="''" step="0.1" min="0" preview="false" id="'speed_opt'"/>
 	    </BuilderRow>
-        <BuilderRow label.translate="Scrolling Mode">
+        <BuilderRow label.translate="Scrolling Mode" t-if="numberOfRecords > 1">
             <BuilderButtonGroup preview="false">
                 <BuilderButton classAction="''">All</BuilderButton>
                 <BuilderButton classAction="'o_carousel_multi_items'">Single</BuilderButton>

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.js
@@ -10,9 +10,9 @@ export class DynamicSnippetOption extends BaseOptionComponent {
 
     setup() {
         super.setup();
-        // specify model name in subclasses to filter the list of available model record filters
-        // Indicates that some current options are a default selection.
-
+        // Specify model name in subclasses to filter the list of available
+        // model record filters. Indicates that some current options are a
+        // default selection.
         this.dynamicOptionParams = useDynamicSnippetOption(this.props.modelNameFilter);
     }
 }

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
@@ -3,16 +3,35 @@
 
 <t t-name="website.DynamicSnippetOption">
     <t t-set="dynamicFilters" t-value="Object.values(dynamicOptionParams.dynamicFilters)"/>
-    <BuilderRow id="filter_opt_row" label.translate="Filter" t-if="dynamicOptionParams.showFilterOption()">
+    <t t-set="snippetModel" t-value="dynamicOptionParams.domState.snippetModel"/>
+    <t t-set="templateKey" t-value="dynamicOptionParams.domState.templateKey"/>
+    <t t-set="filteredTemplates" t-value="dynamicOptionParams.getFilteredTemplates()"/>
+    <t t-set="isSingleMode" t-value="dynamicOptionParams.domState.isSingleMode"/>
+    <t t-set="numberOfRecords" t-value="dynamicOptionParams.domState.numberOfRecords"/>
+    <!-- Single record filter options -->
+    <BuilderRow label.translate="Model" t-if="!props.modelNameFilter and isSingleMode">
+        <BuilderSelect action="'dynamicModel'" preview="false" id="'model_opt'"></BuilderSelect>
+    </BuilderRow>
+    <BuilderRow label.translate="Record" t-if="isSingleMode">
+        <BuilderMany2One
+            model="snippetModel"
+            action="'dynamicRecord'"
+            id="'record_opt'"
+            domain="[['is_published', '=', true]]"
+            allowUnselect="false"
+            fields="['id', 'name']"
+        />
+    </BuilderRow>
+    <!-- Multi record & common options -->
+    <BuilderRow id="filter_opt_row" label.translate="Filter" t-if="!!dynamicOptionParams.showFilterOption()">
         <BuilderSelect action="'dynamicFilter'" preview="false" id="'filter_opt'">
             <t t-foreach="dynamicFilters" t-as="filter" t-key="filter.id">
                 <BuilderSelectItem actionParam="filter" t-out="filter.name" title="filter.help || ''"/>
             </t>
         </BuilderSelect>
     </BuilderRow>
-    <t t-set="filteredTemplates" t-value="dynamicOptionParams.getFilteredTemplates()"/>
-    <BuilderRow id="template_opt_row" label.translate="Template" t-if="filteredTemplates.length > 1">
-        <BuilderSelect action="'dynamicFilterTemplate'" preview="false" id="'template_opt'">
+    <BuilderRow id="template_opt_row" label.translate="Template" t-if="!props.modelNameFilter and filteredTemplates.length > 1">
+        <BuilderSelect action="'dynamicSnippetTemplate'" preview="false" id="'template_opt'">
             <t t-foreach="filteredTemplates" t-as="template" t-key="template.key">
                 <t t-if="template.thumb">
                     <BuilderSelectItem actionParam="template">
@@ -25,18 +44,24 @@
             </t>
         </BuilderSelect>
     </BuilderRow>
-    <BuilderRow id="number_of_records_opt_row" label.translate="Fetched Elements" t-if="!!this.dynamicOptionParams.domState.filterId">
-        <BuilderSelect dataAttributeAction="'numberOfRecords'" preview="false" id="'number_of_records_opt'">
+    <BuilderRow label.translate="Cover Image" t-if="dynamicOptionParams.domState.snippetContentPosition">
+        <BuilderButtonGroup>
+            <BuilderButton title.translate="Left" classAction="'s_dynamic_snippet_cover_left'" iconImg="'/website/static/src/img/snippets_options/pos_left.svg'"/>
+            <BuilderButton title.translate="Right" classAction="''" iconImg="'/website/static/src/img/snippets_options/pos_right.svg'"/>
+        </BuilderButtonGroup>
+    </BuilderRow>
+    <BuilderRow id="number_of_records_opt_row" label.translate="Fetched Elements" t-if="!!dynamicOptionParams.domState.filterId or isSingleMode">
+        <BuilderSelect action="'numberOfRecords'" preview="false" id="'number_of_records_opt'">
             <t t-foreach="['1','2','3','4','5','6','7','8','9','10','11','12','13','14','15','16']" t-as="value" t-key="value">
-                <BuilderSelectItem dataAttributeActionValue="value" t-out="value"/>
+                <BuilderSelectItem actionParam="value" t-out="value"/>
             </t>
         </BuilderSelect>
     </BuilderRow>
-    <BuilderRow label.translate="Section Title">
+    <BuilderRow label.translate="Section Title" t-if="!isSingleMode">
         <BuilderButtonGroup applyTo="'.s_dynamic_snippet_title'">
-            <BuilderButton label.translate="Top" classAction="'justify-content-between'"/>
-            <BuilderButton label.translate="Left" classAction="'s_dynamic_snippet_title_aside col-lg-3 justify-content-between flex-lg-column justify-content-lg-start'"/>
-            <BuilderButton label.translate="None" title.translate="No title" classAction="'d-none'"/>
+            <BuilderButton label.translate="Top" classAction="dynamicOptionParams.getSnippetTitleClasses('top')"/>
+            <BuilderButton label.translate="Left" classAction="dynamicOptionParams.getSnippetTitleClasses('left')"/>
+            <BuilderButton label.translate="None" title.translate="No title" classAction="dynamicOptionParams.getSnippetTitleClasses('none')"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
@@ -13,12 +13,23 @@ class DynamicSnippetOptionPlugin extends Plugin {
     static id = "dynamicSnippetOption";
     static shared = [
         "fetchDynamicFilters",
-        "fetchDynamicFilterTemplates",
+        "fetchDynamicSnippetTemplates",
+        "getDefaultSnippetFilterId",
+        "getDefaultSnippetRecordId",
+        "getDefaultSnippetTemplate",
+        "getSnippetModelName",
+        "getSnippetTitleClasses",
+        "getTemplateByKey",
+        "isModelSnippetTemplate",
+        "isSingleModeSnippet",
+        "isSingleModeSnippetTemplate",
         "setOptionsDefaultValues",
         "updateTemplate",
     ];
     selector = ".s_dynamic_snippet";
     modelNameFilter = "";
+    fetchedDynamicFilters = [];
+    fetchedDynamicFilterTemplates = [];
     resources = {
         builder_options: [
             withSequence(DYNAMIC_SNIPPET, {
@@ -31,8 +42,11 @@ class DynamicSnippetOptionPlugin extends Plugin {
         ],
         builder_actions: {
             DynamicFilterAction,
-            DynamicFilterTemplateAction,
+            DynamicSnippetTemplateAction,
+            DynamicModelAction,
+            DynamicRecordAction,
             CustomizeTemplateAction,
+            NumberOfRecordsAction,
         },
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         is_unremovable_selector: ".s_dynamic_snippet_title",
@@ -40,7 +54,7 @@ class DynamicSnippetOptionPlugin extends Plugin {
     setup() {
         this.dynamicFiltersCache = new Cache(this._fetchDynamicFilters, JSON.stringify);
         this.dynamicFilterTemplatesCache = new Cache(
-            this._fetchDynamicFilterTemplates,
+            this._fetchDynamicSnippetTemplates,
             JSON.stringify
         );
     }
@@ -55,41 +69,68 @@ class DynamicSnippetOptionPlugin extends Plugin {
         }
     }
     async setOptionsDefaultValues(snippetEl, modelNameFilter, contextualFilterDomain = []) {
-        const fetchedDynamicFilters = await this.fetchDynamicFilters({
+        await this.fetchDynamicFilters({
             model_name: modelNameFilter,
             search_domain: contextualFilterDomain,
         });
+        await this.fetchDynamicSnippetTemplates(modelNameFilter);
+
         const dynamicFilters = {};
-        for (const dynamicFilter of fetchedDynamicFilters) {
+        for (const dynamicFilter of this.fetchedDynamicFilters) {
             dynamicFilters[dynamicFilter.id] = dynamicFilter;
         }
-        const fetchedDynamicFilterTemplates = await this.fetchDynamicFilterTemplates({
-            filter_name: modelNameFilter.replaceAll(".", "_"),
-        });
         const dynamicFilterTemplates = {};
-        for (const dynamicFilterTemplate of fetchedDynamicFilterTemplates) {
+        for (const dynamicFilterTemplate of this.fetchedDynamicFilterTemplates) {
             dynamicFilterTemplates[dynamicFilterTemplate.key] = dynamicFilterTemplate;
         }
-        let selectedFilterId = snippetEl.dataset["filterId"];
-        if (Object.keys(dynamicFilters).length > 0) {
-            setDatasetIfUndefined(snippetEl, "numberOfRecords", fetchedDynamicFilters[0].limit);
-            const defaultFilterId = fetchedDynamicFilters[0].id;
-            if (!dynamicFilters[selectedFilterId]) {
-                snippetEl.dataset["filterId"] = defaultFilterId;
-                selectedFilterId = defaultFilterId;
+        const defaultModelName = modelNameFilter || this.fetchedDynamicFilters[0]?.model_name;
+        const isSingleMode = this.isSingleModeSnippet({
+            ...snippetEl.dataset,
+            snippetModel: defaultModelName,
+        });
+        // The snippet simply gets its template from a "template class"
+        // when provided. Otherwise, it will use a default template.
+        let defaultTemplate = this.fetchedDynamicFilterTemplates.find((template) =>
+            snippetEl.classList.contains(this.getTemplateClass(template.key))
+        );
+        if (!defaultTemplate) {
+            defaultTemplate = this.getDefaultSnippetTemplate(defaultModelName, isSingleMode);
+        }
+        if (isSingleMode) {
+            if (defaultModelName) {
+                setDatasetIfUndefined(snippetEl, "snippetModel", defaultModelName);
+            }
+            const defaultSnippetRecordId = await this.getDefaultSnippetRecordId(defaultModelName);
+            if (defaultSnippetRecordId) {
+                setDatasetIfUndefined(snippetEl, "snippetResId", defaultSnippetRecordId);
+            }
+            setDatasetIfUndefined(snippetEl, "templateKey", defaultTemplate.key);
+            this.updateTemplate(snippetEl, defaultTemplate);
+        } else {
+            let selectedFilterId = snippetEl.dataset["filterId"];
+            if (Object.keys(dynamicFilters).length > 0) {
+                if (!snippetEl.dataset.numberOfRecords) {
+                    snippetEl.dataset["numberOfRecords"] = this.fetchedDynamicFilters[0].limit;
+                }
+                const defaultFilterId = this.fetchedDynamicFilters[0].id;
+                if (!dynamicFilters[selectedFilterId]) {
+                    snippetEl.dataset["filterId"] = defaultFilterId;
+                    selectedFilterId = defaultFilterId;
+                }
+            }
+            if (
+                dynamicFilters[selectedFilterId] &&
+                !dynamicFilterTemplates[snippetEl.dataset["templateKey"]]
+            ) {
+                snippetEl.dataset["templateKey"] = defaultTemplate.key;
+                this.updateTemplate(snippetEl, defaultTemplate);
             }
         }
-        if (
-            dynamicFilters[selectedFilterId] &&
-            !dynamicFilterTemplates[snippetEl.dataset["templateKey"]]
-        ) {
-            const modelName = dynamicFilters[selectedFilterId].model_name.replaceAll(".", "_");
-            const defaultFilterTemplate = fetchedDynamicFilterTemplates.find((dynamicTemplate) =>
-                dynamicTemplate.key.includes(modelName)
-            );
-            snippetEl.dataset["templateKey"] = defaultFilterTemplate.key;
-            this.updateTemplate(snippetEl, defaultFilterTemplate);
-        }
+    }
+    getTemplateByKey(templateKey) {
+        return (
+            templateKey && this.fetchedDynamicFilterTemplates.find(({ key }) => key === templateKey)
+        );
     }
     getTemplateClass(templateKey) {
         return templateKey.replace(/.*\.dynamic_filter_template_/, "s_");
@@ -97,6 +138,7 @@ class DynamicSnippetOptionPlugin extends Plugin {
     updateTemplate(el, template) {
         const newTemplateKey = template.key;
         const oldTemplateKey = el.dataset.templateKey;
+        const oldTemplate = this.getTemplateByKey(oldTemplateKey);
         el.dataset.templateKey = newTemplateKey;
         if (oldTemplateKey) {
             el.classList.remove(this.getTemplateClass(oldTemplateKey));
@@ -126,25 +168,93 @@ class DynamicSnippetOptionPlugin extends Plugin {
         } else {
             delete el.dataset.columnClasses;
         }
+        if (oldTemplate) {
+            const snippetContainerEl = el.querySelector(".s_dynamic_snippet_container");
+            const snippetContentEl = el.querySelector(".s_dynamic_snippet_content");
+            snippetContainerEl.classList.remove(
+                ...(oldTemplate.containerClasses?.split(" ") || [])
+            );
+            snippetContainerEl.classList.add(
+                ...(template.containerClasses || "container").split(" ")
+            );
+            snippetContentEl.classList.remove(...(oldTemplate.contentClasses?.split(" ") || []));
+            snippetContentEl.classList.add(...(template.contentClasses?.split(" ") || []));
+            el.classList.remove(...(oldTemplate.extraSnippetClasses?.split(" ") || []));
+            el.classList.add(...(template.extraSnippetClasses?.split(" ") || []));
+        }
         this.dispatchTo("dynamic_snippet_template_updated", { el: el, template: template });
     }
     async fetchDynamicFilters(params) {
-        return this.dynamicFiltersCache.read(params);
+        this.fetchedDynamicFilters = await this.dynamicFiltersCache.read(params);
+        return this.fetchedDynamicFilters;
     }
     async _fetchDynamicFilters(params) {
         return rpc("/website/snippet/options_filters", params);
     }
-    async fetchDynamicFilterTemplates(params) {
-        return this.dynamicFilterTemplatesCache.read(params);
+    async fetchDynamicSnippetTemplates(modelName) {
+        this.fetchedDynamicFilterTemplates = await this.dynamicFilterTemplatesCache.read({
+            filter_name: modelName.replaceAll(".", "_"),
+        });
+        return this.fetchedDynamicFilterTemplates;
     }
-    async _fetchDynamicFilterTemplates(params) {
+    async _fetchDynamicSnippetTemplates(params) {
         return rpc("/website/snippet/filter_templates", params);
     }
-}
-
-export function setDatasetIfUndefined(snippetEl, optionName, value) {
-    if (snippetEl.dataset[optionName] === undefined) {
-        snippetEl.dataset[optionName] = value;
+    isSingleModeSnippet({ numberOfRecords, ...params }) {
+        // TODO: Currently, we need to verify that at least one template is
+        // available for single record mode to be enabled. This check should be
+        // removed once all single record templates have been added.
+        return !!(
+            parseInt(numberOfRecords) === 1 &&
+            this.getDefaultSnippetTemplate(this.getSnippetModelName(params), true) &&
+            !params.carouselInterval
+        );
+    }
+    isSingleModeSnippetTemplate(key) {
+        return key.includes("_single_");
+    }
+    isModelSnippetTemplate(key, modelName) {
+        return key.includes(`_${modelName.replaceAll(".", "_")}_`);
+    }
+    getDefaultSnippetTemplate(modelName, singleMode) {
+        if (modelName) {
+            // Return the default snippet template associated with the current
+            // model for either single or multi-record modes.
+            return this.fetchedDynamicFilterTemplates.find((template) => {
+                const isSingleTemplate = this.isSingleModeSnippetTemplate(template.key);
+                return (
+                    this.isModelSnippetTemplate(template.key, modelName) &&
+                    (singleMode ? isSingleTemplate : !isSingleTemplate)
+                );
+            });
+        }
+    }
+    async getDefaultSnippetRecordId(modelName) {
+        const defaultRecrod = await this.services.orm.searchRead(
+            modelName,
+            [["is_published", "=", true]],
+            ["id"],
+            { limit: 1 }
+        );
+        return defaultRecrod[0]?.id || "";
+    }
+    getDefaultSnippetFilterId(modelName) {
+        return this.fetchedDynamicFilters.find(({ model_name }) => model_name === modelName).id;
+    }
+    getSnippetModelName(snippetData) {
+        return (
+            snippetData.snippetModel ||
+            this.fetchedDynamicFilters.find(({ id }) => id === parseInt(snippetData.filterId))
+                ?.model_name
+        );
+    }
+    getSnippetTitleClasses(position) {
+        const classes = {
+            left: "d-flex justify-content-between s_dynamic_snippet_title_aside col-lg-3 flex-lg-column justify-content-lg-start",
+            top: "d-flex justify-content-between",
+            none: "d-none",
+        };
+        return position ? classes[position] : classes;
     }
 }
 
@@ -154,19 +264,27 @@ export class DynamicFilterAction extends BuilderAction {
     isApplied({ editingElement: el, params }) {
         return parseInt(el.dataset.filterId) === params.id;
     }
-    apply({ editingElement: el, params }) {
+    async apply({ editingElement: el, params }) {
+        const utils = this.dependencies.dynamicSnippetOption;
+        let defaultTemplate = params.defaultTemplate;
         el.dataset.filterId = params.id;
+        // Only if filter's model name changed
         if (
             !el.dataset.templateKey ||
-            !el.dataset.templateKey.includes(`_${params.model_name.replaceAll(".", "_")}_`)
+            !utils.isModelSnippetTemplate(el.dataset.templateKey, params.model_name)
         ) {
-            // Only if filter's model name changed
-            this.dependencies.dynamicSnippetOption.updateTemplate(el, params.defaultTemplate);
+            if (utils.isSingleModeSnippet(el.dataset)) {
+                el.dataset.snippetModel = params.model_name;
+                delete el.dataset.filterId;
+                defaultTemplate = utils.getDefaultSnippetTemplate(params.model_name, true);
+                el.dataset.snippetResId = await utils.getDefaultSnippetRecordId(params.model_name);
+            }
+            utils.updateTemplate(el, defaultTemplate);
         }
     }
 }
-export class DynamicFilterTemplateAction extends BuilderAction {
-    static id = "dynamicFilterTemplate";
+export class DynamicSnippetTemplateAction extends BuilderAction {
+    static id = "dynamicSnippetTemplate";
     static dependencies = ["dynamicSnippetOption"];
     isApplied({ editingElement: el, params }) {
         return el.dataset.templateKey === params.key;
@@ -190,6 +308,116 @@ export class CustomizeTemplateAction extends BuilderAction {
         const customData = JSON.parse(el.dataset.customTemplateData);
         customData[customDataKey] = false;
         el.dataset.customTemplateData = JSON.stringify(customData);
+    }
+}
+export class DynamicModelAction extends BuilderAction {
+    static id = "dynamicModel";
+    static dependencies = ["dynamicSnippetOption"];
+    isApplied({ editingElement: el, params }) {
+        return el.dataset.snippetModel === params.mainParam;
+    }
+    async apply({ editingElement: el, params: { mainParam: modelName } }) {
+        const utils = this.dependencies.dynamicSnippetOption;
+        // Update the snippet data attributes (only available in the
+        // "single record" mode).
+        if (el.dataset.snippetModel !== modelName) {
+            el.dataset.snippetModel = modelName;
+            el.dataset.snippetResId = await utils.getDefaultSnippetRecordId(modelName);
+            utils.updateTemplate(el, utils.getDefaultSnippetTemplate(modelName, true));
+        }
+    }
+}
+export class DynamicRecordAction extends BuilderAction {
+    static id = "dynamicRecord";
+    getValue({ editingElement }) {
+        const id = editingElement.dataset.snippetResId;
+        if (id) {
+            return JSON.stringify({ id: parseInt(id) });
+        }
+    }
+    apply({ editingElement, value }) {
+        const { id } = JSON.parse(value);
+        editingElement.dataset.snippetResId = id;
+    }
+}
+export class NumberOfRecordsAction extends BuilderAction {
+    static id = "numberOfRecords";
+    static dependencies = ["dynamicSnippetOption", "builderActions"];
+
+    setup() {
+        this.defaultRecordId = "";
+        this.previousTemplate = false;
+        this.utils = this.dependencies.dynamicSnippetOption;
+    }
+    async load({ editingElement }) {
+        this.modelName = this.utils.getSnippetModelName(editingElement.dataset);
+        this.defaultRecordId = await this.utils.getDefaultSnippetRecordId(this.modelName);
+    }
+    isApplied({ editingElement: el, params }) {
+        return el.dataset.numberOfRecords === params.mainParam;
+    }
+    apply({ editingElement: el, params }) {
+        const isSingleModeBefore = this.utils.isSingleModeSnippet(el.dataset);
+        el.dataset.numberOfRecords = params.mainParam;
+        // Changing the number of records should automatically switch to a
+        // "single record" filter mode if only one record is selected, and
+        // conversely, revert to the default filter mode when more than one
+        // record is selected.
+        const isSingleModeAfter = this.utils.isSingleModeSnippet(el.dataset);
+        const switchMode = isSingleModeBefore !== isSingleModeAfter;
+        if (switchMode) {
+            const canUsePreviousTemplate =
+                !!this.previousTemplate &&
+                this.utils.isModelSnippetTemplate(this.previousTemplate.key, this.modelName) &&
+                !!this.utils.isSingleModeSnippetTemplate(this.previousTemplate.key) ===
+                    isSingleModeAfter;
+            const newModeDefaultTemplate = !canUsePreviousTemplate
+                ? this.utils.getDefaultSnippetTemplate(this.modelName, isSingleModeAfter)
+                : this.previousTemplate;
+            this.previousTemplate = this.utils.getTemplateByKey(el.dataset.templateKey);
+            if (isSingleModeAfter) {
+                // Remove useless data on the target and set the single
+                // record default values.
+                delete el.dataset.filterId;
+                el.dataset.snippetModel = this.modelName;
+                el.dataset.snippetResId = this.defaultRecordId;
+            } else {
+                el.dataset.filterId = this.utils.getDefaultSnippetFilterId(this.modelName);
+                delete el.dataset.snippetModel;
+                delete el.dataset.snippetResId;
+            }
+            // Update the snippet title section.
+            const titleEl = el.querySelector(".s_dynamic_snippet_title");
+            const classAction = this.dependencies.builderActions.getAction("classAction");
+            const titleClasses = Object.values(this.utils.getSnippetTitleClasses()).find(
+                (classes) =>
+                    titleEl.matches(
+                        classes
+                            .split(" ")
+                            .map((c) => "." + c)
+                            .join("")
+                    )
+            );
+            classAction.clean({
+                editingElement: titleEl,
+                params: { mainParam: titleClasses },
+            });
+            classAction.apply({
+                editingElement: titleEl,
+                params: {
+                    mainParam: this.utils.getSnippetTitleClasses(
+                        isSingleModeAfter ? "none" : "top"
+                    ),
+                },
+            });
+            return this.utils.updateTemplate(el, newModeDefaultTemplate);
+        }
+    }
+}
+
+export function setDatasetIfUndefined(snippetEl, optionName, value) {
+    if (snippetEl.dataset[optionName] === undefined) {
+        snippetEl.dataset[optionName] = value;
     }
 }
 

--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.scss
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.scss
@@ -1,7 +1,13 @@
 .s_dynamic {
-    &.o_dynamic_snippet_empty:not(.o_check_scroll_position) {
-        // TODO Restore once interactions are started in edit mode.
-        // display: none !important;
+    // TODO Dynamic snippet loading style: Temporarily disabled in preview mode
+    // since it needs interactions to be available.
+    #wrap &.o_dynamic_snippet_empty:not(.o_check_scroll_position) {
+        section:not(.s_dynamic_snippet_holder) {
+            display: none !important;
+        }
+        .s_dynamic_snippet_holder {
+            display: block !important;
+        }
     }
     [data-url] {
         cursor: pointer;
@@ -45,6 +51,12 @@
                     flex: 1 1 var(--DynamicSnippet__entry-maxWidth, #{$-entry-min-width});
                 }
             }
+        }
+    }
+
+    &.s_dynamic_snippet_cover_left {
+        .s_dynamic_snippet_content_position {
+            flex-direction: row-reverse;
         }
     }
 }

--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.xml
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.xml
@@ -22,7 +22,7 @@
 
         <!-- Custom Layout -->
         <t t-else="">
-            <div t-attf-class="s_dynamic_snippet_row row #{extraClasses}">
+            <div t-attf-class="#{is_single_record ? 's_dynamic_snippet_row' : ''} row #{extraClasses}">
                 <t t-foreach="data" t-as="data_entry" t-key="data_entry_index">
                     <div t-attf-class="#{columnClasses}">
                         <t t-out="data_entry"/>

--- a/addons/website/static/tests/interactions/snippets/dynamic_snippet.test.js
+++ b/addons/website/static/tests/interactions/snippets/dynamic_snippet.test.js
@@ -37,7 +37,7 @@ test("dynamic snippet loads items and displays them through template", async () 
     });
     const { core } = await startInteractions(`
         <div id="wrapwrap">
-            <section data-snippet="s_dynamic_snippet" class="s_dynamic_snippet s_dynamic s_dynamic_empty pt32 pb32 o_colored_level" data-custom-template-data="{}" data-name="Dynamic Snippet"
+            <section data-snippet="s_dynamic_snippet" class="s_dynamic_snippet s_dynamic pt32 pb32 o_colored_level" data-custom-template-data="{}" data-name="Dynamic Snippet"
                     data-filter-id="1"
                     data-template-key="website.dynamic_filter_template_test_item"
                     data-number-of-records="16"

--- a/addons/website/static/tests/interactions/snippets/dynamic_snippet_carousel.test.js
+++ b/addons/website/static/tests/interactions/snippets/dynamic_snippet_carousel.test.js
@@ -34,7 +34,7 @@ describe.current.tags("interaction_dev");
 
 const testTemplate = /* xml */ `
     <div id="wrapwrap">
-        <section data-snippet="s_dynamic_snippet_carousel" class="s_dynamic_snippet_carousel s_dynamic s_dynamic_empty pt32 pb32 o_colored_level" data-custom-template-data="{}" data-name="Dynamic Carousel"
+        <section data-snippet="s_dynamic_snippet_carousel" class="s_dynamic_snippet_carousel s_dynamic pt32 pb32 o_colored_level" data-custom-template-data="{}" data-name="Dynamic Carousel"
                 data-filter-id="1"
                 data-template-key="website.dynamic_filter_template_test_item"
                 data-number-of-records="16"

--- a/addons/website/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet.xml
@@ -1,10 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="website.s_dynamic_snippet_template">
-        <section t-attf-class="#{snippet_name} #{snippet_classes} s_dynamic s_dynamic_empty pt32 pb32" t-att-data-snippet="snippet_name" t-att-data-custom-template-data="custom_template_data or '{}'">
-            <div class="container">
+        <section t-att-data-snippet="snippet_name"
+            t-attf-class="#{snippet_name} #{snippet_classes} s_dynamic o_dynamic_snippet_empty pt32 pb32"
+            t-att-data-custom-template-data="custom_template_data or '{}'"
+            t-att-data-number-of-records="is_single_record and '1' or ''">
+            <div t-attf-class="s_dynamic_snippet_container {{container_classes or 'container'}}">
                 <div class="row s_nb_column_fixed">
-                    <section class="s_dynamic_snippet_title oe_unremovable oe_unmovable d-flex flex-column flex-md-row justify-content-between mb-lg-0 pb-3 pb-md-0">
+                    <!-- Dynamic snippet loading effect -->
+                    <section class="s_dynamic_snippet_holder d-none px-4 placeholder-glow">
+                        <div class="row">
+                            <span class="placeholder col-3 rounded"/>
+                            <span class="placeholder col-2 offset-7 rounded"/>
+                            <span class="placeholder mt-3 col-6 rounded"/>
+                        </div>
+                        <div class="row mt-4">
+                            <span class="placeholder col-12 rounded" style="height: 250px;"/>
+                        </div>
+                    </section>
+                    <section t-attf-class="{{is_single_record and 'd-none' or 'justify-content-between d-flex'}} s_dynamic_snippet_title oe_unremovable oe_unmovable flex-column flex-md-row mb-lg-0 pb-3 pb-md-0 s_col_no_resize">
                         <div>
                             <h4>Our latest content</h4>
                             <p class="lead">Check out what's new in our company !</p>
@@ -13,10 +27,10 @@
                             <a title="See All" t-att-href="main_page_url">See all<span class="fa fa-long-arrow-right ms-2"/></a>
                         </div>
                     </section>
-                    <section class="s_dynamic_snippet_content oe_unremovable oe_unmovable o_not_editable col">
+                    <section t-attf-class="s_dynamic_snippet_content oe_unremovable oe_unmovable o_not_editable col s_col_no_resize #{content_classes}">
                         <div class="css_non_editable_mode_hidden">
                             <div class="missing_option_warning alert alert-info fade show d-none d-print-none rounded-0">
-                                Your Dynamic Snippet will be displayed here... This message is displayed because you did not provide both a filter and a template to use.<br/>
+                                Your Dynamic Snippet will be displayed here... This message is displayed because you did not provide enough options to retrieve its content.<br/>
                             </div>
                         </div>
                         <div class="dynamic_snippet_template">

--- a/addons/website/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="website.s_dynamic_snippet_template">
         <section t-att-data-snippet="snippet_name"
-            t-attf-class="#{snippet_name} #{snippet_classes} s_dynamic o_dynamic_snippet_empty pt32 pb32"
+            t-attf-class="#{snippet_name} #{snippet_classes} s_dynamic o_dynamic_snippet_empty pt64 pb64"
             t-att-data-custom-template-data="custom_template_data or '{}'"
             t-att-data-number-of-records="is_single_record and '1' or ''">
             <div t-attf-class="s_dynamic_snippet_container {{container_classes or 'container'}}">

--- a/addons/website_blog/models/website_snippet_filter.py
+++ b/addons/website_blog/models/website_snippet_filter.py
@@ -3,7 +3,7 @@
 
 from datetime import timedelta
 
-from odoo import models, fields, _
+from odoo import models, fields, api, _
 
 
 class WebsiteSnippetFilter(models.Model):
@@ -55,3 +55,10 @@ class WebsiteSnippetFilter(models.Model):
                 # merge definitions
             samples = merged
         return samples
+
+    @api.model
+    def default_get(self, fields):
+        defaults = super().default_get(fields)
+        if 'field_names' in defaults and self.env.context.get('model') == 'blog.post':
+            defaults['field_names'] = 'name,teaser,subtitle'
+        return defaults

--- a/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
+++ b/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
@@ -1,5 +1,5 @@
 .s_dynamic {
-    &.s_blog_posts {
+    &.s_dynamic_snippet_blog_posts {
         --Avatar-size: 1.5em;
     }
 
@@ -15,14 +15,9 @@
         @include o-line-clamp(2);
     }
 
-    &.s_blog_post_list {
-        .s_blog_posts_post_author + small.s_blog_posts_post_date::before {
-            content: "•";
-            margin: 0 map-get($spacers, 1);
-        }
-
-        .s_blog_posts_post:hover {
-            background-color: color-mix(in srgb, currentColor 10%, transparent);
+    &.s_blog_post_list:not(:has(.s_dynamic_snippet_title_aside)){
+        .s_dynamic_snippet_content {
+            margin-top: map-get($spacers, 4);
         }
     }
 

--- a/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
+++ b/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
@@ -218,4 +218,11 @@
             --aspect-ratio: 100%;
         }
     }
+
+    // Solo templates
+    &.s_blog_post_single_circle {
+        .o_record_cover_container {
+            max-width: 12.5rem;
+        }
+    }
 }

--- a/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
+++ b/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
@@ -225,4 +225,8 @@
             max-width: 12.5rem;
         }
     }
+
+    &.s_blog_post_single_badge .s_cta_badge:hover {
+        box-shadow: $box-shadow-sm;
+    }
 }

--- a/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.js
+++ b/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.js
@@ -56,4 +56,16 @@ export class DynamicSnippetBlogPostsOption extends BaseOptionComponent {
             "website_blog.dynamic_filter_template_blog_post_single_badge",
         ].includes(this.templateKeyState.templateKey);
     }
+    showNewTagOption() {
+        return (
+            this.templateKeyState.templateKey ===
+            "website_blog.dynamic_filter_template_blog_post_single_badge"
+        );
+    }
+    showHoverEffectOption() {
+        return (
+            this.templateKeyState.templateKey ===
+            "website_blog.dynamic_filter_template_blog_post_big_picture"
+        );
+    }
 }

--- a/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.js
+++ b/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.js
@@ -40,6 +40,20 @@ export class DynamicSnippetBlogPostsOption extends BaseOptionComponent {
             "website_blog.dynamic_filter_template_blog_post_list",
             "website_blog.dynamic_filter_template_blog_post_horizontal",
             "website_blog.dynamic_filter_template_blog_post_card",
+            "website_blog.dynamic_filter_template_blog_post_single_full",
+            "website_blog.dynamic_filter_template_blog_post_single_aside",
+            "website_blog.dynamic_filter_template_blog_post_single_circle",
+        ].includes(this.templateKeyState.templateKey);
+    }
+    showCategoryOption() {
+        return [
+            "website_blog.dynamic_filter_template_blog_post_list",
+            "website_blog.dynamic_filter_template_blog_post_horizontal",
+            "website_blog.dynamic_filter_template_blog_post_card",
+            "website_blog.dynamic_filter_template_blog_post_single_full",
+            "website_blog.dynamic_filter_template_blog_post_single_aside",
+            "website_blog.dynamic_filter_template_blog_post_single_circle",
+            "website_blog.dynamic_filter_template_blog_post_single_badge",
         ].includes(this.templateKeyState.templateKey);
     }
 }

--- a/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.xml
+++ b/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.xml
@@ -38,8 +38,11 @@
         <BuilderRow label.translate="Category" preview="false" t-if="!!showCategoryOption()">
             <BuilderCheckbox id="'category_opt'" action="'customizeTemplate'" actionParam="'blog_posts_post_category_active'"/>
         </BuilderRow>
+        <BuilderRow label.translate="New Tag" preview="false" t-if="!!showNewTagOption()">
+            <BuilderCheckbox id="'new_opt'" action="'customizeTemplate'" actionParam="'blog_posts_post_new_active'"/>
+        </BuilderRow>
         <!-- TODO noWidgetRefresh="true" => refreshInteraction="false" ? -->
-        <BuilderRow label.translate="Hover Effect" t-if="templateKeyState.templateKey === 'website_blog.dynamic_filter_template_blog_post_big_picture'">
+        <BuilderRow label.translate="Hover Effect" t-if="!!showHoverEffectOption()">
             <BuilderSelect>
                 <BuilderSelectItem classAction="''">None</BuilderSelectItem>
                 <BuilderSelectItem classAction="'s_blog_posts_effect_marley'">Marley</BuilderSelectItem>

--- a/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.xml
+++ b/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
+<t t-inherit="website.DynamicSnippetOption" t-inherit-mode="extension">
+    <xpath expr="//BuilderSelect[@id=&quot;'model_opt'&quot;]" position="inside">
+        <BuilderSelectItem actionParam="'blog.post'">Blog Posts</BuilderSelectItem>
+    </xpath>
+</t>
+
 <t t-name="website_blog.DynamicSnippetBlogPostsOption" t-inherit="website.DynamicSnippetOption">
     <xpath expr="//BuilderRow[*[@id=&quot;'filter_opt'&quot;]]" position="after">
-        <BuilderRow label.translate="Blog">
+        <BuilderRow label.translate="Blog" t-if="!isSingleMode">
             <BuilderSelect dataAttributeAction="'filterByBlogId'" preview="false">
                 <BuilderSelectItem dataAttributeActionValue="'-1'">All blogs</BuilderSelectItem>
                 <t t-foreach="blogState.blogs" t-as="blog" t-key="blog.id">
@@ -14,23 +20,26 @@
     </xpath>
     <xpath expr="//BuilderRow[*[@id=&quot;'template_opt'&quot;]]" position="after">
         <!-- TODO noWidgetRefresh="true" => refreshInteraction="false" ? -->
-        <BuilderRow label.translate="Picture Size" level="1" preview="false" t-if="showPictureSizeOption()">
+        <BuilderRow label.translate="Picture Size" preview="false" t-if="showPictureSizeOption()">
             <BuilderButtonGroup id="'picture_size_opt'">
                 <BuilderButton label.translate="Smaller" title.translate="Smaller picture" classAction="'s_blog_posts_post_picture_size_small'"/>
                 <BuilderButton label.translate="Normal" title.translate="Normal picture" classAction="'s_blog_posts_post_picture_size_default'"/>
             </BuilderButtonGroup>
         </BuilderRow>
-        <BuilderRow label.translate="Author" level="1" preview="false">
+        <BuilderRow label.translate="Author" preview="false">
             <BuilderCheckbox id="'author_opt'" action="'customizeTemplate'" actionParam="'blog_posts_post_author_active'"/>
         </BuilderRow>
-        <BuilderRow label.translate="Teaser" level="1" preview="false" t-if="!!showTeaserOption()">
+        <BuilderRow label.translate="Teaser" preview="false" t-if="!!showTeaserOption()">
             <BuilderCheckbox id="'teaser_opt'" action="'customizeTemplate'" actionParam="'blog_posts_post_teaser_active'"/>
         </BuilderRow>
-        <BuilderRow label.translate="Date" level="1" preview="false" t-if="!!showDateOption()">
+        <BuilderRow label.translate="Date" preview="false" t-if="!!showDateOption()">
             <BuilderCheckbox id="'date_opt'" action="'customizeTemplate'" actionParam="'blog_posts_post_date_active'"/>
         </BuilderRow>
+        <BuilderRow label.translate="Category" preview="false" t-if="!!showCategoryOption()">
+            <BuilderCheckbox id="'category_opt'" action="'customizeTemplate'" actionParam="'blog_posts_post_category_active'"/>
+        </BuilderRow>
         <!-- TODO noWidgetRefresh="true" => refreshInteraction="false" ? -->
-        <BuilderRow label.translate="Hover Effect" level="1" t-if="templateKeyState.templateKey === 'website_blog.dynamic_filter_template_blog_post_big_picture'">
+        <BuilderRow label.translate="Hover Effect" t-if="templateKeyState.templateKey === 'website_blog.dynamic_filter_template_blog_post_big_picture'">
             <BuilderSelect>
                 <BuilderSelectItem classAction="''">None</BuilderSelectItem>
                 <BuilderSelectItem classAction="'s_blog_posts_effect_marley'">Marley</BuilderSelectItem>

--- a/addons/website_blog/static/tests/interactions/snippets/blog_posts.test.js
+++ b/addons/website_blog/static/tests/interactions/snippets/blog_posts.test.js
@@ -45,7 +45,7 @@ test("dynamic snippet blog posts loads items and displays them through template"
     });
     const { core } = await startInteractions(`
       <div id="wrapwrap">
-          <section data-snippet="s_blog_posts" class="s_blog_posts s_dynamic_snippet_blog_posts s_blog_post_big_picture s_blog_posts_effect_marley s_blog_posts_post_picture_size_default s_dynamic s_dynamic_empty pt32 pb32 o_colored_level"
+          <section data-snippet="s_blog_posts" class="s_blog_posts s_dynamic_snippet_blog_posts s_blog_post_big_picture s_blog_posts_effect_marley s_blog_posts_post_picture_size_default s_dynamic pt32 pb32 o_colored_level"
                   data-custom-template-data="{&quot;blog_posts_post_author_active&quot;:true, &quot;blog_posts_post_teaser_active&quot;:true, &quot;blog_posts_post_date_active&quot;:true}"
                   data-name="Blog Posts"
                   data-filter-by-blog-id="1"

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -183,6 +183,29 @@
 <!-- Single record templates -->
 <!-- Full Layout -->
 <template id="dynamic_filter_template_blog_post_single_full" name="Solo Full">
+    <t t-if="len(records)" class="s_blog_posts_post" data-extra-snippet-classes="o_cc o_cc5" data-column-classes="col-lg-12">
+        <t t-set="data" t-value="records[0]"/>
+        <t t-set="record" t-value="data['_record']"/>
+        <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>
+        <div>
+            <a class="display-3-fs text-reset" t-att-title="'Read ' + record.name" t-att-href="data['call_to_action_url']" t-field="record.name"/>
+            <div class="d-flex flex-wrap my-3">
+                <span class="w-100 w-sm-auto">
+                    <t t-call="website_blog.s_dynamic_snippet_template_author"/>
+                </span>
+                <span class="d-none d-sm-inline text-muted mx-0 mx-sm-2" t-if="blog_posts_post_date_active and blog_posts_post_author_active">•</span>
+                <t t-call="website_blog.s_dynamic_snippet_template_date"/>
+                <span class="text-muted mx-2" t-if="blog_posts_post_category_active and (blog_posts_post_date_active or blog_posts_post_author_active)">•</span>
+                <t t-call="website_blog.s_dynamic_snippet_template_category"/>
+            </div>
+            <a class="text-reset" t-att-title="'Read ' + record.name" t-att-href="data['call_to_action_url']">
+                <t t-call="website_blog.s_dynamic_snippet_template_teaser">
+                    <t t-set="teaser_custom_class" t-value="'lead h4-fs'"/>
+                </t>
+            </a>
+            <a class="btn btn-primary d-lg-none w-100 w-sm-auto mt-4" t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']">Read Now <i class="fa fa-long-arrow-right" role="presentation"/></a>
+        </div>
+    </t>
 </template>
 <!-- Aside Layout -->
 <template id="dynamic_filter_template_blog_post_single_aside" name="Solo Aside">

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -6,7 +6,7 @@
         <t t-set="snippet_name" t-value="'s_blog_posts'"/>
         <t t-set="main_page_url" t-value="'/blog'"/>
         <t t-set="snippet_classes" t-value="'s_dynamic_snippet_blog_posts %s' % snippet_extra_classes"/>
-        <t t-set="custom_template_data" t-valuef='{"blog_posts_post_author_active":true, "blog_posts_post_teaser_active":true, "blog_posts_post_date_active":true, "blog_posts_post_category_active":true}'/>
+        <t t-set="custom_template_data" t-valuef='{"blog_posts_post_author_active":true, "blog_posts_post_teaser_active":true, "blog_posts_post_date_active":true, "blog_posts_post_category_active":true, "blog_posts_post_new_active":true}'/>
         <t t-out="0"/>
     </t>
 </template>
@@ -271,6 +271,26 @@
 </template>
 <!-- CTA Badge Layout -->
 <template id="dynamic_filter_template_blog_post_single_badge" name="Solo Badge">
+    <t t-if="len(records)" class="s_blog_posts_post" data-column-classes="col-lg-12 text-center">
+        <t t-set="data" t-value="records[0]"/>
+        <t t-set="record" t-value="data['_record']"/>
+        <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>
+        <div class="text-center">
+            <a t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']">
+                <span class="s_cta_badge o_cc o_cc1 d-inline-flex align-items-center justify-content-center flex-wrap gap-3 my-3 border rounded py-2 px-3 text-break" style="border-radius: 32px !important;" data-snippet="s_cta_badge">
+                    <span class="badge text-bg-primary" t-if="blog_posts_post_new_active">NEW</span>
+                    <strong class="text-nowrap" t-field="record.name"/>
+                    <span>
+                        <span class="text-muted" t-field="record.author_id.name" t-if="blog_posts_post_author_active"/>
+                        <span class="text-muted" t-if="blog_posts_post_category_active">
+                            in <span t-field="record.blog_id.name"/>
+                        </span>
+                    </span>
+                    <span class="text-primary text-nowrap">Read Now <i class="fa fa-long-arrow-right"/></span>
+                </span>
+            </a>
+        </div>
+    </t>
 </template>
 
 <!-- Blog Post Author (optional) -->

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -4,23 +4,83 @@
 <template id="s_blog_posts" name="Blog Posts">
     <t t-call="website.s_dynamic_snippet_template">
         <t t-set="snippet_name" t-value="'s_blog_posts'"/>
-        <t t-set="snippet_classes" t-value="'s_dynamic_snippet_blog_posts s_blog_post_big_picture s_blog_posts_effect_marley s_blog_posts_post_picture_size_default'"/>
         <t t-set="main_page_url" t-value="'/blog'"/>
-        <t t-set="custom_template_data" t-valuef='{"blog_posts_post_author_active":true, "blog_posts_post_teaser_active":true, "blog_posts_post_date_active":true}'/>
+        <t t-set="snippet_classes" t-value="'s_dynamic_snippet_blog_posts %s' % snippet_extra_classes"/>
+        <t t-set="custom_template_data" t-valuef='{"blog_posts_post_author_active":true, "blog_posts_post_teaser_active":true, "blog_posts_post_date_active":true, "blog_posts_post_category_active":true}'/>
+        <t t-out="0"/>
+    </t>
+</template>
+<!-- Multi record snippets -->
+<template id="s_blog_posts_big_picture" name="Blog Posts Big Picture">
+    <t t-set="snippet_extra_classes" t-value="'s_blog_post_big_picture s_blog_posts_effect_marley s_blog_posts_post_picture_size_default'"/>
+    <t t-call="website_blog.s_blog_posts">
         <t t-call="website_blog.s_dynamic_snippet_blog_posts_preview_data"/>
     </t>
 </template>
+<template id="s_blog_posts_card" name="Blog Posts Card">
+    <t t-set="snippet_extra_classes" t-value="'s_blog_post_card s_blog_posts_post_picture_size_default'"/>
+    <t t-call="website_blog.s_blog_posts">
+        <t t-call="website_blog.s_dynamic_snippet_blog_posts_card_preview_data"/>
+    </t>
+</template>
+<template id="s_blog_posts_horizontal" name="Blog Posts Horizontal">
+    <t t-set="snippet_extra_classes" t-value="'s_blog_post_horizontal s_blog_posts_post_picture_size_default'"/>
+    <t t-call="website_blog.s_blog_posts">
+        <t t-call="website_blog.s_dynamic_snippet_blog_posts_horizontal_preview_data"/>
+    </t>
+</template>
+<template id="s_blog_posts_list" name="Blog Posts List">
+    <t t-set="snippet_extra_classes" t-value="'s_blog_post_list'"/>
+    <t t-call="website_blog.s_blog_posts">
+        <t t-call="website_blog.s_dynamic_snippet_blog_posts_list_preview_data"/>
+    </t>
+</template>
+<!-- Single record snippets -->
+<template id="s_blog_posts_single_aside" name="Single Blog Post Aside">
+    <t t-set="is_single_record" t-value="True"/>
+    <t t-set="snippet_extra_classes" t-value="'s_blog_post_single_aside'"/>
+    <t t-call="website_blog.s_blog_posts">
+        <t t-call="website_blog.s_dynamic_snippet_blog_posts_single_aside_preview_data"/>
+    </t>
+</template>
+<template id="s_blog_posts_single_full" name="Single Blog Post Full">
+    <t t-set="is_single_record" t-value="True"/>
+    <t t-set="snippet_extra_classes" t-value="'s_blog_post_single_full o_cc o_cc5'"/>
+    <t t-call="website_blog.s_blog_posts">
+        <t t-call="website_blog.s_dynamic_snippet_blog_posts_single_full_preview_data"/>
+    </t>
+</template>
+<template id="s_blog_posts_single_circle" name="Single Blog Post Circle">
+    <t t-set="is_single_record" t-value="True"/>
+    <t t-set="snippet_extra_classes" t-value="'s_blog_post_single_circle o_cc o_cc2'"/>
+    <t t-set="container_classes" t-value="'o_container_small'"/>
+    <t t-call="website_blog.s_blog_posts">
+        <t t-call="website_blog.s_dynamic_snippet_blog_posts_single_circle_preview_data"/>
+    </t>
+</template>
+<template id="s_blog_posts_single_badge" name="Single Blog Post Badge">
+    <t t-set="is_single_record" t-value="True"/>
+    <t t-set="snippet_extra_classes" t-value="'s_blog_post_single_badge'"/>
+    <t t-call="website_blog.s_blog_posts">
+        <t t-call="website_blog.s_dynamic_snippet_blog_posts_single_badge_preview_data"/>
+    </t>
+</template>
 
-<!-- Load-time templates (rendered in JS on page load) -->
+<!-- Multi record "Load-time" templates (rendered in JS on page load) -->
 <!-- List layout -->
 <template id="dynamic_filter_template_blog_post_list" name="List">
-    <div t-foreach="records" t-as="data" class="s_blog_posts_post border-0 rounded-3 p-3" data-extra-classes="g-3" data-column-classes="col-12 col-sm-6 col-lg-4">
+    <div t-foreach="records" t-as="data" class="s_blog_posts_post border-0 rounded-3" data-extra-classes="g-4" data-column-classes="col-12 col-sm-6 col-lg-4">
         <t t-set="record" t-value="data['_record']"/>
-        <a class="text-decoration-none text-reset" t-att-title="'Read ' + data['name']" t-att-href="data['call_to_action_url']">
-            <div class="d-flex align-items-center small">
+        <div class="d-flex flex-wrap mb-2 small">
+            <span class="w-100 w-sm-auto">
                 <t t-call="website_blog.s_dynamic_snippet_template_author"/>
-                <t t-call="website_blog.s_dynamic_snippet_template_date"/>
-            </div>
+            </span>
+            <span class="d-none d-sm-inline text-muted mx-0 mx-sm-2" t-if="blog_posts_post_date_active and blog_posts_post_author_active">•</span>
+            <t t-call="website_blog.s_dynamic_snippet_template_date"/>
+            <span class="text-muted mx-2" t-if="blog_posts_post_category_active and (blog_posts_post_date_active or blog_posts_post_author_active)">•</span>
+            <t t-call="website_blog.s_dynamic_snippet_template_category"/>
+        </div>
+        <a class="text-reset" t-att-title="'Read ' + data['name']" t-att-href="data['call_to_action_url']">
             <h4 class="mt-2">
                 <span t-if="is_sample" class="bg-primary text-uppercase">Sample</span>
                 <span t-field="record.name"/>
@@ -31,7 +91,7 @@
 </template>
 <!-- Big picture layout -->
 <template id="dynamic_filter_template_blog_post_big_picture" name="Big picture">
-    <div t-foreach="records" t-as="data" class="s_blog_posts_post position-relative w-100" data-extra-classes="g-3" data-column-classes="col-12 col-sm-6 col-lg-4">
+    <div t-foreach="records" t-as="data" class="s_blog_posts_post position-relative w-100" data-extra-classes="g-3" data-column-classes="col-12 col-sm-6 col-lg-4" data-extra-snippet-classes="s_blog_posts_effect_marley s_blog_posts_post_picture_size_default">
         <t t-set="record" t-value="data['_record']"/>
         <a class="s_blog_posts_post_cover position-relative d-block h-100 rounded shadow-sm overflow-hidden text-decoration-none text-reset ratio ratio-1x1" t-att-title="'Read ' + data['name']" t-att-href="data['call_to_action_url']">
             <t t-call="website.record_cover">
@@ -78,7 +138,7 @@
                     </a>
                     <div class="d-flex justify-content-between small">
                         <t t-call="website_blog.s_dynamic_snippet_template_author"/>
-                        <span class="text-muted">In <a class="fw-bold" t-field="record.blog_id.name" t-att-href="'/blog/%s' % record.blog_id.id" />
+                        <span class="text-muted" t-if="blog_posts_post_category_active">In <t t-call="website_blog.s_dynamic_snippet_template_category"/>
                             <a t-if="is_sample" class="fw-bold" href="#">Sample</a>
                         </span>
                     </div>
@@ -108,7 +168,7 @@
             </a>
             <div class="card-footer d-flex justify-content-between mt-auto border-0 p-3 pt-0 bg-transparent small">
                 <t t-call="website_blog.s_dynamic_snippet_template_author"/>
-                <span class="text-muted">In <a class="fw-bold" t-field="record.blog_id.name" t-att-href="'/blog/%s' % record.blog_id.id" />
+                <span class="text-muted" t-if="blog_posts_post_category_active">In <t t-call="website_blog.s_dynamic_snippet_template_category"/>
                     <a t-if="is_sample" class="fw-bold" href="#">Sample</a>
                 </span>
             </div>
@@ -116,10 +176,24 @@
     </div>
 </template>
 
+<!-- Single record templates -->
+<!-- Full Layout -->
+<template id="dynamic_filter_template_blog_post_single_full" name="Solo Full">
+</template>
+<!-- Aside Layout -->
+<template id="dynamic_filter_template_blog_post_single_aside" name="Solo Aside">
+</template>
+<!-- Circle Layout -->
+<template id="dynamic_filter_template_blog_post_single_circle" name="Solo Circle">
+</template>
+<!-- CTA Badge Layout -->
+<template id="dynamic_filter_template_blog_post_single_badge" name="Solo Badge">
+</template>
+
 <!-- Blog Post Author (optional) -->
 <template id="website_blog.s_dynamic_snippet_template_author" name="Blog Post Author">
     <div t-if="blog_posts_post_author_active" class="s_blog_posts_post_author d-inline-flex align-items-center">
-        <img class="o_avatar me-2 rounded-pill" t-attf-src="data:image/png;base64,{{record.author_avatar}}"/>
+        <img class="o_avatar me-2 rounded-pill" t-attf-src="data:image/png;base64,{{record.author_avatar}}" t-if="record.author_avatar"/>
         <span t-field="record.author_name"/>
     </div>
 </template>
@@ -132,6 +206,12 @@
 <!-- Blog Post Date (optional for Card, Horizontal and List layouts) -->
 <template id="website_blog.s_dynamic_snippet_template_date" name="Blog Post Date">
     <small t-if="blog_posts_post_date_active" class="s_blog_posts_post_date text-muted" t-field="record.post_date" t-options='{"format": "MMM d, yyyy"}' />
+</template>
+
+<!-- Blog Post Category (optional) -->
+<template id="website_blog.s_dynamic_snippet_template_category" name="Blog Post Category">
+    <a t-if="blog_posts_post_category_active" t-attf-class="s_blog_posts_post_category {{ category_custom_class }}" t-field="record.blog_id.name" t-att-href="'/blog/%s' % record.blog_id.id" />
+    <a t-if="is_sample" href="#">Sample</a>
 </template>
 
 <!-- Options -->

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -209,6 +209,35 @@
 </template>
 <!-- Aside Layout -->
 <template id="dynamic_filter_template_blog_post_single_aside" name="Solo Aside">
+    <t t-if="len(records)" class="s_blog_posts_post" data-column-classes="col-lg-12">
+        <t t-set="data" t-value="records[0]"/>
+        <t t-set="record" t-value="data['_record']"/>
+        <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>
+        <div class="s_dynamic_snippet_content_position row">
+            <div class="col-lg-7 order-2 order-lg-1 align-content-center">
+                <h2 t-field="record.name"/>
+                <div class="d-flex flex-wrap mb-2">
+                    <span class="w-100 w-sm-auto">
+                        <t t-call="website_blog.s_dynamic_snippet_template_author"/>
+                    </span>
+                    <span class="d-none d-sm-inline text-muted mx-0 mx-sm-2" t-if="blog_posts_post_date_active and blog_posts_post_author_active">•</span>
+                    <t t-call="website_blog.s_dynamic_snippet_template_date"/>
+                    <span class="text-muted mx-2" t-if="blog_posts_post_category_active and (blog_posts_post_date_active or blog_posts_post_author_active)">•</span>
+                    <t t-call="website_blog.s_dynamic_snippet_template_category"/>
+                </div>
+                <t t-call="website_blog.s_dynamic_snippet_template_teaser">
+                    <t t-set="teaser_custom_class" t-value="'lead'"/>
+                </t>
+                <a class="btn btn-primary" t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']">Read Now <i class="fa fa-long-arrow-right" role="presentation"/></a>
+            </div>
+            <div class="col-lg-5 order-1 order-lg-2 h-auto mb-4 mb-lg-0">
+                <t t-call="website.record_cover">
+                    <t t-set="_record" t-value="record"/>
+                    <t t-set="additionnal_classes" t-value="'ratio ratio-16x9 rounded overflow-hidden'"/>
+                </t>
+            </div>
+        </div>
+    </t>
 </template>
 <!-- Circle Layout -->
 <template id="dynamic_filter_template_blog_post_single_circle" name="Solo Circle">

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -241,6 +241,33 @@
 </template>
 <!-- Circle Layout -->
 <template id="dynamic_filter_template_blog_post_single_circle" name="Solo Circle">
+    <t t-if="len(records)" class="s_blog_posts_post" data-extra-snippet-classes="o_cc o_cc2" data-column-classes="col-lg-12" data-container-classes="o_container_small">
+        <t t-set="data" t-value="records[0]"/>
+        <t t-set="record" t-value="data['_record']"/>
+        <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>
+        <div class="row">
+            <div class="col-12 col-sm-5 mb-3 mb-lg-0">
+                <t t-call="website.record_cover">
+                    <t t-set="_record" t-value="record"/>
+                    <t t-set="additionnal_classes" t-value="'h-auto mx-auto me-sm-0 rounded-circle overflow-hidden ratio ratio-1x1'"/>
+                </t>
+            </div>
+            <div class="col-12 col-sm-7 align-content-center">
+                <h2 t-field="record.name"/>
+                <div class="d-flex flex-wrap mb-2">
+                    <span class="w-100 w-sm-auto">
+                        <t t-call="website_blog.s_dynamic_snippet_template_author"/>
+                    </span>
+                    <span class="d-none d-sm-inline text-muted mx-0 mx-sm-2" t-if="blog_posts_post_date_active and blog_posts_post_author_active">•</span>
+                    <t t-call="website_blog.s_dynamic_snippet_template_date"/>
+                    <span class="text-muted mx-2" t-if="blog_posts_post_category_active and (blog_posts_post_date_active or blog_posts_post_author_active)">•</span>
+                    <t t-call="website_blog.s_dynamic_snippet_template_category"/>
+                </div>
+                <p class="lead" t-field="record.subtitle"/>
+                <a class="btn btn-primary w-100 w-sm-auto" t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']">Read Now <i class="fa fa-long-arrow-right" role="presentation"/></a>
+            </div>
+        </div>
+    </t>
 </template>
 <!-- CTA Badge Layout -->
 <template id="dynamic_filter_template_blog_post_single_badge" name="Solo Badge">

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -133,7 +133,9 @@
                     <a class="mb-2 mb-md-5 text-decoration-none text-reset" t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']">
                         <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                         <h4 class="mb-2 mt-0" t-field="record.name"/>
-                        <t t-call="website_blog.s_dynamic_snippet_template_date"/>
+                        <t t-call="website_blog.s_dynamic_snippet_template_date">
+                            <t t-set="date_custom_class" t-value="'small'"/>
+                        </t>
                         <p class="s_blog_posts_post_subtitle mt-1 mb-0 lead overflow-hidden" t-field="record.subtitle"/>
                     </a>
                     <div class="d-flex justify-content-between small">
@@ -162,7 +164,9 @@
                 <div class="card-body">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <h5 class="text-truncate" t-field="record.name"/>
-                    <t t-call="website_blog.s_dynamic_snippet_template_date"/>
+                    <t t-call="website_blog.s_dynamic_snippet_template_date">
+                        <t t-set="date_custom_class" t-value="'small'"/>
+                    </t>
                     <t t-call="website_blog.s_dynamic_snippet_template_teaser"/>
                 </div>
             </a>
@@ -194,18 +198,18 @@
 <template id="website_blog.s_dynamic_snippet_template_author" name="Blog Post Author">
     <div t-if="blog_posts_post_author_active" class="s_blog_posts_post_author d-inline-flex align-items-center">
         <img class="o_avatar me-2 rounded-pill" t-attf-src="data:image/png;base64,{{record.author_avatar}}" t-if="record.author_avatar"/>
-        <span t-field="record.author_name"/>
+        <span t-field="record.author_id.name"/>
     </div>
 </template>
 
 <!-- Blog Post Teaser (optional for Card and List layouts) -->
 <template id="website_blog.s_dynamic_snippet_template_teaser" name="Blog Post Teaser">
-    <p t-if="blog_posts_post_teaser_active" class="s_blog_posts_post_teaser my-1 overflow-hidden" t-field="record.teaser"/>
+    <p t-if="blog_posts_post_teaser_active" t-attf-class="s_blog_posts_post_teaser overflow-hidden {{ teaser_custom_class }}" t-field="record.teaser"/>
 </template>
 
 <!-- Blog Post Date (optional for Card, Horizontal and List layouts) -->
 <template id="website_blog.s_dynamic_snippet_template_date" name="Blog Post Date">
-    <small t-if="blog_posts_post_date_active" class="s_blog_posts_post_date text-muted" t-field="record.post_date" t-options='{"format": "MMM d, yyyy"}' />
+    <span t-if="blog_posts_post_date_active" t-attf-class="s_blog_posts_post_date text-muted {{ date_custom_class }}" t-field="record.post_date" t-options='{"format": "MMM d, yyyy"}' />
 </template>
 
 <!-- Blog Post Category (optional) -->

--- a/addons/website_blog/views/snippets/s_dynamic_snippet_blog_posts_preview_data.xml
+++ b/addons/website_blog/views/snippets/s_dynamic_snippet_blog_posts_preview_data.xml
@@ -272,9 +272,16 @@
             </div>
         </div>
     </template>
-    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
     <template id="s_dynamic_snippet_blog_posts_single_badge_preview_data" name="Single Blog Preview Data">
-        <div class="s_dialog_preview row my-4">
+        <div class="s_dialog_preview my-4">
+            <div class="text-center">
+                <span class="o_cc o_cc1 d-inline-flex align-items-center justify-content-center gap-3 border rounded py-2 px-3 rounded-pill">
+                    <span class="badge text-bg-primary">NEW</span>
+                    <strong>Sierra Tarahumara</strong>
+                    <span class="text-muted">Marc Demo in Travel</span>
+                    <span class="text-primary">Read Now <i class="fa fa-long-arrow-right" role="presentation"/></span>
+                </span>
+            </div>
         </div>
     </template>
 </odoo>

--- a/addons/website_blog/views/snippets/s_dynamic_snippet_blog_posts_preview_data.xml
+++ b/addons/website_blog/views/snippets/s_dynamic_snippet_blog_posts_preview_data.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <!-- Multi record preview -->
     <template id="s_dynamic_snippet_blog_posts_preview_data" name="Blogs Preview Data">
-        <div class="s_dialog_preview row my-4">
+        <div class="s_dialog_preview row">
             <div class="col-12 col-sm-6 col-lg-4">
                 <div class="s_blog_posts_post position-relative w-100">
                     <a class="s_blog_posts_post_cover position-relative d-block h-100 rounded shadow-sm overflow-hidden text-decoration-none text-reset ratio ratio-1x1" href="#">
@@ -46,6 +47,211 @@
                     </a>
                 </div>
             </div>
+        </div>
+    </template>
+    <template id="s_dynamic_snippet_blog_posts_card_preview_data" name="Blogs Preview Data">
+        <div class="s_dialog_preview row">
+            <div class="col-3">
+                <div class="card h-100">
+                    <div class="card-img-top ratio ratio-16x9">
+                        <img class="img img-fluid object-fit-cover" src="/website_blog/static/src/img/blog_previews/blog_1.jpg"/>
+                    </div>
+                    <div class="card-body">
+                        <h5 class="mb-2 mt-0">Sierra Tarahumara</h5>
+                        <small class="text-muted">Mar 13, 2025</small>
+                        <p>Sierra Tarahumara, popularly known as Copper Canyon is situated in Mexico. The area is a favorite destination among those...</p>
+                    </div>
+                    <div class="card-footer d-flex justify-content-between mt-auto border-0 p-3 pt-0 bg-transparent small">
+                        <span><i class="fa fa-user-circle-o me-2" role="presentation"/> Marc Demo</span>
+                        <span class="text-muted">In <a href="#">Travel</a></span>
+                    </div>
+                </div>
+            </div>
+            <div class="col-3">
+                <div class="card h-100">
+                    <div class="card-img-top ratio ratio-16x9">
+                        <img class="img img-fluid object-fit-cover" src="/website_blog/static/src/img/blog_previews/blog_2.jpg"/>
+                    </div>
+                    <div class="card-body">
+                        <h5 class="mb-2 mt-0">How to choose the right hotel</h5>
+                        <small class="text-muted">Mar 13, 2025</small>
+                        <p>So you're going abroad, you've chosen your destination and now you have to choose a hotel. Ten years ago, you'd have...</p>
+                    </div>
+                    <div class="card-footer d-flex justify-content-between mt-auto border-0 p-3 pt-0 bg-transparent small">
+                        <span><i class="fa fa-user-circle-o me-2" role="presentation"/> Marc Demo</span>
+                        <span class="text-muted">In <a href="#">Travel</a></span>
+                    </div>
+                </div>
+            </div>
+            <div class="col-3">
+                <div class="card h-100">
+                    <div class="card-img-top ratio ratio-16x9">
+                        <img class="img img-fluid object-fit-cover" src="/website_blog/static/src/img/blog_previews/blog_3.jpg"/>
+                    </div>
+                    <div class="card-body">
+                        <h5 class="mb-2 mt-0">Maui helicopter tours</h5>
+                        <small class="text-muted">Mar 13, 2025</small>
+                        <p>Maui helicopter tours are a great way to see the island from a different perspective and have a fun adventure...</p>
+                    </div>
+                    <div class="card-footer d-flex justify-content-between mt-auto border-0 p-3 pt-0 bg-transparent small">
+                        <span><i class="fa fa-user-circle-o me-2" role="presentation"/> Marc Demo</span>
+                        <span class="text-muted">In <a href="#">Travel</a></span>
+                    </div>
+                </div>
+            </div>
+            <div class="col-3">
+                <div class="card h-100">
+                    <div class="card-img-top ratio ratio-16x9">
+                        <img class="img img-fluid object-fit-cover" src="/website_blog/static/src/img/cover_6.jpg"/>
+                    </div>
+                    <div class="card-body">
+                        <h5 class="mb-2 mt-0">Buying A Telescope</h5>
+                        <small class="text-muted">Mar 13, 2025</small>
+                        <p>Buying the right telescope to take your love of astronomy to the next level is a big next step in the development...</p>
+                    </div>
+                    <div class="card-footer d-flex justify-content-between mt-auto border-0 p-3 pt-0 bg-transparent small">
+                        <span><i class="fa fa-user-circle-o me-2" role="presentation"/> Marc Demo</span>
+                        <span class="text-muted">In <a href="#">Astronomy</a></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </template>
+    <template id="s_dynamic_snippet_blog_posts_horizontal_preview_data" name="Blogs Preview Data">
+        <div class="s_dialog_preview">
+            <div t-attf-class="pb-4 border-bottom">
+                <div class="row">
+                    <div class="col-3">
+                        <div class="rounded overflow-hidden ratio ratio-16x9">
+                            <img class="img img-fluid object-fit-cover" src="/website_blog/static/src/img/blog_previews/blog_1.jpg"/>
+                        </div>
+                    </div>
+                    <div class="col-9 d-flex flex-column justify-content-between">
+                        <div>
+                            <h4 class="mb-2 mt-0">Sierra Tarahumara</h4>
+                            <span class="text-muted">Mar 13, 2025</span>
+                            <p class="mt-1 mb-0 lead">An exciting mix of relaxation, culture, history, wildlife and hiking.</p>
+                        </div>
+                        <div class="d-flex justify-content-between small">
+                            <span><i class="fa fa-user-circle-o me-2" role="presentation"/> Marc Demo</span>
+                            <span class="text-muted">In <a href="#">Travel</a></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div t-attf-class="py-4 border-bottom">
+                <div class="row">
+                    <div class="col-3">
+                        <div class="rounded overflow-hidden ratio ratio-16x9">
+                            <img class="img img-fluid object-fit-cover" src="/website_blog/static/src/img/blog_previews/blog_2.jpg"/>
+                        </div>
+                    </div>
+                    <div class="col-9 d-flex flex-column justify-content-between">
+                        <div>
+                            <h4 class="mb-2 mt-0">How to choose the right hotel</h4>
+                            <span class="text-muted">Mar 13, 2025</span>
+                            <p class="mt-1 mb-0 lead">Facts you should bear in mind.</p>
+                        </div>
+                        <div class="d-flex justify-content-between small">
+                            <span><i class="fa fa-user-circle-o me-2" role="presentation"/> Marc Demo</span>
+                            <span class="text-muted">In <a href="#">Travel</a></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div t-attf-class="pt-4">
+                <div class="row">
+                    <div class="col-3">
+                        <div class="rounded overflow-hidden ratio ratio-16x9">
+                            <img class="img img-fluid object-fit-cover" src="/website_blog/static/src/img/blog_previews/blog_3.jpg"/>
+                        </div>
+                    </div>
+                    <div class="col-9 d-flex flex-column justify-content-between">
+                        <div>
+                            <h4 class="mb-2 mt-0">Maui helicopter tours</h4>
+                            <span class="text-muted">Mar 13, 2025</span>
+                            <p class="mt-1 mb-0 lead">A great way to discover hidden places</p>
+                        </div>
+                        <div class="d-flex justify-content-between small">
+                            <span><i class="fa fa-user-circle-o me-2" role="presentation"/> Marc Demo</span>
+                            <span class="text-muted">In <a href="#">Travel</a></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </template>
+    <template id="s_dynamic_snippet_blog_posts_list_preview_data" name="Blogs Preview Data">
+        <div class="s_dialog_preview row row-cols-3 g-4">
+            <div class="col">
+                <div class="d-flex align-items-center small">
+                    <span><i class="fa fa-user-circle-o me-2" role="presentation"/>Marc Demo</span>
+                    <span class="text-muted"> • Mar 13, 2025</span>
+                </div>
+                <h4 class="mt-2">Sierra Tarahumara</h4>
+                <p>Sierra Tarahumara, popularly known as Copper Canyon is situated in Mexico. The area is a favorite destination among those seeking an adventurous vacation. Copper Canyon is one of the six gorges...</p>
+            </div>
+            <div class="col">
+                <div class="d-flex align-items-center small">
+                    <span><i class="fa fa-user-circle-o me-2" role="presentation"/>Marc Demo</span>
+                    <span class="text-muted"> • Mar 13, 2025</span>
+                </div>
+                <h4 class="mt-2">How to choose the right hotel</h4>
+                <p>So you're going abroad, you've chosen your destination and now you have to choose a hotel. Ten years ago, you'd have probably visited your local travel agent and trusted the face-to-face advice...</p>
+            </div>
+            <div class="col">
+                <div class="d-flex align-items-center small">
+                    <span><i class="fa fa-user-circle-o me-2" role="presentation"/>Marc Demo</span>
+                    <span class="text-muted"> • Mar 13, 2025</span>
+                </div>
+                <h4 class="mt-2">Maui helicopter tours</h4>
+                <p>Maui helicopter tours are a great way to see the island from a different perspective and have a fun adventure. If you have never been on a helicopter before, this is a great place to do it.</p>
+            </div>
+            <div class="col">
+                <div class="d-flex align-items-center small">
+                    <span><i class="fa fa-user-circle-o me-2" role="presentation"/>Marc Demo</span>
+                    <span class="text-muted"> • Mar 13, 2025</span>
+                </div>
+                <h4 class="mt-2">Buying A Telescope</h4>
+                <p>Buying the right telescope to take your love of astronomy to the next level is a big next step in the development of your passion for the stars. In many ways, it is a big step from someone...</p>
+            </div>
+            <div class="col">
+                <div class="d-flex align-items-center small">
+                    <span><i class="fa fa-user-circle-o me-2" role="presentation"/>Marc Demo</span>
+                    <span class="text-muted"> • Mar 13, 2025</span>
+                </div>
+                <h4 class="mt-2">How To Look Up</h4>
+                <p>It is safe to say that at some point on our lives, each and every one of us has that moment when we are suddenly stunned when we come face to face with the enormity of the universe that we...</p>
+            </div>
+            <div class="col">
+                <div class="d-flex align-items-center small">
+                    <span><i class="fa fa-user-circle-o me-2" role="presentation"/>Marc Demo</span>
+                    <span class="text-muted"> • Mar 13, 2025</span>
+                </div>
+                <h4 class="mt-2">Beyond The Eye</h4>
+                <p>For many of us, our very first experience of learning about the celestial bodies begins when we saw our first full moon in the sky. It is truly a magnificent view even to the naked eye....</p>
+            </div>
+        </div>
+    </template>
+
+    <!-- Single record preview -->
+    <template id="s_dynamic_snippet_blog_posts_single_aside_preview_data" name="Single Blog Preview Data">
+        <div class="s_dialog_preview row my-4">
+        </div>
+    </template>
+    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
+    <template id="s_dynamic_snippet_blog_posts_single_full_preview_data" name="Single Blog Preview Data">
+        <div class="s_dialog_preview row my-4">
+        </div>
+    </template>
+    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
+    <template id="s_dynamic_snippet_blog_posts_single_circle_preview_data" name="Single Blog Preview Data">
+        <div class="s_dialog_preview row my-4">
+        </div>
+    </template>
+    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
+    <template id="s_dynamic_snippet_blog_posts_single_badge_preview_data" name="Single Blog Preview Data">
+        <div class="s_dialog_preview row my-4">
         </div>
     </template>
 </odoo>

--- a/addons/website_blog/views/snippets/s_dynamic_snippet_blog_posts_preview_data.xml
+++ b/addons/website_blog/views/snippets/s_dynamic_snippet_blog_posts_preview_data.xml
@@ -235,8 +235,11 @@
     </template>
 
     <!-- Single record preview -->
-    <template id="s_dynamic_snippet_blog_posts_single_aside_preview_data" name="Single Blog Preview Data">
-        <div class="s_dialog_preview row my-4">
+    <template id="s_dynamic_snippet_blog_posts_single_full_preview_data" name="Single Blog Preview Data">
+        <div class="s_dialog_preview">
+            <h2 class="display-3-fs">How to choose the right hotel</h2>
+            <span class="d-block my-3 text-muted"><i class="fa fa-user-circle-o me-2" role="presentation"/><span>Marc Demo</span> • <span>Mar 13, 2025</span> • <a href="#">Travel</a></span>
+            <p class="lead h4-fs">So you're going abroad, you've chosen your destination and now you have to choose a hotel. Ten years ago, you'd have probably visited your local travel agent and trusted the face-to-face advice you we...</p>
         </div>
     </template>
     <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->

--- a/addons/website_blog/views/snippets/s_dynamic_snippet_blog_posts_preview_data.xml
+++ b/addons/website_blog/views/snippets/s_dynamic_snippet_blog_posts_preview_data.xml
@@ -242,9 +242,19 @@
             <p class="lead h4-fs">So you're going abroad, you've chosen your destination and now you have to choose a hotel. Ten years ago, you'd have probably visited your local travel agent and trusted the face-to-face advice you we...</p>
         </div>
     </template>
-    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
-    <template id="s_dynamic_snippet_blog_posts_single_full_preview_data" name="Single Blog Preview Data">
+    <template id="s_dynamic_snippet_blog_posts_single_aside_preview_data" name="Single Blog Preview Data">
         <div class="s_dialog_preview row my-4">
+            <div class="col-lg-7 pe-5 align-content-center">
+                <h2>Sierra Tarahumara</h2>
+                <span class="d-block my-2 text-muted"><i class="fa fa-user-circle-o me-2" role="presentation"/><span>Marc Demo</span> • <span>Mar 13, 2025</span> • <a href="#">Travel</a></span>
+                <p class="lead">Sierra Tarahumara, popularly known as Copper Canyon is situated in Mexico. The area is a favorite destination among those seeking an adventurous vacation. Copper Canyon is one of the six gorges in the...</p>
+                <a class="btn btn-primary" href="#">Read Now <i class="fa fa-long-arrow-right ms-2" role="presentation"/></a>
+            </div>
+            <div class="col-lg-5">
+                <div class="ratio ratio-16x9">
+                    <div class="rounded" style="background-image: url('/website_blog/static/src/img/blog_previews/blog_1.jpg'); background-size: cover;"></div>
+                </div>
+            </div>
         </div>
     </template>
     <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->

--- a/addons/website_blog/views/snippets/s_dynamic_snippet_blog_posts_preview_data.xml
+++ b/addons/website_blog/views/snippets/s_dynamic_snippet_blog_posts_preview_data.xml
@@ -257,9 +257,19 @@
             </div>
         </div>
     </template>
-    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
     <template id="s_dynamic_snippet_blog_posts_single_circle_preview_data" name="Single Blog Preview Data">
         <div class="s_dialog_preview row my-4">
+            <div class="col-4">
+                <div class="rounded-circle overflow-hidden ratio ratio-1x1" style="background-image: url('/website_blog/static/src/img/blog_previews/blog_2.jpg'); background-size: cover;"/>
+            </div>
+            <div class="col-8">
+                <h2>How to choose the right hotel</h2>
+                <div class="mb-2">
+                    <span class="text-muted"><i class="fa fa-user-circle-o me-2" role="presentation"/><span>Marc Demo</span> • <span>Mar 13, 2025</span> • <a href="#">Travel</a></span>
+                </div>
+                <p class="lead">Facts you should bear in mind.</p>
+                <a class="btn btn-primary" href="#">Read Now <i class="fa fa-long-arrow-right" role="presentation"/></a>
+            </div>
         </div>
     </template>
     <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->

--- a/addons/website_blog/views/snippets/snippets.xml
+++ b/addons/website_blog/views/snippets/snippets.xml
@@ -7,7 +7,14 @@
             t-thumbnail="/website/static/src/img/snippets_thumbs/s_blog_posts.svg"/>
     </xpath>
     <xpath expr="//t[@id='blog_posts_hook']" position="replace">
-        <t t-snippet="website_blog.s_blog_posts" string="Blog Posts" group="blogs"/>
+        <t t-snippet="website_blog.s_blog_posts_big_picture" string="Blog Posts" group="blogs"/>
+        <t t-snippet="website_blog.s_blog_posts_card" string="Blog Posts" group="blogs"/>
+        <t t-snippet="website_blog.s_blog_posts_horizontal" string="Blog Posts" group="blogs"/>
+        <t t-snippet="website_blog.s_blog_posts_list" string="Blog Posts" group="blogs"/>
+        <t t-snippet="website_blog.s_blog_posts_single_aside" string="Blog Post" group="blogs"/>
+        <t t-snippet="website_blog.s_blog_posts_single_full" string="Blog Post" group="blogs"/>
+        <t t-snippet="website_blog.s_blog_posts_single_circle" string="Blog Post" group="blogs"/>
+        <t t-snippet="website_blog.s_blog_posts_single_badge" string="Blog Post" group="blogs"/>
     </xpath>
 </template>
 

--- a/addons/website_event/models/website_snippet_filter.py
+++ b/addons/website_event/models/website_snippet_filter.py
@@ -3,7 +3,7 @@
 
 from datetime import timedelta
 
-from odoo import models, fields, _
+from odoo import models, fields, api, _
 
 
 class WebsiteSnippetFilter(models.Model):
@@ -49,3 +49,10 @@ class WebsiteSnippetFilter(models.Model):
                 # merge definitions
             samples = merged
         return samples
+
+    @api.model
+    def default_get(self, fields):
+        defaults = super().default_get(fields)
+        if 'field_names' in defaults and self.env.context.get('model') == 'event.event':
+            defaults['field_names'] = 'name,subtitle'
+        return defaults

--- a/addons/website_event/static/src/snippets/s_events/000.scss
+++ b/addons/website_event/static/src/snippets/s_events/000.scss
@@ -20,7 +20,7 @@
         }
     }
 
-    &.s_event_event_card {
+    &.s_event_event_card, &.s_event_event_single_offset {
         .card {
             .s_events_event_cover {
                 height: 180px;

--- a/addons/website_event/static/src/snippets/s_events/000.scss
+++ b/addons/website_event/static/src/snippets/s_events/000.scss
@@ -47,4 +47,11 @@
             }
         }
     }
+
+    // Solo templates
+    @include media-breakpoint-up(lg) {
+        &.s_event_event_single_offset .position-lg-absolute {
+            transform: translate(-50%, -50%);
+        }
+    }
 }

--- a/addons/website_event/static/src/snippets/s_events/000.scss
+++ b/addons/website_event/static/src/snippets/s_events/000.scss
@@ -54,4 +54,14 @@
             transform: translate(-50%, -50%);
         }
     }
+
+    &.s_event_event_single_badge .s_cta_badge {
+        img {
+            height: var(--body-font-size);
+        }
+
+        &:hover {
+            box-shadow: $box-shadow-sm;
+        }
+    }
 }

--- a/addons/website_event/static/src/website_builder/dynamic_snippet_events_option.xml
+++ b/addons/website_event/static/src/website_builder/dynamic_snippet_events_option.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
+<t t-inherit="website.DynamicSnippetOption" t-inherit-mode="extension">
+    <xpath expr="//BuilderSelect[@id=&quot;'model_opt'&quot;]" position="inside">
+        <BuilderSelectItem actionParam="'event.event'">Events</BuilderSelectItem>
+    </xpath>
+</t>
+
 <t t-name="website_event.DynamicSnippetEventsOption" t-inherit="website.DynamicSnippetOption">
     <xpath expr="//BuilderRow[*[@id=&quot;'filter_opt'&quot;]]" position="after">
     <div/>
-        <BuilderRow label.translate="Event Tags" preview="false">
+        <BuilderRow label.translate="Event Tags" preview="false" t-if="!isSingleMode">
             <BuilderMany2Many id="'event_tag_opt'" model="'event.tag'" limit="10"
                 dataAttributeAction="'filterByTagIds'"
                 fields="['category_id']"

--- a/addons/website_event/static/src/website_builder/dynamic_snippet_events_option.xml
+++ b/addons/website_event/static/src/website_builder/dynamic_snippet_events_option.xml
@@ -25,6 +25,9 @@
         <BuilderRow label.translate="Show time" preview="false">
             <BuilderCheckbox id="'time_opt'" action="'customizeTemplate'" actionParam="'events_event_time_active'"/>
         </BuilderRow>
+        <BuilderRow label.translate="Show location" preview="false">
+            <BuilderCheckbox id="'location_opt'" action="'customizeTemplate'" actionParam="'events_event_location_active'"/>
+        </BuilderRow>
     </xpath>
 </t>
 </templates>

--- a/addons/website_event/static/tests/interactions/snippets/events.test.js
+++ b/addons/website_event/static/tests/interactions/snippets/events.test.js
@@ -45,7 +45,7 @@ test("dynamic snippet loads items and displays them through template", async () 
     });
     const { core } = await startInteractions(`
       <div id="wrapwrap">
-          <section data-snippet="s_events" class="s_events s_event_upcoming_snippet s_event_event_picture s_dynamic s_dynamic_empty pt32 pb32 o_colored_level"
+          <section data-snippet="s_events" class="s_events s_event_upcoming_snippet s_event_event_picture s_dynamic pt32 pb32 o_colored_level"
                   data-custom-template-data="{&quot;events_event_time_active&quot;:true}"
                   data-name="Events"
                   data-filter-id="1"

--- a/addons/website_event/views/snippets/s_event_upcoming_snippet_preview_data.xml
+++ b/addons/website_event/views/snippets/s_event_upcoming_snippet_preview_data.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="s_event_upcoming_snippet_preview_data" name="Events Preview Data">
-        <div class="s_dialog_preview row my-4">
+    <!-- Multi record preview -->
+    <template id="s_event_upcoming_snippet_preview_data" name="Events Picture Preview Data">
+        <div class="s_dialog_preview row">
             <div class="col-12 col-sm-6 col-lg-4">
                 <div class="s_events_event w-100">
                     <a class="s_events_event_cover position-relative d-flex align-items-center rounded overflow-hidden text-decoration-none ratio ratio-1x1" href="#">
@@ -62,6 +63,121 @@
                     </a>
                 </div>
             </div>
+        </div>
+    </template>
+    <template id="s_event_upcoming_snippet_card_preview_data" name="Events Card Preview Data">
+        <div class="s_dialog_preview row">
+            <div class="col-3">
+                <div class="card h-100">
+                    <div class="card-img-top position-relative">
+                        <div class="ratio ratio-16x9">
+                            <img class="img img-fluid object-fit-cover" src="/website_event/static/src/img/event_previews/event_1.jpg"/>
+                        </div>
+                        <div class="position-absolute top-0 end-0 me-3 mt-3 p-3 rounded-circle bg-white shadow-sm text-center text-dark" style="width: 5rem; height: 5rem;">
+                            <span class="fw-bold text-uppercase">AUG</span>
+                            <span class="fw-light lh-1">23</span>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <strong>8:15 PM</strong>
+                        <h5 class="mb-2 mt-0">Innovations in Technology and Society</h5>
+                        <p class="text-muted">Shaping tomorrow through ideas that transform how we live today.</p>
+                    </div>
+                    <div class="card-footer mt-auto border-0 p-3 pt-0 bg-transparent">
+                        <strong>Los Angeles, CA, United States</strong>
+                    </div>
+                </div>
+            </div>
+            <div class="col-3">
+                <div class="card h-100">
+                    <div class="card-img-top position-relative">
+                        <div class="ratio ratio-16x9">
+                            <img class="img img-fluid object-fit-cover" src="/website_event/static/src/img/event_previews/event_2.jpg"/>
+                        </div>
+                        <div class="position-absolute top-0 end-0 me-3 mt-3 p-3 rounded-circle bg-white shadow-sm text-center text-dark" style="width: 5rem; height: 5rem;">
+                            <span class="fw-bold text-uppercase">AUG</span>
+                            <span class="fw-light lh-1">23</span>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <strong>8:15 PM</strong>
+                        <h5 class="mb-2 mt-0">Harmony Under the Stars</h5>
+                        <p class="text-muted">Melancholic melodies and textured soundscapes exploring memory and quiet distance.</p>
+                    </div>
+                    <div class="card-footer mt-auto border-0 p-3 pt-0 bg-transparent">
+                        <strong>Los Angeles, CA, United States</strong>
+                    </div>
+                </div>
+            </div>
+            <div class="col-3">
+                <div class="card h-100">
+                    <div class="card-img-top position-relative">
+                        <div class="ratio ratio-16x9">
+                            <img class="img img-fluid object-fit-cover" src="/website_event/static/src/img/event_previews/event_3.jpg"/>
+                        </div>
+                        <div class="position-absolute top-0 end-0 me-3 mt-3 p-3 rounded-circle bg-white shadow-sm text-center text-dark" style="width: 5rem; height: 5rem;">
+                            <span class="fw-bold text-uppercase">AUG</span>
+                            <span class="fw-light lh-1">23</span>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <strong>8:15 PM</strong>
+                        <h5 class="mb-2 mt-0">Excellence in Achievement Awards</h5>
+                        <p class="text-muted">Honoring outstanding accomplishments, dedication, and impact across all fields.</p>
+                    </div>
+                    <div class="card-footer mt-auto border-0 p-3 pt-0 bg-transparent">
+                        <strong>Los Angeles, CA, United States</strong>
+                    </div>
+                </div>
+            </div>
+            <div class="col-3">
+                <div class="card h-100">
+                    <div class="card-img-top position-relative">
+                        <div class="ratio ratio-16x9">
+                            <img class="img img-fluid object-fit-cover" src="/website_event/static/src/img/event_cover_2.jpg"/>
+                        </div>
+                        <div class="position-absolute top-0 end-0 me-3 mt-3 p-3 rounded-circle bg-white shadow-sm text-center text-dark" style="width: 5rem; height: 5rem;">
+                            <span class="fw-bold text-uppercase">AUG</span>
+                            <span class="fw-light lh-1">23</span>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <strong>8:15 PM</strong>
+                        <h5 class="mb-2 mt-0">Conference for Architects</h5>
+                        <p class="text-muted">Enhance your architectural business and improve professional skills.</p>
+                    </div>
+                    <div class="card-footer mt-auto border-0 p-3 pt-0 bg-transparent">
+                        <strong>Los Angeles, CA, United States</strong>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <!-- Single record preview -->
+    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
+    <template id="s_dynamic_snippet_events_single_offset_preview_data" name="Single Event Offset Preview Data">
+        <div class="s_dialog_preview row my-4">
+        </div>
+    </template>
+    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
+    <template id="s_dynamic_snippet_events_single_entry_preview_data" name="Single Event Entry Preview Data">
+        <div class="s_dialog_preview row my-4">
+        </div>
+    </template>
+    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
+    <template id="s_dynamic_snippet_events_single_card_preview_data" name="Single Event Card Preview Data">
+        <div class="s_dialog_preview row my-4">
+        </div>
+    </template>
+    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
+    <template id="s_dynamic_snippet_events_single_badge_preview_data" name="Single Event Badge Preview Data">
+        <div class="s_dialog_preview row my-4">
+        </div>
+    </template>
+    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
+    <template id="s_dynamic_snippet_events_single_aside_preview_data" name="Single Event Aside Preview Data">
+        <div class="s_dialog_preview row my-4">
         </div>
     </template>
 </odoo>

--- a/addons/website_event/views/snippets/s_event_upcoming_snippet_preview_data.xml
+++ b/addons/website_event/views/snippets/s_event_upcoming_snippet_preview_data.xml
@@ -244,9 +244,28 @@
             </div>
         </div>
     </template>
-    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
     <template id="s_dynamic_snippet_events_single_aside_preview_data" name="Single Event Aside Preview Data">
         <div class="s_dialog_preview row my-4">
+            <div class="col-lg-6 pe-5 align-content-center">
+                <h2>Innovations in Technology and Society</h2>
+                <p class="lead">Shaping tomorrow through ideas that transform how we live today.</p>
+                <a class="btn btn-primary" href="#">Register <i class="fa fa-long-arrow-right ms-2" role="presentation"/></a>
+                <div class="d-flex gap-5 mt-5">
+                    <div>
+                        <p class="text-muted">Date</p>
+                        <span><i class="fa fa-calendar me-2" role="presentation"/>August 23, 2025 at 8:15 PM</span>
+                    </div>
+                    <div>
+                        <p class="text-muted">Location</p>
+                        <span><i class="fa fa-map-marker me-2" role="presentation"/>Los Angeles, CA, United States</span>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-6">
+                <div class="ratio ratio-16x9">
+                    <div class="rounded" style="background-image: url('/website_event/static/src/img/event_previews/event_1.jpg'); background-size: cover;"></div>
+                </div>
+            </div>
         </div>
     </template>
 </odoo>

--- a/addons/website_event/views/snippets/s_event_upcoming_snippet_preview_data.xml
+++ b/addons/website_event/views/snippets/s_event_upcoming_snippet_preview_data.xml
@@ -208,9 +208,28 @@
             </div>
         </div>
     </template>
-    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
     <template id="s_dynamic_snippet_events_single_card_preview_data" name="Single Event Card Preview Data">
-        <div class="s_dialog_preview row my-4">
+        <div class="s_dialog_preview my-4">
+            <div class="w-100 rounded" style="background-image: url('/website_event/static/src/img/event_previews/event_2.jpg'); background-size: cover; background-position: center;">
+                <div class="position-absolute w-100 h-100 rounded bg-black-50"/>
+                <div class="position-relative d-flex align-items-center justify-content-between flex-wrap w-100 h-100 p-4 p-lg-5">
+                    <div class="text-white">
+                        <h2>Excellence in Achievement Awards</h2>
+                        <p class="lead">Honoring outstanding accomplishments, dedication, and impact across all fields.</p>
+                    </div>
+                    <div class="card o_cc o_cc1 border-0 shadow">
+                        <div class="card-body p-4">
+                            <strong>Date</strong>
+                            <p><i class="fa fa-calendar me-2" role="presentation"/>August 23, 2025</p>
+                            <strong>Time</strong>
+                            <p><i class="fa fa-clock-o me-2" role="presentation"/>8:15 PM</p>
+                            <strong>Location</strong>
+                            <p><i class="fa fa-map-marker me-2" role="presentation"/>Los Los Angeles, CA, United States</p>
+                            <a href="#" class="btn btn-primary w-100">Register<i class="fa fa-long-arrow-right ms-2" role="presentation"/></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </template>
     <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->

--- a/addons/website_event/views/snippets/s_event_upcoming_snippet_preview_data.xml
+++ b/addons/website_event/views/snippets/s_event_upcoming_snippet_preview_data.xml
@@ -155,9 +155,33 @@
     </template>
 
     <!-- Single record preview -->
-    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
     <template id="s_dynamic_snippet_events_single_offset_preview_data" name="Single Event Offset Preview Data">
-        <div class="s_dialog_preview row my-4">
+        <div class="s_dialog_preview my-4">
+            <div class="w-100 rounded" style="background-image: url('/website_event/static/src/img/event_previews/event_1.jpg'); background-size: cover; background-position: center;">
+                <div class="position-absolute w-100 h-100 rounded bg-black-50"/>
+                <div class="position-relative p-5 text-white">
+                    <div class="py-5">
+                        <h2>Innovations in Technology and Society</h2>
+                        <p class="lead">Shaping tomorrow through ideas that transform how we live today.</p>
+                    </div>
+                    <div class="o_cc o_cc5 position-absolute top-100 start-50 w-75 d-flex gap-5 mx-0 px-4 py-3 rounded" style="transform: translate(-50%, -50%);">
+                        <div class="me-5">
+                            <p class="mb-2 fw-bold">Time</p>
+                            <span><i class="fa fa-clock-o me-2" role="presentation"/>8:15 PM</span>
+                        </div>
+                        <div>
+                            <p class="mb-2 fw-bold">Location</p>
+                            <span><i class="fa fa-map-marker me-2" role="presentation"/>Los Angeles, CA, United States</span>
+                        </div>
+                        <div class="d-flex align-items-center justify-content-end ms-auto">
+                            <p class="h4-fs mb-0 me-3 pe-3">August 23, 2025</p>
+                            <div class="ps-3 border-start">
+                                <a href="#" class="btn btn-primary">Register</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </template>
     <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->

--- a/addons/website_event/views/snippets/s_event_upcoming_snippet_preview_data.xml
+++ b/addons/website_event/views/snippets/s_event_upcoming_snippet_preview_data.xml
@@ -232,9 +232,16 @@
             </div>
         </div>
     </template>
-    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
     <template id="s_dynamic_snippet_events_single_badge_preview_data" name="Single Event Badge Preview Data">
-        <div class="s_dialog_preview row my-4">
+        <div class="s_dialog_preview my-4">
+            <div class="text-center">
+                <span class="o_cc o_cc1 d-inline-flex align-items-center justify-content-center gap-3 border rounded py-2 px-3 rounded-pill">
+                    <i class="fa fa-calendar" role="presentation"/>
+                    <strong>Harmony Under the Stars</strong>
+                    <span class="text-muted">August 23, 2025 - 8:15 PM</span>
+                    <span class="text-primary">Register <i class="fa fa-long-arrow-right" role="presentation"/></span>
+                </span>
+            </div>
         </div>
     </template>
     <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->

--- a/addons/website_event/views/snippets/s_event_upcoming_snippet_preview_data.xml
+++ b/addons/website_event/views/snippets/s_event_upcoming_snippet_preview_data.xml
@@ -184,9 +184,28 @@
             </div>
         </div>
     </template>
-    <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->
     <template id="s_dynamic_snippet_events_single_entry_preview_data" name="Single Event Entry Preview Data">
-        <div class="s_dialog_preview row my-4">
+        <div class="s_dialog_preview my-4">
+            <div class="w-100 rounded" style="background-image: url('/website_event/static/src/img/event_previews/event_3.jpg'); background-size: cover; background-position: center;">
+                <div class="position-absolute w-100 h-100 rounded bg-black-50"/>
+                <div class="position-relative d-flex flex-column gap-5 w-100 h-100 p-4 p-lg-5 text-white">
+                    <div class="d-flex gap-5">
+                        <div class="flex-grow-1">
+                            <h2>Harmony Under the Stars</h2>
+                            <p class="lead">Melancholic melodies and textured soundscapes exploring memory and quiet distance.</p>
+                        </div>
+                        <div>
+                            <p class="h3-fs text-nowrap">August 23, 2025 at 8:15 PM</p>
+                        </div>
+                    </div>
+                    <div class="d-flex align-items-center gap-5 mt-auto">
+                        <div class="flex-grow-1">
+                            <a href="#" class="btn btn-lg btn-primary">Register Now</a>
+                        </div>
+                        <span class="fs-5"><i class="fa fa-map-marker me-2" role="presentation"/>Los Angeles, CA, United States</span>
+                    </div>
+                </div>
+            </div>
         </div>
     </template>
     <!-- TODO: This template is a placeholder. It will be updated later to match the final single record design. -->

--- a/addons/website_event/views/snippets/s_events.xml
+++ b/addons/website_event/views/snippets/s_events.xml
@@ -35,6 +35,7 @@
 <template id="s_events_single_entry" name="Single Event Entry">
     <t t-set="is_single_record" t-value="True"/>
     <t t-set="snippet_extra_classes" t-value="'s_event_event_single_entry'"/>
+    <t t-set="content_classes" t-value="'o_cc o_cc5 bg-transparent'"/>
     <t t-call="website_event.s_events">
         <t t-call="website_event.s_dynamic_snippet_events_single_entry_preview_data"/>
     </t>
@@ -171,6 +172,36 @@
 </template>
 <!-- Entry Layout -->
 <template id="dynamic_filter_template_event_event_single_entry" name="Solo Entry">
+    <t t-if="len(records)" class="s_events_event" data-column-classes="col-lg-12" data-content-classes="o_cc o_cc5 bg-transparent">
+        <t t-set="data" t-value="records[0]"/>
+        <t t-set="record" t-value="data['_record']"/>
+        <t t-set="bg" t-value="record._get_background()"/>
+        <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>
+        <div class="w-100 rounded" t-att-style="'background-image: ' + bg + '; background-size: cover; background-position: center;'">
+            <div class="position-absolute w-100 h-100 rounded bg-black-50"/>
+            <div class="position-relative d-flex flex-column gap-5 w-100 h-100 p-4 p-lg-5">
+                <div class="d-flex flex-column flex-lg-row gap-lg-5">
+                    <div class="flex-grow-1 order-1 order-lg-0">
+                        <h2 t-field="record.name"/>
+                        <p class="lead" t-field="record.subtitle"/>
+                    </div>
+                    <p class="h3-fs text-end">
+                        <span class="" t-out="record.date_begin" t-options="{'widget': 'datetime', 'date_only': 'true', 'format': 'long', 'tz_name': record.date_tz}"/>
+                        <span class="text-nowrap" t-if="events_event_time_active">at <span t-out="record.date_begin" t-options="{'widget': 'datetime', 'time_only': 'true', 'format': 'short', 'tz_name': record.date_tz}"/></span>
+                    </p>
+                </div>
+                <div class="d-flex flex-column flex-md-row align-items-md-center gap-3 gap-md-5">
+                    <div class="flex-grow-1 order-1 order-md-0">
+                        <a t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']" class="btn btn-lg btn-primary w-100 w-lg-auto text-nowrap">Register Now</a>
+                    </div>
+                    <div t-if="events_event_location_active" class="d-flex align-items-center fs-5">
+                        <i class="fa fa-map-marker me-2" role="img"/>
+                        <span t-field="record.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true', 'null_text': 'Online event'}"/>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
 </template>
 <!-- Card Layout -->
 <template id="dynamic_filter_template_event_event_single_card" name="Solo Card">

--- a/addons/website_event/views/snippets/s_events.xml
+++ b/addons/website_event/views/snippets/s_events.xml
@@ -268,6 +268,38 @@
 </template>
 <!-- Aside Layout -->
 <template id="dynamic_filter_template_event_event_single_aside" name="Solo Aside">
+    <t t-if="len(records)" class="s_events_event" data-column-classes="col-lg-12">
+        <t t-set="data" t-value="records[0]"/>
+        <t t-set="record" t-value="data['_record']"/>
+        <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>
+        <div class="s_dynamic_snippet_content_position row">
+            <div class="col-12 col-lg-6 d-flex d-lg-block flex-column align-content-center align-items-start order-2 order-lg-1">
+                <h2 t-field="record.name"/>
+                <p class="lead" t-field="record.subtitle"/>
+                <a class="btn btn-primary w-100 w-sm-auto mt-4 mt-lg-0 order-last order-lg-auto" t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']">Register Now <i class="fa fa-long-arrow-right" role="presentation"/></a>
+                <div class="d-flex flex-wrap mt-lg-5">
+                    <div class="me-5 mb-3">
+                        <p class="text-muted">Date</p>
+                        <span><i class="fa fa-calendar me-2" role="img"/><span t-out="record.date_begin" t-options="{'widget': 'datetime', 'date_only': 'true', 'format': 'long', 'tz_name': record.date_tz}"/></span>
+                        <span t-if="events_event_time_active">at <span t-out="record.date_begin" t-options="{'widget': 'datetime', 'time_only': 'true', 'format': 'short', 'tz_name': record.date_tz}"/></span>
+                    </div>
+                    <div t-if="events_event_location_active">
+                        <p class="text-muted">Location</p>
+                        <div class="d-flex align-items-center">
+                            <i class="fa fa-map-marker me-2" role="img"/>
+                            <span t-field="record.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true', 'null_text': 'Online event'}"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-lg-6 order-1 order-lg-2 h-auto mb-4 mb-lg-0">
+                <t t-call="website.record_cover">
+                    <t t-set="_record" t-value="record"/>
+                    <t t-set="additionnal_classes" t-value="'ratio ratio-16x9 rounded overflow-hidden'"/>
+                </t>
+            </div>
+        </div>
+    </t>
 </template>
 
 <!--SNIPPET OPTIONS -->

--- a/addons/website_event/views/snippets/s_events.xml
+++ b/addons/website_event/views/snippets/s_events.xml
@@ -6,7 +6,7 @@
         <t t-set="snippet_name" t-value="'s_events'"/>
         <t t-set="snippet_classes" t-value="'s_event_upcoming_snippet %s' % snippet_extra_classes"/>
         <t t-set="main_page_url" t-value="'/event'"/>
-        <t t-set="custom_template_data" t-valuef='{"events_event_time_active":true}'/>
+        <t t-set="custom_template_data" t-valuef='{"events_event_time_active":true, "events_event_location_active":true}'/>
         <t t-out="0"/>
     </t>
 </template>
@@ -78,13 +78,14 @@
             <div class="text-center w-100 h-100 px-3 d-flex flex-column justify-content-center flex-grow-1">
                 <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                 <h3 class="text-white" t-field="record.name"/>
-                <time t-att-datetime="record.date_begin" class="text-white">
+                <time t-att-datetime="record.date_begin" class="text-white text-center">
                     <span t-out="record.date_begin"
                           t-options="{'widget': 'datetime', 'date_only': 'true', 'format': 'long', 'tz_name': record.date_tz}"/>
                     <span t-if="events_event_time_active" class="s_events_event_time">
                         - <span t-out="record.date_begin" t-options="{'widget': 'datetime', 'time_only': 'true', 'format': 'short', 'tz_name': record.date_tz}"/>
                         (<span t-out="record.date_tz.replace('_', ' ')"/>)
                     </span>
+                    <div class="d-flex justify-content-center" t-if="events_event_location_active" t-field="record.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true'}"/>
                 </time>
             </div>
         </a>
@@ -119,7 +120,7 @@
                     <h5 class="text-truncate" t-field="record.name"/>
                     <small class="text-muted" t-field="record.subtitle"/>
                 </div>
-                <div class="mt-2 fw-bold" t-field="record.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true'}"/>
+                <div class="mt-2 fw-bold" t-if="events_event_location_active" t-field="record.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true'}"/>
             </div>
         </a>
     </t>

--- a/addons/website_event/views/snippets/s_events.xml
+++ b/addons/website_event/views/snippets/s_events.xml
@@ -1,18 +1,67 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
-
+<!-- Snippet -->
 <template id="s_events" name="Events">
     <t t-call="website.s_dynamic_snippet_template">
         <t t-set="snippet_name" t-value="'s_events'"/>
-        <t t-set="snippet_classes" t-value="'s_event_upcoming_snippet s_event_event_picture'"/>
+        <t t-set="snippet_classes" t-value="'s_event_upcoming_snippet %s' % snippet_extra_classes"/>
         <t t-set="main_page_url" t-value="'/event'"/>
         <t t-set="custom_template_data" t-valuef='{"events_event_time_active":true}'/>
+        <t t-out="0"/>
+    </t>
+</template>
+<!-- Multi record snippets -->
+<template id="s_events_picture" name="Events Picture">
+    <t t-set="snippet_extra_classes" t-value="'s_event_event_picture'"/>
+    <t t-call="website_event.s_events">
         <t t-call="website_event.s_event_upcoming_snippet_preview_data"/>
     </t>
 </template>
+<template id="s_events_card" name="Events Card">
+    <t t-set="snippet_extra_classes" t-value="'s_event_event_card'"/>
+    <t t-call="website_event.s_events">
+        <t t-call="website_event.s_event_upcoming_snippet_card_preview_data"/>
+    </t>
+</template>
+<!-- Single record snippets -->
+<template id="s_events_single_offset" name="Single Event Offset">
+    <t t-set="is_single_record" t-value="True"/>
+    <t t-set="snippet_extra_classes" t-value="'s_event_event_single_offset'"/>
+    <t t-call="website_event.s_events">
+        <t t-call="website_event.s_dynamic_snippet_events_single_offset_preview_data"/>
+    </t>
+</template>
+<template id="s_events_single_entry" name="Single Event Entry">
+    <t t-set="is_single_record" t-value="True"/>
+    <t t-set="snippet_extra_classes" t-value="'s_event_event_single_entry'"/>
+    <t t-call="website_event.s_events">
+        <t t-call="website_event.s_dynamic_snippet_events_single_entry_preview_data"/>
+    </t>
+</template>
+<template id="s_events_single_card" name="Single Event Card">
+    <t t-set="is_single_record" t-value="True"/>
+    <t t-set="snippet_extra_classes" t-value="'s_event_event_single_card'"/>
+    <t t-call="website_event.s_events">
+        <t t-call="website_event.s_dynamic_snippet_events_single_card_preview_data"/>
+    </t>
+</template>
+<template id="s_events_single_badge" name="Single Event Badge">
+    <t t-set="is_single_record" t-value="True"/>
+    <t t-set="snippet_extra_classes" t-value="'s_event_event_single_badge'"/>
+    <t t-call="website_event.s_events">
+        <t t-call="website_event.s_dynamic_snippet_events_single_badge_preview_data"/>
+    </t>
+</template>
+<template id="s_events_single_aside" name="Single Event Aside">
+    <t t-set="is_single_record" t-value="True"/>
+    <t t-set="snippet_extra_classes" t-value="'s_event_event_single_aside'"/>
+    <t t-call="website_event.s_events">
+        <t t-call="website_event.s_dynamic_snippet_events_single_aside_preview_data"/>
+    </t>
+</template>
 
-<!--TEMPLATES-->
-
+<!-- Multi record templates-->
+<!-- Picture Layout -->
 <template id="dynamic_filter_template_event_event_picture" name="Picture Layout" priority="5">
     <div t-foreach="records" t-as="data" class="s_events_event w-100" data-extra-classes="g-3" data-column-classes="col-12 col-sm-6 col-lg-4">
         <t t-set="record" t-value="data['_record']._set_tz_context()"/>
@@ -41,7 +90,7 @@
         </a>
     </div>
 </template>
-
+<!-- Card Layout -->
 <template id="dynamic_filter_template_event_event_card" name="Card Layout" priority="10">
     <t t-foreach="records" t-as="data" data-extra-classes="g-3" data-column-classes="col-12 col-sm-6 col-lg-4 col-xxl-3">
         <t t-set="record" t-value="data['_record']._set_tz_context()"/>
@@ -74,6 +123,23 @@
             </div>
         </a>
     </t>
+</template>
+
+<!-- Single record templates -->
+<!-- Offset Layout -->
+<template id="dynamic_filter_template_event_event_single_offset" name="Solo Offset">
+</template>
+<!-- Entry Layout -->
+<template id="dynamic_filter_template_event_event_single_entry" name="Solo Entry">
+</template>
+<!-- Card Layout -->
+<template id="dynamic_filter_template_event_event_single_card" name="Solo Card">
+</template>
+<!-- CTA Badge Layout -->
+<template id="dynamic_filter_template_event_event_single_badge" name="Solo Badge">
+</template>
+<!-- Aside Layout -->
+<template id="dynamic_filter_template_event_event_single_aside" name="Solo Aside">
 </template>
 
 <!--SNIPPET OPTIONS -->

--- a/addons/website_event/views/snippets/s_events.xml
+++ b/addons/website_event/views/snippets/s_events.xml
@@ -27,6 +27,7 @@
 <template id="s_events_single_offset" name="Single Event Offset">
     <t t-set="is_single_record" t-value="True"/>
     <t t-set="snippet_extra_classes" t-value="'s_event_event_single_offset'"/>
+    <t t-set="content_classes" t-value="'o_cc o_cc5 bg-transparent'"/>
     <t t-call="website_event.s_events">
         <t t-call="website_event.s_dynamic_snippet_events_single_offset_preview_data"/>
     </t>
@@ -129,6 +130,44 @@
 <!-- Single record templates -->
 <!-- Offset Layout -->
 <template id="dynamic_filter_template_event_event_single_offset" name="Solo Offset">
+    <t t-if="len(records)" class="s_events_event" data-column-classes="col-lg-12" data-content-classes="o_cc o_cc5 bg-transparent">
+        <t t-set="data" t-value="records[0]"/>
+        <t t-set="record" t-value="data['_record']"/>
+        <t t-set="bg" t-value="record._get_background()"/>
+        <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>
+        <div class="w-100 rounded" t-att-style="'background-image: ' + bg + '; background-size: cover; background-position: center;'">
+            <div class="position-absolute w-100 h-100 rounded bg-black-50"/>
+            <div class="position-relative p-4 p-lg-5">
+                <div class="py-lg-5">
+                    <h2 t-field="record.name"/>
+                    <p class="lead" t-field="record.subtitle"/>
+                </div>
+                <div class="o_cc o_cc5 position-lg-absolute top-100 start-50 w-100 d-flex flex-wrap gap-4 w-xl-75 mt-3 mt-lg-0 mx-0 px-4 py-4 py-lg-3 rounded">
+                    <div t-if="events_event_time_active" class="me-lg-5 order-1 order-lg-0">
+                        <p class="mb-2 fw-bold">Time</p>
+                        <span>
+                            <i class="fa fa-clock-o me-2" role="img"/>
+                            <span t-out="record.date_begin" t-options="{'widget': 'datetime', 'time_only': 'true', 'format': 'short', 'tz_name': record.date_tz}"/>
+                        </span>
+                    </div>
+                    <div t-if="events_event_location_active" class="order-1 order-lg-0">
+                        <p class="mb-2 fw-bold">Location</p>
+                        <div class="d-flex align-items-center">
+                            <i class="fa fa-map-marker me-2" role="img"/>
+                            <span t-field="record.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true', 'null_text': 'Online event'}"/>
+                        </div>
+                    </div>
+                    <div class="d-flex flex-wrap align-items-center justify-content-lg-end w-100 w-lg-auto ms-lg-auto order-0">
+                        <p class="h4-fs mb-0 me-3" t-out="record.date_begin" t-options="{'widget': 'datetime', 'date_only': 'true', 'format': 'long', 'tz_name': record.date_tz}"/>
+                        <div class="d-none d-lg-block ps-3 border-start">
+                            <a t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']" class="btn btn-primary">Register</a>
+                        </div>
+                    </div>
+                    <a t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']" class="d-lg-none btn btn-primary w-100 mt-3 order-1">Register</a>
+                </div>
+            </div>
+        </div>
+    </t>
 </template>
 <!-- Entry Layout -->
 <template id="dynamic_filter_template_event_event_single_entry" name="Solo Entry">

--- a/addons/website_event/views/snippets/s_events.xml
+++ b/addons/website_event/views/snippets/s_events.xml
@@ -242,6 +242,29 @@
 </template>
 <!-- CTA Badge Layout -->
 <template id="dynamic_filter_template_event_event_single_badge" name="Solo Badge">
+    <t t-if="len(records)" class="s_events_event" data-column-classes="col-lg-12 text-center">
+        <t t-set="data" t-value="records[0]"/>
+        <t t-set="record" t-value="data['_record']"/>
+        <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>
+        <div class="text-center">
+            <a t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']">
+                <span class="s_cta_badge o_cc o_cc1 d-inline-flex align-items-center justify-content-center flex-wrap gap-3 my-3 border rounded py-2 px-3 text-break" style="border-radius: 32px !important;" data-snippet="s_cta_badge">
+                    <t t-if="events_event_location_active">
+                        <img t-if="record.country_id" t-att-src="record.country_id.image_url"/>
+                        <i t-else="" class="fa fa-calendar text-primary"/>
+                    </t>
+                    <strong class="text-nowrap" t-field="record.name"/>
+                    <span class="text-muted text-nowrap">
+                        <span t-out="record.date_begin" t-options="{'widget': 'datetime', 'date_only': 'true', 'format': 'long', 'tz_name': record.date_tz}"/>
+                        <span t-if="events_event_time_active" class="s_events_event_time">
+                            - <span t-out="record.date_begin" t-options="{'widget': 'datetime', 'time_only': 'true', 'format': 'short', 'tz_name': record.date_tz}"/>
+                        </span>
+                    </span>
+                    <span class="text-primary text-nowrap">Register Now <i class="fa fa-long-arrow-right"/></span>
+                </span>
+            </a>
+        </div>
+    </t>
 </template>
 <!-- Aside Layout -->
 <template id="dynamic_filter_template_event_event_single_aside" name="Solo Aside">

--- a/addons/website_event/views/snippets/s_events.xml
+++ b/addons/website_event/views/snippets/s_events.xml
@@ -43,6 +43,7 @@
 <template id="s_events_single_card" name="Single Event Card">
     <t t-set="is_single_record" t-value="True"/>
     <t t-set="snippet_extra_classes" t-value="'s_event_event_single_card'"/>
+    <t t-set="content_classes" t-value="'o_cc o_cc5 bg-transparent'"/>
     <t t-call="website_event.s_events">
         <t t-call="website_event.s_dynamic_snippet_events_single_card_preview_data"/>
     </t>
@@ -205,6 +206,39 @@
 </template>
 <!-- Card Layout -->
 <template id="dynamic_filter_template_event_event_single_card" name="Solo Card">
+    <t t-if="len(records)" class="s_events_event" data-column-classes="col-lg-12" data-content-classes="o_cc o_cc5 bg-transparent">
+        <t t-set="data" t-value="records[0]"/>
+        <t t-set="record" t-value="data['_record']"/>
+        <t t-set="bg" t-value="record._get_background()"/>
+        <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>
+        <div class="w-100 rounded" t-att-style="'background-image: ' + bg + '; background-size: cover; background-position: center;'">
+            <div class="position-absolute w-100 h-100 rounded bg-black-50"/>
+            <div class="position-relative d-flex align-items-center justify-content-between gap-4 flex-wrap flex-md-nowrap w-100 h-100 p-4 p-lg-5">
+                <div>
+                    <h2 t-field="record.name"/>
+                    <p class="lead" t-field="record.subtitle"/>
+                </div>
+                <div class="s_card card o_cc o_cc1 w-100 w-md-auto border-0 shadow" data-snippet="s_card" data-name="Card" data-vxml="001">
+                    <div class="card-body p-4">
+                        <strong>Date</strong>
+                        <p><i class="fa fa-calendar me-2" role="img"/><span t-out="record.date_begin" t-options="{'widget': 'datetime', 'date_only': 'true', 'format': 'long', 'tz_name': record.date_tz}"/></p>
+                        <div t-if="events_event_time_active" class="s_events_event_time">
+                            <strong>Time</strong>
+                            <p><i class="fa fa-clock-o me-2" role="img"/><span t-out="record.date_begin" t-options="{'widget': 'datetime', 'time_only': 'true', 'format': 'short', 'tz_name': record.date_tz}"/></p>
+                        </div>
+                        <div t-if="events_event_location_active">
+                            <strong>Location</strong>
+                            <div class="d-flex align-items-center mb-2">
+                                <i class="fa fa-map-marker me-2" role="img"/>
+                                <span t-field="record.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true', 'null_text': 'Online event'}"/>
+                            </div>
+                        </div>
+                        <a t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']" class="btn btn-primary w-100"><t t-out="cta_btn_text">Register<i class="fa fa-long-arrow-right ms-2" role="img"/></t></a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
 </template>
 <!-- CTA Badge Layout -->
 <template id="dynamic_filter_template_event_event_single_badge" name="Solo Badge">

--- a/addons/website_event/views/snippets/snippets.xml
+++ b/addons/website_event/views/snippets/snippets.xml
@@ -11,7 +11,13 @@
             t-thumbnail="/website/static/src/img/snippets_thumbs/s_event_upcoming_snippet.svg"/>
     </xpath>
     <xpath expr="//t[@id='event_upcoming_snippet_hook']" position="replace">
-        <t t-snippet="website_event.s_events" string="Events" group="events"/>
+        <t t-snippet="website_event.s_events_picture" string="Events" group="events"/>
+        <t t-snippet="website_event.s_events_card" string="Events" group="events"/>
+        <t t-snippet="website_event.s_events_single_offset" string="Event" group="events"/>
+        <t t-snippet="website_event.s_events_single_entry" string="Event" group="events"/>
+        <t t-snippet="website_event.s_events_single_card" string="Event" group="events"/>
+        <t t-snippet="website_event.s_events_single_badge" string="Event" group="events"/>
+        <t t-snippet="website_event.s_events_single_aside" string="Event" group="events"/>
     </xpath>
 </template>
 

--- a/addons/website_sale/static/src/website_builder/dynamic_snippet_products_option.xml
+++ b/addons/website_sale/static/src/website_builder/dynamic_snippet_products_option.xml
@@ -2,11 +2,16 @@
 <templates xml:space="preserve">
 
 <t t-name="website_sale.DynamicSnippetProductsOption" t-inherit="website.DynamicSnippetCarouselOption">
+    <!-- TODO: The product snippets design will be refactored soon... Hide the template
+     option once the final layouts and previews of the snippets are available. -->
+    <xpath expr="//BuilderRow[*[@id=&quot;'template_opt'&quot;]]" position="attributes">
+        <attribute name="t-if">filteredTemplates.length &gt; 1</attribute>
+    </xpath>
     <xpath expr="//BuilderRow[*[@id=&quot;'filter_opt'&quot;]]" position="after">
 
         <ProductsDesignPanel showLists="false" label.translate="Cards Design"/>
 
-        <BuilderRow label.translate="Category" t-if="!this.domState.isAlternative">
+        <BuilderRow label.translate="Category" t-if="!this.domState.isAlternative and !isSingleMode">
             <BuilderSelect dataAttributeAction="'productCategoryId'" preview="false" id="'product_category_opt'">
                 <BuilderSelectItem dataAttributeActionValue="'all'">All Products</BuilderSelectItem>
                 <BuilderSelectItem dataAttributeActionValue="'current'">Current Category or All</BuilderSelectItem>
@@ -15,7 +20,7 @@
                 </t>
             </BuilderSelect>
         </BuilderRow>
-        <BuilderRow label.translate="Tags" preview="false" t-if="!this.domState.isAlternative">
+        <BuilderRow label.translate="Tags" preview="false" t-if="!this.domState.isAlternative and !isSingleMode">
 	        <BuilderMany2Many id="'product_tag_opt'" model="'product.tag'" limit="10"
 	            dataAttributeAction="'productTagIds'"
 	        />
@@ -27,7 +32,7 @@
         <BuilderRow label.translate="Show variants" preview="false">
             <BuilderCheckbox dataAttributeAction="'showVariants'" dataAttributeActionValue="'true'"/>
         </BuilderRow>
-        <BuilderRow label.translate="Product Names" preview="false" t-if="!this.domState.isAlternative">
+        <BuilderRow label.translate="Product Names" preview="false" t-if="!this.domState.isAlternative and !isSingleMode">
             <BuilderTextInput dataAttributeAction="'productNames'" id="'product_names_opt'"
                 placeholder.translate="e.g. lamp,bin"
                 title.translate="Comma-separated list of parts of product names, barcodes or internal reference"

--- a/addons/website_sale/static/tests/interactions/snippets/dynamic_snippet_products.test.js
+++ b/addons/website_sale/static/tests/interactions/snippets/dynamic_snippet_products.test.js
@@ -68,7 +68,7 @@ test("dynamic snippet products loads items and displays them through template", 
     });
     const { core } = await startInteractions(`
       <div id="wrapwrap">
-          <section data-snippet="s_dynamic_snippet_products" class="s_dynamic_snippet_products s_dynamic s_dynamic_empty pt32 pb32 o_colored_level s_product_product_borderless_1"
+          <section data-snippet="s_dynamic_snippet_products" class="s_dynamic_snippet_products s_dynamic pt32 pb32 o_colored_level s_product_product_borderless_1"
                   data-name="Products"
                   data-filter-id="3"
                   data-product-category-id="current"

--- a/addons/website_sale/views/snippets/s_dynamic_snippet_categories.xml
+++ b/addons/website_sale/views/snippets/s_dynamic_snippet_categories.xml
@@ -5,7 +5,7 @@
         inherit_id="website.s_dynamic_snippet_template"
         primary="True"
     >
-        <xpath expr="//section[hasclass('s_dynamic_snippet_title')]/*" position="replace">
+        <xpath expr="//section[contains(@t-attf-class, 's_dynamic_snippet_title')]/*" position="replace">
             <div>
                 <h2 class="h4">Crafting Beautiful Spaces</h2>
                 <p>Designing elegant, inviting environments that inspire and delight.</p>

--- a/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
+++ b/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <!-- Snippet -->
     <template id="s_dynamic_snippet_products" name="Products">
         <t t-call="website.s_dynamic_snippet_template">
             <t t-set="snippet_name" t-value="'s_dynamic_snippet_products'"/>
@@ -33,6 +34,10 @@
             <t t-call="website_sale.s_dynamic_snippet_products_preview_data"/>
         </t>
     </template>
+    <!-- Multi record snippets (coming soon...) -->
+    <!-- Single record snippets (coming soon...) -->
+
+    <!-- Snippets options -->
     <template id="s_dynamic_snippet_products_options" inherit_id="website.snippet_options">
         <xpath expr="." position="inside">
             <t t-call="website.dynamic_snippet_carousel_options_template">


### PR DESCRIPTION
Currently, dynamic snippets only support filters to display records.
This commit improves the current implementation, and allows users to
select a single record directly in the snippet (which should
automatically switch to the "single record" mode, when the number of
records to fetch is set to "one").

- Generic snippets can switch between models, while specific ones
will limit selection to their related model.

- A loading effect was added while fetching snippet content.

Remarks:

- The single record mode was enabled on "blog" and "event" snippets.
The "appointment"/"product" templates will be added as part of a
separate refactoring.

- This commit also removes the 'Template' option from dynamic snippets.
Instead, the various snippet layouts are now directly accessible from
the snippet selection dialog (For product snippets, this feature will
be enabled right after the snippets design refactoring).

task-4280375

Co-authored-by: Antoine (anso) <anso@odoo.com>