### PR TITLE
[FIX] product: pricelist rule import

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -417,6 +417,14 @@ class PricelistItem(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         for values in vals_list:
+            if values.get('product_id') and not values.get('product_tmpl_id'):
+                # Deduce product template from product variant if not specified.
+                # Ensures that the pricelist rule is properly configured and displayed in the UX
+                # even in case of partial/incomplete data (mostly for imports).
+                values['product_tmpl_id'] = self.env['product.product'].browse(
+                    values.get('product_id')
+                ).product_tmpl_id.id
+
             if not values.get('applied_on'):
                 values['applied_on'] = (
                     '0_product_variant' if values.get('product_id') else


### PR DESCRIPTION
Since recent changes to the pricelists rules, importing a rule with the 'Product Variant' field value specified but not the template field value led to incomplete rules not being displayed (and maybe not even behaving) as expected.

This commit makes sure that if the template was forgotten in the create values, it's correctly deduced from the given product.product record.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
