### PR TITLE
[REM] l10n_ro_edi: remove l10n_ro_edi_oauth_error field

### DIFF
--- a/addons/l10n_ro_edi/i18n/l10n_ro_edi.pot
+++ b/addons/l10n_ro_edi/i18n/l10n_ro_edi.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.4alpha1+e\n"
+"Project-Id-Version: Odoo Server 18.1alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-09 14:33+0000\n"
-"PO-Revision-Date: 2024-07-09 14:33+0000\n"
+"POT-Creation-Date: 2024-12-13 11:04+0000\n"
+"PO-Revision-Date: 2024-12-13 11:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,7 +18,6 @@ msgstr ""
 #. module: l10n_ro_edi
 #: model:ir.model.fields,help:l10n_ro_edi.field_account_bank_statement_line__l10n_ro_edi_state
 #: model:ir.model.fields,help:l10n_ro_edi.field_account_move__l10n_ro_edi_state
-#: model:ir.model.fields,help:l10n_ro_edi.field_account_payment__l10n_ro_edi_state
 msgid ""
 "- Sent: Successfully sent to the SPV, waiting for validation\n"
 "                - Validated: Sent & validated by the SPV\n"
@@ -30,14 +29,6 @@ msgstr ""
 msgid ""
 ".\n"
 "                                        Login or Sign Up if you don't have an account yet"
-msgstr ""
-
-#. module: l10n_ro_edi
-#: model_terms:ir.ui.view,arch_db:l10n_ro_edi.account_move_send_inherit_l10n_ro_edi
-msgid ""
-"<i class=\"fa fa-question-circle\" role=\"img\" aria-label=\"Warning\" "
-"title=\"You can't send now. Some move(s) are waiting for an answer.\" "
-"invisible=\"not l10n_ro_edi_send_readonly\"/>"
 msgstr ""
 
 #. module: l10n_ro_edi
@@ -81,6 +72,11 @@ msgid "Account Move Send"
 msgstr ""
 
 #. module: l10n_ro_edi
+#: model:ir.model,name:l10n_ro_edi.model_account_move_send_wizard
+msgid "Account Move Send Wizard"
+msgstr ""
+
+#. module: l10n_ro_edi
 #: model_terms:ir.ui.view,arch_db:l10n_ro_edi.res_config_settings_form_inherit_l10n_ro_edi
 msgid "Activate test environment for sending E-Factura to SPV"
 msgstr ""
@@ -102,13 +98,13 @@ msgid "CIUS-RO XML attachment not found."
 msgstr ""
 
 #. module: l10n_ro_edi
-#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__res_partner__ubl_cii_format__ciusro
+#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__res_partner__invoice_edi_format__ciusro
 msgid "CIUSRO"
 msgstr ""
 
 #. module: l10n_ro_edi
 #. odoo-python
-#: code:addons/l10n_ro_edi/wizard/account_move_send.py:0
+#: code:addons/l10n_ro_edi/models/account_move_send.py:0
 msgid "Check Invoice(s)"
 msgstr ""
 
@@ -173,7 +169,14 @@ msgid "Datetime"
 msgstr ""
 
 #. module: l10n_ro_edi
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_edi_xml_ubl_ro__display_name
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send__display_name
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send_wizard__display_name
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_l10n_ro_edi_document__display_name
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_partner__display_name
 msgid "Display Name"
 msgstr ""
 
@@ -193,6 +196,8 @@ msgid "E-Factura"
 msgstr ""
 
 #. module: l10n_ro_edi
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_bank_statement_line__l10n_ro_edi_index
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move__l10n_ro_edi_index
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_l10n_ro_edi_document__key_loading
 msgid "E-Factura Index"
 msgstr ""
@@ -200,7 +205,6 @@ msgstr ""
 #. module: l10n_ro_edi
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_account_bank_statement_line__l10n_ro_edi_state
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move__l10n_ro_edi_state
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_payment__l10n_ro_edi_state
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_l10n_ro_edi_document__state
 #: model_terms:ir.ui.view,arch_db:l10n_ro_edi.l10n_ro_edi_view_account_invoice_filter
 msgid "E-Factura Status"
