### PR TITLE
[FIX] l10n_ee: rename xmlid in upgrade script

### DIFF
--- a/addons/l10n_ee/migrations/1.2/pre-migrate.py
+++ b/addons/l10n_ee/migrations/1.2/pre-migrate.py
@@ -1,0 +1,7 @@
+def migrate(cr, version):
+
+    cr.execute("""
+        UPDATE ir_model_data
+           SET name = 'tax_report'
+         WHERE module='l10n_ee' AND name='tax_report_vat'
+    """)


### PR DESCRIPTION
In odoo/odoo#180856, a new version of the Estonian tax report is added with the xmlid tax_report, in order to not overwrite the tax report for users in stable who didn't update their modules.

When upgrading the module, to avoid dropping and recreating the report, we add this upgrade script to rename the xmlid of the tax report.

no-task


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
