### PR TITLE
[FIX] point_of_sale: scale customer display fixes

### DIFF
--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -50,17 +50,16 @@ export class Chrome extends Component {
                     totalPriceOnScale,
                     isScaleScreenVisible,
                 }) => {
-                    if (
-                        !selectedOrder &&
-                        !scaleData &&
-                        !scaleWeight &&
-                        !scaleTare &&
-                        !totalPriceOnScale &&
-                        !isScaleScreenVisible
-                    ) {
-                        return;
+                    if (selectedOrder) {
+                        const allScaleData = {
+                            ...scaleData,
+                            weight: scaleWeight,
+                            tare: scaleTare,
+                            totalPriceOnScale,
+                            isScaleScreenVisible,
+                        };
+                        this.sendOrderToCustomerDisplay(selectedOrder, allScaleData);
                     }
-                    this.sendOrderToCustomerDisplay(selectedOrder, scaleData);
                 }
             ),
             [this.pos]
@@ -69,7 +68,7 @@ export class Chrome extends Component {
 
     sendOrderToCustomerDisplay(selectedOrder, scaleData) {
         const customerDisplayData = selectedOrder.getCustomerDisplayData();
-        customerDisplayData.isScaleScreenVisible = this.pos.isScaleScreenVisible;
+        customerDisplayData.isScaleScreenVisible = scaleData.isScaleScreenVisible;
         if (scaleData) {
             customerDisplayData.scaleData = {
                 productName: scaleData.productName,
@@ -78,9 +77,9 @@ export class Chrome extends Component {
                 productPrice: scaleData.productPrice,
             };
         }
-        customerDisplayData.weight = this.pos.scaleWeight;
-        customerDisplayData.tare = this.pos.scaleTare;
-        customerDisplayData.totalPriceOnScale = this.pos.totalPriceOnScale;
+        customerDisplayData.weight = scaleData.weight;
+        customerDisplayData.tare = scaleData.tare;
+        customerDisplayData.totalPriceOnScale = scaleData.totalPriceOnScale;
 
         if (this.pos.config.customer_display_type === "local") {
             this.customerDisplayChannel.postMessage(customerDisplayData);

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -851,10 +851,9 @@ export class PosStore extends Reactive {
                     ScaleScreen,
                     this.scaleData
                 );
-                if (!weight) {
-                    return;
+                if (weight) {
+                    values.qty = weight;
                 }
-                values.qty = weight;
                 this.isScaleScreenVisible = false;
                 this.scaleWeight = 0;
                 this.scaleTare = 0;

--- a/addons/point_of_sale/static/src/customer_display/customer_display.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.js
@@ -19,7 +19,7 @@ export class CustomerDisplay extends Component {
     }
 
     get netWeight() {
-        const weight = round_pr(this.order.weight || 0, this.order.uomRounding);
+        const weight = round_pr(this.order.weight || 0, this.order.scaleData.uomRounding);
         const weightRound = weight.toFixed(
             Math.ceil(Math.log(1.0 / this.order.scaleData.uomRounding) / Math.log(10))
         );


### PR DESCRIPTION
Since #176062, the customer display is able
to mirror the scale measurements. This commit
fixes some bugs with this feature:
- A traceback when no order is selected (this can happen when returning to the plan view in a restaurant)
- The net weight not updating correctly on the customer display
- The scale values remaining on the customer display indefinitely if weighing is cancelled

opw-4343571, opw-4343559

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