@@ -244,11 +248,6 @@ msgid "Error when decoding the access token payload: %s"
 msgstr ""
 
 #. module: l10n_ro_edi
-#: model_terms:ir.ui.view,arch_db:l10n_ro_edi.res_config_settings_form_inherit_l10n_ro_edi
-msgid "Error when generating token:"
-msgstr ""
-
-#. module: l10n_ro_edi
 #. odoo-python
 #: code:addons/l10n_ro_edi/controllers/main.py:0
 msgid "Error when processing the response: %s"
@@ -256,7 +255,7 @@ msgstr ""
 
 #. module: l10n_ro_edi
 #. odoo-python
-#: code:addons/l10n_ro_edi/wizard/account_move_send.py:0
+#: code:addons/l10n_ro_edi/models/account_move_send.py:0
 msgid "Error when rebuilding the CIUS-RO E-Factura XML"
 msgstr ""
 
@@ -268,7 +267,7 @@ msgstr ""
 
 #. module: l10n_ro_edi
 #. odoo-python
-#: code:addons/l10n_ro_edi/wizard/account_move_send.py:0
+#: code:addons/l10n_ro_edi/models/account_move_send.py:0
 msgid "Error when sending CIUS-RO E-Factura to the SPV"
 msgstr ""
 
@@ -304,12 +303,6 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ro_edi
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_partner__ubl_cii_format
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_users__ubl_cii_format
-msgid "Format"
-msgstr ""
-
-#. module: l10n_ro_edi
 #: model_terms:ir.ui.view,arch_db:l10n_ro_edi.res_config_settings_form_inherit_l10n_ro_edi
 msgid "Generate Token"
 msgstr ""
@@ -330,7 +323,14 @@ msgid "Go to \"Editare profil Oauth\""
 msgstr ""
 
 #. module: l10n_ro_edi
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_edi_xml_ubl_ro__id
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send__id
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send_wizard__id
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_l10n_ro_edi_document__id
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_config_settings__id
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_partner__id
 msgid "ID"
 msgstr ""
 
@@ -355,10 +355,6 @@ msgid "Key Certificate"
 msgstr ""
 
 #. module: l10n_ro_edi
-msgid "Key Loading"
-msgstr ""
-
-#. module: l10n_ro_edi
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_l10n_ro_edi_document__key_signature
 msgid "Key Signature"
 msgstr ""
@@ -366,7 +362,6 @@ msgstr ""
 #. module: l10n_ro_edi
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_account_bank_statement_line__l10n_ro_edi_attachment_id
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move__l10n_ro_edi_attachment_id
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_payment__l10n_ro_edi_attachment_id
 msgid "L10N Ro Edi Attachment"
 msgstr ""
 
@@ -379,24 +374,7 @@ msgstr ""
 #. module: l10n_ro_edi
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_account_bank_statement_line__l10n_ro_edi_document_ids
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move__l10n_ro_edi_document_ids
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_payment__l10n_ro_edi_document_ids
 msgid "L10N Ro Edi Document"
-msgstr ""
-
-#. module: l10n_ro_edi
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_company__l10n_ro_edi_oauth_error
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_config_settings__l10n_ro_edi_oauth_error
-msgid "L10N Ro Edi Oauth Error"
-msgstr ""
-
-#. module: l10n_ro_edi
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send__l10n_ro_edi_send_enable
-msgid "L10N Ro Edi Send Enable"
-msgstr ""
-
-#. module: l10n_ro_edi
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send__l10n_ro_edi_send_readonly
-msgid "L10N Ro Edi Send Readonly"
 msgstr ""
 
 #. module: l10n_ro_edi
@@ -465,27 +443,15 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ro_edi
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send__l10n_ro_edi_send_checkbox
+#. odoo-python
+#: code:addons/l10n_ro_edi/models/account_move_send.py:0
+#: code:addons/l10n_ro_edi/wizard/account_move_send_wizard.py:0
 msgid "Send E-Factura to SPV"
 msgstr ""
 
 #. module: l10n_ro_edi
