### PR TITLE
[FIX] html_editor: move nodes when collaborator on same node

### DIFF
--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
@@ -153,17 +153,17 @@ export class CollaborationSelectionAvatarPlugin extends Plugin {
         this.enableAvatars();
         for (const info of this.selectionInfos.values()) {
             if (info.avatarTargetElement === element) {
-                if (!info.avatarElement.classList.contains("opacity-0")) {
-                    info.avatarElement.classList.add("opacity-0");
+                if (!info.avatarElement.classList.contains("invisible")) {
+                    info.avatarElement.classList.add("invisible");
                 }
             }
         }
     }
     enableAvatars() {
         for (const element of this.avatarOverlay.querySelectorAll(
-            ".oe-collaboration-caret-avatar.opacity-0"
+            ".oe-collaboration-caret-avatar.invisible"
         )) {
-            element.classList.remove("opacity-0");
+            element.classList.remove("invisible");
         }
     }
 }


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

It was not possible to use the move node handler when the collaborator is on the same node, because the collaboration avatar is hidden using opacity 0 which still allowed the avatar to be selectable.

Desired behavior after PR is merged:

Hide the collaboration avatar using visibility hidden, ensuring it is not selectable.

task-4348275

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
