### PR TITLE
[FIX] product_expiry: update exipiration_date when changing lot_id

### DIFF
--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -31,7 +31,7 @@ class StockMoveLine(models.Model):
     @api.depends('product_id', 'lot_id.expiration_date', 'picking_id.scheduled_date')
     def _compute_expiration_date(self):
         for move_line in self:
-            if not move_line.expiration_date and move_line.lot_id.expiration_date:
+            if move_line.lot_id.expiration_date:
                 move_line.expiration_date = move_line.lot_id.expiration_date
             elif move_line.picking_type_use_create_lots:
                 if move_line.product_id.use_expiration_date:
@@ -40,15 +40,6 @@ class StockMoveLine(models.Model):
                         move_line.expiration_date = from_date + datetime.timedelta(days=move_line.product_id.expiration_time)
                 else:
                     move_line.expiration_date = False
-
-    @api.onchange('lot_id')
-    def _onchange_lot_id(self):
-        if not self.picking_type_use_existing_lots or not self.product_id.use_expiration_date:
-            return
-        if self.lot_id:
-            self.expiration_date = self.lot_id.expiration_date
-        else:
-            self.expiration_date = False
 
     @api.onchange('product_id', 'product_uom_id', 'picking_id')
     def _onchange_product_id(self):

--- a/addons/product_expiry/tests/test_stock_lot.py
+++ b/addons/product_expiry/tests/test_stock_lot.py
@@ -525,6 +525,7 @@ class TestStockLot(TestStockCommon):
         the latter should be applied on the SML
         """
         exp_date = fields.Datetime.today() + relativedelta(days=15)
+        sml_exp_date = fields.Datetime.today() + relativedelta(days=10)
 
         lot = self.env['stock.lot'].create({
             'name': 'Lot 1',
@@ -533,16 +534,26 @@ class TestStockLot(TestStockCommon):
             'company_id': self.env.company.id,
         })
 
+        move = self.env['stock.move'].create({
+            'name': 'move_test',
+            'location_id': self.supplier_location,
+            'location_dest_id': self.stock_location,
+            'product_id': self.apple_product.id,
+            'product_uom': self.apple_product.uom_id.id,
+        })
         sml = self.env['stock.move.line'].create({
             'location_id': self.supplier_location,
             'location_dest_id': self.stock_location,
             'product_id': self.apple_product.id,
             'quantity': 3,
             'product_uom_id': self.apple_product.uom_id.id,
-            'lot_id': lot.id,
+            'expiration_date': fields.Datetime.to_string(sml_exp_date),
             'company_id': self.env.company.id,
+            'move_id': move.id,
         })
+        self.assertEqual(sml.expiration_date, sml_exp_date)
 
+        sml.lot_id = lot
         self.assertEqual(sml.expiration_date, exp_date)
 
     def test_apply_same_date_on_expiry_fields(self):


### PR DESCRIPTION
Steps to reproduce the bug:
- Enable “Subcontracting” and “Expiration Date” in MRP settings.
- Create a storable product “P1” with the following configurations:
    - tracked by: LOT
    - Expiration date: True
    - BoM:
        - BoM type: subcontracting
        - subcontractor: Azure interior

- Create a lot “L1” with an expiration date set to 01-01-2026.
    - Expiration date: 01-01-2026 

- Configure the operation type::
    - Receipt:
        - use existing SN: True

- Create a receipt:
    - Receive from: Azure interior
    - Product: one unit of P1
    - Mark it as todo
    - Open the detailed operation:
        - Set the “L1”
        - Record production
    - Reopen the detailed operation

Problem:
The expiration date in the stock.move.line is set to today’s date instead of the lot’s expiration date. 

Cause:
When marking the receipt as “To Do,” the SML is created. Since no lot_id is initially set, today’s date is assigned, thanks to the _compute_expiration_date method:

https://github.com/odoo/odoo/blob/9f1d555ac2d9b6e9d3d0d723d4f042eb44cf30b7/addons/product_expiry/models/stock_move_line.py#L37-L40

But When the lot_id is later set, the compute method is triggered again. However, since the SML already contains a date, the expiration date is not updated to match the lot’s expiration date.

opw-4394662
