### PR TITLE
[FIX] website: restore tooltips (+ translations) on website switcher

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-02-06 13:31+0000\n"
-"PO-Revision-Date: 2024-11-19 13:50+0000\n"
+"PO-Revision-Date: 2024-12-17 14:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -9644,6 +9644,7 @@ msgstr ""
 #. module: website
 #. odoo-javascript
 #: code:addons/website/static/src/systray_items/website_switcher.xml:0
+#: code:addons/website/static/src/systray_items/website_switcher.js:0
 #, python-format
 msgid "This website does not have a domain configured."
 msgstr ""

--- a/addons/website/static/src/systray_items/website_switcher.js
+++ b/addons/website/static/src/systray_items/website_switcher.js
@@ -24,7 +24,7 @@ export class WebsiteSwitcherSystray extends Component {
             dataset: Object.assign({
                 websiteId: website.id,
             }, website.domain ? {} : {
-                tooltipValue: this.env._t('This website does not have a domain configured'),
+                tooltip: this.env._t('This website does not have a domain configured.'),
                 tooltipPosition: 'left',
             }),
             callback: () => {


### PR DESCRIPTION
Commit [1] broke the tooltip about domain configuration on the website switcher. They just did not appear ever anymore.

At the same time, it moved a translatable term from XML to JS, which apparently works without losing translations... but it also changed the actual term by removing the "." at the end, losing the translations. This commit also restore that ".", making existing translations work again automatically, and it also patches the ".pot" to notify about the translatable term move.

[1]: https://github.com/odoo/odoo/commit/dbd2f89b4fe88488d3b02e475fae6ac8878694ae
