### PR TITLE
[FIX] mail: preventing typeerror on clicking unfollow

### DIFF
--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -172,7 +172,7 @@ class MailController(http.Controller):
     def mail_action_unfollow(self, model, res_id, pid, token, **kwargs):
         comparison, record, __ = MailController._check_token_and_record_or_redirect(model, int(res_id), token)
         if not comparison or not record:
-            raise AccessError(_('Non existing record or wrong token.'))
+            raise NotFound()
 
         pid = int(pid)
         record_sudo = record.sudo()

--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -142,5 +142,5 @@ class MailController(mail.MailController):
 
     # Add website=True to support the portal layout
     @http.route('/mail/unfollow', type='http', website=True)
-    def mail_action_unfollow(self, model, res_id, pid, token, **kwargs):
+    def mail_action_unfollow(self, model=False, res_id=False, pid=False, token=False, **kwargs):
         return super().mail_action_unfollow(model, res_id, pid, token, **kwargs)

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -874,7 +874,7 @@ class UnfollowLinkTest(MailCommon, HttpCase):
             with self.subTest(f'Tampered {param}'):
                 tampered_unfollow_url = self._url_update_query_parameters(unfollow_url, **{param: value})
                 response = self.url_open(tampered_unfollow_url)
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, 404)
                 self.assertIn(partner, record.message_partner_ids)
 
     def _test_unfollow_url(self, record, unfollow_url, partner):


### PR DESCRIPTION
Currently a `TypeError` is arising when user clicks 'Unfollow'.

### Steps to reproduce this error:
- Install 'Payroll'
- Go to Payslips > All payslips
- Create a new (or duplicate) playslip.
- Compute Sheet
- Create Draft Entry
- Create Payment report
- Run the "Payroll:Generate pdfs"CRON (model._cron_generate_pdf() on hr.payslip)
- Click the 'Unfollow' at the bottom of the payslip.
- The error appears in the log.

Error: `TypeError: MailController.mail_action_unfollow() missing 4 required positional arguments: 'model', 'res_id', 'pid', and 'token'`

This commit solves the above issue by changing the missing fields to 'False'. 

sentry-4952598215
