### PR TITLE
fix ldap option

### DIFF
--- a/addons/auth_ldap/models/res_company_ldap.py
+++ b/addons/auth_ldap/models/res_company_ldap.py
@@ -89,6 +89,7 @@ class CompanyLDAP(models.Model):
         uri = 'ldap://%s:%d' % (conf['ldap_server'], conf['ldap_server_port'])
 
         connection = ldap.initialize(uri)
+        connection.set_option(ldap.OPT_REFERRALS, 
         ldap_chase_ref_disabled = self.env['ir.config_parameter'].sudo().get_param('auth_ldap.disable_chase_ref')
         if str2bool(ldap_chase_ref_disabled):
             connection.set_option(ldap.OPT_REFERRALS, ldap.OPT_OFF)


### PR DESCRIPTION
https://www.python-ldap.org/en/python-ldap-3.4.3/faq.html 

Q: My script bound to MS Active Directory but a a search operation results in the exception ldap.OPERATIONS_ERROR with the diagnostic message text “In order to perform this operation a successful bind must be completed on the connection.” Alternatively, a Samba 4 AD returns the diagnostic message “Operation unavailable without authentication”. What’s happening here?

A: When searching from the domain level, MS AD returns referrals (search continuations) for some objects to indicate to the client where to look for these objects. Client-chasing of referrals is a broken concept, since LDAPv3 does not specify which credentials to use when chasing the referral. Windows clients are supposed to simply use their Windows credentials, but this does not work in general when chasing referrals received from and pointing to arbitrary LDAP servers.

Therefore, per default, automatically chases the referrals internally with an anonymous access which fails with MS AD.libldap

So, the best thing to do is to switch this behaviour off:

l = ldap.initialize('ldap://foobar')
l.set_option(ldap.OPT_REFERRALS,0)
Note that setting the above option does NOT prevent search continuations from being returned, rather only that won’t attempt to resolve referrals.libldap

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
