### PR TITLE
[FIX] sale_project: fix analytic distribution auto set on accounts payable line

### DIFF
--- a/addons/sale_project/models/account_move_line.py
+++ b/addons/sale_project/models/account_move_line.py
@@ -15,7 +15,8 @@ class AccountMoveLine(models.Model):
         project_id = self._context.get('project_id', False)
         if project_id:
             project = self.env['project.project'].browse(project_id)
-            self.analytic_distribution = project._get_analytic_distribution()
+            lines = self.filtered(lambda line: line.account_type not in ['asset_receivable', 'liability_payable'])
+            lines.analytic_distribution = project._get_analytic_distribution()
 
     def _get_so_mapping_domain(self):
         return OR([

--- a/addons/sale_project/tests/test_analytic_distribution.py
+++ b/addons/sale_project/tests/test_analytic_distribution.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from .common import TestSaleProjectCommon
+from odoo import Command
 from odoo.tests import HttpCase
 from odoo.tests.common import tagged
 
@@ -75,4 +76,33 @@ class TestAnalyticDistribution(HttpCase, TestSaleProjectCommon):
             sale_order_line.analytic_distribution,
             {str(self.project_global.account_id.id): 100},
             "The analytic distribution of the SOL should be set to the account of the project set on the product.",
+        )
+
+    def test_project_analytic_distribution_on_invoice_lines(self):
+        """
+        Test that Analytic Distribution applies from Project to Invoice Lines (excluding payable/receivable lines).
+        Steps:
+          1. Create a project.
+          2. Create an invoice with the project in context.
+          3. Add an invoice line.
+          4. Verify analytic distribution is applied.
+        """
+
+        invoice = self.env['account.move'].with_context({
+            'default_move_type': 'out_invoice',
+            'default_partner_id': self.project_global.partner_id.id,
+            'project_id': self.project_global.id
+        }).create({
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_delivery_manual1.id,
+                'quantity': 1,
+                'price_unit': 10,
+            })]
+        })
+
+        filtered_lines = invoice.line_ids.filtered(lambda l: l.analytic_distribution)
+        self.assertEqual(
+            len(filtered_lines),
+            1,
+            "Analytic distribution is not set on the payable/receivable lines"
         )


### PR DESCRIPTION
### Steps to reproduce:
  - Install sale, project, and accountant.
  - Allow Analytic Accounting from settings.
  - Open project application.
  - Create a project with a billable feature.
  - Add invoices in the topbar.
  - Select invoices and create a new invoice.
  - Add a product to the invoice (you will see analytic is added).
Go to the journal items tab.

### Issue:
When the user opens the Analytical Account, the gross margin is shown incorrectly.

### Cause:
 When a bill or invoice is created from the project topbar, the analytical distribution is set in the payable/receivable journal items,  causing the gross margin to show as 0.

### Fix:
 In this commit, we remove the setting of the analytical distribution  in the payable/receivable journal items. As a result, no journal items related to payable/receivable will be added to the Analytic Line.

task-4377544
