### PR TITLE
[FIX] purchase: no purchase tab if purchase not installed

### DIFF
--- a/addons/account/views/product_view.xml
+++ b/addons/account/views/product_view.xml
@@ -49,9 +49,6 @@
             <field name="priority">5</field>
             <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
-                <xpath expr="//page[@name='purchase']" position="attributes">
-                    <attribute name="invisible" remove="1" separator="or"/>
-                </xpath>
                 <xpath expr="//field[@name='company_id']" position="after">
                     <field name="fiscal_country_codes" invisible="1"/>
                 </xpath>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -75,10 +75,6 @@
                             <field name="sale_ok"/>
                             <label for="sale_ok"/>
                         </span>
-                        <span class="d-inline-flex" invisible="type == 'combo'">
-                            <field name="purchase_ok"/>
-                            <label for="purchase_ok"/>
-                        </span>
                     </div>
                     <notebook>
                         <page string="General Information" name="general_information">

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -83,6 +83,12 @@
                         </group>
                     </group>
                 </group>
+                <div name="options" position='inside'>
+                    <span class="d-inline-flex" invisible="type == 'combo'">
+                        <field name="purchase_ok"/>
+                        <label for="purchase_ok"/>
+                    </span>
+                </div>
             </field>
         </record>
 


### PR DESCRIPTION
Issue Before This Commit:
-----------------------------------------------
- Purchase tab and checkbox is visible in the product form without installing Purchase.

Steps to Produce:
-----------------------------------------------
=> Purchase checkbox
Problem: Purchase checkbox is always visible in the product form which is incorrect.

=> Purchase tab
1. Install Sales.
2. On Unit and Measure. 
Problem: Now Purchase tab is visible in the product form without installing Purchase which is incorrect.

With this commit:
-----------------------------------------------
- Purchase tab and checkbox  is visible in the product form only after installing Purchase.

Task-id: 4391349