### PR TITLE
[FIX] sales_team,crm: add contextual kanban_view_ref in newer versions

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -244,7 +244,7 @@
                             <group invisible="type == 'opportunity'">
                                 <field name="user_id"
                                     context="{'default_sales_team_id': team_id}" widget="many2one_avatar_user"/>
-                                <field name="team_id" options="{'no_open': True, 'no_create': True}" kanban_view_ref="%(sales_team.crm_team_view_kanban)s"/>
+                                <field name="team_id" options="{'no_open': True, 'no_create': True}" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
                             </group>
                             <group name="lead_priority" invisible="type == 'opportunity'">
                                 <field name="priority" widget="priority"/>

--- a/addons/crm/wizard/crm_lead_to_opportunity_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_views.xml
@@ -10,7 +10,7 @@
                 </group>
                 <group string="Assign this opportunity to">
                     <field name="user_id" domain="[('share', '=', False)]"/>
-                    <field name="team_id" options="{'no_open': True, 'no_create': True}" kanban_view_ref="%(sales_team.crm_team_view_kanban)s"/>
+                    <field name="team_id" options="{'no_open': True, 'no_create': True}" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
                 </group>
                 <group string="Opportunities" invisible="name != 'merge'">
                     <field name="lead_id" invisible="1"/>

--- a/addons/sales_team/views/res_partner_views.xml
+++ b/addons/sales_team/views/res_partner_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//page[@name='sales_purchases']//field[@name='user_id']" position="after">
                 <field name="team_id" invisible="1"/>
-                <field name="team_id" groups="base.group_no_one" kanban_view_ref="%(sales_team.crm_team_view_kanban)s"/>
+                <field name="team_id" groups="base.group_no_one" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
             </xpath>
             <field name="parent_id" position="attributes">
                 <attribute name="context">{'default_is_company': True, 'show_vat': True, 'default_user_id': user_id, 'default_team_id': team_id}</attribute>


### PR DESCRIPTION
**Current behavior:**
On the Mobile view, when modifying the Sales Team field of a Partner (team_id field), an error is raised: "Undefined graph model for Sales Team:".

**Expected behavior:**
The user should be able to modify the Sales Team field of a Partner without any error.

**Steps to reproduce:**
1. Install the `sales_team` & `contacts` modules.
2. Create a new Partner.
3. Go to the Mobile view.
4. Click on the Sales Team field and select a Sales Team.
5. The error is immediately raised.

**Cause of the issue:**
The `kanban_view_ref="%(sales_team.crm_team_view_kanban)s"` added to the `team_id` field is not applied, as `kanban_view_ref=` has become deprecated. The kanban view `sales_team.crm_team_view_kanban_dashboard` is loaded instead as it has a lower priority.

**Fix:**
- Use `context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}` instead of `kanban_view_ref="%(sales_team.crm_team_view_kanban)s"`.
- The two remaining `kanban_view_ref=` from crm are modified here.

opw-4413594
Related PRs: #116031, #126044

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
