### PR TITLE
[FIX] base_import_module: fix duplicate ir_model_data entry

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -142,11 +142,13 @@ class IrModule(models.Model):
                         convert_xml_import(self.env, module, fp, idref, mode, noupdate)
                         if filename in exclude_list:
                             self.env['ir.model.data'].create([{
-                                'name': f"cloc_exclude_{key}",
+                                'name': f"{module}_{key}",
                                 'model': self.env['ir.model.data']._xmlid_lookup(f"{module}.{key}")[0],
                                 'module': "__cloc_exclude__",
                                 'res_id': value,
-                            } for key, value in idref.items()])
+                            } for key, value in idref.items() if not self.env.ref(
+                                f"__cloc_exclude__.{module}_{key}", raise_if_not_found=False
+                            )])
 
         path_static = opj(path, 'static')
         IrAttachment = self.env['ir.attachment']

--- a/addons/base_import_module/tests/test_cloc.py
+++ b/addons/base_import_module/tests/test_cloc.py
@@ -252,6 +252,8 @@ class TestClocFields(test_cloc.TestClocCustomization):
         # Import test module
         self.env['ir.module.module']._import_zipfile(stream)
 
+        # Import a second time to upgrade, test that it does not raise error
+        self.env['ir.module.module']._import_zipfile(stream)
 
         cl = cloc.Cloc()
         cl.count_customization(self.env)


### PR DESCRIPTION
Backport of #188693 

When upgrading an industry, the records originating from a file listed in `cloc_exclude` entry of the manifest generate an entry in `ir_model_data` with the module `__cloc_exclude__`. When upgrading the module, it tries to create a second time the same entries, raising the unicity constrain.
This commit fixes the issue by creating only new `ir_model_data` entries. It also changes the name to better distinguish different modules, who can share same id.

opw-4339886
opw-4274755