### PR TITLE
[FIX] purchase_stock: bill discount before receipt price unit

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -60,11 +60,16 @@ class StockMove(models.Model):
             for invoice_line in line._get_po_line_invoice_lines_su():
                 if invoice_line.move_id.state != 'posted':
                     continue
+                # Discount applied on bill prior to reception
+                if invoice_line.discount and not move_layer:
+                    price_unit = invoice_line.price_subtotal / invoice_line.quantity
+                else:
+                    price_unit = invoice_line.price_unit
                 if invoice_line.tax_ids:
                     invoice_line_value = invoice_line.tax_ids.with_context(round=False).compute_all(
-                        invoice_line.price_unit, currency=invoice_line.currency_id, quantity=invoice_line.quantity)['total_void']
+                        price_unit, currency=invoice_line.currency_id, quantity=invoice_line.quantity)['total_void']
                 else:
-                    invoice_line_value = invoice_line.price_unit * invoice_line.quantity
+                    invoice_line_value = price_unit * invoice_line.quantity
                 total_invoiced_value += invoice_line.currency_id._convert(
                         invoice_line_value, order.currency_id, order.company_id, invoice_line.move_id.invoice_date, round=False)
                 invoiced_qty += invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_id.uom_id)


### PR DESCRIPTION
**Current behavior:**
Having a product which with the purchase control policy of "ordered quantities" and avg costing, if you create a vendor bill for a receipt prior to actually validating it and apply a discount on the bill line then validate the receipt, the valuation fails to reflect the discount.

**Expected behavior:**
The valuation layer generated by the reception should take into account this discount for the unit_price/price_unit of the layer.

**Steps to reproduce:**
1. Create a product with average costing and control policy based on ordered quantities (purchase tab in product form)

2. Create a purchase order for the product at a price unit of 10 -> confirm

3. Create the bill, add a 10% discount, post the bill

4. Validate the receiption -> Valuation -> see that the product is valued at 10 instead of the expected 9

**Cause of the issue:**
When the discount is applied in this manner, it is currently not captured in the product's `standard_cost` which is the value which is what will calculate the valuation unit price.

**Fix:**
In this situation, recalculate the price unit of the invoice line using the subtotal and qty information on the invoice line.

opw-4183595