### PR TITLE
[FIX] payment_razorpay: set mandate amount to subscription total amount

### DIFF
--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -163,9 +163,7 @@ class PaymentTransaction(models.Model):
         pm_max_amount = const.MANDATE_MAX_AMOUNT.get(pm_code, 100000)
         mandate_values = self._get_mandate_values()  # The linked document's values.
         if 'amount' in mandate_values and 'MRR' in mandate_values:
-            max_amount = min(
-                pm_max_amount, max(mandate_values['amount'] * 1.5, mandate_values['MRR'] * 5)
-            )
+            max_amount = min(pm_max_amount, mandate_values['amount'])
         else:
             max_amount = pm_max_amount
         return max_amount


### PR DESCRIPTION
Version:
- 17.0

Steps to reproduce:
- Create Subscription order.
- Activate razorpay from payment provider.
- Try to pay subscription from razorpay UPI.
- Keep save my details options checked.
- It will create a mandate for user.

Issue:
- It is creating mandate which is too larger than actual subscription amount.

Cause:
- The mandate's maximum amount is currently set as the greater of:
  - 1.5 times the total subscription amount, or
  - 5 times the monthly recurring revenue (MRR).

Solution:
- Update the logic to set the maximum mandate amount equal to the total subscription order amount.

task-4373461