### PR TITLE
[IMP] spreadsheet_dashboard: put two scorecards per row on mobile

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
     <t t-name="documents_spreadsheet.MobileFigureContainer">
-        <t t-if="!figures.length">
+        <t t-if="!figureRows.length">
             Only chart figures are displayed in small screens but this dashboard doesn't contain any
         </t>
-        <t
-            t-foreach="figures" t-as="figure"
-            t-component="getFigureComponent(figure)"
-            onFigureDeleted="() => {}"
-            figure="figure"
-            t-key="figure.id"/>
+        <t t-foreach="figureRows" t-as="figureRow" t-key="figureRow_index">
+            <div class="o_figure_row d-flex flex-row">
+                <t t-foreach="figureRow" t-as="figure" t-key="figure_index">
+                    <div t-if="figure.tag === 'empty'" class="o_empty_figure w-100 h-100"/>
+                    <t t-else="" figure="figure" t-component="getFigureComponent(figure)" onFigureDeleted="() => {}" />
+                </t>
+            </div>
+        </t>
     </t>
 </templates>
-

--- a/addons/spreadsheet_dashboard/static/tests/mobile/mobile_dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/mobile/mobile_dashboard_action.test.js
@@ -77,6 +77,60 @@ test("displays figures in first sheet", async () => {
     expect(".o-chart-container").toHaveCount(1);
 });
 
+test("scorecards are placed two per row", async () => {
+    const figure = { tag: "chart", height: 500, width: 500, x: 100, y: 100 };
+    const lineChartData = {
+        type: "line",
+        dataSetsHaveTitle: false,
+        dataSets: [{ dataRange: "A1" }],
+        legendPosition: "top",
+        verticalAxisPosition: "left",
+        title: { text: "" },
+    };
+    const scorecardChartData = {
+        type: "scorecard",
+        title: { text: "test" },
+        keyValue: "A1",
+        background: "#fff",
+        baselineMode: "absolute",
+    };
+    const spreadsheetData = {
+        sheets: [
+            {
+                id: "sheet1",
+                figures: [
+                    { ...figure, id: "figure1", data: scorecardChartData },
+                    { ...figure, id: "figure2", data: scorecardChartData },
+                    { ...figure, id: "figure3", data: scorecardChartData },
+                    { ...figure, id: "figure4", data: lineChartData },
+                ],
+            },
+        ],
+    };
+    const serverData = getDashboardServerData();
+    serverData.models["spreadsheet.dashboard.group"].records = [
+        { published_dashboard_ids: [789], id: 1, name: "Chart" },
+    ];
+    serverData.models["spreadsheet.dashboard"].records = [
+        {
+            id: 789,
+            name: "Spreadsheet with chart figure",
+            json_data: JSON.stringify(spreadsheetData),
+            spreadsheet_data: JSON.stringify(spreadsheetData),
+            dashboard_group_id: 1,
+        },
+    ];
+    await createSpreadsheetDashboard({ serverData });
+    const figureRows = queryAll(".o_figure_row");
+    expect(figureRows).toHaveLength(3);
+    expect(figureRows[0].querySelectorAll(".o-scorecard")).toHaveLength(2);
+
+    expect(figureRows[1].querySelectorAll(".o-scorecard")).toHaveLength(1);
+    expect(figureRows[1].querySelectorAll(".o_empty_figure")).toHaveLength(1);
+
+    expect(figureRows[2].querySelectorAll(".o-figure-canvas")).toHaveLength(1);
+});
+
 test("double clicking on a figure doesn't open the side panel", async () => {
     const figure = {
         tag: "chart",


### PR DESCRIPTION
This commit make it so that on mobile, two scorecards are displayed per row instead of one. The other types of figures are still displayed one per row.

Task: [4192959](https://www.odoo.com/web#id=4192959&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
