### PR TITLE
[FIX] stock_landed_costs: exclude uncreated landed cost lines

### DIFF
--- a/addons/stock_landed_costs/models/purchase.py
+++ b/addons/stock_landed_costs/models/purchase.py
@@ -9,7 +9,8 @@ class PurchaseOrderLine(models.Model):
         return res
 
     def _get_po_line_invoice_lines_su(self):
-        return (
-            super()._get_po_line_invoice_lines_su() |
-            self.sudo().invoice_lines.move_id.line_ids.filtered('is_landed_costs_line')
-        )
+        po_line_invoices_lines = super()._get_po_line_invoice_lines_su()
+        move = self.sudo().invoice_lines.move_id
+        if move.landed_costs_ids.filtered(lambda lc: lc.state == 'done'):
+            return po_line_invoices_lines | move.line_ids.filtered('is_landed_costs_line')
+        return po_line_invoices_lines

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -556,3 +556,57 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         receipt2.move_ids[0].quantity_done = 27000
         receipt2.button_validate()
         self.assertEqual(product.standard_price, 1.81)
+
+    def test_landed_costs_avco_invoice_before_receipt(self):
+        """
+        Test the application of landed costs on a product with average cost (AVCO) method
+        when the bill is created and validated before the receipt and the landed costs are
+        not yet created on the bill.
+        """
+
+        self.env.company.anglo_saxon_accounting = True
+        self.product1.purchase_method = 'purchase'
+        self.product1.categ_id.write({
+            'property_stock_account_input_categ_id': self.company_data['default_account_stock_in'].id,
+            'property_stock_account_output_categ_id': self.company_data['default_account_stock_out'].id,
+            'property_stock_valuation_account_id': self.company_data['default_account_stock_valuation'].id,
+            'property_valuation': 'real_time',
+            'property_cost_method': 'average',
+        })
+        self.landed_cost.categ_id = self.product1.categ_id.id
+        product = self.product1
+
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_qty': 1,
+                'price_unit': 10,
+            })],
+        })
+        purchase_order.button_confirm()
+        purchase_order.action_create_invoice()
+        bill = purchase_order.invoice_ids[0]
+        bill.invoice_line_ids[0].quantity = 1
+        bill.invoice_date = '2000-05-05'
+        with Form(bill) as bill_form:
+            with bill_form.invoice_line_ids.new() as inv_line:
+                inv_line.product_id = self.landed_cost
+                inv_line.price_unit = 25
+                inv_line.is_landed_costs_line = True
+        bill.action_post()
+        receipt = purchase_order.picking_ids[0]
+        receipt.move_ids.quantity_done = 1
+        receipt.button_validate()
+
+        # Ensure that the product cost has not been updated yet
+        assert receipt.move_ids[0].stock_valuation_layer_ids[0].unit_cost == 10 
+
+        action = bill.button_create_landed_costs()
+        lc_form = Form(self.env[action['res_model']].browse(action['res_id']))
+        lc_form.picking_ids.add(receipt)
+        lc = lc_form.save()
+        lc.button_validate()
+
+        # 35 = Product price (10) + landed cost price (25)
+        self.assertEqual(product.standard_price, 35)


### PR DESCRIPTION
A stock valuation issue occurs when a landed cost is present in a bill lines of a purchase order (without the `stock.landed_cost` created) and the receipt note is validated after confirming the bill.

Steps to reproduce:
- Create a product with automated inventory valuation and AVCO.
- On the purchase tab, set the control policy to “on ordered quantity”.
- Create a purchase order with this product:
  * Quantity: 1
  * Unit cost: $10
- Validate the PO.
- Create a bill and add a landed cost line:
  * Quantity: 1
  * Cost: $25
- Validate the bill.
- Validate the receipt note.
- Check the valuation:
  * The unit value will be incorrect, calculated as $17.5 ((10 + 25) / 2).

This issue is caused by commit https://github.com/odoo/odoo/commit/5d067851248aaadf4f447f144a22553f9b188b71.

The solution is to include only landed cost lines from bills where the `stock.landed.cost` is created and validated.

opw-4384070
opw-4383063