### PR TITLE
[IMP] test_mail: add discussion test on lead-like model

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3454,8 +3454,11 @@ class MailThread(models.AbstractModel):
         """
         lang_to_recipients = {}
         for data in recipients_data:
+            # filter active lang
+            if lang_code := data.get('lang'):
+                lang_code = bool(self.env['res.lang']._lang_get(lang_code)) and lang_code
             lang_to_recipients.setdefault(
-                data.get('lang') or force_email_lang or self.env.lang,
+                lang_code or force_email_lang or self.env.lang,
                 [],
             ).append(data)
 

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -9,11 +9,11 @@ import logging
 import time
 
 from ast import literal_eval
-from collections import defaultdict
 from contextlib import contextmanager
 from freezegun import freeze_time
 from functools import partial
 from lxml import html
+from random import randint
 from unittest.mock import patch
 
 from odoo.addons.base.models.ir_mail_server import IrMailServer
@@ -25,7 +25,10 @@ from odoo.addons.mail.models.mail_notification import MailNotification
 from odoo.addons.mail.models.res_users import Users
 from odoo.addons.mail.tools.discuss import Store
 from odoo.tests import common, RecordCapturer, new_test_user
-from odoo.tools import email_normalize, formataddr, mute_logger
+from odoo.tools import mute_logger
+from odoo.tools.mail import (
+    email_normalize, email_split_and_format_normalize, formataddr
+)
 from odoo.tools.translate import code_translations
 
 _logger = logging.getLogger(__name__)
@@ -198,7 +201,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
                            with_user=None, **kwargs):
         self.assertFalse(self.env[target_model].search([(target_field, '=', subject)]))
         if not msg_id:
-            msg_id = "<%.7f-test@iron.sky>" % (time.time())
+            msg_id = "<%.7f-%5d-test@iron.sky>" % (time.time(), randint(0, 99998))
 
         if kwargs.pop('debug_log', False):
             _logger.info(
@@ -213,34 +216,104 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         self.env['mail.thread'].with_user(with_user or self.env.user).sudo().message_process(model, mail)
         return self.env[target_model].search([(target_field, '=', subject)])
 
-    def gateway_reply_wrecord(self, template, record, use_in_reply_to=True):
-        """ Deprecated, remove in 14.4 """
-        return self.gateway_mail_reply_wrecord(template, record, use_in_reply_to=use_in_reply_to)
+    def _gateway_mail_reply(self, template, mail=None, email=None,
+                            force_email_from=False, force_email_to=False,
+                            force_return_path=False, cc=False,
+                            extra=False, use_references=True, extra_references=False, use_in_reply_to=False,
+                            target_model='mail.test.gateway', target_field='name',
+                            debug_log=False):
+        """ Low-level helper tool to simulate a reply through mailgateway.
 
-    def gateway_mail_reply_last_email(self, template, force_to=False, force_rp=False, extra=False,
-                                      debug_log=False):
-        """ Tool to automatically reply to last outgoing mail.
-
-        :param str force_to: simulate a forwarding (which forces the To);
-        :param str force_rp: force return-path;
+        :param mail.mail mail: mail.mail to which we are replying
+        :param email.Message email: email to which we are replying
         """
-        self.assertEqual(len(self._mails), 1)
-        mail = self._mails[0]
+        if not mail and not email:
+            raise ValueError('Wrong usage of _gateway_mail_reply')
+        message_id = (mail and mail.message_id) or email['message_id']
+        original_reply_to = (mail and mail.reply_to) or (email and email['reply_to'])
+        original_to = (mail and mail.email_to) or (email and email['email_to'][0])
+        original_subject = (mail and mail.subject) or (email and email['subject'])
+
         extra = f'{extra}\n' if extra else ''
-        extra = f'{extra}References:\r\n\t{mail["message_id"]}'
+        # compute reply headers
+        if use_in_reply_to:
+            extra = f'{extra}In-Reply-To:\r\n\t{message_id}\n'
+        if use_references:
+            extra = f'{extra}References:\r\n\t{message_id}\n'
+            if extra_references:
+                extra = f'{extra}\r{extra_references}\n'
+
+        return self.format_and_process(
+            template,
+            force_email_from or original_to,
+            force_email_to or original_reply_to,
+            cc=cc,
+            extra=extra,
+            return_path=force_return_path or original_to,
+            subject=f'Re: {original_subject}',
+            target_field=target_field,
+            target_model=target_model,
+            debug_log=debug_log,
+        )
+
+    def gateway_mail_reply_from_smtp_email(self, template, source_smtp_to_list,
+                                           reply_all=False, cc=False,
+                                           force_email_from=False, force_return_path=False,
+                                           extra=False, use_references=True, extra_references=False, use_in_reply_to=False,
+                                           debug_log=False):
+        """ Tool to simulate a reply, based on outgoing SMTP emails.
+
+        :param list source_smtp_to_list: find outgoing SMTP email based on their
+          SMTP To header (should be a singleton list actually);
+        """
+        # find SMTP email based on recipients
+        smtp_email = next(
+            (m for m in self.emails if m['smtp_to_list'] == source_smtp_to_list),
+            False
+        )
+        if not smtp_email:
+            raise AssertionError(f'Not found SMTP email for {source_smtp_to_list}')
+        # find matching mail.mail
+        email = next(
+            (m for m in self._mails if sorted(email_normalize(addr) for addr in m['email_to']) == sorted(source_smtp_to_list)),
+            False
+        )
+        if not email:
+            raise AssertionError(f'Not found matching mail.mail for {source_smtp_to_list}')
+
+        # compute reply "To": either "reply-to" of email, either all recipients + reply_to - replier itself
+        if not reply_all:
+            replying_to = email['reply_to']
+        else:
+            replying_to = ','.join([email['reply_to']] + [
+                email for email in email_split_and_format_normalize(smtp_email['msg_to'])
+                if email_normalize(email) not in source_smtp_to_list]
+            )
         with RecordCapturer(self.env['mail.message'], []) as capture_messages, \
              self.mock_mail_gateway():
