### PR TITLE
[IMP] l10n_in: auto apply fiscal position to overseas/sez

### DIFF
--- a/addons/l10n_in/tests/test_l10n_in_fiscal_position.py
+++ b/addons/l10n_in/tests/test_l10n_in_fiscal_position.py
@@ -132,3 +132,20 @@ class TestFiscal(L10nInTestInvoicingCommon):
             out_invoice.fiscal_position_id,
             self.env['account.chart.template'].ref('fiscal_position_in_export_sez_in')
         )
+
+    def test_l10n_in_auto_apply_fiscal_partner(self):
+        # For overseas gst treatment
+        self.partner_a.write({
+            'country_id': self.country_us.id,
+            'l10n_in_gst_treatment': 'overseas'
+        })
+        self.partner_a._onchange_l10n_in_gst_treatment()
+        self.assertEqual(self.partner_a.property_account_position_id, self.env['account.chart.template'].ref('fiscal_position_in_export_sez_in'))
+
+        # For regular gst treatment
+        self.partner_a.write({
+            'country_id': self.country_in.id,
+            'l10n_in_gst_treatment': 'regular'
+        })
+        self.partner_a._onchange_l10n_in_gst_treatment()
+        self.assertFalse(self.partner_a.property_account_position_id)


### PR DESCRIPTION
Before this PR, when the Fiscal Position was determined based on the Place of Supply, the GST Treatment set on the Partner was ignored. This caused the Fiscal Position for Export/SEZ to be incorrectly applied on Vendor Bills and Invoices, resulting in inaccurate tax calculations.

With this PR, if the Partner's GST Treatment is 'Overseas' or 'SEZ', the Fiscal Position 'LUT - Export/SEZ' or 'Export/SEZ' will be automatically applied to the Partner, prioritizing the sequence.

task-4405282

