### PR TITLE
[FIX] web: x2many: keep orderBy after save

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -529,7 +529,9 @@ export class StaticList extends DataPoint {
                             }
                             changes[fieldName] = command[2][fieldName];
                         }
-                        record._applyChanges(record._parseServerValues(changes, record.data));
+                        record._applyChanges(
+                            record._parseServerValues(changes, { currentValues: record.data })
+                        );
                     }
                     break;
                 }
@@ -996,9 +998,9 @@ export class StaticList extends DataPoint {
             }
         }
         const allRecords = currentIds.map((id) => this._cache[id]);
-        const sortedRecords = allRecords.sort((r1, r2) => {
-            return compareRecords(r1, r2, orderBy, this.fields);
-        });
+        const sortedRecords = allRecords.sort((r1, r2) =>
+            compareRecords(r1, r2, orderBy, this.fields)
+        );
         await this._load({
             orderBy,
             nextCurrentIds: sortedRecords.map((r) => r.resId || r._virtualId),

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -344,7 +344,7 @@ function getFieldContextForSpec(activeFields, fields, fieldName, evalContext) {
     }
 }
 
-export function getFieldsSpec(activeFields, fields, evalContext, { withInvisible } = {}) {
+export function getFieldsSpec(activeFields, fields, evalContext, { orderBys, withInvisible } = {}) {
     const fieldsSpec = {};
     const properties = [];
     for (const fieldName in activeFields) {
@@ -371,8 +371,9 @@ export function getFieldsSpec(activeFields, fields, evalContext, { withInvisible
                         evalContext
                     );
                     fieldsSpec[fieldName].limit = limit;
-                    if (defaultOrderBy) {
-                        fieldsSpec[fieldName].order = orderByToString(defaultOrderBy);
+                    const orderBy = orderBys?.[fieldName] || defaultOrderBy || [];
+                    if (orderBy.length) {
+                        fieldsSpec[fieldName].order = orderByToString(orderBy);
                     }
                 }
                 break;

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -3633,14 +3633,12 @@ test(`onchange send only the present fields to the server`, async () => {
                     },
                 },
                 limit: 40,
-                order: "",
             },
             type_ids: {
                 fields: {
                     name: {},
                 },
                 limit: 40,
-                order: "",
             },
         });
     });
@@ -3852,7 +3850,6 @@ test(`default record with a one2many and an onchange on sub field`, async () => 
                     foo: {},
                 },
                 limit: 40,
-                order: "",
             },
         });
     });
@@ -3922,7 +3919,6 @@ test(`form with one2many with dynamic context`, async () => {
                 },
                 context: { static: 4 },
                 limit: 40,
-                order: "",
             },
         });
     });
@@ -6458,7 +6454,6 @@ test(`display_name not sent for onchanges if not in view`, async () => {
                     color: {},
                 },
                 limit: 40,
-                order: "",
             },
         });
     });
@@ -6482,7 +6477,6 @@ test(`display_name not sent for onchanges if not in view`, async () => {
                     color: {},
                 },
                 limit: 40,
-                order: "",
             },
         });
     });


### PR DESCRIPTION
Have a form view with an x2many list. Click on a column header to sort the list by a given field. Then do a change in the form and save. Before this commit, the order of the x2many was lost. With this commit, it is kept. Note that the order is UI only, it doesn't impact the order of records in the relation in database, i.e. if the user leaves and comes back, the order will be lost.

task~4366529

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
