### PR TITLE
[REF] im_livechat: add field for is_forward_operator chatbot step

### DIFF
--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -70,7 +70,7 @@ class LivechatChatbotScriptController(http.Controller):
                 "id": (next_step.id, discuss_channel.id),
                 "isLast": next_step._is_last_step(discuss_channel),
                 "message": posted_message.id,
-                "operatorFound": next_step.step_type == "forward_operator"
+                "operatorFound": next_step.is_forward_operator
                 and discuss_channel.livechat_operator_id != chatbot.operator_partner_id,
                 "scriptStep": next_step.id,
             },

--- a/addons/im_livechat/models/chatbot_script.py
+++ b/addons/im_livechat/models/chatbot_script.py
@@ -36,7 +36,7 @@ class ChatbotScript(models.Model):
         for script in self:
             script.livechat_channel_count = mapped_channels.get(script.id, 0)
 
-    @api.depends('script_step_ids.step_type')
+    @api.depends("script_step_ids.is_forward_operator", "script_step_ids.step_type" )
     def _compute_first_step_warning(self):
         for script in self:
             allowed_first_step_types = [
@@ -47,7 +47,7 @@ class ChatbotScript(models.Model):
                 'free_input_multi',
             ]
             welcome_steps = script.script_step_ids and script._get_welcome_steps()
-            if welcome_steps and welcome_steps[-1].step_type == 'forward_operator':
+            if welcome_steps and welcome_steps[-1].is_forward_operator:
                 script.first_step_warning = 'first_step_operator'
             elif welcome_steps and welcome_steps[-1].step_type not in allowed_first_step_types:
                 script.first_step_warning = 'first_step_invalid'

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -63,7 +63,7 @@ class DiscussChannel(models.Model):
             current_step_sudo = channel.chatbot_current_step_id.sudo().with_context(lang=lang)
             chatbot_script = current_step_sudo.chatbot_script_id
             step_message = self.env["chatbot.message"]
-            if current_step_sudo.step_type != "forward_operator":
+            if not current_step_sudo.is_forward_operator:
                 step_message = channel.sudo().chatbot_message_ids.filtered(
                     lambda m: m.script_step_id == current_step_sudo
                     and m.mail_message_id.author_id == chatbot_script.operator_partner_id
@@ -71,7 +71,7 @@ class DiscussChannel(models.Model):
             current_step = {
                 "scriptStep": current_step_sudo.id,
                 "message": step_message.mail_message_id.id,
-                "operatorFound": current_step_sudo.step_type == "forward_operator"
+                "operatorFound": current_step_sudo.is_forward_operator
                 and channel.livechat_operator_id != chatbot_script.operator_partner_id,
             }
             store.add(current_step_sudo)

--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -51,8 +51,8 @@ class MailMessage(models.Model):
                         "id": (step.id, channel.id),
                         "message": message.id,
                         "scriptStep": step.id,
-                        "operatorFound": step.step_type == "forward_operator"
-                        and channel.livechat_operator_id != chatbot
+                        "operatorFound": step.is_forward_operator
+                        and channel.livechat_operator_id != chatbot,
                     }
                     if answer := chatbot_message.user_script_answer_id:
                         step_data["selectedAnswer"] = answer.id

--- a/addons/im_livechat/views/chatbot_script_step_views.xml
+++ b/addons/im_livechat/views/chatbot_script_step_views.xml
@@ -10,7 +10,7 @@
                 <div class="alert alert-info text-center mb-0" role="alert" invisible="not is_forward_operator_child">
                     <span>Reminder: This step will only be played if no operator is available.</span>
                 </div>
-                <div class="alert alert-info text-center mb-0" role="alert" invisible="step_type != 'forward_operator'">
+                <div class="alert alert-info text-center mb-0" role="alert" invisible="not is_forward_operator">
                     <span>Tip: Plan further steps for the Bot in case no operator is available.</span>
                 </div>
                 <sheet>
@@ -18,7 +18,7 @@
                         <group>
                             <field name="sequence" invisible="1"/>
                             <field name="message" widget="text_emojis" placeholder="e.g. 'How can I help you?'"
-                                required="step_type != 'forward_operator'"/>
+                                required="not is_forward_operator"/>
                             <field name="chatbot_script_id" invisible="1"/>
                             <field name="step_type"/>
                             <field name="operator_expertise_ids" widget="many2many_tags" options="{'edit_tags': True}" invisible="step_type != 'forward_operator'"/>


### PR DESCRIPTION
The compute needs to be overridden in `crm_livechat` in a following commit.

Part of task-4354325

Co-authored-by: ramh <ramh@odoo.com>

See https://github.com/odoo/odoo/pull/190364
The new field must be merged before the freeze.