### PR TITLE
[REF] point_of_sale: use parameter instead of context

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1381,13 +1381,13 @@ class PosOrderLine(models.Model):
         return super().write(values)
 
     @api.model
-    def get_existing_lots(self, company_id, product_id):
+    def get_existing_lots(self, company_id, config_id, product_id):
         """
         Return the lots that are still available in the given company.
         The lot is available if its quantity in the corresponding stock_quant and pos stock location is > 0.
         """
         self.check_access('read')
-        pos_config = self.env['pos.config'].browse(self._context.get('config_id'))
+        pos_config = self.env['pos.config'].browse(config_id)
         if not pos_config:
             raise UserError(_('No PoS configuration found'))
 

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1741,16 +1741,11 @@ export class PosStore extends WithLazyGetterTrap {
 
         let existingLots = [];
         try {
-            existingLots = await this.data.call(
-                "pos.order.line",
-                "get_existing_lots",
-                [this.company.id, product.id],
-                {
-                    context: {
-                        config_id: this.config.id,
-                    },
-                }
-            );
+            existingLots = await this.data.call("pos.order.line", "get_existing_lots", [
+                this.company.id,
+                this.config.id,
+                product.id,
+            ]);
             if (!canCreateLots && (!existingLots || existingLots.length === 0)) {
                 this.dialog.add(AlertDialog, {
                     title: _t("No existing serial/lot number"),


### PR DESCRIPTION

- add `config_id` parameter to `get_existing_lots` method instead of relying on the context.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
