### PR TITLE
[IMP] website: enables sending a copy of the filled form to visitors

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -35,6 +35,7 @@
         'data/website_data.xml',
         'data/website_visitor_cron.xml',
         'data/digest_data.xml',
+        'data/mail_template_data.xml',
         'views/website_templates.xml',
         'views/snippets/snippets.xml',
         'views/snippets/s_framed_intro.xml',

--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -69,7 +69,7 @@ class WebsiteForm(http.Controller):
             })
 
         user_email = kwargs.get("email_from") or kwargs.get("email")
-        visitor_name = kwargs.get("partner_name") or kwargs.get("contact_name") or kwargs.get("name") or 'Visitor'
+        visitor_name = kwargs.get("partner_name") or kwargs.get("contact_name") or kwargs.get("name")
 
         try:
             data = self.extract_data(model_record, kwargs)
@@ -99,9 +99,7 @@ class WebsiteForm(http.Controller):
                     request.env[model_name].sudo().browse(id_record).send()
 
                 try:
-                    send_email_flag = kwargs.get("send_a_copy", False)
-
-                    if send_email_flag and user_email:
+                    if user_email and kwargs.get("send_a_copy", False):
                         send_a_copy_dict = json.loads(kwargs.get("send_a_copy"))
                         template = request.env.ref("website.email_template_form_submission")
                         filled_values = nl2br(
@@ -116,8 +114,8 @@ class WebsiteForm(http.Controller):
                         ).send_mail(
                             2, force_send=True, raise_exception=True
                         )
-                except Exception as e:
-                    _logger.exception("Error while sending a copy of the form submission to the user: %s", e)
+                except Exception:
+                    _logger.exception("Error while sending a copy of the form submission to the user")
 
         # Some fields have additional SQL constraints that we can't check generically
         # Ex: crm.lead.probability which is a float between 0 and 1

--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -4,10 +4,11 @@ import base64
 import json
 import psycopg2
 
-from markupsafe import Markup
+from markupsafe import Markup, escape
 from psycopg2 import IntegrityError
 import re
 from werkzeug.exceptions import BadRequest
+import logging
 
 from odoo import http, SUPERUSER_ID
 from odoo.addons.base.models.ir_qweb_fields import nl2br, nl2br_enclose
@@ -18,6 +19,7 @@ from odoo.tools.misc import hmac, consteq
 from odoo.tools.translate import _, LazyTranslate
 
 _lt = LazyTranslate(__name__)
+_logger = logging.getLogger(__name__)
 
 
 class WebsiteForm(http.Controller):
@@ -66,6 +68,9 @@ class WebsiteForm(http.Controller):
                 'error': _("The form's specified model does not exist")
             })
 
+        user_email = kwargs.get("email_from") or kwargs.get("email")
+        visitor_name = kwargs.get("partner_name") or kwargs.get("contact_name") or kwargs.get("name") or 'Visitor'
+
         try:
             data = self.extract_data(model_record, kwargs)
         # If we encounter an issue while extracting data
@@ -74,6 +79,7 @@ class WebsiteForm(http.Controller):
             return json.dumps({'error_fields': e.args[0]})
 
         try:
+            data["custom"] = data["custom"].split("send_a_copy")[0].strip()
             id_record = self.insert_record(request, model_record, data['record'], data['custom'], data.get('meta'))
             if id_record:
                 self.insert_attachment(model_record, id_record, data['attachments'])
@@ -91,6 +97,27 @@ class WebsiteForm(http.Controller):
                         if not consteq(kwargs["website_form_signature"], hash_value):
                             raise AccessDenied(self.env._('invalid website_form_signature'))
                     request.env[model_name].sudo().browse(id_record).send()
