### PR TITLE
[FIX] point_of_sale: Improve logging for PoS order sync

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from markupsafe import Markup
 from itertools import groupby
 from collections import defaultdict
+from random import randrange
+from pprint import pformat
 
 import psycopg2
 import pytz
@@ -918,6 +920,10 @@ class PosOrder(models.Model):
     def _get_open_order(self, order):
         return self.env["pos.order"].search([('uuid', '=', order.get('uuid'))], limit=1)
 
+    @staticmethod
+    def _get_order_log_representation(order):
+        return dict((k, order.get(k)) for k in ("name", "uuid"))
+
     @api.model
     def sync_from_ui(self, orders):
         """ Create and update Orders from the frontend PoS application.
@@ -932,9 +938,13 @@ class PosOrder(models.Model):
         :type draft: bool.
         :Returns: list -- list of db-ids for the created and updated orders.
         """
+        sync_token = randrange(100_000_000)  # Use to differentiate 2 parallels calls to this function in the logs
+        _logger.info("PoS synchronisation #%d started for PoS orders references: %s", sync_token, [self._get_order_log_representation(order) for order in orders])
         order_ids = []
         session_ids = set({order.get('session_id') for order in orders})
         for order in orders:
+            order_log_name = self._get_order_log_representation(order)
+            _logger.debug("PoS synchronisation #%d processing order %s order full data: %s", sync_token, order_log_name, pformat(order))
             existing_order = self._get_open_order(order)
 
             if len(self._get_refunded_orders(order)) > 1:
@@ -942,8 +952,13 @@ class PosOrder(models.Model):
 
             if existing_order and existing_order.state == 'draft':
                 order_ids.append(self._process_order(order, existing_order))
+                _logger.info("PoS synchronisation #%d order %s updated pos.order #%d", sync_token, order_log_name, order_ids[-1])
             elif not existing_order:
                 order_ids.append(self._process_order(order, False))
+                _logger.info("PoS synchronisation #%d order %s created pos.order #%d", sync_token, order_log_name, order_ids[-1])
+            else:
+                # Give as much information as this situation shouldn't be normal and we might lose information
+                _logger.warning("PoS synchronisation #%d unprocessed order %s order full data: %s", sync_token, order_log_name, pformat(order))
 
         # Sometime pos_orders_ids can be empty.
         pos_order_ids = self.env['pos.order'].browse(order_ids)
@@ -954,6 +969,8 @@ class PosOrder(models.Model):
 
         # If the previous session is closed, the order will get a new session_id due to _get_valid_session in _process_order
         is_new_session = any(order.get('session_id') not in session_ids for order in orders)
