### PR TITLE
[FIX] stock: fix product transfer description

### DIFF
--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -151,13 +151,13 @@
                 <page name="inventory" position="inside">
                     <group>
                         <group string="Description for Receipts">
-                            <field name="description_pickingin" nolabel="1" placeholder="This note is added to receipt orders (e.g. where to store the product in the warehouse)."/>
+                            <field colspan="2" name="description_pickingin" nolabel="1" placeholder="This note is added to receipt orders (e.g. where to store the product in the warehouse)."/>
                         </group>
                         <group string="Description for Delivery Orders">
-                            <field name="description_pickingout" nolabel="1" placeholder="This note is added to delivery orders."/>
+                            <field colspan="2" name="description_pickingout" nolabel="1" placeholder="This note is added to delivery orders."/>
                         </group>
                         <group string="Description for Internal Transfers" groups="stock.group_stock_multi_locations">
-                            <field name="description_picking" nolabel="1" placeholder="This note is added to internal transfer orders (e.g. where to pick the product in the warehouse)."/>
+                            <field colspan="2" name="description_picking" nolabel="1" placeholder="This note is added to internal transfer orders (e.g. where to pick the product in the warehouse)."/>
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
Issue Before This Commit:
-----------------------------------------------
- The product description fields were not displayed properly in the Inventory tab of the product form.

With this commit:
-----------------------------------------------
- The product description fields are now displayed correctly in the Inventory tab of the product form.

Task-id: 4404117