### PR TITLE
[FIX] pos_self_order: correctly scan product

### DIFF
--- a/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.xml
@@ -12,7 +12,7 @@
                         <span class="modal-body o_self_order_main_desc fs-3 p-4 ps-5 overflow-auto" t-out="props.product.public_description" />
                         <div class="modal-footer d-flex flex-row-reverse justify-content-between align-items-center">
                             <button type="button" class="btn btn-primary" t-on-click.stop="() => this.addToCartAndClose()">Add to Cart</button>
-                            <div t-if="!props.product.isCombo and !props.product.attributes.length > 0" class="o_self_order_incr_button btn-group " role="group" aria-label="Quantity select" >
+                            <div t-if="!props.product.isCombo() and !props.product.isConfigurable() > 0" class="o_self_order_incr_button btn-group " role="group" aria-label="Quantity select" >
                                 <button type="button"
                                     t-on-click = "() => this.changeQuantity(false)"
                                     class="btn btn-secondary"><span class="fs-2 lh-1 fa-fw d-inline-block">－</span></button>

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -132,7 +132,7 @@ export class SelfOrder extends Reactive {
                 });
                 return;
             }
-            if (product.attributes.length) {
+            if (product.isConfigurable()) {
                 this.router.navigate("product", { id: product.id });
                 return;
             }


### PR DESCRIPTION
Before this commit, scanning a product barcode would result in an error. Additionally, the product info popup did not check for combo and configurable correctly to show the quantity change option.

opw-4393761

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
