### PR TITLE
[FIX] pos_sale: load sale order without error

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -13,7 +13,7 @@ import { Reactive } from "@web/core/utils/reactive";
 import { HWPrinter } from "@point_of_sale/app/printer/hw_printer";
 import { memoize } from "@web/core/utils/functions";
 import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
-import { ConnectionLostError } from "@web/core/network/rpc_service";
+import { ConnectionLostError, RPCError } from "@web/core/network/rpc_service";
 import { _t } from "@web/core/l10n/translation";
 import { CashOpeningPopup } from "@point_of_sale/app/store/cash_opening_popup/cash_opening_popup";
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
@@ -1767,7 +1767,16 @@ export class PosStore extends Reactive {
      */
     async _addProducts(ids, setAvailable = true) {
         if (setAvailable) {
-            await this.orm.write("product.product", ids, { available_in_pos: true });
+            try {
+                await this.orm.write("product.product", ids, { available_in_pos: true });
+            } catch (error) {
+                const ignoreError =
+                    error instanceof RPCError &&
+                    error.exceptionName === "odoo.exceptions.AccessError";
+                if (!ignoreError) {
+                    throw error;
+                }
+            }
         }
         const product = await this.orm.call("pos.session", "get_pos_ui_product_product_by_params", [
             odoo.pos_session_id,


### PR DESCRIPTION
This is practically a forward port of https://github.com/odoo/odoo/pull/154154. When loading a sale.order in pos for payment, the products in the sale.order are automatically set to be available in pos. In some cases, the current user doesn't have access to make such modification in the product. There is no point on blocking the user to load the sale.order when he doesn't have write access to the product. Therefore, we can just ignore the access error during write.

