### PR TITLE
[FIX] l10n_my: phone validation, db duplicate.

### DIFF
--- a/addons/account_edi_proxy_client/data/neutralize.sql
+++ b/addons/account_edi_proxy_client/data/neutralize.sql
@@ -1,6 +1,8 @@
 -- disable edi connections in general, and the Italian one (l10n_it_edi_sdicoop) in particular
+-- for malaysian edi, this script can cause issue as you could have both a demo and prod user, in which case it breaks the unique constrain. Another neutralize in the malaysian module disable the clients instead.
 UPDATE account_edi_proxy_client_user
 SET edi_mode = CASE
                     WHEN proxy_type = 'l10n_it_edi' THEN 'demo'
                     ELSE 'test'
-               END;
+               END
+WHERE proxy_type != 'l10n_my_edi';

--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -299,6 +299,12 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
 
             if not partner.state_id:
                 self._l10n_my_edi_make_validation_error(constraints, 'no_state', partner_type, partner.display_name)
+            if not partner.city:
+                self._l10n_my_edi_make_validation_error(constraints, 'no_city', partner_type, partner.display_name)
+            if not partner.country_id:
+                self._l10n_my_edi_make_validation_error(constraints, 'no_country', partner_type, partner.display_name)
+            if not partner.street:
+                self._l10n_my_edi_make_validation_error(constraints, 'no_street', partner_type, partner.display_name)
 
             if partner.sst_registration_number and len(partner.sst_registration_number.split(';')) > 2:
                 self._l10n_my_edi_make_validation_error(constraints, 'too_many_sst', partner_type, partner.display_name)
@@ -437,6 +443,8 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
     def _l10n_my_edi_get_formatted_phone_number(self, number):
         # the phone number MUST follow the E.164 format.
         # Don't try to reformat too much, we don't want to risk messing it up
+        if not number:
+            return ''  # This wouldn't happen in the file as it's caught in the validation errors, but the vals are exported before these checks are done.
         return number.replace(' ', '').replace('(', '').replace(')', '').replace('-', '')
 
     @api.model
@@ -463,6 +471,18 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
             ),
             'no_state': _(
                 "The following partner's state is missing: %(partner_name)s",
+                partner_name=record_name
+            ),
+            'no_city': _(
+                "The following partner's city is missing: %(partner_name)s",
+                partner_name=record_name
+            ),
+            'no_country': _(
+                "The following partner's country is missing: %(partner_name)s",
+                partner_name=record_name
+            ),
+            'no_street': _(
+                "The following partner's street is missing: %(partner_name)s",
                 partner_name=record_name
             ),
             'class_code_required': _(

--- a/addons/l10n_my_edi/tests/test_file_generation.py
+++ b/addons/l10n_my_edi/tests/test_file_generation.py
@@ -22,7 +22,7 @@ NS_MAP = {
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
-class L10nMyEDITestSubmission(AccountTestInvoicingCommon):
+class L10nMyEDITestFileSubmission(AccountTestInvoicingCommon):
 
     @classmethod
     def setUpClass(cls, chart_template_ref='my'):
@@ -38,6 +38,7 @@ class L10nMyEDITestSubmission(AccountTestInvoicingCommon):
             'l10n_my_identification_number': '202001234567',
             'state_id': cls.env.ref('base.state_my_jhr').id,
             'street': 'that one street, 5',
+            'city': 'Main city',
             'phone': '+60123456789',
         })
         cls.partner_a.write({
@@ -47,6 +48,7 @@ class L10nMyEDITestSubmission(AccountTestInvoicingCommon):
             'country_id': cls.env.ref('base.my').id,
             'state_id': cls.env.ref('base.state_my_jhr').id,
             'street': 'that other street, 3',
+            'city': 'Main city',
             'phone': '+60123456786',
         })
 

--- a/addons/l10n_my_edi/tests/test_submissions.py
+++ b/addons/l10n_my_edi/tests/test_submissions.py
@@ -34,13 +34,18 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
             'l10n_my_identification_type': 'BRN',
             'l10n_my_identification_number': '202001234567',
             'state_id': cls.env.ref('base.state_my_jhr').id,
+            'street': 'that one street, 5',
+            'city': 'Main city',
             'phone': '+60123456789',
         })
         cls.partner_a.write({
             'vat': 'C2584563201',
             'l10n_my_identification_type': 'BRN',
             'l10n_my_identification_number': '202001234568',
+            'country_id': cls.env.ref('base.my').id,
             'state_id': cls.env.ref('base.state_my_jhr').id,
+            'street': 'that other street, 3',
+            'city': 'Main city',
             'phone': '+60123456786',
         })
 

--- a/addons/l10n_my_edi/views/res_partner_view.xml
+++ b/addons/l10n_my_edi/views/res_partner_view.xml
@@ -8,8 +8,8 @@
             <group name="container_row_2" position="inside">
                 <field name="l10n_my_tin_validation_state" invisible="1"/>
                 <field name="l10n_my_edi_display_tin_warning" invisible="1"/>
-                <!-- I believe the customer must be registered for TIN in malaysia, and thus it makes sense to limit this to malaysian customer -->
-                <group name="l10n_my_edi" string="MyInvois Information" invisible="country_code != 'MY'">
+                <!-- Foreigner with a tax number registered in Malaysia could be customer of an e-invoice. -->
+                <group name="l10n_my_edi" string="MyInvois Information">
                     <group colspan="2">
                         <label for="l10n_my_identification_type" string="Identification"/>
                         <div class="d-flex gap-2" invisible="'MY' not in fiscal_country_codes">


### PR DESCRIPTION
Fixes an issue due to the phone number being formatted before the verification that it is actually set.
The formatting will now support receiving no phone number, and it won't cause an issue as its existence is checked right after.

Also avoid running the account_edi_proxy_client neutralize on malaysian users, as it simply set the type to test. The malaysian edi supports having both a test and production user set on the same db (only one is being use at any given time of course), so that neutralize could result in having two test users, which is not allowed by the constrains.

opw-4352823

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
