### PR TITLE
[FIX] l10n_ro_eFactura: Invoice content error detection

### DIFF
--- a/addons/account/static/src/components/document_state/document_state_field.scss
+++ b/addons/account/static/src/components/document_state/document_state_field.scss
@@ -1,5 +1,5 @@
 .account_document_state_popover {
-    width: 360px;
+    width: 500px;
 }
 
 .account_document_state_popover_clone {

--- a/addons/l10n_ro_efactura/models/account_move.py
+++ b/addons/l10n_ro_efactura/models/account_move.py
@@ -250,13 +250,14 @@ class AccountMove(models.Model):
                     company=invoice.company_id,
                     key_download=result['key_download'],
                     session=session,
+                    status=result['state_status'],
                 )
                 to_delete_documents |= invoice._l10n_ro_edi_get_sending_and_failed_documents()
                 final_result['key_loading'] = active_sending_document.key_loading
-                if 'error' in final_result:
+                if final_result.get('error'):
                     final_result['attachment_raw'] = previous_raw
                     invoice._l10n_ro_edi_create_document_invoice_sending_failed(
-                        message=final_result['error'],
+                        message=final_result['error'].replace('\t', ''),
                         attachment_raw=final_result['attachment_raw'],
                         key_loading=final_result['key_loading'],
                     )


### PR DESCRIPTION
### Before
-When the eFactura status was fetched and there was an invoice content error it was not displayed. This issue was due to both the overlooking of:
-  ​the 'nok' status (sent back by the Romanian authorities regarding the presence of errors in the invoice content) 
-  the file provided in the zip that would contain the errors

-The error message shown would also only contain the first error even if many were present.

### Now

-If the status fetched contains 'nok' and is therefore signaling the presence of invoice content errors, then the apposite error file is chosen instead of the file with the electronic signature. This allows for following logic to account for errors, to retrieve the error message and to provide the error file as the downloadable document. 

-The pop up shows all the errors with an increased width to account for more content.

task-4306506