### PR TITLE
[FIX] web_editor, *: remove double unnecessary slashes in tel protocol

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -10,6 +10,7 @@ import unicodedata
 import werkzeug.exceptions
 import werkzeug.routing
 import werkzeug.urls
+import urllib.parse
 from werkzeug.exceptions import HTTPException, NotFound
 
 # optional python-slugify import (https://github.com/un33k/python-slugify)
@@ -142,9 +143,9 @@ def url_lang(path_or_uri, lang_code=None):
     location = pycompat.to_text(path_or_uri).strip()
     force_lang = lang_code is not None
     try:
-        url = werkzeug.urls.url_parse(location)
+        url = urllib.parse.urlparse(location)
     except ValueError:
-        # e.g. Invalid IPv6 URL, `werkzeug.urls.url_parse('http://]')`
+        # e.g. Invalid IPv6 URL, `urllib.parse.urlparse('http://]')`
         url = False
     # relative URL with either a path or a force_lang
     if url and not url.netloc and not url.scheme and (url.path or force_lang):

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
@@ -122,7 +122,7 @@ export function deduceURLfromText(text, link) {
    // Check for telephone url.
    match = label.match(PHONE_REGEX);
    if (match) {
-        return (match[1] ? match[0] : "tel://" + match[0]).replace(/\s+/g, "");
+        return (match[1] ? match[0] : "tel:" + match[0]).replace(/\s+/g, "");
    }
    return null;
 }

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -245,11 +245,16 @@ export class Link extends Component {
      * @private
      */
     _correctLink(url) {
-        if (url.indexOf('tel:') === 0) {
-            url = url.replace(/^tel:([0-9]+)$/, 'tel://$1');
-        } else if (url && !url.startsWith('mailto:') && url.indexOf('://') === -1
-                    && url[0] !== '/' && url[0] !== '#' && url.slice(0, 2) !== '${') {
-            url = 'http://' + url;
+        if (
+            url &&
+            !url.startsWith("tel:") &&
+            !url.startsWith("mailto:") &&
+            !url.includes("://") &&
+            !url.startsWith("/") &&
+            !url.startsWith("#") &&
+            !url.startsWith("${")
+        ) {
+            url = "http://" + url;
         }
         return url;
     }


### PR DESCRIPTION
*: http_routing

Since [1], the tel:// format was preferred over tel: due to reasons stated in [2]. However, the change in [2] was a workaround for a bug in the Python library used to parse URLs. According to the relevant RFC, the tel: protocol should not include double slashes.

When clicking on a link like `tel://+112351221233` in a browser, a popup may appear attempting to handle the communication using `http://tel//+112351221233` as the browser does not recognize the tel protocol when double slashes are included.

![image](https://github.com/user-attachments/assets/439daa46-d0d7-4ae7-8ad6-830bced02dad)

![image](https://github.com/user-attachments/assets/11b1be76-289b-4013-8115-fb518c314509)


This commit removes the unnecessary double slashes to comply with RFC recommendations and just add a trailing white space to be sure that the
url_parse method from werkzeug works properly.

[1]: https://github.com/odoo/odoo/commit/6d4a3b3ab5c0f3361d1d681d05b974e295dcbabe
[2]: https://github.com/odoo/odoo/commit/56ce29e71f75a657d4b518d86c1d7084891e898e

task-4331070