-#: model:ir.model.fields,help:l10n_ro_edi.field_account_move_send__l10n_ro_edi_send_checkbox
-msgid "Send the CIUS-RO XML to the Romanian Government via the ANAF platform"
-msgstr ""
-
-#. module: l10n_ro_edi
-msgid "Sending"
-msgstr ""
-
-#. module: l10n_ro_edi
-#: model_terms:ir.ui.view,arch_db:l10n_ro_edi.l10n_ro_edi_view_account_invoice_filter
-msgid "Sending E-Factura"
-msgstr ""
-
-#. module: l10n_ro_edi
-#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__account_move__l10n_ro_edi_state__invoice_sending
-#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__l10n_ro_edi_document__state__invoice_sending
+#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__account_move__l10n_ro_edi_state__invoice_sent
+#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__l10n_ro_edi_document__state__invoice_sent
 msgid "Sent"
 msgstr ""
 
@@ -509,8 +475,10 @@ msgstr ""
 
 #. module: l10n_ro_edi
 #. odoo-python
-#: code:addons/l10n_ro_edi/wizard/account_move_send.py:0
-msgid "The following move(s) are waiting for answer from the Romanian SPV: %s"
+#: code:addons/l10n_ro_edi/models/account_move_send.py:0
+msgid ""
+"The following invoice(s) are waiting for answer from the Romanian SPV: %s.We"
+" won't send them again."
 msgstr ""
 
 #. module: l10n_ro_edi
@@ -557,14 +525,19 @@ msgid "Use Test Environment"
 msgstr ""
 
 #. module: l10n_ro_edi
-#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__account_move__l10n_ro_edi_state__invoice_sent
-#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__l10n_ro_edi_document__state__invoice_sent
+#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__account_move__l10n_ro_edi_state__invoice_validated
+#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__l10n_ro_edi_document__state__invoice_validated
 msgid "Validated"
 msgstr ""
 
 #. module: l10n_ro_edi
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi.l10n_ro_edi_view_account_invoice_filter
+msgid "Validated E-Factura"
+msgstr ""
+
+#. module: l10n_ro_edi
 #. odoo-python
-#: code:addons/l10n_ro_edi/wizard/account_move_send.py:0
+#: code:addons/l10n_ro_edi/models/account_move_send.py:0
 msgid "View Invoice(s)"
 msgstr ""
 
@@ -577,8 +550,20 @@ msgstr ""
 
 #. module: l10n_ro_edi
 #. odoo-python
+#: code:addons/l10n_ro_edi/wizard/account_move_send_wizard.py:0
+msgid "You can't send now. Invoice is waiting for an answer."
+msgstr ""
+
+#. module: l10n_ro_edi
+#. odoo-python
 #: code:addons/l10n_ro_edi/models/ciusro_document.py:0
 msgid "You reached the limit of requests. Please try again later."
+msgstr ""
+
+#. module: l10n_ro_edi
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_partner__invoice_edi_format
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_users__invoice_edi_format
+msgid "eInvoice format"
 msgstr ""
 
 #. module: l10n_ro_edi

--- a/addons/l10n_ro_edi/i18n/ro.po
+++ b/addons/l10n_ro_edi/i18n/ro.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.4alpha1+e\n"
+"Project-Id-Version: Odoo Server 18.1alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-09 14:33+0000\n"
-"PO-Revision-Date: 2024-07-09 14:33+0000\n"
+"POT-Creation-Date: 2024-12-13 11:04+0000\n"
+"PO-Revision-Date: 2024-12-13 11:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,18 +16,19 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_ro_edi
+#: model:ir.model.fields,help:l10n_ro_edi.field_account_bank_statement_line__l10n_ro_edi_state
+#: model:ir.model.fields,help:l10n_ro_edi.field_account_move__l10n_ro_edi_state
+msgid ""
+"- Sent: Successfully sent to the SPV, waiting for validation\n"
+"                - Validated: Sent & validated by the SPV\n"
+"                - Error: Sending error or validation error from the SPV"
+msgstr ""
+
+#. module: l10n_ro_edi
 #: model_terms:ir.ui.view,arch_db:l10n_ro_edi.res_config_settings_form_inherit_l10n_ro_edi
 msgid ""
 ".\n"
 "                                        Login or Sign Up if you don't have an account yet"
