### PR TITLE
[FIX] website_slides: fix website description field

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -118,7 +118,7 @@ class Slide(models.Model):
     active = fields.Boolean(default=True, tracking=100)
     sequence = fields.Integer('Sequence', default=0)
     user_id = fields.Many2one('res.users', string='Uploaded by', default=lambda self: self.env.uid)
-    description = fields.Html('Description', translate=True, sanitize_attributes=False)
+    description = fields.Html('Description', translate=True, sanitize_attributes=False, sanitize_overridable=True)
     channel_id = fields.Many2one('slide.channel', string="Course", required=True, ondelete='cascade')
     tag_ids = fields.Many2many('slide.tag', 'rel_slide_tag', 'slide_id', 'tag_id', string='Tags')
     is_preview = fields.Boolean('Allow Preview', default=False, help="The course is accessible by anyone : the users don't need to join the channel to access the content of the course.")


### PR DESCRIPTION
This commit adds the parameter `sanitize_overridable=True` to the `description` field of `website_slides` slides. It means that the description can now be properly edited as an user with enough rights.

The issue is that the `slide.description` field is sanitized after saving a `slide/*` page, which removes `<button>` elements. This is not easily testable in version 16.0 because no blocks contain `<button>` elements. However, starting from version 18.0, new blocks like the `accordion` block include buttons, and these are removed after saving a `slide/*` page when they are dropped into it.

opw-4273436