### PR TITLE
[IMP] mail: followers cleanup

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4394,7 +4394,6 @@ class MailThread(models.AbstractModel):
         domain = [
             ("res_id", "=", self.id),
             ("res_model", "=", self._name),
-            ("partner_id", "!=", self.env.user.partner_id.id),
         ]
         if filter_recipients:
             subtype_id = self.env["ir.model.data"]._xmlid_to_res_id("mail.mt_comment")
@@ -4572,14 +4571,6 @@ class MailThread(models.AbstractModel):
                 res["followersCount"] = self.env["mail.followers"].search_count(
                     [("res_id", "=", thread.id), ("res_model", "=", self._name)]
                 )
-                self_follower = self.env["mail.followers"].search(
-                    [
-                        ("res_id", "=", thread.id),
-                        ("res_model", "=", self._name),
-                        ["partner_id", "=", self.env.user.partner_id.id],
-                    ]
-                )
-                res["selfFollower"] = Store.One(self_follower)
                 thread._message_followers_to_store(store, reset=True)
                 subtype_id = self.env["ir.model.data"]._xmlid_to_res_id("mail.mt_comment")
                 res["recipientsCount"] = self.env["mail.followers"].search_count(

--- a/addons/mail/static/src/core/web/base_recipients_list.js
+++ b/addons/mail/static/src/core/web/base_recipients_list.js
@@ -8,7 +8,6 @@ import { RecipientList } from "@mail/core/web/recipient_list";
 import { SuggestedRecipientsList } from "@mail/core/web/suggested_recipient_list";
 import { Thread } from "@mail/core/common/thread_model";
 
-
 export class BaseRecipientsList extends Component {
     static template = "mail.BaseRecipientsList";
     static components = { SuggestedRecipientsList };
@@ -20,17 +19,19 @@ export class BaseRecipientsList extends Component {
 
     /** @returns {Markup} */
     getRecipientListToHTML() {
-        const recipients = this.props.thread.recipients.slice(0, 5).map((
-            { partner }) => {
-                const text = partner.email ? partner.emailWithoutDomain : partner.name;
-                return `<span class="text-muted" title="${escape(
-                    partner.email || _t("no email address")
-                )}">${escape(text)}</span>`;
-            });
+        const recipients = this.props.thread.otherRecipients.slice(0, 5).map(({ partner }) => {
+            const text = partner.email ? partner.emailWithoutDomain : partner.name;
+            return `<span class="text-muted" title="${escape(
+                partner.email || _t("no email address")
+            )}">${escape(text)}</span>`;
+        });
         if (this.props.thread.recipients.length > 5) {
-            recipients.push(escape(
-                _t("%(recipientCount)s more", {
-                    recipientCount: this.props.thread.recipients.length - 5}))
+            recipients.push(
+                escape(
+                    _t("%(recipientCount)s more", {
+                        recipientCount: this.props.thread.recipients.length - 5,
+                    })
+                )
             );
         }
         return markup(formatList(recipients));
@@ -42,7 +43,7 @@ export class BaseRecipientsList extends Component {
             return this.recipientsPopover.close();
         }
         this.recipientsPopover.open(ev.target, {
-            thread: this.props.thread
+            thread: this.props.thread,
         });
     }
-};
+}

--- a/addons/mail/static/src/core/web/follower_list.xml
+++ b/addons/mail/static/src/core/web/follower_list.xml
@@ -14,14 +14,12 @@
         </t>
         <div t-if="props.thread.followers.length > 0" role="separator" class="dropdown-divider"/>
     </t>
-    <t t-if="props.thread.followers.length > 0">
-        <t t-foreach="props.thread.followers" t-as="follower" t-key="follower.id">
-            <t t-call="mail.Follower">
-                <t t-set="follower" t-value="follower"/>
-            </t>
-        </t>
-        <span t-if="!props.thread.followersFullyLoaded" class="btn btn-link" t-on-click="props.thread.loadMoreFollowers" t-ref="load-more">Load more</span>
+    <t t-foreach="props.thread.otherFollowers" t-as="follower" t-key="follower.id">
+      <t t-call="mail.Follower">
+        <t t-set="follower" t-value="follower"/>
+      </t>
     </t>
+    <span t-if="!props.thread.followersFullyLoaded" class="btn btn-link" t-on-click="props.thread.loadMoreFollowers" t-ref="load-more">Load more</span>
     <div t-elif="!props.thread.hasWriteAccess" class="dropdown-item disabled">
         No Followers
     </div>

--- a/addons/mail/static/src/core/web/recipient_list.xml
+++ b/addons/mail/static/src/core/web/recipient_list.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.RecipientList">
         <div class="o-mail-RecipientList p-2 overflow-auto">
             <ul class="list-unstyled mb-0">
-                <li t-foreach="props.thread.recipients" t-as="recipient" t-key="recipient.id">
+                <li t-foreach="props.thread.otherRecipients" t-as="recipient" t-key="recipient.id">
                     <t t-out="getRecipientText(recipient)"/>
                 </li>
                 <span t-if="!props.thread.recipientsFullyLoaded" class="btn btn-link w-100" t-on-click="props.thread.loadMoreRecipients" t-ref="load-more">Load more</span>

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -11,6 +11,11 @@ const threadPatch = {
     setup() {
         super.setup();
         this.recipients = Record.many("mail.followers");
+        this.otherRecipients = Record.many("mail.followers", {
+            compute() {
+                return this.recipients.filter((f) => f.partner.notEq(this.store.self));
+            },
+        });
         this.activities = Record.many("mail.activity", {
             sort: (a, b) => compareDatetime(a.date_deadline, b.date_deadline) || a.id - b.id,
             onDelete(r) {
@@ -19,7 +24,7 @@ const threadPatch = {
         });
     },
     get recipientsFullyLoaded() {
-        return this.recipientsCount === this.recipients.length;
+        return this.recipientsCount === this.otherRecipients.length;
     },
     closeChatWindow() {
         const chatWindow = this.store.ChatWindow.get({ thread: this });

--- a/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
+++ b/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
@@ -163,24 +163,22 @@ test("Load 100 followers at once", async () => {
         [...Array(210).keys()].map((i) => ({ display_name: `Partner${i}`, name: `Partner${i}` }))
     );
     pyEnv["mail.followers"].create(
-        [...Array(210).keys()].map((i) => {
-            return {
-                is_active: true,
-                partner_id: i === 0 ? serverState.partnerId : partnerIds[i],
-                res_id: partnerIds[0],
-                res_model: "res.partner",
-            };
-        })
+        [...Array(210).keys()].map((i) => ({
+            is_active: true,
+            partner_id: i === 0 ? serverState.partnerId : partnerIds[i],
+            res_id: partnerIds[0],
+            res_model: "res.partner",
+        }))
     );
     await start();
     await openFormView("res.partner", partnerIds[0]);
     await contains("button[title='Show Followers']", { text: "210" });
     await click("button[title='Show Followers']");
     await contains(".o-mail-Follower", { text: "Mitchell Admin" });
-    await contains(".o-mail-Follower", { count: 101 }); // 100 more followers + self follower (Mitchell Admin)
+    await contains(".o-mail-Follower", { count: 100 }); // 100 more followers + self follower (Mitchell Admin)
     await contains(".o-mail-Followers-dropdown", { text: "Load more" });
     await scroll(".o-mail-Followers-dropdown", "bottom");
-    await contains(".o-mail-Follower", { count: 201 });
+    await contains(".o-mail-Follower", { count: 200 });
     await tick(); // give enough time for the useVisible hook to register load more as hidden
     await scroll(".o-mail-Followers-dropdown", "bottom");
     await contains(".o-mail-Follower", { count: 210 });
@@ -197,14 +195,12 @@ test("Load 100 recipients at once", async () => {
         }))
     );
     pyEnv["mail.followers"].create(
-        [...Array(210).keys()].map((i) => {
-            return {
-                is_active: true,
-                partner_id: i === 0 ? serverState.partnerId : partnerIds[i],
-                res_id: partnerIds[0],
-                res_model: "res.partner",
-            };
-        })
+        [...Array(210).keys()].map((i) => ({
+            is_active: true,
+            partner_id: i === 0 ? serverState.partnerId : partnerIds[i],
+            res_id: partnerIds[0],
+            res_model: "res.partner",
+        }))
     );
     await start();
     await openFormView("res.partner", partnerIds[0]);
@@ -215,10 +211,10 @@ test("Load 100 recipients at once", async () => {
     });
     await contains("button[title='Show all recipients']");
     await click("button[title='Show all recipients']");
-    await contains(".o-mail-RecipientList li", { count: 100 });
+    await contains(".o-mail-RecipientList li", { count: 99 });
     await contains(".o-mail-RecipientList", { text: "Load more" });
     await scroll(".o-mail-RecipientList", "bottom");
-    await contains(".o-mail-RecipientList li", { count: 200 });
+    await contains(".o-mail-RecipientList li", { count: 199 });
     await tick(); // give enough time for the useVisible hook to register load more as hidden
     await scroll(".o-mail-RecipientList", "bottom");
     await contains(".o-mail-RecipientList li", { count: 209 });

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -63,7 +63,6 @@ export class MailThread extends models.ServerModel {
         const domain = [
             ["res_id", "=", ids[0]],
             ["res_model", "=", this._name],
-            ["partner_id", "!=", this.env.user.partner_id],
         ];
         if (after) {
             domain.push(["id", ">", after]);
@@ -593,8 +592,6 @@ export class MailThread extends models.ServerModel {
         const IrAttachment = this.env["ir.attachment"];
         /** @type {import("mock_models").MailActivity} */
         const MailActivity = this.env["mail.activity"];
-        /** @type {import("mock_models").MailFollowers} */
-        const MailFollowers = this.env["mail.followers"];
         /** @type {import("mock_models").MailThread} */
         const MailThread = this.env["mail.thread"];
         /** @type {import("mock_models").MailScheduledMessage} */
@@ -640,15 +637,6 @@ export class MailThread extends models.ServerModel {
                 ["res_id", "=", thread.id],
                 ["res_model", "=", this._name],
             ]);
-            res["selfFollower"] = mailDataHelpers.Store.one(
-                MailFollowers.browse(
-                    MailFollowers.search([
-                        ["res_id", "=", thread.id],
-                        ["res_model", "=", this._name],
-                        ["partner_id", "=", this.env.user.partner_id],
-                    ])
-                )
-            );
             MailThread._message_followers_to_store.call(
                 this,
                 [id],


### PR DESCRIPTION
Before this PR, `_message_followers_to_store` did not return the logged users.
This route should not make exceptions for the UI. This commit removes the
exception and handles the logged user in the JS code.
Since the UI can compute this, we also remove the `selfFollowers' from the _to_store.
