### PR TITLE
[FIX] product, *: clear product combo before creating product data

### DIFF
--- a/addons/point_of_sale/data/scenarios/clothes_data.xml
+++ b/addons/point_of_sale/data/scenarios/clothes_data.xml
@@ -339,6 +339,7 @@
             <field
                 name="combo_item_ids"
                 eval="[
+                    Command.clear(),
                     Command.create({
                         'product_id': ref('product_blue_denim_jeans_slim'),
                         'extra_price': 0,
@@ -356,6 +357,7 @@
             <field
                 name="combo_item_ids"
                 eval="[
+                    Command.clear(),
                     Command.create({
                         'product_id': ref('casual_t_shirt'),
                         'extra_price': 0,

--- a/addons/pos_restaurant/data/scenarios/restaurant_data.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_data.xml
@@ -537,6 +537,7 @@
             <field
                 name="combo_item_ids"
                 eval="[
+                    Command.clear(),
                     Command.create({
                         'product_id': ref('pos_food_cheeseburger'),
                         'extra_price': 0,
@@ -554,6 +555,7 @@
             <field
                 name="combo_item_ids"
                 eval="[
+                    Command.clear(),
                     Command.create({
                         'product_id': ref('coke'),
                         'extra_price': 0,

--- a/addons/product/data/product_demo.xml
+++ b/addons/product/data/product_demo.xml
@@ -621,6 +621,7 @@
             <field
                 name="combo_item_ids"
                 eval="[
+                    Command.clear(),
                     Command.create({
                         'product_id': ref('product.desk_organizer'),
                         'extra_price': 0,
@@ -642,6 +643,7 @@
             <field
                 name="combo_item_ids"
                 eval="[
+                    Command.clear(),
                     Command.create({
                         'product_id': ref('product.product_product_3'),
                         'extra_price': 0,
@@ -659,6 +661,7 @@
             <field
                 name="combo_item_ids"
                 eval="[
+                    Command.clear(),
                     Command.create({
                         'product_id': ref('product.product_product_11'),
                         'extra_price': 0,


### PR DESCRIPTION
*=point_of_sale,pos_restaurant

Currently an exception was generated when the user clicked on "Furnitures" in the Choose Your Store section after following the below steps:

- Created database without demo and install 'Point of Sale'
- Open 'Point of Sale' > Click on "Furnitures" in the Choose Your Store
- Archive "Furniture Shop" POS
- Click on "Furnitures" in the Choose Your Store
- Delete "Furniture Shop" POS
- Again, click on "Furnitures" in the Choose Your Store » error generated

This is because [1] tries to create a combo product, but it was already created the first time when we loaded data by clicking "furniture", so it generates a validation error from [2] because we cannot link the same product in a combo.

This commit solves the above issue by using 'Command.clear()' at [1], which is clear linked combo product before creating it, so it always sets product from data when user loads data.

[1] - https://github.com/odoo/odoo/blob/64515f56b3987ffdea6618eb14b6062f95542ac6/addons/product/data/product_demo.xml#L619-L638
[2] - https://github.com/odoo/odoo/blob/64515f56b3987ffdea6618eb14b6062f95542ac6/addons/product/models/product_combo.py#L73

sentry-6101630952
