### PR TITLE
[FIX] crm: display the missing line in crm helper

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1258,7 +1258,7 @@ class Lead(models.Model):
         else:
             help_title = _('Create an opportunity to start playing with your pipeline.')
         alias_domain = [
-            ('company_id', '=', self.env.company.id),
+            ('company_id', 'in', [self.env.company.id, False]),
             ('alias_id.alias_name', '!=', False),
             ('alias_id.alias_name', '!=', ''),
             ('alias_id.alias_model_id.model', '=', 'crm.lead'),


### PR DESCRIPTION
**Specifications:**
When the domain is specified, helper in crm helper should display an extra line, which explains that any email sent to alias@domain will create a lead.

**Technical reason:**
A code was added in `crm.lead` which checks for the company, but in data file company was already specified as `False`. Hence, the missing line.

**After this PR:**
If the custom email domain is set, crm helper will display an extra line.

Task-4377574