### PR TITLE
[IMP] base: soften server actions validation - mail: use field selector for server actions

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -248,6 +248,11 @@ class BaseAutomation(models.Model):
     @api.constrains('trigger', 'action_server_ids')
     def _check_trigger_state(self):
         for record in self:
+            warning_actions = record.action_server_ids.filtered('warning')
+            if warning_actions:
+                raise exceptions.ValidationError(
+                    _("Following child actions have warnings: %(children)s", children=', '.join(warning_actions.mapped('name')))
+                )
             no_code_actions = record.action_server_ids.filtered(lambda a: a.state != 'code')
             if record.trigger == 'on_change' and no_code_actions:
                 raise exceptions.ValidationError(

--- a/addons/base_automation/models/ir_actions_server.py
+++ b/addons/base_automation/models/ir_actions_server.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.tools.json import scriptsafe as json_scriptsafe
 
-from odoo import api, exceptions, fields, models, _
+from odoo import api, fields, models, _
 
 from .base_automation import get_webhook_request_payload
 
@@ -17,16 +17,26 @@ class IrActionsServer(models.Model):
     ], ondelete={'base_automation': 'cascade'})
     base_automation_id = fields.Many2one('base.automation', string='Automation Rule', ondelete='cascade')
 
-    @api.constrains('model_id', 'base_automation_id')
-    def _check_model_coherency_with_automation(self):
-        for action in self.filtered('base_automation_id'):
-            if action.model_id != action.base_automation_id.model_id:
-                raise exceptions.ValidationError(
-                    _("Model of action %(action_name)s should match the one from automated rule %(rule_name)s.",
-                      action_name=action.name,
-                      rule_name=action.base_automation_id.name
-                     )
-                )
+    @api.model
+    def _warning_depends(self):
+        return super()._warning_depends() + [
+            'model_id',
+            'base_automation_id',
+        ]
+
+    def _get_warning_messages(self):
+        self.ensure_one()
+        warnings = super()._get_warning_messages()
+
+        if self.base_automation_id and self.model_id != self.base_automation_id.model_id:
+            warnings.append(
+                _("Model of action %(action_name)s should match the one from automated rule %(rule_name)s.",
+                    action_name=self.name,
+                    rule_name=self.base_automation_id.name
+                    )
+            )
+
+        return warnings
 
     @api.depends('usage')
     def _compute_available_model_ids(self):

--- a/addons/base_automation/models/ir_actions_server.py
+++ b/addons/base_automation/models/ir_actions_server.py
@@ -44,8 +44,11 @@ class IrActionsServer(models.Model):
         for action in to_update:
             match action.state:
                 case 'object_write':
-                    action_type = _("Update") if action.evaluation_type == 'value' else _("Compute")
-                    action.name = f"{action_type} {action._stringify_path()}"
+                    _field_chain, field_chain_str = action._get_relation_chain("update_path")
+                    if action.evaluation_type == 'value':
+                        action.name = _("Update %(field_chain_str)s", field_chain_str=field_chain_str)
+                    else:
+                        action.name = _("Compute %(field_chain_str)s", field_chain_str=field_chain_str)
                 case 'object_create':
                     action.name = _(
                     "Create %(model_name)s with name %(value)s",
@@ -66,9 +69,10 @@ class IrActionsServer(models.Model):
                     )
                 case 'followers':
                     if action.followers_type == 'generic':
+                        _field_chain, field_chain_str = action._get_relation_chain("followers_partner_field_name")
                         action.name = _(
-                            'Add followers based on field: %(field_name)s',
-                            field_name=action.followers_partner_field_name
+                            'Add followers based on field: %(field_chain_str)s',
+                            field_chain_str=field_chain_str
                         )
                     else:
                         action.name = _(
@@ -77,9 +81,10 @@ class IrActionsServer(models.Model):
                         )
                 case 'remove_followers':
                     if action.followers_type == 'generic':
