### PR TITLE
[IMP] website, website_blog: adaptions for `s_appointments` design improvements

### DIFF
--- a/addons/web/static/src/scss/utilities_custom.scss
+++ b/addons/web/static/src/scss/utilities_custom.scss
@@ -185,10 +185,13 @@ $utilities: map-merge(
 
 // Define opacity:hover classes while defining the triggerer behavior.
 // Use'.opacity-trigger-hover' class to allow hovered parents to
-// trigger their children ':hover' opacity state.
+// trigger their children ':hover' and ':focus-visible' opacity states.
 @each $-opacity-key, $-opacity-level in $utilities-opacity {
     .opacity-#{$-opacity-key}-hover {
-        &:hover, .opacity-trigger-hover:hover & {
+        &:hover,
+        &:focus-visible,
+        .opacity-trigger-hover:hover &,
+        .opacity-trigger-hover:focus-visible & {
             opacity: $-opacity-level!important;
         }
     }

--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.scss
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.scss
@@ -22,7 +22,7 @@
             @include media-breakpoint-up(lg) {
                 // Switch to a fluid layout in order to keep entries readable.
                 // Our target grid is 2columns based
-                flex: 0 1 MAX($-entry-min-width, 50%);
+                flex: 0 1 MAX(var(--DynamicSnippet__entry-maxWidth, #{$-entry-min-width}), 50%);
             }
         }
     }
@@ -30,7 +30,7 @@
     > .o_container_small {
         .s_dynamic_snippet_row > * {
             @include media-breakpoint-up(lg) {
-                flex: 0 1 MAX($-entry-min-width, 50%);
+                flex: 0 1 MAX(var(--DynamicSnippet__entry-maxWidth, #{$-entry-min-width}), 50%);
             }
         }
 
@@ -41,7 +41,7 @@
 
             + .s_dynamic_snippet_content .s_dynamic_snippet_row > * {
                 @include media-breakpoint-up(lg) {
-                    flex: 1 1 $-entry-min-width;
+                    flex: 1 1 var(--DynamicSnippet__entry-maxWidth, #{$-entry-min-width});
                 }
             }
         }

--- a/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
+++ b/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
@@ -1,5 +1,7 @@
 .s_dynamic {
-    --Avatar-size: 1.5em;
+    &.s_blog_posts {
+        --Avatar-size: 1.5em;
+    }
 
     .s_blog_posts_post_teaser {
         @include o-line-clamp(2);


### PR DESCRIPTION
The adaptations made in this PR are related to the design improvements of the appointment snippet made in https://github.com/odoo/enterprise/pull/74494

---

### Allows to customize the size of s_dynamic_snippet entries 
Prior to this PR, the minimum size of entries was based on a calculation. This works with the default card template but would not work with other layout types (eg. a list-group). 
This PR allows to customize the size of entries for other layouts defined for `s_dynamic_snippet`.

### Reduces css variable scope for `s_blog_posts`
Prior to this PR, the `--Avatar-size` variable was set on the global `s_dynamic` selector. This had an impact on other dynamic snippets using this variable (e.g. `s_appointment`).
This PR reduces the scope of this variable so that it only applies to `s_blog_posts` in order to avoid conflicts with other dynamic snippets using this variable.

### Extends opacity classes to be triggered on focus
Prior to this PR, the utility classes used to change opacity on hover didn't manage the focus state.
For example, if we created a complex button that displayed items on hover, these items were not displayed when we used the keyboard to select the button.
This PR extends these utility classes to improve usability when using the keyboard.

task-4317830

---

Requires:
- https://github.com/odoo/enterprise/pull/74494

---


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
