### PR TITLE
[FIX] mail: adapt convert_inline tests for community build

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.scss
+++ b/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.scss
@@ -37,7 +37,7 @@ $embedded-toc-bg--active: #1ba1e4;
 }
 
 .o_field_html {
-    .note-editable,
+    .odoo-editor-editable,
     .o_readonly {
         h1, h2, h3, h4, h5, h6 {
             transition: background-color 0.5s ease;

--- a/addons/mail/static/src/views/web/fields/html_mail_field/html_mail_field.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/html_mail_field.js
@@ -17,7 +17,7 @@ export class HtmlMailField extends HtmlField {
         }
         const cssRules = cssRulesByElement.get(editor.editable);
         // Insert the cloned element inside an DOM so we can get its computed style.
-        document.body.append(el);
+        editor.editable.after(el);
         el.classList.remove("odoo-editor-editable");
         await toInline(el, cssRules);
         el.remove();

--- a/addons/mail/static/tests/inline/html_mail_field.test.js
+++ b/addons/mail/static/tests/inline/html_mail_field.test.js
@@ -1,7 +1,7 @@
 import { setSelection } from "@html_editor/../tests/_helpers/selection";
 import { insertText } from "@html_editor/../tests/_helpers/user_actions";
 import { HtmlMailField } from "@mail/views/web/fields/html_mail_field/html_mail_field";
-import { beforeEach, expect, test } from "@odoo/hoot";
+import { after, before, beforeEach, expect, test } from "@odoo/hoot";
 import { press, queryOne } from "@odoo/hoot-dom";
 import {
     contains,
@@ -19,6 +19,19 @@ function setSelectionInHtmlField(selector = "p", fieldName = "body") {
     const anchorNode = queryOne(`[name='${fieldName}'] .odoo-editor-editable ${selector}`);
     setSelection({ anchorNode, anchorOffset: 0 });
     return anchorNode;
+}
+
+function useCustomStyleRules(rules = "") {
+    let style;
+    before(() => {
+        style = document.createElement("STYLE");
+        style.type = "text/css";
+        style.append(document.createTextNode(rules));
+        document.head.append(style);
+    });
+    after(() => {
+        style.remove();
+    });
 }
 
 class CustomMessage extends models.Model {
@@ -52,9 +65,10 @@ beforeEach(() => {
 });
 
 test("HtmlMail save inline html", async function () {
+    useCustomStyleRules(`.test-h1-inline .note-editable h1 { color: #111827 !important; }`);
     onRpc("web_save", ({ args }) => {
-        expect(args[1].body.replace(/font-size: (\d+(\.\d+)?)px/, "font-size: []px")).toBe(
-            `<h1 style="margin: 0px 0px 8px; box-sizing: border-box; font-size: []px; color: #111827; line-height: 1.2; font-weight: 500; font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Ubuntu, 'Noto Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';">first</h1>`
+        expect(args[1].body.replace(/font-size: ?(\d+(\.\d+)?)px/, "font-size: []px")).toBe(
+            `<h1 style="margin:0px 0 8px 0;box-sizing:border-box;font-size: []px;color:#111827;line-height:1.2;font-weight:500;font-family:'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Ubuntu, 'Noto Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';">first</h1>`
         );
         expect.step("web_save");
     });
@@ -64,7 +78,7 @@ test("HtmlMail save inline html", async function () {
         resModel: "custom.message",
         arch: `
         <form>
-            <field name="body" widget="html_mail"/>
+            <field name="body" widget="html_mail" class="test-h1-inline"/>
         </form>`,
     });
     setSelectionInHtmlField();
@@ -97,8 +111,14 @@ test("HtmlMail don't have access to column commands", async function () {
 });
 
 test("HtmlMail add icon and save inline html", async function () {
+    useCustomStyleRules(
+        `.test-icon-inline .note-editable .fa {
+            color: rgb(55,65,81) !important;
+            background-color: rgb(249,250,251) !important;
+        }`
+    );
     onRpc("web_save", ({ args }) => {
-        expect(args[1].body.replace(/font-size: (\d+(\.\d+)?)px/, "font-size: []px")).toBe(
+        expect(args[1].body).toBe(
             `<p style="margin:0px 0 16px 0;box-sizing:border-box;"><span style="display: inline-block; width: 14px; height: 14px; vertical-align: text-bottom;" class="oe_unbreakable "><img width="14" height="14" src="/web_editor/font_to_img/61440/rgb(55%2C65%2C81)/rgb(249%2C250%2C251)/14x14" data-class="fa fa-glass" data-style="null" style="box-sizing: border-box; line-height: 14px; width: 14px; height: 14px; vertical-align: unset; margin: 0px;"></span>first</p>`
         );
         expect.step("web_save");
@@ -109,7 +129,7 @@ test("HtmlMail add icon and save inline html", async function () {
         resModel: "custom.message",
         arch: `
         <form>
-            <field name="body" widget="html_mail"/>
+            <field name="body" widget="html_mail" class="test-icon-inline"/>
         </form>`,
     });
     setSelectionInHtmlField();


### PR DESCRIPTION
Tests introduced with [commit] were failing on community builds because the style sheets have slight variations.

This commit also specifies the DOM position of the cloned editable for style extraction. Instead of adding it blindly to the `body`, it is added as a sibling of the original `editable` element, which will provide a more accurate style context.

[commit]: https://github.com/odoo/odoo/commit/1d709e8858ffdd86e79056c0f3a992e4410e127e

Runbot tasks:
110278, 110279

task-4414541
