### PR TITLE
[FIX] l10n_ro_edi: Fix condition to display the Romanian EDI checkbox…

### DIFF
--- a/addons/l10n_ro_edi/models/account_move_send.py
+++ b/addons/l10n_ro_edi/models/account_move_send.py
@@ -7,7 +7,7 @@ class AccountMoveSend(models.AbstractModel):
     @api.model
     def _is_ro_edi_applicable(self, move):
         return all([
-            move._need_ubl_cii_xml('ro_edi') or move.ubl_cii_xml_id,
+            move._need_ubl_cii_xml('ciusro') or move.ubl_cii_xml_id,
             move.country_code == 'RO',
             not move.l10n_ro_edi_state,
         ])


### PR DESCRIPTION
… on Send & Print

During the previous refactor [1], we broke the display of the checkbox of the Romanian EDI.

[1]: https://github.com/odoo/odoo/commit/9e769e1b11f22890e5245859053bc8dd31e42634

task-4403772
