### PR TITLE
[IMP] base: fine tuning `res.device.log` GC

### DIFF
--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -116,18 +116,47 @@ class ResDeviceLog(models.Model):
     def _gc_device_log(self):
         # Keep the last device log
         # (even if the session file no longer exists on the filesystem)
-        self.env.cr.execute("""
+
+        soft_gc = int(self.env['ir.config_parameter'].sudo().get_param(
+            'base.res_device_log_detail_retention_days', 0
+        ))
+        # If there is a value for this parameter other than `0`, the details for a session
+        # whose last activity has exceeded the number of days will be garbage collected.
+        # The last log for a session identifier will never be garbage collected
+        # when a value is set for this parameter.
+
+        hard_gc = int(self.env['ir.config_parameter'].sudo().get_param(
+            'base.res_device_log_retention_days', 0
+        ))
+        # If there is a value for this parameter other than `0` and the last activity date
+        # has exceeded the number of days, the log will be deleted (even if it is the last).
+
+        self.env.cr.execute(SQL("""
             DELETE FROM res_device_log log1
-            WHERE EXISTS (
-                SELECT 1 FROM res_device_log log2
-                WHERE
-                    log1.session_identifier = log2.session_identifier
-                    AND log1.platform = log2.platform
-                    AND log1.browser = log2.browser
-                    AND log1.ip_address = log2.ip_address
-                    AND log1.last_activity < log2.last_activity
+            WHERE (
+                EXISTS (
+                    SELECT 1 FROM res_device_log log2
+                    WHERE
+                        log1.session_identifier = log2.session_identifier AND
+                        log1.last_activity < log2.last_activity AND
+                        (
+                            (
+                                log1.platform IS NOT DISTINCT FROM log2.platform AND
+                                log1.browser IS NOT DISTINCT FROM log2.browser AND
+                                log1.ip_address = log2.ip_address
+                            ) OR
+                            (
+                                %s AND
+                                log1.last_activity + INTERVAL '%s DAYS' < CURRENT_TIMESTAMP
+                            )
+                        )
+                ) OR
+                (
+                    %s AND
+                    log1.last_activity + INTERVAL '%s DAYS' < CURRENT_TIMESTAMP
+                )
             )
-        """)
+        """, bool(soft_gc), soft_gc, bool(hard_gc), hard_gc))
         _logger.info("GC device logs delete %d entries", self.env.cr.rowcount)
 
 

--- a/odoo/addons/test_http/tests/test_device.py
+++ b/odoo/addons/test_http/tests/test_device.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime, timedelta
 from freezegun import freeze_time
 from unittest.mock import patch
 
@@ -365,3 +366,37 @@ class TestDevice(TestHttpBase):
         # This means that the device logic will not create a session file
         # (because we are not passing in the `_update_device` logic).
         self.assertFalse(session['_trace'])
+
+    # --------------------
+    # GARBAGE COLLECTOR
+    # --------------------
+
+    def test_garbage_collector_device_log(self):
+
+        def count_garbage(session_identifier):
+            count_before_gc = self.DeviceLog.search_count([('session_identifier', '=', session_identifier)])
+            self.DeviceLog._gc_device_log()
+            count_after_gc = self.DeviceLog.search_count([('session_identifier', '=', session_identifier)])
+            return count_before_gc - count_after_gc
+
+        session = self.authenticate(self.user_admin.login, self.user_admin.login)
+        session_identifier = session.sid[:42]
+
+        now = lambda days=0:datetime.now() + timedelta(days=days)
+
+        self.hit(now(days=-40), '/test_http/greeting-public', ip='191.0.1.41', headers={'User-Agent': USER_AGENT_linux_chrome})  # normal GC
+        self.hit(now(days=-30), '/test_http/greeting-public', ip='191.0.1.41', headers={'User-Agent': USER_AGENT_linux_chrome})  # soft GC (25 days)
+        self.assertEqual(count_garbage(session_identifier), 1)
+
+        self.hit(now(days=-35), '/test_http/greeting-public', ip='191.0.1.41', headers={'User-Agent': USER_AGENT_linux_firefox})  # normal GC
+        self.hit(now(days=-31), '/test_http/greeting-public', ip='191.0.1.41', headers={'User-Agent': USER_AGENT_linux_firefox})  # soft GC (25 days)
+        self.hit(now(days=-29), '/test_http/greeting-public', ip='191.0.1.42', headers={'User-Agent': USER_AGENT_linux_firefox})  # hard GC (25 days) because last log
+        self.assertEqual(count_garbage(session_identifier), 1)
+
+        # Soft garbage
+        self.env['ir.config_parameter'].set_param('base.res_device_log_detail_retention_days', 25)
+        self.assertEqual(count_garbage(session_identifier), 2)
+
+        # Hard garbage
+        self.env['ir.config_parameter'].set_param('base.res_device_log_retention_days', 25)
+        self.assertEqual(count_garbage(session_identifier), 1)


### PR DESCRIPTION
The `res.device.log` table contains a huge amount of data. It makes sense to provide a way for administrators to garbage collect these logs according to their retention policy.

Two system parameters (`ir.config_parameter`) can be used:
- `base.res_device_log_detail_retention_days`: soft garbage collector
- `base.res_device_log_retention_days`: hard garbage collector

Normal garbage collector (by default):
A log will be deleted if a more recent log is found for the `session_identifier, platform, browser, ip_address` tuple. We therefore keep one log per device (which can be differentiated by their ip address) and which may be quite large (for example for IPv6 devices).

Soft garbage collector:
A log will be deleted if a more recent log is found for a session identifier (all devices combined) and if its last activity exceeds the number of days specified in the parameter. We will therefore keep at least one log per session (which will be the most recent).

Hard garbage collector:
A log will be deleted if its last activity has exceeded the number of days specified in the parameter. This can remove all traces of a session identifier. For example, this can be useful if the parameter is chosen judiciously according to the database backups.