### PR TITLE
[IMP] crm: add preference domain for lead assignation

### DIFF
--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -199,7 +199,7 @@ class CrmTeam(models.Model):
         The cron is designed to run at least once a day or more.
         A number of leads will be assigned each time depending on the daily leads
         already assigned.
-        This allows the assignation process based on the cron to work on a daily basis
+        This allows the assignment process based on the cron to work on a daily basis
         without allocating too much leads on members if the cron is executed multiple
         times a day.
         The daily quota of leads can be forcefully assigned with force_quota
@@ -444,8 +444,8 @@ class CrmTeam(models.Model):
                 ])
 
             leads = self.env["crm.lead"].search(lead_domain)
-            # Fill duplicate cache: search for duplicate lead before the assignation
-            # avoid to flush during the search at every assignation
+            # Fill duplicate cache: search for duplicate lead before the assignment
+            # avoid to flush during the search at every assignment
             for lead in leads:
                 if lead not in duplicates_lead_cache:
                     duplicates_lead_cache[lead] = lead._get_lead_duplicates(email=lead.email_from)
@@ -611,6 +611,30 @@ class CrmTeam(models.Model):
             # and make sure we need them before fetching them
             ['id:array_agg'],
         ))
+
+        def _assign_lead(lead, members, member_leads, members_quota, assign_lst, optional_lst=None):
+            """ Find relevant member whose domain(s) accept the lead. If found convert
+            and update internal structures accordingly. """
+            member_found = next((member for member in members if lead in member_leads[member]), False)
+            if not member_found:
+                return
+            lead.with_context(mail_auto_subscribe_no_notify=True).convert_opportunity(
+                lead.partner_id,
+                user_ids=member_found.user_id.ids
+            )
+            result_data[member_found]['assigned'] += lead
+
+            # if member still has quota, move at end of list; otherwise just remove
+            assign_lst.remove(member_found)
+            if optional_lst is not None:
+                optional_lst.remove(member_found)
+            members_quota[member_found] -= 1
+            if members_quota[member_found] > 0:
+                assign_lst.append(member_found)
+                if optional_lst is not None:
+                    optional_lst.append(member_found)
+            return member_found
+
         for team, leads_to_assign_ids in leads_per_team.items():
             members_to_assign = list(team.crm_team_member_ids.filtered(lambda member:
                 not member.assignment_optout and quota_per_member.get(member, 0) > 0
@@ -621,41 +645,68 @@ class CrmTeam(models.Model):
                 member: {"assigned": self.env["crm.lead"], "quota": quota_per_member[member]}
                 for member in members_to_assign
             })
