### PR TITLE
[FIX] web,mail: ribbon misplaced

### DIFF
--- a/addons/mail/static/src/scss/kanban_view.scss
+++ b/addons/mail/static/src/scss/kanban_view.scss
@@ -2,7 +2,8 @@ $o-kanban-attachement-image-size: 80px;
 
 .o_kanban_renderer {
     .o_kanban_record.o_kanban_attachment {
-        padding: map-get($spacers, 0);
+        --KanbanRecord-padding-h: #{map-get($spacers, 0)};
+        --KanbanRecord-padding-v: #{map-get($spacers, 0)};
 
         .o_kanban_image {
             width: $o-kanban-attachement-image-size;

--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -122,12 +122,11 @@
 
     // ----------------------------------------------------------------------------
     // Inner components contextual adaptations
-
-    --Ribbon-font-size: #{$font-size-sm};
-    --Ribbon-gap-top: calc(var(--KanbanRecord-padding-v) * -1 - #{$border-width});
-    --Ribbon-gap-right: 0;
-    --Ribbon-wrapper-width: 6.5rem;
-    --Ribbon-height:  calc(var(--Ribbon-font-size) * 2);
+    .o_kanban_record {
+        --Ribbon-font-size: #{$font-size-sm};
+        --Ribbon-wrapper-width: 6.5rem;
+        --Ribbon-height:  calc(var(--Ribbon-font-size) * 2);
+    }
 
     // ----------------------------------------------------------------------------
 

--- a/addons/web/static/src/views/widgets/ribbon/ribbon.scss
+++ b/addons/web/static/src/views/widgets/ribbon/ribbon.scss
@@ -63,3 +63,7 @@
         }
     }
 }
+
+.modal .modal-dialog .o_form_sheet:has(> .o_widget_web_ribbon) {
+    position: static !important;
+}

--- a/addons/web/static/src/views/widgets/ribbon/ribbon.scss
+++ b/addons/web/static/src/views/widgets/ribbon/ribbon.scss
@@ -39,12 +39,9 @@
     }
 
     &-top-right {
-        --Ribbon-gap-top-default: calc(var(--formView-sheet-padding-y, 0) * -1 - #{$border-width});
-        --Ribbon-gap-right-default: -#{$border-width};
-
         pointer-events: none;
-        margin-top: var(--Ribbon-gap-top, var(--Ribbon-gap-top-default));
-        right: var(--Ribbon-gap-right, var(--Ribbon-gap-right-default));
+        top: 0;
+        right: 0;
 
         & span {
             --Ribbon-top-position-default: calc((var(--Ribbon-height-default) * -1));


### PR DESCRIPTION
[FIX] web,mail: ribbon misplaced in some kanban

This commit sets fixed position and adapts some kanban so the ribbon is
placed correctly.

task-4330690

[FIX] web: ribbon in modal form

This commit adds a CSS specific rule when there is a ribbon in a form's
modal as there is no border when the form is in the modal so the ribbon
seems ugly (pinned not at the top right). So we change the stacking
context to an ancestor DIV.

task-4330690 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
