### PR TITLE
[IMP] stock_account: improve clarity of automatic accounting setting

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -965,8 +965,8 @@ class ProductCategory(models.Model):
     property_valuation = fields.Selection(
         string="Inventory Valuation",
         selection=[
-            ('manual_periodic', "Manual"),
-            ('real_time', "Automated"),
+            ('manual_periodic', "Periodic (Manual)"),
+            ('real_time', "Perpetual (Automated)"),
         ],
         company_dependent=True, copy=True,
         help="""Manual: The accounting entries to value the inventory are not posted automatically.

--- a/addons/stock_account/views/product_views.xml
+++ b/addons/stock_account/views/product_views.xml
@@ -22,7 +22,7 @@
                         <field name="property_cost_method" required="True"/>
                         <label for="property_valuation" groups="stock_account.group_stock_accounting_automatic"/>
                         <div groups="stock_account.group_stock_accounting_automatic">
-                            <field name="property_valuation" groups="account.group_account_readonly,stock.group_stock_manager"/>
+                            <field name="property_valuation" widget="radio" groups="account.group_account_readonly,stock.group_stock_manager"/>
                         </div>
                     </group>
                 </group>


### PR DESCRIPTION
The 'Automatic Accounting' setting name was unclear and did not accurately
describe its function. It has been renamed to 'Inventory Valuation,' and the
accounting method is now explicitly referred to as 'Perpetual' to better reflect
its purpose. This improves clarity and helps users understand how inventory
valuation is managed.

task-4328288