### PR TITLE
[FIX] point_of_sale: keep paid order in IndexedDB

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -116,13 +116,13 @@ export class PosData extends Reactive {
         const dataToDelete = {};
 
         for (const model of this.opts.databaseTable) {
-            const nbrRecords = Object.values(records[model.name]).length;
+            const modelRecords = Object.values(records[model.name]);
 
-            if (!nbrRecords) {
+            if (!modelRecords.length) {
                 continue;
             }
 
-            const data = dataSorter(this.models[model.name].getAll(), model.condition, model.key);
+            const data = dataSorter(modelRecords, model.condition, model.key);
             this.indexedDB.create(model.name, data.put);
             dataToDelete[model.name] = data.remove;
         }


### PR DESCRIPTION
Before this commit, if you opened the PoS, made it offline, validated an order, stayed on the receipt screen, then made the PoS online and refreshed the page, the paid order would become a draft order. This caused the loss of tracking for the paid receipt-printed order. This issue occurred because using readAll prevented the effect from triggering on data modification.

opw-4371425

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
