### PR TITLE
[FIX] point_of_sale: window.print extra blank page on receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.scss
@@ -17,7 +17,8 @@
 }
 
 @media print {
-    body {
+    .pos-receipt {
+        contain: paint;
         background-color: transparent;
     }
     body * {


### PR DESCRIPTION
An extra blank page was being printed when printing the receipt from the POS.

Adding
```
.pos-receipt {
    contain: paint;
    background-color: transparent;
}
```
to the receipt_screen.scss file fixes the issue.

opw-4292890
