### PR TITLE
[IMP] l10n_ro_efactura: safe and correct `json.loads`

### DIFF
--- a/addons/l10n_ro_efactura/models/res_company.py
+++ b/addons/l10n_ro_efactura/models/res_company.py
@@ -9,7 +9,7 @@ from werkzeug.urls import url_join
 from odoo import fields, models, api, _
 from odoo.exceptions import UserError, ValidationError
 from odoo.http import request
-from odoo.tools import json
+from odoo.tools.safe_eval import json
 
 
 class ResCompany(models.Model):


### PR DESCRIPTION
The import origin of `json` will be changed to `odoo.tools.safe_eval`
for 2 reasons:

1. From 18.0 onwards, it refers to the `json.py` file, not the intended `json` module. This leads to an `AttributeError` when we're calling `json.loads(...)` method.

2. The `json` module from `safe_eval` is, from a security perspective, the intended way to load a json string (rather than the usual `json` from `import json`).

follow up of: https://github.com/odoo/odoo/pull/187708
more info: https://github.com/odoo/odoo/commit/5ef4c07ada1b47cd08a0fc7a2dd626f92d79b715#diff-6e39afafc5c2078cdfdc27335b7cf8b0867853dc34b5b907a0190f6453949bb2R21
opw-4187186