### PR TITLE
[FIX] html_editor: hide link button when selection includes blocks

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -1,6 +1,11 @@
 import { Plugin } from "@html_editor/plugin";
 import { cleanTrailingBR, unwrapContents } from "@html_editor/utils/dom";
-import { closestElement, descendants, selectElements } from "@html_editor/utils/dom_traversal";
+import {
+    childNodes,
+    closestElement,
+    descendants,
+    selectElements,
+} from "@html_editor/utils/dom_traversal";
 import { findInSelection, callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { _t } from "@web/core/l10n/translation";
 import { LinkPopover } from "./link_popover";
@@ -32,6 +37,16 @@ function isLinkActive(selection) {
     }
 
     return false;
+}
+
+/**
+ * @param {EditorSelection} selection
+ */
+function isLinkDisabled(selection) {
+    const blockElements = childNodes(selection.commonAncestorContainer).filter(
+        (el) => isBlock(el) && el.isContentEditable
+    );
+    return blockElements.length >= 1;
 }
 
 function isSelectionHasLink(selection) {
@@ -172,6 +187,7 @@ export class LinkPlugin extends Plugin {
                 groupId: "link",
                 commandId: "toggleLinkTools",
                 isActive: isLinkActive,
+                isDisabled: isLinkDisabled,
             },
             {
                 id: "unlink",

--- a/addons/html_editor/static/src/main/toolbar/toolbar.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.js
@@ -26,6 +26,7 @@ export class Toolbar extends Component {
                                             groupId: String,
                                             title: String,
                                             isAvailable: { type: Function, optional: true },
+                                            isDisabled: { type: Function, optional: true },
                                         };
                                         if (button.Component) {
                                             validate(button, {
@@ -40,7 +41,6 @@ export class Toolbar extends Component {
                                                 icon: { type: String, optional: true },
                                                 text: { type: String, optional: true },
                                                 isActive: { type: Function, optional: true },
-                                                isDisabled: { type: Function, optional: true },
                                             });
                                         }
                                         return true;

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -449,19 +449,6 @@ describe("Link creation", () => {
                 '<p>a<a href="http://test.com/">bcde[]</a>f</p>'
             );
         });
-        test("when selection includes another block and the link extending stays inside of the block", async () => {
-            const { el } = await setupEditor(
-                '<p>a[b<a href="http://test.com/">cd</a>ef</p><p>gh]</p>'
-            );
-            await waitFor(".o-we-toolbar");
-
-            await click(".o-we-toolbar .fa-link");
-            await waitFor(".o-we-linkpopover", { timeout: 1500 });
-            expect(".o-we-linkpopover").toHaveCount(1);
-            expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>a<a href="http://test.com/">bcdef[]</a></p><p>gh</p>'
-            );
-        });
         test("when create a link on selection which doesn't include a link, it should create a new one", async () => {
             await setupEditor(
                 '<p><strong>abc<a href="http://test.com/">de</a>te[st</strong> m]e</p>'

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -210,6 +210,19 @@ test("toolbar format buttons should react to format change", async () => {
     expect(".btn[name='bold']").toHaveClass("active");
 });
 
+test("toolbar disable link button when selection cross blocks", async () => {
+    await setupEditor("<div>[<div>a<p>b</p></div>]</div>");
+    await waitFor(".o-we-toolbar");
+    expect(".btn[name='link']").toHaveClass("disabled");
+});
+
+test("toolbar enable link button when selection has only link", async () => {
+    await setupEditor(`<p>[<a href="test.com">test.com</a>]</p>`);
+
+    await waitFor(".o-we-toolbar");
+    expect(".btn[name='link']").not.toHaveClass("disabled");
+});
+
 test("toolbar works: can select font", async () => {
     const { el } = await setupEditor("<p>test</p>");
     expect(getContent(el)).toBe("<p>test</p>");


### PR DESCRIPTION
**Problem**:
In previous versions, the link button (AI & translation too) was not displayed in the toolbar when the selection included block elements. However, this behavior has regressed, and the link button (AI and Translation too) now appears even when the selection spans blocks.

**Solution**:
Hide the link button (AI & translation too) in the toolbar when the selection includes block elements.

**Steps to reproduce**:
1. Create a table in the editor.
2. Select multiple columns.
3. Observe that the toolbar incorrectly displays the link button.

opw-4397649
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
