### PR TITLE
[IMP] project: setting a parent task should not reset the state of the sub-task

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1326,6 +1326,10 @@ class ProjectTask(models.Model):
         elif 'project_id' in vals:
             self.filtered(lambda t: t.state != '04_waiting_normal').state = '01_in_progress'
 
+        # Do not recompute the state when changing the parent (to avoid resetting the state)
+        if 'parent_id' in vals:
+            self.env.remove_to_compute(self._fields['state'], self)
+
         self._task_message_auto_subscribe_notify({task: task.user_ids - old_user_ids[task] - self.env.user for task in self})
 
         if partner_ids:

--- a/addons/project/tests/test_task_state.py
+++ b/addons/project/tests/test_task_state.py
@@ -169,3 +169,12 @@ class TestTaskState(TestProjectCommon):
         })
 
         self.assertEqual(task.state, '01_in_progress', "The task should be in progress")
+
+    def test_changing_parent_do_not_reset_task_state(self):
+        self.task_2.state = '04_waiting_normal'
+        self.task_2.parent_id = self.task_1
+        self.assertEqual(
+            self.task_2.state,
+            '04_waiting_normal',
+            "Changing the task's parent should not reset the task's state.",
+        )


### PR DESCRIPTION
This commit aims to solve this situation:
- Create a task A > Set its state to 'changes requested' (or anything else besides 'in progress')
- Action > Convert to task/sub-task > Select task B
- The state of task A switches from 'changes requested' to 'in progress' 

=> Setting a parent task shouldn't have any impact on the state of the task

task-4358261

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
