### PR TITLE
[FIX] account: correct overdue filter search

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1600,7 +1600,7 @@
                     <filter name="late" string="Overdue" domain="[
                         ('invoice_date_due', '&lt;', time.strftime('%Y-%m-%d')),
                         ('state', '=', 'posted'),
-                        ('payment_state', 'in', ('not_paid', 'partial', 'in_payment'))
+                        ('payment_state', 'in', ('not_paid', 'partial'))
                     ]" help="Overdue invoices, maturity date passed"/>
                     <separator/>
                     <filter name="invoice_date" string="Invoice Date" date="invoice_date"/>


### PR DESCRIPTION
Steps to reproduce:
------------------

- Go to invoices
- filters on "Overdue"
- Filter includes "in_payment"

Issue:
-----

This is not intended, the overdue filter should only include the not paid and partial.

Fix:
---

Removed it.

opw-4383117

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
