### PR TITLE
[FIX] spreadsheet: apply global filters after list update

### DIFF
--- a/addons/spreadsheet/static/src/list/plugins/list_ui_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_ui_plugin.js
@@ -48,6 +48,9 @@ export default class ListUIPlugin extends spreadsheet.UIPlugin {
             case "REFRESH_ALL_DATA_SOURCES":
                 this._refreshOdooLists();
                 break;
+            case "UPDATE_ODOO_LIST_DOMAIN":
+                this._addDomain(cmd.listId);
+                break;
             case "ADD_GLOBAL_FILTER":
             case "EDIT_GLOBAL_FILTER":
             case "REMOVE_GLOBAL_FILTER":
@@ -63,6 +66,7 @@ export default class ListUIPlugin extends spreadsheet.UIPlugin {
                             "ADD_GLOBAL_FILTER",
                             "EDIT_GLOBAL_FILTER",
                             "REMOVE_GLOBAL_FILTER",
+                            "UPDATE_ODOO_LIST_DOMAIN",
                         ].includes(command.type)
                     )
                 ) {

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
@@ -1994,4 +1994,46 @@ QUnit.module("spreadsheet > Global filters model", {}, () => {
             );
         }
     );
+
+    QUnit.test(
+        "Updating the list domain should keep the global filter domain",
+        async function (assert) {
+            patchDate(2022, 4, 16, 0, 0, 0);
+            const { model } = await createSpreadsheetWithList();
+            const filter = {
+                id: "43",
+                type: "date",
+                label: "This Year",
+                rangeType: "year",
+                defaultValue: {},
+                defaultsToCurrentPeriod: true,
+            };
+            await addGlobalFilter(
+                model,
+                { filter },
+                { list: { 1: { chain: "date", type: "date", offset: 0 } } }
+            );
+            let computedDomain = new Domain(model.getters.getListComputedDomain("1"));
+            assert.strictEqual(
+                computedDomain.toString(),
+                `["&", ("date", ">=", "2022-01-01"), ("date", "<=", "2022-12-31")]`
+            );
+            const [listId] = model.getters.getListIds();
+            model.dispatch("UPDATE_ODOO_LIST_DOMAIN", {
+                listId,
+                domain: [["foo", "in", [55]]],
+            });
+            computedDomain = new Domain(model.getters.getListComputedDomain("1"));
+            assert.strictEqual(
+                computedDomain.toString(),
+                `["&", ("foo", "in", [55]), "&", ("date", ">=", "2022-01-01"), ("date", "<=", "2022-12-31")]`
+            );
+            model.dispatch("REQUEST_UNDO");
+            computedDomain = new Domain(model.getters.getListComputedDomain("1"));
+            assert.strictEqual(
+                computedDomain.toString(),
+                `["&", ("date", ">=", "2022-01-01"), ("date", "<=", "2022-12-31")]`
+            );
+        }
+    );
 });


### PR DESCRIPTION
Steps to reproduce:

- Insert a list in a spreadsheet (e.g. CRM Lead)
- Create a global filter, set a value on it (filter on CRM Stages -> Select new)
- Open the list side panel, update the domain (add Marc Demo as Salesperson)
- Save => The domain does not take the global filter into account

Task:4398467

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