-            self.format_and_process(
-                template, mail['email_to'][0], force_to or mail['reply_to'],
-                extra=extra,
-                return_path=force_rp or mail['email_to'][0],
-                subject=f'Re: {mail["subject"]}',
+            self._gateway_mail_reply(
+                template, email=email,
+                force_email_from=force_email_from, force_email_to=replying_to,
+                force_return_path=force_return_path, cc=cc,
+                extra=extra, use_references=use_references, extra_references=extra_references, use_in_reply_to=use_in_reply_to,
+                debug_log=debug_log
+            )
+        return capture_messages
+
+    def gateway_mail_reply_last_email(self, template, force_email_to=False, debug_log=False):
+        """ Tool to automatically reply to last outgoing mail. """
+        self.assertEqual(len(self._mails), 1)
+        email = self._mails[0]  # keep out of mock, otherwise _mails is rewritten
+        with RecordCapturer(self.env['mail.message'], []) as capture_messages, \
+             self.mock_mail_gateway():
+            self._gateway_mail_reply(
+                template, email=email,
+                force_email_to=force_email_to,
                 debug_log=debug_log,
             )
         return capture_messages
 
-    def gateway_mail_reply_wrecord(self, template, record, use_in_reply_to=True,
-                                   target_model=None, target_field=None):
+    def gateway_mail_reply_wrecord(self, template, record, use_in_reply_to=True, debug_log=False):
         """ Simulate a reply through the mail gateway. Usage: giving a record,
         find an email sent to them and use its message-ID to simulate a reply.
 
@@ -248,44 +321,34 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         mail_mail = self._find_mail_mail_wrecord(record)
 
         if use_in_reply_to:
-            extra = 'In-Reply-To:\r\n\t%s\n' % mail_mail.message_id
+            disturbing_other_msg_id = False
+            use_references = False
         else:
             disturbing_other_msg_id = '<123456.654321@another.host.com>'
-            extra = 'References:\r\n\t%s\n\r%s' % (mail_mail.message_id, disturbing_other_msg_id)
-
-        return self.format_and_process(
-            template,
-            mail_mail.email_to,
-            mail_mail.reply_to,
-            subject='Re: %s' % mail_mail.subject,
-            extra=extra,
-            msg_id='<123456.%s.%d@test.example.com>' % (record._name, record.id),
-            target_model=target_model or record._name,
-            target_field=target_field or record._rec_name,
+            use_references = True
+        return self._gateway_mail_reply(
+            template, mail=mail_mail,
+            use_references=use_references, extra_references=disturbing_other_msg_id,
+            use_in_reply_to=use_in_reply_to,
+            target_field=record._rec_name,
+            target_model=record._name,
+            debug_log=debug_log,
         )
 
-    def gateway_mail_reply_wemail(self, template, email_to, use_in_reply_to=True,
-                                  target_model=None, target_field=None):
+    def gateway_mail_reply_wemail(self, template, email_to,
+                                  target_model=None, target_field='name',
+                                  debug_log=False):
         """ Simulate a reply through the mail gateway. Usage: giving a record,
         find an email sent to them and use its message-ID to simulate a reply.
 
         Some noise is added in References just to test some robustness. """
-        sent_mail = self._find_sent_mail_wemail(email_to)
-
-        if use_in_reply_to:
-            extra = 'In-Reply-To:\r\n\t%s\n' % sent_mail['message_id']
-        else:
-            disturbing_other_msg_id = '<123456.654321@another.host.com>'
-            extra = 'References:\r\n\t%s\n\r%s' % (sent_mail['message_id'], disturbing_other_msg_id)
-
-        return self.format_and_process(
-            template,
-            sent_mail['email_to'],
-            sent_mail['reply_to'],
-            subject='Re: %s' % sent_mail['subject'],
-            extra=extra,
+        email = self._find_sent_mail_wemail(email_to)
+        return self._gateway_mail_reply(
+            template, email=email,
+            use_in_reply_to=True,
+            target_field=target_field,
             target_model=target_model,
-            target_field=target_field or 'name',
+            debug_log=debug_log,
         )
 
     def from_string(self, text):
@@ -333,7 +396,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
             raise AssertionError(f'sent mail not found for email_to {email_to}\n{debug_info}')
         return sent_email
 
-    def _filter_mail(self, status=None, mail_message=None, author=None, email_from=None):
+    def _filter_mail(self, status=None, mail_message=None, author=None, content=None, email_from=None):
         """ Filter mail generated during mock, based on common parameters
 
         :param status: state of mail.mail. If not void use it to filter mail.mail
@@ -342,6 +405,8 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
           a ``mail.message`` record;
         :param author: optional check/filter on author_id field aka a ``res.partner``
           record;
+        :param content: optional check/filter on content, aka body_html (using an
+          assertIn, not a pure equality check);
         :param email_from: optional check/filter on email_from field (may differ from
           author, used notably in case of concurrent mailings to distinguish emails);
         """
@@ -353,19 +418,21 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
                 continue
             if author is not None and mail.author_id != author:
                 continue
+            if content is not None and content not in mail.body_html:
+                continue
             if email_from is not None and mail.email_from != email_from:
                 continue
             filtered += mail
         return filtered
 
-    def _find_mail_mail_wid(self, mail_id, status=None, mail_message=None, author=None, email_from=None):
+    def _find_mail_mail_wid(self, mail_id, status=None, mail_message=None, author=None, content=None, email_from=None):
         """ Find a ``mail.mail`` record based on a given ID (used notably when having
         mail ID in mailing traces).
 
         :return mail: a ``mail.mail`` record generated during the mock and matching
           given ID;
         """
-        filtered = self._filter_mail(status=status, mail_message=mail_message, author=author, email_from=email_from)
+        filtered = self._filter_mail(status=status, mail_message=mail_message, author=author, content=content, email_from=email_from)
         for mail in filtered:
             if mail.id == mail_id:
                 break
@@ -379,7 +446,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
             )
         return mail
 
-    def _find_mail_mail_wpartners(self, recipients, status, mail_message=None, author=None, email_from=None):
+    def _find_mail_mail_wpartners(self, recipients, status, mail_message=None, author=None, content=None, email_from=None):
         """ Find a mail.mail record based on various parameters, notably a list
         of recipients (partners).
 
@@ -389,7 +456,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         :return mail: a ``mail.mail`` record generated during the mock and matching
           given parameters and filters;
         """
-        filtered = self._filter_mail(status=status, mail_message=mail_message, author=author, email_from=email_from)
+        filtered = self._filter_mail(status=status, mail_message=mail_message, author=author, content=content, email_from=email_from)
         for mail in filtered:
             if all(p in mail.recipient_ids for p in recipients):
                 break
@@ -404,7 +471,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
             )
         return mail
 
-    def _find_mail_mail_wemail(self, email_to, status, mail_message=None, author=None, email_from=None):
+    def _find_mail_mail_wemail(self, email_to, status, mail_message=None, author=None, content=None, email_from=None):
         """ Find a mail.mail record based on various parameters, notably a list
         of email to (string emails).
 
@@ -414,7 +481,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         :return mail: a ``mail.mail`` record generated during the mock and matching
           given parameters and filters;
         """
-        filtered = self._filter_mail(status=status, mail_message=mail_message, author=author, email_from=email_from)
+        filtered = self._filter_mail(status=status, mail_message=mail_message, author=author, content=content, email_from=email_from)
         for mail in filtered:
             if (mail.email_to == email_to and not mail.recipient_ids) or (not mail.email_to and mail.recipient_ids.email == email_to):
                 break
@@ -428,12 +495,12 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
             )
         return mail
 
-    def _find_mail_mail_wrecord(self, record, status=None, mail_message=None, author=None, email_from=None):
+    def _find_mail_mail_wrecord(self, record, status=None, mail_message=None, author=None, content=None, email_from=None):
         """ Find a mail.mail record based on model / res_id of a record.
 
         :return mail: a ``mail.mail`` record generated during the mock;
         """
-        filtered = self._filter_mail(status=status, mail_message=mail_message, author=author, email_from=email_from)
+        filtered = self._filter_mail(status=status, mail_message=mail_message, author=author, content=content, email_from=email_from)
         for mail in filtered:
             if mail.model == record._name and mail.res_id == record.id:
                 break
@@ -552,7 +619,9 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         """
         found_mail = self._find_mail_mail_wpartners(
             recipients, status, mail_message=mail_message,
-            author=author, email_from=(fields_values or {}).get('email_from')
+            author=author,
+            content=content,
+            email_from=(fields_values or {}).get('email_from')
         )
         self.assertTrue(bool(found_mail))
         self._assertMailMail(
@@ -580,7 +649,9 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         for email_to in emails:
             found_mail = self._find_mail_mail_wemail(
                 email_to, status, mail_message=mail_message,
-                author=author, email_from=(fields_values or {}).get('email_from')
+                author=author,
+                content=content,
+                email_from=(fields_values or {}).get('email_from'),
             )
             self.assertTrue(bool(found_mail))
             self._assertMailMail(
@@ -607,7 +678,9 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         """
         found_mail = self._find_mail_mail_wrecord(
             record, status, mail_message=mail_message,
-            author=author, email_from=(fields_values or {}).get('email_from')
+            author=author,
+            content=content,
+            email_from=(fields_values or {}).get('email_from')
         )
         self.assertTrue(bool(found_mail))
         self._assertMailMail(
@@ -1042,8 +1115,7 @@ class MailCase(MockEmail):
             'email_values': values to check in outgoing emails, check 'assertMailMail'
               and 'assertSentEmail';
             'mail_mail_values': values to check in generated <mail.mail>, check
-              'assertMailMail'. 'fields_values' is supported for compabitility
-              with other asserts;
+              'assertMailMail';
             'message_values': values to check in found <mail.message>, check
               'assertMessageFields';
             'notif': list of notified recipients: [
@@ -1072,6 +1144,10 @@ class MailCase(MockEmail):
         if messages is not None:
             base_domain += [('mail_message_id', 'in', messages.ids)]
         notifications = self.env['mail.notification'].sudo().search(base_domain)
+        debug_info = '\n-'.join(
+            f'Notif: partner {notif.res_partner_id.id}, type {notif.notification_type}'
+            for notif in notifications
+        )
 
         done_msgs = self.env['mail.message'].sudo()
         done_notifs = self.env['mail.notification'].sudo()
@@ -1081,7 +1157,6 @@ class MailCase(MockEmail):
             extra_keys = set(message_info.keys()) - {
                 'content',
                 'email_values',
-                'fields_values',
                 'mail_mail_values',
                 'message_type',
                 'message_values',
@@ -1114,26 +1189,56 @@ class MailCase(MockEmail):
                 self.assertMessageFields(message, message_values)
 
             # check notifications and prepare assert data
-            email_groups = defaultdict(list)
-            mail_groups = {'failure': [], 'outgoing': []}
+            email_groups = {}
+            status_groups = {
+                'exception': {'email_lst': [], 'partners': []},
+                'outgoing': {'email_lst': [], 'partners': []},
+            }
+            self.assertEqual(len(message.notification_ids), len(message_info['notif']))
             for recipient in message_info['notif']:
-                partner, ntype, ngroup, nstatus = recipient['partner'], recipient['type'], recipient.get('group'), recipient.get('status', 'sent')
-                nis_read, ncheck_send = recipient.get('is_read', False if recipient['type'] == 'inbox' else True), recipient.get('check_send', True)
+                # sanity check
+                extra_keys = set(recipient.keys()) - {
+                    'check_send',
+                    'email_to_recipients',
+                    'is_read',
+                    'failure_reason',
+                    'failure_type',
+                    'group',
+                    'partner',
+                    'status',
+                    'type',
+                }
+                if extra_keys:
+                    raise ValueError(f'Unsupported recipient values: {extra_keys}')
+
+                partner = recipient.get('partner', self.env['res.partner'])
+                email_to_lst, email_cc_lst = recipient.get('email_to', []), recipient.get('email_cc', [])
+                ntype, ngroup, nstatus = recipient['type'], recipient.get('group'), recipient.get('status', 'sent')
+                nis_read = recipient.get('is_read', recipient['type'] != 'inbox')
+                ncheck_send = recipient.get('check_send', True)
+
                 if not ngroup:
                     ngroup = 'user'
                     if partner and not partner.user_ids:
                         ngroup = 'customer'
                     elif partner and partner.partner_share:
                         ngroup = 'portal'
+                if ngroup not in email_groups:
+                    email_groups[ngroup] = {
+                        'email_cc_lst': [],
+                        'email_to_lst': [],
+                        'email_to_recipients': [],
+                        'partners': self.env['res.partner'].sudo(),
+                    }
 
                 # find notification
-                partner_notif = notifications.filtered(
-                    lambda n: n.mail_message_id == message and
+                partner_notif = notifications.filtered(lambda n: (
+                    n.mail_message_id == message and
                     n.res_partner_id == partner and
                     n.notification_type == ntype
-                )
+                ))
                 self.assertEqual(len(partner_notif), 1,
-                                 f'Mail: not found notification for {partner} (type: {ntype}, message: {message.id})')
+                                 f'Mail: not found notification for {partner} (type: {ntype}, message: {message.id})\n{debug_info}')
                 self.assertEqual(partner_notif.author_id, partner_notif.mail_message_id.author_id)
                 self.assertEqual(partner_notif.is_read, nis_read)
                 if 'failure_reason' in recipient:
@@ -1144,21 +1249,25 @@ class MailCase(MockEmail):
 
                 # prepare further asserts
                 if ntype == 'email':
-                    if nstatus == 'sent':
-                        if ncheck_send:
-                            email_groups[ngroup].append(partner)
+                    if nstatus in ('sent', 'ready', 'exception') and ncheck_send:
+                        email_groups[ngroup]['partners'] += partner
+                        if 'email_to_recipients' in recipient:
+                            email_groups[ngroup]['email_to_recipients'] += recipient['email_to_recipients']
+                        if email_cc_lst:
+                            email_groups[ngroup]['email_cc_lst'] += email_cc_lst
+                        if email_to_lst:
+                            email_groups[ngroup]['email_to_lst'] += email_to_lst
                     # when force_send is False notably, notifications are ready and emails outgoing
-                    elif nstatus == 'ready':
-                        mail_groups['outgoing'].append(partner)
-                        if ncheck_send:
-                            email_groups[ngroup].append(partner)
-                    # canceled: currently nothing checked
-                    elif nstatus == 'exception':
-                        mail_groups['failure'].append(partner)
-                        if ncheck_send:
-                            email_groups[ngroup].append(partner)
-                    # canceled: currently nothing checked
-                    elif nstatus == 'canceled':
+                    if nstatus in ('ready', 'exception'):
+                        state = 'outgoing' if nstatus == 'ready' else 'exception'
+                        if partner:
+                            status_groups[state]['partners'].append(partner)
+                        if email_cc_lst:
+                            status_groups[state]['email_lst'] += email_cc_lst
+                        if email_to_lst:
+                            status_groups[state]['email_lst'] += email_to_lst
+                    # canceled: currently nothing checked - sent: already managed
+                    elif nstatus in ('sent', 'canceled'):
                         pass
                     else:
                         raise NotImplementedError()
@@ -1178,21 +1287,31 @@ class MailCase(MockEmail):
             }
             if message_info.get('email_values'):
                 email_values.update(message_info['email_values'])
-            for recipients in email_groups.values():
-                partners = self.env['res.partner'].sudo().concat(*recipients)
-                if all(p in mail_groups['failure'] for p in partners):
+            for group in email_groups.values():
+                partners = group['partners']
+                email_cc_lst = group['email_cc_lst']
+                email_to_lst = group['email_to_lst']
+
+                # compute expected mail status
+                mail_status = 'sent'
+                if partners and all(p in status_groups['exception']['partners'] for p in partners):
                     mail_status = 'exception'
-                elif all(p in mail_groups['outgoing'] for p in partners):
+                if email_to_lst and all(p in status_groups['exception']['email_lst'] for p in email_to_lst):
+                    mail_status = 'exception'
+                if partners and all(p in status_groups['outgoing']['partners'] for p in partners):
                     mail_status = 'outgoing'
-                else:
-                    mail_status = 'sent'
-                if not self.mail_unlink_sent:
+                if email_to_lst and all(p in status_groups['outgoing']['email_lst'] for p in email_to_lst):
+                    mail_status = 'outgoing'
+                if not self.mail_unlink_sent and partners:
                     self.assertMailMail(
-                        partners, mail_status,
-                        author=message_info.get('fields_values', {}).get('author_id') or message.author_id or message.email_from,
-                        mail_message=message,
+                        partners,
+                        mail_status,
+                        author=message_info.get('mail_mail_values', {}).get('author_id') or message.author_id or message.email_from,
+                        content=mbody,
+                        email_to_recipients=group['email_to_recipients'] or None,
                         email_values=email_values,
-                        fields_values=message_info.get('fields_values') or message_info.get('mail_mail_values'),
+                        fields_values=message_info.get('mail_mail_values'),
+                        mail_message=message,
                     )
                 else:
                     for recipient in partners:

--- a/addons/test_mail/models/__init__.py
+++ b/addons/test_mail/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import mail_test_access
+from . import mail_test_lead
 from . import test_mail_corner_case_models
 from . import test_mail_feature_models
 from . import test_mail_models

--- a/addons/test_mail/models/mail_test_lead.py
+++ b/addons/test_mail/models/mail_test_lead.py
@@ -1,0 +1,69 @@
+from odoo import fields, models, _
+from odoo.tools.mail import parse_contact_from_email
+
+
+class MailTestTLead(models.Model):
+    """ Lead-like model for business flows testing """
+    _name = "mail.test.lead"
+    _description = 'Lead-like model'
+    _inherit = [
+        'mail.thread.blacklist',
+        'mail.thread.cc',
+        'mail.activity.mixin',
+    ]
+    _mail_defaults_to_email = True
+    _primary_email = 'email_from'
+
+    name = fields.Char()
+    company_id = fields.Many2one('res.company')
+    user_id = fields.Many2one('res.users', tracking=1)
+    email_from = fields.Char()
+    customer_name = fields.Char()
+    partner_id = fields.Many2one('res.partner', tracking=2)
+    lang_code = fields.Char()
+    mobile = fields.Char()
+    phone = fields.Char()
+
+    def _creation_message(self):
+        self.ensure_one()
+        return _('A new lead has been created and is assigned to %(user_name)s.', user_name=self.user_id.name or _('nobody'))
+
+    def _get_customer_information(self):
+        email_normalized_to_values = super()._get_customer_information()
+
+        for lead in self:
+            email_key = lead.email_normalized or lead.email
+            values = email_normalized_to_values.setdefault(email_key, {})
+            values['lang'] = values.get('lang') or lead.lang_code
+            values['name'] = values.get('name') or lead.customer_name or parse_contact_from_email(lead.email_from)[0] or lead.email_from
+            values['mobile'] = values.get('mobile') or lead.mobile
+            values['phone'] = values.get('phone') or lead.phone
+        return email_normalized_to_values
+
+    def _message_get_suggested_recipients(self):
+        recipients = super()._message_get_suggested_recipients()
+        # check if that language is correctly installed (and active) before using it
+        lang_code = self.env['res.lang']._get_data(code=self.lang_code).code or None
+        if self.partner_id:
+            self._message_add_suggested_recipient(
+                recipients, partner=self.partner_id, lang=lang_code, reason=_('Customer'))
+        elif self.email_from:
+            self._message_add_suggested_recipient(
+                recipients, email=self.email_from, lang=lang_code, reason=_('Customer Email'))
+        return recipients
+
+    def _message_post_after_hook(self, message, msg_vals):
+        if self.email_from and not self.partner_id:
+            # we consider that posting a message with a specified recipient (not a follower, a specific one)
+            # on a document without customer means that it was created through the chatter using
+            # suggested recipients. This heuristic allows to avoid ugly hacks in JS.
+            new_partner = message.partner_ids.filtered(
+                lambda partner: partner.email == self.email_from or (self.email_normalized and partner.email_normalized == self.email_normalized)
+            )
+            if new_partner:
+                if new_partner[0].email_normalized:
+                    email_domain = ('email_normalized', '=', new_partner[0].email_normalized)
+                else:
+                    email_domain = ('email_from', '=', new_partner[0].email)
+                self.search([('partner_id', '=', False), email_domain]).write({'partner_id': new_partner[0].id})
+        return super()._message_post_after_hook(message, msg_vals)

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -26,6 +26,7 @@ access_mail_test_activity_portal,mail.test.activity.portal,model_mail_test_activ
 access_mail_test_activity_user,mail.test.activity.user,model_mail_test_activity,base.group_user,1,1,1,1
 access_mail_test_field_type_portal,mail.test.field.type.portal,model_mail_test_field_type,base.group_portal,0,0,0,0
 access_mail_test_field_type_user,mail.test.field.type.user,model_mail_test_field_type,base.group_user,1,1,1,1
+access_mail_test_lead_user,mail.test.lead.user,model_mail_test_lead,base.group_user,1,1,1,1
 access_mail_test_ticket_portal,mail.test.ticket.portal,model_mail_test_ticket,base.group_portal,1,0,0,0
 access_mail_test_ticket_user,mail.test.ticket.user,model_mail_test_ticket,base.group_user,1,1,1,1
 access_mail_test_ticket_el_portal,mail.test.ticket.el.portal,model_mail_test_ticket_el,base.group_portal,1,0,0,0

--- a/addons/test_mail/tests/__init__.py
+++ b/addons/test_mail/tests/__init__.py
@@ -10,6 +10,7 @@ from . import test_mail_composer
 from . import test_mail_composer_mixin
 from . import test_mail_followers
 from . import test_mail_gateway
+from . import test_mail_flow
 from . import test_mail_mail
 from . import test_mail_management
 from . import test_mail_message

--- a/addons/test_mail/tests/test_ir_actions.py
+++ b/addons/test_mail/tests/test_ir_actions.py
@@ -78,7 +78,7 @@ class TestServerActionsEmail(MailCommon, TestServerActionsBase):
         with self.assertSinglePostNotifications(
                 [{'partner': self.test_partner, 'type': 'email', 'status': 'ready'}],
                 message_info={'content': 'Hello %s' % self.test_partner.name,
-                              'fields_values': {
+                              'mail_mail_values': {
                                 'author_id': self.env.user.partner_id,
                               },
                               'message_type': 'notification',

--- a/addons/test_mail/tests/test_mail_alias.py
+++ b/addons/test_mail/tests/test_mail_alias.py
@@ -769,15 +769,15 @@ class TestMailAliasMixin(TestMailAliasCommon):
         """ Various base checks on alias mixin behavior """
         self.assertEqual(self.env.company.alias_domain_id, self.mail_alias_domain)
 
-        record = self.env['mail.test.container'].create({
+        record = self.env['mail.test.gateway.groups'].create({
             'name': 'Test Record',
             'alias_name': 'alias.test',
             'alias_contact': 'followers',
         })
         self.assertEqual(record.alias_id.alias_domain_id, self.mail_alias_domain)
-        self.assertEqual(record.alias_id.alias_model_id, self.env['ir.model']._get('mail.test.container'))
+        self.assertEqual(record.alias_id.alias_model_id, self.env['ir.model']._get('mail.test.gateway.groups'))
         self.assertEqual(record.alias_id.alias_force_thread_id, record.id)
-        self.assertEqual(record.alias_id.alias_parent_model_id, self.env['ir.model']._get('mail.test.container'))
+        self.assertEqual(record.alias_id.alias_parent_model_id, self.env['ir.model']._get('mail.test.gateway.groups'))
         self.assertEqual(record.alias_id.alias_parent_thread_id, record.id)
         self.assertEqual(record.alias_id.alias_name, 'alias.test')
         self.assertEqual(record.alias_id.alias_contact, 'followers')
@@ -804,7 +804,7 @@ class TestMailAliasMixin(TestMailAliasCommon):
         with self.assertRaises(exceptions.ValidationError):
             record.write({'alias_defaults': "{'custom_field': brokendict"})
 
-        rec = self.env['mail.test.container'].create({
+        rec = self.env['mail.test.gateway.groups'].create({
             'name': 'Test Record2',
             'alias_name': 'alias.test',
             'alias_domain_id': self.mail_alias_domain_c2.id,
@@ -897,7 +897,7 @@ class TestMailAliasMixin(TestMailAliasCommon):
             self.env.user.has_group('base.group_system'),
             'Test user should not have Administrator access')
 
-        record = self.env['mail.test.container'].create({
+        record = self.env['mail.test.gateway.groups'].create({
             'name': 'Test Record',
             'alias_name': 'test.record',
             'alias_contact': 'followers',

--- a/addons/test_mail/tests/test_mail_flow.py
+++ b/addons/test_mail/tests/test_mail_flow.py
@@ -1,0 +1,319 @@
+from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
+from odoo.addons.test_mail.data.test_mail_data import MAIL_TEMPLATE
+from odoo.addons.test_mail.tests.common import TestRecipients
+from odoo.tools.mail import email_normalize, formataddr
+from odoo.tests import tagged
+
+
+@tagged('mail_gateway', 'mail_flow', 'post_install', '-at_install')
+class TestMailFlow(MailCommon, TestRecipients):
+    """ Test flows matching business cases with incoming / outgoing emails. """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.user_employee_2 = mail_new_test_user(
+            cls.env,
+            company_id=cls.user_employee.company_id.id,
+            email='eglantine@example.com',
+            groups='base.group_user,base.group_partner_manager',
+            login='employee2',
+            name='Eglantine Employee',
+            notification_type='email',
+            signature='--\nEglantine',
+        )
+        cls.partner_employee_2 = cls.user_employee_2.partner_id
+        cls.user_employee_3 = mail_new_test_user(
+            cls.env,
+            company_id=cls.user_employee.company_id.id,
+            email='emmanuel@example.com',
+            groups='base.group_user,base.group_partner_manager',
+            login='employee3',
+            name='Emmanuel Employee',
+            notification_type='email',
+            signature='--\nEmmanuel',
+        )
+        cls.partner_employee_3 = cls.user_employee_3.partner_id
+        cls.user_portal = cls._create_portal_user()
+        cls.partner_portal = cls.user_portal.partner_id
+
+        cls.test_emails = [
+            # emails only
+            '"Sylvie Lelitre" <sylvie.lelitre@zboing.com>',
+            '"Josiane Quichopoils" <accounting@zboing.com>',
+            'pay@zboing.com',
+            'invoicing@zboing.com',
+            # existing partners
+            '"Robert Brutijus" <robert@zboing.com>',
+            # existing portal users
+            '"Portal Zboing" <portal@zboing.com>',
+        ]
+        cls.test_emails_normalized = [
+            'sylvie.lelitre@zboing.com', 'accounting@zboing.com', 'invoicing@zboing.com',
+            'pay@zboing.com', 'robert@zboing.com', 'portal@zboing.com',
+        ]
+        cls.customer_zboing = cls.env['res.partner'].create({
+            'email': cls.test_emails[4],
+            'name': 'Robert Brutijus',
+            'phone': '+32455335577',
+        })
+        cls.user_portal_zboing = mail_new_test_user(
+            cls.env,
+            email=cls.test_emails[5],
+            groups='base.group_portal',
+            login='portal_zboing',
+            name='Portal Zboing',
+        )
+        cls.customer_portal_zboing = cls.user_portal_zboing.partner_id
+
+        # lead@test.mycompany.com will cause the creation of new mail.test.lead
+        cls.mail_test_lead_model = cls.env['ir.model']._get('mail.test.lead')
+        cls.alias = cls.env['mail.alias'].create({
+            'alias_domain_id': cls.mail_alias_domain.id,
+            'alias_contact': 'everyone',
+            'alias_model_id': cls.mail_test_lead_model.id,
+            'alias_name': 'lead',
+        })
+        # help@test.mycompany.com will cause the creation of new mail.test.ticket.mc
+        cls.container = cls.env['mail.test.container.mc'].create({
+            'alias_name': 'help',
+            'company_id': cls.user_employee.company_id.id,
+            'name': 'help',
+        })
+
+    def test_assert_initial_values(self):
+        """ Assert base values for tests """
+        self.assertEqual(
+            self.env['res.partner'].search([('email_normalized', 'in', self.test_emails_normalized)]),
+            self.customer_zboing + self.customer_portal_zboing,
+        )
+
+    def test_lead_mailgateway(self):
+        """ Flow of this test
+        * incoming email creating a lead -> email set as first message
+        * a salesperson is assigned
+        * - he adds followers (internal and portal)
+        * - he replies through chatter, using suggested recipients
+        * customer replies, adding other people
+
+        Tested features
+        * cc / to support
+        * suggested recipients computation
+        """
+        # incoming customer email: lead alias + recipients (to + cc)
+        # ------------------------------------------------------------
+        email_to = f'lead@{self.alias_domain}, {self.test_emails[1]}, {self.partner_employee.email_formatted}'
+        email_cc = f'{self.test_emails[2]}, {self.test_emails[5]}'
+        with self.mock_mail_gateway(), self.mock_mail_app():
+            lead = self.format_and_process(
+                MAIL_TEMPLATE,
+                self.test_emails[0],
+                email_to,
+                cc=email_cc,
+                subject='Inquiry',
+                target_model='mail.test.lead',
+            )
+        self.assertEqual(lead.email_cc, email_cc, 'Filled by mail.thread.cc mixin')
+        self.assertEqual(lead.email_from, self.test_emails[0])
+        self.assertEqual(lead.name, 'Inquiry')
+        self.assertFalse(lead.partner_id)
+        # followers
+        self.assertFalse(lead.message_partner_ids)
+        # messages
+        self.assertEqual(len(lead.message_ids), 1, 'Incoming email should be only message, no creation message')
+        incoming_email = lead.message_ids
+        self.assertMailNotifications(
+            incoming_email,
+            [
+                {
+                    'content': 'Please call me as soon as possible',
+                    'message_type': 'email',
+                    'message_values': {
+                        'author_id': self.env['res.partner'],
+                        'email_from': self.test_emails[0],
+                        'mail_server_id': self.env['ir.mail_server'],
+                        'parent_id': self.env['mail.message'],
+                        'notified_partner_ids': self.env['res.partner'],
+                        'partner_ids': self.partner_employee + self.customer_portal_zboing,
+                        'subtype_id': self.env.ref('mail.mt_comment'),
+                    },
+                    'notif': [],  # no notif, mailgateway sets recipients without notification
+                },
+            ],
+        )
+
+        # user is assigned, should notify him
+        with self.mock_mail_gateway(), self.mock_mail_app():
+            lead.write({'user_id': self.user_employee.id})
+        lead_as_emp = lead.with_user(self.user_employee.id)
+        self.assertEqual(lead_as_emp.message_partner_ids, self.partner_employee)
+        # adds other employee and a portal customer as followers
+        lead_as_emp.message_subscribe(partner_ids=(self.partner_employee_2 + self.partner_portal).ids)
+        self.assertEqual(lead_as_emp.message_partner_ids, self.partner_employee + self.partner_employee_2 + self.partner_portal)
+        # updates some customer information
+        lead_as_emp.write({
+            'customer_name': 'Sylvie Lelitre (Zboing)',
+            'phone': '+32455001122',
+            'lang_code': 'fr_FR',
+        })
+
+        # uses Chatter: fetches suggested recipients, post a message
+        # - checks all suggested: incoming email to + cc are included
+        # - for all notified people: expected 'email_to' is them + external
+        #   email addresses -> including portal customers
+        # ------------------------------------------------------------
+        suggested_all = lead_as_emp._message_get_suggested_recipients()
+        expected_all = [
+            {  # mail.thread.cc: email_cc field
+                'create_values': {},
+                'email': 'pay@zboing.com',
+                'lang': None,
+                'name': 'pay@zboing.com',
+                'reason': 'CC Email',
+            },
+            {  # mail.thread.cc: email_cc field (linked to partner)
+                'email': 'portal@zboing.com',
+                'lang': None,
+                'name': 'Portal Zboing',
+                'reason': 'CC Email',
+                'partner_id': self.customer_portal_zboing.id,
+            },
+            {  # then primary emailadditional_values
+                'create_values': {
+                    'lang': 'fr_FR',
+                    'mobile': False,
+                    'name': 'Sylvie Lelitre (Zboing)',
+                    'phone': '+32455001122',
+                },
+                'email': '"Sylvie Lelitre" <sylvie.lelitre@zboing.com>',
+                'lang': None,
+                'name': 'Sylvie Lelitre (Zboing)',
+                'reason': 'Customer Email',
+            },
+        ]
+        for suggested, expected in zip(suggested_all, expected_all):
+            self.assertDictEqual(suggested, expected)
+        # check recipients, which creates them (simulating discuss in a quick way)
+        self.env["res.partner"]._find_or_create_from_emails(
+            [sug['email'] for sug in suggested_all],
+            {email_normalize(sug['email']): sug.get('create_values') or {} for sug in suggested_all},
+        )
+        partner_sylvie = self.env['res.partner'].search(
+            [('email_normalized', '=', 'sylvie.lelitre@zboing.com')]
+        )
+        partner_pay = self.env['res.partner'].search(
+            [('email_normalized', '=', 'pay@zboing.com')]
+        )
+        self.assertEqual(
+            len(partner_sylvie + partner_pay), 2,
+            'Mail: should have created partners for emails')
+        self.assertFalse(
+            self.env['res.partner'].search([('email_normalized', '=', 'accounting@zboing.com')]),
+            'Mail: currently other "To" in incoming emails are lost if not linked to existing partners'
+        )
+        # finally post the message with recipients
+        with self.mock_mail_gateway():
+            responsible_answer = lead_as_emp.message_post(
+                body='<p>Well received !',
+                partner_ids=(partner_sylvie + partner_pay + self.customer_portal_zboing).ids,
+                message_type='comment',
+                subject=f'Re: {lead.name}',
+                subtype_id=self.env.ref('mail.mt_comment').id,
+            )
+        self.assertEqual(lead_as_emp.message_partner_ids, self.partner_employee + self.partner_employee_2 + self.partner_portal)
+
+        external_partners = partner_sylvie + partner_pay + self.customer_portal_zboing + self.partner_portal
+        internal_partners = self.partner_employee + self.partner_employee_2
+        expected_chatter_reply_to = formataddr((f'{self.env.company.name} {lead.name}', f'{self.alias_catchall}@{self.alias_domain}'))
+
+        self.assertMailNotifications(
+            responsible_answer,
+            [
+                {
+                    'content': 'Well received !',
+                    'mail_mail_values': {
+                        'mail_server_id': self.env['ir.mail_server'],  # no specified server
+                    },
+                    'message_type': 'comment',
+                    'message_values': {
+                        'author_id': self.partner_employee,
+                        'email_from': self.partner_employee.email_formatted,
+                        'mail_server_id': self.env['ir.mail_server'],
+                        'notified_partner_ids': external_partners + self.partner_employee_2,
+                        'parent_id': incoming_email,
+                        'partner_ids': partner_sylvie + partner_pay + self.customer_portal_zboing,
+                        'reply_to': expected_chatter_reply_to,
+                        'subtype_id': self.env.ref('mail.mt_comment'),
+                    },
+                    'notif': [
+                        {'partner': partner_sylvie, 'type': 'email'},
+                        {'partner': partner_pay, 'type': 'email'},
+                        {'partner': self.customer_portal_zboing, 'type': 'email'},
+                        {'partner': self.partner_employee_2, 'type': 'email'},
+                        {'partner': self.partner_portal, 'type': 'email'},
+                    ],
+                },
+            ],
+        )
+        # expected Msg['To'] : actual recipient + all "not internal partners" + catchall (to receive answers)
+        for partner in responsible_answer.notified_partner_ids:
+            with self.subTest(name=partner.name):
+                self.assertSMTPEmailsSent(
+                    mail_server=self.mail_server_notification,
+                    msg_from=formataddr((self.partner_employee.name, f'{self.default_from}@{self.alias_domain}')),
+                    smtp_from=self.mail_server_notification.from_filter,
+                    smtp_to_list=[partner.email_normalized],
+                    msg_to_lst=[partner.email_formatted],
+                )
+
+        # customer replies using "Reply All" + adds new people
+        # ------------------------------------------------------------
+        self.gateway_mail_reply_from_smtp_email(
+            MAIL_TEMPLATE, [partner_sylvie.email_normalized], reply_all=True,
+            cc=f'{self.test_emails[3]}, {self.test_emails[4]}',  # used mainly for existing partners currently
+        )
+        self.assertEqual(len(lead.message_ids), 3, 'Incoming email + chatter reply + customer reply')
+        self.assertMailNotifications(
+            lead.message_ids[0],
+            [
+                {
+                    'content': 'Please call me as soon as possible',
+                    'message_type': 'email',
+                    'message_values': {
+                        'author_id': partner_sylvie,
+                        'email_from': partner_sylvie.email_formatted,
+                        'mail_server_id': self.env['ir.mail_server'],
+                        # notified: followers, behaves like classic post
+                        'notified_partner_ids': internal_partners + self.partner_portal,
+                        'parent_id': incoming_email,
+                        # reply-all when being only recipients = no other recipients
+                        'partner_ids': self.customer_zboing,
+                        'subject': f'Re: Re: {lead.name}',
+                        'subtype_id': self.env.ref('mail.mt_comment'),
+                    },
+                    # portal was already in email_to, hence not notified twice through odoo
+                    'notif': [
+                        {'partner': self.partner_employee, 'type': 'inbox'},
+                        {'partner': self.partner_employee_2, 'type': 'email'},
+                        {'partner': self.partner_portal, 'type': 'email'},
+                    ],
+                },
+            ],
+        )
+
+    def test_ticket_mailgateway(self):
+        # incoming customer email: help alias + recipients (to + cc)
+        # ------------------------------------------------------------
+        email_to = f'help@{self.alias_domain}, {self.test_emails[1]}, {self.partner_employee.email_formatted}'
+        email_cc = f'{self.test_emails[2]}, {self.test_emails[5]}'
+        with self.mock_mail_gateway(), self.mock_mail_app():
+            ticket = self.format_and_process(
+                MAIL_TEMPLATE,
+                self.test_emails[0],
+                email_to,
+                cc=email_cc,
+                subject='Inquiry',
+                target_model='mail.test.ticket.mc',
+            )
+        self.assertEqual(ticket.name, 'Inquiry')

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -2229,12 +2229,12 @@ class TestMailGatewayLoops(MailGatewayCommon):
         original_mail = self._mails
 
         # auto-reply: write to bounce = no more bounce
-        self.gateway_mail_reply_last_email(MAIL_TEMPLATE, force_to=f'{self.alias_bounce}@{self.alias_domain}')
+        self.gateway_mail_reply_last_email(MAIL_TEMPLATE, force_email_to=f'{self.alias_bounce}@{self.alias_domain}')
         self.assertNotSentEmail()
 
         # auto-reply but forwarded to catchall -> should not bounce again
         self._mails = original_mail  # just to revert state prior to auto reply
-        self.gateway_mail_reply_last_email(MAIL_TEMPLATE, force_to=f'{self.alias_catchall}@{self.alias_domain}')
+        self.gateway_mail_reply_last_email(MAIL_TEMPLATE, force_email_to=f'{self.alias_catchall}@{self.alias_domain}')
         # TDE FIXME: this should not bounce again
         # self.assertNotSentEmail()
         self.assertSentEmail(

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -2036,6 +2036,49 @@ class TestMessagePostLang(MailCommon, TestRecipients):
 
     @users('employee')
     @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_post_multi_lang_inactive(self):
+        """ Test posting using an inactive lang, due do some data in DB. It
+        should not crash when trying to search for translated terms / fetch
+        lang bits. """
+        installed = self.env['res.lang'].get_installed()
+        self.assertNotIn('fr_FR', [code for code, _name in installed])
+        test_records = self.test_records.with_env(self.env)
+        customer_inactive_lang = self.env['res.partner'].create({
+            'email': 'test.partner.fr@test.example.com',
+            'lang': 'fr_FR',
+            'name': 'French Inactive Customer',
+        })
+        test_records.message_subscribe(partner_ids=customer_inactive_lang.ids)
+
+        for record in test_records:
+            with self.subTest(record=record.name):
+                with self.mock_mail_gateway(mail_unlink_sent=False), \
+                        self.mock_mail_app():
+                    record.message_post(
+                        body=Markup('<p>Hi there</p>'),
+                        email_layout_xmlid='mail.test_layout',
+                        message_type='comment',
+                        subject='TeDeum',
+                        subtype_xmlid='mail.mt_comment',
+                    )
+                    message = record.message_ids[0]
+                    self.assertEqual(message.notified_partner_ids, customer_inactive_lang)
+
+                    email = self._find_sent_email(
+                        self.partner_employee.email_formatted,
+                        [customer_inactive_lang.email_formatted]
+                    )
+                    self.assertTrue(bool(email), 'Email not found, check recipients')
+
+                    exp_layout_content_en = 'English Layout for Lang Chatter Model'
+                    exp_button_en = 'View Lang Chatter Model'
+                    exp_action_en = 'NotificationButtonTitle'
+                    self.assertIn(exp_layout_content_en, email['body'])
+                    self.assertIn(exp_button_en, email['body'])
+                    self.assertIn(exp_action_en, email['body'])
+
+    @users('employee')
+    @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_post_multi_lang_recipients(self):
         """ Test posting on a document in a multilang environment. Currently
         current user's lang determines completely language used for notification

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import threading
-
 from contextlib import contextmanager
 from unittest.mock import patch, Mock
 
-from odoo.tests.common import new_test_user, TransactionCase, HttpCase
 from odoo import Command, modules
+from odoo.tests.common import new_test_user, TransactionCase, HttpCase
+from odoo.tools.mail import email_split_and_format
 
 DISABLED_MAIL_CONTEXT = {
     'tracking_disable': True,
@@ -401,19 +400,15 @@ class MockSmtplibCase:
 
             def send_message(self, message, smtp_from, smtp_to_list):
                 origin.emails.append({
-                    'smtp_from': smtp_from,
-                    'smtp_to_list': smtp_to_list,
+                    # message
                     'message': message.as_string(),
+                    'msg_cc': message['Cc'],
                     'msg_from': message['From'],
-                    'from_filter': self.from_filter,
-                })
-
-            def sendmail(self, smtp_from, smtp_to_list, message_str, mail_options):
-                origin.emails.append({
+                    'msg_from_fmt': email_split_and_format(message['From'])[0],
+                    'msg_to': message['To'],
+                    # smtp
                     'smtp_from': smtp_from,
                     'smtp_to_list': smtp_to_list,
-                    'message': message_str,
-                    'msg_from': None,  # to fix if necessary
                     'from_filter': self.from_filter,
                 })
 
@@ -456,12 +451,14 @@ class MockSmtplibCase:
             yield
 
     def _build_email(self, mail_from, return_path=None, **kwargs):
+        headers = {'Return-Path': return_path} if return_path else {}
+        headers.update(**kwargs.pop('headers', {}))
         return self.env['ir.mail_server'].build_email(
             mail_from,
             kwargs.pop('email_to', 'dest@example-é.com'),
             kwargs.pop('subject', 'subject'),
             kwargs.pop('body', 'body'),
-            headers={'Return-Path': return_path} if return_path else None,
+            headers=headers,
             **kwargs,
         )
 
@@ -470,9 +467,11 @@ class MockSmtplibCase:
             self.env['ir.mail_server'].send_email(msg, smtp_session=smtp_session)
         return smtp_session.messages.pop()
 
-    def assertSMTPEmailsSent(self, smtp_from=None, smtp_to_list=None, message_from=None,
+    def assertSMTPEmailsSent(self, smtp_from=None, smtp_to_list=None,
+                             message_from=None, msg_from=None,
                              mail_server=None, from_filter=None,
-                             emails_count=1):
+                             emails_count=1,
+                             msg_cc_lst=None, msg_to_lst=None):
         """Check that the given email has been sent. If one of the parameter is
         None it is just ignored and not used to retrieve the email.
 
@@ -484,40 +483,47 @@ class MockSmtplibCase:
         :param from_filter: from_filter of the <ir.mail_server> used to send the
           email. False means 'match everything';'
         :param emails_count: the number of emails which should match the condition
+        :param msg_cc: optional check msg_cc value of email;
+        :param msg_to: optional check msg_to value of email;
+
         :return: True if at least one email has been found with those parameters
         """
         if from_filter is not None and mail_server:
             raise ValueError('Invalid usage: use either from_filter either mail_server')
+
         if from_filter is None and mail_server is not None:
             from_filter = mail_server.from_filter
-        matching_emails = filter(
+        matching_emails = list(filter(
             lambda email:
                 (smtp_from is None or smtp_from == email['smtp_from'])
                 and (smtp_to_list is None or smtp_to_list == email['smtp_to_list'])
                 and (message_from is None or 'From: %s' % message_from in email['message'])
+                # might have header being name <email> instead of "name" <email>, to check
+                and (msg_from is None or (msg_from == email['msg_from'] or msg_from == email['msg_from_fmt']))
                 and (from_filter is None or from_filter == email['from_filter']),
             self.emails,
-        )
+        ))
 
         debug_info = ''
-        matching_emails_count = len(list(matching_emails))
+        matching_emails_count = len(matching_emails)
         if matching_emails_count != emails_count:
-            emails_from = []
-            for email in self.emails:
-                from_found = next((
-                    line.split('From:')[1].strip() for line in email['message'].splitlines()
-                    if line.startswith('From:')), '')
-                emails_from.append(from_found)
             debug_info = '\n'.join(
-                f"SMTP-From: {email['smtp_from']}, SMTP-To: {email['smtp_to_list']}, Msg-From: {email_msg_from}, From_filter: {email['from_filter']})"
-                for email, email_msg_from in zip(self.emails, emails_from)
+                f"SMTP-From: {email['smtp_from']}, SMTP-To: {email['smtp_to_list']}, "
+                f"Msg-From: {email['msg_from']}, From_filter: {email['from_filter']})"
+                for email in self.emails
             )
         self.assertEqual(
             matching_emails_count, emails_count,
             msg=f'Incorrect emails sent: {matching_emails_count} found, {emails_count} expected'
-                f'\nConditions\nSMTP-From: {smtp_from}, SMTP-To: {smtp_to_list}, Msg-From: {message_from}, From_filter: {from_filter}'
+                f'\nConditions\nSMTP-From: {smtp_from}, SMTP-To: {smtp_to_list}, Msg-From: {message_from or msg_from}, From_filter: {from_filter}'
                 f'\nNot found in\n{debug_info}'
         )
+        if msg_to_lst is not None:
+            for email in matching_emails:
+                self.assertListEqual(sorted(email_split_and_format(email['msg_to'])), sorted(msg_to_lst))
+        if msg_cc_lst is not None:
+            for email in matching_emails:
+                self.assertListEqual(sorted(email_split_and_format(email['msg_cc'])), sorted(msg_cc_lst))
 
     @classmethod
     def _init_mail_gateway(cls):


### PR DESCRIPTION
PURPOSE

Add an email discussion like flow, on a lead-like model. This allows to
test a full discussion with some real-life use cases and see how it
behaves in current codebase.

Improve tools and asserts while doing so.

Fix an issue when having customer having a lang that is inactive.

NEXT

This is done in 18 in order to assert behavior and also ease future
changes. Indeed email flow is going to change in between Odoo 18 and
19 and it is a good practice to have a flow for the "current behavior"
not only the new one.

Prepares Task-4281157: [mail] Allow to alter email.message To
Prepares Task-4332797: [mail] Partner from emails 3.0
Prepares Task-4286232: [mail] Store email{cc/to} on mail.message
Prepares Task-4273569: [mail] Reply, Quotes, Expand and Forward
Prepares Task-4273479: [mail] Email-like recipients