### PR TITLE
[FIX] im_livechat,*: operator missing livechat_username

### DIFF
--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -346,8 +346,17 @@ class ChatbotScriptStep(models.Model):
                 # first post the message of the step (if we have one)
                 posted_message = discuss_channel._chatbot_post_message(self.chatbot_script_id, plaintext2html(self.message))
 
-            # next, add the human_operator to the channel and post a "Operator joined the channel" notification
-            discuss_channel.with_user(human_operator).sudo().add_members(human_operator.partner_id.ids, open_chat_window=True)
+            # next, add the human_operator to the channel
+            discuss_channel.with_user(human_operator).sudo().add_members(human_operator.partner_id.ids, open_chat_window=True, post_joined_message=False)
+            # post a "Operator joined the channel" notification
+            discuss_channel.message_post(
+                author_id=human_operator.partner_id.id,
+                body=Markup('<div class="o_mail_notification">%s</div>') % _(
+                    '%s has joined',
+                    human_operator.livechat_username or human_operator.partner_id.name
+                ),
+                subtype_xmlid='mail.mt_comment'
+            )
 
             # finally, rename the channel to include the operator's name
             discuss_channel.sudo().name = ' '.join([

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -75,7 +75,7 @@ class TestLivechatChatbotUI(TestLivechatCommon, ChatbotCase):
             ("How can I help you?", operator, self.step_dispatch_operator),
             ("I want to speak with an operator", False, False),
             ("I will transfer you to a human", operator, False),
-            ("joined the channel", self.operator.partner_id, False), # human_operator has joined the channel
+            (f"{self.operator.livechat_username} has joined", self.operator.partner_id, False),
         ]
 
         self.assertEqual(len(conversation_messages), len(expected_messages))


### PR DESCRIPTION
*=website_livechat

Purpose of this commit:
The PR https://github.com/odoo/odoo/pull/188530 fixed logging the operator's join message as a notification, but it missed the case where the operator could have a different livechat_username. This commit handles that issue.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
