### PR TITLE
[FIX] l10n_sa: Fix CoA Data

### DIFF
--- a/addons/l10n_sa/data/l10n_sa_chart_data.xml
+++ b/addons/l10n_sa/data/l10n_sa_chart_data.xml
@@ -6,8 +6,8 @@
         <field name="property_account_payable_id" ref="sa_account_201002"/>
         <field name="property_account_expense_categ_id" ref="sa_account_400001"/>
         <field name="property_account_income_categ_id" ref="sa_account_500001"/>
-        <field name="income_currency_exchange_account_id" ref="sa_account_400053"/>
-        <field name="expense_currency_exchange_account_id" ref="sa_account_500011"/>
+        <field name="income_currency_exchange_account_id" ref="sa_account_500011"/>
+        <field name="expense_currency_exchange_account_id" ref="sa_account_400053"/>
         <field name="default_pos_receivable_account_id" ref="sa_account_102012" />
         <field name="property_tax_payable_account_id" ref="sa_account_202003"/>
         <field name="property_tax_receivable_account_id" ref="sa_account_100103"/>


### PR DESCRIPTION
Set the correct accounts for expense & income currency exchange accounts

Description of the issue/feature this PR addresses:
task: https://www.odoo.com/odoo/my-tasks/4179478
swap Exchange Difference Gain & Exchange Difference Loss

Current behavior before PR:
- The exchange difference accounts were wrongly assigned
Desired behavior after PR is merged:
- Fix issue by swapping them



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
