### PR TITLE
[FIX] web: Update correctly reference char field

### DIFF
--- a/addons/web/static/src/views/fields/reference/reference_field.js
+++ b/addons/web/static/src/views/fields/reference/reference_field.js
@@ -59,21 +59,21 @@ export class ReferenceField extends Component {
         if (this._isCharField(this.props)) {
             /** Fetch the display name of the record referenced by the field */
             let currentValue = undefined;
-            useRecordObserver(async (record) => {
-                if (currentValue !== record.data[this.props.name]) {
-                    this.state.formattedCharValue = await this._fetchReferenceCharData(this.props);
-                    currentValue = record.data[this.props.name];
+            useRecordObserver(async (record, props) => {
+                if (currentValue !== record.data[props.name]) {
+                    this.state.formattedCharValue = await this._fetchReferenceCharData(props);
+                    currentValue = record.data[props.name];
                 }
             });
         } else if (this.props.modelField) {
             /** Fetch the technical name of the co model */
-            useRecordObserver(async (record) => {
-                if (this.currentModelId !== record.data[this.props.modelField]?.[0]) {
-                    this.state.modelName = await this._fetchModelTechnicalName(this.props);
+            useRecordObserver(async (record, props) => {
+                if (this.currentModelId !== record.data[props.modelField]?.[0]) {
+                    this.state.modelName = await this._fetchModelTechnicalName(props);
                     if (this.currentModelId !== undefined) {
-                        record.update({ [this.props.name]: false });
+                        record.update({ [props.name]: false });
                     }
-                    this.currentModelId = record.data[this.props.modelField]?.[0];
+                    this.currentModelId = record.data[props.modelField]?.[0];
                 }
             });
         }

--- a/addons/web/static/tests/views/fields/reference_field_tests.js
+++ b/addons/web/static/tests/views/fields/reference_field_tests.js
@@ -527,10 +527,9 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test("Many2One 'Search more...' updates on resModel change", async function (assert) {
-
         serverData.views = {
             "product,false,list": '<tree><field name="display_name"/></tree>',
-            "product,false,search": '<search/>',
+            "product,false,search": "<search/>",
         };
 
         await makeView({
@@ -541,14 +540,25 @@ QUnit.module("Fields", (hooks) => {
         });
 
         // Selecting a relation
-        await editSelect(target.querySelector("div.o_field_reference"), "select.o_input", "partner_type");
+        await editSelect(
+            target.querySelector("div.o_field_reference"),
+            "select.o_input",
+            "partner_type"
+        );
 
         // Selecting another relation
-        await editSelect(target.querySelector("div.o_field_reference"), "select.o_input", "product");
+        await editSelect(
+            target.querySelector("div.o_field_reference"),
+            "select.o_input",
+            "product"
+        );
 
         // Opening the Search More... option
         await click(target.querySelector("div.o_field_reference"), "input.o_input");
-        await click(target.querySelector("div.o_field_reference"), ".o_m2o_dropdown_option_search_more");
+        await click(
+            target.querySelector("div.o_field_reference"),
+            ".o_m2o_dropdown_option_search_more"
+        );
 
         assert.strictEqual(
             target.querySelector("div.modal td.o_data_cell").innerText,
@@ -1058,8 +1068,12 @@ QUnit.module("Fields", (hooks) => {
             await click(target, ".o_list_table td.o_list_many2one");
             await click(target, ".o_list_table .o_list_many2one input");
             //Select the "Partner" option, different from original "Product"
-            const dropdownItems = [...target.querySelectorAll(".o_list_table .o_list_many2one .o_input_dropdown .dropdown-item")];
-            await click(dropdownItems.filter(item => item.text === "Partner")[0]);
+            const dropdownItems = [
+                ...target.querySelectorAll(
+                    ".o_list_table .o_list_many2one .o_input_dropdown .dropdown-item"
+                ),
+            ];
+            await click(dropdownItems.filter((item) => item.text === "Partner")[0]);
             await nextTick();
             assert.strictEqual(target.querySelector(".reference_field input").value, "");
             assert.strictEqual(target.querySelector(".o_list_many2one input").value, "Partner");
@@ -1152,5 +1166,28 @@ QUnit.module("Fields", (hooks) => {
 
         await nextTick();
         assert.containsOnce(target, ".o_form_view");
+    });
+
+    QUnit.test("reference char with list view pager navigation", async function (assert) {
+        assert.expect(2);
+        serverData.models.partner.records[0].reference_char = "product,37";
+        serverData.models.partner.records[1].reference_char = "product,41";
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            serverData,
+            arch: `<form edit="0"><field name="reference_char" widget="reference" string="Record"/></form>`,
+            resIds: [1, 2],
+        });
+        assert.strictEqual(
+            target.querySelector(".o_field_reference .o_form_uri").textContent,
+            "xphone"
+        );
+        await click(target, ".o_pager_next");
+        assert.strictEqual(
+            target.querySelector(".o_field_reference .o_form_uri").textContent,
+            "xpad"
+        );
     });
 });


### PR DESCRIPTION
Let say we have two record with a reference field with char type. Record X with reference A
Record Y with reference B

If we open the record x form view directly from the list view the fetch will works as wanted (reference A)
But if we use the pager to navigate to record Y, the reference field will not be correct, it will dispay the old one (reference A instead of B)

This is because in the `ReferenceField` setup method we use an `useRecordObserver` to track record changes and update reference data.

But before this commit, we passed the wrong `props` to `_fetchReferenceCharData`

`useRecordObserver` has a second argument, which is the new `props`, so we can use it instead of `this.props` still referring to the previous record

This can be reproduced on `External Identifiers` view (accessible with debug)

opw-4349296