### PR TITLE
[IMP] web: improve placeholder of SelectionField

### DIFF
--- a/addons/web/static/src/views/fields/selection/selection_field.scss
+++ b/addons/web/static/src/views/fields/selection/selection_field.scss
@@ -5,3 +5,6 @@ body:not(.o_touch_device) .o_field_selection {
         }
     }
 }
+select:has(option.o_select_placeholder:checked) {
+    color: $input-placeholder-color;
+}

--- a/addons/web/static/src/views/fields/selection/selection_field.xml
+++ b/addons/web/static/src/views/fields/selection/selection_field.xml
@@ -6,19 +6,22 @@
             <span t-esc="string" t-att-raw-value="value" />
         </t>
         <t t-else="">
+            <t t-set="isPlaceholder" t-value="false === value" />
             <select
-                class="o_input pe-3"
+                t-attf-class="o_input pe-3 {{isPlaceholder ? 'o_selected_placeholder' : ''}}"
                 t-on-change="onChange"
                 t-on-click.stop="() =&gt; {}"
                 t-att-id="props.id">
                 <option
-                    t-att-selected="false === value"
+                    t-if="!props.required || !value"
+                    t-attf-class="o_select_placeholder {{isPlaceholder ? 'd-none' : ''}}"
+                    t-att-selected="isPlaceholder"
                     t-att-value="stringify(false)"
-                    t-esc="this.props.placeholder || ''"
-                    t-attf-style="{{ props.required ? 'display:none' : '' }}"
+                    t-esc="isPlaceholder and this.props.placeholder || ''"
                 />
                 <t t-foreach="options" t-as="option" t-key="option[0]">
                     <option
+                        class="text-black"
                         t-att-selected="option[0] === value"
                         t-att-value="stringify(option[0])"
                         t-esc="option[1]"

--- a/addons/web/static/tests/views/fields/filterable_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/filterable_selection_field.test.js
@@ -34,7 +34,7 @@ test(`FilterableSelectionField test whitelist`, async () => {
         `,
         resId: 1,
     });
-    expect(`select option`).toHaveCount(3);
+    expect(`select option`).toHaveCount(2);
     expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
     expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);
 });
@@ -50,7 +50,7 @@ test(`FilterableSelectionField test blacklist`, async () => {
         `,
         resId: 1,
     });
-    expect(`select option`).toHaveCount(3);
+    expect(`select option`).toHaveCount(2);
     expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
     expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);
 });
@@ -67,13 +67,13 @@ test(`FilterableSelectionField test with invalid value`, async () => {
         `,
         resId: 2,
     });
-    expect(`select option`).toHaveCount(4);
+    expect(`select option`).toHaveCount(3);
     expect(`.o_field_widget[name="type"] select option[value='"gift_card"']`).toHaveCount(1);
     expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
     expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);
 
     await contains(`.o_field_widget[name="type"] select`).select(`"coupon"`);
-    expect(`select option`).toHaveCount(3);
+    expect(`select option`).toHaveCount(2);
     expect(`.o_field_widget[name="type"] select option[value='"gift_card"']`).toHaveCount(0);
     expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
     expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);
@@ -91,7 +91,7 @@ test(`FilterableSelectionField test whitelist_fname`, async () => {
         `,
         resId: 1,
     });
-    expect(`select option`).toHaveCount(3);
+    expect(`select option`).toHaveCount(2);
     expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
     expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);
 });

--- a/addons/web/static/tests/views/fields/selection_field.test.js
+++ b/addons/web/static/tests/views/fields/selection_field.test.js
@@ -236,72 +236,24 @@ test("required selection widget should not have blank option", async () => {
                 </form>`,
     });
 
-    expect(queryAll(".o_field_widget[name='color'] option").map((n) => n.style.display)).toEqual([
-        "",
-        "",
-        "",
+    expect(queryAll(".o_field_widget[name='color'] option").map((n) => n.value)).toEqual([
+        "false",
+        '"red"',
+        '"black"',
     ]);
 
-    expect(
-        queryAll(".o_field_widget[name='feedback_value'] option").map((n) => n.style.display)
-    ).toEqual(["none", "", ""]);
+    expect(queryAll(".o_field_widget[name='feedback_value'] option").map((n) => n.value)).toEqual([
+        '"good"',
+        '"bad"',
+    ]);
 
     // change value to update widget modifier values
     await click(".o_field_widget[name='feedback_value'] select");
     await select('"bad"');
     await animationFrame();
-    expect(queryAll(".o_field_widget[name='color'] option").map((n) => n.style.display)).toEqual([
-        "none",
-        "",
-        "",
-    ]);
-});
-
-test("required selection widget should have only one blank option", async () => {
-    Partner._fields.feedback_value = fields.Selection({
-        required: true,
-        selection: [
-            ["good", "Good"],
-            ["bad", "Bad"],
-        ],
-        default: "good",
-        string: "Good",
-    });
-
-    Partner._fields.color = fields.Selection({
-        selection: [
-            [false, ""],
-            ["red", "Red"],
-            ["black", "Black"],
-        ],
-        default: "red",
-        string: "Color",
-    });
-
-    await mountView({
-        type: "form",
-        resModel: "partner",
-        resId: 1,
-        arch: /* xml */ `
-                <form>
-                    <field name="feedback_value" />
-                    <field name="color" required="feedback_value == 'bad'" />
-                </form>`,
-    });
-
-    expect(".o_field_widget[name='color'] option").toHaveCount(3, {
-        message: "Three options in non required field (one blank option)",
-    });
-
-    // change value to update widget modifier values
-    await click(".o_field_widget[name='feedback_value'] select");
-    await select('"bad"');
-    await animationFrame();
-
-    expect(queryAll(".o_field_widget[name='color'] option").map((n) => n.style.display)).toEqual([
-        "none",
-        "",
-        "",
+    expect(queryAll(".o_field_widget[name='color'] option").map((n) => n.value)).toEqual([
+        '"red"',
+        '"black"',
     ]);
 });
 
@@ -314,6 +266,11 @@ test("selection field with placeholder", async () => {
 
     expect(".o_field_widget[name='trululu'] select option:first").toHaveText("Placeholder");
     expect(".o_field_widget[name='trululu'] select option:first").toHaveValue("false");
+    expect(".o_field_widget[name='trululu'] select option:first").toHaveClass("d-none");
+    await click(".o_field_widget[name='trululu'] select");
+    await select(1);
+    await animationFrame();
+    expect(".o_field_widget[name='trululu'] select option:first").not.toHaveClass("d-none");
 });
 
 test("SelectionField in kanban view", async () => {


### PR DESCRIPTION
This commit brings a better placeholder experience to the <select> element being used in the SelectionField component.

To match the visual style of a native placeholder of an input, we grey out the text element when the placeholder is selected.

Tests have been adapted to this latest improvement.

task-4277083