### PR TITLE
[FIX] hr_holidays: allow date modification for unapproved time off requests

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -983,7 +983,8 @@ class HolidaysRequest(models.Model):
 
         is_officer = self.env.user.has_group('hr_holidays.group_hr_holidays_user') or self.env.is_superuser()
         if not is_officer and values.keys() - {'attachment_ids', 'supported_attachment_ids', 'message_main_attachment_id'}:
-            if any(hol.date_from.date() < fields.Date.today() and hol.employee_id.leave_manager_id != self.env.user for hol in self):
+            if any(hol.date_from.date() < fields.Date.today() and hol.employee_id.leave_manager_id != self.env.user
+                   and hol.state not in ('confirm', 'draft') for hol in self):
                 raise UserError(_('You must have manager rights to modify/validate a time off that already begun'))
 
         # Unlink existing resource.calendar.leaves for validated time off

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1134,3 +1134,24 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
         with self.assertRaises(UserError):
             self.holidays_type_2.requires_allocation = 'yes'
+
+    def test_time_off_date_edit(self):
+        user_id = self.employee_emp.user_id
+        employee_id = self.employee_emp.id
+
+        leave = self.env['hr.leave'].with_user(user_id).create({
+            'name': 'Test leave',
+            'employee_id': employee_id,
+            'holiday_status_id': self.holidays_type_2.id,
+            'date_from': (datetime.today() - relativedelta(days=2)),
+            'date_to': datetime.today()
+        })
+
+        two_days_after = (datetime.today() + relativedelta(days=2)).date()
+        with Form(leave.with_user(user_id)) as leave_form:
+            leave_form.request_date_from = two_days_after
+            leave_form.request_date_to = two_days_after
+        modified_leave = leave_form.save()
+
+        self.assertEqual(modified_leave.request_date_from, two_days_after)
+        self.assertEqual(modified_leave.request_date_to, two_days_after)


### PR DESCRIPTION
Steps to Reproduce:
• Install the Time Off app.
• Create a new user and corresponding employee without any group in Time Off. 
• Create a new time off request with a start date < today's date. 
• Attempt to change the date, which results in a validation error.

Issue:
- Users are unable to modify time off requests, even if they are not yet approved.

Fix:
- Added a check to ensure that modifications are allowed for time off requests that are not in an approved state.

task-4236572

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
