### PR TITLE
[FIX] hr_expense: restrict available expense products

### DIFF
--- a/addons/hr_expense/wizard/hr_expense_split.py
+++ b/addons/hr_expense/wizard/hr_expense_split.py
@@ -28,7 +28,7 @@ class HrExpenseSplit(models.TransientModel):
     name = fields.Char('Description', required=True)
     wizard_id = fields.Many2one('hr.expense.split.wizard')
     expense_id = fields.Many2one('hr.expense', string='Expense')
-    product_id = fields.Many2one('product.product', string='Product', required=True)
+    product_id = fields.Many2one('product.product', string='Product', required=True, domain="[('can_be_expensed', '=', True), '|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     tax_ids = fields.Many2many('account.tax', domain="[('company_id', '=', company_id), ('type_tax_use', '=', 'purchase')]")
     total_amount = fields.Monetary("Total In Currency", required=True, compute='_compute_from_product_id', store=True, readonly=False)
     amount_tax = fields.Monetary(string='Tax amount in Currency', compute='_compute_amount_tax')


### PR DESCRIPTION
**Issue:**
When splitting an expense, all products are available to define the split expense categories.
![Capture d’écran 2024-12-16 à 16 31 47](https://github.com/user-attachments/assets/eeca207f-4395-46d2-8292-121fe1f7d63c)

**Expected:**
The wizard should only display products related to `Expense Categories` to keep consistency with base expense creation.

**Steps to reproduce:**
- Activate Expense app;
- Create a new expense;
- *(opt) Try changing the expense category and see available categories to compare;*

![Capture d’écran 2024-12-16 à 16 32 39](https://github.com/user-attachments/assets/bb19c547-d314-42c2-90eb-3c14d28e1ce4)

- Save and click `Split Expense`;
- In the `Product` column, select a product not listed in `Expense Categories` (cf. optional step);
- Split expense and see the new expenses having the normally unavailable product as category.

![Capture d’écran 2024-12-16 à 16 36 43](https://github.com/user-attachments/assets/0ac51ede-63ca-4b5e-8536-b2bc98899789)

**Cause:**
All products are retrieved by the wizard, unlike the category field of the base `hr_expense`.

**Fix:**
Add restrictive domain as for base `hr_expense`.
https://github.com/odoo/odoo/blob/573cbe3b19e91a134ee65168b3021437a39b6093/addons/hr_expense/models/hr_expense.py#L57
<img width="1439" alt="Capture d’écran 2024-12-16 à 16 32 57" src="https://github.com/user-attachments/assets/c9fa8b43-bd7b-4ab3-8759-b4d6a0e269d6" />


opw-4357521

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
