### PR TITLE
[IMP] repair: move `create_repair` to `service_tracking` selection

### DIFF
--- a/addons/repair/data/repair_demo.xml
+++ b/addons/repair/data/repair_demo.xml
@@ -6,7 +6,7 @@
         <field name="standard_price">20.5</field>
         <field name="list_price">30.75</field>
         <field name="type">service</field>
-        <field name="create_repair">True</field>
+        <field name="service_tracking">repair</field>
     </record>
 
     <record id="repair_r1" model="repair.order">

--- a/addons/repair/models/product.py
+++ b/addons/repair/models/product.py
@@ -54,5 +54,5 @@ class ProductProduct(models.Model):
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    service_tracking = fields.Selection(selection_add=[('repair', 'Repair')],
+    service_tracking = fields.Selection(selection_add=[('repair', 'Repair Order')],
                                         ondelete={'repair': 'set default'})

--- a/addons/repair/models/product.py
+++ b/addons/repair/models/product.py
@@ -54,4 +54,5 @@ class ProductProduct(models.Model):
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    create_repair = fields.Boolean('Create Repair', help="Create a linked Repair Order on Sale Order confirmation of this product.", groups='stock.group_stock_user')
+    service_tracking = fields.Selection(selection_add=[('repair', 'Repair')],
+                                        ondelete={'repair': 'set default'})

--- a/addons/repair/views/product_views.xml
+++ b/addons/repair/views/product_views.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="view_product_template_form_inherit_repair" model="ir.ui.view">
         <field name="name">product.template.form.inherit.repair</field>
         <field name="model">product.template</field>
-        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="inherit_id" ref="sale.product_template_form_view"/>
         <field name="arch" type="xml">
-            <group name="group_general" position="inside">
-                <field name="create_repair" invisible="type not in ('consu', 'service')"/>
-            </group>
+            <field name="service_tracking" position="attributes">
+                <attribute name="invisible" remove="1" separator="or"/>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
The `create_repair` field used for a checkbox in the product form view is being incorporated into the `service_tracking` selection, as repair is a form of service and there is no need to keep the two separate.

Task ID: [4384881](https://www.odoo.com/odoo/project/966/tasks/4384881)