### PR TITLE
[FIX] sale: remove draft indicator for pos down payment

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -718,6 +718,8 @@ class SaleOrderLine(models.Model):
             return ''
 
         invoice_lines = self._get_invoice_lines()
+        if self.invoice_status == 'invoiced' and not invoice_lines:
+            return ''
         if all(line.parent_state == 'draft' for line in invoice_lines):
             return 'draft'
         if all(line.parent_state == 'cancel' for line in invoice_lines):


### PR DESCRIPTION
## Versions:
16.0
17.0
No fix needed for saas-17.2 as per https://github.com/odoo/odoo/commit/5542bfd48fad3b89e3e54c9534da2e4963a90d54

## Issue:
A `(Draft)` text appears on sale orders lines when a down payment is done from the `Point of Sale` app.
This text keeps appearing during the entire process, even on the invoice.

## Expected:
A down payment made from the PoS app should not be a draft as it has been paid. The trailing text should not appear.

## Steps to reproduce:
- Activate Sales and Point Of Sale apps;
- Ensure, in the PoS settings, the shop you will use has a down payment product setup (`Down Payment (POS)`;
- Create a new `Quotation` from the `Sales` app with a product available in the PoS;
- Got to the shop view (open a session) and click on the `Quotation/Order` button;
- Select the lately created order and `Apply a down payment` with any value;
- Proceed payment with any method and navigate to backend;
- Go back to the quotation and look at the notebook.

## Cause:
`(Draft)` text is added at the end of the down payment product's line as the `dp_state` is equal to `'draft'`.

## Fix:
The problem has been correctly managed from saas-17.4 but needs more database fields: https://github.com/odoo/odoo/blob/0c0754b0fa9ee1f9efa20d1ae78a34df3dac5110/addons/sale/models/sale_order_line.py#L135-L145


opw-4380985