-msgstr ""
-
-#. module: l10n_ro_edi
-#: model_terms:ir.ui.view,arch_db:l10n_ro_edi.account_move_send_inherit_l10n_ro_edi
-msgid ""
-"<i class=\"fa fa-question-circle\" role=\"img\" aria-label=\"Warning\" "
-"title=\"You can't send now. Some move(s) are waiting for an answer.\" "
-"invisible=\"not l10n_ro_edi_send_readonly\"/>"
 msgstr ""
 
 #. module: l10n_ro_edi
@@ -71,6 +72,11 @@ msgid "Account Move Send"
 msgstr ""
 
 #. module: l10n_ro_edi
+#: model:ir.model,name:l10n_ro_edi.model_account_move_send_wizard
+msgid "Account Move Send Wizard"
+msgstr ""
+
+#. module: l10n_ro_edi
 #: model_terms:ir.ui.view,arch_db:l10n_ro_edi.res_config_settings_form_inherit_l10n_ro_edi
 msgid "Activate test environment for sending E-Factura to SPV"
 msgstr ""
@@ -92,13 +98,13 @@ msgid "CIUS-RO XML attachment not found."
 msgstr ""
 
 #. module: l10n_ro_edi
-#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__res_partner__ubl_cii_format__ciusro
+#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__res_partner__invoice_edi_format__ciusro
 msgid "CIUSRO"
 msgstr ""
 
 #. module: l10n_ro_edi
 #. odoo-python
-#: code:addons/l10n_ro_edi/wizard/account_move_send.py:0
+#: code:addons/l10n_ro_edi/models/account_move_send.py:0
 msgid "Check Invoice(s)"
 msgstr ""
 
@@ -163,9 +169,16 @@ msgid "Datetime"
 msgstr ""
 
 #. module: l10n_ro_edi
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_edi_xml_ubl_ro__display_name
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send__display_name
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send_wizard__display_name
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_l10n_ro_edi_document__display_name
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_partner__display_name
 msgid "Display Name"
-msgstr ""
+msgstr "Nume afișat"
 
 #. module: l10n_ro_edi
 #: model:ir.model,name:l10n_ro_edi.model_l10n_ro_edi_document
@@ -183,12 +196,26 @@ msgid "E-Factura"
 msgstr ""
 
 #. module: l10n_ro_edi
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_bank_statement_line__l10n_ro_edi_index
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move__l10n_ro_edi_index
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_l10n_ro_edi_document__key_loading
+msgid "E-Factura Index"
+msgstr ""
+
+#. module: l10n_ro_edi
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_account_bank_statement_line__l10n_ro_edi_state
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move__l10n_ro_edi_state
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_payment__l10n_ro_edi_state
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_l10n_ro_edi_document__state
 #: model_terms:ir.ui.view,arch_db:l10n_ro_edi.l10n_ro_edi_view_account_invoice_filter
 msgid "E-Factura Status"
+msgstr ""
+
+#. module: l10n_ro_edi
+#. odoo-python
+#: code:addons/l10n_ro_edi/models/account_move.py:0
+msgid ""
+"E-Factura has been sent and is now being validated by the SPV with index "
+"key: %s"
 msgstr ""
 
 #. module: l10n_ro_edi
@@ -207,19 +234,40 @@ msgid "Error E-Factura"
 msgstr ""
 
 #. module: l10n_ro_edi
-#: model_terms:ir.ui.view,arch_db:l10n_ro_edi.res_config_settings_form_inherit_l10n_ro_edi
-msgid "Error when generating token:"
+#. odoo-python
+#: code:addons/l10n_ro_edi/controllers/main.py:0
+#: code:addons/l10n_ro_edi/models/res_company.py:0
+msgid "Error when converting response to json: %s"
 msgstr ""
 
 #. module: l10n_ro_edi
 #. odoo-python
