### PR TITLE
[IMP] web_editor: add new option for video selector "start at"

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -318,11 +318,13 @@ class HTML_Editor(http.Controller):
     @http.route(['/web_editor/video_url/data', '/html_editor/video_url/data'], type='jsonrpc', auth='user', website=True)
     def video_url_data(self, video_url, autoplay=False, loop=False,
                        hide_controls=False, hide_fullscreen=False,
-                       hide_dm_logo=False, hide_dm_share=False):
+                       hide_dm_logo=False, hide_dm_share=False,
+                       start_from=False):
         return get_video_url_data(
             video_url, autoplay=autoplay, loop=loop,
             hide_controls=hide_controls, hide_fullscreen=hide_fullscreen,
-            hide_dm_logo=hide_dm_logo, hide_dm_share=hide_dm_share
+            hide_dm_logo=hide_dm_logo, hide_dm_share=hide_dm_share,
+            start_from=start_from
         )
 
     @http.route(['/web_editor/attachment/add_data', '/html_editor/attachment/add_data'], type='jsonrpc', auth='user', methods=['POST'], website=True)

--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
@@ -11,7 +11,9 @@ class VideoOption extends Component {
         description: { type: String, optional: true },
         label: { type: String, optional: true },
         onChangeOption: Function,
-        value: { type: Boolean, optional: true },
+        onChangeStartAt: Function,
+        value: { type: String, optional: true },
+        name: { type: String, optional: true },
     };
 }
 
@@ -61,41 +63,42 @@ export class VideoSelector extends Component {
                 description: _t("Videos are muted when autoplay is enabled"),
                 platforms: [
                     this.PLATFORMS.youtube,
-                    this.PLATFORMS.dailymotion,
                     this.PLATFORMS.vimeo,
                 ],
-                urlParameter: "autoplay=1",
+                urlParameter: () => "autoplay=1",
             },
             loop: {
                 label: _t("Loop"),
                 platforms: [this.PLATFORMS.youtube, this.PLATFORMS.vimeo],
-                urlParameter: "loop=1",
+                urlParameter: () => "loop=1",
             },
             hide_controls: {
                 label: _t("Hide player controls"),
                 platforms: [
                     this.PLATFORMS.youtube,
-                    this.PLATFORMS.dailymotion,
                     this.PLATFORMS.vimeo,
                 ],
-                urlParameter: "controls=0",
+                urlParameter: () => "controls=0",
             },
             hide_fullscreen: {
                 label: _t("Hide fullscreen button"),
                 platforms: [this.PLATFORMS.youtube],
-                urlParameter: "fs=0",
+                urlParameter: () => "fs=0",
                 isHidden: () =>
                     this.state.options.filter((option) => option.id === "hide_controls")[0].value,
             },
-            hide_dm_logo: {
-                label: _t("Hide Dailymotion logo"),
-                platforms: [this.PLATFORMS.dailymotion],
-                urlParameter: "ui-logo=0",
-            },
-            hide_dm_share: {
-                label: _t("Hide sharing button"),
-                platforms: [this.PLATFORMS.dailymotion],
-                urlParameter: "sharing-enable=0",
+            start_from: {
+                label: _t("Start at"),
+                platforms: [this.PLATFORMS.youtube, this.PLATFORMS.vimeo, this.PLATFORMS.dailymotion],
+                urlParameter: () => {
+                    if (this.state.platform === this.PLATFORMS.youtube) {
+                        return "start";
+                    } else if (this.state.platform === this.PLATFORMS.vimeo) {
+                        return "#t=";
+                    } else if (this.state.platform === this.PLATFORMS.dailymotion) {
+                        return "startTime";
+                    }
+                },
             },
         };
 
@@ -119,12 +122,10 @@ export class VideoSelector extends Component {
                     "";
                 if (src) {
                     this.state.urlInput = src;
-                    await this.updateVideo();
-
-                    this.state.options = this.state.options.map((option) => {
-                        const { urlParameter } = this.OPTIONS[option.id];
-                        return { ...option, value: src.indexOf(urlParameter) >= 0 };
-                    });
+                    if(!src.includes("https:") && !src.includes("http:")) {
+                        this.state.urlInput = "https:" + this.state.urlInput;
+                    }
+                    await this.syncOptionsWithUrl();
                 }
             }
         });
