### PR TITLE
[IMP] website: allow user to choose multiple dependency values

### DIFF
--- a/addons/test_website/static/tests/tours/form.js
+++ b/addons/test_website/static/tests/tours/form.js
@@ -58,6 +58,16 @@ registerWebsitePreviewTour(
             trigger: '[data-select-data-attribute="!selected"]',
             run: "click",
         },
+        {
+            content: "Open model selector",
+            trigger: "we-select:has([data-select-data-attribute='2'])",
+            run: "click",
+        },
+        {
+            content: "Set model to tag #2",
+            trigger: "[data-select-data-attribute='2']",
+            run: "click",
+        },
         ...clickOnSave(),
         {
             content: "Name field is shown",

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2196,7 +2196,7 @@ const ListUserValueWidget = UserValueWidget.extend({
      */
     start() {
         this.addItemTitle = this.el.dataset.addItemTitle || _t("Add");
-        this.noAddItemButton = this.el.dataset.noAddItemOption;
+        this.noAddItemButton = this.el.dataset.noAddItemButton;
         if (this.el.dataset.availableRecords) {
             this.records = JSON.parse(this.el.dataset.availableRecords);
         } else {

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2196,6 +2196,7 @@ const ListUserValueWidget = UserValueWidget.extend({
      */
     start() {
         this.addItemTitle = this.el.dataset.addItemTitle || _t("Add");
+        this.noAddItemButton = this.el.dataset.noAddItemOption;
         if (this.el.dataset.availableRecords) {
             this.records = JSON.parse(this.el.dataset.availableRecords);
         } else {
@@ -2258,7 +2259,7 @@ const ListUserValueWidget = UserValueWidget.extend({
             this.createWidget.setValue('');
             this.createWidget.inputEl.value = '';
             $(this.createWidget.inputEl).trigger('input');
-        } else {
+        } else if (!this.noAddItemButton) {
             if (this.isCustom) {
                 this.addItemButton = document.createElement('we-button');
                 this.addItemButton.textContent = this.addItemTitle;
@@ -2288,7 +2289,7 @@ const ListUserValueWidget = UserValueWidget.extend({
                 this._addItemToTable(value, value);
             }
         });
-        if (!this.createWidget && !this.isCustom) {
+        if (!this.createWidget && !this.noAddItemButton && !this.isCustom) {
             this._reloadSelectDropdown(currentValues);
         }
         this._makeListItemsSortable();
@@ -2435,7 +2436,7 @@ const ListUserValueWidget = UserValueWidget.extend({
         } else {
             this._onUserValueChange();
         }
-        if (!this.createWidget && !this.isCustom) {
+        if (!this.createWidget && !this.noAddItemButton && !this.isCustom) {
             this._reloadSelectDropdown(values);
         }
     },

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -1218,6 +1218,14 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
         await this._replaceField(field);
     },
     /**
+     * Apply the we-list on the target and rebuild the input(s)
+     */
+    renderDependencyListItems(previewMode, value, params) {
+        const values = JSON.parse(value);
+        const selectedList = values.filter(({ selected }) => selected).map(({ name }) => name);
+        this.$target[0].dataset.visibilityCondition = JSON.stringify(selectedList);
+    },
+    /**
      * Sets the visibility of the field.
      *
      * @see this.selectClass for parameters
@@ -1290,6 +1298,8 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                 return this.$target[0].classList.contains(params.activeValue) ? params.activeValue : 'false';
             case 'renderListItems':
                 return JSON.stringify(this._getListItems(true));
+            case "renderDependencyListItems":
+                return JSON.stringify(this._getDependencyListItem());
             case 'setVisibilityDependency':
                 return this.$target[0].dataset.visibilityDependency || '';
         }
@@ -1328,8 +1338,24 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                 }
                 return (['text', 'email', 'tel', 'url', 'search', 'password', 'number'].includes(dependencyEl.type)
                     || dependencyEl.nodeName === 'TEXTAREA') && !['set', '!set'].includes(this.$target[0].dataset.visibilityComparator);
-            case 'hidden_condition_no_text_opt':
+            case 'hidden_condition_no_text_opt_1':
                 return dependencyEl && (dependencyEl.type === 'checkbox' || dependencyEl.type === 'radio' || dependencyEl.nodeName === 'SELECT');
+            case "hidden_condition_no_text_opt_2":
+                return (
+                    dependencyEl &&
+                    (dependencyEl.type === "checkbox" ||
+                        dependencyEl.type === "radio" ||
+                        dependencyEl.nodeName === "SELECT") &&
+                    ["selected", "!selected"].includes(this.$target[0].dataset.visibilityComparator)
+                );
+            case "hidden_condition_no_text_multi_opt":
+                return (
+                    dependencyEl &&
+                    (dependencyEl.type === "checkbox" ||
+                        dependencyEl.type === "radio" ||
+                        dependencyEl.nodeName === "SELECT") &&
+                    ["contains", "!contains"].includes(this.$target[0].dataset.visibilityComparator)
+                );
             case 'hidden_condition_num_opt':
                 return dependencyEl && dependencyEl.type === 'number';
             case 'hidden_condition_text_opt':
@@ -1485,13 +1511,9 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                 fieldType === "record"
             ) {
                 // Update available visibility options
-                const selectOptName =
-                    fieldType === "record"
-                        ? "hidden_condition_record_opt"
-                        : "hidden_condition_no_text_opt";
-                const selectOptEl = uiFragment.querySelectorAll(
-                    `we-select[data-name="${selectOptName}"]`,
-                )[1];
+                const selectOptEl = fieldType === "record" ?
+                    uiFragment.querySelectorAll(`we-select[data-name="hidden_condition_record_opt"]`)[1] :
+                    uiFragment.querySelector(`we-select[data-name="hidden_condition_no_text_opt_2"]`);
                 const inputContainerEl = this.$target[0];
                 const dependencyEl = this._getDependencyEl();
                 if (dependencyEl.nodeName === 'SELECT') {
@@ -1627,7 +1649,7 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
         const hasConditionalVisibility = this.$target[0].classList.contains('s_website_form_field_hidden_if');
         const previousInputEl = this.$target[0].querySelector('.s_website_form_input');
         const previousName = previousInputEl.name;
-        const previousType = previousInputEl.type;
+        const previousType = this.$target[0].dataset.type;
         [...this.$target[0].childNodes].forEach(node => node.remove());
         [...fieldEl.childNodes].forEach(node => this.$target[0].appendChild(node));
         [...fieldEl.attributes].forEach(el => this.$target[0].removeAttribute(el.nodeName));
@@ -1638,7 +1660,7 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
         const dependentFieldEls = this.formEl.querySelectorAll(`.s_website_form_field[data-visibility-dependency="${CSS.escape(previousName)}"]`);
         const newFormInputEl = this.$target[0].querySelector('.s_website_form_input');
         const newName = newFormInputEl.name;
-        const newType = newFormInputEl.type;
+        const newType = this.$target[0].dataset.type;
         if ((previousName !== newName || previousType !== newType) && dependentFieldEls) {
             // In order to keep the visibility conditions consistent,
             // when the name has changed, it means that the type has changed so
@@ -1694,6 +1716,35 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                 selected: select ? opt.selected : opt.checked,
             };
         });
+    },
+    /**
+     *
+     * @private
+     * @returns {Array} List of values of dependency element
+     */
+    _getDependencyListItem() {
+        const dependencyEl = this._getDependencyEl();
+        if (!dependencyEl) {
+            return [];
+        }
+        const isSelect = dependencyEl.nodeName === "SELECT";
+        const isMultipleInputs = ["radio", "checkbox"].includes(dependencyEl.type);
+        const visibilityCondition = this.$target[0].dataset.visibilityCondition;
+        let optionEls = [];
+        if (isSelect) {
+            optionEls = dependencyEl.querySelectorAll("option");
+        } else if (isMultipleInputs) {
+            optionEls = dependencyEl
+                .closest(".s_website_form_field")
+                ?.querySelectorAll(".s_website_form_input");
+        }
+        return Array.from(optionEls).map((el) => ({
+            id: el.value,
+            name: el.value,
+            display_name: isSelect ? el.textContent : el.labels[0]?.textContent,
+            undeletable: true,
+            selected: visibilityCondition?.includes(el.value),
+        }));
     },
     /**
      * Returns the select element if it exist else null

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -1106,3 +1106,59 @@ registerWebsitePreviewTour("website_form_special_characters", {
         trigger: ":iframe body:not(:has([data-snippet='s_website_form'])) .fa-paper-plane",
     },
 ]);
+
+// Check that multivalue condition visibility works as expected.
+registerWebsitePreviewTour("website_form_contains_conditional_visibility", {
+    url: "/",
+    edition: true,
+}, () => [
+    {
+        content: "Drop the form snippet",
+        trigger: "#oe_snippets .oe_snippet .oe_snippet_thumbnail[data-snippet=s_website_form]",
+        run: "drag_and_drop :iframe #wrap",
+    }, {
+        trigger: ":iframe .s_website_form_field",
+    },
+    ...addCustomField("one2many", "checkbox", "Products", true),
+    ...addCustomField("char", "text", "Conditional Visibility Check 1", false, {visibility: CONDITIONALVISIBILITY}),
+    ...selectButtonByData("data-set-visibility-dependency='Products'"),
+    ...selectButtonByText("Doesn't contain"),
+    {
+        content: "Tie the visibility with the option 'Option 2' of Products field.",
+        trigger: "[data-name='hidden_condition_no_text_multi_opt'] we-button:eq(1)",
+        run: "click",
+    },
+    ...clickOnSave(),
+    {
+        content: "Check 'Conditional Visibility Check 1' field is visible.",
+        trigger: `:iframe .s_website_form:has(${triggerFieldByLabel("Conditional Visibility Check 1")}:visible)`,
+    }, {
+        content: "choose the option 'Option 1' of Products.",
+        trigger: ":iframe .checkbox:has(label:contains('Option 2')) input[type='checkbox']",
+        run: "click",
+    }, {
+        content: "Check 'Conditional Visibility Check 1' field is not visible.",
+        trigger: `:iframe .s_website_form:has(${triggerFieldByLabel("Conditional Visibility Check 1")}:not(:visible))`,
+    },
+    ...clickOnEditAndWaitEditMode(),
+    ...addCustomField("char", "text", "Conditional Visibility Check 2", false, {visibility: CONDITIONALVISIBILITY}),
+    ...selectButtonByData("data-set-visibility-dependency='company'"),
+    ...selectButtonByText("contains"),
+    {
+        content: "Tie the visibility with Your Company field containing 'peek-a-boo'",
+        trigger: "we-input[data-name=hidden_condition_additional_text] input",
+        run: "edit odoo",
+    },
+    ...clickOnSave(),
+    {
+        content: "Check 'Conditional Visibility Check 2' field is not visible.",
+        trigger: `:iframe .s_website_form:has(${triggerFieldByLabel("Conditional Visibility Check 2")}:not(:visible))`,
+    }, {
+        content: "Edit the Phone Number field",
+        trigger: ":iframe input[name='company']",
+        run: "edit odoo IN",
+    }, {
+        content: "Check 'Conditional Visibility Check 2' field is visible.",
+        trigger: `:iframe .s_website_form:has(${triggerFieldByLabel("Conditional Visibility Check 2")}:visible)`,
+    },
+]);

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -1112,11 +1112,8 @@ registerWebsitePreviewTour("website_form_contains_conditional_visibility", {
     url: "/",
     edition: true,
 }, () => [
+    ...insertSnippet({id: "s_website_form", name: "Form"}),
     {
-        content: "Drop the form snippet",
-        trigger: "#oe_snippets .oe_snippet .oe_snippet_thumbnail[data-snippet=s_website_form]",
-        run: "drag_and_drop :iframe #wrap",
-    }, {
         trigger: ":iframe .s_website_form_field",
     },
     ...addCustomField("one2many", "checkbox", "Products", true),
@@ -1133,7 +1130,7 @@ registerWebsitePreviewTour("website_form_contains_conditional_visibility", {
         content: "Check 'Conditional Visibility Check 1' field is visible.",
         trigger: `:iframe .s_website_form:has(${triggerFieldByLabel("Conditional Visibility Check 1")}:visible)`,
     }, {
-        content: "choose the option 'Option 1' of Products.",
+        content: "Choose the option 'Option 1' of Products.",
         trigger: ":iframe .checkbox:has(label:contains('Option 2')) input[type='checkbox']",
         run: "click",
     }, {

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -247,7 +247,7 @@
                 <we-select data-name="hidden_condition_opt" data-no-preview="true">
                     <!-- Load every existing form input -->
                 </we-select>
-                <we-select data-name="hidden_condition_no_text_opt" data-attribute-name="visibilityComparator" data-no-preview="true">
+                <we-select data-name="hidden_condition_no_text_opt_1" data-attribute-name="visibilityComparator" data-no-preview="true">
                     <we-button data-select-data-attribute="selected">Is equal to</we-button>
                     <we-button data-select-data-attribute="!selected">Is not equal to</we-button>
                     <we-button data-select-data-attribute="contains">Contains</we-button>
@@ -296,9 +296,18 @@
                     <we-button data-select-data-attribute="!selected">Is not equal to</we-button>
                 </we-select>
             </we-row>
-            <we-select class="o_we_large" data-name="hidden_condition_no_text_opt" data-attribute-name="visibilityCondition" data-no-preview="true">
-                <!-- checkbox, select, radio possible values -->
+            <we-select class="o_we_large" data-name="hidden_condition_no_text_opt_2" data-attribute-name="visibilityCondition" data-no-preview="true">
+                <!-- checkbox, select, radio possible values - single select -->
             </we-select>
+            <we-list data-name="hidden_condition_no_text_multi_opt"
+                data-render-dependency-list-items=""
+                data-has-default="multiple"
+                data-unsortable="true"
+                data-not-editable="true"
+                data-no-add-item-option="true"
+                data-no-preview="true">
+                <!-- checkbox, select, radio possible values - multi select -->
+            </we-list>
             <we-select class="o_we_large" data-name="hidden_condition_record_opt" data-attribute-name="visibilityCondition" data-no-preview="true">
                 <!-- checkbox, select, radio possible values -->
             </we-select>

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -247,7 +247,7 @@
                 <we-select data-name="hidden_condition_opt" data-no-preview="true">
                     <!-- Load every existing form input -->
                 </we-select>
-                <we-select data-name="hidden_condition_no_text_opt_1" data-attribute-name="visibilityComparator" data-no-preview="true">
+                <we-select data-name="hidden_condition_no_text_opt" data-attribute-name="visibilityComparator" data-no-preview="true">
                     <we-button data-select-data-attribute="selected">Is equal to</we-button>
                     <we-button data-select-data-attribute="!selected">Is not equal to</we-button>
                     <we-button data-select-data-attribute="contains">Contains</we-button>
@@ -296,17 +296,17 @@
                     <we-button data-select-data-attribute="!selected">Is not equal to</we-button>
                 </we-select>
             </we-row>
-            <we-select class="o_we_large" data-name="hidden_condition_no_text_opt_2" data-attribute-name="visibilityCondition" data-no-preview="true">
-                <!-- checkbox, select, radio possible values - single select -->
+            <we-select class="o_we_large" data-name="hidden_condition_no_text_select_opt" data-attribute-name="visibilityCondition" data-no-preview="true">
+                <!-- checkbox, select, radio possible values -->
             </we-select>
             <we-list data-name="hidden_condition_no_text_multi_opt"
                 data-render-dependency-list-items=""
                 data-has-default="multiple"
                 data-unsortable="true"
                 data-not-editable="true"
-                data-no-add-item-option="true"
+                data-no-add-item-button="true"
                 data-no-preview="true">
-                <!-- checkbox, select, radio possible values - multi select -->
+                <!-- checkbox, select, radio possible values -->
             </we-list>
             <we-select class="o_we_large" data-name="hidden_condition_record_opt" data-attribute-name="visibilityCondition" data-no-preview="true">
                 <!-- checkbox, select, radio possible values -->


### PR DESCRIPTION
Steps to Reproduce:
1. Go to Website → Edit Mode.
2. Drag and drop a "Contact Us" form.
3. Add two new fields:
    - A selection field (e.g., "Author").
    - A text field.
4. Attempt to set the visibility of the text field such that it only
appears when the user selects multiple values. (e.g., "Mitchell Admin"
and "Marc Demo").

Users cannot select multiple values for visibility conditions when the
comparator is `Contains/Doesn't Contain`, and its behavior is similar to
`Is Equal To/Is Not Equal To`.

This commit introduces support for selecting multiple values when the
visibility comparator is set to `Contains/Doesn't Contain`, provided
the dependency field type is `select`, `checkbox` or `radio`.

task-4203938