+
+        _logger.info("PoS synchronisation #%d finished", sync_token)
         return {
             'pos.order': pos_order_ids.read(pos_order_ids._load_pos_data_fields(config_id), load=False) if config_id else [],
             'pos.session': pos_order_ids.session_id._load_pos_data({})['data'] if config_id and is_new_session else [],

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -8,7 +8,8 @@ from odoo.addons.point_of_sale.tests.common import TestPoSCommon
 from freezegun import freeze_time
 from dateutil.relativedelta import relativedelta
 from datetime import datetime, timedelta
-
+from pprint import pformat
+import unittest.mock
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestPoSBasicConfig(TestPoSCommon):
@@ -821,7 +822,20 @@ class TestPoSBasicConfig(TestPoSCommon):
         session = self.pos_session
         order_data = self.create_ui_order_data([(self.product3, 1)])
         amount_paid = order_data['amount_paid']
-        self.env['pos.order'].sync_from_ui([order_data])
+        with (
+            self.assertLogs('odoo.addons.point_of_sale.models.pos_order', level='DEBUG') as cm,
+            unittest.mock.patch('odoo.addons.point_of_sale.models.pos_order.randrange', return_value=1996)
+        ):
+            res = self.env['pos.order'].sync_from_ui([order_data])
+            # Basic check for logs on order synchronization
+            order_log_str = self.env['pos.order']._get_order_log_representation(order_data)
+            odoo_order_id = res['pos.order'][0]['id']
+            self.assertEqual(len(cm.output), 4)
+            self.assertEqual(cm.output[0], f"INFO:odoo.addons.point_of_sale.models.pos_order:PoS synchronisation #1996 started for PoS orders references: [{order_log_str}]")
+            self.assertTrue(cm.output[1].startswith(f'DEBUG:odoo.addons.point_of_sale.models.pos_order:PoS synchronisation #1996 processing order {order_log_str} order full data: '))
+            self.assertEqual(cm.output[2], f'INFO:odoo.addons.point_of_sale.models.pos_order:PoS synchronisation #1996 order {order_log_str} created pos.order #{odoo_order_id}')
+            self.assertEqual(cm.output[3], 'INFO:odoo.addons.point_of_sale.models.pos_order:PoS synchronisation #1996 finished')
+            
         session.post_closing_cash_details(amount_paid)
         session.close_session_from_ui()
 


### PR DESCRIPTION
Before this commit
PoS orders synchronisation can sometime happen in parallel. When it is the case, we can end up with situation of duplicated PoS orders stored in the backend. This can also be useful to cases where "there is a receipt for the order XXX-YYY-ZZZ, but it does not appear in the backend!"

After this commit:
To ease the investigation of such cases, logs are added with various information to better understand customer flows and tracability when a PoS order is synced.

The main idea was added to the "PoS order" capture PR: https://github.com/odoo/odoo/pull/174562
But this one is waiting for other PR to be deployed due to the heavy PoS refactoring in 17.4. In the mean time, the logs part can be easily pushed in 17.4

Logs example:

New PoS order logs:
```
2024-12-16 16:55:32,254 49677 INFO oes_17.4_pos odoo.addons.point_of_sale.models.pos_order: PoS synchronisation #89627943 started for PoS orders references: [{'name': 'Order 00007-003-0001', 'uuid': '838043cb-8324-4b52-a45e-c8707f8975ff'}] 
2024-12-16 16:55:32,413 49677 INFO oes_17.4_pos odoo.addons.point_of_sale.models.pos_order: PoS synchronisation #89627943 order {'name': 'Order 00007-003-0001', 'uuid': '838043cb-8324-4b52-a45e-c8707f8975ff'} created pos.order #38 
2024-12-16 16:55:32,414 49677 INFO oes_17.4_pos odoo.addons.point_of_sale.models.pos_order: PoS synchronisation #89627943 finished 
2024-12-16 16:55:32,434 49677 INFO oes_17.4_pos werkzeug: 127.0.0.1 - - [16/Dec/2024 16:55:32] "POST /web/dataset/call_kw/pos.order/sync_from_ui HTTP/1.1" 200 - 90 0.070 0.114
```

Updated PoS restaurant order:
```
2024-12-16 16:36:27,190 43869 INFO oes_17.4_pos odoo.addons.point_of_sale.models.pos_order: PoS synchronisation #99444056 started for PoS orders references: [{'name': 'Restaurant/00004', 'uuid': '9653201c-1c04-4679-99b8-61d2ae91fc87'}] 
2024-12-16 16:36:27,331 43869 INFO oes_17.4_pos odoo.addons.point_of_sale.models.pos_order: PoS synchronisation #99444056 order {'name': 'Restaurant/00004', 'uuid': '9653201c-1c04-4679-99b8-61d2ae91fc87'} updated pos.order #12 
2024-12-16 16:36:27,331 43869 INFO oes_17.4_pos odoo.addons.point_of_sale.models.pos_order: PoS synchronisation #99444056 finished 
2024-12-16 16:36:27,348 43869 INFO oes_17.4_pos werkzeug: 127.0.0.1 - - [16/Dec/2024 16:36:27] "POST /web/dataset/call_kw/pos.order/sync_from_ui HTTP/1.1" 200 - 101 0.059 0.425
```

opw-3650239
