### PR TITLE
[FIX] fix dropping near an image

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2908,6 +2908,13 @@ var SnippetsMenu = Widget.extend({
         exclude += `${exclude && ', '}.o_snippet_not_selectable`;
 
         let filterFunc = function () {
+            if (forDrop) {
+                // Prevents blocks from being dropped into an image field.
+                const selfOrParentEl = isChildren ? this.parentNode : this;
+                if (selfOrParentEl.closest("[data-oe-type=image]")) {
+                    return false;
+                }
+            }
             // Exclude what it is asked to exclude.
             if ($(this).is(exclude)) {
                 return false;

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -122,6 +122,13 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
         // grid padding option so it is not applied on inner rows.
         const $gridPaddingOptions = $html.find('[data-css-property="--grid-item-padding-y"], [data-css-property="--grid-item-padding-x"]');
         $gridPaddingOptions.attr("data-apply-to", ".row.o_grid_mode");
+
+        // TODO remove in master and adapt XML.
+        const contentAdditionEl = $html.find("#so_content_addition")[0];
+        if (contentAdditionEl) {
+            // Allows dropping "inner blocks" next to an image link.
+            contentAdditionEl.dataset.dropNear += ", .row > div:not(.o_grid_item_image) > a:has(img)";
+        }
     },
     /**
      * Depending of the demand, reconfigure they gmap key or configure it


### PR DESCRIPTION
This commit prevents dropping an "inner content" block into an image
field.

Steps to reproduce:

- Go to the "/shop" page.
- Click on one of the products to go to its product page.
- Enter edit mode.
- Bug: It is possible to drop any "inner content" block into the
"product" image field.

This commit also fixes the following bug:

- Go to the homepage in edit mode.
- Drag and drop a "text-image" block onto the page.
- Drag and drop a "badge" (or any other "inner content" block) under the
image. This is possible, and it's the intended behavior.
- Click on the image and add a link to it.
- Bug: Try dragging and dropping a "badge" under the image again, it is
no longer possible.

[opw-4273436](https://www.odoo.com/web#id=4273436&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)