### PR TITLE
[FIX] pos_self_order, pos_*: fix when sending order to PDIS from kiosk

### DIFF
--- a/addons/pos_online_payment_self_order/static/src/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/self_order_service.js
@@ -47,7 +47,13 @@ patch(SelfOrder.prototype, {
     },
     filterPaymentMethods(pms) {
         const pm = super.filterPaymentMethods(...arguments);
-        const online_pms = pms.filter((rec) => rec.is_online_payment);
+        const online_pms = pms.filter(
+            (rec) =>
+                rec.is_online_payment &&
+                (this.config.self_order_online_payment_method_id?.id === rec.id ||
+                    (this.config.self_ordering_mode === "kiosk" &&
+                        this.config.payment_method_ids.includes(rec.id)))
+        );
         return [...new Set([...pm, ...online_pms])];
     },
 });

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -77,9 +77,9 @@ export class ConfirmationPage extends Component {
         order.tracking_number = "S" + order.tracking_number;
         this.confirmedOrder = order;
 
-        const paymentMethods = this.selfOrder.models["pos.payment.method"].filter(
-            (p) => p.is_online_payment
-        );
+        const paymentMethods = this.selfOrder.filterPaymentMethods(
+            this.selfOrder.models["pos.payment.method"].getAll()
+        ); // Stripe, Adyen, Online
 
         if (
             !order ||


### PR DESCRIPTION
*: pos_online_payment_self_order

When creating an order from the kiosk and pay it at the counter, it should be sent to PDIS when creating it.

opw-4364309

