### PR TITLE
[IMP] *: use `fa-circle-o-notch` for spinners

### DIFF
--- a/addons/auth_signup/static/src/js/signup.js
+++ b/addons/auth_signup/static/src/js/signup.js
@@ -17,7 +17,7 @@ publicWidget.registry.SignUpForm = publicWidget.Widget.extend({
         const btn = this.$('.oe_login_buttons > button[type="submit"]');
         if (!btn.prop("disabled")) {
             btn.attr("disabled", "disabled");
-            btn.prepend('<i class="fa fa-refresh fa-spin"/> ');
+            btn.prepend('<i class="fa fa-circle-o-notch fa-spin"/> ');
         }
     },
 });

--- a/addons/google_recaptcha/static/src/js/captcha.js
+++ b/addons/google_recaptcha/static/src/js/captcha.js
@@ -22,7 +22,7 @@ publicWidget.registry.reCaptcha = publicWidget.Widget.extend({
         const btn = this.$('button[type="submit"]');
         if (!btn.prop("disabled")) {
             btn.attr("disabled", "disabled");
-            btn.prepend('<i class="fa fa-refresh fa-spin"/> ');
+            btn.prepend('<i class="fa fa-circle-o-notch fa-spin"/> ');
         }
         if (!this.$el.find("input[name='recaptcha_token_response']")[0]) {
             event.preventDefault();

--- a/addons/html_editor/static/src/main/media/media_dialog/file_selector.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/file_selector.xml
@@ -21,7 +21,7 @@
                     <t t-esc="props.addText"/>
             </button>
             <div class="d-flex align-items-center">
-                <span t-if="state.urlInput and state.isValidatingUrl" class="o_we_url_loading mx-2 fa fa-lg fa-spinner" title="Loading..."/>
+                <span t-if="state.urlInput and state.isValidatingUrl" class="o_we_url_loading mx-2 fa fa-lg fa-circle-o-notch fa-spin" title="Loading..."/>
                 <span t-elif="state.urlInput and state.isValidUrl and state.isValidFileFormat" class="o_we_url_success text-success mx-2 fa fa-lg fa-check" title="The URL seems valid."/>
                 <span t-elif="state.urlInput and !state.isValidUrl" class="o_we_url_error text-danger mx-2 fa fa-lg fa-times" title="The URL does not seem to work."/>
                 <span t-elif="props.urlWarningTitle and state.urlInput and state.isValidUrl and !state.isValidFileFormat" class="o_we_url_warning text-warning mx-2 fa fa-lg fa-warning" t-att-title="props.urlWarningTitle"/>

--- a/addons/im_livechat/static/src/embed/common/feedback_panel/transcript_sender.xml
+++ b/addons/im_livechat/static/src/embed/common/feedback_panel/transcript_sender.xml
@@ -11,7 +11,7 @@
         <input t-model="state.email" t-att-disabled="[STATUS.SENDING, STATUS.SENT].includes(state.status)" type="text" class="form-control" placeholder="mail@example.com"/>
         <button class="btn btn-primary" type="button" data-action="sendTranscript" t-att-disabled="!state.email or !isValidEmail(state.email) or [STATUS.SENDING, STATUS.SENT].includes(state.status)" t-on-click="onClickSend">
             <i class="fa" t-att-class="{
-                'fa-spinner fa-spin': state.status === STATUS.SENDING,
+                'fa-circle-o-notch fa-spin': state.status === STATUS.SENDING,
                 'fa-check': state.status === STATUS.SENT,
                 'fa-paper-plane': state.status === STATUS.IDLE,
                 'fa-repeat': state.status === STATUS.FAILED,

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -32,7 +32,7 @@
                         t-on-load="onImageLoaded"
                     />
                     <div t-if="attachment.uploading" class="position-absolute top-0 bottom-0 start-0 end-0 d-flex align-items-center justify-content-center" title="Uploading">
-                        <i class="fa fa-spin fa-spinner"/>
+                        <i class="fa fa-circle-o-notch fa-spin"/>
                     </div>
                     <ImageActions actions="getActions(attachment)" imagesHeight="props.imagesHeight"/>
                 </div>
@@ -63,7 +63,7 @@
                     <div class="flex-grow-1"/>
                     <div class="o-mail-AttachmentCard-aside position-relative rounded-end overflow-hidden d-flex" t-att-class="{ 'o-hasMultipleActions d-flex flex-column': showDelete and !env.inComposer }">
                         <div t-if="attachment.uploading" class="d-flex justify-content-center align-items-center w-100 h-100" title="Uploading">
-                            <i class="fa fa-spin fa-spinner"/>
+                            <i class="fa fa-circle-o-notch fa-spin"/>
                         </div>
                         <div t-if="!attachment.uploading and env.inComposer" class="d-flex justify-content-center me-2 align-items-center w-100 h-100 text-primary" title="Uploaded">
                             <i class="fa fa-check"/>

--- a/addons/mail/static/src/core/common/search_message_input.xml
+++ b/addons/mail/static/src/core/common/search_message_input.xml
@@ -10,7 +10,7 @@
                 </div>
                 <button class="btn" t-att-class="state.searchedTerm === state.searchTerm ? 'btn-outline-secondary' : 'btn-secondary'" t-on-click="() => this.search()" aria-label="Search button">
                     <i t-if="!props.messageSearch.searching" class="o_searchview_icon oi oi-search" role="img" aria-label="Search Messages" title="Search Messages"/>
-                    <i t-else="" class="fa fa-spin fa-spinner" aria-label="Search in progress" title="Search in progress"/>
+                    <i t-else="" class="fa fa-circle-o-notch fa-spin" aria-label="Search in progress" title="Search in progress"/>
                 </button>
             </div>
             <button t-if="env.inChatter" class="btn btn-outline-secondary ms-3" t-on-click="() => this.clear()" aria-label="Close button">

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -12,7 +12,7 @@
                         </div>
                         <button class="btn btn-outline-secondary px-2 py-1" aria-label="Search button" t-on-click="search">
                             <i t-if="!state.loading" class="o_searchview_icon oi oi-search" role="img" aria-label="Search Sub Channels" title="Search Sub Channels"/>
-                            <i t-else="" class="fa fa-spin fa-spinner" aria-label="Search in progress" title="Search in progress"/>
+                            <i t-else="" class="fa fa-circle-o-notch fa-spin" aria-label="Search in progress" title="Search in progress"/>
                         </button>
                         <button t-if="store.self.isInternalUser" class="ms-1 btn btn-primary smaller" aria-label="Create Thread" t-on-click="onClickCreate">Create</button>
                     </div>

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1775,7 +1775,7 @@ test("warning on send with shortcut when attempting to post message with still-u
     await insertText(".o-mail-Composer-input", "Dummy Message");
     await editInput(document.body, ".o-mail-Composer input[type=file]", [file]);
     await contains(".o-mail-AttachmentCard");
-    await contains(".o-mail-AttachmentCard .fa.fa-spinner");
+    await contains(".o-mail-AttachmentCard .fa.fa-circle-o-notch");
     await press("Enter"); // Try to send message
     await contains(".o_notification", { text: "Please wait while the file is uploading." });
 });

--- a/addons/mail/static/tests/thread/file_upload.test.js
+++ b/addons/mail/static/tests/thread/file_upload.test.js
@@ -47,5 +47,5 @@ test("Attachment shows spinner during upload", async () => {
     await start();
     await openDiscuss(channelId);
     await inputFiles(".o-mail-Composer input[type=file]", [text2]);
-    await contains(".o-mail-AttachmentCard .fa-spinner");
+    await contains(".o-mail-AttachmentCard .fa-circle-o-notch");
 });

--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
@@ -23,7 +23,7 @@
                     <button class="btn w-50 fs-3" t-att-class="this.state.tareLoading ? 'btn-secondary' : 'btn-primary'" t-on-click="handleTareButtonClick">
                         <t t-if="!this.state.tareLoading">Tare</t>
                         <t t-if="this.state.tareLoading">
-                            <i class="fa fa-spinner fa-spin"></i>
+                            <i class="fa fa-circle-o-notch fa-spin"></i>
                         </t>
                     </button>
                     </div>

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -104,7 +104,7 @@
                         </t>
                         <CenteredIcon
                             t-else=""
-                            icon="this.pos.data.network.loading ? 'fa-spinner fa-spin' : 'fa-shopping-cart fa-4x'"
+                            icon="this.pos.data.network.loading ? 'fa-circle-o-notch fa-spin' : 'fa-shopping-cart fa-4x'"
                             text="this.pos.data.network.loading ? 'Loading...' : 'No orders found'"
                             class="'h-100'"/>
                     </div>

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
@@ -81,7 +81,7 @@
                     </div>
                     <button t-attf-class="btn btn-outline-secondary btn-lg d-flex align-items-center justify-content-center gap-2 lh-lg" t-on-click.stop="doCreateTable.call" t-att-disabled="doCreateTable.status === 'loading'">
                         <t t-if="doCreateTable.status === 'loading'">
-                            <i class="fa fa-spinner fa-spin icon-button" role="img" aria-label="Loading" title="Loading"></i>
+                            <i class="fa fa-circle-o-notch fa-spin icon-button" role="img" aria-label="Loading" title="Loading"></i>
                         </t>
                         <t t-else="">
                             <i class="fa fa-plus-circle" role="img" aria-label="Add Table" title="Add Table"/>

--- a/addons/spreadsheet/static/src/components/share_button/share_button.xml
+++ b/addons/spreadsheet/static/src/components/share_button/share_button.xml
@@ -31,7 +31,7 @@
           </div>
         </t>
         <div t-else="" class="d-flex align-items-center justify-content-center h-100">
-          <i class="fa fa-spin fa-spinner px-2"/><span>Generating sharing link</span>
+          <i class="fa fa-circle-o-notch fa-spin px-2"/><span>Generating sharing link</span>
         </div>
       </t>
     </Dropdown>

--- a/addons/web/static/src/core/commands/command_palette.xml
+++ b/addons/web/static/src/core/commands/command_palette.xml
@@ -14,7 +14,7 @@
               aria-haspopup="listbox"
           />
           <div class="input-group-text border-0 bg-transparent">
-              <i t-if="state.isLoading" title="Loading..." role="img" aria-label="Loading..." class="fa fa-spinner fa-spin"/>
+              <i t-if="state.isLoading" title="Loading..." role="img" aria-label="Loading..." class="fa fa-circle-o-notch fa-spin"/>
               <i t-else="" t-att-title="state.placeholder" role="img"  t-att-aria-label="state.placeholder" class="oi oi-search"/>
           </div>
         </div>

--- a/addons/web/static/src/core/install_scoped_app/install_scoped_app.xml
+++ b/addons/web/static/src/core/install_scoped_app/install_scoped_app.xml
@@ -6,7 +6,7 @@
                     <path fill="#000" d="M8 8V1a1 1 0 1 1 2 0v8a1 1 0 0 1-1 1H1a1 1 0 1 1 0-2h7z"></path>
                 </svg>
             </button>
-            <i t-if="!state.showInstallUI" class="fa fa-spinner fa-spin fa-2x text-primary position-absolute"/>
+            <i t-if="!state.showInstallUI" class="fa fa-circle-o-notch fa-spin fa-2x text-primary position-absolute"/>
             <div t-attf-class="h-100 w-100 d-flex align-items-center justify-content-center flex-column fade {{state.showInstallUI ? 'show': ''}}">
                 <div class="d-flex align-items-center justify-content-center flex-wrap gap-3 m-4 mw-75 mw-md-50">
                     <img style="height:100px;width:100px;" class="rounded-4 p-4 bg-white shadow" t-att-src="state.manifest.icons?.[0]?.src"/>

--- a/addons/web/static/src/core/utils/ui.js
+++ b/addons/web/static/src/core/utils/ui.js
@@ -183,7 +183,7 @@ export function addLoadingEffect(btnEl) {
     btnEl.classList.add("o_btn_loading", "disabled", "pe-none");
     btnEl.disabled = true;
     const loaderEl = document.createElement("span");
-    loaderEl.classList.add("fa", "fa-refresh", "fa-spin", "me-2");
+    loaderEl.classList.add("fa", "fa-circle-o-notch", "fa-spin", "me-2");
     btnEl.prepend(loaderEl);
     return () => {
         btnEl.classList.remove("o_btn_loading", "disabled", "pe-none");

--- a/addons/web/static/tests/core/commands/command_palette.test.js
+++ b/addons/web/static/tests/core/commands/command_palette.test.js
@@ -1486,13 +1486,13 @@ test("display spinner while loading results from providers", async () => {
 
     await animationFrame();
     expect(".o_command_palette_search i.oi.oi-search").toHaveCount(1);
-    expect(".o_command_palette_search i.fa.fa-spinner").toHaveCount(0);
+    expect(".o_command_palette_search i.fa.fa-circle-o-notch").toHaveCount(0);
     await contains(".o_command_palette_search input").edit("? blabla", { confirm: false });
     await runAllTimers();
     expect(".o_command_palette_search i.oi.oi-search").toHaveCount(0);
-    expect(".o_command_palette_search i.fa.fa-spinner").toHaveCount(1);
+    expect(".o_command_palette_search i.fa.fa-circle-o-notch").toHaveCount(1);
     provideDef.resolve();
     await animationFrame();
     expect(".o_command_palette_search i.oi.oi-search").toHaveCount(1);
-    expect(".o_command_palette_search i.fa.fa-spinner").toHaveCount(0);
+    expect(".o_command_palette_search i.fa.fa-circle-o-notch").toHaveCount(0);
 });

--- a/addons/web_editor/static/src/components/media_dialog/file_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/file_selector.xml
@@ -22,7 +22,7 @@
                     <t t-esc="props.addText"/>
             </button>
             <div class="d-flex align-items-center">
-                <span t-if="state.urlInput and state.isValidatingUrl" class="o_we_url_loading mx-2 fa fa-lg fa-spinner" title="Loading..."/>
+                <span t-if="state.urlInput and state.isValidatingUrl" class="o_we_url_loading mx-2 fa fa-lg fa-circle-o-notch fa-spin" title="Loading..."/>
                 <span t-elif="state.urlInput and state.isValidUrl and state.isValidFileFormat" class="o_we_url_success text-success mx-2 fa fa-lg fa-check" title="The URL seems valid."/>
                 <span t-elif="state.urlInput and !state.isValidUrl" class="o_we_url_error text-danger mx-2 fa fa-lg fa-times" title="The URL does not seem to work."/>
                 <span t-elif="props.urlWarningTitle and state.urlInput and state.isValidUrl and !state.isValidFileFormat" class="o_we_url_warning text-warning mx-2 fa fa-lg fa-warning" t-att-title="props.urlWarningTitle"/>

--- a/addons/website/static/src/components/dialog/add_page_dialog.xml
+++ b/addons/website/static/src/components/dialog/add_page_dialog.xml
@@ -87,7 +87,7 @@
                             role="tab"
                             tabindex="0"
                         >
-                            <span t-if="page.isPreloading" class="fa fa-spin fa-spinner me-1"/>
+                            <span t-if="page.isPreloading" class="fa fa-spin fa-circle-o-notch me-1"/>
                             <t t-out="page.title"/>
                         </a>
                     </li>

--- a/addons/website/static/src/components/resource_editor/resource_editor.xml
+++ b/addons/website/static/src/components/resource_editor/resource_editor.xml
@@ -57,7 +57,7 @@
                     </div>
                 </label>
                 <div>
-                    <button class="btn btn-primary" t-on-click="onSave"><i t-if="state.saving" class="fa fa-spin fa-spinner mr8"/>Save</button>
+                    <button class="btn btn-primary" t-on-click="onSave"><i t-if="state.saving" class="fa fa-circle-o-notch fa-spin mr8"/>Save</button>
                     <button class="btn btn-secondary" t-on-click="this.props.close">Close</button>
                 </div>
             </div>

--- a/addons/website/static/src/systray_items/edit_website.xml
+++ b/addons/website/static/src/systray_items/edit_website.xml
@@ -4,7 +4,7 @@
     <div class="o_menu_systray_item o_edit_website_container d-none d-md-flex">
         <a t-if="!translatable and !this.websiteService.is404" href="#" class="o-website-btn-custo-primary btn position-relative d-flex align-items-center rounded-0 border-0 px-3" accesskey="a" t-on-click="startEdit">
             <span t-if="this.state.isLoading" class="position-absolute top-50 start-50 translate-middle">
-                <i class="fa fa-refresh fa-spin"/>
+                <i class="fa fa-circle-o-notch fa-spin"/>
             </span>
             <span t-out="label" t-attf-class="{{ this.state.isLoading ? 'opacity-0' : 'opacity-100' }}"/>
         </a>

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_category.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_category.xml
@@ -154,7 +154,7 @@
             class="o_wslides_slide_upload_loading position-absolute h-100 w-100 text-center d-flex flex-column justify-content-center"
         >
             <h2 class="text-white">
-                <span class="fa fa-spinner fa-pulse"/>
+                <span class="fa fa-circle-o-notch fa-spin"/>
                 <span>Loading content...</span>
             </h2>
         </div>


### PR DESCRIPTION
*: auth_signup,google_recaptcha,html_editor,im_livechat,mail,
point_of_sale,pos_restaurant,spreadsheet,web,web_editor,
website,website_slides

Our spinner icons are inconsistent, sometimes using `fa-refresh` or `fa-spinner`  this commit replaces the inconsistent icons to use `fa-circle-o-notch` instead.

task-3861323

Enterprise PR: https://github.com/odoo/enterprise/pull/75684

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
