### PR TITLE
[FIX] mrp: prevent re-count global lead days if not 1-step manufacture

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -218,7 +218,7 @@ class StockRule(models.Model):
             for wh in warehouse:
                 if wh.manufacture_steps != 'mrp_one_step':
                     wh_manufacture_rules = product._get_rules_from_location(product.property_stock_production, route_ids=wh.pbm_route_id)
-                    extra_delays, extra_delay_description = (wh_manufacture_rules - self)._get_lead_days(product, **values)
+                    extra_delays, extra_delay_description = (wh_manufacture_rules - self).with_context(ignore_global_visibility_days=True)._get_lead_days(product, **values)
                     for key, value in extra_delays.items():
                         delays[key] += value
                     delay_description += extra_delay_description

--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime, timedelta
 from freezegun import freeze_time
+from json import loads
 
 from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
-from odoo import fields
+from odoo import Command, fields
 
 
 
@@ -120,3 +122,33 @@ class TestMrpReplenish(TestMrpCommon):
         replenish_picking = basic_mo.picking_ids.filtered(lambda x: x.state == 'assigned')
         replenish_picking.button_validate()
         self.assertEqual(basic_mo.move_raw_ids.mapped('state'), ['assigned', 'assigned'])
+
+    def test_global_visibility_days_affect_lead_time_manufacture_rule(self):
+        """ Ensure global visibility days will only be captured one time in an orderpoint's
+        lead_days/json_lead_days.
+        """
+        wh = self.env.user._get_default_warehouse_id()
+        wh.manufacture_steps = 'pbm'
+        finished_product = self.product_4
+        finished_product.route_ids = [(6, 0, self.env['stock.route'].search([('name', '=', 'Manufacture')], limit=1).ids)]
+        self.env['ir.config_parameter'].set_param('stock.visibility_days', '365')
+
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({'product_id': finished_product.id})
+        out_picking = self.env['stock.picking'].create({
+            'picking_type_id': self.env.ref('stock.picking_type_out').id,
+            'location_id': wh.lot_stock_id.id,
+            'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+            'move_ids': [Command.create({
+                'name': 'TGVDALTMR out move',
+                'product_id': finished_product.id,
+                'product_uom_qty': 2,
+                'location_id': wh.lot_stock_id.id,
+                'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+            })],
+        })
+        out_picking.action_assign()
+        r = orderpoint.action_stock_replenishment_info()
+        repl_info = self.env[r['res_model']].browse(r['res_id'])
+        lead_days_date = datetime.strptime(
+            loads(repl_info.json_lead_days)['lead_days_date'], '%m/%d/%Y').date()
+        self.assertEqual(lead_days_date, fields.Date.today() + timedelta(days=365))


### PR DESCRIPTION
**Current behavior:**
The global lead days system parameter may be counted in the lead days breakdown in the replenishment report when:
A) product has manufacture route and,
B) WH manufacture steps is not 1-step

**Expected behavior:**
The parameter is counted once.

**Steps to reproduce:**
1. Create a product with a simple BoM and the manufacture route

2. Enable 2 or 3 step manufacturing in WH

3. Create an out move for the product

4. Open the replenishment report in inventory

5. Click the (i) in the orderpoint line for the product -> see the global vis. days are counted 2x

**Cause of the issue:**
Like the issue solved by 38d8e77
In some instances the `_get_lead_days()` must be called a second time to capture some additional lead time (in this case because we have > 1-step manufacturing).

**Fix:**
Use the context added in the referenced similar commit to ignore the global days in the second call.

opw-4410790