### PR TITLE
[I18N] base_vat: no translations in pot file

### DIFF
--- a/addons/base_vat/i18n/base_vat.pot
+++ b/addons/base_vat/i18n/base_vat.pot
@@ -20,7 +20,7 @@ msgstr ""
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "'219999830019' (should be 12 digits)"
-msgstr "219999830019' (deberían ser 12 digitos)"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python


### PR DESCRIPTION
Probably a copy-paste error, causes sync to throw an error probably due to pot files not expecting to have translated terms in it.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
