### PR TITLE
[FIX] sale_project: compute distribution for sale order's company

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1078,7 +1078,7 @@ class SaleOrderLine(models.Model):
             else:
                 line.amount_to_invoice = 0.0
 
-    @api.depends('order_id.partner_id', 'product_id')
+    @api.depends('order_id.partner_id', 'company_id', 'product_id')
     def _compute_analytic_distribution(self):
         for line in self:
             if not line.display_type:

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -121,6 +121,20 @@ class SaleOrder(models.Model):
             order.project_ids = projects
             order.project_count = len(projects)
 
+    @api.onchange('company_id')
+    def _onchange_company_id_warning(self):
+        result = super()._onchange_company_id_warning()
+        if (
+            self.order_line
+            and self.state == 'draft'
+            and self.env.user.has_group('analytic.group_analytic_accounting')
+        ):
+            result['warning']['message'] = " ".join([
+                result['warning']['message'],
+                _("You might also consider updating analytic distributions.")
+            ])
+        return result
+
     def _action_confirm(self):
         """ On SO confirmation, some lines should generate a task or a project. """
         if len(self.company_id) == 1:

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -125,13 +125,13 @@ class SaleOrderLine(models.Model):
             sol_id = line.id or line._origin.id
             line.qty_delivered = reached_milestones_per_sol.get(sol_id, 0.0) * line.product_uom_qty
 
-    @api.depends('order_id.partner_id', 'product_id', 'order_id.project_id')
+    @api.depends('order_id.partner_id', 'company_id', 'product_id', 'order_id.project_id')
     def _compute_analytic_distribution(self):
         super()._compute_analytic_distribution()
         for line in self:
             if line.display_type or line.analytic_distribution or not line.product_id:
                 continue
-            project = line.product_id.project_id or line.order_id.project_id
+            project = line.product_id.with_company(line.company_id).project_id or line.order_id.project_id
             distribution = project._get_analytic_distribution()
             if distribution:
                 line.analytic_distribution = distribution


### PR DESCRIPTION
To reproduce:
- Setup 2 companies: Company A and Company B

- Create a product with:
  * Name: Pack
  * Product Type: Service
  * Create on Order: Task

  * For Company A:
    - Create and set project to: Pack A (default analytic: Project / Pack A)

  * For Company B:
    - Create and set project to: Pack B (default analytic: Project / Pack B)

With a user that have access to both companies:

- Switch user main company to Company A (Company B is enabled in the multicompany selector)

- Create a new sale order:
  * Choose a partner
  * Change company to Company B
  * Add a line with product "Pack", the analytic distribution is computed for "Pack A".

Here the analytic distribution is computed relative to the user's current company, whereas it should be computed for the sale order's company.

This commit force compute the analytic distribution in the context of the order's company and force recompute it when the company change.

[opw-4394763](https://www.odoo.com/odoo/project.task/4394763)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
