### PR TITLE
[FIX] iap: handle timeout error while calling JSON-RPC endpoint

### DIFF
--- a/addons/iap/i18n/iap.pot
+++ b/addons/iap/i18n/iap.pot
@@ -148,6 +148,15 @@ msgstr ""
 #: code:addons/iap/tools/iap_tools.py:0
 #, python-format
 msgid ""
+"The request to the service timed out. Please contact the author of the app. "
+"The URL it tried to contact was %s"
+msgstr ""
+
+#. module: iap
+#. odoo-python
+#: code:addons/iap/tools/iap_tools.py:0
+#, python-format
+msgid ""
 "The url that this service requested returned an error. Please contact the "
 "author of the app. The url it tried to contact was %s"
 msgstr ""


### PR DESCRIPTION
Currently, a connection error shows when the ReadTimeout error
occurs when calling the JSON-RPC endpoint in IAP.

This commit will show users a timeout error when a "ReadTimeout"
error is found in the JSON response in the RPC call.

sentry-6059323528


