### PR TITLE
[FIX] web: Field: apply decorations on select

### DIFF
--- a/addons/web/static/src/views/fields/fields.scss
+++ b/addons/web/static/src/views/fields/fields.scss
@@ -14,7 +14,7 @@
 // but bootstrap contextual classes do not work on input/textarea, so we have to
 // explicitely set their color to the one of their parent
 .o_field_widget {
-    input, textarea {
+    input, textarea, select {
         color: inherit;
     }
 }


### PR DESCRIPTION
This is a regression since 48ef812a.

Before, the field's views were rendered directly, getting all the decoration classes on them. Since 48ef812a, they are rendered as a child of a parent `Field` component (a `div`), which gets the decoration classes instead [^1].

The issue was partially fixed by 2f99f7dc, but only for `<input/>` and `<textarea/>` elements. The same fix is now applied to the `<select/>` element.



[^1]: https://github.com/odoo/odoo/blob/60c7b65f/addons/web/static/src/views/fields/field.xml#L4-L8

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
