### PR TITLE
[FIX] sale_product_configurator: ensure safe assignment of 'excluded' property 

### DIFF
--- a/addons/sale_product_configurator/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/sale_product_configurator/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -285,7 +285,10 @@ export class ProductConfiguratorDialog extends Component {
         if (parentCombination) {
             for(const ptavId of parentCombination) {
                 for(const excludedPtavId of (parentExclusions[ptavId]||[])) {
-                    ptavList.find(ptav => ptav.id === excludedPtavId).excluded = true;
+                    const ptav = ptavList.find(ptav => ptav.id === excludedPtavId);
+                    if (ptav) {
+                        ptav.excluded = true; // Assign only if the element exists
+                    }
                 }
             }
         }


### PR DESCRIPTION
Current behavior before PR:
- currently, we directly set the excluded property to 'true', which do not check for 'undefined' values, which are possible in certain cases. This fix ensure to set the property only if it is present.

Desired behavior after PR is merged:
- excluded property will set only for defined objects.

## steps to reproduce:

- create two product, `main` & `optional`
- for `main`, add two attribute values : eg height: 20, 30
- for `optional`, add attribute values : eg width : 100, 200, 300
- set `optional` as optional product for main product
- configure height values for `main` product-> for value 20: exclude  `optional` product of attribute 200,300
- create a sale order with `optional` product and attribute 200. ( confirm the SO)
- now remove the attribute value 200 from `optional` product.
- try to create new quotation for main product.(traceback will appear)

## Traceback
```py
TypeError: Cannot set properties of undefined (setting 'excluded')
    at ProductConfiguratorDialog._checkExclusions (http://localhost:9000/web/assets/00d1566/web.assets_web_dark.min.js:16288:175)
    at ProductConfiguratorDialog._checkExclusions (http://localhost:9000/web/assets/00d1566/web.assets_web_dark.min.js:16291:181)
    at ProductConfiguratorDialog._updateProductTemplateSelectedPTAV (http://localhost:9000/web/assets/00d1566/web.assets_web_dark.min.js:16283:100)
    at ProductTemplateAttributeLine.updateSelectedPTAV (http://localhost:9000/web/assets/00d1566/web.assets_web_dark.min.js:16310:1317)
    at Object.mainEventHandler 
```

## Description

the moment we removed 200 attribute from optinal product, it went for check to be [unlink or become archived](https://github.com/odoo/odoo/blob/17.0/addons/product/models/product_template_attribute_value.py#L140-L147).
as it is linked to a SO, it cannot be deleted and simply left to archive.
due to this flow, the related record from product.template.attribute.exclusion still remains, 
and when we fetch the list of ids of parent_exclusion, it [return](https://github.com/odoo/odoo/blob/17.0/addons/product/models/product_template.py#L974-L976) the archived value too, which is not present in ptavlist

We cannot simple delete the value from the relation table, as when the ptav 300 is again added, it is reused ( ptav_active sets to true) , and old relation starts to work together


## solution:
ignore the archived ptavs. 

opw-4365068


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
