### PR TITLE
[IMP] point_of_sale: add invoicing emails in receipt screen

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -16,6 +16,7 @@
         'data/digest_data.xml',
         'data/pos_note_data.xml',
         'data/point_of_sale_tour.xml',
+        'data/mail_template_data.xml',
         'wizard/pos_details.xml',
         'wizard/pos_payment.xml',
         'wizard/pos_close_session_wizard.xml',

--- a/addons/point_of_sale/data/mail_template_data.xml
+++ b/addons/point_of_sale/data/mail_template_data.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="email_template_pos_receipt" model="mail.template">
+            <field name="name">Point of Sale: Receipt</field>
+            <field name="description">Sent to customers with the receipt in attachment</field>
+            <field name="model_id" ref="point_of_sale.model_pos_order"/>
+            <field name="subject">Your {{ object.config_id.name }} receipt</field>
+            <field name="email_from">{{ (object.company_id.email_formatted or object.user_id.email_formatted)}}</field>
+            <field name="email_to" eval="False"/>
+            <field name="partner_to" eval="False"/>
+             <field name="use_default_to" eval="False"/>
+            <field name="lang">{{ object.partner_id.lang or user.lang }}</field>
+            <field name="auto_delete" eval="False"/>
+            <field name="body_html" type="html">
+                <div style="margin: 0; padding: 0; font-size: 14px;">
+                    <t t-set="client_name" t-value="object.partner_id.name"/>
+                    <t t-set="store_name" t-value="object.config_id.name"/>
+                    <t t-set="tz" t-value="object.env.user.tz"/>
+                    <t t-set="lg" t-value="object.partner_id.lang or user.lang"/>
+                    <div>
+                        <t t-if="client_name">Hello <t t-out="client_name">Client name</t>,</t>
+                        <t t-else="">Hello,</t>
+                    </div>
+                    <br/>
+                    <div>Thank you for purchasing from <t t-out="store_name">Store name</t>!</div>
+                    <div>Attached, you will find your receipt for the purchase of <span><t
+                            t-out="format_datetime(dt=object.date_order, tz=tz, dt_format=&quot;EEEE d MMMM&quot;,
+                         lang_code=lg) or ''">date</t> <t t-out="format_time(time=object.date_order, tz=tz, time_format='short',
+                         lang_code=lg)">time</t>.</span>
+                    </div>
+                    <br/>
+                    <div>With kind regards,</div>
+                    <br/>
+                    <t t-out="store_name">Store name</t>
+                </div>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1194,49 +1194,53 @@ class PosOrder(models.Model):
             'target': 'new'
         }
 
-    def _add_mail_attachment(self, name, ticket, basic_ticket):
-        attachment = []
-        filename = 'Receipt-' + name + '.jpg'
+    def action_send_receipt(self, email, ticket_image, basic_image):
+        self.ensure_one()
+        self.email = email
+        mail_template_id = 'point_of_sale.email_template_pos_receipt'
+        mail_template = self.env.ref(mail_template_id, raise_if_not_found=False)
+        if not mail_template:
+            raise UserError(_("The mail template with xmlid %s has been deleted.", mail_template_id))
+        mail_template.send_mail(self.id, force_send=True, email_values={'email_to': email,
+                                                                        'attachment_ids': self._get_mail_attachments(self.name, ticket_image, basic_image)})
+
+    def _get_mail_attachments(self, name, ticket, basic_ticket):
+        attachments = []
         receipt = self.env['ir.attachment'].create({
-            'name': filename,
+            'name': 'Receipt-' + name + '.jpg',
             'type': 'binary',
             'datas': ticket,
             'res_model': 'pos.order',
             'res_id': self.ids[0],
             'mimetype': 'image/jpeg',
         })
-        attachment += [(4, receipt.id)]
+        attachments += [(4, receipt.id)]
+
         if basic_ticket:
-            filename = 'Receipt-' + name + '-1' + '.jpg'
             basic_receipt = self.env['ir.attachment'].create({
-                'name': filename,
+                'name': 'Receipt-' + name + '-1' + '.jpg',
                 'type': 'binary',
                 'datas': basic_ticket,
                 'res_model': 'pos.order',
                 'res_id': self.ids[0],
                 'mimetype': 'image/jpeg',
             })
