### PR TITLE
[FIX] web_editor: call _applyColspan with a valid element

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -267,8 +267,10 @@ function bootstrapToTable(editable) {
                 } else if (gridIndex + columnSize === 12) {
                     // Finish the row.
                     currentCol = grid[gridIndex];
-                    _applyColspan(currentCol, columnSize, containerWidth);
-                    currentRow.append(...grid.filter(td => td.getAttribute('colspan')));
+                    if (currentCol) {
+                        _applyColspan(currentCol, columnSize, containerWidth);
+                    }
+                    currentRow.append(...grid.filter(td => td.getAttribute('colspan')));    
                     if (columnIndex !== bootstrapColumns.length - 1) {
                         // The row was filled before we handled all of its
                         // columns. Create a new one and start again from there.


### PR DESCRIPTION
**Problem**:
The function `_getColumnSize` returns the size of the columns. When `gridIndex = columnSize;` is assigned and `columnSize` equals 12, it causes an overflow in the `grid` array. This leads to invalid elements being passed to `_applyColspan`.

**Solution**:
Ensure `_applyColspan` is only called when `gridIndex` is within valid bounds.

**Steps to reproduce**:
1. Open an email marketing template.
2. Extend the "Centered Logo" snippet to the maximum size (`col-12`).
3. Observe a traceback error.

opw-4381159
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
