### PR TITLE
[IMP] point_of_sale: multi category filtering for kitchen printer

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1564,11 +1564,17 @@ export class PosStore extends Reactive {
             );
             const diningModeUpdate = orderChange.modeUpdate;
             if (diningModeUpdate || !Object.keys(lastChangedLines).length) {
+                // Prepare orderlines as per the format of the receipt
+                const lines =
+                    diningModeUpdate && Object.keys(lastChangedLines).length
+                        ? Object.values(lastChangedLines)
+                        : changes.new;
+
                 const printed = await this.printReceipts(
                     order,
                     printer,
                     "New",
-                    changes.new,
+                    lines,
                     true,
                     diningModeUpdate
                 );
@@ -1579,7 +1585,7 @@ export class PosStore extends Reactive {
                 // Print all receipts related to line changes
                 const toPrintArray = this.preparePrintingData(order, changes);
                 for (const [key, value] of Object.entries(toPrintArray)) {
-                    const printed = await this.printReceipts(order, printer, key, value, false);
+                    const printed = await this.printReceipts(order, printer, key, value);
                     if (!printed) {
                         unsuccedPrints.push(key);
                     }


### PR DESCRIPTION
Before this commit:
------------------------
- If we enable 2 different printers for 2 categories the
kitchen prints were not as per the category. It was not filtered.
- When we change mode of sitting (dinein, takeout) it doesn't
have any orderlines.

After this commit:
-----------------------
- Now if category wise printers are set the tickets will
follow and printers will have that category tickets only,
- Now all the orderlines will be there on the tickets when
dinning mode updated.

task: 4422475