### PR TITLE
[IMP] event: clarify the Timezone field name and tooltips

### DIFF
--- a/addons/event/i18n/event.pot
+++ b/addons/event/i18n/event.pot
@@ -1998,6 +1998,13 @@ msgid "In Progress"
 msgstr ""
 
 #. module: event
+#: model:ir.model.fields,help:event.field_event_event__date_tz
+msgid ""
+"Indicates the timezone in which the event dates/times will be displayed on "
+"the website."
+msgstr ""
+
+#. module: event
 #: model:ir.model.fields,field_description:event.field_event_mail__interval_nbr
 #: model:ir.model.fields,field_description:event.field_event_type_mail__interval_nbr
 msgid "Interval"
@@ -3374,6 +3381,14 @@ msgstr ""
 #: model:ir.model.fields.selection,name:event.selection__event_mail__interval_unit__weeks
 #: model:ir.model.fields.selection,name:event.selection__event_type_mail__interval_unit__weeks
 msgid "Weeks"
+msgstr ""
+
+#. module: event
+#: model:ir.model.fields,help:event.field_event_event__date_begin
+#: model:ir.model.fields,help:event.field_event_registration__event_begin_date
+msgid ""
+"When the event is scheduled to take place (expressed in your local timezone "
+"on the form view)."
 msgstr ""
 
 #. module: event

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -194,9 +194,11 @@ class EventEvent(models.Model):
 
     # Date fields
     date_tz = fields.Selection(
-        _tz_get, string='Timezone', required=True,
-        compute='_compute_date_tz', precompute=True, readonly=False, store=True)
-    date_begin = fields.Datetime(string='Start Date', required=True, tracking=True)
+        _tz_get, string='Display Timezone', required=True,
+        compute='_compute_date_tz', precompute=True, readonly=False, store=True,
+        help="Indicates the timezone in which the event dates/times will be displayed on the website.")
+    date_begin = fields.Datetime(string='Start Date', required=True, tracking=True,
+        help="When the event is scheduled to take place (expressed in your local timezone on the form view).")
     date_end = fields.Datetime(string='End Date', required=True, tracking=True)
     date_begin_located = fields.Char(string='Start Date Located', compute='_compute_date_begin_tz')
     date_end_located = fields.Char(string='End Date Located', compute='_compute_date_end_tz')


### PR DESCRIPTION
### Issue:

The current descriptions and naming of the `Date` fields (`date_begin`, `date_end`) and the `Timezone` field (`date_tz`) can be confusing in the form view of the event model. Specifically:

The timezone used for converting the form dates to the database is determined by the context and not by the `Timezone` field present on the form. However, this `Timezone` field determines the timezone used for displaying the event's date/time on the website. This change tries to clarify the situation.

opw-4323142
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
