### PR TITLE
[FIX] website_sale: display the correct variant tags

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1362,6 +1362,15 @@
                                         </div>
                                         <div id="product_option_block" class="d-flex flex-wrap w-100"/>
                                     </div>
+                                    <t
+                                        t-if="is_view_active('website_sale.product_tags')"
+                                        t-call="website_sale.product_tags"
+                                    >
+                                      <t
+                                            t-set="all_product_tags"
+                                            t-value="product_variant.all_product_tag_ids"
+                                        />
+                                    </t>
                                 </div>
                             </form>
                             <p t-elif="not product.active" class="alert alert-warning">
@@ -1390,15 +1399,6 @@
                                     </div>
                                 </section>
                             </div>
-                            <t
-                                t-if="is_view_active('website_sale.product_tags')"
-                                t-call="website_sale.product_tags"
-                            >
-                                <t
-                                    t-set="all_product_tags"
-                                    t-value="product_variant.all_product_tag_ids"
-                                />
-                            </t>
                             <div
                                 t-if="not is_view_active('website_sale_comparison.accordion_specs_item')"
                                 id="product_attributes_simple"
@@ -1492,7 +1492,7 @@
     </template>
 
     <template id="product_tags" name="Product Tags" active="True">
-        <div class="o_product_tags o_field_tags d-flex flex-wrap align-items-center gap-2 mb-4">
+        <div class="o_product_tags o_field_tags d-flex flex-wrap align-items-center gap-2 mb-2 mt-1">
             <t t-foreach="all_product_tags" t-as="tag">
                 <t t-if="tag.visible_on_ecommerce">
                     <span t-if="tag.image"


### PR DESCRIPTION
Steps to reproduce:
------------------

- Set a product tag for a specific variant.
- Go to the shop.
- Select different variants of the product.

Issue:
-----

The tags of the variant is not shown. This is due to the JS file: odoo/addons/website_sale/static/src/js/sale_variant_mixin.js In this file we set the parent to:
var $parent = $(ev.target).closest('.js_product'); To update the product tags we do a find('.o_product_tags') However this falls outside of the div of the parent. This "find" then results with nothing. And nothing is updated.

Fix:
----

To fix this the call to website_sale.product_tags was inserted inside the right div so it can be found and thus updated.

opw-4357477

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