-#: code:addons/l10n_ro_edi/wizard/account_move_send.py:0
+#: code:addons/l10n_ro_edi/controllers/main.py:0
+#: code:addons/l10n_ro_edi/models/res_company.py:0
+msgid "Error when decoding the access token payload: %s"
+msgstr ""
+
+#. module: l10n_ro_edi
+#. odoo-python
+#: code:addons/l10n_ro_edi/controllers/main.py:0
+msgid "Error when processing the response: %s"
+msgstr ""
+
+#. module: l10n_ro_edi
+#. odoo-python
+#: code:addons/l10n_ro_edi/models/account_move_send.py:0
 msgid "Error when rebuilding the CIUS-RO E-Factura XML"
 msgstr ""
 
 #. module: l10n_ro_edi
 #. odoo-python
-#: code:addons/l10n_ro_edi/wizard/account_move_send.py:0
+#: code:addons/l10n_ro_edi/models/res_company.py:0
+msgid "Error when refreshing the access token: %s"
+msgstr ""
+
+#. module: l10n_ro_edi
+#. odoo-python
+#: code:addons/l10n_ro_edi/models/account_move_send.py:0
 msgid "Error when sending CIUS-RO E-Factura to the SPV"
 msgstr ""
 
@@ -255,12 +303,6 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ro_edi
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_partner__ubl_cii_format
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_users__ubl_cii_format
-msgid "Format"
-msgstr ""
-
-#. module: l10n_ro_edi
 #: model_terms:ir.ui.view,arch_db:l10n_ro_edi.res_config_settings_form_inherit_l10n_ro_edi
 msgid "Generate Token"
 msgstr ""
@@ -281,7 +323,14 @@ msgid "Go to \"Editare profil Oauth\""
 msgstr ""
 
 #. module: l10n_ro_edi
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_edi_xml_ubl_ro__id
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send__id
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send_wizard__id
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_l10n_ro_edi_document__id
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_config_settings__id
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_partner__id
 msgid "ID"
 msgstr ""
 
@@ -306,11 +355,6 @@ msgid "Key Certificate"
 msgstr ""
 
 #. module: l10n_ro_edi
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_l10n_ro_edi_document__key_loading
-msgid "Key Loading"
-msgstr ""
-
-#. module: l10n_ro_edi
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_l10n_ro_edi_document__key_signature
 msgid "Key Signature"
 msgstr ""
@@ -318,7 +362,6 @@ msgstr ""
 #. module: l10n_ro_edi
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_account_bank_statement_line__l10n_ro_edi_attachment_id
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move__l10n_ro_edi_attachment_id
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_payment__l10n_ro_edi_attachment_id
 msgid "L10N Ro Edi Attachment"
 msgstr ""
 
@@ -331,24 +374,7 @@ msgstr ""
 #. module: l10n_ro_edi
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_account_bank_statement_line__l10n_ro_edi_document_ids
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move__l10n_ro_edi_document_ids
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_payment__l10n_ro_edi_document_ids
 msgid "L10N Ro Edi Document"
-msgstr ""
-
-#. module: l10n_ro_edi
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_company__l10n_ro_edi_oauth_error
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_config_settings__l10n_ro_edi_oauth_error
-msgid "L10N Ro Edi Oauth Error"
-msgstr ""
-
-#. module: l10n_ro_edi
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send__l10n_ro_edi_send_enable
-msgid "L10N Ro Edi Send Enable"
-msgstr ""
-
-#. module: l10n_ro_edi
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send__l10n_ro_edi_send_readonly
-msgid "L10N Ro Edi Send Readonly"
 msgstr ""
 
 #. module: l10n_ro_edi
@@ -367,6 +393,12 @@ msgid "Message"
 msgstr ""
 
 #. module: l10n_ro_edi
+#. odoo-python
+#: code:addons/l10n_ro_edi/controllers/main.py:0
+msgid "Received access key: %s"
+msgstr ""
+
+#. module: l10n_ro_edi
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_res_company__l10n_ro_edi_refresh_token
 #: model:ir.model.fields,field_description:l10n_ro_edi.field_res_config_settings__l10n_ro_edi_refresh_token
 msgid "Refresh Token"
