### PR TITLE
[FIX] spreadsheet: apply global filters after pivot update

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
@@ -121,6 +121,9 @@ export default class PivotUIPlugin extends spreadsheet.UIPlugin {
             case "REFRESH_ALL_DATA_SOURCES":
                 this._refreshOdooPivots();
                 break;
+            case "UPDATE_ODOO_PIVOT_DOMAIN":
+                this._addDomain(cmd.pivotId);
+                break;
             case "ADD_GLOBAL_FILTER":
             case "EDIT_GLOBAL_FILTER":
             case "REMOVE_GLOBAL_FILTER":
@@ -136,6 +139,7 @@ export default class PivotUIPlugin extends spreadsheet.UIPlugin {
                             "ADD_GLOBAL_FILTER",
                             "EDIT_GLOBAL_FILTER",
                             "REMOVE_GLOBAL_FILTER",
+                            "UPDATE_ODOO_PIVOT_DOMAIN",
                         ].includes(command.type)
                     )
                 ) {


### PR DESCRIPTION
Steps to reproduce:

- Insert a pivot in a spreadsheet (e.g. CRM Lead)
- Create a global filter, set a value on it (filter on CRM Stages -> Select new)
- Open the pivot side panel, update something (move up a dimension)
- Save => The domain does not take the global filter into account

Task: 4398645

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
