### PR TITLE
[REF] web_tour: make debugging easier

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -4,7 +4,7 @@ import { TourStepAutomatic } from "./tour_step_automatic";
 import { Macro } from "@web/core/macro";
 import { browser } from "@web/core/browser/browser";
 import { setupEventActions } from "@web/../lib/hoot-dom/helpers/events";
-import { delay } from "@odoo/hoot-dom";
+import * as hoot from "@odoo/hoot-dom";
 
 export class TourAutomatic {
     mode = "auto";
@@ -53,7 +53,7 @@ export class TourAutomatic {
                             // IMPROVEMENT: Find a way to remove this delay.
                             await new Promise((resolve) => requestAnimationFrame(resolve));
                             if (this.config.stepDelay > 0) {
-                                await delay(this.config.stepDelay);
+                                await hoot.delay(this.config.stepDelay);
                             }
                         },
                     },
@@ -79,7 +79,7 @@ export class TourAutomatic {
                                 if (!step.skipped && this.showPointerDuration > 0 && step.element) {
                                     // Useful in watch mode.
                                     pointer.pointTo(step.element, this);
-                                    await delay(this.showPointerDuration);
+                                    await hoot.delay(this.showPointerDuration);
                                     pointer.hide();
                                 }
                                 console.log(step.element);
@@ -102,6 +102,7 @@ export class TourAutomatic {
             });
 
         const end = () => {
+            delete window.hoot;
             transitionConfig.disabled = false;
             tourState.clear();
             pointer.stop();
@@ -142,6 +143,7 @@ export class TourAutomatic {
             debugger;
         }
         transitionConfig.disabled = true;
+        window.hoot = hoot;
         this.macro.start();
     }
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1207,7 +1207,7 @@ class ChromeBrowser:
             switches['--touch-events'] = ''
         if debug is not False:
             switches['--auto-open-devtools-for-tabs'] = ''
-            switches['--start-maximized'] = ''
+            switches['--start-fullscreen'] = ''
 
         cmd = [self.executable]
         cmd += ['%s=%s' % (k, v) if v else k for k, v in switches.items()]


### PR DESCRIPTION
In this commit, we change two small things to make debugging tours much easier.
The first is to use the --start-fullscreen flag instead of --start-maximized because the first one seems to not work properly depending on the chrome versions.
The second is to make hoot more easily available in the console so that it can be used more quickly.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
