### PR TITLE
[FIX] website_sale: keep Buy Now button size modest

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1096,6 +1096,7 @@
                                     <div id="o_wsale_cta_wrapper" class="d-flex flex-wrap align-items-center">
                                         <t t-set="hasQuantities" t-value="false"/>
                                         <t t-set="hasBuyNow" t-value="false"/>
+                                        <!-- TODO: remove line below in master -->
                                         <t t-set="ctaSizeBig" t-value="not hasQuantities or not hasBuyNow"/>
 
                                         <div id="add_to_cart_wrap" t-attf-class="{{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-flex'}} align-items-center mb-2 me-auto">
@@ -1300,7 +1301,7 @@
             <attribute name="t-value" remove="false" add="true" separator=" "/>
         </xpath>
         <xpath expr="//a[@id='add_to_cart']" position="after">
-            <a role="button" t-attf-class="btn btn-outline-primary o_we_buy_now ms-1 #{'btn-lg' if ctaSizeBig else ''}" href="#">
+            <a role="button" class="btn btn-outline-primary o_we_buy_now ms-1" href="#">
                 <i class="fa fa-bolt me-2"/>
                 Buy now
             </a>


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Edit a product page in eCommerce;
2. enable "Buy Now" button;
3. disable "Select Quantity".

Issue
-----
The "Buy Now" button becomes comically large.

Cause
-----
In 16.0, this specific configuration also enlarged the "Add to Cart" button, so a conditional was added to keep the "Buy Now" button the same size.

With the UI changes in 16.3+, the cart button no longer changes size, but doing the same for the "Buy Now" button was overlooked.

Solution
--------
No longer change the button size on `not hasQuantities or not hasBuyNow`

opw-4404060
