### PR TITLE
[FIX] web: change Map to WeakMap in tooltip service

### DIFF
--- a/addons/web/static/src/core/tooltip/tooltip_service.js
+++ b/addons/web/static/src/core/tooltip/tooltip_service.js
@@ -52,7 +52,7 @@ export const tooltipService = {
         let target = null;
         let touchPressed;
         let mouseEntered;
-        const elementsWithTooltips = new Map();
+        const elementsWithTooltips = new WeakMap();
 
         /**
          * Closes the currently opened tooltip if any, or prevent it from opening.


### PR DESCRIPTION
The PR [1] fixes a memory leak in the tooltip service. The `Map` was used with `HTMLElement` as key. These elements were not removed and so never garbage collected. A more important issue is that these elements could retain info from components like views with models.

In a forward port, the change `Map` to `WeakMap` dispeared. This PR just re-adds this diff.

[1]: https://github.com/odoo/odoo/pull/186579