### PR TITLE
[FIX] account: fix traceback when registering payment with no invoice date

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2519,7 +2519,11 @@ class AccountMove(models.Model):
         return self.currency_id == currency \
             and self.move_type in ('out_invoice', 'out_receipt', 'in_invoice', 'in_receipt') \
             and self.invoice_payment_term_id.early_discount \
-            and (not reference_date or reference_date <= self.invoice_payment_term_id._get_last_discount_date(self.invoice_date)) \
+            and (
+                not reference_date
+                or not self.invoice_date
+                or reference_date <= self.invoice_payment_term_id._get_last_discount_date(self.invoice_date)
+            ) \
             and not (payment_terms.matched_debit_ids + payment_terms.matched_credit_ids)
 
     # -------------------------------------------------------------------------

--- a/addons/account/models/account_payment_term.py
+++ b/addons/account/models/account_payment_term.py
@@ -255,6 +255,8 @@ class AccountPaymentTerm(models.Model):
 
     def _get_last_discount_date(self, date_ref):
         self.ensure_one()
+        if not date_ref:
+            return None
         return date_ref + relativedelta(days=self.discount_days or 0) if self.early_discount else False
 
     def _get_last_discount_date_formatted(self, date_ref):


### PR DESCRIPTION
Currently, a traceback occurs when there is no invoice date and tries to register a payment
from actions.

To reproduce this issue:

1) Install accounting
2) Create a customer invoice with payment term having an early discount 
3) Make sure the invoice date to be empty
4) Add a line and from actions click pay

Error:-
```
TypeError: unsupported operand type(s) for +: 'bool' and 'relativedelta'
```

In account move, `invoice_date` is not required. So when the user tries to 
register a payment with payment term having an early discount and no invoice date, 
It leads to the above traceback from below line.

https://github.com/odoo/odoo/blob/ee48df7f33a3aeb1798bf5852be8c6d26a7db7fd/addons/account/models/account_payment_term.py#L256-L258

Indeed, a date is required to get an early discount date. 
so without date, we should not execute the `_get_last_discount_date` method.

In some other locations, it was managed in a similar manner as indicated in the below line.

https://github.com/odoo/odoo/blob/ee48df7f33a3aeb1798bf5852be8c6d26a7db7fd/addons/account/models/account_payment_term.py#L262-L264

We can resolve this issue by adding an additional check of invoice_date, 
Which makes the code more robust.

sentry-6149404219
