### PR TITLE
[IMP] l10n_latam_check: Allow multiple liquidity lines in own check

### DIFF
--- a/addons/l10n_latam_check/models/l10n_latam_check.py
+++ b/addons/l10n_latam_check/models/l10n_latam_check.py
@@ -171,10 +171,6 @@ class l10nLatamAccountPaymentCheck(models.Model):
         move = self._get_reconciled_move()
         return move._get_records_action()
 
-    def action_show_journal_entry(self):
-        self.ensure_one()
-        return self.outstanding_line_id.move_id._get_records_action()
-
     def _get_reconciled_move(self):
         reconciled_line = self.outstanding_line_id.full_reconcile_id.reconciled_line_ids - self.outstanding_line_id
         return (reconciled_line.move_id.line_ids - reconciled_line).mapped('move_id')

--- a/addons/l10n_latam_check/views/l10n_latam_check_view.xml
+++ b/addons/l10n_latam_check/views/l10n_latam_check_view.xml
@@ -102,7 +102,6 @@
         <field name="model">l10n_latam.check</field>
         <field name="arch" type="xml">
             <form create="false" edit="false" delete="false">
-                <field name="outstanding_line_id" invisible="True"/>
                 <header>
                     <button name="action_void" string="Void Check" invisible="issue_state != 'handed'" type="object" class="oe_highlight" confirm="Marking a check as void will cancel the check and generate a new entry that will re-open the debt."  data-hotkey="v"/>
                     <field name="issue_state" statusbar_visible="issue_state" widget="statusbar"/>
@@ -114,9 +113,6 @@
                         </button>
                         <button  icon="fa-bars" type="object" name="button_open_payment" invisible="payment_method_code != 'own_checks'">
                             <span>Payment</span>
-                        </button>
-                        <button  icon="fa-bars" type="object" invisible="not outstanding_line_id" name="action_show_journal_entry" groups="account.group_account_user,account.group_account_readonly">
-                            <span>Journal Entry</span>
                         </button>
                         <button  icon="fa-bars" type="object" invisible="not issue_state or issue_state == 'handed'" name="action_show_reconciled_move" groups="account.group_account_user,account.group_account_readonly">
                             <span>Reconciled move</span>


### PR DESCRIPTION
This PR introduces an improvement to the account and l10n_latam_check modules that allows for multiple liquidity lines (one per check) to be recorded in a single journal entry. Currently, a split journal entry is created for each liquidity line, which presents several disadvantages:
   - Incorrect computation of payment and invoice states
   - Simplified workflow: By using a single journal entry for all liquidity lines, the workflow is significantly simplified and accounting complexity is reduced.
   - First step towards a refactor: This improvement is a first step towards a broader refactor that will allow adapting the own check flow in payment registration without the need to create journal entries.

Changes made:
   - Enhanced _synchronize_to_moves() method: 
        - Allows for the creation and update of multiple liquidity lines within a single journal entry. 
        - Removes excess liquidity lines if _prepare_move_line_default_vals() returns fewer lines than currently exist. 
        - Account type-based counterparty identification: Replaces the previous position-based identification with an approach based on account types. 
        - The starting index for extra line values is now dynamic, determined by the number of liquidity lines

   - Removed _l10n_latam_check_split_move method:
       - This method is no longer necessary given the new implementation that supports multiple liquidity lines in a single journal entry.
   - Modified _prepare_move_line_default_vals() method: - Now returns one liquidity line for each registered own check, simplifying the generation of journal entries.
   - Preserved _l10n_latam_check_unlink_split_move() method:
       - Maintained for backward compatibility purposes, allowing payments containing split moves to be set to draft status.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


opw-4236815

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
