### PR TITLE
[IMP] website_blog: regression test for sitemap language

### DIFF
--- a/addons/website_blog/tests/__init__.py
+++ b/addons/website_blog/tests/__init__.py
@@ -4,3 +4,4 @@
 from . import test_ui
 from . import test_website_blog_flow
 from . import test_performance
+from . import test_sitemap

--- a/addons/website_blog/tests/test_sitemap.py
+++ b/addons/website_blog/tests/test_sitemap.py
@@ -1,0 +1,50 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import odoo.tests
+from odoo.tests import HttpCase
+
+
+@odoo.tests.common.tagged('post_install', '-at_install')
+class TestSitemap(HttpCase):
+
+    def setUp(self):
+        super().setUp()
+
+        # Set up a website in French
+        self.website = self.env.ref('website.default_website')
+        self.lang_fr = self.env['res.lang']._activate_lang('fr_FR')
+        self.website.language_ids = self.env.ref('base.lang_en') + self.lang_fr
+        self.website.default_lang_id = self.env.ref('base.lang_en')
+
+        # Load translations for testing
+        self.env['ir.module.module'].search([('name', '=', 'website_blog')])._update_translations(['fr_FR'])
+
+        # Fetch the first blog post for testing
+        self.blog_post = self.env['blog.post'].search([], limit=1)
+
+    def test_01_sitemap_language(self):
+        """Ensure sitemap is in English even when navigating to the French version of the website."""
+
+        # Navigate to the French version of the website
+        response = self.url_open("/fr_FR")
+        self.assertIn('/fr/contactus', response.text)
+
+        # Access the sitemap
+        response = self.url_open("/sitemap.xml")
+
+        # Ensure the sitemap content is still in English as it's the default language
+        if self.blog_post:
+            self.assertIn(self.blog_post.website_url, response.text)
+
+    def test_02_sitemap_language(self):
+        """Ensure sitemap is in the default language"""
+
+        # Set the default language to French
+        self.website.default_lang_id = self.env['res.lang'].sudo()._activate_lang('fr_FR')
+
+        # Access the sitemap
+        response = self.url_open("/sitemap.xml")
+
+        # Ensure the sitemap content is in French
+        if self.blog_post:
+            translated_url = self.blog_post.with_context(lang='fr_FR').website_url
+            self.assertIn(translated_url, response.text)


### PR DESCRIPTION
This PR introduces a regression test to ensure that the sitemap
remains in the default language of the website, regardless of the
language version being accessed.

Tests 2 scenarios:

- First, configure a website with English and French language.
- Set the default language to French.
- Access the sitemap at /sitemap.xml -> The sitemap should be displayed
    in French.
- Second, let the default language to be English.
- Navigate to the French version of the website at /fr.
- Access the sitemap at /sitemap.xml -> The sitemap should now be
    displayed in English.

This test addresses an issue that was previously fixed in commit
https://github.com/odoo/odoo/commit/809854c5d10735fb280141f5291bdb84d8d36569, but lacked a corresponding test to prevent future
regressions. This test ensures the bug reported in task-3935135 does ``
not reoccur.

**Added test in website_blog as it has routes that were translated.
Reference:
[1]: https://github.com/odoo/odoo/pull/154993#pullrequestreview-1900639267