### PR TITLE
[IMP] web: use loadBundle on iframe

### DIFF
--- a/addons/web/static/tests/core/utils/assets.test.js
+++ b/addons/web/static/tests/core/utils/assets.test.js
@@ -1,18 +1,34 @@
-import { describe, expect, test } from "@odoo/hoot";
-import { manuallyDispatchProgrammaticEvent } from "@odoo/hoot-dom";
+import { after, describe, expect, test } from "@odoo/hoot";
+import { animationFrame, manuallyDispatchProgrammaticEvent } from "@odoo/hoot-dom";
+import { mockFetch } from "@odoo/hoot-mock";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 
-import { assets, loadCSS, loadJS } from "@web/core/assets";
+import { assets, cacheMapByDocument, loadBundle, loadCSS, loadJS } from "@web/core/assets";
 
 describe.current.tags("headless");
 
 /**
  * @param {(node: Node) => void} callback
  */
-const mockHeadAppendChild = (callback) =>
+const mockHeadAppendChild = (callback) => {
+    const currentDocumentMap = cacheMapByDocument.get(document);
+    cacheMapByDocument.set(document, new Map());
+    after(() => {
+        cacheMapByDocument.set(document, currentDocumentMap);
+    });
     patchWithCleanup(document.head, {
         appendChild: callback,
     });
+};
+
+const bundles = {
+    "/web/bundle/test.bundle": [
+        { type: "link", src: "file1.css" },
+        { type: "link", src: "file2.css" },
+        { type: "script", src: "file1.js" },
+        { type: "script", src: "file2.js" },
+    ],
+};
 
 test("loadJS: load invalid JS lib", async () => {
     expect.assertions(4);
@@ -51,4 +67,116 @@ test("loadCSS: load invalid CSS lib", async () => {
         /The loading of \/some\/invalid\/file.css failed/,
         { message: "Trying to load an invalid file rejects the promise" }
     );
+});
+
+test("loadBundle: load js and css files", async () => {
+    mockFetch((route) => {
+        expect.step(`fetch bundle: ${route.pathname}`);
+        return bundles[route.pathname];
+    });
+
+    mockHeadAppendChild(async (node) => {
+        const srcAttribute = node.tagName === "LINK" ? "href" : "src";
+        expect.step(`add ${node.tagName} - ${node.type} - ${node.getAttribute(srcAttribute)}`);
+    });
+
+    loadBundle("test.bundle");
+    await animationFrame();
+    expect.verifySteps([
+        "fetch bundle: /web/bundle/test.bundle",
+        "add LINK - text/css - file1.css",
+        "add LINK - text/css - file2.css",
+        "add SCRIPT - text/javascript - file1.js",
+        "add SCRIPT - text/javascript - file2.js",
+    ]);
+});
+
+test("loadBundle: load only js files", async () => {
+    mockFetch((route) => {
+        expect.step(`fetch bundle: ${route.pathname}`);
+        return bundles[route.pathname];
+    });
+
+    mockHeadAppendChild(async (node) => {
+        const srcAttribute = node.tagName === "LINK" ? "href" : "src";
+        expect.step(`add ${node.tagName} - ${node.type} - ${node.getAttribute(srcAttribute)}`);
+    });
+
+    loadBundle("test.bundle", { css: false });
+    await animationFrame();
+    expect.verifySteps([
+        "fetch bundle: /web/bundle/test.bundle",
+        "add SCRIPT - text/javascript - file1.js",
+        "add SCRIPT - text/javascript - file2.js",
+    ]);
+});
+
+test("loadBundle: load only css files", async () => {
+    mockFetch((route) => {
+        expect.step(`fetch bundle: ${route.pathname}`);
+        return bundles[route.pathname];
+    });
+
+    mockHeadAppendChild(async (node) => {
+        const srcAttribute = node.tagName === "LINK" ? "href" : "src";
+        expect.step(`add ${node.tagName} - ${node.type} - ${node.getAttribute(srcAttribute)}`);
+    });
+
+    loadBundle("test.bundle", { js: false });
+    await animationFrame();
+    expect.verifySteps([
+        "fetch bundle: /web/bundle/test.bundle",
+        "add LINK - text/css - file1.css",
+        "add LINK - text/css - file2.css",
+    ]);
+});
+
+test("loadBundle: load same bundle in main document and an iframe", async () => {
+    mockFetch((route) => {
+        expect.step(`fetch bundle: ${route.pathname}`);
+        return bundles[route.pathname];
+    });
+
+    mockHeadAppendChild(async (node) => {
+        const srcAttribute = node.tagName === "LINK" ? "href" : "src";
+        expect.step(
+            `add document ${node.tagName} - ${node.type} - ${node.getAttribute(srcAttribute)}`
+        );
+    });
+
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    const iframeDocument = iframe.contentDocument;
+    patchWithCleanup(iframeDocument.head, {
+        appendChild: (node) => {
+            const srcAttribute = node.tagName === "LINK" ? "href" : "src";
+            expect.step(
+                `add iframe document ${node.tagName} - ${node.type} - ${node.getAttribute(
+                    srcAttribute
+                )}`
+            );
+        },
+    });
+
+    loadBundle("test.bundle");
+    await animationFrame();
+    expect.verifySteps([
+        "fetch bundle: /web/bundle/test.bundle",
+        "add document LINK - text/css - file1.css",
+        "add document LINK - text/css - file2.css",
+        "add document SCRIPT - text/javascript - file1.js",
+        "add document SCRIPT - text/javascript - file2.js",
+    ]);
+
+    loadBundle("test.bundle", { targetDoc: iframeDocument });
+    await animationFrame();
+    expect.verifySteps([
+        "fetch bundle: /web/bundle/test.bundle",
+        "add iframe document LINK - text/css - file1.css",
+        "add iframe document LINK - text/css - file2.css",
+        "add iframe document SCRIPT - text/javascript - file1.js",
+        "add iframe document SCRIPT - text/javascript - file2.js",
+    ]);
+
+    iframe.remove();
 });


### PR DESCRIPTION
The goal of this commit is to enable:
- the use of loadBundle on an iframe
- load only the js or css files of a bundle

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
