### PR TITLE
[REF] web_tour: decrease default checkDelay value to 200ms

### DIFF
--- a/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
@@ -90,6 +90,7 @@ const registerSteps = [
     {
         content: "Fill attendees details",
         trigger: '.modal form[id="attendee_registration"] .btn[type=submit]',
+        run: "hover",
     },
     {
         trigger: ".modal input[name*='1-name']",

--- a/addons/test_website_modules/static/tests/tours/configurator_flow.js
+++ b/addons/test_website_modules/static/tests/tours/configurator_flow.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { queryAll } from "@odoo/hoot-dom";
+import { delay } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('configurator_flow', {
@@ -89,25 +89,35 @@ registry.category("web_tour.tours").add('configurator_flow', {
     }, {
         content: "check menu and footer links are correct",
         trigger: 'body:not(.editor_enable)', // edit mode left
-        run: function () {
-            for (const menu of ['Home', 'Events', 'Courses', 'Pricing', 'News', 'Success Stories', 'Contact us']) {
-                const check = queryAll(`:iframe .top_menu a:contains(${menu})`).length;
-                if (!check) {
-                    console.error(`Missing ${menu} menu. It should have been created by the configurator.`);
-                }
-            }
-            for (const url of ['/', '/event', '/slides', '/pricing', '/blog/', '/blog/', '/contactus']) {
-                const check = queryAll(`:iframe .top_menu a[href^='${url}']`).length;
-                if (!check) {
-                    console.error(`Missing ${url} menu URL. It should have been created by the configurator.`);
-                }
-            }
-            for (const link of ['Privacy Policy', 'Contact us']) {
-                const check = queryAll(`:iframe #footer ul a:contains(${link})`).length;
-                if (!check) {
-                    console.error(`Missing ${link} footer link. It should have been created by the configurator.`);
-                }
-            }
-        },
     },
-]});
+        {
+            content: "Check footer Contact Us link is there",
+            trigger: ":iframe #footer ul a:contains(Contact us)",
+        },
+        {
+            content: "Check footer Privacy Policy link is there",
+            trigger: ":iframe #footer ul a:contains(Privacy Policy)",
+        },
+        ...["Home", "Events", "Courses", "Pricing", "News", "Success Stories", "Contact us"].map(
+            (menu) => {
+                return {
+                    content: `Check menu ${menu} is there`,
+                    trigger: `:iframe .top_menu a:contains(${menu}):not(:visible)`,
+                };
+            }
+        ),
+        ...["/", "/event", "/slides", "/pricing", "/blog/", "/blog/", "/contactus"].map((url) => {
+            return {
+                content: `Check url ${url} is there`,
+                trigger: `:iframe .top_menu a[href^='${url}']:not(:visible)`,
+            };
+        }),
+        {
+            trigger: ":iframe h1:contains(your journey starts here)",
+            async run() {
+                //Wait assets are loaded
+                await delay(1000);
+            },
+        },
+    ],
+});

--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -5,6 +5,7 @@ import { Macro } from "@web/core/macro";
 import { browser } from "@web/core/browser/browser";
 import { setupEventActions } from "@web/../lib/hoot-dom/helpers/events";
 import * as hoot from "@odoo/hoot-dom";
+import { patch } from "@web/core/utils/patch";
 
 export class TourAutomatic {
     mode = "auto";
@@ -102,6 +103,11 @@ export class TourAutomatic {
             });
 
         const end = () => {
+            //Tour is finished, it's too late to console.
+            patch(console, {
+                error: () => {},
+                warn: () => {},
+            });
             delete window.hoot;
             transitionConfig.disabled = false;
             tourState.clear();
@@ -113,7 +119,7 @@ export class TourAutomatic {
 
         this.macro = new Macro({
             name: this.name,
-            checkDelay: this.checkDelay || 300,
+            checkDelay: this.checkDelay || 200,
             steps: macroSteps,
             onError: (error) => {
                 this.throwError([error]);

--- a/addons/website/static/tests/tours/parallax.js
+++ b/addons/website/static/tests/tours/parallax.js
@@ -14,6 +14,7 @@ const coverSnippet = {id: "s_cover", name: "Cover", groupName: "Intro"};
 registerWebsitePreviewTour("test_parallax", {
     url: "/",
     edition: true,
+    checkDelay: 500,
 }, () => [
     ...insertSnippet(coverSnippet),
     ...clickOnSnippet(coverSnippet),

--- a/addons/website_event_sale/static/tests/tours/website_event_sale.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale.js
@@ -42,7 +42,8 @@ registry.category("web_tour.tours").add("event_buy_tickets", {
         },
         {
             content: "Fill attendees details",
-            trigger: 'form[id="attendee_registration"] .btn[type=submit]',
+            trigger: '.modal form[id="attendee_registration"] .btn[type=submit]',
+            run: "hover",
         },
         {
             trigger: ".modal#modal_attendees_registration input[name*='1-email']",

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
@@ -23,8 +23,8 @@ registry.category("web_tour.tours").add("event_sale_pricelists_different_currenc
             run: "click",
         },
         {
-            trigger:
-                '.modal#modal_attendees_registration:not(.o_inactive_modal) form[id="attendee_registration"]',
+            trigger: '.modal form[id="attendee_registration"] .btn[type=submit]',
+            run: "hover",
         },
         {
             trigger:

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -61,13 +61,17 @@ registerBackendAndFrontendTour("question", {
     content: _t("Click to post your question."),
     tooltipPosition: "bottom",
     run: "click",
-}, {
+},
+{
+    trigger: ".o_wforum_content_wrapper h3:contains(test)",
+},
+{
     isActive: ["auto"],
     trigger: ".modal .modal-header button.btn-close",
     run: "click",
 },
 {
-    trigger: "a:contains(\"Reply\").collapsed",
+    trigger: "a:contains(Reply).collapsed",
     content: _t("Click to reply."),
     tooltipPosition: "bottom",
     run: "click",
@@ -87,9 +91,13 @@ registerBackendAndFrontendTour("question", {
     content: _t("Click to post your answer."),
     tooltipPosition: "bottom",
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_wforum_content_wrapper h3:contains(test)",
+},
+{
     isActive: ["auto"],
-    trigger: ".modal .modal-header button.btn-close",
+    trigger: ".modal:contains(thanks for posting!) .modal-header button.btn-close",
     run: "click",
 }, {
     trigger: ".o_wforum_validate_toggler[data-karma]:first",

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -46,8 +46,11 @@ registry.category("web_tour.tours").add('forum_question', {
         trigger: '#wrap:has(.fa-star)',
     },
     {
+        trigger: ".o_wforum_question:contains(marc demo)",
+    },
+    {
         content: "Close modal once modal animation is done.",
-        trigger: ".modal .modal-header button.btn-close",
+        trigger: ".modal:contains(thanks for posting!) .modal-header button.btn-close",
         run: "click",
     },
     {


### PR DESCRIPTION
In macro.js, we check at each mutation of the DOM if the trigger is
present as soon as there has been no more mutation in the {checkDelay}
milliseconds. By default, this {checkDelay} is at 300ms in the
tourAutomatic class. In this commit, this default value is descreased
to 200ms for performance reasons.