@@ -133,7 +134,23 @@ export class VideoSelector extends Component {
 
         useAutofocus();
 
-        this.onChangeUrl = debounce((ev) => this.updateVideo(ev.target.value), 500);
+        this.onChangeUrl = debounce(async (ev) => {
+            await this.syncOptionsWithUrl();
+        }, 500);
+
+        this.onChangeStartAt = debounce(async (ev, optionId) => {
+            const start_from = this.convertTimestampToSeconds(ev.target.value);
+
+            this.state.options = this.state.options.map(option => {
+                if (option.id === optionId) {
+                    return { ...option, value: start_from };
+                }
+                return option;
+            });
+            await this.updateVideo();
+            this.state.urlInput = "https:" + this.state.src;
+        }, 1000);
+
     }
 
     get shownOptions() {
@@ -148,11 +165,14 @@ export class VideoSelector extends Component {
     async onChangeOption(optionId) {
         this.state.options = this.state.options.map((option) => {
             if (option.id === optionId) {
-                return { ...option, value: !option.value };
+                // used "0:00" here, to set the initial "startAt" value if option is toggled on,
+                // for other option it works as truthy value.
+                return { ...option, value: !option.value && "0:00" };
             }
             return option;
         });
         await this.updateVideo();
+        this.state.urlInput = "https:" + this.state.src;
     }
 
     async onClickSuggestion(src) {
@@ -184,9 +204,11 @@ export class VideoSelector extends Component {
         const url = embedMatch ? embedMatch[1] : this.state.urlInput;
 
         const options = {};
-        if (this.props.isForBgVideo) {
-            Object.keys(this.OPTIONS).forEach((key) => {
-                options[key] = true;
+        if (this.props.isForBgVideo && URL.canParse(url)) {
+            const urlParams = new URLSearchParams(new URL(url).search);
+            const start_from = urlParams.get("start") || urlParams.get("startTime") || urlParams.get("t");
+            Object.keys(this.OPTIONS).forEach(key => {
+                options[key] = key === "start_from" ? start_from : true;
             });
         } else {
             for (const option of this.shownOptions) {
@@ -279,5 +301,48 @@ export class VideoSelector extends Component {
                 });
             })
         );
+    }
+
+    /**
+     * Utility method, called to make options and urlInput state consistent with state of component.
+     */
+    async syncOptionsWithUrl() {
+        await this.updateVideo();
+        if (URL.canParse(this.state.urlInput)) {
+            const urlParams = new URLSearchParams(new URL(this.state.urlInput).search);
+            this.state.options = this.state.options.map((option) => {
+                const urlParameter = this.OPTIONS[option.id].urlParameter();
+                // Empty strings are used to maintain String type of state attribute "value".
+                if (urlParameter === "#t=") {
+                    return { ...option, value: this.state.urlInput.split("#t=")[1] || "" };
+                }
+                else if (urlParameter === "start") {
+                    return { ...option, value: urlParams.get(urlParameter) || urlParams.get("t") || "" };
+                }
+                else if (urlParameter === "startTime") {
+                    return { ...option, value: urlParams.get(urlParameter) || urlParams.get("start") || "" };
+                }
+                return { ...option, value: this.state.urlInput.includes(urlParameter) || "" };
+            });
+        }
+        await this.updateVideo();
+    }
+
+    /**
+     * Utility method, called to convert timestamp to seconds.
+     * @param {string} timestamp - The start time in HH:MM:SS format or seconds.
+     * @returns {string} - The start time in seconds.
+     */
+    convertTimestampToSeconds(timestamp) {
+        timestamp = timestamp.trim();
+        // Regular expression for HH:MM:SS format
+        const timeRegex = /^(?:(\d+):)?([0-5]?\d):([0-5]?\d)$/;
+
+        if (timeRegex.test(timestamp)) {
+            timestamp = timestamp.split(":").reduce((acc, time) => acc * 60 + +time, 0) + "";
+        } else if (isNaN(timestamp)) {
+            timestamp = "0:00";
+        }
+        return timestamp;
     }
 }

--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.xml
@@ -1,7 +1,7 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="html_editor.VideoOption">
-    <div class="mb-1">
+    <div class="mb-1" t-attf-class="{{ props.name === 'start_from' ? 'd-flex align-items-start gap-2 cursor-pointer' : ''}}">
         <label class="d-flex align-items-start gap-2 cursor-pointer" t-on-change="props.onChangeOption">
             <div class="o_switch flex-shrink-0">
                 <input type="checkbox" t-att-checked="props.value"/>
@@ -10,6 +10,9 @@
             <span t-esc="props.label"/>
             <span t-if="props.description" class="text-muted" t-esc="props.description"/>
         </label>
+        <t t-if="props.name === 'start_from'">
+            <input type="text" placeholder="MM:SS" class="o_input w-lg-auto" t-att-value="props.value" t-on-input="props.onChangeStartAt"/>
+        </t>
     </div>
 </t>
 
@@ -34,8 +37,10 @@
             </div>
             <div t-if="shownOptions.length" class="o_video_dialog_options">
                 <VideoOption t-foreach="shownOptions" t-as="option" t-key="option.id"
+                    name="option.id"
                     value="option.value"
                     onChangeOption="() => this.onChangeOption(option.id)"
+                    onChangeStartAt="(ev) => this.onChangeStartAt(ev, option.id)"
                     label="option.label"
                     description="option.description"/>
             </div>

--- a/addons/html_editor/static/src/main/youtube_plugin.js
+++ b/addons/html_editor/static/src/main/youtube_plugin.js
@@ -50,11 +50,29 @@ export class YoutubePlugin extends Plugin {
      * @param {string} url
      */
     async getYoutubeVideoElement(url) {
-        const { embed_url: src } = await rpc("/html_editor/video_url/data", {
-            video_url: url,
-        });
-        const [savedVideo] = VideoSelector.createElements([{ src }]);
-        savedVideo.classList.add(...VideoSelector.mediaSpecificClasses);
-        return savedVideo;
+        if (URL.canParse(url)) {
+            const urlParams = new URLSearchParams(new URL(url).search);
+            const start_from = urlParams.get("start") || urlParams.get("t");
+
+            const autoplay = url.includes("autoplay=1");
+            const loop = url.includes("loop=1");
+            const hide_controls = url.includes("controls=0");
+            const hide_fullscreen = url.includes("fs=0");
+
+            const { embed_url: src } = await rpc(
+                "/html_editor/video_url/data",
+                {
+                    video_url: url,
+                    autoplay,
+                    loop,
+                    hide_controls,
+                    hide_fullscreen,
+                    start_from,
+                },
+            );
+            const [savedVideo] = VideoSelector.createElements([{ src }]);
+            savedVideo.classList.add(...VideoSelector.mediaSpecificClasses);
+            return savedVideo;
+        }
     }
 }

--- a/addons/web_editor/static/src/components/media_dialog/video_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="web_editor.VideoOption">
-    <div class="mb-1">
+    <div class="mb-1" t-attf-class="{{ props.name === 'start_from' ? 'd-flex align-items-start gap-2 cursor-pointer' : ''}}">
         <label class="d-flex align-items-start gap-2 cursor-pointer" t-on-change="props.onChangeOption">
             <div class="o_switch flex-shrink-0">
                 <input type="checkbox" t-att-checked="props.value"/>
@@ -11,6 +11,9 @@
             <span t-esc="props.label"/>
             <span t-if="props.description" class="text-muted" t-esc="props.description"/>
         </label>
+        <t t-if="props.name === 'start_from'">
+            <input type="text" placeholder="MM:SS" class="o_input w-lg-auto" t-att-value="props.value" t-on-input="props.onChangeStartAt"/>
+        </t>
     </div>
 </t>
 
@@ -35,8 +38,10 @@
             </div>
             <div t-if="shownOptions.length" class="o_video_dialog_options">
                 <VideoOption t-foreach="shownOptions" t-as="option" t-key="option.id"
+                    name="option.id"
                     value="option.value"
                     onChangeOption="() => this.onChangeOption(option.id)"
+                    onChangeStartAt="(ev) => this.onChangeStartAt(ev, option.id)"
                     label="option.label"
                     description="option.description"/>
             </div>

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -403,13 +403,30 @@ export class Wysiwyg extends Component {
         }
 
         const getYoutubeVideoElement = async (url) => {
-            const { embed_url: src } = await this._serviceRpc(
-                '/web_editor/video_url/data',
-                { video_url: url },
-            );
-            const [savedVideo] = VideoSelector.createElements([{src}]);
-            savedVideo.classList.add(...VideoSelector.mediaSpecificClasses);
-            return savedVideo;
+            if (URL.canParse(url)) {
+                const urlParams = new URLSearchParams(new URL(url).search);
+                const start_from = urlParams.get("start") || urlParams.get("t");
+
+                const autoplay = url.includes("autoplay=1");
+                const loop = url.includes("loop=1");
+                const hide_controls = url.includes("controls=0");
+                const hide_fullscreen = url.includes("fs=0");
+
+                const { embed_url: src } = await this._serviceRpc(
+                    "/web_editor/video_url/data",
+                    {
+                        video_url: url,
+                        autoplay,
+                        loop,
+                        hide_controls,
+                        hide_fullscreen,
+                        start_from,
+                    },
+                );
+                const [savedVideo] = VideoSelector.createElements([{ src }]);
+                savedVideo.classList.add(...VideoSelector.mediaSpecificClasses);
+                return savedVideo;
+            }
         };
 
         weUtils.setEditableDocument(this.options.document);


### PR DESCRIPTION
Improvement:

- Add new option for video selector "start at" to set the start
time of the video.
- Made improvement in dailymotion regEx to get the video id from
the URL, as new dailymotion URL redirects to domain 'geo.dailymotion.com'
for embedded videos.

Before this PR:

- The urlInput had no effect if the user changed the option for a given video.
- Vice-versa, the option had no effect if the user added a params in urlInput
for a given video.

After this PR:

- Both issues are now resolved.
- The urlInput updates correctly when options are changed
- options adapt its state according urlInput's params for a given video.
- Also added protocol to urlInput to continue what we did in task 4091138.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
