### PR TITLE
[FIX] base: fix tz test for us

### DIFF
--- a/odoo/addons/base/tests/test_tz.py
+++ b/odoo/addons/base/tests/test_tz.py
@@ -61,4 +61,7 @@ class TestTZ(TransactionCase):
         self.env.cr.execute("""UPDATE res_partner set tz='US/Eastern' WHERE id=%s""", (partner.id,))
         partner.invalidate_cache()
         self.assertEqual(partner.tz, 'US/Eastern')  # tz was update despite selection not existing, but data was not migrated
-        self.assertEqual(partner.tz_offset, '-0400', "We don't expect pytz.timezone to fail if the timezone diseapeared when chaging os version")
+        # comparing with 'America/New_York' see tools/_monkeypatches_pytz.py for mapping
+        expected_offset = datetime.datetime.now(pytz.timezone('America/New_York')).strftime('%z')
+        # offest will be -0400 in summer, -0500 in winter
+        self.assertEqual(partner.tz_offset, expected_offset, "We don't expect pytz.timezone to fail if the timezone diseapeared when chaging os version")


### PR DESCRIPTION
This commit https://github.com/odoo/odoo/pull/186108/commits/b53718fc9a90be2380ac40c469983acbd2630bf3 fixed a test in 16.0. As it breaks also in 15.0, I add the fix in this version.

linked:https://github.com/odoo/enterprise/pull/72619

no-task