### PR TITLE
[FIX] hr_timesheet: fixed traceback when selecting task from helpdesk project

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -287,6 +287,7 @@
             <field name="model">account.analytic.line</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1">
+                    <field name="company_id" invisible="1"/>
                     <templates>
                         <t t-name="card">
                             <div class="d-flex gap-1">


### PR DESCRIPTION
Steps to reproduce:

- In  Timesheets app, go to kanban view.
- Start the timer.
- Select any Helpdesk project.
- Try to select a task.

Issue:

- A traceback is thrown.

Fix:

- It is due to the fact that company_id field is removed from the kanban xml.
- Thus not getting the value is throwing out a traceback.

Solution:

- Inject back the field into the kanban view.

Issue from the PR: https://github.com/odoo/odoo/pull/172375

task-4382051
