### PR TITLE
[FIX] mail: messaging menu failure return thread.display_name

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1127,7 +1127,7 @@ class Message(models.Model):
                     Store.one(
                         self.env[message.model].browse(message.res_id) if message.model else False,
                         as_thread=True,
-                        fields=["modelName", "name"],
+                        fields=["modelName", "name" if message.model == "discuss.channel" else "display_name"],
                     )
                 ),
             }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -513,7 +513,13 @@ export class MailMessage extends models.ServerModel {
                 ),
                 thread: mailDataHelpers.Store.one(
                     message.model ? this.env[message.model].browse(message.res_id) : false,
-                    makeKwArgs({ as_thread: true, fields: ["modelName", "name"] })
+                    makeKwArgs({
+                        as_thread: true,
+                        fields: [
+                            "modelName",
+                            message.model === "discuss.channel" ? "name" : "display_name",
+                        ],
+                    })
                 ),
             });
         }

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -30,6 +30,15 @@ class MailTestSimple(models.Model):
         headers['X-Custom'] = 'Done'
         return headers
 
+class MailTestSimpleUnnamed(models.Model):
+    """ A very simple model only inheriting from mail.thread when only
+    communication history is necessary, and has no 'name' field """
+    _description = 'Simple Chatter Model without "name" field'
+    _name = 'mail.test.simple.unnamed'
+    _inherit = ['mail.thread']
+    _rec_name = "description"
+
+    description = fields.Char()
 
 class MailTestSimpleWithMainAttachment(models.Model):
     _description = 'Simple Chatter Model With Main Attachment Management'

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -10,6 +10,8 @@ access_mail_test_alias_optional_portal,mail.test.alias.optional.portal,model_mai
 access_mail_test_alias_optional_user,mail.test.alias.optional.user,model_mail_test_alias_optional,base.group_user,1,1,1,1
 access_mail_test_simple_portal,mail.test.simple.portal,model_mail_test_simple,base.group_portal,1,0,0,0
 access_mail_test_simple_user,mail.test.simple.user,model_mail_test_simple,base.group_user,1,1,1,1
+access_mail_test_simple_unnamed_portal,mail.test.simple.unnamed.portal,model_mail_test_simple_unnamed,base.group_portal,1,0,0,0
+access_mail_test_simple_unnamed_user,mail.test.simple.unnamed.user,model_mail_test_simple_unnamed,base.group_user,1,1,1,1
 access_mail_test_simple_unfollow_portal,mail.test.simple.unfollow.portal,model_mail_test_simple_unfollow,base.group_portal,0,0,0,0
 access_mail_test_simple_unfollow_user,mail.test.simple.unfollow.user,model_mail_test_simple_unfollow,base.group_user,1,1,1,1
 access_mail_test_simple_main_attachment_portal,mail.test.simple.main.attachment.portal,model_mail_test_simple_main_attachment,base.group_portal,1,0,0,0


### PR DESCRIPTION
Follow-up of [1]

PR above was a backport of some improvements made in master [2]. The original PR was using `thread.display_name`, from a recent other improvement in master that split `channel.name` and `thread.display_name` for clarity on the actual python field being used in client-side code [3].

The backport version [1] changed `thread.display_name` to `thread.name`, because the web client has to receive thread name from server in formatted data as `name`.

However, the commit forgot that the internal formatter of thread had to pass `display_name` in the named field, and under-the-hood it is turning it into the expected `name` [4].

This commit fixes the issue by passing `display_name` as expected for non-channels. Note that channel's `display_name` is not the same as `name`, and we must always `name` for them rather than `display_name`, hence the enforced `"name"` for discuss channels.

[1]: https://github.com/odoo/odoo/pull/190486
[2]: https://github.com/odoo/odoo/pull/189805
[3]: https://github.com/odoo/odoo/pull/190243
[4]: https://github.com/odoo/odoo/blob/18.0/addons/mail/models/mail_thread.py#L4607

opw-4412441
opw-4415546