### PR TITLE
[IMP] account: remove files that depends on legacy bus test helpers

### DIFF
--- a/addons/account/static/tests/helpers/model_definitions_setup.js
+++ b/addons/account/static/tests/helpers/model_definitions_setup.js
@@ -1,3 +1,0 @@
-import { addModelNamesToFetch } from '@bus/../tests/helpers/model_definitions_helpers';
-
-addModelNamesToFetch(['account.move']);


### PR DESCRIPTION
Purpose of this commit:
Remove files that depends on legacy 'bus/../test/helpers'.

Part of:3818666



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