@@ -381,7 +413,21 @@ msgstr ""
 #. module: l10n_ro_edi
 #. odoo-python
 #: code:addons/l10n_ro_edi/models/res_company.py:0
+msgid "Refresh token failed [company=%(company_id)s]"
+msgstr ""
+
+#. module: l10n_ro_edi
+#. odoo-python
+#: code:addons/l10n_ro_edi/models/res_company.py:0
 msgid "Refresh token not found"
+msgstr ""
+
+#. module: l10n_ro_edi
+#. odoo-python
+#: code:addons/l10n_ro_edi/controllers/main.py:0
+msgid ""
+"Response (code=%(status_code)s) to %(url)s failed:\n"
+"%(text)s"
 msgstr ""
 
 #. module: l10n_ro_edi
@@ -397,30 +443,24 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ro_edi
-#: model:ir.model.fields,field_description:l10n_ro_edi.field_account_move_send__l10n_ro_edi_send_checkbox
+#. odoo-python
+#: code:addons/l10n_ro_edi/models/account_move_send.py:0
+#: code:addons/l10n_ro_edi/wizard/account_move_send_wizard.py:0
 msgid "Send E-Factura to SPV"
-msgstr ""
-
-#. module: l10n_ro_edi
-#: model:ir.model.fields,help:l10n_ro_edi.field_account_move_send__l10n_ro_edi_send_checkbox
-msgid "Send the CIUS-RO XML to the Romanian Government via the ANAF platform"
-msgstr ""
-
-#. module: l10n_ro_edi
-#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__account_move__l10n_ro_edi_state__invoice_sending
-#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__l10n_ro_edi_document__state__invoice_sending
-msgid "Sending"
-msgstr ""
-
-#. module: l10n_ro_edi
-#: model_terms:ir.ui.view,arch_db:l10n_ro_edi.l10n_ro_edi_view_account_invoice_filter
-msgid "Sending E-Factura"
 msgstr ""
 
 #. module: l10n_ro_edi
 #: model:ir.model.fields.selection,name:l10n_ro_edi.selection__account_move__l10n_ro_edi_state__invoice_sent
 #: model:ir.model.fields.selection,name:l10n_ro_edi.selection__l10n_ro_edi_document__state__invoice_sent
 msgid "Sent"
+msgstr ""
+
+#. module: l10n_ro_edi
+#: model:ir.model.fields,help:l10n_ro_edi.field_l10n_ro_edi_document__state
+msgid ""
+"Sent -> Successfully sent to the SPV, waiting for validation.\n"
+"                Validated -> Sent & validated by the SPV.\n"
+"                Error -> Sending error or validation error from the SPV."
 msgstr ""
 
 #. module: l10n_ro_edi
@@ -435,8 +475,10 @@ msgstr ""
 
 #. module: l10n_ro_edi
 #. odoo-python
-#: code:addons/l10n_ro_edi/wizard/account_move_send.py:0
-msgid "The following move(s) are waiting for answer from the Romanian SPV: %s"
+#: code:addons/l10n_ro_edi/models/account_move_send.py:0
+msgid ""
+"The following invoice(s) are waiting for answer from the Romanian SPV: %s.We"
+" won't send them again."
 msgstr ""
 
 #. module: l10n_ro_edi
@@ -485,8 +527,19 @@ msgid "Use Test Environment"
 msgstr ""
 
 #. module: l10n_ro_edi
+#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__account_move__l10n_ro_edi_state__invoice_validated
+#: model:ir.model.fields.selection,name:l10n_ro_edi.selection__l10n_ro_edi_document__state__invoice_validated
+msgid "Validated"
+msgstr ""
+
+#. module: l10n_ro_edi
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi.l10n_ro_edi_view_account_invoice_filter
+msgid "Validated E-Factura"
+msgstr ""
+
+#. module: l10n_ro_edi
 #. odoo-python
