### PR TITLE
[IMP] rating: remove files that depends on legacy bus test helpers

### DIFF
--- a/addons/rating/__manifest__.py
+++ b/addons/rating/__manifest__.py
@@ -28,10 +28,6 @@ This module allows a customer to give rating.
         ],
         'web.assets_unit_tests': [
             'rating/static/tests/**/*',
-            ('remove', 'rating/static/tests/helpers/**/*'),
-        ],
-        'web.tests_assets': [
-            'rating/static/tests/helpers/**/*',
         ],
         "mail.assets_public": [
             "rating/static/src/core/common/**/*",

--- a/addons/rating/static/tests/helpers/model_definitions_setup.js
+++ b/addons/rating/static/tests/helpers/model_definitions_setup.js
@@ -1,3 +1,0 @@
-import { addModelNamesToFetch } from '@bus/../tests/helpers/model_definitions_helpers';
-
-addModelNamesToFetch(['rating.rating']);


### PR DESCRIPTION
Purpose of this commit:
Remove files that depends on legacy 'bus/../test/helpers'.

Part of:3818666




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
