### PR TITLE
[FIX] mail: update follower counter when a follower is removed

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -238,3 +238,19 @@ class ThreadController(http.Controller):
     @classmethod
     def _can_delete_attachment(cls, message, **kwargs):
         return cls._can_edit_message(message, **kwargs)
+
+    @http.route("/mail/thread/unsubscribe", methods=["POST"], type="jsonrpc", auth="user")
+    def mail_thread_unsubscribe(self, res_model, res_id, partner_ids):
+        thread = self.env[res_model].browse(res_id)
+        thread.message_unsubscribe(partner_ids)
+        return Store(
+            thread, [], as_thread=True, request_list=["followers", "suggestedRecipients"]
+        ).get_result()
+
+    @http.route("/mail/thread/subscribe", methods=["POST"], type="jsonrpc", auth="user")
+    def mail_thread_subscribe(self, res_model, res_id, partner_ids):
+        thread = self.env[res_model].browse(res_id)
+        thread.message_subscribe(partner_ids)
+        return Store(
+            thread, [], as_thread=True, request_list=["followers", "suggestedRecipients"]
+        ).get_result()

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -318,9 +318,12 @@ patch(Chatter.prototype, {
     },
 
     async _follow(thread) {
-        await this.orm.call(thread.model, "message_subscribe", [[thread.id]], {
+        const data = await rpc("/mail/thread/subscribe", {
+            res_model: thread.model,
+            res_id: thread.id,
             partner_ids: [this.store.self.id],
         });
+        this.store.insert(data);
         this.onFollowerChanged(thread);
     },
 
@@ -372,8 +375,10 @@ patch(Chatter.prototype, {
 
     async onClickUnfollow() {
         const thread = this.state.thread;
-        await thread.selfFollower.remove();
-        this.onFollowerChanged(thread);
+        if (thread.selfFollower) {
+            await thread.selfFollower.remove();
+            this.onFollowerChanged(thread);
+        }
     },
 
     onCloseFullComposerCallback() {
@@ -385,7 +390,6 @@ patch(Chatter.prototype, {
     onFollowerChanged(thread) {
         document.body.click(); // hack to close dropdown
         this.reloadParentView();
-        this.load(thread, ["followers", "suggestedRecipients"]);
     },
 
     _onMounted() {

--- a/addons/mail/static/src/core/common/follower_model.js
+++ b/addons/mail/static/src/core/common/follower_model.js
@@ -1,4 +1,5 @@
 import { Record } from "@mail/core/common/record";
+import { rpc } from "@web/core/network/rpc";
 
 export class Follower extends Record {
     static _name = "mail.followers";
@@ -32,11 +33,12 @@ export class Follower extends Record {
     }
 
     async remove() {
-        await this.store.env.services.orm.call(this.thread.model, "message_unsubscribe", [
-            [this.thread.id],
-            [this.partner.id],
-        ]);
-        this.delete();
+        const data = await rpc("/mail/thread/unsubscribe", {
+            res_model: this.thread.model,
+            res_id: this.thread.id,
+            partner_ids: [this.partner.id],
+        });
+        this.store.insert(data);
     }
 
     removeRecipient() {

--- a/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
+++ b/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
@@ -9,13 +9,7 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
 import { tick } from "@odoo/hoot-dom";
-import {
-    asyncStep,
-    mockService,
-    onRpc,
-    serverState,
-    waitForSteps,
-} from "@web/../tests/web_test_helpers";
+import { asyncStep, mockService, serverState, waitForSteps } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -108,17 +102,11 @@ test("click on remove follower", async () => {
         res_id: partnerId_1,
         res_model: "res.partner",
     });
-    onRpc("res.partner", "message_unsubscribe", ({ args, method }) => {
-        asyncStep(method);
-        expect(args).toEqual([[partnerId_1], [partnerId_2]]);
-    });
     await start();
     await openFormView("res.partner", partnerId_1);
     await click(".o-mail-Followers-button");
     await contains(".o-mail-Follower");
-    await contains("button[title='Remove this follower']");
     await click("button[title='Remove this follower']");
-    await waitForSteps(["message_unsubscribe"]);
     await contains(".o-mail-Follower", { count: 0 });
 });
 

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -931,6 +931,30 @@ async function search(request) {
     return store.get_result();
 }
 
+registerRoute("/mail/thread/unsubscribe", mail_thread_unsubscribe);
+/** @type {RouteCallback} */
+async function mail_thread_unsubscribe(request) {
+    const { res_model, res_id, partner_ids } = await parseRequestParams(request);
+    const thread = this.env[res_model].browse(res_id);
+    this.env["mail.thread"].message_unsubscribe.call(thread, [res_id], partner_ids);
+    return new mailDataHelpers.Store(
+        thread,
+        makeKwArgs({ as_thread: true, request_list: ["followers", "suggestedRecipients"] })
+    ).get_result();
+}
+
+registerRoute("/mail/thread/subscribe", mail_thread_subscribe);
+/** @type {RouteCallback} */
+async function mail_thread_subscribe(request) {
+    const { res_model, res_id, partner_ids } = await parseRequestParams(request);
+    const thread = this.env[res_model].browse(res_id);
+    this.env["mail.thread"].message_subscribe.call(thread, [res_id], partner_ids);
+    return new mailDataHelpers.Store(
+        thread,
+        makeKwArgs({ as_thread: true, request_list: ["followers", "suggestedRecipients"] })
+    ).get_result();
+}
+
 /** @type {RouteCallback} */
 async function processRequest(request) {
     /** @type {import("mock_models").DiscussChannel} */


### PR DESCRIPTION
Before this commit, `followersCount` was briefly desynced with the server when deleting a follower leading to "load more" being displayed in the UI (this also triggers an unwanted `message_get_followers` RPC). This commit updates the `followersCount` when a follower is removed.

Task-4404011