+
+                try:
+                    send_email_flag = kwargs.get("send_a_copy", False)
+
+                    if send_email_flag and user_email:
+                        send_a_copy_dict = json.loads(kwargs.get("send_a_copy"))
+                        template = request.env.ref("website.email_template_form_submission")
+                        filled_values = nl2br(
+                            Markup("").join(
+                                Markup("<b>{label}:</b> {value}<br/>").format(
+                                    label=escape(key), value=escape(value)
+                                ) for key, value in send_a_copy_dict.items()
+                            )
+                        )
+                        template.sudo().with_context(
+                            filled_values=filled_values, visitor_name=visitor_name, to_mail=user_email
+                        ).send_mail(
+                            2, force_send=True, raise_exception=True
+                        )
+                except Exception as e:
+                    _logger.exception("Error while sending a copy of the form submission to the user: %s", e)
 
         # Some fields have additional SQL constraints that we can't check generically
         # Ex: crm.lead.probability which is a float between 0 and 1

--- a/addons/website/data/mail_template_data.xml
+++ b/addons/website/data/mail_template_data.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Email template for new users -->
+        <record id="email_template_form_submission" model="mail.template">
+            <field name="name">Website: Send a copy of the form to Visitor</field>
+            <field name="model_id" ref="base.model_res_users"/>
+            <field name="email_from">{{ object.company_id.email }}</field>
+            <field name="email_to">{{ ctx.get("to_mail","") }}</field>
+            <field name="subject">Your answers on Form</field>
+            <field name="description">Send a copy of the form to the user after successful submission</field>
+            <field name="body_html" type="html">
+                <table border="0" cellpadding="0" cellspacing="0" style="padding: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;">
+                    <tr>
+                        <td align="center">
+                            <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 16px; background-color: #FFFFFF; color: #454748; border-collapse:separate;">
+                                <tbody>
+                                    <tr>
+                                        <td>
+                                            <h3 class="mb-2">Copy of your Form Submission</h3>
+                                            <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;"/>
+                                            <div style="font-size: 13px;">
+                                                Hello <t t-out="ctx.get('visitor_name','')">OdooBot</t>,<br /><br />
+                                                Thanks to have filling in the form. <br /><br />
+                                                <t t-out="ctx.get('filled_values', '')"/><br />
+                                                Completed on <t t-out="format_date(datetime.datetime.now(), 'short')"/>. <br /><br />
+                                                Thank you, <br />
+                                                <t t-if="object.signature">
+                                                    <t t-out="object.signature or ''">--<br/>Mitchell Admin</t>
+                                                </t>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td style="text-align:center;">
+                                            <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;"/>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td style="font-size: 11px;">
+                                            <t t-out="object.company_id.name or ''">YourCompany</t> <br />
+                                            <div style="opacity: 0.7;">
+                                                <t t-if="object.company_id.phone">
+                                                    <a t-att-href="'tel:%s' % object.company_id.phone" style="text-decoration:none; color: #454748;" t-out="object.company_id.phone or ''">+1 650-123-4567</a>
+                                                </t>
+                                                <t t-if="object.company_id.email">
+                                                    | <a t-att-href="'mailto:%s' % object.company_id.email" style="text-decoration:none; color: #454748;" t-out="object.company_id.email or ''">info@yourcompany.com</a>
+                                                </t>
+                                                <t t-if="object.company_id.website">
+                                                    | <a t-att-href="'%s' % object.company_id.website" style="text-decoration:none; color: #454748;" t-out="object.company_id.website or ''">http://www.example.com</a>
+                                                </t>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </field>
+            <field name="lang">{{ object.lang }}</field>
+            <field name="use_default_to" eval="False"/>
+            <field name="auto_delete" eval="True"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/website/data/mail_template_data.xml
+++ b/addons/website/data/mail_template_data.xml
@@ -6,7 +6,7 @@
             <field name="name">Website: Send a copy of the form to Visitor</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="email_from">{{ object.company_id.email }}</field>
