### PR TITLE
[FIX] mail: emoji picker bg color is wrong in dark theme

### DIFF
--- a/addons/mail/static/src/core/common/picker_content.xml
+++ b/addons/mail/static/src/core/common/picker_content.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.PickerContent">
-    <div class="o-mail-PickerContent d-flex flex-column flex-grow-1 o-min-height-0" t-on-click="onClick">
+    <div class="o-mail-PickerContent d-flex flex-column flex-grow-1 o-min-height-0 bg-100" t-on-click="onClick">
         <div class="o-mail-PickerContent-picker d-flex flex-grow-1 rounded overflow-auto">
             <div t-if="props.state.picker === props.PICKERS.EMOJI" class="o-mail-PickerContent-emojiPicker d-flex flex-grow-1 mw-100">
                 <EmojiPicker close="props.close" onSelect="props.pickers.emoji" state="props.state" storeScroll="props.storeScroll"/>

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="web.EmojiPicker">
-    <div class="o-EmojiPicker d-flex flex-column justify-content-center rounded-3" t-att-class="{ 'align-items-center': emojis.length === 0 }" t-on-click="onClick" t-on-keydown="onKeydown">
+    <div class="o-EmojiPicker d-flex flex-column justify-content-center rounded-3 bg-100" t-att-class="{ 'align-items-center': emojis.length === 0 }" t-on-click="onClick" t-on-keydown="onKeydown">
         <t t-if="emojis.length === 0">
             <span class="o-EmojiPicker-empty">😵‍💫</span>
             <span class="fs-5 text-muted">Failed to load emojis...</span>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/190586

Backport mistakenly removed the `.bg-view` on EmojiPicker rather than replacing it to `.bg-100`. As a result, the style of emoji picker is off in dark theme.

White theme color is slightly off but the difference is barely visible, so this is a non-issue in white theme.

This commit makes the correct intended change: replace `.bg-view` by `.bg-100`.

Also in master the component PickerContent is no more, but in 18.0 we have to take into account for the overall bg-color. This commit also makes this change.

Before 
<img width="307" alt="Screenshot 2024-12-16 at 12 48 09" src="https://github.com/user-attachments/assets/f4bc0a49-9e63-43c6-acb5-1fb2c41bb0fb" />

After
<img width="306" alt="Screenshot 2024-12-16 at 12 48 36" src="https://github.com/user-attachments/assets/2b2ff197-e0f3-48bd-9830-9715142fbebe" />

