### PR TITLE
[FIX] mrp: state computation for work orders

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -228,6 +228,7 @@ class MrpWorkorder(models.Model):
                 workorder.production_id.qty_producing = workorder.qty_producing
                 workorder.production_id._set_qty_producing()
 
+    @api.depends('blocked_by_workorder_ids')
     def _compute_qty_ready(self):
         for workorder in self:
             if workorder.production_state not in ('confirmed', 'progress') or workorder.state in ('cancel', 'done'):

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -3432,7 +3432,7 @@ class TestMrpOrder(TestMrpCommon):
 
         self.assertEqual(mo_backorder.workorder_ids[0].state, 'cancel')
         self.assertEqual(mo_backorder.workorder_ids[1].state, 'ready')
-        self.assertEqual(mo_backorder.workorder_ids[2].state, 'ready')
+        self.assertEqual(mo_backorder.workorder_ids[2].state, 'pending')
         self.assertFalse(mo_backorder.workorder_ids[0].date_start)
         self.assertEqual(mo_backorder.workorder_ids[1].date_start, datetime(2023, 3, 1, 12, 0))
         self.assertEqual(mo_backorder.workorder_ids[2].date_start, datetime(2023, 3, 1, 12, 45))


### PR DESCRIPTION
Before this Commit:
----------------------------
Whenever a manufacturing order (MO) with work orders is split, the work order states in the backorder MO are incorrect.

Step to Produce:
----------------------------
1. Create a MO with work orders.
2. Split the MO.
3. Open the backorder MO and check the work order states.

With this Commit:
----------------------------
The issue was due to improper state computation and a lack of necessary dependencies. The dependencies have been properly applied, ensuring the correct state computation of work orders in backorder MOs.

Task-id: 4410926