### PR TITLE
[FIX] pos_restaurant, point_of_sale: fix transfer table and showScreen

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -136,7 +136,11 @@ export class PosStore extends Reactive {
             await this.connectToProxy();
         }
         this.closeOtherTabs();
-        this.showScreen("ProductScreen");
+        this.showScreen(this.firstScreen);
+    }
+
+    get firstScreen() {
+        return "ProductScreen";
     }
 
     useProxy() {
@@ -1317,6 +1321,7 @@ export class PosStore extends Reactive {
     }
     showScreen(name, props) {
         this.previousScreen = this.mainScreen.component?.name;
+        name = !name ? this.firstScreen : name;
         const component = registry.category("pos_screens").get(name);
         this.mainScreen = { component, props };
         // Save the screen to the order so that it is shown again when the order is selected.


### PR DESCRIPTION
When transfering table some orderlines were not transfered to the new table.

The showScreen method was not working properly when the next screen was an empty screen, that can happen when synching orders.

opw-4186184
