### PR TITLE
[FIX] l10n_in: fix traceback when user removes vat and tries to update gst warning

### DIFF
--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -98,7 +98,8 @@ class ResPartner(models.Model):
 
     def action_update_state_as_per_gstin(self):
         self.ensure_one()
-        state_id = self.env['res.country.state'].search([('l10n_in_tin', '=', self.vat[:2])], limit=1)
-        self.state_id = state_id
+        if self.check_vat_in(self.vat):
+            state_id = self.env['res.country.state'].search([('l10n_in_tin', '=', self.vat[:2])], limit=1)
+            self.state_id = state_id
         if self.ref_company_ids:
             self.ref_company_ids._update_l10n_in_fiscal_position()

--- a/addons/l10n_in/tests/test_l10n_in_fiscal_position.py
+++ b/addons/l10n_in/tests/test_l10n_in_fiscal_position.py
@@ -249,3 +249,18 @@ class TestFiscal(AccountTestInvoicingCommon):
                 vendor_bill.fiscal_position_id,
                 self.env['account.chart.template'].ref('fiscal_position_in_export_sez_in')
             )
+
+    def test_l10n_in_company_with_no_vat(self):
+        """
+        Test the company with no VAT and update the partner and company states as per the GSTIN number
+        """
+        company = self.default_company
+
+        company.write({'vat': False})
+        self.assertFalse(company.vat)
+        company.action_update_state_as_per_gstin()
+        self.assertEqual(company.partner_id.state_id, self.env.ref('base.state_in_gj'))
+
+        company.write({'vat': '36AABCT1332L011'})
+        company.action_update_state_as_per_gstin()
+        self.assertEqual(company.state_id, self.env.ref('base.state_in_ts'))


### PR DESCRIPTION
Currently, a traceback is occurring when the user clicks on the update button 
of GST warning after removing the vat.

To reproduce this issue:

1) Install l10n_in
2) Open the Indian company
3) Change the VAT to get the GST warning
4) After getting the GST warning remove the VAT and click the `update it` button

Error:- 
```
TypeError: 'bool' object is not subscriptable
```

On company, VAT is not a required field, so the user can indeed remove it.

When the user removes the vat and clicks on the `update it` button from GST warnings, the `action_update_state_as_per_gstin` method triggers.

https://github.com/odoo/odoo/blob/c96d2b1d1ee917b1c665842010c56c23df91ccd3/addons/l10n_in/models/res_partner.py#L99-L101

From the above method we try to access the vat value. Here in our case, the `VAT` value is False. So it leads to the above traceback.

We can resolve this issue by adding check, which makes the code more robust.

sentry-6151570042

