### PR TITLE
[IMP] crm: remove files that depends on legacy bus test helpers

### DIFF
--- a/addons/crm/static/tests/model_definitions_setup.js
+++ b/addons/crm/static/tests/model_definitions_setup.js
@@ -1,3 +1,0 @@
-import { addModelNamesToFetch } from "@bus/../tests/helpers/model_definitions_helpers";
-
-addModelNamesToFetch(["crm.lead"]);


### PR DESCRIPTION
Purpose of this commit:
Remove files that depends on legacy 'bus/../test/helpers'.

Part of:3818666



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
