### PR TITLE
[FIX] account_move: fix account_move access error

### DIFF
--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -10,7 +10,7 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     expense_sheet_id = fields.Many2one(comodel_name='hr.expense.sheet', ondelete='set null', copy=False, index='btree_not_null')
-    show_commercial_partner_warning = fields.Boolean(compute='_compute_show_commercial_partner_warning')
+    show_commercial_partner_warning = fields.Boolean(compute='_compute_show_commercial_partner_warning', compute_sudo=True)
 
     def action_open_expense_report(self):
         self.ensure_one()


### PR DESCRIPTION
Current behaviour before commit:
When trying to access bill which has the current company as partner_id through a user without HR access, an access error appears.

Reason:
The access error occurs because, in the account.move model there is a computation field that tries to use employee_ids in the computations. The user does not have access rights to check employee_ids as they need to have HR access in this case.

Fix:
To resolve this, we can skip the access rights check by adding compute_sudo = True to the field show_commercial_partner_warning.

Steps:
1) Create a new user without any HR-related access rights (e.g., "Employees" or "Officer: Manage All Employees") and name the user USER. 
2) Log in as an admin.
3) Go to Accounting > Vendors > Bills and create a new bill:
	3.1) Set the Vendor (partner_id) to the current company.
	3.2) Add any random break or placeholder.
4) Log in as the user USER.
5) Attempt to access the bill created in step 3.
6) Observe the access error message displayed due to restricted permissions.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

opw-4391972


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
