### PR TITLE
[FIX] mail: remove field with tracking=True

### DIFF
--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -177,6 +177,8 @@ class BaseModel(models.AbstractModel):
         """ Find tracking sequence of a given field, given their name. Current
         parameter 'tracking' should be an integer, but attributes with True
         are still supported; old naming 'track_sequence' also. """
+        if fname not in self._fields:
+            return 100
         sequence = getattr(
             self._fields[fname], 'tracking',
             getattr(self._fields[fname], 'track_sequence', 100)


### PR DESCRIPTION
Steps to reproduce:

1. In a module, add a field with tracking=True on any model
2. Change this field on any record, to force the creation of a tracking value
3. Remove the field from the code
4. Update the module

Result:

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/service/server.py", line 1313, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-16>", line 2, in new
  File "/home/odoo/src/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/modules/registry.py", line 114, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 536, in load_modules
    env['ir.model.data']._process_end(processed_modules)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_model.py", line 2558, in _process_end
    self._process_end_unlink_record(record)
  File "/home/odoo/custom/odoo/addons/website/models/ir_model_data.py", line 36, in _process_end_unlink_record
    return super()._process_end_unlink_record(record)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_model.py", line 2487, in _process_end_unlink_record
    record.unlink()
  File "/home/odoo/custom/odoo/addons/mail/models/ir_model_fields.py", line 52, in unlink
    'sequence': self.env[field.model_id.model]._mail_track_get_field_sequence(field.name),
  File "/home/odoo/custom/odoo/addons/mail/models/models.py", line 181, in _mail_track_get_field_sequence
    self._fields[fname], 'tracking',
KeyError: 'field_name'
```

Explanation:

It fails when trying to find the sequence for the new tracking values.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