-            <field name="email_to">{{ ctx.get("to_mail","") }}</field>
+            <field name="email_to">{{ ctx.get("to_mail", "") }}</field>
             <field name="subject">Your answers on Form</field>
             <field name="description">Send a copy of the form to the user after successful submission</field>
             <field name="body_html" type="html">
@@ -20,7 +20,7 @@
                                             <h3 class="mb-2">Copy of your Form Submission</h3>
                                             <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;"/>
                                             <div style="font-size: 13px;">
-                                                Hello <t t-out="ctx.get('visitor_name','')">OdooBot</t>,<br /><br />
+                                                Hello <t t-out="ctx.get('visitor_name')">Visitor</t>,<br /><br />
                                                 Thanks to have filling in the form. <br /><br />
                                                 <t t-out="ctx.get('filled_values', '')"/><br />
                                                 Completed on <t t-out="format_date(datetime.datetime.now(), 'short')"/>. <br /><br />

--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -51,7 +51,7 @@
                                 </p>
                                 <section class="s_website_form" data-vcss="001" data-snippet="s_website_form">
                                     <div class="container">
-                                        <form id="contactus_form" action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-model_name="mail.mail" data-success-mode="redirect" data-success-page="/contactus-thank-you" data-pre-fill="true">
+                                        <form id="contactus_form" action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required o_send_a_copy" data-mark="*" data-model_name="mail.mail" data-success-mode="redirect" data-success-page="/contactus-thank-you" data-pre-fill="true">
                                             <div class="s_website_form_rows row s_col_no_bgcolor">
                                                 <div class="mb-3 col-lg-6 s_website_form_field s_website_form_custom s_website_form_required" data-type="char" data-name="Field">
                                                     <label class="s_website_form_label" style="width: 200px" for="contact1">

