### PR TITLE
[FIX] hw_drivers: always use pi as home directory

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
@@ -181,7 +181,7 @@ class KeyboardUSBDriver(Driver):
                 - variant (str): An optional key to represent the variant of the
                                  selected layout
         """
-        file_path = Path.home() / 'odoo-keyboard-layouts.conf'
+        file_path = helpers.path_file('odoo-keyboard-layouts.conf')
         if file_path.exists():
             data = json.loads(file_path.read_text())
         else:
@@ -193,7 +193,7 @@ class KeyboardUSBDriver(Driver):
         """Read the layout from the saved filed and set it as current layout.
         If no file or no layout is found we use 'us' by default.
         """
-        file_path = Path.home() / 'odoo-keyboard-layouts.conf'
+        file_path = helpers.path_file('odoo-keyboard-layouts.conf')
         if file_path.exists():
             data = json.loads(file_path.read_text())
             layout = data.get(self.device_identifier, {'layout': 'us'})
@@ -213,7 +213,7 @@ class KeyboardUSBDriver(Driver):
         scanner_name = ['barcode', 'scanner', 'reader']
         is_scanner = any(x in device_name for x in scanner_name) or self.dev.interface_protocol == '0'
 
-        file_path = Path.home() / 'odoo-keyboard-is-scanner.conf'
+        file_path = helpers.path_file('odoo-keyboard-is-scanner.conf')
         if file_path.exists():
             data = json.loads(file_path.read_text())
             is_scanner = data.get(self.device_identifier, {}).get('is_scanner', is_scanner)
@@ -255,7 +255,7 @@ class KeyboardUSBDriver(Driver):
         We need that in order to keep the selected type of device after a reboot.
         """
         is_scanner = {'is_scanner': data.get('is_scanner')}
-        file_path = Path.home() / 'odoo-keyboard-is-scanner.conf'
+        file_path = helpers.path_file('odoo-keyboard-is-scanner.conf')
         if file_path.exists():
             data = json.loads(file_path.read_text())
         else:

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -389,8 +389,7 @@ def download_iot_handlers(auto=True):
             if resp.data:
                 delete_iot_handlers()
                 with writable():
-                    drivers_path = ['odoo', 'addons', 'hw_drivers', 'iot_handlers']
-                    path = path_file(str(Path().joinpath(*drivers_path)))
+                    path = path_file('odoo', 'addons', 'hw_drivers', 'iot_handlers')
                     zip_file = zipfile.ZipFile(io.BytesIO(resp.data))
                     zip_file.extractall(path)
         except Exception:
@@ -431,12 +430,16 @@ def odoo_restart(delay):
     IR = IoTRestart(delay)
     IR.start()
 
-def path_file(filename):
+def path_file(*args):
+    """Return the path to the file from IoT Box root or Windows Odoo
+    server folder
+    :return: The path to the file
+    """
     platform_os = platform.system()
     if platform_os == 'Linux':
-        return Path.home() / filename
+        return Path("~pi", *args).expanduser() # Path.home() returns odoo user's home instead of pi's
     elif platform_os == 'Windows':
-        return Path().absolute().parent.joinpath('server/' + filename)
+        return Path().absolute().parent.joinpath('server', *args)
 
 def read_file_first_line(filename):
     path = path_file(filename)


### PR DESCRIPTION
To allow compatibility between all db versions and new IoT Box images, we need to ensure that `path_file` method returns the path starting from `/home/pi` instead of the path of the service user (which is `/home/odoo` in newer images).

