### PR TITLE
[FIX] l10n_cl: translate VAT in invoice tax total

### DIFF
--- a/addons/l10n_cl/i18n/es.po
+++ b/addons/l10n_cl/i18n/es.po
@@ -799,6 +799,11 @@ msgid "U(JGO)"
 msgstr ""
 
 #. module: l10n_cl
+#: model_terms:ir.ui.view,arch_db:l10n_cl.tax_totals_widget
+msgid "VAT"
+msgstr "IVA"
+
+#. module: l10n_cl
 #. odoo-python
 #: code:addons/l10n_cl/models/res_partner.py:0
 #: model:ir.model.fields.selection,name:l10n_cl.selection__res_partner__l10n_cl_sii_taxpayer_type__1

--- a/addons/l10n_cl/i18n/l10n_cl.pot
+++ b/addons/l10n_cl/i18n/l10n_cl.pot
@@ -758,6 +758,11 @@ msgid "U(JGO)"
 msgstr ""
 
 #. module: l10n_cl
+#: model_terms:ir.ui.view,arch_db:l10n_cl.tax_totals_widget
+msgid "VAT"
+msgstr ""
+
+#. module: l10n_cl
 #. odoo-python
 #: code:addons/l10n_cl/models/res_partner.py:0
 #: model:ir.model.fields.selection,name:l10n_cl.selection__res_partner__l10n_cl_sii_taxpayer_type__1

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -266,7 +266,7 @@
             </t>
             <t t-if="subtotal_amounts['vat_amount'] != 0.0">
                 <tr>
-                    <td t-esc="'VAT %s' % subtotal_amounts['vat_percent']"/>
+                    <td>VAT <t t-esc="subtotal_amounts['vat_percent']"/></td>
                     <td class="text-end" t-esc="subtotal_amounts['vat_amount']"
                         t-options="{'widget': 'monetary', 'display_currency': subtotal_amounts['main_currency']}"/></tr>
             </t>


### PR DESCRIPTION
Problem: When printing an invoice with l10n_cl installed, the tax total will display the lavel as 'VAT.' The user expects 'VAT' to be translated to maybe 'IVA.' It is hardcoded into the view, thus the .pot file needs to be updated.

Note: Starting from v17, there are missing translations
for strings "Net Amount", "Total", "Exempt Amount" in the
.pot file for the view l10n_cl.tax_totals_widget. However,
these are present for v16. Will probably need to modify
the fw-ports to include these strings in the file.

Purpose: Updating the .pot file to include the hardcoded VAT string will ensure there are translations for that label.

Steps to Reproduce on Runbot:
1. Install l10n_cl and Accounting
2. Add Spanish as a language
3. Switch to the CL company
4. Create an invoice for a customer whose language is Spanish
5. Print the invoice and notice 'VAT' is not translated

opw-4383092




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
