### PR TITLE
[FIX] point_of_sale: redesign mobile view

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/category_selector/category_selector.scss
+++ b/addons/point_of_sale/static/src/app/generic_components/category_selector/category_selector.scss
@@ -1,3 +1,12 @@
 .category-button {
     --btn-border-color: #{$o-gray-200};
 }
+
+.category-list {
+    @include media-breakpoint-down(sm) {
+        overflow-y: auto;
+        flex-shrink: 0;
+        margin-bottom: map-get($spacers, 2);
+        max-height: 9rem;
+    }
+}

--- a/addons/point_of_sale/static/src/app/generic_components/category_selector/category_selector.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/category_selector/category_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.CategorySelector">
-        <div t-att-class="props.class" class="d-grid product-list gap-2" t-att-style="props.style">
+        <div t-att-class="props.class" class="d-grid product-list category-list gap-2" t-att-style="props.style">
             <t t-foreach="props.categories" t-as="category" t-key="category.id">
                 <button t-on-click="() => props.onClick(category.id)"
                     t-attf-class="o_colorlist_item_color_{{!category.isSelected and !category.isChildren ? 'transparent_': ''}}{{category.color or 'none'}}"

--- a/addons/point_of_sale/static/src/app/navbar/navbar.scss
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.scss
@@ -5,6 +5,10 @@
     }
 }
 
+.pos-topheader {
+    flex-shrink: 0;
+}
+
 .navbar-height {
     height: $navbar-height;
 }


### PR DESCRIPTION
Currently when users have too many categories in their pos, their are not able to see the products and cannot scroll.

Steps to reproduce:
-------------------
* Add categories to the pos `> 20`
* Open pos shop
* Change the view size to a mobile view
> Observation: We cannot see all categories, cannot scroll through them,
and cannot see/select products

Why the fix:
------------

In mobile view we will show only 2 rows of categories and allow to scroll to see the rest. This allows for space for the products to be shown.

If we have less than 3 categories and sub categories to show we will restrict the height to 1 row.

opw-4371390


## Before
![2024-12-16_mobile_before](https://github.com/user-attachments/assets/01e33d4c-0eed-4472-b64c-f53fba1edcfc)

## After
![2024-12-16_mobile_after](https://github.com/user-attachments/assets/a505df82-e45c-4448-afa8-1aea3739befb)
https://drive.google.com/file/d/1yBOEFqX6NbI-mCLjQ9aSR-yEzJ3am50E/view?usp=sharing
