### PR TITLE
[FIX] project_todo: can't edit tag and user in mobile view

### DIFF
--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -102,19 +102,15 @@
                   js_class="todo_form">
                 <field name="name" invisible="1"/>
                 <header>
-                    <div class="py-1 px-2 border rounded bg-view">
-                        <field name="tag_ids"
-                               widget="many2many_tags"
-                               options="{'color_field': 'color', 'no_create_edit': True}"
-                               class="me-2"
-                               placeholder="Tags"/>
-                    </div>
-                    <div class="py-1 px-2 border rounded bg-view">
-                        <field name="user_ids"
-                               widget="many2many_avatar_user"
-                               options="{'no_quick_create': True}"
-                               placeholder="Assignees"/>
-                    </div>
+                    <field name="tag_ids"
+                           widget="many2many_tags"
+                           options="{'color_field': 'color', 'no_create_edit': True}"
+                           class="me-2"
+                           placeholder="Tags"/>
+                    <field name="user_ids"
+                           widget="many2many_avatar_user"
+                           options="{'no_quick_create': True}"
+                           placeholder="Assignees"/>
                     <field name="personal_stage_type_id"
                            domain="[('user_id','=',uid)]"
                            widget="statusbar"


### PR DESCRIPTION
Close #190304
* STEP TO REPRODUCE: go to todo app with mobile view, then open any record and try to edit tags or assignee, the dropdown menu keep closing after click

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
