### PR TITLE
[FIX] l10n_in_edi_ewaybill: inward and outward type for credit note

### DIFF
--- a/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
+++ b/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
@@ -16,7 +16,7 @@
                     <group name="ewaybill_group">
                         <group string="Transaction Details" name="Transaction_group" 
                             attrs="{'invisible': [('l10n_in_edi_ewaybill_direct_api', '!=', True)]}">
-                            <field name="l10n_in_type_id" domain="[('allowed_supply_type', 'in', ('in', 'both')) if move_type in ('in_invoice', 'in_refund', 'in_receipt') else ('allowed_supply_type', 'in', ('out', 'both'))]"/>
+                            <field name="l10n_in_type_id" domain="[('allowed_supply_type', 'in', ('in', 'both')) if move_type in ('in_invoice', 'out_refund', 'in_receipt') else ('allowed_supply_type', 'in', ('out', 'both'))]"/>
                         </group>
                         <group string="Transportation Details" name="transportation_group">
                             <field name="l10n_in_mode" widget="radio"  options="{'horizontal': True}"/>


### PR DESCRIPTION
Before this commit:
When user created Sales Credit Note, and
send it for E-waybill. On the portal, it
shows as a Supple Type as `Inward` instead
of `Outward`.

In this commit:
We fix the above issue.

opw-4402929



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
