### PR TITLE
[FIX] web_editor: preserve cursor position when removing ZWS

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
@@ -228,9 +228,10 @@ class Sanitize {
                 ) &&
                 !isBlock(node.parentElement)
             ) {
+                const { anchorNode, focusNode, anchorOffset, focusOffset } = selection;
                 const restoreCursor = shouldPreserveCursor(node, this.root) && preserveCursor(this.root.ownerDocument);
-                const shouldAdaptAnchor = anchor === node && selection.anchorOffset > node.textContent.indexOf('\u200B');
-                const shouldAdaptFocus = selection.focusNode === node && selection.focusOffset > node.textContent.indexOf('\u200B');
+                const shouldAdaptAnchor = anchorNode === node && anchorOffset > node.textContent.indexOf('\u200B');
+                const shouldAdaptFocus = focusNode === node && focusOffset > node.textContent.indexOf('\u200B');
                 node.textContent = node.textContent.replace('\u200B', '');
                 node.parentElement.removeAttribute("data-oe-zws-empty-inline");
                 if (restoreCursor) {
@@ -238,8 +239,8 @@ class Sanitize {
                 }
                 if (shouldAdaptAnchor || shouldAdaptFocus) {
                     setSelection(
-                        selection.anchorNode, shouldAdaptAnchor ? selection.anchorOffset - 1 : selection.anchorOffset,
-                        selection.focusNode, shouldAdaptFocus ? selection.focusOffset - 1 : selection.focusOffset,
+                        anchorNode, shouldAdaptAnchor ? anchorOffset - 1 : anchorOffset,
+                        focusNode, shouldAdaptFocus ? focusOffset - 1 : focusOffset,
                     );
                 }
             }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -157,6 +157,14 @@ describe('Editor', () => {
                 });
             });
         });
+        describe('Sanitize ZWS', () => {
+            it('should remove zws while preserving the selection', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p><font data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">&ZeroWidthSpace;a[]</font></p>',
+                    contentAfter: '<p><font style="color: rgb(255, 0, 0);">a[]</font></p>',
+                })
+            })
+        })
     });
     describe('deleteForward', () => {
         describe('Selection collapsed', () => {


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

The selection offsets became stale after modifying `textContent` to remove the zero-width space (ZWS), causing the cursor to shift unexpectedly.

Desired behavior after PR is merged:

We now capture the selection offset before changing `textContent`, preventing unexpected cursor shifts.

task-4397732


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
