### PR TITLE
[IMP] html_editor: rename category from basic_block to modules

### DIFF
--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -110,6 +110,7 @@ export class PowerboxPlugin extends Plugin {
         powerbox_categories: [
             withSequence(10, { id: "structure", name: _t("Structure") }),
             withSequence(60, { id: "widget", name: _t("Widget") }),
+            withSequence(100, { id: "modules", name: _t("Modules") }),
         ],
         power_buttons: withSequence(100, {
             commandId: "openPowerbox",


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- The Signature Plugin was defined in the sign module by extending the html_editor plugin under the basic_block category.
- The mass_mailing builder removed config.plugins, preventing the Signature Plugin from working.

### Desired behavior after PR is merged:

- The category is now defined in html_editor and renamed to modules so other modules can also use it.
- Mass Mailing:
  - Signature Plugin is registered in  `mass_mailing-plugins` for mass_mailing.
  - For simple editor, Signature Plugin is registered in `basic-editor-plugins`.

**enterprise: https://github.com/odoo/enterprise/pull/75612**

task-4224624