### PR TITLE
[FIX] website: stop product carousel auto sliding

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -617,6 +617,7 @@ publicWidget.registry.CarouselBootstrapUpgradeFix = publicWidget.Widget.extend({
         "[data-snippet='s_image_gallery'] .carousel",
         "[data-snippet='s_carousel'] .carousel",
         "[data-snippet='s_quotes_carousel'] .carousel",
+        "#o-carousel-product.carousel", // TODO adapt the shop XML directly in master
     ].join(", "),
     disabledInEditableMode: false,
     events: {
@@ -650,7 +651,7 @@ publicWidget.registry.CarouselBootstrapUpgradeFix = publicWidget.Widget.extend({
             // instead of "carousel", it's better not to change the behavior and
             // let the user update the snippet manually to avoid making changes
             // that they don't expect.
-            const snippetName = this.el.closest("[data-snippet]").dataset.snippet;
+            const snippetName = this.el.closest("[data-snippet]")?.dataset.snippet;
             this.el.dataset.bsRide = this.OLD_AUTO_SLIDING_SNIPPETS.includes(snippetName) ? "carousel" : "true";
             await this._destroyCarouselInstance();
             const options = this.editableMode ? {ride: false, pause: true} : undefined;


### PR DESCRIPTION
In 17.2 and prior, the product carousel did not auto slide. However, after upgrading to Bootstrap 3.5.5 in 17.4, this commit 7da319c81f0a0 changed the behavior of the carousel and made it auto slide after user interactions, using `data-bs-ride="true"` attribute.

This issue is known, and fixes were provided for some carousels in 9eff9ae and 1db386b.

Here we apply the same fix for the products carousel.

opw-4391294
opw-4404683