### PR TITLE
[IMP] delivery,website_sale: do not show pickup location on checkout

### DIFF
--- a/addons/delivery/models/res_partner.py
+++ b/addons/delivery/models/res_partner.py
@@ -7,3 +7,4 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     property_delivery_carrier_id = fields.Many2one('delivery.carrier', company_dependent=True, string="Delivery Method", help="Used in sales orders.")
+    is_pickup_location = fields.Boolean()  # Whether it is a pickup point address.

--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -17,6 +17,13 @@ class SaleOrder(models.Model):
     is_all_service = fields.Boolean("Service Product", compute="_compute_is_service_products")
     shipping_weight = fields.Float("Shipping Weight", compute="_compute_shipping_weight", store=True, readonly=False)
 
+    def _compute_partner_shipping_id(self):
+        """ Override to reset the delivery address when a pickup location was selected. """
+        super()._compute_partner_shipping_id()
+        for order in self:
+            if order.partner_shipping_id.is_pickup_location:
+                order.partner_shipping_id = order.partner_id
+
     @api.depends('order_line')
     def _compute_is_service_products(self):
         for so in self:
@@ -186,6 +193,7 @@ class SaleOrder(models.Model):
                 'country_id': country,
                 'email': email,
                 'phone': phone,
+                'is_pickup_location': True,
             })
             order.with_context(update_delivery_shipping_partner=True).write({'partner_shipping_id': shipping_partner})
         return super()._action_confirm()

--- a/addons/delivery/tests/__init__.py
+++ b/addons/delivery/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_delivery_cost
 from . import test_delivery_availability
+from . import test_sale_order

--- a/addons/delivery/tests/test_sale_order.py
+++ b/addons/delivery/tests/test_sale_order.py
@@ -1,0 +1,12 @@
+from odoo.tests import tagged
+
+from odoo.addons.sale.tests.common import SaleCommon
+
+
+@tagged('post_install', '-at_install')
+class TestSaleOrder(SaleCommon):
+
+    def test_avoid_setting_pickup_location_as_default_delivery_address(self):
+        self._create_partner(type='delivery', parent_id=self.partner.id, is_pickup_location=True)
+        so = self.env['sale.order'].create({'partner_id': self.partner.id})
+        self.assertFalse(so.partner_shipping_id.is_pickup_location)

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -878,6 +878,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             '|',
             ('type', 'in', ['delivery', 'other']),
             ('id', '=', commercial_partner_sudo.id),
+            ('is_pickup_location', '=', False),
         ], order='id desc') | order_sudo.partner_id
 
         if order_sudo.partner_id != commercial_partner_sudo:  # Child of the commercial partner.


### PR DESCRIPTION
Before this commit when a customer selected a pickup location a corresponding partner was created with `delivery` type. It was displayed on the checkout page along with customer's delivery addresses which was confusing as pickup locations are meant to be chosen only with the corresponding delivery method.
This commit aims to distinguish pickup addresses partners by adding new field in order to prevent from displaying them on the checkout and computing it as a default on SO.

task-4370310

