### PR TITLE
[FIX] account: correct test_in_invoice_payment_register_wizard

### DIFF
--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1583,7 +1583,6 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
 
         # If the move is already fully paid, we should alert the user
         with self.assertRaisesRegex(UserError, r"You can't register a payment because there is nothing left"):
-            action_register_payment = move.action_force_register_payment()
             self.env[action_register_payment['res_model']].with_context(action_register_payment['context']).create({})
 
     def test_in_invoice_switch_type_1(self):


### PR DESCRIPTION
* If only using Odoo CE, this test will fail because action_force_register_payment will raise usererror like 'you can only ...' which will not match the expected out come

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
