### PR TITLE
[IMP] website_sale: Dynamic ribbon assignment

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -458,6 +458,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
         ) or ''
 
         values = {
+            'auto_assign_ribbons': lazy(
+                lambda: self.env['product.ribbon'].sudo().search([('assign', '!=', 'manual')])
+            ),
             'search': fuzzy_search_term or search,
             'original_search': fuzzy_search_term and search,
             'order': post.get('order', ''),

--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -28,6 +28,7 @@
             <field name="position">left</field>
             <field name="text_color">#FFFFFF</field>
             <field name="bg_color">#0CA725</field>
+            <field name="sequence">3</field>
         </record>
 
         <record id="website_sale.sold_out_ribbon" model="product.ribbon">
@@ -35,6 +36,7 @@
             <field name="position">left</field>
             <field name="text_color">#FFFFFF</field>
             <field name="bg_color">#d9534f</field>
+            <field name="sequence">1</field>
         </record>
 
         <record id="website_sale.out_of_stock_ribbon" model="product.ribbon">
@@ -42,6 +44,7 @@
             <field name="position">left</field>
             <field name="text_color">#FFFFFF</field>
             <field name="bg_color">#ffc107</field>
+            <field name="sequence">2</field>
         </record>
 
         <record id="website_sale.new_ribbon" model="product.ribbon">
@@ -49,6 +52,7 @@
             <field name="position">left</field>
             <field name="text_color">#FFFFFF</field>
             <field name="bg_color">#0275d8</field>
+            <field name="sequence">4</field>
         </record>
 
         <record id="sales_team.salesteam_website_sales" model="crm.team">

--- a/addons/website_sale/models/product_ribbon.py
+++ b/addons/website_sale/models/product_ribbon.py
@@ -1,13 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ProductRibbon(models.Model):
     _name = 'product.ribbon'
     _description = "Product ribbon"
+    _order = 'sequence ASC, id'
 
     name = fields.Char(string="Ribbon Name", required=True, translate=True, size=20)
+    sequence = fields.Integer(default=10)
     bg_color = fields.Char(string="Background Color", required=True, default='#000000')
     text_color = fields.Char(string="Text Color", required=True, default='#FFFFFF')
     position = fields.Selection(
@@ -16,8 +19,111 @@ class ProductRibbon(models.Model):
         required=True,
         default='left',
     )
+    style = fields.Selection(
+        string="Style",
+        selection=[('ribbon', "Ribbon"), ('tag', "Badge")],
+        required=True,
+        default='ribbon',
+        help=(
+            "Defines the display style:\n"
+            "- Ribbon: Shows a ribbon banner on the product image.\n"
+            "- Badge: Shows a small badge label on the product image."
+        ),
+    )
+    assign = fields.Selection(
+        string="Assign",
+        selection=[
+            ('manual', "Manually"),
+            ('sale', "on sale"),
+            ('new', "when new"),
+        ],
+        required=True,
+        default='manual',
+        help=(
+            "Defines how this ribbon is assigned to products:\n"
+            "- Manually: You assign the ribbon manually to products.\n"
+            "- Sale: Applied when the product is visibly on sale.\n"
+            "- New: Applied based on the New period you will define.\n"
+        ),
+    )
+    new_period = fields.Integer(default=30)
 
-    def _get_position_class(self):
-        if not self:
-            return 'd-none'
-        return 'o_ribbon_left' if self.position == 'left' else 'o_ribbon_right'
+    @api.constrains('assign')
+    def _check_assign(self):
+        """
+        Ensure only one ribbon exists per automatic assign type.
+        This prevents duplicates, since automatic assignment logic always uses the first ribbon
+        with a given assign value.
+        """
+        for ribbon in self:
+            if ribbon.assign != 'manual':
+                existing_ribbons = self.search([
+                    ('id', '!=', ribbon.id),
+                    ('assign', '=', ribbon.assign)
+                ], limit=1)
+                if existing_ribbons:
+                    raise ValidationError(
+                        _(
+                            "Only one ribbon with the assign %s is allowed.",
+                            dict(self._fields['assign'].selection).get(ribbon.assign)
+                        )
+                    )
+
+    def _get_css_classes(self):
+        """
+        Return the CSS classes for this ribbon based on style and position.
+        rtype: str
+        """
+        css_classes = ""
+        match self.style:
+            case 'ribbon':
+                css_classes += "o_wsale_ribbon"
+            case 'tag':
+                css_classes += "o_wsale_badge"
+
+        match self.position:
+            case 'left':
+                css_classes += " o_left"
+            case 'right':
+                css_classes += " o_right"
+        return css_classes
+
+    def _is_applicable_for(self, product, price_data):
+        """Return whether the product matches the criteria of the ribbon automatic assignment.
+
+        :param product.product product: the displayed product
+        :param dict price_data: price information for the given product
+            (sales price for shop page, combination information for product page)
+
+        :return: Whether the ribbon matches the given product and price.
+        :rtype: bool
+        """
+        self.ensure_one()
+
+        # Check if a discount is applied to the product using a pricelist, comparison price, or
+        # others.
+        if (  # noqa: SIM103
+            self.assign == 'sale'
+            and price_data
+            and (
+                # for /shop page
+                (
+                    'base_price' in price_data
+                    and (price_data['base_price'] > price_data['price_reduce'])
+                )
+                # for /product page
+                or (
+                    'compare_list_price' in price_data
+                    and price_data['compare_list_price'] > price_data['price']
+                )
+                or price_data.get('has_discounted_price')
+            )
+        ):
+            return True
+        # Check if the product is published within the ribbon's new period.
+        if (  # noqa: SIM103
+            self.assign == 'new'
+            and self.new_period >= (fields.Datetime.today() - product.publish_date).days
+        ):
+            return True
+        return False

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1683,3 +1683,52 @@ a.no-decoration {
 body.modal-open:has(.js_sale.o_wsale_product_page) {
     overflow: hidden;
 }
+
+// Product Ribbon Classes
+.oe_website_sale{
+    @mixin o-ribbon-tag() {
+        margin: 0;
+        @include font-size(0.8rem);
+        white-space: nowrap;
+        text-align: center;
+        pointer-events: none;
+
+        &:empty {
+            display: none;
+        }
+    }
+
+    .o_wsale_ribbon {
+        @include o-ribbon-tag();
+        padding: map-get($spacers, 2) $ribbon-padding;
+        transform-origin: top right;
+    }
+
+    .o_wsale_badge {
+        @include o-ribbon-tag();
+        padding: map-get($spacers, 1) map-get($spacers, 2);
+        border-radius: var(--border-radius) !important;
+    }
+
+    .o_wsale_ribbon.o_right {
+        @include o-position-absolute($top: 0, $right: 0);
+        // 0.708 is 1 - cos(45deg)
+        // Transforms are applied right-to-left
+        // Cannot use matrix because of the use of % values.
+        transform: translateX(calc(-0.708 * (100% - #{2 * $ribbon-padding}))) rotate(45deg) translateX(calc(100% - #{$ribbon-padding}));
+    }
+
+    .o_wsale_ribbon.o_left{
+        @include o-position-absolute($top: 0, $left: 0);
+        transform: translateX(calc(0.708 * (100% - #{2 * $ribbon-padding}) - 100%)) rotate(-45deg) translateX($ribbon-padding);
+    }
+
+    .o_wsale_badge.o_left {
+        @include o-position-absolute($top: map-get($spacers, 2), $left: map-get($spacers, 2));
+    }
+
+    .o_wsale_badge.o_right {
+        @include o-position-absolute($top: map-get($spacers, 2), $right: map-get($spacers, 2));
+    }
+
+}

--- a/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
@@ -57,6 +57,14 @@ class ProductPageOptionPlugin extends Plugin {
                 }
             });
         },
+        patch_builder_options: [
+            {
+                target_name: 'ProductsRibbonOption',
+                target_element: 'selector',
+                method: 'add',
+                value: productPageSelector,
+            },
+        ],
     };
     setup() {
         const mainEl = this.document.querySelector(productPageSelector);

--- a/addons/website_sale/static/src/website_builder/product_ribbon_options.js
+++ b/addons/website_sale/static/src/website_builder/product_ribbon_options.js
@@ -1,0 +1,23 @@
+import { BaseOptionComponent } from "@html_builder/core/utils";
+import { onWillStart, useState } from "@odoo/owl";
+
+export class ProductsRibbonOption extends BaseOptionComponent {
+    static template = 'website_sale.ProductsRibbonOptionPlugin';
+    static props = {
+        loadInfo: Function,
+        count: Object,
+    };
+
+    setup() {
+        super.setup();
+
+        this.state = useState({
+            ribbons: [],
+            ribbonEditMode: false,
+        });
+
+        onWillStart(async () => {
+            this.state.ribbons = await this.props.loadInfo();
+        });
+    }
+}

--- a/addons/website_sale/static/src/website_builder/product_ribbon_options.xml
+++ b/addons/website_sale/static/src/website_builder/product_ribbon_options.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="website_sale.ProductsRibbonOptionPlugin" name="Product ribbon options">
+        <BuilderRow label.translate="Ribbon">
+            <BuilderSelect
+                action="'setRibbon'"
+                t-key="props.count.value"
+                className="'o_wsale_ribbon_select'"
+                t-on-click="() => state.ribbonEditMode = false"
+            >
+                <BuilderSelectItem actionValue="''" id="'no_ribbon_opt'">
+                    None
+                </BuilderSelectItem>
+                <t t-foreach="this.state.ribbons" t-as="ribbon" t-key="ribbon.id">
+                    <BuilderSelectItem actionValue="ribbon.id" label="ribbon.name">
+                        <div>
+                            <t t-out="ribbon.name" />
+                            <span t-attf-class="fa fa-arrow-#{ribbon.position} ms-1"/>
+                            <span
+                                t-attf-class="o_wsale_color_preview ms-1"
+                                t-attf-style="background-color: #{ribbon.bg_color}; border: {{(ribbon.bg_color == '#FFFFFF' || ribbon.bg_color == '') ? '2px solid #CCCCCC' : ''}};"
+                            />
+                            <span
+                                t-attf-class="o_wsale_color_preview ms-1"
+                                t-attf-style="background-color: #{ribbon.text_color} !important; border: {{ribbon.text_color == '#FFFFFF' ? '2px solid #CCCCCC' : ''}};"
+                            />
+                        </div>
+                    </BuilderSelectItem>
+                </t>
+            </BuilderSelect>
+            <BuilderButton
+                t-if="!this.isActiveItem('no_ribbon_opt')"
+                t-on-click="() => state.ribbonEditMode = !state.ribbonEditMode"
+                title.translate="Edit"
+                className="'fa fa-edit'"
+            />
+            <BuilderButton
+                t-if="!state.ribbonEditMode"
+                title.translate="Create"
+                action="'createRibbon'"
+                className="'fa fa-plus text-success border-0'"
+                style="'background-color: transparent !important;'"
+                preview="false"
+                t-on-click="() => state.ribbonEditMode = true"
+            />
+        </BuilderRow>
+
+        <t t-if="state.ribbonEditMode">
+            <BuilderContext action="'modifyRibbon'">
+                <BuilderRow label.translate="Name" level="1">
+                    <BuilderTextInput actionParam="'name'" />
+                </BuilderRow>
+                <BuilderRow label.translate="Style" level="1">
+                    <BuilderButtonGroup actionParam="'style'">
+                        <BuilderButton actionValue="'ribbon'">Ribbon</BuilderButton>
+                        <BuilderButton actionValue="'tag'">Badge</BuilderButton>
+                    </BuilderButtonGroup>
+               </BuilderRow>
+
+                <BuilderRow label.translate="Background" level="1">
+                    <BuilderColorPicker
+                        actionParam="'bg_color'"
+                        enabledTabs="['solid', 'custom']"
+                    />
+                </BuilderRow>
+                <BuilderRow label.translate="Text" level="1">
+                    <BuilderColorPicker
+                        actionParam="'text_color'"
+                        enabledTabs="['solid', 'custom']"
+                    />
+                </BuilderRow>
+                <BuilderRow label.translate="Position" level="1">
+                    <BuilderSelect actionParam="'position'">
+                        <BuilderSelectItem actionValue="'left'">Left</BuilderSelectItem>
+                        <BuilderSelectItem actionValue="'right'">Right</BuilderSelectItem>
+                    </BuilderSelect>
+                </BuilderRow>
+            </BuilderContext>
+            <BuilderRow label.translate=" ">
+                <BuilderButton
+                    action="'deleteRibbon'"
+                    preview="false"
+                    className="'o_we_bg_danger'"
+                    t-on-click="() => state.ribbonEditMode = false"
+                >
+                    Delete Ribbon
+                </BuilderButton>
+            </BuilderRow>
+        </t>
+    </t>
+</templates>

--- a/addons/website_sale/static/src/website_builder/product_ribbon_options_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_ribbon_options_plugin.js
@@ -1,0 +1,402 @@
+import { Plugin } from "@html_editor/plugin";
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { SNIPPET_SPECIFIC_NEXT } from "@html_builder/utils/option_sequence";
+import { withSequence } from "@html_editor/utils/resource";
+import { reactive } from "@odoo/owl";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { ProductsRibbonOption } from "./product_ribbon_options";
+
+class ProductsRibbonOptionPlugin extends Plugin {
+    static id = 'productsRibbonOptionPlugin';
+    static dependencies = ['history'];
+    static shared = [
+        'getRibbonsObject',
+        'setRibbonObject',
+        'addRibbon',
+        'getRibbons',
+        'setRibbon',
+        'deleteRibbon',
+        '_setRibbon',
+        'setProductTemplateID',
+        'getProductTemplateID',
+        'addProductTemplatesRibbons'
+    ];
+    count = reactive({ value: 0 });
+
+    resources = {
+        builder_options: [
+            withSequence(SNIPPET_SPECIFIC_NEXT, {
+                OptionComponent: ProductsRibbonOption,
+                name: 'ProductsRibbonOption',
+                props: {
+                    loadInfo: this.loadInfo.bind(this),
+                    count: this.count,
+                },
+                selector: "#products_grid .oe_product",
+                editableOnly: false,
+                groups: ['website.group_website_designer'],
+            }),
+        ],
+        builder_actions: {
+            SetRibbonAction,
+            CreateRibbonAction,
+            ModifyRibbonAction,
+            DeleteRibbonAction,
+        },
+    };
+
+    setup() {
+        this.positionClasses = { left: "o_left", right: "o_right" };
+        this.styleClasses = { ribbon: "o_wsale_ribbon", tag: "o_wsale_badge" };
+        this.productTemplatesRibbons = [];
+        this.editMode = false;
+    }
+
+    async loadInfo() {
+        if (!this.ribbons) {
+            const result = await this.services.orm.searchRead(
+                'product.ribbon',
+                [['assign', '=', 'manual']],
+                ['id', 'name', 'bg_color', 'text_color', 'position', 'style']
+            );
+            this.ribbons = reactive(result);
+        }
+
+        this.ribbonsObject = this.ribbons.reduce((acc, ribbon) => {
+            acc[ribbon.id] = ribbon;
+            return acc;
+        }, {});
+
+        this.originalRibbons = JSON.parse(JSON.stringify(this.ribbonsObject));
+
+        return this.ribbons;
+    }
+
+    async _setRibbon(editingElement, ribbon, save = true) {
+        const ribbonId = ribbon.id;
+        const editableBody = editingElement.ownerDocument.body;
+        editingElement.dataset.ribbonId = ribbonId;
+
+        // Update all ribbons with this ID
+        const ribbons = editableBody.ownerDocument.querySelectorAll(
+            `[data-ribbon-id="${ribbonId}"]`,
+        );
+
+        for (const ribbonElement of ribbons) {
+            ribbonElement.textContent = ribbon.name;
+            ribbonElement.classList.remove('o_wsale_ribbon', 'o_wsale_badge', 'o_right', 'o_left');
+            if (ribbonElement.classList.contains('d-none')) {
+                ribbonElement.classList.remove('d-none');
+            }
+
+            ribbonElement.classList.add(
+                this.positionClasses[ribbon.position],
+                this.styleClasses[ribbon.style],
+            );
+            ribbonElement.style.backgroundColor = ribbon.bg_color || "";
+            ribbonElement.style.color = ribbon.text_color || "";
+        }
+
+        return save ? await this._saveRibbons() : "";
+    }
+
+    async _saveRibbons() {
+        const originalIds = Object.keys(this.originalRibbons).map((id) => parseInt(id));
+        const currentIds = this.ribbons.map((ribbon) => parseInt(ribbon.id));
+        const created = this.ribbons.filter((ribbon) => !originalIds.includes(ribbon.id));
+        const deletedIds = originalIds.filter((id) => !currentIds.includes(id));
+        const modified = this.ribbons.filter((ribbon) => {
+            if (created.includes(ribbon)) {
+                return false;
+            }
+            const original = this.originalRibbons[ribbon.id];
+            return Object.entries(ribbon).some(([key, value]) => value !== original[key]);
+        });
+
+        const createdRibbonProms = [];
+        let createdRibbonIds;
+        if (created.length > 0) {
+            createdRibbonProms.push(
+                this.services.orm.create(
+                    'product.ribbon',
+                    created.map((ribbon) => {
+                        ribbon = Object.assign({}, ribbon);
+                        this.originalRibbons[ribbon.id] = ribbon;
+                        delete ribbon.id;
+                        return ribbon;
+                    })
+                ).then((ids) => (createdRibbonIds = ids))
+            );
+        }
+        await Promise.all(createdRibbonProms);
+
+        const localToServer = Object.assign(
+            this.ribbonsObject,
+            Object.fromEntries(
+                created.map((ribbon, index) => [
+                    ribbon.id,
+                    { ...this.ribbonsObject[ribbon.id], id: createdRibbonIds[index] },
+                ])
+            ),
+            {
+                false: {
+                    id: "",
+                },
+            }
+        );
+
+        const proms = [];
+        for (const ribbon of modified) {
+            const ribbonData = {
+                name: ribbon.name,
+                bg_color: ribbon.bg_color,
+                text_color: ribbon.text_color,
+                position: ribbon.position,
+                style: ribbon.style,
+            };
+            const serverId = localToServer[ribbon.id]?.id || ribbon.id;
+            proms.push(this.services.orm.write('product.ribbon', [serverId], ribbonData));
+            this.originalRibbons[ribbon.id] = Object.assign({}, ribbon);
+        }
+
+        if (deletedIds.length > 0) {
+            proms.push(this.services.orm.unlink('product.ribbon', deletedIds));
+        }
+
+        await Promise.all(proms);
+
+        // Building the final template to ribbon-id map so that we can remove duplicate entries
+        const finalTemplateRibbons = this.productTemplatesRibbons.reduce(
+            (acc, { templateId, ribbonId }) => {
+                acc[templateId] = ribbonId;
+                return acc;
+            }, {},
+        );
+        // Inverting the relationship so that we have all templates that have the same ribbon to
+        // reduce RPCs
+        const ribbonTemplates = {};
+        for (const [templateId, ribbonId] of Object.entries(finalTemplateRibbons)) {
+            const rid = ribbonTemplates[ribbonId] ||= [];
+            rid.push(parseInt(templateId));
+        }
+
+        const promises = [];
+        for (const ribbonId in ribbonTemplates) {
+            const templateIds = ribbonTemplates[ribbonId];
+            const parsedId = parseInt(ribbonId);
+            const validRibbonId = currentIds.includes(parsedId) ? ribbonId : false;
+            promises.push(
+                this.services.orm.write('product.template', templateIds, {
+                    website_ribbon_id: localToServer[validRibbonId]?.id || false,
+                })
+            );
+        }
+
+        return Promise.all(promises);
+    }
+
+    /**
+     * Deletes a ribbon.
+     *
+     */
+    deleteRibbon(editingElement) {
+        const ribbonId = parseInt(editingElement.querySelector('.o_ribbons').dataset.ribbonId);
+        if (this.ribbonsObject[ribbonId]) {
+            const ribbonIndex = this.ribbons.findIndex(ribbon => ribbon.id === ribbonId);
+            if (ribbonIndex !== -1 ) {
+                this.ribbons.splice(ribbonIndex, 1);
+            }
+            delete this.ribbonsObject[ribbonId];
+
+            // update "reactive" count to trigger rerendering the BuilderSelect component (which
+            // has the value as a t-key)
+            this.count.value++;
+        }
+        const isProductPage = editingElement.ownerDocument.querySelector('#product_detail');
+        this.productTemplateID = parseInt(
+            editingElement
+                .querySelector('[data-oe-model="product.template"]')
+                .getAttribute("data-oe-id")
+        );
+        const ribbons = editingElement.ownerDocument.querySelectorAll(
+            `[data-ribbon-id="${ribbonId}"]`
+        );
+        ribbons.forEach((ribbonElement) => {
+            ribbonElement.classList.add("d-none");
+            ribbonElement.dataset.ribbonId = "";
+            this.productTemplatesRibbons.push({
+                templateId: isProductPage
+                    ? this.productTemplateID
+                    : parseInt(ribbonElement.previousElementSibling.dataset.oeId),
+                ribbonId: false,
+            });
+        });
+        this._saveRibbons();
+    }
+    getProductTemplateID() {
+        return this.productTemplateID;
+    }
+    setProductTemplateID(id) {
+        this.productTemplateID = id
+    }
+    addProductTemplatesRibbons(value) {
+        this.productTemplatesRibbons.push(value);
+    }
+    getRibbonsObject() {
+        return this.ribbonsObject;
+    }
+    setRibbonObject(key, value) {
+        this.ribbonsObject[key] = value;
+    }
+    addRibbon(value) {
+        this.ribbons.push(value);
+    }
+    getRibbons() {
+        return this.ribbons;
+    }
+    setRibbon(key, value){
+        const index = this.ribbons.findIndex((ribbon) => ribbon.id == key);
+        if (index !== -1) {
+            this.ribbons[index] = value;
+        }
+    }
+}
+
+class SetRibbonAction extends BuilderAction {
+    static id = 'setRibbon';
+    static dependencies = ['productsRibbonOptionPlugin'];
+    setup(){
+        this.ribbonOptions = this.dependencies.productsRibbonOptionPlugin
+    }
+    isApplied({ editingElement, value }) {
+        const ribbonId = parseInt(
+            editingElement.querySelector('.o_ribbons').dataset.ribbonId,
+        );
+        const match = !ribbonId || !this.ribbonOptions.getRibbonsObject().hasOwnProperty(ribbonId)
+            ? ''
+            : ribbonId;
+        return match === value;
+    }
+    apply({ isPreviewing, editingElement, value }) {
+        const productTemplateID = parseInt(
+            editingElement
+                .querySelector('[data-oe-model="product.template"]')
+                .getAttribute('data-oe-id')
+        );
+        this.ribbonOptions.setProductTemplateID(productTemplateID)
+        this.ribbonOptions.addProductTemplatesRibbons({
+            templateId: productTemplateID,
+            ribbonId: value,
+        });
+
+        const ribbon = this.ribbonOptions.getRibbonsObject()[value] || {
+            id: '',
+            name: '',
+            bg_color: '',
+            text_color: '',
+            position: 'left',
+            style: 'ribbon',
+        };
+
+        return this.ribbonOptions._setRibbon(
+            editingElement.querySelector('.o_ribbons'),
+            ribbon,
+            !isPreviewing,
+        );
+    }
+}
+class CreateRibbonAction extends BuilderAction {
+    static id = 'createRibbon';
+    static dependencies = ['productsRibbonOptionPlugin']
+    setup(){
+        this.ribbonOptions = this.dependencies.productsRibbonOptionPlugin
+    }
+    apply({ editingElement }) {
+        const productTemplateId = editingElement
+            .querySelector('[data-oe-model="product.template"]')
+            .getAttribute('data-oe-id')
+        this.ribbonOptions.setProductTemplateID(parseInt(
+            productTemplateId
+        ));
+        const ribbonId = Date.now();
+        this.ribbonOptions.addProductTemplatesRibbons({
+            templateId: productTemplateId,
+            ribbonId: ribbonId,
+        });
+        const ribbon = reactive({
+            id: ribbonId,
+            name: 'Ribbon Name',
+            bg_color: '',
+            text_color: 'purple',
+            position: 'left',
+            style: 'ribbon',
+        });
+        this.ribbonOptions.addRibbon(ribbon);
+        this.ribbonOptions.setRibbonObject(ribbonId, ribbon);
+        return this.ribbonOptions._setRibbon(editingElement.querySelector('.o_ribbons'), ribbon);
+    }
+}
+class ModifyRibbonAction extends BuilderAction {
+    static id = 'modifyRibbon';
+    static dependencies = ['productsRibbonOptionPlugin', 'history'];
+    setup() {
+        this.ribbonOptions = this.dependencies.productsRibbonOptionPlugin
+    }
+    getValue({ editingElement, params }) {
+        const ribbonId = parseInt(
+            editingElement.querySelector('.o_ribbons').dataset.ribbonId
+        );
+        if (!ribbonId || !this.ribbonOptions.getRibbonsObject().hasOwnProperty(ribbonId)) {
+            return;
+        }
+
+        return this.ribbonOptions.getRibbonsObject()[ribbonId][params.mainParam];
+    }
+    isApplied({ editingElement, params, value }) {
+        let ribbonId = parseInt(
+            editingElement.querySelector('.o_ribbons').dataset.ribbonId
+        );
+        if (!ribbonId || !this.ribbonOptions.getRibbonsObject().hasOwnProperty(ribbonId)) {
+            return;
+        }
+        return this.ribbonOptions.getRibbonsObject()[ribbonId][params.mainParam] === value;
+    }
+    apply({ editingElement, params, value }) {
+        const isPreviewMode = this.dependencies.history.getIsPreviewing();
+        const ribbonEl = editingElement.querySelector('.o_ribbons')
+        const setting = params.mainParam;
+        const ribbonId = parseInt(ribbonEl.dataset.ribbonId);
+        const previousRibbon = this.ribbonOptions.getRibbonsObject()[ribbonId];
+        this.ribbonOptions.setRibbonObject(ribbonId, {...previousRibbon, [setting]: value});
+        this.ribbonOptions.setRibbon(ribbonId, {...previousRibbon, [setting]: value});
+        const res = this.ribbonOptions._setRibbon(ribbonEl, {...previousRibbon, [setting]: value}, !isPreviewMode);
+        if(isPreviewMode){
+            this.ribbonOptions.setRibbonObject(ribbonId, previousRibbon)
+            this.ribbonOptions.setRibbon(ribbonId, previousRibbon)
+        }
+        return res
+    }
+}
+class DeleteRibbonAction extends BuilderAction {
+    static id = 'deleteRibbon';
+    static dependencies = ['productsRibbonOptionPlugin'];
+    async apply({ editingElement }) {
+        const save = await new Promise((resolve) => {
+            this.services.dialog.add(ConfirmationDialog, {
+                body: _t("Are you sure you want to delete this ribbon?"),
+                confirm: () => resolve(true),
+                cancel: () => resolve(false),
+            });
+        });
+        if (!save) {
+            return;
+        }
+        return this.dependencies.productsRibbonOptionPlugin.deleteRibbon(editingElement);
+    }
+}
+
+registry.category('website-plugins').add(
+    ProductsRibbonOptionPlugin.id, ProductsRibbonOptionPlugin,
+);

--- a/addons/website_sale/static/src/website_builder/products_item_option.js
+++ b/addons/website_sale/static/src/website_builder/products_item_option.js
@@ -7,7 +7,6 @@ export class ProductsItemOption extends BaseOptionComponent {
     static props = {
         loadInfo: Function,
         itemSize: Object,
-        count: Object,
     };
 
     setup() {
@@ -16,15 +15,11 @@ export class ProductsItemOption extends BaseOptionComponent {
         this.tableRef = useRef("table");
 
         this.state = useState({
-            ribbons: [],
-            ribbonEditMode: false,
             itemSize: this.props.itemSize,
         });
 
         onWillStart(async () => {
-            const [ribbons, defaultSort] = await this.props.loadInfo();
-            this.state.ribbons = ribbons;
-            this.defaultSort = defaultSort;
+            this.defaultSort = await this.props.loadInfo();
 
             // need to display "re-order" option only if shop_default_sort is 'website_sequence asc'
             this.displayReOrder = this.defaultSort[0].shop_default_sort === "website_sequence asc";

--- a/addons/website_sale/static/src/website_builder/products_item_option.xml
+++ b/addons/website_sale/static/src/website_builder/products_item_option.xml
@@ -26,47 +26,5 @@
                 <BuilderButton actionValue="'bottom'" title.translate="Push to bottom" className="'fa fa-fw fa-angle-double-right'" />
             </BuilderButtonGroup>
         </BuilderRow>
-        <BuilderRow label.translate="Ribbon">
-            <BuilderSelect action="'setRibbon'" t-key="props.count.value" className="'o_wsale_ribbon_select'" t-on-click="()=>state.ribbonEditMode=false">
-                <BuilderSelectItem actionValue="''" id="'no_ribbon_opt'">
-                    None
-                </BuilderSelectItem>
-                <t t-foreach="this.state.ribbons" t-as="ribbon" t-key="ribbon.id">
-                    <BuilderSelectItem actionValue="ribbon.id" label="ribbon.name">
-                        <div>
-                            <t t-out="ribbon.name" />
-                            <span t-attf-class="fa fa-arrow-#{ribbon.position} ms-1"></span>
-                            <span t-attf-class="o_wsale_color_preview ms-1" t-attf-style="background-color: #{ribbon.bg_color}; border: {{(ribbon.bg_color == '#FFFFFF' || ribbon.bg_color == '') ? '2px solid #CCCCCC' : ''}};" />
-                            <span t-attf-class="o_wsale_color_preview ms-1" t-attf-style="background-color: #{ribbon.text_color} !important; border: {{ribbon.text_color == '#FFFFFF' ? '2px solid #CCCCCC' : ''}};" />
-                        </div>
-                    </BuilderSelectItem>
-                </t>
-            </BuilderSelect>
-            <BuilderButton title.translate="Edit" className="'fa fa-edit'" t-if="!this.isActiveItem('no_ribbon_opt')" t-on-click="()=>state.ribbonEditMode = !state.ribbonEditMode"/>
-            <BuilderButton action="'createRibbon'" preview="false" title.translate="Create" className="'fa fa-plus text-success border-0'" style="'background-color: transparent !important;'" t-if="!state.ribbonEditMode" t-on-click="()=>state.ribbonEditMode = true" />
-        </BuilderRow>
-
-        <t t-if="state.ribbonEditMode">
-            <BuilderContext action="'modifyRibbon'">
-                <BuilderRow label.translate="Name" level="1">
-                    <BuilderTextInput actionParam="'name'" />
-                </BuilderRow>
-                <BuilderRow label.translate="Background" level="1">
-                    <BuilderColorPicker actionParam="'bg_color'" enabledTabs="['solid', 'custom']" />
-                </BuilderRow>
-                <BuilderRow label.translate="Text" level="1">
-                    <BuilderColorPicker actionParam="'text_color'" enabledTabs="['solid', 'custom']" />
-                </BuilderRow>
-                <BuilderRow label.translate="Position" level="1">
-                    <BuilderSelect actionParam="'position'">
-                        <BuilderSelectItem actionValue="'left'">Left</BuilderSelectItem>
-                        <BuilderSelectItem actionValue="'right'">Right</BuilderSelectItem>
-                    </BuilderSelect>
-                </BuilderRow>
-            </BuilderContext>
-            <BuilderRow label.translate=" ">
-                <BuilderButton action="'deleteRibbon'" preview="false" className="'o_we_bg_danger'" t-on-click="()=>state.ribbonEditMode = false">Delete Ribbon</BuilderButton>
-            </BuilderRow>
-        </t>
     </t>
 </templates>

--- a/addons/website_sale/static/tests/builder/products_item_option.test.js
+++ b/addons/website_sale/static/tests/builder/products_item_option.test.js
@@ -28,6 +28,11 @@ test("add a new ribbon", async () => {
                             <span class="o_ribbon o_not_editable d-none" style=""></span>
                         </a>
                     </div>
+                    <span
+                        data-ribbon-id=""
+                        class="o_ribbons o_not_editable"
+                        style=""
+                    />
                     <div class="o_wsale_product_information">
                             <div class="o_wsale_product_information_text">
                                 <h6 class="o_wsale_products_item_title">
@@ -51,5 +56,5 @@ test("add a new ribbon", async () => {
     );
     await contains(":iframe .oe_product").click();
     await contains("button[data-action-id='createRibbon']").click();
-    expect(":iframe .oe_product .o_ribbon").toHaveText("Ribbon Name");
+    expect(":iframe .oe_product .o_ribbons").toHaveText("Ribbon Name");
 });

--- a/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
@@ -47,5 +47,5 @@ registerWebsitePreviewTour("shop_editor_set_product_ribbon", {
 ...clickOnSave(),
 {
     content: "Check that the ribbon was properly saved",
-    trigger: ':iframe .oe_product:first .o_ribbon:contains("Sale")',
+    trigger: ':iframe .oe_product:first .o_ribbons:contains("Sale")',
 }]);

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -37,3 +37,4 @@ from . import test_website_sale_show_compare_list_price
 from . import test_website_sale_snippets
 from . import test_website_sale_visitor
 from . import test_website_sequence
+from . import test_website_sale_product_ribbon

--- a/addons/website_sale/tests/test_website_sale_product_ribbon.py
+++ b/addons/website_sale/tests/test_website_sale_product_ribbon.py
@@ -1,0 +1,93 @@
+from datetime import timedelta
+
+from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+
+
+class TestProductRibbon(WebsiteSaleCommon):
+
+    def setUp(self):
+        super().setUp()
+        # Manual ribbon
+        self.manual_ribbon = self.env['product.ribbon'].create({
+            'name': "Manual Ribbon",
+            'assign': 'manual',
+        })
+
+        # Sale ribbon
+        self.sale_ribbon = self.env['product.ribbon'].create({
+            'name': "Sale Ribbon",
+            'assign': 'sale',
+        })
+
+        # New ribbon
+        self.new_ribbon = self.env['product.ribbon'].create({
+            'name': "New Ribbon",
+            'assign': 'new',
+        })
+
+        self.auto_assign_ribbon = self.env['product.ribbon'].search([('assign', '!=', 'manual')])
+
+    def test_manual_ribbon_assignment(self):
+        self.product.website_ribbon_id = self.manual_ribbon.id
+        products_prices = {'base_price': 100, 'price_reduce': 100}
+        ribbon = self.product.product_tmpl_id._get_ribbon(products_prices, self.auto_assign_ribbon)
+        self.assertEqual(
+            ribbon, self.manual_ribbon, "Manual ribbon should be returned",
+        )
+
+    def test_sale_ribbon_assignment(self):
+        self.product.list_price = 100
+        products_prices = {'base_price': 100, 'price_reduce': 80}  # discounted
+        ribbon = self.product.product_tmpl_id._get_ribbon(products_prices, self.auto_assign_ribbon)
+        self.assertEqual(
+            ribbon, self.sale_ribbon, "Sale ribbon should be returned",
+        )
+
+    def test_new_ribbon_assignment(self):
+        self.product.publish_date -= timedelta(days=10)
+        products_prices = {'base_price': 100, 'price_reduce': 100}
+        ribbon = self.product.product_tmpl_id._get_ribbon(products_prices, self.auto_assign_ribbon)
+        self.assertEqual(
+            ribbon,
+            self.new_ribbon,
+            "New ribbon should be returned for recently published products",
+        )
+
+    def test_no_ribbon_if_none_match(self):
+        self.product.publish_date -= timedelta(days=100)
+        products_prices = {'base_price': 100, 'price_reduce': 100}
+        ribbon = self.product.product_tmpl_id._get_ribbon(products_prices, self.auto_assign_ribbon, self.product)
+        self.assertFalse(
+            ribbon, "No ribbon should be returned when no condition is matched",
+        )
+
+    def test_ribbon_priority_assignment(self):
+        self.product.website_ribbon_id = self.manual_ribbon.id
+        self.product.publish_date -= timedelta(days=10)
+        products_prices = {'base_price': 100, 'price_reduce': 80}  # discounted
+        self.sale_ribbon.sequence = 1
+        self.new_ribbon.sequence = 2
+        ribbon = self.product.product_tmpl_id._get_ribbon(products_prices, self.auto_assign_ribbon)
+        self.assertEqual(
+            ribbon,
+            self.manual_ribbon,
+            "Manual ribbon should have the highest priority",
+        )
+
+        self.product.website_ribbon_id = False
+        ribbon = self.product.product_tmpl_id._get_ribbon(products_prices, self.auto_assign_ribbon)
+        self.assertEqual(
+            ribbon,
+            self.sale_ribbon,
+            "Sale ribbon should have the highest priority",
+        )
+
+        self.new_ribbon.sequence = 1
+        self.sale_ribbon.sequence = 2
+        self.auto_assign_ribbon = self.env['product.ribbon'].search([('assign', '!=', 'manual')])
+        ribbon = self.product.product_tmpl_id._get_ribbon(products_prices, self.auto_assign_ribbon)
+        self.assertEqual(
+            ribbon,
+            self.new_ribbon,
+            "New ribbon should have the highest priority",
+        )

--- a/addons/website_sale/views/product_ribbon_views.xml
+++ b/addons/website_sale/views/product_ribbon_views.xml
@@ -7,16 +7,32 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="New Collection"/>
+                        </h1>
+                    </div>
                     <group>
-                        <group>
-                            <field name="name" widget="char"/>
-                            <field name="position" widget="radio"/>
-                        </group>
-                        <group>
-                            <field name="text_color" widget="color"/>
-                            <field name="bg_color" widget="color"/>
-                        </group>
+                        <label for="assign"/>
+                        <div>
+                            <field name="assign" class="oe_inline"/>
+                            <div invisible="assign != 'new'" class="text-muted ms-2 d-inline-flex align-items-center">
+                                <span>for</span>
+                                <field name="new_period" style="width: 3rem; !important" class="ms-1 mb-0"/>
+                                <span>days after publication.</span>
+                            </div>
+                        </div>
                     </group>
+                    <notebook>
+                        <page string="Display">
+                            <group>
+                                <field name="position" widget="radio" options="{'horizontal': True}"/>
+                                <field name="style" widget="radio" options="{'horizontal': True}"/>
+                                <field name="text_color" widget="color"/>
+                                <field name="bg_color" widget="color"/>
+                            </group>
+                        </page>
+                    </notebook>
                 </sheet>
             </form>
         </field>
@@ -27,6 +43,7 @@
         <field name="model">product.ribbon</field>
         <field name="arch" type="xml">
             <list string="Product Ribbon">
+                <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="position"/>
                 <field name="text_color" widget="color" readonly="1"/>

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -214,7 +214,6 @@
                 <field name="public_categ_ids" widget="many2many_tags" string="Categories"/>
                 <field
                     name="website_ribbon_id"
-                    groups="base.group_no_one"
                     options="{'no_quick_create': True}"
                 />
             </group>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -311,14 +311,13 @@
                     <span t-field="image_holder.image_1920"
                         t-options="{'widget': 'image', 'preview_image': image_type, 'class': 'h-100 w-100 position-absolute'}"
                         class="oe_product_image_img_wrapper d-flex h-100 justify-content-center align-items-center position-absolute"/>
-
-                    <t t-set="bg_color" t-value="td_product['ribbon'].bg_color"/>
-                    <t t-set="text_color" t-value="td_product['ribbon'].text_color"/>
-                    <t t-set="bg_class" t-value="td_product['ribbon']._get_position_class()"/>
+                    <t t-set="bg_color" t-value="ribbon.bg_color"/>
+                    <t t-set="text_color" t-value="ribbon.text_color"/>
                     <span
-                        t-attf-class="o_ribbon o_not_editable #{bg_class}"
+                        t-att-data-ribbon-id="ribbon.id"
+                        t-attf-class="o_ribbons o_not_editable #{ribbon._get_css_classes()}"
                         t-attf-style="#{text_color and ('color: %s;' % text_color)} #{bg_color and 'background-color:' + bg_color}"
-                        t-out="td_product['ribbon'].name or ''"
+                        t-out="ribbon.name or ''"
                     />
                 </a>
             </div>
@@ -345,7 +344,6 @@
                     <t t-call="website_sale.product_variant_preview" />
                 </div>
                 <div class="o_wsale_product_sub d-flex align-items-center justify-content-between flex-nowrap gap-3">
-                    <t t-set="template_price_vals" t-value="get_product_prices(product)"/>
                     <div class="product_price">
                         <span class="h6 mb-0"
                               t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale"
@@ -738,19 +736,24 @@
                                                    t-value="(td_product['x'] &gt;= td_product['y'] * 2)"/>
                                                 <t t-set="col_is_custom_portrait"
                                                    t-value="not col_is_stretched and (col_height &gt; td_product['x'])"/>
+                                                <t t-set="product" t-value="td_product['product']"/>
+                                                <t t-set="template_price_vals" t-value="get_product_prices(product)"/>
+                                                <t
+                                                    t-set="ribbon"
+                                                    t-value="product._get_ribbon(
+                                                        price_vals=template_price_vals,
+                                                        auto_assign_ribbons=auto_assign_ribbons,
+                                                    )"
+                                                />
                                                 <div
                                                     t-attf-class="oe_product {{col_is_custom_portrait and 'oe_product_custom_portrait'}} {{col_class}} {{col_class_md}} {{col_class_lg}} {{col_is_stretched and 'oe_product_size_stretch'}}"
                                                     t-attf-style="--o-wsale-products-grid-product-col-height: {{col_height}};"
-                                                    t-att-data-ribbon-id="td_product['ribbon'].id"
                                                     t-att-data-colspan="td_product['x'] != 1 and td_product['x']"
                                                     t-att-data-rowspan="td_product['y'] != 1 and td_product['y']"
                                                     t-att-data-name="product_block_name"
                                                 >
                                                     <div t-attf-class="o_wsale_product_grid_wrapper position-relative h-100 o_wsale_product_grid_wrapper_#{td_product['x']}_#{td_product['y']}">
-                                                        <t t-call="website_sale.products_item">
-                                                            <t t-set="product"
-                                                               t-value="td_product['product']"/>
-                                                        </t>
+                                                        <t t-call="website_sale.products_item"/>
                                                     </div>
                                                 </div>
                                             </t>
@@ -3965,14 +3968,22 @@
     <!-- Product page images -->
     <template id="website_sale.shop_product_images" name="Shop Product Images">
         <t t-set="product_images" t-value="product_variant._get_images() if product_variant else product._get_images()"/>
-        <t t-set="ribbon" t-value="product_variant.sudo().variant_ribbon_id or product.sudo().website_ribbon_id"/>
-        <t t-set="bg_color" t-value="ribbon['bg_color'] or ''"/>
-        <t t-set="text_color" t-value="ribbon['text_color']"/>
-        <t t-set="bg_class" t-value="ribbon._get_position_class()"/>
+        <t
+            t-set="ribbon"
+            t-value="product.sudo()._get_ribbon(price_vals=combination_info, variant=product_variant)"
+        />
+        <t t-set="bg_color" t-value="ribbon.bg_color"/>
+        <t t-set="text_color" t-value="ribbon.text_color"/>
         <t t-call="website_sale.shop_product_#{website.product_page_image_layout}"/>
     </template>
 
     <template id="website_sale.shop_product_image">
+        <span
+            t-attf-class="o_ribbons o_not_editable #{ribbon._get_css_classes()} z-1"
+            t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"
+            t-att-data-ribbon-id="ribbon.id"
+            t-out="ribbon.name or ''"
+        />
         <div
             t-if="product_image._name == 'product.image' and product_image.embed_code"
             t-att-class="image_classes + ' ratio ratio-16x9'"
@@ -3983,11 +3994,7 @@
             t-elif="len(product_images) == 1 and website.product_page_image_layout != 'grid'"
             class="position-relative d-inline-flex overflow-hidden m-auto w-100"
         >
-            <span t-attf-class="o_ribbon #{ribbon._get_position_class()} z-1"
-                  t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"
-                  t-out="ribbon['name'] or ''"
-            />
-            <div
+            <span
                 t-field="product_image.image_1920"
                 name="o_img_with_max_suggested_width"
                 class="d-flex align-items-start justify-content-center w-100 oe_unmovable"
@@ -3999,6 +4006,7 @@
                     'zoom': product_image.can_image_1024_be_zoomed and 'image_1920',
                 }"
             />
+
         </div>
         <div
             t-else=""
@@ -4025,10 +4033,12 @@
             <div
                 class="o_carousel_product_outer carousel-outer position-relative d-flex align-items-center w-100 overflow-hidden"
             >
-                <span t-if="len(product_images) > 1"
-                      t-attf-class="o_ribbon #{ribbon._get_position_class()} z-1"
-                      t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"
-                      t-out="ribbon['name'] or ''"
+                <span
+                    t-if="len(product_images) > 1"
+                    t-attf-class="o_ribbons #{ribbon._get_css_classes()} z-1"
+                    t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"
+                    t-out="ribbon.name or ''"
+                    t-att-data-ribbon-id="ribbon.id"
                 />
                 <div class="carousel-inner h-100">
                     <t t-set="image_classes" t-value="'d-flex align-items-center justify-content-center h-100'"/>
@@ -4164,9 +4174,11 @@
             t-att-data-grid_columns="website.product_page_grid_columns"
         >
             <div class="container position-relative overflow-hidden">
-                <span t-attf-class="o_ribbon #{ribbon._get_position_class()}"
-                      t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"
-                      t-out="ribbon['name'] or ''"
+                <span
+                    t-attf-class="o_ribbons #{ribbon._get_css_classes()}"
+                    t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"
+                    t-out="ribbon.name or ''"
+                    t-att-data-ribbon-id="ribbon.id"
                 />
                 <!-- One row for every two images -->
                 <t t-set="image_classes" t-value="'w-100'"/>

--- a/addons/website_sale_stock/data/website_sale_stock_demo.xml
+++ b/addons/website_sale_stock/data/website_sale_stock_demo.xml
@@ -6,4 +6,7 @@
     <record id="stock.product_cable_management_box_product_template" model="product.template">
         <field name="public_categ_ids" eval="[(6,0,[ref('website_sale.public_category_boxes')])]"/>
     </record>
+    <record id="website_sale.out_of_stock_ribbon" model="product.ribbon">
+        <field name="assign">out_of_stock</field>
+    </record>
 </odoo>

--- a/addons/website_sale_stock/models/__init__.py
+++ b/addons/website_sale_stock/models/__init__.py
@@ -4,6 +4,7 @@
 from . import website
 from . import product_combo
 from . import product_product
+from . import product_ribbon
 from . import product_template
 from . import res_config_settings
 from . import sale_order

--- a/addons/website_sale_stock/models/product_ribbon.py
+++ b/addons/website_sale_stock/models/product_ribbon.py
@@ -1,0 +1,28 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ProductRibbon(models.Model):
+    _inherit = 'product.ribbon'
+
+    assign = fields.Selection(
+        selection_add=[('out_of_stock', "when out of stock")],
+        ondelete={'out_of_stock': 'cascade'},
+        help=(
+            "Defines how this ribbon is assigned to products:\n"
+            "- Manually: You assign the ribbon manually to products.\n"
+            "- Sale: Applied when the product is visibly on sale.\n"
+            "- New: Applied based on the New period you will define.\n"
+            "- Out Of Stock: Applied when the product is out of stock."
+        ),
+    )
+
+    def _is_applicable_for(self, product, price_data):
+        """Override of `website_sale` to handle `out_of_stock` ribbons."""
+        return super()._is_applicable_for(product, price_data) or (
+            product
+            and self.assign == 'out_of_stock'
+            and not product.product_tmpl_id.allow_out_of_stock_order
+            and product._is_sold_out()
+        )


### PR DESCRIPTION
prior this commit:
- Ribbons were assigned manually using web editor
- Only one type of ribbon was available

post this commit:
- Automatic ribbon assignment is possible based on 4 categories
- Added badge as another type of ribbon
- Added possibility to change ribbon type from web editor
- Added priority for ribbons in ribbon list view for dynamic assignment
- Added ribbon management on /product page in web editor and generalized both the editor code in product ribbon plugin.

Task-4367608

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
