### PR TITLE
[FIX] mass_mailing: avoid automatic unsubscribe from mail

### DIFF
--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -11,6 +11,7 @@ from werkzeug.exceptions import BadRequest, NotFound, Unauthorized
 from odoo import _, fields, http, tools
 from odoo.http import request, Response
 from odoo.tools import consteq
+from lxml import etree
 
 
 class MassMailController(http.Controller):
@@ -105,34 +106,100 @@ class MassMailController(http.Controller):
     @http.route(['/mailing/<int:mailing_id>/confirm_unsubscribe'], type='http', website=True, auth='public')
     def mailing_confirm_unsubscribe(self, mailing_id, document_id=None, email=None, hash_token=None):
         mailing = request.env['mailing.mailing'].sudo().browse(mailing_id)
-
-        unsubscribed_list = ''
+        # check that mailing exists/has access
         email_found, hash_token_found = self._fetch_user_information(email, hash_token)
         try:
-            mailing_sudo = self._check_mailing_email_token(
+            self._check_mailing_email_token(
                 mailing_id, document_id, email_found, hash_token_found,
                 required_mailing_id=True
             )
-            if mailing.mailing_model_real == 'mailing.contact':
-                unsubscribed_list = ', '.join(str(list.name) for list in mailing.contact_list_ids if list.is_public)
         except NotFound as e:  # avoid leaking ID existence
             raise Unauthorized() from e
-        template = request.env.ref('mass_mailing.page_confirm_unsubscribe',raise_if_not_found=False)
-        if template:
-            return request.render('mass_mailing.page_confirm_unsubscribe', {
-                    'mailing_id': mailing_id,
-                    'document_id': document_id,
-                    'email': email,
-                    'hash_token': hash_token,
-                    'unsubscribed_list': unsubscribed_list,
-                })
-        else:
-            return self.mailing_confirm_unsubscribe_post(mailing_id, document_id, email, hash_token)
 
+        unsubscribed_str = _("Are you sure you want to unsubscribe from our mailing list?")
+        # Display list name if list is public
+        if mailing.mailing_model_real == 'mailing.contact':
+            unsubscribed_lists = ', '.join(mailing_list.name for mailing_list in mailing.contact_list_ids if mailing_list.is_public)
+            if unsubscribed_lists:
+                unsubscribed_str = _(
+                    'Are you sure you want to unsubscribe from the mailing list "%(unsubscribed_lists)s"?',
+                    unsubscribed_lists=unsubscribed_lists
+                )
+        unsubscribe_btn = _("Unsubscribe")
+
+        template = etree.fromstring("""
+            <t t-call="mass_mailing.layout">
+                <div class="container o_unsubscribe_form">
+                    <div class="row">
+                        <div class="col-lg-6 offset-lg-3 mt-4">
+                            <div id="info_state"  class="alert alert-success">
+                                <div class="text-center">
+                                    <form action="/mailing/confirm_unsubscribe" method="POST">
+                                        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                        <input type="hidden" name="mailing_id" t-att-value="mailing_id"/>
+                                        <input type="hidden" name="document_id" t-att-value="document_id"/>
+                                        <input type="hidden" name="email" t-att-value="email"/>
+                                        <input type="hidden" name="hash_token" t-att-value="hash_token"/>
+                                        <p t-out="unsubscribed_str"/>
+                                        <button type="submit" class="btn btn-primary" t-out="unsubscribe_btn"/>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </t>
+        """)
+        return request.render(template, {
+            'mailing_id': mailing_id,
+            'document_id': document_id,
+            'email': email,
+            'hash_token': hash_token,
+            'unsubscribed_str': unsubscribed_str,
+            'unsubscribe_btn': unsubscribe_btn,
+        })
+
+    # POST method
     @http.route(['/mailing/confirm_unsubscribe'], type='http', website=True, auth='public', methods=['POST'])
     def mailing_confirm_unsubscribe_post(self, mailing_id, document_id=None, email=None, hash_token=None):
-        url = f'/mailing/{mailing_id}/unsubscribe?document_id={document_id}&email={email}&hash_token={hash_token}'
-        return request.redirect(url)
+        # Unsubscribe user
+        email_found, hash_token_found = self._fetch_user_information(email, hash_token)
+        try:
+            mailing_sudo = self._check_mailing_email_token(
+                int(mailing_id), document_id, email_found, hash_token_found,
+                required_mailing_id=True
+            )
+        except NotFound as e:  # fails if mailing doesn't exist or token is wrong
+            raise Unauthorized() from e
+
+        if mailing_sudo.mailing_on_mailing_list:
+            self._mailing_unsubscribe_from_list(mailing_sudo, document_id, email_found, hash_token_found)
+        else:
+            self._mailing_unsubscribe_from_document(mailing_sudo, document_id, email_found, hash_token_found)
+
+        success_str = _("Successfully unsubscribed!")
+        manage_btn = _("Manage Subscriptions")
+        template = etree.fromstring("""
+            <t t-call="mass_mailing.layout">
+                <div class="container o_unsubscribe_form">
+                    <div class="row">
+                        <div class="col-lg-6 offset-lg-3 mt-4">
+                            <div id="info_state"  class="alert alert-success">
+                                <div class="text-center">
+                                    <p t-out="success_str"/>
+                                    <a t-att-href="settings_url" class="btn btn-primary" t-out="manage_btn"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </t>
+        """)
+        return request.render(template, {
+                'settings_url': f'/mailing/{mailing_id}/unsubscribe?document_id={document_id}&email={email}&hash_token={hash_token}',
+                'success_str': success_str,
+                'manage_btn': manage_btn,
+        })
 
     @http.route(['/mailing/<int:mailing_id>/unsubscribe'], type='http', website=True, auth='public')
     def mailing_unsubscribe(self, mailing_id, document_id=None, email=None, hash_token=None):

--- a/addons/mass_mailing/i18n/mass_mailing.pot
+++ b/addons/mass_mailing/i18n/mass_mailing.pot
@@ -960,6 +960,20 @@ msgstr ""
 
 #. module: mass_mailing
 #. odoo-python
+#: code:addons/mass_mailing/controllers/main.py:0
+#, python-format
+msgid "Are you sure you want to unsubscribe from our mailing list?"
+msgstr ""
+
+#. module: mass_mailing
+#. odoo-python
+#: code:addons/mass_mailing/controllers/main.py:0
+#, python-format
+msgid "Are you sure you want to unsubscribe from the mailing list \"%(unsubscribed_lists)s\"?"
+msgstr ""
+
+#. module: mass_mailing
+#. odoo-python
 #: code:addons/mass_mailing/models/mailing_list.py:0
 msgid ""
 "At least one of the mailing list you are trying to archive is used in an "
@@ -2950,6 +2964,13 @@ msgid "Manage mass mailing campaigns"
 msgstr ""
 
 #. module: mass_mailing
+#. odoo-python
+#: code:addons/mass_mailing/controllers/main.py:0
+#, python-format
+msgid "Manage Subscriptions"
+msgstr ""
+
+#. module: mass_mailing
 #: model:ir.model.fields.selection,name:mass_mailing.selection__utm_campaign__ab_testing_winner_selection__manual
 msgid "Manual"
 msgstr ""
@@ -4366,6 +4387,18 @@ msgid "Subscription Information"
 msgstr ""
 
 #. module: mass_mailing
+#: model:ir.actions.act_window,name:mass_mailing.mailing_subscription_action_report_optout
+msgid "Subscriptions"
+msgstr ""
+
+#. module: mass_mailing
+#. odoo-python
+#: code:addons/mass_mailing/controllers/main.py:0
+#, python-format
+msgid "Successfully unsubscribed!"
+msgstr ""
+
+#. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.unsubscribe_form
 msgid "Successfully Unsubscribed"
 msgstr ""
@@ -4734,6 +4767,13 @@ msgstr ""
 #. module: mass_mailing
 #: model:ir.model.fields.selection,name:mass_mailing.selection__mailing_trace__failure_type__unknown
 msgid "Unknown error"
+msgstr ""
+
+#. module: mass_mailing
+#. odoo-python
+#: code:addons/mass_mailing/controllers/main.py:0
+#, python-format
+msgid "Unsubscribe"
 msgstr ""
 
 #. module: mass_mailing

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1048,7 +1048,7 @@ class MassMailing(models.Model):
 
     def _get_unsubscribe_url(self, email_to, res_id):
         url = werkzeug.urls.url_join(
-            self.get_base_url(), 'mailing/%(mailing_id)s/unsubscribe?%(params)s' % {
+            self.get_base_url(), 'mailing/%(mailing_id)s/confirm_unsubscribe?%(params)s' % {
                 'mailing_id': self.id,
                 'params': werkzeug.urls.url_encode({
                     'document_id': res_id,

--- a/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
@@ -1,39 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="page_confirm_unsubscribe" name="Confirm Unsubscribe">
-        <t t-call="mass_mailing.layout">
-            <t t-call="mass_mailing.confirm_unsubscribe"/>
-        </t>
-    </template>
-
-    <template id="confirm_unsubscribe">
-        <div class="container o_unsubscribe_form">
-            <div class="row">
-                <form action="/mailing/confirm_unsubscribe" method="POST" class="col-lg-6 offset-lg-3 mt-4">
-                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
-                    <input type="hidden" name="mailing_id" t-att-value="mailing_id"/>
-                    <input type="hidden" name="document_id" t-att-value="document_id"/>
-                    <input type="hidden" name="email" t-att-value="email"/>
-                    <input type="hidden" name="hash_token" t-att-value="hash_token"/>
-
-                    <div id="info_state"  class="alert alert-success">
-                        <div class="text-center">
-                            <t t-if="len(unsubscribed_list) > 0">
-                                <p>You are about to unsubscribe from the following mailing list: <t t-out="unsubscribed_list"/></p>
-                            </t>
-                            <t t-else="">
-                                <p>You are about to unsubscribe from a mailing list.</p>
-                            </t>
-                            <div>
-                                <button type="submit" class="btn btn-primary">Unsubscribe</button>
-                            </div>
-                        </div>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </template>
-
     <template id="page_mailing_unsubscribe" name="Unsubscribe">
         <t t-call="mass_mailing.layout">
             <t t-call="mass_mailing.unsubscribe_form"/>

--- a/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
@@ -1,5 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <template id="page_confirm_unsubscribe" name="Confirm Unsubscribe">
+        <t t-call="mass_mailing.layout">
+            <t t-call="mass_mailing.confirm_unsubscribe"/>
+        </t>
+    </template>
+
+    <template id="confirm_unsubscribe">
+        <div class="container o_unsubscribe_form">
+            <div class="row">
+                <form action="/mailing/confirm_unsubscribe" method="POST" class="col-lg-6 offset-lg-3 mt-4">
+                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                    <input type="hidden" name="mailing_id" t-att-value="mailing_id"/>
+                    <input type="hidden" name="document_id" t-att-value="document_id"/>
+                    <input type="hidden" name="email" t-att-value="email"/>
+                    <input type="hidden" name="hash_token" t-att-value="hash_token"/>
+
+                    <div id="info_state"  class="alert alert-success">
+                        <div class="text-center">
+                            <t t-if="len(unsubscribed_list) > 0">
+                                <p>You are about to unsubscribe from the following mailing list: <t t-out="unsubscribed_list"/></p>
+                            </t>
+                            <t t-else="">
+                                <p>You are about to unsubscribe from a mailing list.</p>
+                            </t>
+                            <div>
+                                <button type="submit" class="btn btn-primary">Unsubscribe</button>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </template>
+
     <template id="page_mailing_unsubscribe" name="Unsubscribe">
         <t t-call="mass_mailing.layout">
             <t t-call="mass_mailing.unsubscribe_form"/>

--- a/addons/test_mail_full/tests/test_mass_mailing.py
+++ b/addons/test_mail_full/tests/test_mass_mailing.py
@@ -99,7 +99,7 @@ class TestMassMailing(TestMailFullCommon):
                     email['body'])
                 # rendered unsubscribe
                 self.assertIn(
-                    '%s/mailing/%s/unsubscribe' % (mailing.get_base_url(), mailing.id),
+                    '%s/mailing/%s/confirm_unsubscribe' % (mailing.get_base_url(), mailing.id),
                     email['body'])
                 unsubscribe_href = self._get_href_from_anchor_id(email['body'], "url6")
                 unsubscribe_url = werkzeug.urls.url_parse(unsubscribe_href)


### PR DESCRIPTION
## Do not merge; commit will be cherry-picked into fw-port PRs
16.0 PR: https://github.com/odoo/odoo/pull/189561


Email clients have begun implementing security measures to protect
users from phishing by analyzing email links, and interacting with
them (see task-3972953).

This has the side effect of automatically unsubscribing email
recipients from mailing lists by clicking the link in the footer of
the emails.

This commit adds an intermediate step to the process, by requiring
users to click on a button before they are unsubscribed.

task-4364446

--

The current unsubscription destination page for emails makes it unclear
for the user whether they've been unsubscribed or not.

This is because the "unsubscription confirmed" box is placed below the
"manage subscription settings" box on the confirmation page.

To avoid confusion, while ensuring current Studio customizations to
stable instances are not impacted, a new intercalate page is added
to clarify that the user is unsubscribed, and offer the option
to manage unsubscriptions by reaching the previous page.

task-4364446