### PR TITLE
[FIX] mass_mailing: prevent adding videos in mass_mailing

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_wysiwyg.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_wysiwyg.js
@@ -202,7 +202,7 @@ export class MassMailingWysiwyg extends Wysiwyg {
      */
     _getEditorOptions() {
         const options = super._getEditorOptions(...arguments);
-        const finalOptions = { autoActivateContentEditable: false, ...options };
+        const finalOptions = { ...options, autoActivateContentEditable: false, allowCommandVideo: false };
         return finalOptions;
     }
 }


### PR DESCRIPTION
**Problem**:
Videos are not supported in email marketing, yet the powerbox allows users to add videos.

**Solution**:
Disable the option to add videos when editing email templates in mass_mailing.

**Steps to reproduce**:
1. Create a new email template.
2. Open the powerbox.
3. Observe that the option to add videos is available.

opw-4395333

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
