### PR TITLE
[FIX] hr: fix `list.many2many_avatar_employee` widget

### DIFF
--- a/addons/hr/static/src/views/fields/many2many_avatar_employee_field/many2many_avatar_employee_field.js
+++ b/addons/hr/static/src/views/fields/many2many_avatar_employee_field/many2many_avatar_employee_field.js
@@ -2,6 +2,7 @@ import { registry } from "@web/core/registry";
 import {
     Many2ManyTagsAvatarUserField,
     KanbanMany2ManyTagsAvatarUserField,
+    ListMany2ManyTagsAvatarUserField,
     many2ManyTagsAvatarUserField,
     kanbanMany2ManyTagsAvatarUserField,
     listMany2ManyTagsAvatarUserField,
@@ -48,13 +49,25 @@ export const kanbanMany2ManyTagsAvatarEmployeeField = {
 registry
     .category("fields")
     .add("kanban.many2many_avatar_employee", kanbanMany2ManyTagsAvatarEmployeeField);
+
+
+export class ListMany2ManyTagsAvatarEmployeeField extends EmployeeFieldRelationMixin(
+    ListMany2ManyTagsAvatarUserField
+) {}
+
 export const listMany2ManyTagsAvatarEmployeeField = {
     ...listMany2ManyTagsAvatarUserField,
+    component: ListMany2ManyTagsAvatarEmployeeField,
     additionalClasses: [
         ...listMany2ManyTagsAvatarUserField.additionalClasses,
         "o_field_many2many_avatar_user",
     ],
+    extractProps: (fieldInfo, dynamicInfo) => ({
+        ...listMany2ManyTagsAvatarUserField.extractProps(fieldInfo, dynamicInfo),
+        relation: fieldInfo.options?.relation,
+    }),
 };
+
 registry
     .category("fields")
     .add("list.many2many_avatar_employee", listMany2ManyTagsAvatarEmployeeField);

--- a/addons/hr/static/tests/m2x_avatar_employee.test.js
+++ b/addons/hr/static/tests/m2x_avatar_employee.test.js
@@ -330,7 +330,7 @@ test("many2one with hr group widget in form view", async () => {
     ]);
 });
 
-test("many2one widget in list view", async () => {
+test("many2many widget in list view", async () => {
     const { env } = await makeMockServer();
     const [partnerId_1, partnerId_2] = env["res.partner"].create([
         { name: "Mario" },
@@ -356,16 +356,17 @@ test("many2one widget in list view", async () => {
     env["m2x.avatar.employee"].create({
         employee_ids: [employeeId_1, employeeId_2],
     });
+    onRpc("has_group", () => false);
     await start();
     await mountView({
         type: "list",
         resModel: "m2x.avatar.employee",
         arch: `<list><field name="employee_ids" widget="many2many_avatar_employee"/></list>`,
     });
-    expect(".o_data_cell:first .o_field_many2many_avatar_employee > div > span").toHaveCount(2);
+    expect(".o_data_cell:first .o_field_many2many_avatar_employee img.o_m2m_avatar").toHaveCount(2);
 
     // Clicking on first employee's avatar
-    await contains(".o_data_cell .o_m2m_avatar:eq(0)").click();
+    await contains(".o_data_cell img.o_m2m_avatar:eq(0)").click();
     await waitFor(".o_avatar_card");
     expect(".o_card_user_infos > span").toHaveText("Mario");
     expect(".o_card_user_infos > a").toHaveText("Mario@partner.com");
@@ -375,7 +376,7 @@ test("many2one widget in list view", async () => {
     await waitFor(".o-mail-ChatWindow-header:contains('Mario')");
 
     // Clicking on second employee's avatar
-    await contains(".o_data_cell .o_m2m_avatar:eq(1)").click();
+    await contains(".o_data_cell img.o_m2m_avatar:eq(1)").click();
     expect(".o_card_user_infos span").toHaveText("Yoshi");
     expect(".o_avatar_card").toHaveCount(1);
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");


### PR DESCRIPTION
### reproduce

- log with a user which has no permissions but set as Goal Manager
- for the goals list view -> all the employees avatar image would not load

### solve

- add the `extractProps` function to the widget object to call `hr.employee.puplic` insted of `hr.employee` to unify the interaction with the form and kanban ones

Task: 4391198



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
