### PR TITLE
[FIX] fleet: allow overriding the behavior on contract easily

### DIFF
--- a/addons/fleet/models/fleet_vehicle_log_contract.py
+++ b/addons/fleet/models/fleet_vehicle_log_contract.py
@@ -156,13 +156,13 @@ class FleetVehicleLogContract(models.Model):
                 user_id=contract.user_id.id)
 
         expired_contracts = self.search([('state', 'not in', ['expired', 'closed']), ('expiration_date', '<',fields.Date.today() )])
-        expired_contracts.write({'state': 'expired'})
+        expired_contracts.action_expire()
 
         futur_contracts = self.search([('state', 'not in', ['futur', 'closed']), ('start_date', '>', fields.Date.today())])
-        futur_contracts.write({'state': 'futur'})
+        futur_contracts.action_draft()
 
         now_running_contracts = self.search([('state', '=', 'futur'), ('start_date', '<=', fields.Date.today())])
-        now_running_contracts.write({'state': 'open'})
+        now_running_contracts.action_open()
 
     def run_scheduler(self):
         self.scheduler_manage_contract_expiration()


### PR DESCRIPTION
Since there are two mechanism that changes the status of a contract (a cron and the write of a date), we have to override 2 different places when we want to add a behavior on closing or opening of contracts.

As there are already functions (action_expire, ...) that exist and are use in the write part, we also use them in the cron, so we'll have only one place where we need to override it.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
