### PR TITLE
[FIX] survey: `test_tour_test_survey_form_triggers` with new headless engine

### DIFF
--- a/addons/survey/static/tests/tours/survey_form.js
+++ b/addons/survey/static/tests/tours/survey_form.js
@@ -129,6 +129,12 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
     },
     ...changeTab("options"),
     {
+        trigger: ".modal .modal-content .o_field_widget[name=triggering_answer_ids] input",
+        run() {
+            this.anchor.scrollIntoView(true);
+        }
+    },
+    {
         content: "Add a second trigger to confirm we can now use Question 2 again",
         trigger: ".modal .modal-content .o_field_widget[name=triggering_answer_ids] input",
         run: "click",


### PR DESCRIPTION
Because reasons the answers field may end up partially outside the viewport when we try to click on it. In the new headless engine, this apparently causes the field to be visible so the "Add a second trigger" trigger succeeds *but* some events to still be suppressed, and in this case the `click` doesn't cause the dropdown menu to open and the tour fails on "Add the second question's second answer as trigger".

Ensuring the element is fully in view seems to fix the issue.
