### PR TITLE
[FIX] point_of_sale: not show discount on price manually set

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -3185,7 +3185,7 @@ class Order extends PosModel {
         return round_pr(this.orderlines.reduce((sum, orderLine) => {
             if (!ignored_product_ids.includes(orderLine.product.id)) {
                 sum += (orderLine.getUnitDisplayPriceBeforeDiscount() * (orderLine.get_discount()/100) * orderLine.get_quantity());
-                if (orderLine.display_discount_policy() === 'without_discount'){
+                if (orderLine.display_discount_policy() === 'without_discount' && !orderLine.price_manually_set){
                     sum += ((orderLine.get_taxed_lst_unit_price() - orderLine.getUnitDisplayPriceBeforeDiscount()) * orderLine.get_quantity());
                 }
             }

--- a/addons/point_of_sale/static/tests/tours/ReceiptScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ReceiptScreen.tour.js
@@ -79,6 +79,15 @@ odoo.define('point_of_sale.tour.ReceiptScreen', function (require) {
     PaymentScreen.do.clickValidate();
     ReceiptScreen.check.discountAmountIs('0.7');
 
+    ReceiptScreen.do.clickNextOrder();
+    ProductScreen.exec.addOrderline('Test Product', '1');
+    ProductScreen.do.pressNumpad('Price');
+    ProductScreen.do.pressNumpad('9');
+    ProductScreen.do.clickPayButton();
+    PaymentScreen.do.clickPaymentMethod('Cash');
+    PaymentScreen.do.clickValidate();
+    ReceiptScreen.check.noDiscountAmount();
+
     Tour.register('ReceiptScreenDiscountWithPricelistTour', { test: true, url: '/pos/ui' }, getSteps());
 
     startSteps();

--- a/addons/point_of_sale/static/tests/tours/helpers/ReceiptScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ReceiptScreenTourMethods.js
@@ -90,6 +90,14 @@ odoo.define('point_of_sale.tour.ReceiptScreenTourMethods', function (require) {
                 },
             ];
         }
+        noDiscountAmount() {
+            return [
+                {
+                    trigger: `.pos-receipt:not(:contains("Discounts"))`,
+                    run: () => {},
+                },
+            ];
+        }
         noOrderlineContainsDiscount() {
             return [
                 {


### PR DESCRIPTION
Currently, when using pricelists, if you change the price of a product inside the session, it will show a discount value on the receipt.

Steps to reproduce:
-------------------
* Activate advanced pricelist
* Modify the shop's default pricelist
  * Discount policy: Show public price & discounts
  * Add a rule: 10% discount on all products with min qty of 10
* Open shop session
* Add any product qty 1
* Manually change price to a higher amount
* Pay the order
> Observation: On the receipt we can see a negative discount value.

Why the fix:
------------
Changing the price of a product through the price button in the session should never be considered as a discount. Lines for which the product price was manually set should not be counted toward overall discount (positive or negative).

opw-4366651
