### PR TITLE
[FIX] sale_project : Check if sale order has project_id

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -350,7 +350,10 @@ class SaleOrderLine(models.Model):
         for so_line in so_line_new_project:
             project = False
             if so_line.product_id.service_tracking in ['project_only', 'task_in_project']:
-                project = so_line.project_id
+                project = so_line.project_id or so_line.order_id.project_id
+                if project:
+                    project.company_id = self.company_id.id
+                    self.write({'project_id': project.id})
             if not project and _can_create_project(so_line):
                 project = so_line._timesheet_create_project()
                 if so_line.product_id.project_template_id:

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1032,3 +1032,24 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
             'sale_line_id': sale_order_line.id,
         })
         self.assertEqual(sale_order.state, 'sale')
+
+    def test_create_sale_order_with_service_product_through_project(self):
+        """
+        Test when creating a sales order through a billable project
+        and have an order line that creates a project and a task. Make sure
+        no other project has been created.
+        """
+        project = self.env['project.project'].create({
+            'name': 'Test Project',
+            'allow_billable': True,
+            'partner_id': self.partner.id,
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'name': 'Sale Order',
+            'partner_id': self.partner.id,
+            'project_id': project.id,
+            'order_line': [Command.create({'product_id': self.product_order_service3.id})],
+        })
+        sale_order.action_confirm()
+        self.assertEqual(project, sale_order.tasks_ids.project_id)

--- a/addons/sale_timesheet/tests/test_reinvoice.py
+++ b/addons/sale_timesheet/tests/test_reinvoice.py
@@ -42,6 +42,11 @@ class TestReInvoice(TestCommonSaleTimesheet):
             'partner_id': cls.partner_a.id
         })
 
+        cls.project_analytic_account = cls.env['account.analytic.account'].create({
+            'name': 'Test Project AA',
+            'plan_id': int(cls.env['ir.config_parameter'].sudo().get_param('analytic.project_plan')),
+        })
+
         cls.project = cls.env['project.project'].create({
             'name': 'SO Project',
             'allow_timesheets': False,
@@ -70,6 +75,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
             'product_id': self.company_data['product_order_cost'].id,
             'product_uom_qty': 2,
             'order_id': self.sale_order.id,
+            'analytic_distribution': {self.project_analytic_account.id: 100},
         })
         sale_order_line2 = self.env['sale.order.line'].create({
             'product_id': self.company_data['product_delivery_cost'].id,
@@ -91,6 +97,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
             'unit_amount': 1,
             'employee_id': self.employee_user.id,
             'company_id': self.company_data['company'].id,
+            'so_line': sale_order_line1.id,
         })
 
         move_form = Form(self.Invoice)
@@ -165,6 +172,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
             'product_uom_qty': 2,
             'qty_delivered': 1,
             'order_id': self.sale_order.id,
+            'analytic_distribution': {self.project_analytic_account.id: 100},
         })
         sale_order_line2 = self.env['sale.order.line'].create({
             'product_id': self.company_data['product_order_sales_price'].id,
@@ -182,6 +190,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
             'task_id': task_sol1.id,
             'unit_amount': 1,
             'employee_id': self.employee_user.id,
+            'so_line': sale_order_line1.id,
         })
 
         # create invoice lines and validate it
@@ -254,6 +263,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
             'product_uom_qty': 2,
             'qty_delivered': 1,
             'order_id': self.sale_order.id,
+            'analytic_distribution': {self.project_analytic_account.id: 100},
         })
         self.sale_order.action_confirm()
 
@@ -275,6 +285,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
             'task_id': task_sol1.id,
             'unit_amount': 1,
             'employee_id': self.employee_user.id,
+            'so_line': sale_order_line.id,
         })
 
         self.assertEqual(len(self.sale_order.order_line), 1, "No SO line should have been created (or removed) when validating vendor bill")


### PR DESCRIPTION
### Steps to reproduce:
	- Create a project and make it billable
	- Add a customer and add the first quotation from smart button on the project
	- On the quotation, add a service product that creates Project and Task and save
	- Notice another project has been created with a task inside

### Cause:
This is happening because when creating an order that has an SO line that creates a project and a task we only check if the so_line has a project or not but we should fallback on order.project_id too. https://github.com/odoo/odoo/blob/saas-17.4/addons/sale_project/models/sale_order_line.py#L323

### Fix:
We fallback on the project of the order if we didn't find a project for the SO line.

opw-4409810