### PR TITLE
[FIX] html_editor: incorrect module's author name

### DIFF
--- a/addons/html_editor/__manifest__.py
+++ b/addons/html_editor/__manifest__.py
@@ -9,7 +9,6 @@ Html Editor
 This addon provides an extensible, maintainable editor.
     """,
 
-    'author': "odoo",
     'website': "https://www.odoo.com",
     'version': '1.0',
     'category': 'Hidden',


### PR DESCRIPTION
Author was set as "odoo" (lowercase). This commit removes the author key so it fallbacks to the default one, i.e. Odoo S.A.

This also aligns keys with previous commits like 42bad1a6 and ef7005f5.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