+                        _field_chain, field_chain_str = action._get_relation_chain("followers_partner_field_name")
                         action.name = _(
-                            'Remove followers based on field: %(field_name)s',
-                            field_name=action.followers_partner_field_name
+                            'Remove followers based on field: %(field_chain_str)s',
+                            field_chain_str=field_chain_str
                         )
                     else:
                         action.name = _(

--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -173,6 +173,7 @@
                                                         'webhook': 'fa-paper-plane',
                                                     }[record.state.raw_value]"
                                                 />
+                                                <i class="fa fa-warning text-warning px-2 m-0" invisible="not warning" t-att-title="record.warning.raw_value"/>
                                                 <field name="name" class="text-truncate" />
                                                 <t invisible="state != 'object_write'">
                                                     <t invisible="not (update_field_type == 'many2many' and update_m2m_operation == 'clear') or evaluation_type != 'value'">

--- a/addons/mail/views/ir_actions_server_views.xml
+++ b/addons/mail/views/ir_actions_server_views.xml
@@ -20,8 +20,14 @@
                             <field name="activity_date_deadline_range_type" class="oe_inline" required="state == 'next_activity' and activity_date_deadline_range &gt; 0"/>
                         </div>
                         <field name="activity_user_type" required="state == 'next_activity'"/>
-                        <field name="activity_user_field_name" placeholder="e.g. user_id" invisible="activity_user_type == 'specific'" required="state == 'next_activity' and activity_user_type == 'generic'"/>
-                        <field name="activity_user_id" placeholder="Choose a user..." invisible="activity_user_type == 'generic'" required="state == 'next_activity' and activity_user_type == 'specific'"/>
+                        <field name="activity_user_field_name"
+                               widget="field_selector" options="{'model': 'model_name'}"
+                               invisible="activity_user_type != 'generic'"
+                               required="state == 'next_activity' and activity_user_type == 'generic'"/>
+                        <field name="activity_user_id"
+                               placeholder="Choose a user..."
+                               invisible="activity_user_type != 'specific'"
+                               required="state == 'next_activity' and activity_user_type == 'specific'"/>
                     </group>
                     <field name="activity_note" class="oe-bordered-editor" placeholder="Add a description to your activity..." invisible="state != 'next_activity'"/>
                 </xpath>
@@ -39,7 +45,7 @@
                            invisible="state != 'remove_followers' or followers_type != 'specific'"
                            required="state == 'remove_followers' and followers_type == 'specific'"/>
                     <field name="followers_partner_field_name"
-                           placeholder="e.g. partner_id"
+                           widget="field_selector" options="{'model': 'model_name'}"
                            invisible="state not in ['followers', 'remove_followers'] or followers_type != 'generic'"
                            required="state in ['followers', 'remove_followers'] and followers_type == 'generic'"/>
                     <!-- Send Email -->

--- a/addons/test_base_automation/tests/__init__.py
+++ b/addons/test_base_automation/tests/__init__.py
@@ -2,4 +2,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_flow
+from . import test_server_actions
 from . import test_tour

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -1014,6 +1014,19 @@ if env.context.get('old_values', None):  # on write
         })
         self.assertEqual(thread_test.message_follower_ids.partner_id, user.partner_id)
 
+    def test_cannot_have_actions_with_warnings(self):
+        with self.assertRaises(ValidationError) as e:
+            create_automation(
+                self,
+                model_id=self.env['ir.model']._get('ir.actions.server').id,
+                trigger='on_time',
+                _actions={
+                    'state': 'webhook',
+                    'webhook_field_ids': [self.env['ir.model.fields']._get('ir.actions.server', 'code').id],
+                },
+            )
+        self.assertEqual(e.exception.args[0], "Following child actions have warnings: Send Webhook Notification")
+
 
 @common.tagged('post_install', '-at_install')
 class TestCompute(common.TransactionCase):

