### PR TITLE
[FIX] point_of_sale: set a specific background for free text color attribute

### DIFF
--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.scss
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.scss
@@ -15,6 +15,11 @@
             background-repeat: no-repeat;
         }
     }
+
+    &.custom_value {
+        background-image: linear-gradient(to bottom right, #FF0000, #FFF200, #1E9600);
+    }
+
 }
 .ptav-not-available{
     opacity: .5;

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
@@ -79,7 +79,7 @@
                     <t t-set="color_style" t-value="value.is_custom ? '' : 'background-color: ' + value.html_color" />
                     <span class="d-flex flex-row justify-content-center align-items-center">
                         <label t-attf-class="configurator_color rounded-circle border position-relative {{ value.id == state.attribute_value_ids ? 'active border-3 border-primary' : 'border-3 border-secondary' }}"
-                            t-att-class="{'ptav-not-available' : value.excluded}"
+                            t-att-class="{'ptav-not-available' : value.excluded, 'custom_value': value.is_custom}"
                             t-attf-style="{{ img_style or color_style }}" t-att-data-color="value.name">
                             <input class="m-2 opacity-0" type="radio" t-model="state.attribute_value_ids" t-att-value="value.id" t-att-name="value.attribute_id.id"/>
                         </label>


### PR DESCRIPTION
Steps to reproduce:

- Create a product with attribute "color" (most important thing is that the display type of the attribute is set on color) and add values (make sure the values of the attribute has a color selected + enable the free text option on those values)
- Go to the POS and select the product
- In the variant selection screen that pops up  => the color of the value for which the free text is enabled is not rendered (it's white instead)

The same background gradient used in the Sales/Website module is now applied for 'free text' color attribute.

opw-4387411
