### PR TITLE
[FIX] html_editor: prevent fixing table dimensions on insert

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -158,7 +158,7 @@ export class TablePlugin extends Plugin {
     addColumn(position, reference) {
         const columnIndex = getColumnIndex(reference);
         const table = closestElement(reference, "table");
-        const tableWidth = table.style.width ? parseFloat(table.style.width) : table.clientWidth;
+        const tableWidth = table.style.width && parseFloat(table.style.width);
         const referenceColumn = table.querySelectorAll(`tr td:nth-of-type(${columnIndex + 1})`);
         const referenceCellWidth = reference.style.width
             ? parseFloat(reference.style.width)
@@ -169,17 +169,19 @@ export class TablePlugin extends Plugin {
             (child) => child.nodeName === "TD" || child.nodeName === "TH"
         );
         let totalWidth = 0;
-        for (const cell of firstRowCells) {
-            const width = cell.style.width ? parseFloat(cell.style.width) : cell.clientWidth;
-            cell.style.width = width + "px";
-            // Spread the widths to preserve proportions.
-            // -1 for the width of the border of the new column.
-            const newWidth = Math.max(
-                Math.round((width * tableWidth) / (tableWidth + referenceCellWidth - 1)),
-                13
-            );
-            cell.style.width = newWidth + "px";
-            totalWidth += newWidth;
+        if (tableWidth) {
+            for (const cell of firstRowCells) {
+                const width = parseFloat(cell.style.width);
+                cell.style.width = width + "px";
+                // Spread the widths to preserve proportions.
+                // -1 for the width of the border of the new column.
+                const newWidth = Math.max(
+                    Math.round((width * tableWidth) / (tableWidth + referenceCellWidth - 1)),
+                    13
+                );
+                cell.style.width = newWidth + "px";
+                totalWidth += newWidth;
+            }
         }
         referenceColumn.forEach((cell, rowIndex) => {
             const newCell = this.document.createElement("td");
@@ -187,35 +189,35 @@ export class TablePlugin extends Plugin {
             p.append(this.document.createElement("br"));
             newCell.append(p);
             cell[position](newCell);
-            if (rowIndex === 0) {
+            if (rowIndex === 0 && tableWidth) {
                 newCell.style.width = cell.style.width;
                 totalWidth += parseFloat(cell.style.width);
             }
         });
-        if (totalWidth !== tableWidth - 1) {
-            // -1 for the width of the border of the new column.
-            firstRowCells[firstRowCells.length - 1].style.width =
-                parseFloat(firstRowCells[firstRowCells.length - 1].style.width) +
-                (tableWidth - totalWidth - 1) +
-                "px";
+        if (tableWidth) {
+            if (totalWidth !== tableWidth - 1) {
+                // -1 for the width of the border of the new column.
+                firstRowCells[firstRowCells.length - 1].style.width =
+                    parseFloat(firstRowCells[firstRowCells.length - 1].style.width) +
+                    (tableWidth - totalWidth - 1) +
+                    "px";
+            }
+            // Fix the table and row's width so it doesn't change.
+            table.style.width = tableWidth + "px";
         }
-        // Fix the table and row's width so it doesn't change.
-        table.style.width = tableWidth + "px";
     }
     /**
      * @param {'before'|'after'} position
      * @param {HTMLTableRowElement} reference
      */
     addRow(position, reference) {
-        const referenceRowHeight = reference.style.height
-            ? parseFloat(reference.style.height)
-            : reference.clientHeight;
+        const referenceRowHeight = reference.style.height && parseFloat(reference.style.height);
         const newRow = this.document.createElement("tr");
-        newRow.style.height = referenceRowHeight + "px";
+        if (referenceRowHeight) {
+            newRow.style.height = referenceRowHeight + "px";
+        }
         const cells = reference.querySelectorAll("td");
-        const referenceRowWidths = [...cells].map(
-            (cell) => cell.style.width || cell.clientWidth + "px"
-        );
+        const referenceRowWidths = [...cells].map((cell) => cell.style.width);
         newRow.append(
             ...Array.from(Array(cells.length)).map(() => {
                 const td = this.document.createElement("td");
@@ -226,7 +228,9 @@ export class TablePlugin extends Plugin {
             })
         );
         reference[position](newRow);
-        newRow.style.height = referenceRowHeight + "px";
+        if (referenceRowHeight) {
+            newRow.style.height = referenceRowHeight + "px";
+        }
         // Preserve the width of the columns (applied only on the first row).
         if (getRowIndex(newRow) === 0) {
             let columnIndex = 0;

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -420,12 +420,12 @@ test("insert column left operation", async () => {
     await click("div[name='insert_left']");
     expect(getContent(el)).toBe(
         unformat(`
-        <table style="width: 20px;">
+        <table>
             <tbody>
                 <tr>
-                    <td class="a" style="width: 13px;">1[]</td>
-                    <td style="width: 13px;"><p><br></p></td>
-                    <td class="b" style="width: 13px;">2</td>
+                    <td class="a">1[]</td>
+                    <td><p><br></p></td>
+                    <td class="b">2</td>
                 </tr>
                 <tr>
                     <td class="c">3</td>
@@ -472,12 +472,12 @@ test("insert column right operation", async () => {
     await click("div[name='insert_right']");
     expect(getContent(el)).toBe(
         unformat(`
-        <table style="width: 20px;">
+        <table>
             <tbody>
                 <tr>
-                    <td class="a" style="width: 13px;">1[]</td>
-                    <td style="width: 13px;"><p><br></p></td>
-                    <td class="b" style="width: 13px;">2</td>
+                    <td class="a">1[]</td>
+                    <td><p><br></p></td>
+                    <td class="b">2</td>
                 </tr>
                 <tr>
                     <td class="c">3</td>
@@ -530,7 +530,7 @@ test("insert row above operation", async () => {
                     <td class="a">1[]</td>
                     <td class="b">2</td>
                 </tr>
-                <tr style="height: 23px;">
+                <tr>
                     <td><p><br></p></td>
                     <td><p><br></p></td>
                 </tr>
@@ -549,6 +549,49 @@ test("insert row above operation", async () => {
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
+});
+
+test("insert row above operation should not retain height and width styles", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1[]</td><td class="b">2</td></tr>
+                <tr><td class="c">3</td><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
+    expect(".o-we-table-menu").toHaveCount(0);
+
+    // hover on td to show row ui
+    await hover(el.querySelector("td.a"));
+    await waitFor(".o-we-table-menu");
+
+    // click on it to open dropdown
+    await click(".o-we-table-menu");
+    await waitFor("div[name='insert_above']");
+
+    // insert row above
+    await click("div[name='insert_above']");
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                </tr>
+                <tr>
+                    <td class="a">1[]</td>
+                    <td class="b">2</td>
+                </tr>
+                <tr>
+                    <td class="c">3</td>
+                    <td class="d">4</td>
+                </tr>
             </tbody>
         </table>`)
     );
@@ -584,7 +627,7 @@ test("insert row below operation", async () => {
                     <td class="a">1[]</td>
                     <td class="b">2</td>
                 </tr>
-                <tr style="height: 23px;">
+                <tr>
                     <td><p><br></p></td>
                     <td><p><br></p></td>
                 </tr>


### PR DESCRIPTION
### Steps to reproduce:

- Insert a table.
- Observe the HTML, noticing that the table does not have a fixed width or height.
- Insert a new column or row.
- Observe the HTML, noticing that the width and/or height of the table has been fixed.

### Description of the issue/feature this PR addresses:

- When a new column is inserted into the table, the table's width is fixed, and the
widths of the first row/column cells (TDs and THs) are also fixed.
- When a new row is inserted, the height is added to the table rows (TRs), even if
the table initially did not have fixed dimensions.

### Desired behavior after PR is merged:

- The width and height of the table will not be fixed when a new column or row is added,
as long as the table did not have fixed dimensions (width/height) to begin with.

task-4402552