### PR TITLE
[FIX] l10n_it_edi: SDI refuses lines with negative quantity

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -10,7 +10,7 @@ from odoo import _, api, Command, fields, models, modules
 from odoo.addons.base.models.ir_qweb_fields import Markup, nl2br, nl2br_enclose
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
 from odoo.exceptions import UserError
-from odoo.tools import float_repr, cleanup_xml_node, float_is_zero
+from odoo.tools import float_compare, float_repr, cleanup_xml_node, float_is_zero
 
 _logger = logging.getLogger(__name__)
 
@@ -477,6 +477,13 @@ class AccountMove(models.Model):
                 if line.price_subtotal < 0 and line._get_downpayment_lines():
                     downpayment_lines.append(base_line)
                     base_lines.remove(base_line)
+
+            if float_compare(quantity, 0, 2) < 0:
+                # Negative quantity is refused by SDI, so we invert quantity and price_unit to keep the price_subtotal
+                base_line.update({
+                    'quantity': -quantity,
+                    'price_unit': -price_unit,
+                })
 
         dispatched_results = self.env['account.tax']._dispatch_negative_lines(base_lines)
         base_lines = dispatched_results['result_lines'] + dispatched_results['orphan_negative_lines'] + downpayment_lines


### PR DESCRIPTION
Lines with negative quantity are refused by SDI.
To avoid this issue, we invert the quantity and price unit in this case.

opw-4402782



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
