### PR TITLE
[FIX] hr_attendance: kiosk images out of box

### DIFF
--- a/addons/hr_attendance/static/src/components/greetings/greetings.xml
+++ b/addons/hr_attendance/static/src/components/greetings/greetings.xml
@@ -2,9 +2,11 @@
 <templates xml:space="preserve">
     <t t-name="hr_attendance.public_kiosk_greetings">
         <t t-if="this.attendance">
-            <t t-call="hr_attendance.EmployeeBadge">
-                <t t-set="employeeAvatar" t-value="this.employeeAvatar"/>
-            </t>
+            <div class="position-relative" style="margin: 15px;">
+                <t t-call="hr_attendance.EmployeeBadge">
+                    <t t-set="employeeAvatar" t-value="this.employeeAvatar"/>
+                </t>
+            </div>
             <div t-if="attendance.check_out" class="flex-grow-1">
                 <h1 class="mt-5">Goodbye <t t-esc="this.employeeName"/>!</h1>
                 <div class="alert alert-info fs-2 mx-3" role="status">

--- a/addons/hr_attendance/static/src/components/manual_selection/manual_selection.xml
+++ b/addons/hr_attendance/static/src/components/manual_selection/manual_selection.xml
@@ -17,9 +17,9 @@
     </t>
     <t t-name="hr_attendance.public_kiosk_manual_selection">
         <t t-if="!this.props.displayBackButton">
-            <button t-on-click="() => this.props.onClickBack()" class="o_hr_attendance_back_button o_hr_attendance_back_button_md btn btn-secondary d-none d-md-inline-flex align-items-center position-absolute top-0 start-0 rounded-circle">
-            <i class="oi fa-2x fa-fw oi-chevron-left me-1" role="img" aria-label="Go back" title="Go back"/>
-        </button>
+            <button t-on-click="() => this.props.onClickBack()" class="o_hr_attendance_back_button o_hr_attendance_back_button_md btn btn-secondary d-none d-md-inline-flex align-items-center position-absolute top-0 start-0 rounded-circle" style="margin-left: 50px; margin-top: 50px;">
+                <i class="oi fa-2x fa-fw oi-chevron-left me-1" role="img" aria-label="Go back" title="Go back"/>
+            </button>
         </t>
             <div class="o_kanban_view o_view_controller o_action">
                 <div class="o_control_panel d-flex flex-column gap-3 gap-lg-1 px-3 pt-2 pb-3" style="top: 0px;">


### PR DESCRIPTION
Issue:
When using the kiosk in versions 17.0 & 17.2, 2 visual issues arise:
- when trying to identify manually, the "Go back" arrow is cropped out of its' container
- when identified, the user's profile picture is cropped out of the greeting container

Steps to reproduce:
- Install the attendance module
- Go to Kiosk Mode
- Identify Manually

Cause:
For the "Go back arrow", its' position in the container is set to the top left corner (absolute 0;0). The problem is that these coordinates are set for the center of the button and not its' top-left end. For the profile pictures, they are displayed through "t" fields without any specific container. They thus have no styling/margination.

Since the overall style has already been revamped in 17.4, a simple "bandaid" fix should do.

Ticket:
opw-4366047
