### PR TITLE
[FIX] pos_viva_wallet: fix viva wallet callback

### DIFF
--- a/addons/pos_viva_wallet/static/src/app/pos_bus.js
+++ b/addons/pos_viva_wallet/static/src/app/pos_bus.js
@@ -8,10 +8,15 @@ patch(PosBus.prototype, {
     dispatch(message) {
         super.dispatch(...arguments);
 
-        if (message.type === "VIVA_WALLET_LATEST_RESPONSE" && message.payload === this.pos.config.id) {
-            this.pos
-                .getPendingPaymentLine("viva_wallet")
-                .payment_method.payment_terminal.handleVivaWalletStatusResponse();
+        if (
+            message.type === "VIVA_WALLET_LATEST_RESPONSE" &&
+            message.payload === this.pos.config.id
+        ) {
+            const pendingLine = this.pos.getPendingPaymentLine("viva_wallet");
+
+            if (pendingLine) {
+                pendingLine.payment_method.payment_terminal.handleVivaWalletStatusResponse();
+            }
         }
     },
 });


### PR DESCRIPTION
Add a check on Viva Wallet callback when paying. Verify if the pending payment line exist before processing the callback.

Adapted from: https://github.com/odoo/odoo/pull/186580

opw-4242322
opw-4374450