### PR TITLE
[IMP] hr_recruitment: unfollow old recruiter from job position

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -308,6 +308,10 @@ class HrJob(models.Model):
                 ]
                 job.message_unsubscribe(to_unsubscribe)
                 job.message_subscribe(job.user_id.partner_id.ids)
+                application_ids = job.application_ids.filtered(lambda x: x.user_id == old_recruiters[job])
+                if application_ids:
+                    application_ids.message_unsubscribe(to_unsubscribe)
+                    application_ids.user_id = job.user_id
 
         # Update the availability on all hired candidates if the mission end date is changed
         if "date_to" in vals:


### PR DESCRIPTION
In this PR,
- Unfollow the recruiter from the job position while we are setting up a new.
- This change will also apply to the application for that job.

Task-4037606

