### PR TITLE
[FIX] mrp: make workorder tree view timer not editable

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -2690,7 +2690,11 @@ class TestMrpOrder(TestMrpCommon):
         production_form = Form(production)
         production_form.qty_producing = 1
         with production_form.workorder_ids.edit(0) as wo:
-            wo.duration = 15 # in 15 minutes
+            with wo.time_ids.new() as time:
+                time.workcenter_id = wo.workcenter_id
+                now = fields.Datetime.now()
+                time.date_start = now
+                time.date_end = now + timedelta(minutes=15) # in 15 minutes
         production = production_form.save()
         production.button_mark_done()
         # It is saved and done, registered in the db. There are now 1 productions of that operation
@@ -2707,7 +2711,11 @@ class TestMrpOrder(TestMrpCommon):
         production_form = Form(production)
         production_form.qty_producing = 1
         with production_form.workorder_ids.edit(0) as wo:
-            wo.duration = 10  # In 10 minutes this time
+            with wo.time_ids.new() as time:
+                time.workcenter_id = wo.workcenter_id
+                now = fields.Datetime.now()
+                time.date_start = now
+                time.date_end = now + timedelta(minutes=10) # in 10 minutes
         production = production_form.save()
         production.button_mark_done()
         # It is saved and done, registered in the db. There are now 2 productions of that operation
@@ -2738,7 +2746,11 @@ class TestMrpOrder(TestMrpCommon):
         production_form = Form(production)
         production_form.qty_producing = 1
         with production_form.workorder_ids.edit(0) as wo:
-            wo.duration = 10  # in 10 minutes
+            with wo.time_ids.new() as time:
+                time.workcenter_id = wo.workcenter_id
+                now = fields.Datetime.now()
+                time.date_start = now
+                time.date_end = now + timedelta(minutes=10) # in 10 minutes
         production = production_form.save()
         production.button_mark_done()
         # It is saved and done, registered in the db. There are now 1 productions of that operation
@@ -2757,7 +2769,11 @@ class TestMrpOrder(TestMrpCommon):
         production_form = Form(production)
         production_form.qty_producing = 2
         with production_form.workorder_ids.edit(0) as wo:
-            wo.duration = 10  # In 10 minutes this time
+            with wo.time_ids.new() as time:
+                time.workcenter_id = wo.workcenter_id
+                now = fields.Datetime.now()
+                time.date_start = now
+                time.date_end = now + timedelta(minutes=10) # in 10 minutes
         production = production_form.save()
         production.button_mark_done()
         # It is saved and done, registered in the db. There are now 2 productions of that operation but they have the same duration
@@ -2791,7 +2807,11 @@ class TestMrpOrder(TestMrpCommon):
         production_form = Form(production)
         production_form.qty_producing = 1
         with production_form.workorder_ids.edit(0) as wo:
-            wo.duration = 10  # in 10 minutes
+            with wo.time_ids.new() as time:
+                time.workcenter_id = wo.workcenter_id
+                now = fields.Datetime.now()
+                time.date_start = now
+                time.date_end = now + timedelta(minutes=10) # in 10 minutes
         production = production_form.save()
         production.button_mark_done()
 
@@ -4880,7 +4900,11 @@ class TestMrpOrder(TestMrpCommon):
         production_form = Form(production)
         production_form.qty_producing = 1
         with production_form.workorder_ids.edit(0) as wo:
-            wo.duration = 15  # Complete the work order in 15 minutes
+            with wo.time_ids.new() as time:
+                time.workcenter_id = wo.workcenter_id
+                now = fields.Datetime.now()
+                time.date_start = now
+                time.date_end = now + timedelta(minutes=15)# Complete the work order in 15 minutes
         production = production_form.save()
         production.button_mark_done()
 

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -85,7 +85,7 @@
                 <field name="duration_expected" widget="float_time" sum="expected duration" readonly="state in ['cancel', 'done']"/>
                 <field name="duration" widget="mrp_timer"
                   invisible="production_state == 'draft'"
-                  readonly="is_user_working" sum="real duration"/>
+                  readonly="True" sum="real duration"/>
                 <field name="state" widget="badge" decoration-warning="state == 'progress'" decoration-success="state == 'done'" decoration-danger="state == 'cancel'" decoration-info="state not in ('progress', 'done', 'cancel')"
                   column_invisible="parent and parent.state == 'draft'"
                   invisible="production_state == 'draft'"/>

--- a/addons/project_mrp_account/tests/test_analytic_account.py
+++ b/addons/project_mrp_account/tests/test_analytic_account.py
@@ -1,5 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime, timedelta
+
+from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 from odoo.tests import Form
@@ -147,8 +150,12 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
 
         # change duration to 60
         mo_form = Form(mo)
-        with mo_form.workorder_ids.edit(0) as line_edit:
-            line_edit.duration = 60.0
+        with mo_form.workorder_ids.edit(0) as wo:
+            with wo.time_ids.new() as time:
+                time.workcenter_id = wo.workcenter_id
+                now = fields.Datetime.now()
+                time.date_start = now - timedelta(minutes=60)
+                time.date_end = now
         mo_form.save()
         self.assertEqual(mo.workorder_ids.mo_analytic_account_line_ids.amount, -10.0)
         self.assertEqual(mo.workorder_ids.mo_analytic_account_line_ids[self.analytic_plan._column_name()], self.analytic_account)
@@ -156,8 +163,12 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         self.assertEqual(mo.workorder_ids.wc_analytic_account_line_ids[analytic_plan._column_name()], wc_analytic_account)
 
         # change duration to 120
-        with mo_form.workorder_ids.edit(0) as line_edit:
-            line_edit.duration = 120.0
+        with mo_form.workorder_ids.edit(0) as wo:
+            with wo.time_ids.new() as time:
+                time.workcenter_id = wo.workcenter_id
+                now = fields.Datetime.now()
+                time.date_start = now - timedelta(minutes=120)
+                time.date_end = now
         mo_form.save()
         self.assertEqual(mo.workorder_ids.mo_analytic_account_line_ids.amount, -20.0)
         self.assertEqual(mo.workorder_ids.mo_analytic_account_line_ids[self.analytic_plan._column_name()], self.analytic_account)
@@ -194,8 +205,12 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
 
         # Change duration to 60
         mo_form = Form(mo)
-        with mo_form.workorder_ids.edit(0) as line_edit:
-            line_edit.duration = 60.0
+        with mo_form.workorder_ids.edit(0) as wo:
+            with wo.time_ids.new() as time:
+                time.workcenter_id = wo.workcenter_id
+                now = fields.Datetime.now()
+                time.date_start = now - timedelta(minutes=60)
+                time.date_end = now
         mo_form.save()
         self.assertEqual(mo.workorder_ids.mo_analytic_account_line_ids[self.analytic_plan._column_name()], self.analytic_account)
 


### PR DESCRIPTION
task-id: 4369475

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
