### PR TITLE
[FIX] l10n_ch: force report paper format with snailmail

### DIFF
--- a/addons/l10n_ch/models/ir_actions_report.py
+++ b/addons/l10n_ch/models/ir_actions_report.py
@@ -103,3 +103,11 @@ class IrActionsReport(models.Model):
                 invoice_stream.close()
                 additional_stream['stream'].close()
         return res
+
+    def get_paperformat(self):
+        if self.env.context.get('snailmail_layout'):
+            if self.report_name == 'l10n_ch.qr_report_main':
+                return self.env.ref('l10n_ch.paperformat_euro_no_margin')
+            if self.report_name == 'l10n_ch.qr_report_header':
+                return self.env.ref('l10n_din5008.paperformat_euro_din')
+        return super(IrActionsReport, self).get_paperformat()


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_ch" and switch to "CH company"
- Create a new invoice with a Swiss partner and confirm
- Click "Send & Print" and select "Send by Post", confirm
- Go in Setting > technical > Email > Snailmail Letters and find your invoice
- Download the PDF document
- The QR code and several other information are missing

### Cause:
The snailmail module is setting specific paper format (base.paperformat_euro) when generating the PDF. 

https://github.com/odoo/odoo/blob/ce92dedea0fd3cdc73da6366c20b8052bb04f7e9/addons/snailmail/models/ir_actions_report.py#L17-L24

But the Swiss reports have their own formats to display the QR code correctly. So the generated PDF have its QR code on another page that is lost when merging the PDF for the header and the one with the QR code.

### Solution:
Force the paper format for the two "IrActionReports" responsible for the page with the Qr-code.

opw-4399150