### PR TITLE
[FIX] sale_mrp, stock_delivery: compute sale price for kits

### DIFF
--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.tests.common import TransactionCase, Form, tagged
 
 
@@ -141,6 +142,76 @@ class TestSaleMrpKitBom(TransactionCase):
         line = so.order_line
         purchase_price = line.product_id.with_company(line.company_id)._compute_average_price(0, line.product_uom_qty, line.move_ids)
         self.assertEqual(purchase_price, 92, "The purchase price must be the total cost of the components multiplied by their unit of measure")
+
+    def test_sale_mrp_kit_sale_price(self):
+        """Check the total sale price of a KIT:
+            # BoM of Kit A:
+                # - BoM Type: Kit
+                # - Quantity: 1
+                # - Components:
+                # * 1 x Component A (Price: $ 8, QTY: 10, UOM: Meter)
+                # * 1 x Component B (Price: $ 5, QTY: 2, UOM: Dozen)
+            # sale price of Kit A = (8 * 10) + (5 * 2 * 12) = $ 200
+        """
+        if "sale_price" not in self.env["stock.move.line"]._fields:
+            self.skipTest("This test only runs with both sale_mrp and stock_delivery installed")
+
+        self.customer = self.env['res.partner'].create({
+            'name': 'customer',
+        })
+        self.warehouse = self.env["stock.warehouse"].create({
+            'name': 'Warehouse #2',
+            'code': 'WH02',
+        })
+
+        self.kit_product = self._create_product('Kit Product', 'product', 1.00)
+        # Creating components
+        self.component_a = self._create_product('Component A', 'product', 1.00)
+        self.component_a.uom_id = self.env.ref('uom.product_uom_meter').id
+        self.component_a.product_tmpl_id.list_price = 8
+        self.component_b = self._create_product('Component B', 'product', 1.00)
+        self.component_b.product_tmpl_id.list_price = 5
+
+        location_id = self.warehouse.lot_stock_id.id
+        self.env["stock.quant"].with_context(inventory_mode=True).create([
+            {"product_id": self.component_a.id, "inventory_quantity": 10, "location_id": location_id},
+            {"product_id": self.component_b.id, "inventory_quantity": 24, "location_id": location_id},
+        ]).action_apply_inventory()
+
+        self.bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.kit_product.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': self.component_a.id,
+                    'product_qty': 10.0,
+                    'product_uom_id': self.env.ref('uom.product_uom_meter').id,
+                }),
+                Command.create({
+                    'product_id': self.component_b.id,
+                    'product_qty': 2.0,
+                    'product_uom_id': self.env.ref('uom.product_uom_dozen').id,
+                }),
+            ]
+        })
+
+        # Create a SO with one unit of the kit product
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.kit_product.name,
+                    'product_id': self.kit_product.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': self.kit_product.uom_id.id,
+                })],
+            'warehouse_id': self.warehouse.id,
+        })
+        so.action_confirm()
+        so.picking_ids._action_done()
+        move_lines = so.picking_ids.move_ids.move_line_ids
+        self.assertEqual(move_lines.mapped("sale_price"), [80, 120], 'wrong shipping value')
 
     def test_qty_delivered_with_bom(self):
         """Check the quantity delivered, when a bom line has a non integer quantity"""

--- a/addons/stock_delivery/models/stock_move.py
+++ b/addons/stock_delivery/models/stock_move.py
@@ -57,10 +57,12 @@ class StockMoveLine(models.Model):
     @api.depends('quantity', 'product_uom_id', 'product_id', 'move_id.sale_line_id', 'move_id.sale_line_id.price_reduce_taxinc', 'move_id.sale_line_id.product_uom')
     def _compute_sale_price(self):
         for move_line in self:
-            if move_line.move_id.sale_line_id:
-                unit_price = move_line.move_id.sale_line_id.price_reduce_taxinc
-                qty = move_line.product_uom_id._compute_quantity(move_line.quantity, move_line.move_id.sale_line_id.product_uom)
+            sale_line_id = move_line.move_id.sale_line_id
+            if sale_line_id and sale_line_id.product_id == move_line.product_id:
+                unit_price = sale_line_id.price_reduce_taxinc
+                qty = move_line.product_uom_id._compute_quantity(move_line.quantity, sale_line_id.product_uom)
             else:
+                # For kits, use the regular unit price
                 unit_price = move_line.product_id.list_price
                 qty = move_line.product_uom_id._compute_quantity(move_line.quantity, move_line.product_id.uom_id)
             move_line.sale_price = unit_price * qty


### PR DESCRIPTION
This commit is a hack to work around the module loading order without creating a new bridge module, to fix the issue in stable versions.

### Steps to reproduce:
1. Install both `stock`, `delivery` and `mrp`
2. Create a product with a kit BOM and weight
   - Set the kit UoM to Unit and the components to Kg
   - Add a weight to the components too
3. Create SO with the kit product
4. Add shipping (UPS)
5. Delivery product
6. `The unit of measure Unit defined on the order line doesn't belong to the same category as the unit of measure Kg`

The sale price computed in `stock_delivery` does not take kits into account, which leads to conversion of UoM from different products (and therefore different UoM categories).
However, `sale_mrp` already computes the right value for kits.

It worked in earlier versions, thanks to the module loading order, but `_compute_sale_price` moved from the module `delivery` to `stock_delivery`.

Here is the (simplified) module dependency graph:
```
Odoo 16.0:
sale
`-> sale_management
   `-> delivery
`-> sale_stock
   `-> sale_mrp

Odoo 17.0:
sale
`-> delivery
   `-> stock_delivery
`-> sale_stock
  `-> sale_mrp
```

Odoo sorts modules by depth in the graph, and ordered alphabetically for modules with the same depth.
So in Odoo 16.0, `delivery` was loaded before `sale_mrp`, but starting Odoo 17.0, `stock_delivery` is loaded after `sale_mrp` since they both have the same depth.

opw-4385052