### PR TITLE
[FIX] website_sale_collect: hide 'Send to Shipper' button for 'in_store' delivery type

### DIFF
--- a/addons/website_sale_collect/__manifest__.py
+++ b/addons/website_sale_collect/__manifest__.py
@@ -17,6 +17,7 @@ Allows customers to check in-store stock, pay on site, and pick up their orders 
         'views/delivery_carrier_views.xml',
         'views/delivery_form_templates.xml',
         'views/res_config_settings_views.xml',
+        'views/stock_picking_views.xml',
         'views/stock_warehouse_views.xml',
         'views/templates.xml',
     ],

--- a/addons/website_sale_collect/views/stock_picking_views.xml
+++ b/addons/website_sale_collect/views/stock_picking_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock_picking_form" model="ir.ui.view">
+        <field name="name">stock.picking.form</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock_delivery.view_picking_withcarrier_out_form"/>
+        <field name="arch" type="xml">
+            <button name="send_to_shipper" position="attributes">
+                <attribute name="invisible" add="delivery_type == 'in_store'" separator=" or "/>
+            </button>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This issue occurs when a delivery order is created with the ``Carrier`` set to ``Pick up in Store``. After saving and validating the order, click the ``Send to Shipper`` button.

Steps to reproduce:
---
- Install ``website_sale_collect`` module
- Create a new ``Delivery Order`` and in ``Additional Info`` select ``Carrier`` as ``Pick up in Store`` > Save and Validate
- Click on the ``Send to Shipper`` button

Traceback:
--- 
``TypeError: 'NoneType' object is not subscriptable``

This commit resolves the issue by adding an XPath to the view to hide the ``Send to Shipper`` button for orders with the delivery type set to ``in_store``.

sentry-6040319897

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
