### PR TITLE
[FIX] crm: onboarding tour bubble fix

### DIFF
--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -28,7 +28,7 @@ registry.category("web_tour.tours").add('crm_tour', {
     trigger: ".o_opportunity_kanban",
 },
 {
-    trigger: '.o-kanban-button-new',
+    trigger: '.o_opportunity_kanban .o-kanban-button-new',
     content: markup(_t("<b>Create your first opportunity.</b>")),
     position: 'bottom',
     run: "click",


### PR DESCRIPTION
Tour bubble points to every New button in kanban.
Fixed it to only point at New button in crm lead kanban view.

Task-4377574