### PR TITLE
[FIX] im_livechat: assign operator according to lang

### DIFF
--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -59,7 +59,7 @@ class LivechatChatbotScriptController(http.Controller):
                 user_answer = user_messages.sorted(lambda message: message.id)[-1]
             next_step = discuss_channel.chatbot_current_step_id._process_answer(discuss_channel, user_answer.body)
         elif chatbot_script_id:  # when restarting, we don't have a "current step" -> set "next" as first step of the script
-            chatbot = request.env['chatbot.script'].sudo().browse(chatbot_script_id)
+            chatbot = request.env['chatbot.script'].sudo().browse(chatbot_script_id).with_context(lang=chatbot_language)
             if chatbot.exists():
                 next_step = chatbot.script_step_ids[:1]
 
@@ -106,4 +106,6 @@ class LivechatChatbotScriptController(http.Controller):
         return result
 
     def _get_chatbot_language(self):
-        return request.httprequest.cookies.get('frontend_lang', request.env.user.lang or get_lang(request.env).code)
+        return get_lang(
+            request.env, lang_code=request.httprequest.cookies.get("frontend_lang")
+        ).code

--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -83,7 +83,9 @@ class LivechatController(http.Controller):
         # find the first matching rule for the given country and url
         matching_rule = request.env['im_livechat.channel.rule'].sudo().match_rule(channel_id, url, country_id)
         if matching_rule and (not matching_rule.chatbot_script_id or matching_rule.chatbot_script_id.script_step_ids):
-            frontend_lang = request.httprequest.cookies.get('frontend_lang', request.env.user.lang or 'en_US')
+            frontend_lang = tools.get_lang(
+                request.env, lang_code=request.httprequest.cookies.get("frontend_lang")
+            ).code
             matching_rule = matching_rule.with_context(lang=frontend_lang)
             rule = {
                 'action': matching_rule.action,

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -330,8 +330,7 @@ class ChatbotScriptStep(models.Model):
 
         if discuss_channel.livechat_channel_id:
             human_operator = discuss_channel.livechat_channel_id._get_operator(
-                lang=discuss_channel.livechat_visitor_id.lang_id.code if hasattr(discuss_channel, "livechat_visitor_id") else None,
-                country_id=discuss_channel.country_id.id
+                lang=self.env.context.get("lang"), country_id=discuss_channel.country_id.id
             )
 
         # handle edge case where we found yourself as available operator -> don't do anything

--- a/addons/im_livechat/tests/common.py
+++ b/addons/im_livechat/tests/common.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import HttpCase
+from odoo.tests.common import HttpCase, new_test_user
 
 
 class TestImLivechatCommon(HttpCase):
@@ -43,9 +43,28 @@ class TestImLivechatCommon(HttpCase):
 
     def setUp(self):
         super().setUp()
+        self.operator_id = 0
 
         def _compute_available_operator_ids(channel_self):
             for record in channel_self:
                 record.available_operator_ids = record.user_ids
 
         self.patch(type(self.env['im_livechat.channel']), '_compute_available_operator_ids', _compute_available_operator_ids)
+
+    def _create_operator(self, lang_code=None, country_code=None):
+        self.env["res.lang"].with_context(active_test=False).search(
+            [("code", "=", lang_code)]
+        ).active = True
+        operator = new_test_user(self.env, login=f"operator_{lang_code or country_code}_{self.operator_id}")
+        operator.partner_id = self.env["res.partner"].create(
+            {
+                "name": f"Operator {lang_code or country_code}",
+                "lang": lang_code,
+                "country_id": self.env["res.country"].search([("code", "=", country_code)]).id
+                if country_code
+                else None,
+            }
+        )
+        self.env["bus.presence"].create({"user_id": operator.id, "status": "online"})  # Simulate online status
+        self.operator_id += 1
+        return operator

--- a/addons/im_livechat/tests/test_get_operator.py
+++ b/addons/im_livechat/tests/test_get_operator.py
@@ -1,28 +1,12 @@
 import odoo
 from odoo import Command
-from odoo.tests import HttpCase
-from odoo.tests.common import new_test_user
+from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 
 from unittest.mock import patch
 
 
 @odoo.tests.tagged("-at_install", "post_install")
-class TestGetOperator(HttpCase):
-    def _create_operator(self, lang_code=None, country_code=None):
-        operator = new_test_user(self.env, login=f"operator_{lang_code or country_code}_{self.operator_id}")
-        operator.partner_id = self.env["res.partner"].create(
-            {
-                "name": f"Operator {lang_code or country_code}",
-                "lang": lang_code,
-                "country_id": self.env["res.country"].search([("code", "=", country_code)]).id
-                if country_code
-                else None,
-            }
-        )
-        self.env["bus.presence"].create({"user_id": operator.id, "status": "online"})  # Simulate online status
-        self.operator_id += 1
-        return operator
-
+class TestGetOperator(TestImLivechatCommon):
     def _create_chat(self, livechat, operator, in_call=False):
         channel = self.env["discuss.channel"].create(
             {
@@ -48,9 +32,6 @@ class TestGetOperator(HttpCase):
     def setUp(self):
         super().setUp()
         self.operator_id = 0
-        self.env["res.lang"].with_context(active_test=False).search(
-            [("code", "in", ["fr_FR", "es_ES", "de_DE", "en_US"])]
-        ).write({"active": True})
         random_choice_patch = patch("random.choice", lambda arr: arr[0])
         self.startPatcher(random_choice_patch)
 

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_fw_operator_matching_lang.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_fw_operator_matching_lang.js
@@ -1,0 +1,21 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("chatbot_fw_operator_matching_lang", {
+    test: true,
+    shadow_dom: ".o-livechat-root",
+    steps: () => [
+        {
+            trigger: `.o-mail-Message:contains("Hello! I'm a bot!")`,
+        },
+        {
+            trigger: "li:contains(I want to speak with an operator)",
+            run: "click",
+        },
+        {
+            trigger: ".o-mail-Composer-input:enabled",
+            run: () => {},
+        },
+    ],
+});


### PR DESCRIPTION
Before this PR, the `forward_operator` chat bot step was not taking the user lang into account. It uses the `livechat_visitor_id` field which is not available in im_livechat. It should instead use the lang from the context.

At the same time, this PR fixes an issue when restarting the chat bot: the lang of the first message following a restart is incorrect. It occurs because the lang is not properly propagated.

task-4411088
opw-4341694