### PR TITLE
[FIX] html_editor: trailing br at the end of link

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -1,5 +1,5 @@
 import { Plugin } from "../plugin";
-import { isBlock } from "../utils/blocks";
+import { closestBlock, isBlock } from "../utils/blocks";
 import { hasAnyNodesColor } from "@html_editor/utils/color";
 import { cleanTextNode, splitTextNode, unwrapContents } from "../utils/dom";
 import {
@@ -9,6 +9,7 @@ import {
     isTextNode,
     isVisibleTextNode,
     isZWS,
+    previousLeaf,
 } from "../utils/dom_info";
 import { childNodes, closestElement, descendants, selectElements } from "../utils/dom_traversal";
 import { FONT_SIZE_CLASSES, formatsSpecs } from "../utils/formatting";
@@ -17,6 +18,7 @@ import { prepareUpdate } from "@html_editor/utils/dom_state";
 import { _t } from "@web/core/l10n/translation";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { withSequence } from "@html_editor/utils/resource";
+import { isFakeLineBreak } from "../utils/dom_state";
 
 const allWhitespaceRegex = /^[\s\u200b]*$/;
 
@@ -236,7 +238,9 @@ export class FormatPlugin extends Plugin {
                 .filter(
                     (n) =>
                         ((isTextNode(n) && (isVisibleTextNode(n) || isZWS(n))) ||
-                            n.nodeName === "BR") &&
+                            (n.nodeName === "BR" &&
+                                (isFakeLineBreak(n) ||
+                                    previousLeaf(n, closestBlock(n))?.nodeName === "BR"))) &&
                         isContentEditable(n)
                 )
         );

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -1,5 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
-import { unwrapContents } from "@html_editor/utils/dom";
+import { cleanTrailingBR, unwrapContents } from "@html_editor/utils/dom";
 import { closestElement, selectElements } from "@html_editor/utils/dom_traversal";
 import { findInSelection, callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { _t } from "@web/core/l10n/translation";
@@ -12,7 +12,7 @@ import { KeepLast } from "@web/core/utils/concurrency";
 import { rpc } from "@web/core/network/rpc";
 import { memoize } from "@web/core/utils/functions";
 import { withSequence } from "@html_editor/utils/resource";
-import { isBlock } from "@html_editor/utils/blocks";
+import { isBlock, closestBlock } from "@html_editor/utils/blocks";
 
 /**
  * @typedef {import("@html_editor/core/selection_plugin").EditorSelection} EditorSelection
@@ -460,6 +460,7 @@ export class LinkPlugin extends Plugin {
                     } else {
                         this.linkElement.removeAttribute("class");
                     }
+                    cleanTrailingBR(closestBlock(this.linkElement));
                     this.dependencies.selection.focusEditable();
                     this.removeCurrentLinkIfEmtpy();
                     this.dependencies.history.addStep();

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -7,6 +7,8 @@ import { Plugin } from "@html_editor/plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { animationFrame } from "@odoo/hoot-mock";
 import { execCommand } from "../_helpers/userCommands";
+import { press } from "@odoo/hoot-dom";
+import { getContent } from "../_helpers/selection";
 
 test("should change the font size of a few characters", async () => {
     await testEditor({
@@ -194,4 +196,22 @@ test("should apply font size on topmost `u` or `s` tags if multiple applied", as
         stepFunction: setFontSize("18px"),
         contentAfter: `<p>a<span style="font-size: 18px;"><s><u>[b]</u></s></span>c</p>`,
     });
+});
+
+test("should add style to br except line-break br", async () => {
+    const { editor, el } = await setupEditor("<p>[]abc<br><br></p>");
+    await press(["ctrl", "a"]);
+    execCommand(editor, "formatFontSize", { size: "36px" });
+    expect(getContent(el)).toBe(
+        `<p><span style="font-size: 36px;">[abc</span><br><span style="font-size: 36px;">]<br></span></p>`
+    );
+});
+
+test("should add style to br except line-break br (2)", async () => {
+    const { editor, el } = await setupEditor("<p>[]abc<br><br><br></p>");
+    await press(["ctrl", "a"]);
+    execCommand(editor, "formatFontSize", { size: "36px" });
+    expect(getContent(el)).toBe(
+        `<p><span style="font-size: 36px;">[abc</span><br><span style="font-size: 36px;"><br>]<br></span></p>`
+    );
 });

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -234,6 +234,20 @@ describe("Link creation", () => {
             });
         });
 
+        test("creating link in an empty block using link command should not contain trailing br", async () => {
+            const { editor, el } = await setupEditor("<p>[]<br></p>");
+            await insertText(editor, "/link");
+            await animationFrame();
+            expect(".active .o-we-command-name").toHaveText("Link");
+            await click(".o-we-command-name:first");
+            await waitFor(".o-we-linkpopover");
+            await fill("test.com");
+            await click(".o_we_apply_link");
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p><a href="https://test.com">test.com[]</a></p>'
+            );
+        });
+
         test("when create a new link by powerbox and not input anything, the link should be removed", async () => {
             const { editor, el } = await setupEditor("<p>ab[]</p>");
             await insertText(editor, "/link");
@@ -954,7 +968,7 @@ describe("upload file via link popover", () => {
         await animationFrame();
         // Created link has the correct href and label
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p><a href="${expectedUrl}">file.txt[]</a><br></p>`
+            `<p><a href="${expectedUrl}">file.txt[]</a></p>`
         );
     });
 


### PR DESCRIPTION
**Current behaviour before PR:**

Creating a link in an empty block using powerbox contains trailing `br` at the end of link. Due to this `br` , when user presses `ctrl + A` and applies any format, `br` also gets formatted along with link. In such case when user selects link using double click and removes format using remove-format button, the link gets unformatted but `br` remains formatted because it is not traversed in selection.

**Desired behaviour after PR:**

There should be no trailing `br` after creating a link as the block is not empty anymore.

task-4399010




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
