### PR TITLE
[IMP] account: improve activity UI in misc dashboard

### DIFF
--- a/addons/account/static/src/components/journal_dashboard_activity/journal_dashboard_activity.xml
+++ b/addons/account/static/src/components/journal_dashboard_activity/journal_dashboard_activity.xml
@@ -13,7 +13,7 @@
                         <t t-out="activity.name"/>
                     </a>
                 </div>
-                <div class="col text-end text-nowrap">
+                <div class="col-auto text-end text-nowrap">
                     <span><t t-out="activity.date"/></span>
                 </div>
             </div>


### PR DESCRIPTION
In an effort to improve l10n_be this commit improves the UI of the activity section in the Accounting dashboard. Now the activities are listed without the need for unnecessary line breaks.

Task ID: 4291228