### PR TITLE
[FIX] {purchase_,}stock: decrease the SOL qty with MTSO rule

### DIFF
--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -134,3 +134,44 @@ class TestSalePurchaseStockFlow(TransactionCase):
             {'product_id': product_1.id, 'product_uom_qty': 1.0},
             {'product_id': product_2.id, 'product_uom_qty': 0.0},
         ])
+
+    def test_mto_cancel_reset_to_quotation_and_update(self):
+        """
+        Confirm a SO with an MTO + Buy routes line. Cancel the SO,
+        reset it to quotation confirm it and decrease the quantity.
+
+        The quantity of the second delivery should be updated accordingly.
+        """
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [
+                Command.create({
+                    'name': self.mto_product.name,
+                    'product_id': self.mto_product.id,
+                    'product_uom_qty': 2,
+                    'product_uom': self.mto_product.uom_id.id,
+                    'price_unit': 10,
+                }),
+            ],
+        })
+        so.action_confirm()
+        delivery = so.picking_ids
+        self.assertRecordValues(delivery.move_ids, [
+            {'product_id': self.mto_product.id, 'product_uom_qty': 2.0},
+        ])
+        so.with_context(disable_cancel_warning=True).action_cancel()
+        self.assertEqual(delivery.state, 'cancel')
+        so.action_draft()
+        so.action_confirm()
+        new_delivery = so.picking_ids - delivery
+        self.assertEqual(len(new_delivery), 1)
+        self.assertRecordValues(new_delivery.move_ids, [
+            {'product_id': self.mto_product.id, 'product_uom_qty': 2.0},
+        ])
+        with Form(so) as so_form:
+            with so_form.order_line.edit(0) as line:
+                line.product_uom_qty = 1
+        self.assertEqual(so.picking_ids, delivery | new_delivery)
+        self.assertRecordValues(new_delivery.move_ids, [
+            {'product_id': self.mto_product.id, 'product_uom_qty': 1.0},
+        ])

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -256,7 +256,7 @@ class StockRule(models.Model):
                 if float_compare(qty_needed, 0, precision_rounding=procurement.product_id.uom_id.rounding) <= 0:
                     procure_method = 'make_to_order'
                     for move in procurement.values.get('group_id', self.env['procurement.group']).stock_move_ids:
-                        if move.product_id != procurement.product_id:
+                        if move.product_id != procurement.product_id or move.state == 'cancel':
                             continue
                         elif move.rule_id == rule and float_compare(move.product_uom_qty, 0, precision_rounding=move.product_uom.rounding) > 0:
                             procure_method = move.procure_method


### PR DESCRIPTION
### Steps to reproduce:

- In Settings, enable "Multi-Step Routes"
- In the Routes, unarchive "Replenish on Order (MTO)"
- Create a storable product P with routes: MTO, Buy and a set vendor
- Create and confirm a sale order with one line:
    - 2 x product P
> A delivery has been created.
- Cancel the SO, set it back to quotation and confirm it once more.
> The first delivery has been cancelled and a new one has been created
- Decrease the quantity of the SOL from 2 to 1 and save
#### > Issue: The delivery from stock to customer was not updated but an incoming picking was created from customer to stock.

### Cause of the Issue:

When confirming the SO, `_run_pull` will be called and will create an outgoing move SM01 based on our rule. Initially and because of the rule used for its creation, the `procure_method` of this move is `make_to_order`. However, once the SO is cancelled, this move `procure_method` will be updated to be `make_to_stock`: https://github.com/odoo/odoo/blob/ef161136fe2034752c2cc923cb892e933b78d4c0/addons/stock/models/stock_move.py#L1794-L1798 Once the SO is reset to draft and confirmed once more, a new outgoing move SM02 will be created by the `_run_pull` using the same rule as SM01 Then, when the quantity of the SOL is decreased from 2 to 1, a negative outgoing move SM03 will be created by the `_run_pull` and is expected to be absorbed by SM02 during the `_merge_move` of its `action_confirm`: https://github.com/odoo/odoo/blob/ef161136fe2034752c2cc923cb892e933b78d4c0/addons/stock/models/stock_move.py#L1397

However, the merging process will fail since:

While the `procure_method` is a valid comparaison key for negative moves, it is a tricky field to use as the `procure_method` present on the move we want to merge with might not correspond to the `procure_method` set by our rule (`make_to_order` for SM03). The purpose of these lines is therefore to update the `procure_method` of negative moves to match valid merging candidates:
https://github.com/odoo/odoo/blob/ef161136fe2034752c2cc923cb892e933b78d4c0/addons/stock/models/stock_rule.py#L260-L269 However, SM01 is not a valid merging candidtes as it was cancelled and its `procure_method` has changed during its cancellation so that it will wrongly update the `procure_method` of SM03 to `make_to_stock`: https://github.com/odoo/odoo/blob/ef161136fe2034752c2cc923cb892e933b78d4c0/addons/stock/models/stock_rule.py#L267-L268 and will therefore not match its only valid merging candidate: SM02.

opw-4368599
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
