### PR TITLE
[FIX] link_tracker: improve link shortener blacklist accuracy

### DIFF
--- a/addons/link_tracker/models/mail_render_mixin.py
+++ b/addons/link_tracker/models/mail_render_mixin.py
@@ -45,7 +45,7 @@ class MailRenderMixin(models.AbstractModel):
             if long_url.startswith(short_schema):
                 continue
             # Don't shorten urls present in blacklist (aka to skip list)
-            if blacklist and any(s in long_url for s in blacklist):
+            if blacklist and any(re.search(s + r'([#?/]|$)', long_url) for s in blacklist):
                 continue
             label = (match[3] or '').strip()
 
@@ -76,7 +76,7 @@ class MailRenderMixin(models.AbstractModel):
                 continue
             # support blacklist items in path, like /u/
             parsed = urls.url_parse(original_url, scheme='http')
-            if blacklist and any(item in parsed.path for item in blacklist):
+            if blacklist and any(re.search(item + r'([#?/]|$)', parsed.path) for item in blacklist):
                 continue
 
             create_vals = dict(link_tracker_vals, url=unescape(original_url))

--- a/addons/link_tracker/tests/test_mail_render_mixin.py
+++ b/addons/link_tracker/tests/test_mail_render_mixin.py
@@ -157,3 +157,24 @@ class TestMailRenderMixin(common.TransactionCase):
             .format(old_short_url=created_short_url, base_url=self.base_url)
         )
         self.assertRegex(new_content, expected)
+
+    def test_shorten_blacklisted_links(self):
+        test_links = [
+            ('This link should not be shortened: <a href="https://www.example.com/page/blacklist">text</a>', 'blacklist', False),
+            ('Neither should this link: <a href="https://www.example.com/page/view?param=true">text</a>', 'view', False),
+            ('But this link should be shortened: <a href="https://www.example.com/page/viewform">text</a>', 'view', True),
+            ('This link should not be shortened: <a href="https://www.example.com/page/blacklist/">text</a>', 'blacklist', False),
+            ('This link should not get shortened: <a href="https://example.com/blacklist/somepage">text</a>', 'blacklist', False),
+        ]
+        blacklist = ['/blacklist', '/view']
+
+        for (link, keyword, should_shorten) in test_links:
+            with self.subTest(msg=link, link=link):
+                shorten_html = self.env['mail.render.mixin']._shorten_links(link, {}, blacklist=blacklist)
+                shorten_text = self.env['mail.render.mixin']._shorten_links(link, {}, blacklist=blacklist)
+                if should_shorten:
+                    self.assertNotIn(keyword, shorten_html)
+                    self.assertNotIn(keyword, shorten_text)
+                else:
+                    self.assertIn(keyword, shorten_html)
+                    self.assertIn(keyword, shorten_text)


### PR DESCRIPTION
During the rendering of email marketing templates, links will be automatically shortened to aliases, which also enable tracking on the links' activity.

However, since some links are generated by Odoo, these are protected (blacklisted) from being shortened during the email generation process.

Since that blacklist is keyword-based, some external pages are also affected by this (notably Google Docs' forms, whose URL contains "/viewform", matching keyword /view.

Steps to reproduce:
- Create a new mass mailing
- Add a link to a Google Docs form, and a link to a Wikipedia page
- Send the mass mailing
- On the received email: The link to Wikipedia is shortened, the Google Docs form link is not

To reduce the number of false positives, this commit makes it so that blacklist elements need to be followed by a path symbol ( / # ? or link termination) to be counted as positives.

task-4196321