-            # Need to check that record still exists since the ids have been fetched at the begining of the process
-            # Previous iteration has commited the change, records may have been deleted in the meanwhile
-            leads_to_assign = self.env['crm.lead'].browse(leads_to_assign_ids).exists()
-            leads_per_member = {
-                member: leads_to_assign.filtered_domain(literal_eval(member.assignment_domain or '[]'))
-                for member in members_to_assign
+            # Need to check that record still exists since the ids have been fetched at the beginning of the process
+            # Previous iteration has committed the change, records may have been deleted in the meanwhile
+            to_assign = self.env['crm.lead'].browse(leads_to_assign_ids).exists()
+
+            members_to_assign_wpref = [
+                m for m in members_to_assign
+                if m.assignment_domain_preferred and literal_eval(m.assignment_domain_preferred or '')
+            ]
+            preferred_leads_per_member = {
+                member: to_assign.filtered_domain(
+                    expression.AND([
+                        literal_eval(member.assignment_domain or '[]'),
+                        literal_eval(member.assignment_domain_preferred)
+                    ])
+                ) for member in members_to_assign_wpref
             }
-            for lead in leads_to_assign.sorted(lambda lead: (-lead.probability, id)):
+            preferred_leads = self.env['crm.lead'].concat(*[lead for lead in preferred_leads_per_member.values()])
+            assigned_preferred_leads = self.env['crm.lead']
+
+            # first assign loop: preferred leads, always priority
+            for lead in preferred_leads.sorted(lambda lead: (-lead.probability, id)):
                 counter += 1
-                member_found = next((member for member in members_to_assign if lead in leads_per_member[member]), False)
+                member_found = _assign_lead(lead, members_to_assign_wpref, preferred_leads_per_member, quota_per_member, members_to_assign, members_to_assign_wpref)
                 if not member_found:
                     continue
-                lead.with_context(mail_auto_subscribe_no_notify=True).convert_opportunity(
-                    lead.partner_id,
-                    user_ids=member_found.user_id.ids
-                )
-                result_data[member_found]['assigned'] += lead
-                members_to_assign.remove(member_found)
-                quota_per_member[member_found] -= 1
-                if quota_per_member[member_found] > 0:
-                    # If the member should receive more lead, send him back at the end of the list
-                    members_to_assign.append(member_found)
-
+                assigned_preferred_leads += lead
                 if auto_commit and counter % commit_bundle_size == 0:
                     self.env.cr.commit()
+
+            # second assign loop: fill up with other leads
+            to_assign = to_assign - assigned_preferred_leads
+            leads_per_member = {
+                member: to_assign.filtered_domain(literal_eval(member.assignment_domain or '[]'))
+                for member in members_to_assign
+            }
+            for lead in to_assign.sorted(lambda lead: (-lead.probability, id)):
+                counter += 1
+                member_found = _assign_lead(lead, members_to_assign, leads_per_member, quota_per_member, members_to_assign)
+                if not member_found:
+                    continue
+                if auto_commit and counter % commit_bundle_size == 0:
+                    self.env.cr.commit()
+
             # Make sure we commit at least at the end of the team
             if auto_commit:
                 self.env.cr.commit()
             # Once we are done with a team we don't need to keep the leads in memory
             # Try to avoid to explode memory usage
             self.env.invalidate_all()
-
-        _logger.info('Assigned %s leads to %s salesmen', sum(len(r['assigned']) for r in result_data.values()), len(result_data))
+            _logger.info(
+                'Team %s: Assigned %s leads based on preference, on a potential of %s (limited by quota)',
+                team.name, len(assigned_preferred_leads), len(preferred_leads)
+            )
+        _logger.info(
+            'Assigned %s leads to %s salesmen',
+            sum(len(r['assigned']) for r in result_data.values()), len(result_data)
+        )
         for member, member_info in result_data.items():
-            _logger.info('-> member %s of team %s: assigned %d/%d leads (%s)', member.id, member.crm_team_id.id, len(member_info["assigned"]), member_info["quota"], member_info["assigned"])
+            _logger.info(
+                '-> member %s of team %s: assigned %d/%d leads (%s)',
+                member.id, member.crm_team_id.id, len(member_info["assigned"]), member_info["quota"], member_info["assigned"]
+            )
         return result_data
 
     # ------------------------------------------------------------

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -58,7 +58,7 @@ class TestLeadConvertForm(crm_common.TestLeadConvertCommon):
 @tagged('lead_manage')
 class TestLeadConvert(crm_common.TestLeadConvertCommon):
     """
-    TODO: created partner (handle assignation) has team of lead
+    TODO: created partner (handle assignment) has team of lead
     TODO: create partner has user_id  coming from wizard
     """
 

--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -89,7 +89,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
                 self.assertEqual(new_partner.name, 'Amy Wong')
                 self.assertEqual(new_partner.email, 'amy.wong@test.example.com')
 
-        # test unforced assignation
+        # test unforced assignment
         mass_convert.write({
             'user_ids': self.user_sales_salesman.ids,
         })

--- a/addons/crm/views/crm_team_member_views.xml
+++ b/addons/crm/views/crm_team_member_views.xml
@@ -42,20 +42,25 @@
         <field name="inherit_id" ref="sales_team.crm_team_member_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='member_partner_info']" position="after">
-                <group name="group_assign" invisible="not assignment_enabled">
-                    <field name="assignment_enabled" invisible="1"/>
-                    <field name="assignment_optout"/>
-                    <label for="lead_month_count" invisible="assignment_optout"/>
-                    <div invisible="assignment_optout">
-                        <field name="lead_month_count" class="oe_inline"/>
-                        <span class="oe_inline"> / </span>
-                        <field name="assignment_max" class="oe_inline"/>
-                        <span class="oe_inline"> (max) </span>
-                    </div>
-                    <field name="assignment_domain" string="Domain" widget="domain"
-                        options="{'model': 'crm.lead'}"
-                        invisible="assignment_max == 0 or assignment_optout"/>
-                </group>
+                <field name="assignment_enabled" invisible="1"/>
+                <notebook>
+                    <page string="Lead Assignment" name="lead_assign" invisible="not assignment_enabled">
+                        <group>
+                            <div invisible="assignment_optout" colspan="2">
+                                <field name="lead_month_count" class="oe_inline"/>
+                                <span> leads assigned the last 30 days out of a maximum of </span>
+                                <field name="assignment_max" class="oe_inline o_field_highlight o_input_3ch"/>
+                            </div>
+                            <field name="assignment_optout"/>
+                            <field name="assignment_domain_preferred" string="Lead Priority Filter" widget="domain"
+                                options="{'model': 'crm.lead', 'foldable': True}"
+                                invisible="assignment_max == 0 or assignment_optout"/>
+                            <field name="assignment_domain" string="Lead Assignment Filter" widget="domain"
+                                options="{'model': 'crm.lead', 'foldable': True}"
+                                invisible="assignment_max == 0 or assignment_optout"/>
+                        </group>
+                    </page>
+                </notebook>
             </xpath>
         </field>
     </record>

--- a/addons/crm/views/res_config_settings_views.xml
+++ b/addons/crm/views/res_config_settings_views.xml
@@ -52,7 +52,7 @@
                         <setting title="This can be used to automatically assign leads to sales persons based on rules" documentation="/applications/sales/crm/track_leads/lead_scoring.html#assign-leads">
                             <field name="crm_use_auto_assignment"/>
                             <div class="text-muted">
-                                <span>Periodically assign leads based on rules</span><br />
+                                <span>Periodically assign leads based on priorities and filters.</span><br />
                                 <span invisible="not crm_use_auto_assignment">
                                     All sales teams will use this setting by default unless
                                     specified otherwise.

--- a/addons/sales_team/views/crm_team_member_views.xml
+++ b/addons/sales_team/views/crm_team_member_views.xml
@@ -112,15 +112,20 @@
                             <field name="user_id" class="flex-grow-1"
                                 options="{'no_quick_create': True}"/>
                         </h1>
+                        <!-- <div class="o_row" name="crm_team_id">
+                            <label for="crm_team_id"/> -->
+                            <group name="crm_team_id">
+                                <field id="crm_team_id" name="crm_team_id" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
+                            </group>
+                        <!-- </div> -->
                     </div>
                     <group name="member_partner_info">
-                        <group name="group_owner">
-                            <field name="crm_team_id" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
-                        </group>
-                        <group class="ps-0" name="group_user">
+                        <group>
+                            <field name="email" invisible="not user_id"/>
                             <field name="company_id" invisible="not user_id"
                                 groups="base.group_multi_company"/>
-                            <field name="email" invisible="not user_id"/>
+                        </group>
+                        <group>
                             <field name="phone" invisible="not user_id"/>
                         </group>
                     </group>
@@ -137,7 +142,8 @@
         <field name="mode">primary</field>
         <field name="priority">32</field>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='group_owner']" position="replace"/>
+            <!-- <xpath expr="//div[@name='crm_team_id']" position="replace"/> -->
+            <xpath expr="//group[@name='crm_team_id']" position="replace"/>
         </field>
     </record>
 


### PR DESCRIPTION
We want to have a preferenced domain for the lead assignation, which means that a lead will prefereably to a crm team member matching this extra domain, but we won't restrict the assignation to the member based on this domain.

TASK-ID: 4261217



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
