### PR TITLE
[FIX] hw_drivers: compatibility between v18.1 images and <=v18 db

### DIFF
--- a/addons/iot_box_image/build_image.sh
+++ b/addons/iot_box_image/build_image.sh
@@ -65,6 +65,7 @@ if [ ! -d $CLONE_DIR ]; then
     echo "addons/web
 addons/hw_*
 addons/iot_box_image/configuration
+addons/point_of_sale/tools/posbox/configuration
 odoo/
 odoo-bin" | tee --append .git/info/sparse-checkout > /dev/null
     git read-tree -mu HEAD

--- a/addons/iot_box_image/configuration/checkout.sh
+++ b/addons/iot_box_image/configuration/checkout.sh
@@ -10,21 +10,19 @@ if [[ "$(git remote get-url "$localremote")" != *odoo/odoo* ]]; then
     git remote set-url "${localremote}" "https://github.com/odoo/odoo.git"
 fi
 
-echo "addons/iot_box_image/overwrite_after_init/home/pi/odoo" >> .git/info/sparse-checkout
-
 git fetch "${localremote}" "${localbranch}" --depth=1
 git reset "${localremote}"/"${localbranch}" --hard
-
 sudo git clean -dfx
-if [ -d /home/pi/odoo/addons/iot_box_image/overwrite_after_init ]; then
-    cp -a /home/pi/odoo/addons/iot_box_image/overwrite_after_init/home/pi/odoo/* /home/pi/odoo/
-    rm -r /home/pi/odoo/addons/iot_box_image/overwrite_after_init
-fi
 
-# TODO: Remove this code when v16 is deprecated
-odoo_conf="addons/iot_box_image/configuration/odoo.conf"
-if ! grep -q "server_wide_modules" $odoo_conf; then
-    echo "server_wide_modules=hw_drivers,hw_posbox_homepage,web" >> $odoo_conf
+if [ -d /home/pi/odoo/addons/point_of_sale ]; then
+  # TODO: remove this when v18.0 is deprecated (point_of_sale/tools/posbox/ -> iot_box_image/)
+  sudo sed -i 's|iot_box_image|point_of_sale/tools/posbox|g' /root_bypass_ramdisks/etc/systemd/system/ramdisks.service
+
+  # TODO: Remove this code when v16 is deprecated
+  odoo_conf="addons/point_of_sale/tools/posbox/configuration/odoo.conf"
+  if ! grep -q "server_wide_modules" $odoo_conf; then
+      echo "server_wide_modules=hw_drivers,hw_posbox_homepage,web" >> $odoo_conf
+  fi
 fi
 
 {

--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -127,6 +127,7 @@ PKGS_TO_INSTALL="
     python3-dev \
     python3-docutils \
     python3-geoip2 \
+    python3-jinja2 \
     python3-ldap \
     python3-libsass \
     python3-lxml \


### PR DESCRIPTION
As we moved build tools from `point_of_sale` to a new module (`iot_box_image`) we need to ensure compatibility:

- on boot, `ramdisks.service` was trying to execute a script in non-existing module `iot_box_image` (on <=18.0 branches), `checkout.sh` now updates the service with the right path,
- `checkout.sh` couldn't checkout `point_of_sale/tools/configuration` on older branches as it was not part of the `sparse-checkout` anymore, we added it back.
- `python3-jinja2` had previously been removed as we don't need it anymore, we added it back in order to ensure retro compatibility.
