### PR TITLE
[FIX] point_of_sale: add partner valuation move

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -137,6 +137,7 @@ class StockPicking(models.Model):
                         'journal_id': rec.pos_order_id.sale_journal.id,
                         'date': rec.pos_order_id.date_order,
                         'ref': 'pos_order_'+str(rec.pos_order_id.id),
+                        'partner_id': rec.pos_order_id.partner_id.id,
                         'line_ids': [
                             (0, 0, {
                                 'name': rec.pos_order_id.name,


### PR DESCRIPTION
Before this fix it was not possible to reconcile the stock valuation
lines created from PoS as one of them was missing the partner_id

Steps to reproduce:
-------------------
* Activate automatic stock valuation for the `All` category
* Sell a product and ship it later
* Close the session and go to the accounting entries
> Observation: 2 of them are not reconciled, when clicking on reconcile
it was not finding the good one to reconcile with

opw-4395468