--- a/addons/test_base_automation/tests/test_server_actions.py
+++ b/addons/test_base_automation/tests/test_server_actions.py
@@ -1,0 +1,77 @@
+# # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.addons.base.models.ir_actions import ServerActionWithWarningsError
+from odoo.exceptions import ValidationError
+from odoo.addons.base.tests.test_ir_actions import TestServerActionsBase
+
+
+class TestServerActionsValidation(TestServerActionsBase):
+    def test_multi_action_children_warnings(self):
+        self.action.write({
+            'state': 'multi',
+            'child_ids': [self.test_server_action.id]
+        })
+        self.assertEqual(self.action.model_id.model, "res.partner")
+        self.assertEqual(self.test_server_action.model_id.model, "ir.actions.server")
+        self.assertEqual(self.action.warning, "Following child actions should have the same model (Contact): TestDummyServerAction")
+
+        new_action = self.action.copy()
+        with self.assertRaises(ValidationError) as ve:
+            new_action.write({
+                'child_ids': [self.action.id]
+            })
+        self.assertEqual(ve.exception.args[0], "Following child actions have warnings: TestAction")
+
+    def test_webhook_payload_includes_group_restricted_fields(self):
+        self.test_server_action.write({
+            'state': 'webhook',
+            'webhook_field_ids': [self.env['ir.model.fields']._get('ir.actions.server', 'code').id],
+        })
+        self.assertEqual(self.test_server_action.warning, "Group-restricted fields cannot be included in "
+            "webhook payloads, as it could allow any user to "
+            "accidentally leak sensitive information. You will "
+            "have to remove the following fields from the webhook payload:\n"
+            "- Python Code")
+
+    def test_recursion_in_child(self):
+        new_action = self.action.copy()
+        self.action.write({
+            'state': 'multi',
+            'child_ids': [new_action.id]
+        })
+        with self.assertRaises(ValidationError) as ve:
+            new_action.write({
+                'child_ids': [self.action.id]
+            })
+        self.assertEqual(ve.exception.args[0], "Recursion found in child server actions")
+
+    def test_non_relational_field_traversal(self):
+        self.action.write({
+            'state': 'object_write',
+            'update_path': 'parent_id.name',
+            'value': 'TestNew',
+        })
+        with self.assertRaises(ValidationError) as ve:
+            self.action.write({'update_path': 'parent_id.name.something_else'})
+        self.assertEqual(ve.exception.args[0], "The path contained by the field "
+                        "'Field to Update Path' contains a non-relational field"
+                        " (Name) that is not the last field in the path. You "
+                        "can't traverse non-relational fields (even in the quantum"
+                        " realm). Make sure only the last field in the path is non-relational.")
+
+    def test_python_bad_expr(self):
+        with self.assertRaises(ValidationError) as ve:
+            self.test_server_action.write({'code': 'this is invalid python code'})
+        self.assertEqual(
+            ve.exception.args[0],
+            "SyntaxError : invalid syntax at line 1\n"
+            "this is invalid python code\n")
+
+    def test_cannot_run_if_warnings(self):
+        self.action.write({
+            'state': 'multi',
+            'child_ids': [self.test_server_action.id]
+        })
+        self.assertTrue(self.action.warning)
+        with self.assertRaises(ServerActionWithWarningsError) as e:
+            self.action.run()
+        self.assertEqual(e.exception.args[0], "Server action TestAction has one or more warnings, address them first.")

--- a/addons/test_mail/tests/test_ir_actions.py
+++ b/addons/test_mail/tests/test_ir_actions.py
@@ -61,6 +61,17 @@ class TestServerActionsEmail(MailCommon, TestServerActionsBase):
         self.action.with_context(self.context).run()
         self.assertEqual(self.test_partner.message_partner_ids, self.env.ref('base.partner_admin') | random_partner)
 
