### PR TITLE
[FIX] mail,base: avoid creep in tag_quote

### DIFF
--- a/addons/mail/static/src/core/web_portal/message_patch.js
+++ b/addons/mail/static/src/core/web_portal/message_patch.js
@@ -128,7 +128,8 @@ patch(Message.prototype, {
             const index = this.state.lastReadMoreIndex++;
             // Insert link just before the first node
             const readMoreLessEl = document.createElement("a");
-            readMoreLessEl.className = "o-mail-read-more-less d-block";
+            readMoreLessEl.style.display = "block";
+            readMoreLessEl.className = "o-mail-read-more-less";
             readMoreLessEl.href = "#";
             readMoreLessEl.textContent = _t("Read More");
             group[0].parentNode.insertBefore(readMoreLessEl, group[0]);

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -313,6 +313,28 @@ class TestSanitizer(BaseCase):
             for text in in_lst:
                 self.assertIn(text, new_html)
 
+    def test_quote_signature_container_propagation(self):
+        """Test that applying normalization twice doesn't quote more than wanted."""
+        # quote signature with bare signature in main block
+        bare_signature_body = (
+            "<div>"
+            "<div><p>Hello</p><p>Here is your document</p></div>"
+            "<div>--<br>Mark Demo</div>"
+            "<div class=\"bg-300\"></div>"
+            "</div>"
+        )
+        expected_result = (
+            "<div data-o-mail-quote-container=\"1\">"
+            "<div><p>Hello</p><p>Here is your document</p></div>"
+            "<div data-o-mail-quote=\"1\">--<br data-o-mail-quote=\"1\">Mark Demo</div>"
+            "<div class=\"bg-300\" data-o-mail-quote=\"1\"></div>"
+            "</div>"
+        )
+        sanitized_once = html_sanitize(bare_signature_body)
+        sanitized_twice = html_sanitize(sanitized_once)
+        self.assertEqual(sanitized_once, expected_result)
+        self.assertEqual(sanitized_twice, expected_result)
+
     def test_quote_gmail(self):
         html = html_sanitize(test_mail_examples.GMAIL_1)
         for ext in test_mail_examples.GMAIL_1_IN:

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -218,8 +218,18 @@ def tag_quote(el):
         # remove single node
         el.set('data-o-mail-quote-node', '1')
         el.set('data-o-mail-quote', '1')
-    if el.getparent() is not None and (el.getparent().get('data-o-mail-quote') or el.getparent().get('data-o-mail-quote-container')) and not el.getparent().get('data-o-mail-quote-node'):
-        el.set('data-o-mail-quote', '1')
+    if el.getparent() is not None and not el.getparent().get('data-o-mail-quote-node'):
+        if el.getparent().get('data-o-mail-quote'):
+            el.set('data-o-mail-quote', '1')
+        # only quoting the elements following the first quote in the container
+        # avoids issues with repeated calls to html_normalize
+        elif el.getparent().get('data-o-mail-quote-container'):
+            if (first_sibling_quote := el.getparent().find("*[@data-o-mail-quote]")) is not None:
+                siblings = el.getparent().getchildren()
+                quote_index = siblings.index(first_sibling_quote)
+                element_index = siblings.index(el)
+                if quote_index < element_index:
+                    el.set('data-o-mail-quote', '1')
 
 
 def html_normalize(src, filter_callback=None, output_method="html"):


### PR DESCRIPTION
Since html_normalize is now run multiple times on the same body in mail it
has become apparent that the heuristics for tag_quote are not suited to multiple
passes on the same body.

tag_quote is used to detect and tag nodes in a document that are likely
mail signatures. So that they may be hidden in the front-end.

The detection of the signature using the "-- <br>" sets the parent of the element
where is is detected to be a "quote container". However a quote container will
set all of its children to be quotes too. If the signature is in the main div of
the email, as is the case in most templates this means the whole content is
marked as being inside a "quote container".

Because the processing of the elements is done in order of their appearance in
the document, this does not lead to the entire document becoming a quote the
first time html_normalize is called. As the signature is typically
the last element, the "container" attribute is only set after the whole body
was already processed.

However if the body is normalized again, the main div is now marked as a
"quote container" and the whole body becomes a quote.

- `<div><p>body</p><div>--<br>John</div></div>`
- `<div quote-container><p>body</p><div quote>--<br quote>John</div></div>`
- `<div quote-container><p quote>body</p><div quote>--<br quote>John</div></div>`

We now check whether a quoted sibling exists in the container before marking a
node as "quote". All nodes following the original quote and their children will
be quoted as before, all nodes before will not be quoted anymore.

triggered by https://github.com/odoo-dev/odoo/commit/24731938f75358fd3c72b91465b72ab80d62d208

task-4381505
