### PR TITLE
[FIX] l10n_lb_account: Avoid warning demo data Liban

### DIFF
--- a/addons/l10n_lb_account/demo/demo_company.xml
+++ b/addons/l10n_lb_account/demo/demo_company.xml
@@ -38,5 +38,6 @@
         <value eval="[]" />
         <value>lb</value>
         <value model="res.company" eval="obj().env.ref('l10n_lb_account.demo_company_lb')" />
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>


### PR DESCRIPTION
The install_demo is missing from the try_loading of the Libanese demo company.

runbot-109449




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