+    def test_action_followers_warning(self):
+        self.test_partner.message_unsubscribe(self.test_partner.message_partner_ids.ids)
+        self.action.write({
+            'state': 'followers',
+            "followers_type": "generic",
+            "followers_partner_field_name": "user_id.name"
+        })
+        self.assertEqual(self.action.warning, "The field 'Salesperson > Name' is not a partner field.")
+        self.action.write({"followers_partner_field_name": "parent_id.child_ids"})
+        self.assertEqual(self.action.warning, False)
+
     def test_action_message_post(self):
         # initial state
         self.assertEqual(len(self.test_partner.message_ids), 1,
@@ -119,6 +130,18 @@ class TestServerActionsEmail(MailCommon, TestServerActionsBase):
         self.assertFalse(run_res, 'ir_actions_server: create next activity action correctly finished should return False')
         self.assertEqual(self.env['mail.activity'].search_count([]), before_count + 1)
         self.assertEqual(self.env['mail.activity'].search_count([('summary', '=', 'TestNew')]), 1)
+
+    def test_action_next_activity_warning(self):
+        self.action.write({
+            'state': 'next_activity',
+            'activity_user_type': 'generic',
+            "activity_user_field_name": "user_id.name",
+            'activity_type_id': self.env.ref('mail.mail_activity_data_meeting').id,
+            'activity_summary': 'TestNew',
+        })
+        self.assertEqual(self.action.warning, "The field 'Salesperson > Name' is not a user field.")
+        self.action.write({"activity_user_field_name": "parent_id.user_id"})
+        self.assertEqual(self.action.warning, False)
 
     def test_action_next_activity_due_date(self):
         """ Make sure we don't crash if a due date is set without a type. """

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -332,6 +332,9 @@
                             <label for="state"/>
                             <field name="state" widget="selection_badge" options="{'size': 'sm'}"/>
                         </div>
+                        <div class="alert alert-warning" role="alert" invisible="not warning">
+                            <i class="fa fa-warning pe-2" title="Warning"/><field class="d-inline" name="warning" nolabel="1"/>
+                        </div>
                         <group string="Technical Settings" groups="base.group_no_one">
                             <group>
                                 <field name="model_id" options="{'no_create': True, 'no_open': True}" />

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -1722,13 +1722,11 @@ class PropertiesCase(TestPropertiesMixin):
             'model_name': 'test_new_api.emailmessage',
             'state': 'object_write',
         })
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as ve:
             action.update_path = 'attributes.discussion_color_code'
-            # call _stringify_path directly because it's only called for
-            # server action linked to a base_automation
-            self.assertEqual(action._stringify_path(),
-                'Properties > discussion_color_code'
-            )
+        self.assertEqual(ve.exception.args[0],
+            "The path contained by the field 'Field to Update Path' contains a non-relational field (Properties) that is not the last field in the path. You can't traverse non-relational fields (even in the quantum realm). Make sure only the last field in the path is non-relational."
+        )
 
 
 class PropertiesSearchCase(TestPropertiesMixin):


### PR DESCRIPTION
### [IMP] base: soften server actions validation
When applied, this commit will soften server actions validation by
displaying an inline warning on server actions form views instead of
validation error dialogs in numerous cases:
- "Update record": when targeting a JSON field
- "Webhook": when including group-restricted fields in the payload
- For mail/sms related actions, if the model is transient or does not
  use mail mixins.
- "Next activity": when 'Due date' is negative
- "Send SMS": template model should match action model
- "Send Email": template model should match action model

The following validation errors are still displayed:
- "Multi actions": Recursion found in child server actions
- "Update record": ...You can't traverse non-relational fields...
- "Execute code": Execute python syntax errors

Also a new validation error has been added for base.automation records
when any of its actions has some warning.

### [IMP] mail: use field selector for server actions
For the activity/followers related server actions, we use the field
selector to select the right fields to configure the action.

Warnings are displayed when targeting the wrong field type:
- Add/Remove Followers: field should target a partner
- Create activity: field should target a user

Note that some other compute methods needed adaptations
in order to avoid tracebacks when computing warnings.

Task: opw-4388736