-#: code:addons/l10n_ro_edi/wizard/account_move_send.py:0
+#: code:addons/l10n_ro_edi/models/account_move_send.py:0
 msgid "View Invoice(s)"
 msgstr ""
 
@@ -499,8 +552,20 @@ msgstr ""
 
 #. module: l10n_ro_edi
 #. odoo-python
+#: code:addons/l10n_ro_edi/wizard/account_move_send_wizard.py:0
+msgid "You can't send now. Invoice is waiting for an answer."
+msgstr ""
+
+#. module: l10n_ro_edi
+#. odoo-python
 #: code:addons/l10n_ro_edi/models/ciusro_document.py:0
 msgid "You reached the limit of requests. Please try again later."
+msgstr ""
+
+#. module: l10n_ro_edi
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_partner__invoice_edi_format
+#: model:ir.model.fields,field_description:l10n_ro_edi.field_res_users__invoice_edi_format
+msgid "eInvoice format"
 msgstr ""
 
 #. module: l10n_ro_edi

--- a/addons/l10n_ro_edi/models/res_company.py
+++ b/addons/l10n_ro_edi/models/res_company.py
@@ -23,7 +23,6 @@ class ResCompany(models.Model):
     l10n_ro_edi_refresh_expiry_date = fields.Date(string='Refresh Token Expiry Date')
     l10n_ro_edi_callback_url = fields.Char(compute='_compute_l10n_ro_edi_callback_url')
     l10n_ro_edi_test_env = fields.Boolean(string='Use Test Environment', default=True)
-    l10n_ro_edi_oauth_error = fields.Char()  # Error field to be shown in case of error from the authentication process
 
     @api.depends('country_code')
     def _compute_l10n_ro_edi_callback_url(self):
@@ -72,7 +71,6 @@ class ResCompany(models.Model):
             'l10n_ro_edi_refresh_token': response_json['refresh_token'],
             'l10n_ro_edi_access_expiry_date': access_expiry_date,
             'l10n_ro_edi_refresh_expiry_date': refresh_expiry_date,
-            'l10n_ro_edi_oauth_error': False,
         })
 
     def _l10n_ro_edi_refresh_access_token(self, session):

--- a/addons/l10n_ro_edi/models/res_config_settings.py
+++ b/addons/l10n_ro_edi/models/res_config_settings.py
@@ -12,7 +12,6 @@ class ResConfigSettings(models.TransientModel):
     l10n_ro_edi_refresh_expiry_date = fields.Date(related='company_id.l10n_ro_edi_refresh_expiry_date', readonly=False)
     l10n_ro_edi_callback_url = fields.Char(related='company_id.l10n_ro_edi_callback_url')
     l10n_ro_edi_test_env = fields.Boolean(related='company_id.l10n_ro_edi_test_env', readonly=False)
-    l10n_ro_edi_oauth_error = fields.Char(related='company_id.l10n_ro_edi_oauth_error')
 
     def button_l10n_ro_edi_generate_token(self):
         """ Redirects to controllers/main.py ~ `authorize` method """

--- a/addons/l10n_ro_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_ro_edi/views/res_config_settings_views.xml
@@ -44,10 +44,6 @@
                                     <li>With the digital signature USB token inserted, generate the token using the button below</li>
                                 </ul>
                             </div>
-                            <div class="row text-warning" invisible="not l10n_ro_edi_oauth_error">
-                                Error when generating token:
-                                <field name="l10n_ro_edi_oauth_error" widget="text" class="w-100"/>
-                            </div>
                             <div class="row">
                                 <label for="l10n_ro_edi_client_id" class="col-lg-3 o_light_label"/>
                                 <field name="l10n_ro_edi_client_id"/>


### PR DESCRIPTION
This commit removes the now unusued `l10n_ro_edi_oauth_error` field in `res.company` and `res.config.settings`, after an improvement on stable was made that changes how we save/log authentication error in romania.

Follow-up for: https://github.com/odoo/odoo/pull/187708
related-upgrade-PR: https://github.com/odoo/upgrade/pull/6930
related-opw: 4187186