### PR TITLE
[FIX] registry: allow readonly check signaling

### DIFF
--- a/addons/test_website/tests/test_performance.py
+++ b/addons/test_website/tests/test_performance.py
@@ -8,7 +8,7 @@ class TestPerformance(UtilPerf):
     def test_10_perf_sql_website_controller_minimalist(self):
         url = '/empty_controller_test'
         select_tables_perf = {
-            'base_registry_signaling': 1,
+            'orm_signaling_registry': 1,
         }
         self._check_url_hot_query(url, 1, select_tables_perf)
         self.assertEqual(self._get_url_hot_query(url, cache=False), 1)

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -125,7 +125,7 @@ class TestStandardPerformance(UtilPerf):
         self.env['res.users'].sudo().browse(2).website_published = True
         url = '/web/image/res.users/2/image_256'
         select_tables_perf = {
-            'base_registry_signaling': 1,
+            'orm_signaling_registry': 1,
             'res_company': 1,
             'res_users': 2,
             'res_partner': 1,
@@ -138,7 +138,7 @@ class TestStandardPerformance(UtilPerf):
     def test_20_perf_sql_img_controller_bis(self):
         url = '/web/image/website/1/favicon'
         select_tables_perf = {
-            'base_registry_signaling': 1,
+            'orm_signaling_registry': 1,
             'website': 2,
             # 1. `_find_record()` performs an access right check through
             #    `exists()` which perform a request on the website.
@@ -197,7 +197,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             self.env.registry.test_readonly_enabled = readonly_enabled
             with self.subTest(readonly_enabled=readonly_enabled), self.env.cr.savepoint() as savepoint:
                 select_tables_perf = {
-                    'base_registry_signaling': 1,
+                    'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
                     'website_page': 2,
@@ -222,7 +222,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             self.env.registry.test_readonly_enabled = readonly_enabled
             with self.subTest(readonly_enabled=readonly_enabled), self.env.cr.savepoint() as savepoint:
                 select_tables_perf = {
-                    'base_registry_signaling': 1,
+                    'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
                     'website_page': 2,
@@ -256,7 +256,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             self.env.registry.test_readonly_enabled = readonly_enabled
             with self.subTest(readonly=readonly_enabled), self.env.cr.savepoint() as savepoint:
                 select_tables_perf = {
-                    'base_registry_signaling': 1,
+                    'orm_signaling_registry': 1,
                     'website_menu': 1,
                     # homepage controller is prefetching all menus for perf in one go
                     'website_page': 2,
@@ -283,7 +283,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
         # untrack website.page with no call to layout templates
         self.page.arch = '<div>I am a blank page</div>'
         select_tables_perf = {
-            'base_registry_signaling': 1,
+            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
             'website_page': 2,
@@ -314,7 +314,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
         menu_aa.parent_id = menu_a
 
         select_tables_perf = {
-            'base_registry_signaling': 1,
+            'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
             'website_page': 2,
@@ -335,7 +335,7 @@ class TestWebsitePerformancePost(UtilPerf):
         assets_url = self.env['ir.qweb']._get_asset_bundle('web.assets_frontend_lazy', css=False, js=True).get_links()[0]
         self.assertIn('web.assets_frontend_lazy.min.js', assets_url)
         select_tables_perf = {
-            'base_registry_signaling': 1,
+            'orm_signaling_registry': 1,
             'ir_attachment': 2,
             # All 2 coming from the /web/assets and ir.binary stack
             # 1. `search() the attachment`

--- a/odoo/addons/test_http/tests/test_registry.py
+++ b/odoo/addons/test_http/tests/test_registry.py
@@ -96,7 +96,7 @@ class TestHttpRegistry(BaseCase):
 
         # invalidate the registry of the current db
         with Registry(get_db_name()).cursor() as cr:
-            cr.execute("select nextval('base_registry_signaling')")
+            cr.execute("INSERT INTO orm_signaling_registry default values")
 
         # the registry should rebuild itself just fine
         with self.assertLogs('odoo.registry', logging.INFO) as capture:
@@ -166,7 +166,7 @@ class TestHttpRegistry(BaseCase):
         ])
 
     @mute_logger('odoo.sql_db')
-    def test_corrupt_sequences(self):
+    def test_corrupt_signaling(self):
         db_duplicate = self.duplicate_current_db('corrupt-sequence')
 
         # open a registry + session on the current db (for first subtest)
@@ -177,7 +177,7 @@ class TestHttpRegistry(BaseCase):
         # drop the signaling sequence
         with db_connect(db_duplicate).cursor() as cr:
             cr.execute('''
-                DROP SEQUENCE "base_registry_signaling"
+                DROP table "orm_signaling_registry"
             ''')
 
         with self.subTest(name="existing registry"):
@@ -187,7 +187,7 @@ class TestHttpRegistry(BaseCase):
                 self.assertEqual(res.status_code, 404)
             self.assertEqual(capture.output, [
                 Like("WARNING:odoo.http:Database or registry unusable, trying without\n"
-                     'Traceback...relation "base_registry_signaling" does not exist...')
+                     'Traceback...relation "orm_signaling_registry" does not exist...')
             ])
 
         with self.subTest(name="new registry"):

--- a/odoo/modules/registry/__init__.py
+++ b/odoo/modules/registry/__init__.py
@@ -1,3 +1,3 @@
 # ruff: noqa: F401
 # Exposed here so that exist code is unaffected.
-from odoo.orm.registry import DummyRLock, Registry, _REGISTRY_CACHES
+from odoo.orm.registry import DummyRLock, Registry, _REGISTRY_CACHES, _CACHES_BY_KEY


### PR DESCRIPTION
Followup of https://github.com/odoo/odoo/pull/190407

Aims to re-enable readonly cursor by replacing sequence by tables.

# Chosen solution: one table per signal

Simply replace sequence by a table. The only technical change is that the increments became transactional so we need to commit the cursor. Since the cursor is isolated (outside of any other transaction) the behavior should remains almost the same.

**Note:** a Date field is add mainly for monitoring, and more flexible garbage collecting. it is not strictly necessary.
**Note:** the garbage collection proposes to use  `id < max(id) -10`, even if this may looks wrong `id < max(id)` is good enough, the minus 10 will keep a ten-ish history. This doesn't need to be precise, but this should be good enough since we don't expect to have any concurrent update. (signal_changes transaction only inserts row) 
**This is completely arbitrary and could be replace by `id < max(id)` if it causes any issue.**

**This is the solution with the minimal change, good performance, reasonable complexity**

# Alternative solutions considered but rejected

## Alternative solution A, one table, one sequence per signal

https://github.com/odoo/odoo/compare/master...odoo-dev:odoo:master-fix-signaling-ro-onetable-multisequences-xdo
One table, but using one sequence per signal. Manual select nextval and insert. 

The only difference with solution one is that a single index will be used to get all signals.
This complexifies a little table creation. Performances are quite bad with a simple group by, they are equivalent (slighly better) than this solution but with added complexity.

## Alternative solution B: one table, one sequence for all signals

**SPOILER:** doesn't work
See https://github.com/odoo/odoo/compare/master...odoo-dev:odoo:master-fix-signaling-ro-onetable-xdo for implementation

One table for all signals: Instead of creating one table per cache, create a single table with a "key" column for all signals. This simplifies the creation of the table and signal retrieval (one single group by) but we have less information since the sequence is shared among process.
This can make invalidating a cache/registry without risking a second invalidation a little tricky. 

With solution one, we expect to have increment of one. So when invalidating a cache, we can just do 

`self.cache_sequences[cache_name] += 1`

Unfortunately, this is not correct using a single sequence. Lets imagine that the current value of the caches sequences are

In memory:
```
registry: 1
default_cache: 2
other_cache: 3
```

If we invalidate the default_cache, the new in memory value would be 3, but the real new value after the insert would be 4 since 3 was already used by the other_cache. 

In memory:
```
registry: 1
default_cache: 3
other_cache: 3
```
This means that on the next request, the default cache will be invalidated on check_signaling since `3 != 4`

A workaround for that can be to estimate the next value of the sequence by using the max values of all sequences. 

`self.cache_sequences[cache_name] = max(*self.cache_sequences.values(), self.registry_sequence) + 1`

In memory:
```
registry: 1
default_cache: 4
other_cache: 3
```

This is better but still not perfect. If another concurrent requests increments another sequence, lets say `other_cache` before the current request increments the `default_cache`

Real sequences:
In memory:
```
registry: 1
default_cache: 5
other_cache: 4
```
On next request, 4 != to 5 meaning that both `default_cache` and `other_cache` will be invalidated even if the invalidation for `default_cacheµ came from the current_worker.

Taking the id of the inserted record does not work either since we may miss a concurrent update on the same cache.

So, solution B could work but has more drawback than solution 1 (IMHO)

## Solution C (not tested), one table, one sequence, but used as a message queue

Use a single table but change check mechanism.

The main problem with solution 2 is that it is hard to know what signal is coming from where just based on increments. 
It could be possible to select all signals coming from the table and process them if we have any. The easiest solution could be to store the pid of the process that sent the signal (more simple than keeping a list of sent signal, even if this one is possible too) 

Instead of incrementing the counter when sending the signal and having one sequence for each signal, we can select all signal above the last checked one. The new sequence is the max of all signals, then we can process all new signals except the one coming from the current process. 

The major benefit of this solution is that it may allow to have a more precise signal: we could have a message explaining the change. (the module to invalidate, cache key to invalidate, a cache key to remove from cache....)
But on the topic of cache invalidation, this may look like a better idea on the paper that it is in reality. 

**Note** After discussion t looks like this third solution could have some issue regarding order of commit. It is possible that a transaction will consume a sequence, and commit it after another one with a higher sequence

Process a: nextval (10) (registry)
Process b: nextval (11) (default_cache)
process b: commit
process b: check signaling (11)
process c: check signaling (11)
process a: commit

process b and c will never see  update 10 and miss a registry update

