### PR TITLE
[FIX] l10n_sa: add delivery address to SA invoice report

### DIFF
--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -20,11 +20,17 @@
         </xpath>
         <xpath expr="//t[@t-set='address']" position="after">
             <t t-set="information_block">
-                <p>
-                    <img t-if="o.l10n_sa_qr_code_str"
-                         style="display:block;"
-                         t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', quote_plus(o.l10n_sa_qr_code_str), 200, 200)"/>
-                </p>
+                <div class="row">
+                    <p class="col-6 me-3">
+                        <img t-if="o.l10n_sa_qr_code_str"
+                            style="display:block;"
+                            t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', quote_plus(o.l10n_sa_qr_code_str), 200, 200)"/>
+                    </p>
+                    <div class="col-6" t-if="o.partner_shipping_id and (o.partner_shipping_id != o.partner_id)" groups="account.group_delivery_invoice_address" name="shipping_address_block">
+                        <strong>Shipping Address:</strong>
+                        <div t-field="o.partner_shipping_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
+                    </div>
+                </div>
             </t>
         </xpath>
         <xpath expr="//th[@name='th_total']//span[2]" position="attributes">


### PR DESCRIPTION
**Issue:**
in the Saudi Arabia localization, the delivery address is not displayed on invoices even if `Customer Addresses` is enabled.

**Steps to reproduce:**
1. Go to settings and enable `Customer Addresses`.
2. Install the Saudi Arabia localization.
3. create an invoice with a delivery address other than the customer's.
4. Print the invoice.
5. notice that the delivery address is not displayed on the invoice.

**Solution:**
- Added the delivery address to the invoice report next to the QR code.

opw-4337379

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