-            attachment += [(4, basic_receipt.id)]
-
+            attachments += [(4, basic_receipt.id)]
 
         if self.mapped('account_move'):
             report = self.env['ir.actions.report']._render_qweb_pdf("account.account_invoices", self.account_move.ids[0])
-            filename = name + '.pdf'
             invoice = self.env['ir.attachment'].create({
-                'name': filename,
+                'name': name + '.pdf',
                 'type': 'binary',
                 'datas': base64.b64encode(report[0]),
                 'res_model': 'pos.order',
                 'res_id': self.ids[0],
-                'mimetype': 'application/x-pdf'
+                'mimetype': 'application/pdf'
             })
-            attachment += [(4, invoice.id)]
+            attachments += [(4, invoice.id)]
 
-        return attachment
+        return attachments
 
-    def action_send_receipt(self, email, ticket_image, basic_image):
-        self.env['mail.mail'].sudo().create(self._prepare_mail_values(email, ticket_image, basic_image)).send()
-        self.email = email
 
     @api.model
     def remove_from_ui(self, server_ids):

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -22,8 +22,9 @@ export class ReceiptScreen extends Component {
         this.dialog = useService("dialog");
         this.currentOrder = this.pos.getOrder();
         const partner = this.currentOrder.getPartner();
+        const email = partner?.invoice_emails || partner?.email || "";
         this.state = useState({
-            email: partner?.email || "",
+            email: email,
             phone: partner?.mobile || "",
         });
         this.sendReceipt = useTrackedAsync(this._sendReceiptToCustomer.bind(this));

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
@@ -29,7 +29,7 @@
                                 </div>
                                 <div class="d-flex flex-column gap-2">
                                     <div class="d-flex">
-                                        <input type="text" class="flex-grow-1 border p-3 bg-view pe-5 border-end-0 rounded-start-2 position-relative send-receipt-email-input" t-attf-placeholder="e.g. john.doe@mail.com" t-model="state.email" />
+                                        <input type="text" class="flex-grow-1 border p-3 bg-view border-end-0 rounded-start-2 position-relative send-receipt-email-input" t-attf-placeholder="e.g. john.doe@mail.com" t-model="state.email" />
                                         <div>
                                             <button t-att-style="`width: ${this.ui.isSmall ? '4rem' : '8rem'}`" class="btn btn-primary btn-lg lh-lg rounded-start-0 h-100" t-att-disabled="!isValidEmail" t-on-click="() => this.actionSendReceiptOnEmail()">
                                                 <i t-attf-class="fa {{sendReceipt.status === 'loading' and sendReceipt.lastArgs?.[0]?.name === 'Email' ? 'fa-fw fa-spin fa-circle-o-notch' : 'fa-paper-plane'}}" />
@@ -44,7 +44,9 @@
                                 <div class="notice text-center">
                                     <t t-set="usedMethod" t-value="sendReceipt.lastArgs?.[0]?.name" />
                                     <div t-if="sendReceipt.status === 'loading'" class="text-info">Sending <t t-esc="usedMethod"/> in progress</div>
-                                    <div t-if="sendReceipt.status === 'success'" class="text-success"><t t-esc="usedMethod"/> is sent successfully</div>
+                                    <div t-if="sendReceipt.status === 'success'" class="text-success">
+                                        <t t-if="this.currentOrder.is_invoiced">Receipt and invoice sent successfully</t>
+                                        <t t-else="">Receipt sent successfully</t></div>
                                     <div t-if="sendReceipt.status === 'error'" class="text-danger">Sending <t t-esc="usedMethod"/> failed. Please try again</div>
                                 </div>
                             </div>


### PR DESCRIPTION
The default customer email isn’t always the correct address for sending receipts.
To ensure they reach the right recipient, customer contact emails marked as ‘invoice address’ are now automatically added as recipients in the receipt screen.
Additionally, a new email template for sending receipts has been added.

task-4398274
