### PR TITLE
[FIX] web: display correctly purchase report

### DIFF
--- a/addons/purchase_stock/report/purchase_report_templates.xml
+++ b/addons/purchase_stock/report/purchase_report_templates.xml
@@ -38,14 +38,11 @@
             </t>
         </xpath>
         <xpath expr="//span[@t-field='o.name']/.." position="after">
-            <div id="informations" class="row mt16 mb16">
-                <div t-if="o.incoterm_id" class="col-3 bm-2">
-                    <strong>Incoterm:</strong>
-                    <p t-if="o.incoterm_location">
-                        <span t-field="o.incoterm_id.code"/> <br/>
-                        <span t-field="o.incoterm_location"/>
-                    </p>
-                    <p t-else="" t-field="o.incoterm_id.code" class="m-0"/>
+            <div id="informations" class="row mt2 mb16">
+                <div t-if="o.incoterm_id" class="col-3 bm-2" style="font-size: 20px;">
+                <strong>Incoterm:</strong>
+                <span t-field="o.incoterm_id.code"/>
+                <span t-if="o.incoterm_location" t-field="o.incoterm_location"/>
                 </div>
             </div>
         </xpath>


### PR DESCRIPTION
Steps to reproduce:
------------------
 - Go to settings
 - Change the Document Layout to folder
 - Go to purchase
 - Print a RFQ or a PO

Issue:
------

Currently the display of the folder wants the layout_document_title to fit in the upper right corner, which is not always possible especially in the purchase. This leads to the title being malformed. However this fix will also changes other apps display for this layout.

Fix:
----

The fix replace the ```html <h2 t-out="layout_document_title"/> ``` where it is in every other layout. This fix the issue and does not break other apps display.

opw-4380886



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
