### PR TITLE
[FIX] web: RelationalModel: pass context to search_count requests

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -672,7 +672,9 @@ export class RelationalModel extends Model {
      * @returns {Promise<number>}
      */
     async _updateCount(config) {
-        const count = await this.keepLast.add(this.orm.searchCount(config.resModel, config.domain));
+        const count = await this.keepLast.add(
+            this.orm.searchCount(config.resModel, config.domain, { context: config.context })
+        );
         config.countLimit = Number.MAX_SAFE_INTEGER;
         return count;
     }

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -4153,9 +4153,8 @@ QUnit.module("Views", (hooks) => {
         const tbodySelectors = target.querySelectorAll("tbody .o_list_record_selector input");
         const theadSelector = target.querySelector("thead .o_list_record_selector input");
 
-        const getFooterTextArray = () => {
-            return [...target.querySelectorAll("tfoot td")].map((td) => td.innerText);
-        };
+        const getFooterTextArray = () =>
+            [...target.querySelectorAll("tfoot td")].map((td) => td.innerText);
 
         assert.deepEqual(getFooterTextArray(), ["", "", "32", "1.50"]);
 
@@ -6801,6 +6800,17 @@ QUnit.module("Views", (hooks) => {
                 if (args.method === "web_search_read") {
                     assert.strictEqual(args.kwargs.count_limit, expectedCountLimit);
                 }
+                if (args.method === "search_count") {
+                    assert.deepEqual(args.kwargs.context, {
+                        lang: "en",
+                        tz: "taht",
+                        uid: 7,
+                        xyz: "abc",
+                    });
+                }
+            },
+            context: {
+                xyz: "abc",
             },
         });
 


### PR DESCRIPTION
Have a list or kanban views with more than 10k records such that the count limit is reached, and the pager displays something like "1-80/10000+". Click on "10000+" to compute the real count. Before this commit, the context wasn't given to that call, which could obviously return a wrong result, for instance if the context has the "active_test" key set to false.

task~4331708

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
