### PR TITLE
[FIX] website_payment: test_01_donation tour

### DIFF
--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -4,12 +4,15 @@ import {
     clickOnSave,
     registerWebsitePreviewTour,
     insertSnippet,
-} from '@website/js/tours/tour_utils';
+} from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour('donation_snippet_edition', {
-    url: '/',
-    edition: true,
-}, () => [
+registerWebsitePreviewTour(
+    "donation_snippet_edition",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
         ...insertSnippet({
             id: "s_donation",
             name: "Donation",
@@ -66,12 +69,7 @@ registerWebsitePreviewTour('donation_snippet_edition', {
         {
             content: "Change custom amount to 67",
             trigger: ":iframe input[name='o_donation_amount'][type='number']",
-            run: function(action) {
-                const input = action.anchor;
-                input.value = "67";
-                input.dispatchEvent(new Event("input", { bubbles: true }));
-                input.dispatchEvent(new Event("change", { bubbles: true }));
-            }
+            run: "edit 67",
         },
         {
             content: "Select the custom amount radio button",
@@ -87,6 +85,9 @@ registerWebsitePreviewTour('donation_snippet_edition', {
             content: "Verify that the amount displayed is 67",
             trigger: ':iframe span.oe_currency_value:contains("67.00")',
             timeout: 10000, // Make sure the payment process animation is finished
+        },
+        {
+            trigger: ":iframe [name=o_payment_status_alert]:contains(thank you!)",
         },
     ]
 );


### PR DESCRIPTION
In this commit, we fix the tour test_01_donation by adding a final step that attest the donation has successfully completed. By adding this final step, we avoid a "failed to fetch" type error.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
