### PR TITLE
[FIX] base: correct batch use to create api keys via RPC

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -2493,7 +2493,8 @@ class APIKeyDescription(models.TransientModel):
 
     def create(self, vals_list):
         res = super().create(vals_list)
-        self.env['res.users.apikeys']._check_expiration_date(res.expiration_date)
+        for apikey_description in res:
+            self.env['res.users.apikeys']._check_expiration_date(apikey_description.expiration_date)
         return res
 
     @check_identity

--- a/odoo/addons/base/tests/test_xmlrpc.py
+++ b/odoo/addons/base/tests/test_xmlrpc.py
@@ -223,6 +223,19 @@ class TestAPIKeys(common.HttpCase):
         ])
         self.assertEqual(ctx['tz'], 'Australia/Eucla')
 
+        api_key_ids = call_kw(
+            model=self.env['res.users.apikeys.description'],
+            name='create',
+            args=[
+                [
+                    {'name': 'Name of the key A'},
+                    {'name': 'Name of the key B'},
+                ],
+            ],
+            kwargs={}
+        )
+        self.assertTrue(isinstance(api_key_ids, list))
+
     def test_delete(self):
         env = self.env(user=self._user)
         env['res.users.apikeys.description'].create({'name': 'b',}).make_key()


### PR DESCRIPTION
Commit 3b3ee6bb5f2d3edc69f4166e0e63074f8b1e1c87 allows apikey creation via batch RPC call.
However, this will not work when dereferencing `res.expiration_date`.