### PR TITLE
[FIX] point_of_sale: use the correct quantity string in the command line

### DIFF
--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
@@ -11,7 +11,7 @@
             <div class="d-flex flex-column w-100 gap-1 p-1">
                 <div class="line-details d-flex justify-content-between">
                     <div class="product-name d-inline-block flex-grow-1 fw-bolder pe-1 text-truncate">
-                    <span class="qty px-1 fw-bolder me-1" t-esc="line.qty"/>
+                    <span class="qty px-1 fw-bolder me-1" t-esc="line.getQuantityStr()"/>
                         <span class="text-wrap" t-esc="line.getFullProductName()"/>
                         <t t-slot="product-name" />
                     </div>

--- a/addons/pos_restaurant/static/src/app/components/orderline/orderline.xml
+++ b/addons/pos_restaurant/static/src/app/components/orderline/orderline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_sale.Orderline" t-inherit="point_of_sale.Orderline" t-inherit-mode="extension">
-        <xpath expr="//span[@t-esc='line.qty']" position="attributes" >
+        <xpath expr="//span[@t-esc='line.getQuantityStr()']" position="attributes" >
             <attribute name="t-esc">line.uiState.splitQty or line.getQuantityStr()</attribute>
         </xpath>
     </t>


### PR DESCRIPTION
The `quantityStr` variable in the command line must be the one displayed in the command display, not the `qty` variable.

This error caused the quantity to be displayed without decimal point precision and rounding. This led to errors in the tests.

For example:
`ProductScreen.clickDisplayedProduct("Wall Shelf", true, "1.0"),`