--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -488,16 +488,15 @@ export class Form extends Interaction {
      * @private
      */
     _onPrepareEmailData() {
-        const formEl = this.el;
-        const fieldEls = formEl.querySelectorAll(
-            ".s_website_form_field:not(.s_website_form_dnone)"
+        const fieldEls = this.el.querySelectorAll(
+            ".s_website_form_field:not(.s_website_form_dnone):not([data-type='binary'])"
         );
 
         let result = {};
 
-        fieldEls.forEach((element) => {
-            const labelEl = element.querySelector("label.s_website_form_label");
-            const inputEl = element.querySelector("input, select, textarea");
+        fieldEls.forEach((fieldEl) => {
+            const labelEl = fieldEl.querySelector("label.s_website_form_label");
+            const inputEl = fieldEl.querySelector(".s_website_form_input");
 
             if (labelEl && inputEl) {
                 const labelContent = labelEl
@@ -505,20 +504,18 @@ export class Form extends Interaction {
                     ?.innerText.trim();
                 let inputValue;
 
-                if (inputEl.type === "button") {
-                    return;
-                } else if (inputEl.type === "checkbox") {
-                    const checkboxes = element.querySelectorAll("input[type='checkbox']:checked");
+                if (inputEl.type === "checkbox") {
+                    const checkboxes = fieldEl.querySelectorAll("input[type='checkbox']:checked");
                     inputValue = Array.from(checkboxes)
                         .map((checkbox) => {
-                            const label = element.querySelector("label[for='${checkbox.id}']");
+                            const label = fieldEl.querySelector("label[for='${checkbox.id}']");
                             return label ? label.textContent.trim() : checkbox.value;
                         })
                         .join(", ");
                 } else if (inputEl.type === "radio") {
-                    const radio = element.querySelector('input[type="radio"]:checked');
+                    const radio = fieldEl.querySelector('input[type="radio"]:checked');
                     if (radio) {
-                        const label = element.querySelector("label[for='${radio.id}']");
+                        const label = fieldEl.querySelector("label[for='${radio.id}']");
                         inputValue = label ? label.textContent.trim() : radio.value;
                     } else {
                         inputValue = "";
@@ -534,13 +531,13 @@ export class Form extends Interaction {
         });
 
         const hiddenFieldValue = JSON.stringify(result);
-        let hiddenField = formEl.querySelector("input[name='send_a_copy']");
+        let hiddenField = this.el.querySelector("input[name='send_a_copy']");
 
         if (!hiddenField) {
             hiddenField = document.createElement("input");
             hiddenField.type = "hidden";
             hiddenField.name = "send_a_copy";
-            formEl.appendChild(hiddenField);
+            this.el.appendChild(hiddenField);
         }
         hiddenField.value = hiddenFieldValue;
     } 

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -540,23 +540,25 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
         this.updateUIEndMessage();
     },
     toggleEmailField: function (previewMode, widgetValue, params) {
-        const inputEl =
-            this.$target[0].querySelector("input[name=email_from]") ||
-            this.$target[0].querySelector("input[name=email]");
-
         if (widgetValue) {
+            const inputEl =
+                this.$target[0].querySelector("input[name=email_from]") ||
+                this.$target[0].querySelector("input[name=email]");
+
             if (inputEl) {
                 const fieldEl = inputEl.closest("div[data-name=Field]");
                 fieldEl.classList.add("s_website_form_model_required");
-                fieldEl.setAttribute("id", "custom_for_send_a_copy");
+                fieldEl.setAttribute("data-remove-class-send-a-copy", true);
             } else {
                 const field = this._getCustomField("email", "Your Email");
                 field.formatInfo = this._getDefaultFormat();
 
                 const fieldEl = this._renderField(field);
-                fieldEl.classList.add("s_website_form_model_required", "custom_for_email")
-                fieldEl.setAttribute("id", "custom_for_send_a_copy");
-                fieldEl.dataset.type = "email";
+                Object.assign(fieldEl.dataset, {
+                    type: "email",
+                    removeInputSendACopy: true,
+                });
+                fieldEl.classList.add("s_website_form_model_required")
                 fieldEl.classList.remove("s_website_form_custom");
 
                 if (this.$target[0].classList.contains("o_mark_required")) {
@@ -567,24 +569,19 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
                 }
 
                 const fieldInputEl = fieldEl.querySelector("input");
-                fieldInputEl.classList.add("custom_for_email");
-                fieldInputEl.name = "email_from";
-                fieldInputEl.id = "custom_for_email";
-                fieldInputEl.required = true;
-                fieldInputEl.setAttribute("data-fill-with", "email");
+                fieldInputEl.dataset.fillWith = "email";
+                Object.assign(fieldInputEl, {
+                    name: "email_from",
+                    required: true,
+                });
 
                 this.$target[0].querySelector(".s_website_form_rows").prepend(fieldEl);
             }
         } else {
-            const customEmailField = this.$target[0].querySelector(".custom_for_email");
-            if (customEmailField) {
-                customEmailField.remove();
-            } else {
-                const emailField = this.$target[0].querySelector("#custom_for_send_a_copy");
-                if (emailField) {
-                    emailField.classList.remove("s_website_form_model_required");
-                }
-            }
+            this.$target[0].querySelector("div[data-remove-input-send-a-copy")?.remove();
+            this.$target[0]
+                .querySelector("div[data-remove-class-send-a-copy")
+                ?.classList.remove("s_website_form_model_required");
         }
         this.trigger_up("reload_snippet_template");
     },
@@ -1867,8 +1864,8 @@ options.registry.WebsiteFormFieldRequired = DisableOverlayButtonOption.extend({
             .querySelector("input.s_website_form_input").getAttribute("name");
         const spanEl = document.createElement("span");
         let optionSendACopy = "";
-        if (this.$target[0].id == "custom_for_send_a_copy") {
-            optionSendACopy = "Send a Copy";
+        if (this.$target[0].closest("form").classList.contains("o_send_a_copy")) {
+            optionSendACopy = _t("Send a Copy");
         }
         spanEl.innerText = _t("The field “%(field)s” is mandatory for the action “%(action)s”.", {
             field: fieldName,

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -1120,10 +1120,12 @@ registerWebsitePreviewTour(
             groupName: "Contact & Forms",
         }),
         {
+            content: "Select the form by clicking on an input field",
             trigger: ":iframe input[name=email_from]",
             run: "click",
         },
         {
+            content: "Check if the 'Send a Copy' option is enabled by default.", 
             trigger: "we-button[data-select-class=o_send_a_copy] we-checkbox",
             run: function () {
                 // to check whether the option is active by default or not.
@@ -1131,34 +1133,42 @@ registerWebsitePreviewTour(
             },
         },
         {
+            content: "Open dropdown to change Action",
             trigger: "we-toggler:contains('Send an E-mail')",
             run: "click",
         },
         {
+            content: "Select 'Apply for a Job' action",
             trigger: "we-button.o_we_user_value_widget div:contains('Apply for a Job')",
             run: "click",
         },
         {
+            content: "Select the 'email_from' input field from the form. ",
             trigger: ":iframe input[name=email_from]",
             run: "click",
         },
         {
+            content: "Remove email field from the form",
             trigger: ":iframe button.oe_snippet_remove",
             run: "click",
         },
         {
+            content: "Verify whether the email field has been removed.",
             trigger:
                 ":iframe section[data-snippet=s_website_form] form:not(input[name=email_from])",
         },
         {
+            content: "Enble 'Send a Copy' option",
             trigger: "we-button[data-select-class=o_send_a_copy] we-checkbox",
             run: "click",
         },
         {
+            content: "Select the 'email_from' input field from the form.",
             trigger: ":iframe input[name=email_from]",
             run: "click",
         },
         {
+            content: "Verify that the email field can no longer removable.",
             trigger:
                 "we-alert span:contains('The field “email_from” is mandatory for the action “Send a Copy”.')",
         },

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -1106,3 +1106,61 @@ registerWebsitePreviewTour("website_form_special_characters", {
         trigger: ":iframe body:not(:has([data-snippet='s_website_form'])) .fa-paper-plane",
     },
 ]);
+
+registerWebsitePreviewTour(
+    "website_form_send_a_copy_option",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        ...insertSnippet({
+            id: "s_title_form",
+            name: "Title - Form",
+            groupName: "Contact & Forms",
+        }),
+        {
+            trigger: ":iframe input[name=email_from]",
+            run: "click",
+        },
+        {
+            trigger: "we-button[data-select-class=o_send_a_copy] we-checkbox",
+            run: function () {
+                // to check whether the option is active by default or not.
+                this.anchor.closest("we-button").classList.contains("active");
+            },
+        },
+        {
+            trigger: "we-toggler:contains('Send an E-mail')",
+            run: "click",
+        },
+        {
+            trigger: "we-button.o_we_user_value_widget div:contains('Apply for a Job')",
+            run: "click",
+        },
+        {
+            trigger: ":iframe input[name=email_from]",
+            run: "click",
+        },
+        {
+            trigger: ":iframe button.oe_snippet_remove",
+            run: "click",
+        },
+        {
+            trigger:
+                ":iframe section[data-snippet=s_website_form] form:not(input[name=email_from])",
+        },
+        {
+            trigger: "we-button[data-select-class=o_send_a_copy] we-checkbox",
+            run: "click",
+        },
+        {
+            trigger: ":iframe input[name=email_from]",
+            run: "click",
+        },
+        {
+            trigger:
+                "we-alert span:contains('The field “email_from” is mandatory for the action “Send a Copy”.')",
+        },
+    ]
+);

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -67,6 +67,9 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
 
     def test_website_form_nested_forms(self):
         self.start_tour('/my/account', 'website_form_nested_forms', login='admin')
+        
+    def test_website_form_send_a_copy_option(self):
+        self.start_tour("/", "website_form_send_a_copy_option", login="admin")
 
 @tagged('post_install', '-at_install')
 class TestWebsiteForm(TransactionCase):

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -29,9 +29,9 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
     def test_website_form_contact_us_edition_with_email(self):
         self.start_tour('/odoo', 'website_form_contactus_edition_with_email', login="admin")
         self.start_tour('/contactus', 'website_form_contactus_submit', login="portal")
-        mail = self.env['mail.mail'].search([], order='id desc', limit=1)
+        mail = self.env['mail.mail'].search([], order='id desc', limit=2)
         self.assertEqual(
-            mail.email_to,
+            mail[1].email_to,
             'test@test.test',
             'The email was edited, the form should have been sent to the configured email')
 
@@ -39,9 +39,9 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
         self.env.company.email = 'website_form_contactus_edition_no_email@mail.com'
         self.start_tour('/odoo', 'website_form_contactus_edition_no_email', login="admin")
         self.start_tour('/contactus', 'website_form_contactus_submit', login="portal")
-        mail = self.env['mail.mail'].search([], order='id desc', limit=1)
+        mail = self.env['mail.mail'].search([], order='id desc', limit=2)
         self.assertEqual(
-            mail.email_to,
+            mail[1].email_to,
             self.env.company.email,
             'The email was not edited, the form should still have been sent to the company email')
 
@@ -67,7 +67,7 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
 
     def test_website_form_nested_forms(self):
         self.start_tour('/my/account', 'website_form_nested_forms', login='admin')
-        
+
     def test_website_form_send_a_copy_option(self):
         self.start_tour("/", "website_form_send_a_copy_option", login="admin")
 

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -94,7 +94,6 @@
 <template id="s_website_form_options" inherit_id="website.snippet_options">
     <!-- Extend drop locations to columns -->
     <xpath expr="//t[@t-set='so_content_addition_selector']" position="inside" t-translation="off">, .s_website_form</xpath>
-
     <xpath expr="//div" position="after">
         <!-- Form -->
         <div data-js="WebsiteFormEditor" data-selector=".s_website_form" data-target="form" data-drop-exclude-ancestor="form">

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -4,7 +4,7 @@
 <template id="s_website_form" name="Form">
     <section class="s_website_form pt16 pb16" data-vcss="001" data-snippet="s_website_form">
         <div class="container-fluid">
-            <form action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-pre-fill="true" data-model_name="mail.mail" data-success-mode="redirect" data-success-page="/contactus-thank-you">
+            <form action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required o_send_a_copy" data-mark="*" data-pre-fill="true" data-model_name="mail.mail" data-success-mode="redirect" data-success-page="/contactus-thank-you">
                 <div class="s_website_form_rows row s_col_no_bgcolor">
                     <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_dnone">
                         <div class="row s_col_no_resize s_col_no_bgcolor">
@@ -98,6 +98,13 @@
     <xpath expr="//div" position="after">
         <!-- Form -->
         <div data-js="WebsiteFormEditor" data-selector=".s_website_form" data-target="form" data-drop-exclude-ancestor="form">
+            <we-checkbox
+                string="Send a Copy"
+                title="Email a copy of the answers to the visitor."
+                data-select-class="o_send_a_copy"
+                data-no-preview="true"
+                data-toggle-email-field="true"
+            />
             <we-select string="Marked Fields" data-name="field_mark_select">
                 <we-button data-select-class="">None</we-button>
                 <we-button data-select-class="o_mark_required" data-name="form_required_opt">Required</we-button>


### PR DESCRIPTION
**Specification:**
When a visitor successfully submits a form, they will receive a copy of the filled values via email.

**Changes Introduced:**
This commit introduces a feature that enables users to send a copy of the filled form to the visitor. By default, this option is enabled for the "Send an E-mail" action.

The same functionality is applied to the form on the "Contact Us" page by default.

Additionally, a new email template, `email_template_form_submission`, has been created, along with a test tour to verify the feature's functionality.

task-4364668