### PR TITLE
[IMP] web: tree_editor: rename basic operators

### DIFF
--- a/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
@@ -10,12 +10,12 @@ import { Select } from "@web/core/tree_editor/tree_editor_components";
 
 const OPERATOR_DESCRIPTIONS = {
     // valid operators (see TERM_OPERATORS in expression.py)
-    "=": "=",
-    "!=": "!=",
-    "<=": "<=",
-    "<": "<",
-    ">": ">",
-    ">=": ">=",
+    "=": _t("is equal"),
+    "!=": _t("is not equal"),
+    "<=": _t("is lower or equal"),
+    "<": _t("is lower"),
+    ">": _t("is greater"),
+    ">=": _t("is greater or equal"),
     "=?": "=?",
     "=like": _t("=like"),
     "=ilike": _t("=ilike"),

--- a/addons/web/static/tests/core/domain_field.test.js
+++ b/addons/web/static/tests/core/domain_field.test.js
@@ -741,7 +741,7 @@ test("domain field with 'inDialog' options", async function () {
     await contains(`.modal ${SELECTORS.addNewRule}`).click();
     await contains(".modal-footer .btn-primary").click();
     expect(SELECTORS.condition).toHaveCount(1);
-    expect(getConditionText()).toBe("Id = 1");
+    expect(getConditionText()).toBe("Id is equal 1");
 });
 
 test("invalid value in domain field with 'inDialog' options", async function () {
@@ -921,7 +921,7 @@ test("domain field can be foldable", async function () {
     // Fold domain selector
     await contains(".o_field_domain a i").click();
 
-    expect(".o_field_domain .o_facet_values:contains('Color index = 2')").toHaveCount(1);
+    expect(".o_field_domain .o_facet_values:contains('Color index is equal 2')").toHaveCount(1);
 });
 
 test("add condition in empty foldable domain", async function () {
@@ -1000,7 +1000,7 @@ test("folded domain field with any operator", async function () {
                 </sheet>
             </form>`,
     });
-    expect(`.o_field_domain .o_facet_values`).toHaveText("Company matches ( Id = 1 )");
+    expect(`.o_field_domain .o_facet_values`).toHaveText("Company matches ( Id is equal 1 )");
 });
 
 test("folded domain field with withinh operator", async function () {

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -185,7 +185,7 @@ test("building a domain with an invalid path", async () => {
     expect(".o_model_field_selector_warning").toHaveCount(1);
     expect(".o_model_field_selector_warning").toHaveAttribute("title", "Invalid field chain");
     expect(getOperatorOptions()).toHaveLength(1);
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("abc");
 
     await openModelFieldSelectorPopover();
@@ -205,12 +205,12 @@ test("building a domain with an invalid path (2)", async () => {
 
     expect(getCurrentPath()).toBe("bloup");
     expect(isNotSupportedPath()).toBe(true);
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("abc");
 
     await clearNotSupported();
     expect(getCurrentPath()).toBe("Id");
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("1");
 });
 
@@ -229,7 +229,7 @@ test("building a domain with an invalid path (3)", async () => {
 
     expect(getCurrentPath()).toBe("bloup");
     expect(isNotSupportedPath()).toBe(true);
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("abc");
 
     await clearNotSupported();
@@ -256,7 +256,7 @@ test("building a domain with an invalid operator", async () => {
     expect(getCurrentPath()).toBe("Foo");
     expect(".o_model_field_selector_warning").toHaveCount(0);
     expect(getOperatorOptions()).toHaveLength(10);
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("abc");
 });
 
@@ -284,13 +284,13 @@ test("building a domain with an expression in value", async () => {
     });
 
     expect(getCurrentPath()).toBe("Int");
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("id");
 
     await selectOperator("<");
 
     expect(getCurrentPath()).toBe("Int");
-    expect(getCurrentOperator()).toBe("<");
+    expect(getCurrentOperator()).toBe("is lower");
     expect(getCurrentValue()).toBe("1");
 });
 
@@ -376,7 +376,7 @@ test("set [(1, '=', 1)] or [(0, '=', 1)] as domain with the debug textarea", asy
     });
     expect(SELECTORS.condition).toHaveCount(1);
     expect(getCurrentPath()).toBe("0");
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("1");
 });
 
@@ -404,7 +404,7 @@ test("selection field with operator change from 'is set' to '='", async () => {
 
     await selectOperator("=");
     expect(getCurrentPath()).toBe("State");
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe(`ABC`);
 });
 
@@ -454,7 +454,7 @@ test("multi selection", async () => {
 test("json field with operator change from 'equal' to 'ilike'", async () => {
     await makeDomainSelector({ domain: `[['json_field', '=', "hey"]]` });
     expect(getCurrentPath()).toBe(`Json Field`);
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe(`hey`);
 
     await selectOperator("ilike");
@@ -606,7 +606,7 @@ test("debug input in model field selector popover", async () => {
     expect(getCurrentPath()).toBe("a");
     expect(".o_model_field_selector_warning").toHaveCount(1);
     expect(getOperatorOptions()).toHaveLength(1);
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("1");
     expect(SELECTORS.debugArea).toHaveValue(`[("a", "=", 1)]`);
 });
@@ -642,7 +642,7 @@ test("between operator (2)", async () => {
         domain: `["&", "&", ("foo", "=", "abc"), ("datetime", ">=", "2023-01-01 00:00:00"), ("datetime", "<=", "2023-01-10 00:00:00")]`,
     });
     expect(SELECTORS.condition).toHaveCount(2);
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentOperator(1)).toBe("is between");
     expect(".o_datetime_input").toHaveCount(2);
 });
@@ -654,7 +654,7 @@ test("between operator (3)", async () => {
     });
     expect(SELECTORS.condition).toHaveCount(2);
     expect(getCurrentOperator()).toBe("is between");
-    expect(getCurrentOperator(1)).toBe("=");
+    expect(getCurrentOperator(1)).toBe("is equal");
     expect(".o_datetime_input").toHaveCount(2);
 });
 
@@ -665,7 +665,7 @@ test("between operator (4)", async () => {
     });
     expect(SELECTORS.condition).toHaveCount(2);
     expect(getCurrentOperator()).toBe("is between");
-    expect(getCurrentOperator(1)).toBe("=");
+    expect(getCurrentOperator(1)).toBe("is equal");
     expect(".o_datetime_input").toHaveCount(2);
 });
 
@@ -676,7 +676,7 @@ test("between operator (5)", async () => {
         readonly: true,
     });
     expect(".o_domain_selector").toHaveText(
-        `Match\nany\nof the following rules:\nCreated on\nis between\n04/01/2023 00:00:00\nand\n04/30/2023 23:59:59\n0\n=\n1`
+        `Match\nany\nof the following rules:\nCreated on\nis between\n04/01/2023 00:00:00\nand\n04/30/2023 23:59:59\n0\nis equal\n1`
     );
 });
 
@@ -708,99 +708,99 @@ test("support of connector '!' (mode readonly)", async () => {
     const toTest = [
         {
             domain: `["!", ("foo", "=", "abc")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n!=\nabc`,
+            result: `Match\nall\nof the following rules:\nFoo\nis not equal\nabc`,
         },
         {
             domain: `["!", "!", ("foo", "=", "abc")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n=\nabc`,
+            result: `Match\nall\nof the following rules:\nFoo\nis equal\nabc`,
         },
         {
             domain: `["!", "!", "!", ("foo", "=", "abc")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n!=\nabc`,
+            result: `Match\nall\nof the following rules:\nFoo\nis not equal\nabc`,
         },
         {
             domain: `["!", "&", ("foo", "=", "abc"), ("foo", "=", "def")]`,
-            result: `Match\nany\nof the following rules:\nFoo\n!=\nabc\nFoo\n!=\ndef`,
+            result: `Match\nany\nof the following rules:\nFoo\nis not equal\nabc\nFoo\nis not equal\ndef`,
         },
         {
             domain: `["!", "|", ("foo", "=", "abc"), ("foo", "=", "def")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n!=\nabc\nFoo\n!=\ndef`,
+            result: `Match\nall\nof the following rules:\nFoo\nis not equal\nabc\nFoo\nis not equal\ndef`,
         },
         {
             domain: `["&", "!", ("foo", "=", "abc"), ("foo", "=", "def")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n!=\nabc\nFoo\n=\ndef`,
+            result: `Match\nall\nof the following rules:\nFoo\nis not equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["&", "!", "!", ("foo", "=", "abc"), ("foo", "=", "def")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n=\nabc\nFoo\n=\ndef`,
+            result: `Match\nall\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["&", ("foo", "=", "abc"), "!", ("foo", "=", "def")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n=\nabc\nFoo\n!=\ndef`,
+            result: `Match\nall\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis not equal\ndef`,
         },
         {
             domain: `["&", ("foo", "=", "abc"), "!", "!", ("foo", "=", "def")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n=\nabc\nFoo\n=\ndef`,
+            result: `Match\nall\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["|", "!", ("foo", "=", "abc"), ("foo", "=", "def")]`,
-            result: `Match\nany\nof the following rules:\nFoo\n!=\nabc\nFoo\n=\ndef`,
+            result: `Match\nany\nof the following rules:\nFoo\nis not equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["|", "!", "!", ("foo", "=", "abc"), ("foo", "=", "def")]`,
-            result: `Match\nany\nof the following rules:\nFoo\n=\nabc\nFoo\n=\ndef`,
+            result: `Match\nany\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["|", ("foo", "=", "abc"), "!", ("foo", "=", "def")]`,
-            result: `Match\nany\nof the following rules:\nFoo\n=\nabc\nFoo\n!=\ndef`,
+            result: `Match\nany\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis not equal\ndef`,
         },
         {
             domain: `["|", ("foo", "=", "abc"), "!", "!", ("foo", "=", "def")]`,
-            result: `Match\nany\nof the following rules:\nFoo\n=\nabc\nFoo\n=\ndef`,
+            result: `Match\nany\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["&", "!", "&", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nall\nof the following rules:\nany\nof:\nFoo\n!=\nabc\nFoo\n!=\ndef\nFoo\n=\nghi`,
+            result: `Match\nall\nof the following rules:\nany\nof:\nFoo\nis not equal\nabc\nFoo\nis not equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["&", "!", "|", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n!=\nabc\nFoo\n!=\ndef\nFoo\n=\nghi`,
+            result: `Match\nall\nof the following rules:\nFoo\nis not equal\nabc\nFoo\nis not equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["|", "!", "&", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nany\nof the following rules:\nFoo\n!=\nabc\nFoo\n!=\ndef\nFoo\n=\nghi`,
+            result: `Match\nany\nof the following rules:\nFoo\nis not equal\nabc\nFoo\nis not equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["|", "!", "|", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nany\nof the following rules:\nall\nof:\nFoo\n!=\nabc\nFoo\n!=\ndef\nFoo\n=\nghi`,
+            result: `Match\nany\nof the following rules:\nall\nof:\nFoo\nis not equal\nabc\nFoo\nis not equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["!", "&", "&", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nany\nof the following rules:\nFoo\n!=\nabc\nFoo\n!=\ndef\nFoo\n!=\nghi`,
+            result: `Match\nany\nof the following rules:\nFoo\nis not equal\nabc\nFoo\nis not equal\ndef\nFoo\nis not equal\nghi`,
         },
         {
             domain: `["!", "|", "|", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n!=\nabc\nFoo\n!=\ndef\nFoo\n!=\nghi`,
+            result: `Match\nall\nof the following rules:\nFoo\nis not equal\nabc\nFoo\nis not equal\ndef\nFoo\nis not equal\nghi`,
         },
         {
             domain: `["!", "&", "|", ("foo", "=", "abc"), "!", ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nany\nof the following rules:\nall\nof:\nFoo\n!=\nabc\nFoo\n=\ndef\nFoo\n!=\nghi`,
+            result: `Match\nany\nof the following rules:\nall\nof:\nFoo\nis not equal\nabc\nFoo\nis equal\ndef\nFoo\nis not equal\nghi`,
         },
         {
             domain: `["!", "|", "&", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nall\nof the following rules:\nany\nof:\nFoo\n!=\nabc\nFoo\n!=\ndef\nFoo\n!=\nghi`,
+            result: `Match\nall\nof the following rules:\nany\nof:\nFoo\nis not equal\nabc\nFoo\nis not equal\ndef\nFoo\nis not equal\nghi`,
         },
         {
             domain: `["!", "&", ("foo", "=", "abc"), "|", ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nany\nof the following rules:\nFoo\n!=\nabc\nall\nof:\nFoo\n!=\ndef\nFoo\n!=\nghi`,
+            result: `Match\nany\nof the following rules:\nFoo\nis not equal\nabc\nall\nof:\nFoo\nis not equal\ndef\nFoo\nis not equal\nghi`,
         },
         {
             domain: `["!", "|", ("foo", "=", "abc"), "&", ("foo", "=", "def"), ("foo", "!=", "ghi")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n!=\nabc\nany\nof:\nFoo\n!=\ndef\nFoo\n=\nghi`,
+            result: `Match\nall\nof the following rules:\nFoo\nis not equal\nabc\nany\nof:\nFoo\nis not equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["!", "|", ("foo", "=", "abc"), "&", ("foo", "!=", "def"), "!", ("foo", "=", "ghi")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n!=\nabc\nany\nof:\nFoo\n=\ndef\nFoo\n=\nghi`,
+            result: `Match\nall\nof the following rules:\nFoo\nis not equal\nabc\nany\nof:\nFoo\nis equal\ndef\nFoo\nis equal\nghi`,
         },
     ];
 
@@ -826,99 +826,99 @@ test("support of connector '!' (debug mode)", async () => {
     const toTest = [
         {
             domain: `["!", ("foo", "=", "abc")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n!=\nabc`,
+            result: `Match\nall\nof the following rules:\nFoo\nis not equal\nabc`,
         },
         {
             domain: `["!", "!", ("foo", "=", "abc")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n=\nabc`,
+            result: `Match\nall\nof the following rules:\nFoo\nis equal\nabc`,
         },
         {
             domain: `["!", "!", "!", ("foo", "=", "abc")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n!=\nabc`,
+            result: `Match\nall\nof the following rules:\nFoo\nis not equal\nabc`,
         },
         {
             domain: `["!", "&", ("foo", "=", "abc"), ("foo", "=", "def")]`,
-            result: `Match\nnot all\nof the following rules:\nFoo\n=\nabc\nFoo\n=\ndef`,
+            result: `Match\nnot all\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["!", "|", ("foo", "=", "abc"), ("foo", "=", "def")]`,
-            result: `Match\nnone\nof the following rules:\nFoo\n=\nabc\nFoo\n=\ndef`,
+            result: `Match\nnone\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["&", "!", ("foo", "=", "abc"), ("foo", "=", "def")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n!=\nabc\nFoo\n=\ndef`,
+            result: `Match\nall\nof the following rules:\nFoo\nis not equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["&", "!", "!", ("foo", "=", "abc"), ("foo", "=", "def")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n=\nabc\nFoo\n=\ndef`,
+            result: `Match\nall\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["&", ("foo", "=", "abc"), "!", ("foo", "=", "def")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n=\nabc\nFoo\n!=\ndef`,
+            result: `Match\nall\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis not equal\ndef`,
         },
         {
             domain: `["&", ("foo", "=", "abc"), "!", "!", ("foo", "=", "def")]`,
-            result: `Match\nall\nof the following rules:\nFoo\n=\nabc\nFoo\n=\ndef`,
+            result: `Match\nall\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["|", "!", ("foo", "=", "abc"), ("foo", "=", "def")]`,
-            result: `Match\nany\nof the following rules:\nFoo\n!=\nabc\nFoo\n=\ndef`,
+            result: `Match\nany\nof the following rules:\nFoo\nis not equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["|", "!", "!", ("foo", "=", "abc"), ("foo", "=", "def")]`,
-            result: `Match\nany\nof the following rules:\nFoo\n=\nabc\nFoo\n=\ndef`,
+            result: `Match\nany\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["|", ("foo", "=", "abc"), "!", ("foo", "=", "def")]`,
-            result: `Match\nany\nof the following rules:\nFoo\n=\nabc\nFoo\n!=\ndef`,
+            result: `Match\nany\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis not equal\ndef`,
         },
         {
             domain: `["|", ("foo", "=", "abc"), "!", "!", ("foo", "=", "def")]`,
-            result: `Match\nany\nof the following rules:\nFoo\n=\nabc\nFoo\n=\ndef`,
+            result: `Match\nany\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis equal\ndef`,
         },
         {
             domain: `["&", "!", "&", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nall\nof the following rules:\nnot all\nof:\nFoo\n=\nabc\nFoo\n=\ndef\nFoo\n=\nghi`,
+            result: `Match\nall\nof the following rules:\nnot all\nof:\nFoo\nis equal\nabc\nFoo\nis equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["&", "!", "|", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nall\nof the following rules:\nnone\nof:\nFoo\n=\nabc\nFoo\n=\ndef\nFoo\n=\nghi`,
+            result: `Match\nall\nof the following rules:\nnone\nof:\nFoo\nis equal\nabc\nFoo\nis equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["|", "!", "&", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nany\nof the following rules:\nnot all\nof:\nFoo\n=\nabc\nFoo\n=\ndef\nFoo\n=\nghi`,
+            result: `Match\nany\nof the following rules:\nnot all\nof:\nFoo\nis equal\nabc\nFoo\nis equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["|", "!", "|", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nany\nof the following rules:\nnone\nof:\nFoo\n=\nabc\nFoo\n=\ndef\nFoo\n=\nghi`,
+            result: `Match\nany\nof the following rules:\nnone\nof:\nFoo\nis equal\nabc\nFoo\nis equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["!", "&", "&", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nnot all\nof the following rules:\nFoo\n=\nabc\nFoo\n=\ndef\nFoo\n=\nghi`,
+            result: `Match\nnot all\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["!", "|", "|", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nnone\nof the following rules:\nFoo\n=\nabc\nFoo\n=\ndef\nFoo\n=\nghi`,
+            result: `Match\nnone\nof the following rules:\nFoo\nis equal\nabc\nFoo\nis equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["!", "&", "|", ("foo", "=", "abc"), "!", ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nnot all\nof the following rules:\nany\nof:\nFoo\n=\nabc\nFoo\n!=\ndef\nFoo\n=\nghi`,
+            result: `Match\nnot all\nof the following rules:\nany\nof:\nFoo\nis equal\nabc\nFoo\nis not equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["!", "|", "&", ("foo", "=", "abc"), ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nnone\nof the following rules:\nall\nof:\nFoo\n=\nabc\nFoo\n=\ndef\nFoo\n=\nghi`,
+            result: `Match\nnone\nof the following rules:\nall\nof:\nFoo\nis equal\nabc\nFoo\nis equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["!", "&", ("foo", "=", "abc"), "|", ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nnot all\nof the following rules:\nFoo\n=\nabc\nany\nof:\nFoo\n=\ndef\nFoo\n=\nghi`,
+            result: `Match\nnot all\nof the following rules:\nFoo\nis equal\nabc\nany\nof:\nFoo\nis equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["!", "|", ("foo", "=", "abc"), "&", ("foo", "=", "def"), ("foo", "=", "ghi")]`,
-            result: `Match\nnone\nof the following rules:\nFoo\n=\nabc\nall\nof:\nFoo\n=\ndef\nFoo\n=\nghi`,
+            result: `Match\nnone\nof the following rules:\nFoo\nis equal\nabc\nall\nof:\nFoo\nis equal\ndef\nFoo\nis equal\nghi`,
         },
         {
             domain: `["!", "|", ("foo", "=", "abc"), "&", ("foo", "=", "def"), "!", ("foo", "=", "ghi")]`,
-            result: `Match\nnone\nof the following rules:\nFoo\n=\nabc\nall\nof:\nFoo\n=\ndef\nFoo\n!=\nghi`,
+            result: `Match\nnone\nof the following rules:\nFoo\nis equal\nabc\nall\nof:\nFoo\nis equal\ndef\nFoo\nis not equal\nghi`,
         },
     ];
 
@@ -999,7 +999,7 @@ test("support properties", async () => {
     expectedDomain = `[("properties.xpad_prop_1", "=", False)]`;
     await contains(".o_model_field_selector_popover_item[data-name='xpad_prop_1'] button").click();
     expect(getCurrentPath()).toBe("Properties > M2O");
-    expect(getOperatorOptions()).toEqual(["=", "!=", "is set", "is not set"]);
+    expect(getOperatorOptions()).toEqual(["is equal", "is not equal", "is set", "is not set"]);
 
     const toTests = [
         {
@@ -1010,14 +1010,14 @@ test("support properties", async () => {
         {
             name: "xphone_prop_2",
             domain: `[("properties.xphone_prop_2", "=", False)]`,
-            options: ["=", "!=", "is set", "is not set"],
+            options: ["is equal", "is not equal", "is set", "is not set"],
         },
         {
             name: "xphone_prop_3",
             domain: `[("properties.xphone_prop_3", "=", "")]`,
             options: [
-                "=",
-                "!=",
+                "is equal",
+                "is not equal",
                 "contains",
                 "does not contain",
                 "is in",
@@ -1032,12 +1032,12 @@ test("support properties", async () => {
             name: "xphone_prop_4",
             domain: `[("properties.xphone_prop_4", "=", 1)]`,
             options: [
-                "=",
-                "!=",
-                ">",
-                ">=",
-                "<",
-                "<=",
+                "is equal",
+                "is not equal",
+                "is greater",
+                "is greater or equal",
+                "is lower",
+                "is lower or equal",
                 "is between",
                 "contains",
                 "does not contain",
@@ -1049,12 +1049,12 @@ test("support properties", async () => {
             name: "xphone_prop_5",
             domain: `[("properties.xphone_prop_5", "=", "2023-10-05")]`,
             options: [
-                "=",
-                "!=",
-                ">",
-                ">=",
-                "<",
-                "<=",
+                "is equal",
+                "is not equal",
+                "is greater",
+                "is greater or equal",
+                "is lower",
+                "is lower or equal",
                 "is between",
                 "is within",
                 "is set",
@@ -1123,13 +1123,19 @@ test("support properties (mode readonly)", async () => {
         },
         {
             domain: `[("properties.xphone_prop_2", "=", "abc")]`,
-            result: "Properties ➔ Selection = ABC",
+            result: "Properties ➔ Selection is equal ABC",
         },
-        { domain: `[("properties.xphone_prop_3", "=", "def")]`, result: "Properties ➔ Char = def" },
-        { domain: `[("properties.xphone_prop_4", "=", 1)]`, result: "Properties ➔ Integer = 1" },
+        {
+            domain: `[("properties.xphone_prop_3", "=", "def")]`,
+            result: "Properties ➔ Char is equal def",
+        },
+        {
+            domain: `[("properties.xphone_prop_4", "=", 1)]`,
+            result: "Properties ➔ Integer is equal 1",
+        },
         {
             domain: `[("properties.xphone_prop_5", "=", "2023-10-05")]`,
-            result: "Properties ➔ Date = 05|10|2023",
+            result: "Properties ➔ Date is equal 05|10|2023",
         },
         {
             domain: `[("properties.xphone_prop_6", "in", "g")]`,
@@ -1139,7 +1145,10 @@ test("support properties (mode readonly)", async () => {
             domain: `[("properties.xphone_prop_7", "in", [37])]`,
             result: "Properties ➔ M2M is in ( xphone )",
         },
-        { domain: `[("properties.xpad_prop_1", "=", 41)]`, result: "Properties ➔ M2O = xpad" },
+        {
+            domain: `[("properties.xpad_prop_1", "=", 41)]`,
+            result: "Properties ➔ M2O is equal xpad",
+        },
     ];
 
     class Parent extends Component {
@@ -1299,7 +1308,7 @@ test("display of a contextual value (readonly)", async () => {
         domain: `[("foo", "=", uid)]`,
         readonly: true,
     });
-    expect(getConditionText()).toBe("Foo = uid");
+    expect(getConditionText()).toBe("Foo is equal uid");
 });
 
 test("boolean field (readonly)", async () => {
@@ -1325,16 +1334,16 @@ test("integer field (readonly)", async () => {
         domain: `[]`,
     });
     const toTest = [
-        { domain: `[("int", "=", True)]`, text: `Int = true` },
+        { domain: `[("int", "=", True)]`, text: `Int is equal true` },
         { domain: `[("int", "=", False)]`, text: `Int is not set` },
-        { domain: `[("int", "!=", True)]`, text: `Int != true` },
+        { domain: `[("int", "!=", True)]`, text: `Int is not equal true` },
         { domain: `[("int", "!=", False)]`, text: `Int is set` },
-        { domain: `[("int", "=", 1)]`, text: `Int = 1` },
-        { domain: `[("int", "!=", 1)]`, text: `Int != 1` },
-        { domain: `[("int", "<", 1)]`, text: `Int < 1` },
-        { domain: `[("int", "<=", 1)]`, text: `Int <= 1` },
-        { domain: `[("int", ">", 1)]`, text: `Int > 1` },
-        { domain: `[("int", ">=", 1)]`, text: `Int >= 1` },
+        { domain: `[("int", "=", 1)]`, text: `Int is equal 1` },
+        { domain: `[("int", "!=", 1)]`, text: `Int is not equal 1` },
+        { domain: `[("int", "<", 1)]`, text: `Int is lower 1` },
+        { domain: `[("int", "<=", 1)]`, text: `Int is lower or equal 1` },
+        { domain: `[("int", ">", 1)]`, text: `Int is greater 1` },
+        { domain: `[("int", ">=", 1)]`, text: `Int is greater or equal 1` },
         {
             domain: `["&", ("int", ">=", 1),("int","<=", 2)]`,
             text: `Int is between 1 and 2`,
@@ -1357,15 +1366,15 @@ test("date field (readonly)", async () => {
         domain: `[]`,
     });
     const toTest = [
-        { domain: `[("date", "=", False)]`, text: `Date = false` },
-        { domain: `[("date", "!=", False)]`, text: `Date != false` },
-        { domain: `[("date", "=", "2023-07-03")]`, text: `Date = 03|07|2023` },
-        { domain: `[("date", "=", context_today())]`, text: `Date = context_today()` },
-        { domain: `[("date", "!=", "2023-07-03")]`, text: `Date != 03|07|2023` },
-        { domain: `[("date", "<", "2023-07-03")]`, text: `Date < 03|07|2023` },
-        { domain: `[("date", "<=", "2023-07-03")]`, text: `Date <= 03|07|2023` },
-        { domain: `[("date", ">", "2023-07-03")]`, text: `Date > 03|07|2023` },
-        { domain: `[("date", ">=", "2023-07-03")]`, text: `Date >= 03|07|2023` },
+        { domain: `[("date", "=", False)]`, text: `Date is equal false` },
+        { domain: `[("date", "!=", False)]`, text: `Date is not equal false` },
+        { domain: `[("date", "=", "2023-07-03")]`, text: `Date is equal 03|07|2023` },
+        { domain: `[("date", "=", context_today())]`, text: `Date is equal context_today()` },
+        { domain: `[("date", "!=", "2023-07-03")]`, text: `Date is not equal 03|07|2023` },
+        { domain: `[("date", "<", "2023-07-03")]`, text: `Date is lower 03|07|2023` },
+        { domain: `[("date", "<=", "2023-07-03")]`, text: `Date is lower or equal 03|07|2023` },
+        { domain: `[("date", ">", "2023-07-03")]`, text: `Date is greater 03|07|2023` },
+        { domain: `[("date", ">=", "2023-07-03")]`, text: `Date is greater or equal 03|07|2023` },
         {
             domain: `["&", ("date", ">=", "2023-07-03"),("date","<=", "2023-07-15")]`,
             text: `Date is between 03|07|2023 and 15|07|2023`,
@@ -1389,9 +1398,9 @@ test("char field (readonly)", async () => {
     const toTest = [
         { domain: `[("foo", "=", False)]`, text: `Foo is not set` },
         { domain: `[("foo", "!=", False)]`, text: `Foo is set` },
-        { domain: `[("foo", "=", "abc")]`, text: `Foo = abc` },
-        { domain: `[("foo", "=", expr)]`, text: `Foo = expr` },
-        { domain: `[("foo", "!=", "abc")]`, text: `Foo != abc` },
+        { domain: `[("foo", "=", "abc")]`, text: `Foo is equal abc` },
+        { domain: `[("foo", "=", expr)]`, text: `Foo is equal expr` },
+        { domain: `[("foo", "!=", "abc")]`, text: `Foo is not equal abc` },
         { domain: `[("foo", "ilike", "abc")]`, text: `Foo contains abc` },
         { domain: `[("foo", "not ilike", "abc")]`, text: `Foo does not contain abc` },
         { domain: `[("foo", "in", ["abc", "def"])]`, text: `Foo is in ( abc , def )` },
@@ -1411,9 +1420,9 @@ test("selection field (readonly)", async () => {
     const toTest = [
         { domain: `[("state", "=", False)]`, text: `State is not set` },
         { domain: `[("state", "!=", False)]`, text: `State is set` },
-        { domain: `[("state", "=", "abc")]`, text: `State = ABC` },
-        { domain: `[("state", "=", expr)]`, text: `State = expr` },
-        { domain: `[("state", "!=", "abc")]`, text: `State != ABC` },
+        { domain: `[("state", "=", "abc")]`, text: `State is equal ABC` },
+        { domain: `[("state", "=", expr)]`, text: `State is equal expr` },
+        { domain: `[("state", "!=", "abc")]`, text: `State is not equal ABC` },
         { domain: `[("state", "in", ["abc", "def"])]`, text: `State is in ( ABC , DEF )` },
         { domain: `[("state", "in", ["abc", False])]`, text: `State is in ( "ABC" , false )` },
         {
@@ -1466,15 +1475,15 @@ test("selection property (readonly)", async () => {
         },
         {
             domain: `[("properties.selection_prop", "=", "abc")]`,
-            text: `Properties ➔ Selection = ABC`,
+            text: `Properties ➔ Selection is equal ABC`,
         },
         {
             domain: `[("properties.selection_prop", "=", expr)]`,
-            text: `Properties ➔ Selection = expr`,
+            text: `Properties ➔ Selection is equal expr`,
         },
         {
             domain: `[("properties.selection_prop", "!=", "abc")]`,
-            text: `Properties ➔ Selection != ABC`,
+            text: `Properties ➔ Selection is not equal ABC`,
         },
     ];
     for (const { domain, text } of toTest) {
@@ -1487,23 +1496,23 @@ test("many2one field (readonly)", async () => {
     const toTest = [
         {
             domain: `[("product_id", "=", 37)]`,
-            text: "Product = xphone",
+            text: "Product is equal xphone",
         },
         {
             domain: `[("product_id", "=", 2)]`,
-            text: "Product = Inaccessible/missing record ID: 2",
+            text: "Product is equal Inaccessible/missing record ID: 2",
         },
         {
             domain: `[("product_id", "!=", 37)]`,
-            text: "Product != xphone",
+            text: "Product is not equal xphone",
         },
         {
             domain: `[("product_id", "=", false)]`,
-            text: "Product = false",
+            text: "Product is equal false",
         },
         {
             domain: `[("product_id", "!=", false)]`,
-            text: "Product != false",
+            text: "Product is not equal false",
         },
         {
             domain: `[("product_id", "in", [])]`,
@@ -1548,8 +1557,8 @@ test("many2one field operators (edit)", async () => {
     expect(getOperatorOptions()).toEqual([
         "is in",
         "is not in",
-        "=",
-        "!=",
+        "is equal",
+        "is not equal",
         "contains",
         "does not contain",
         "is set",
@@ -1602,7 +1611,7 @@ test("many2one field and operator =/!= (edit)", async () => {
             expect.step(domain);
         },
     });
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("");
     expect.verifySteps([]);
     expect(".dropdown-menu").toHaveCount(0);
@@ -1611,30 +1620,30 @@ test("many2one field and operator =/!= (edit)", async () => {
     await runAllTimers();
     expect(".dropdown-menu").toHaveCount(1);
     expect(queryAllTexts(".dropdown-menu li")).toEqual(["xphone"]);
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("xph");
 
     await contains(".dropdown-menu li").click();
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("xphone");
     expect.verifySteps([`[("product_id", "=", 37)]`]);
     expect(".dropdown-menu").toHaveCount(0);
 
     await editValue("", { confirm: false });
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("");
     await contains(".o_domain_selector").click();
     expect.verifySteps([`[("product_id", "=", False)]`]);
 
     await selectOperator("!=");
-    expect(getCurrentOperator()).toBe("!=");
+    expect(getCurrentOperator()).toBe("is not equal");
     expect(getCurrentValue()).toBe("");
     expect.verifySteps([`[("product_id", "!=", False)]`]);
 
     await editValue("xpa", { confirm: false });
     await runAllTimers();
     await contains(".dropdown-menu li").click();
-    expect(getCurrentOperator()).toBe("!=");
+    expect(getCurrentOperator()).toBe("is not equal");
     expect(getCurrentValue()).toBe("xpad");
     expect.verifySteps([`[("product_id", "!=", 41)]`]);
 });
@@ -1644,7 +1653,7 @@ test("many2one field on record with falsy display_name", async () => {
     await makeDomainSelector({
         domain: `[("product_id", "=", False)]`,
     });
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("");
     expect(".dropdown-menu").toHaveCount(0);
 
@@ -1719,7 +1728,7 @@ test("many2many field and operator set/not set (edit)", async () => {
             expect.step(domain);
         },
     });
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("");
     expect.verifySteps([]);
 
@@ -1735,7 +1744,7 @@ test("many2many field and operator set/not set (edit)", async () => {
     expect.verifySteps([`[("product_id", "!=", False)]`]);
 
     await selectOperator("!=");
-    expect(getCurrentOperator()).toBe("!=");
+    expect(getCurrentOperator()).toBe("is not equal");
     expect(getCurrentValue()).toBe("");
     expect.verifySteps([`[("product_id", "!=", False)]`]);
 });
@@ -1747,7 +1756,7 @@ test("many2many field: clone a set/not set condition", async () => {
             expect.step(domain);
         },
     });
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("");
     expect.verifySteps([]);
 
@@ -1772,8 +1781,8 @@ test("x2many field operators (edit)", async () => {
     expect(getOperatorOptions()).toEqual([
         "is in",
         "is not in",
-        "=",
-        "!=",
+        "is equal",
+        "is not equal",
         "contains",
         "does not contain",
         "is set",
@@ -1863,12 +1872,12 @@ test("many2many field: operator =/!=/in/not in (edit)", async () => {
     expect.verifySteps([`[("product_ids", "not in", [41])]`]);
 
     await selectOperator("=");
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("xpad");
     expect.verifySteps([`[("product_ids", "=", [41])]`]);
 
     await selectOperator("!=");
-    expect(getCurrentOperator()).toBe("!=");
+    expect(getCurrentOperator()).toBe("is not equal");
     expect(getCurrentValue()).toBe("xpad");
     expect.verifySteps([`[("product_ids", "!=", [41])]`]);
 });
@@ -2000,7 +2009,7 @@ test("date/datetime edition: switch !=/is set", async () => {
             expect.step(domain);
         },
     });
-    expect(getCurrentOperator()).toBe("!=");
+    expect(getCurrentOperator()).toBe("is not equal");
     expect(".o_datetime_input").toHaveCount(1);
     expect(getCurrentValue()).toBe("");
 
@@ -2010,7 +2019,7 @@ test("date/datetime edition: switch !=/is set", async () => {
     expect.verifySteps([`[("date", "!=", False)]`]);
 
     await selectOperator("!=");
-    expect(getCurrentOperator()).toBe("!=");
+    expect(getCurrentOperator()).toBe("is not equal");
     expect(".o_datetime_input").toHaveCount(1);
     expect(getCurrentValue()).toBe("");
     expect.verifySteps([`[("date", "!=", False)]`]);
@@ -2018,9 +2027,9 @@ test("date/datetime edition: switch !=/is set", async () => {
 
 test("render false and true leaves", async () => {
     await makeDomainSelector({ domain: `[(0, "=", 1), (1, "=", 1)]` });
-    expect(getOperatorOptions()).toEqual(["="]);
+    expect(getOperatorOptions()).toEqual(["is equal"]);
     expect(getValueOptions()).toEqual(["1"]);
-    expect(getOperatorOptions(-1)).toEqual(["="]);
+    expect(getOperatorOptions(-1)).toEqual(["is equal"]);
     expect(getValueOptions(-1)).toEqual(["1"]);
 });
 
@@ -2187,11 +2196,11 @@ test(`any/not any operator (readonly)`, async () => {
         },
         {
             domain: `[("product_id", "any", ["&", ("name", "in", ["JD7", "KDB"]), ("team_id", "not any", ["&", ("id", "=", 17), ("name", "ilike", "mancity")])])]`,
-            text: `Match\nall\nof the following rules:\nProduct\nmatches\nall\nof:\nProduct Name\nis in\n(\nJD7\n,\nKDB\n)\nProduct Team\nmatches none of\nall\nof:\nId\n=\n17\nTeam Name\ncontains\nmancity`,
+            text: `Match\nall\nof the following rules:\nProduct\nmatches\nall\nof:\nProduct Name\nis in\n(\nJD7\n,\nKDB\n)\nProduct Team\nmatches none of\nall\nof:\nId\nis equal\n17\nTeam Name\ncontains\nmancity`,
         },
         {
             domain: `[("product_id", "any", ["|", ("name", "in", ["JD7", "KDB"]), ("team_id", "not any", ["|", ("id", "=", 17), ("name", "ilike", "mancity")])])]`,
-            text: `Match\nall\nof the following rules:\nProduct\nmatches\nany\nof:\nProduct Name\nis in\n(\nJD7\n,\nKDB\n)\nProduct Team\nmatches none of\nany\nof:\nId\n=\n17\nTeam Name\ncontains\nmancity`,
+            text: `Match\nall\nof the following rules:\nProduct\nmatches\nany\nof:\nProduct Name\nis in\n(\nJD7\n,\nKDB\n)\nProduct Team\nmatches none of\nany\nof:\nId\nis equal\n17\nTeam Name\ncontains\nmancity`,
         },
     ];
     const parent = await makeDomainSelector({ readonly: true });
@@ -2325,7 +2334,7 @@ test("many2one: no domain in autocompletion", async () => {
             expect.step(domain);
         },
     });
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("");
     expect.verifySteps([]);
     expect(".dropdown-menu").toHaveCount(0);
@@ -2335,11 +2344,11 @@ test("many2one: no domain in autocompletion", async () => {
 
     expect(".dropdown-menu").toHaveCount(1);
     expect(queryAllTexts(".dropdown-menu li")).toEqual(["xphone", "xpad"]);
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("x");
 
     await contains(".dropdown-menu li").click();
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("xphone");
     expect.verifySteps([`[("product_id", "=", 37)]`]);
     expect(".dropdown-menu").toHaveCount(0);
@@ -2354,7 +2363,7 @@ test("many2many: domain in autocompletion", async () => {
             expect.step(domain);
         },
     });
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("");
     expect.verifySteps([]);
     expect(".dropdown-menu").toHaveCount(0);
@@ -2364,11 +2373,11 @@ test("many2many: domain in autocompletion", async () => {
 
     expect(".dropdown-menu").toHaveCount(1);
     expect(queryAllTexts(".dropdown-menu li")).toEqual(["xpad"]);
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("x");
 
     await contains(".dropdown-menu li").click();
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("xpad");
     expect.verifySteps([`[("product_ids", "=", [41])]`]);
     expect(".dropdown-menu").toHaveCount(0);

--- a/addons/web/static/tests/core/expression_editor/expression_editor.test.js
+++ b/addons/web/static/tests/core/expression_editor/expression_editor.test.js
@@ -114,7 +114,7 @@ test("rendering of falsy values", async () => {
         await parent.set(expr);
         expect(getTreeEditorContent()).toEqual([
             { value: "all", level: 0 },
-            { value: ["0", "=", "1"], level: 1 },
+            { value: ["0", "is equal", "1"], level: 1 },
         ]);
     }
 });
@@ -206,8 +206,8 @@ test("create a new branch from a complex condition control panel", async () => {
         { level: 0, value: "all" },
         { level: 1, value: "expr" },
         { level: 1, value: "any" },
-        { level: 2, value: ["Id", "=", "1"] },
-        { level: 2, value: ["Id", "=", "1"] },
+        { level: 2, value: ["Id", "is equal", "1"] },
+        { level: 2, value: ["Id", "is equal", "1"] },
     ]);
 });
 
@@ -216,8 +216,8 @@ test("rendering of a valid fieldName in fields", async () => {
 
     const toTests = [
         { expr: `foo`, condition: ["Foo", "is set"] },
-        { expr: `foo == "a"`, condition: ["Foo", "=", "a"] },
-        { expr: `foo != "a"`, condition: ["Foo", "!=", "a"] },
+        { expr: `foo == "a"`, condition: ["Foo", "is equal", "a"] },
+        { expr: `foo != "a"`, condition: ["Foo", "is not equal", "a"] },
         // { expr: `foo is "a"`, complexCondition: `foo is "a"` },
         // { expr: `foo is not "a"`, complexCondition: `foo is not "a"` },
         { expr: `not foo`, condition: ["Foo", "is not set"] },
@@ -247,18 +247,18 @@ test("rendering of simple conditions", async () => {
     const parent = await makeExpressionEditor({ fieldFilters: ["foo", "bar"] });
 
     const toTests = [
-        { expr: `bar == "a"`, condition: ["Bar", "=", "a"] },
-        { expr: `foo == expr`, condition: ["Foo", "=", "expr"] },
-        { expr: `"a" == foo`, condition: ["Foo", "=", "a"] },
-        { expr: `expr == foo`, condition: ["Foo", "=", "expr"] },
+        { expr: `bar == "a"`, condition: ["Bar", "is equal", "a"] },
+        { expr: `foo == expr`, condition: ["Foo", "is equal", "expr"] },
+        { expr: `"a" == foo`, condition: ["Foo", "is equal", "a"] },
+        { expr: `expr == foo`, condition: ["Foo", "is equal", "expr"] },
         { expr: `foo == bar`, complexCondition: `foo == bar` },
         { expr: `"a" == "b"`, complexCondition: `"a" == "b"` },
         { expr: `expr1 == expr2`, complexCondition: `expr1 == expr2` },
 
-        { expr: `foo < "a"`, condition: ["Foo", "<", "a"] },
-        { expr: `foo < expr`, condition: ["Foo", "<", "expr"] },
-        { expr: `"a" < foo`, condition: ["Foo", ">", "a"] },
-        { expr: `expr < foo`, condition: ["Foo", ">", "expr"] },
+        { expr: `foo < "a"`, condition: ["Foo", "is lower", "a"] },
+        { expr: `foo < expr`, condition: ["Foo", "is lower", "expr"] },
+        { expr: `"a" < foo`, condition: ["Foo", "is greater", "a"] },
+        { expr: `expr < foo`, condition: ["Foo", "is greater", "expr"] },
         { expr: `foo < bar`, complexCondition: `foo < bar` },
         { expr: `"a" < "b"`, complexCondition: `"a" < "b"` },
         { expr: `expr1 < expr2`, complexCondition: `expr1 < expr2` },
@@ -297,7 +297,7 @@ test("rendering of connectors", async () => {
         { level: 0, value: "any" },
         { level: 1, value: "all" },
         { level: 2, value: "expr" },
-        { level: 2, value: ["Foo", "=", "abc"] },
+        { level: 2, value: ["Foo", "is equal", "abc"] },
         { level: 1, value: ["Bar", "is", "not set"] },
     ]);
 });
@@ -313,7 +313,7 @@ test("rendering of connectors (2)", async () => {
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "none" },
         { level: 1, value: "expr" },
-        { level: 1, value: ["Foo", "=", "abc"] },
+        { level: 1, value: ["Foo", "is equal", "abc"] },
     ]);
     expect.verifySteps([]);
     expect(queryOne(SELECTORS.debugArea)).toHaveValue(`not (expr or foo == "abc")`);
@@ -323,7 +323,7 @@ test("rendering of connectors (2)", async () => {
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
         { level: 1, value: "expr" },
-        { level: 1, value: ["Foo", "=", "abc"] },
+        { level: 1, value: ["Foo", "is equal", "abc"] },
     ]);
     expect.verifySteps([`expr and foo == "abc"`]);
     expect(queryOne(SELECTORS.debugArea)).toHaveValue(`expr and foo == "abc"`);
@@ -334,11 +334,11 @@ test("rendering of if else", async () => {
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "any" },
         { level: 1, value: "all" },
-        { level: 2, value: ["0", "=", "1"] },
-        { level: 2, value: ["1", "=", "1"] },
+        { level: 2, value: ["0", "is equal", "1"] },
+        { level: 2, value: ["1", "is equal", "1"] },
         { level: 1, value: "all" },
-        { level: 2, value: ["1", "=", "1"] },
-        { level: 2, value: ["0", "=", "1"] },
+        { level: 2, value: ["1", "is equal", "1"] },
+        { level: 2, value: ["0", "is equal", "1"] },
     ]);
 });
 
@@ -350,7 +350,7 @@ test("check condition by default when creating a new rule", async () => {
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
         { level: 1, value: "expr" },
-        { level: 1, value: ["Country ID", "=", ""] },
+        { level: 1, value: ["Country ID", "is equal", ""] },
     ]);
 });
 
@@ -370,9 +370,9 @@ test("allow selection of boolean field", async () => {
 
 test("render false and true leaves", async () => {
     await makeExpressionEditor({ expression: `False and True` });
-    expect(getOperatorOptions()).toEqual(["="]);
+    expect(getOperatorOptions()).toEqual(["is equal"]);
     expect(getValueOptions()).toEqual(["1"]);
-    expect(getOperatorOptions(-1)).toEqual(["="]);
+    expect(getOperatorOptions(-1)).toEqual(["is equal"]);
     expect(getValueOptions(-1)).toEqual(["1"]);
 });
 
@@ -420,7 +420,7 @@ test("no special fields in fields", async () => {
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
         { level: 1, value: ["Bar", "is not", "not set"] },
-        { level: 1, value: ["Foo", "=", ""] },
+        { level: 1, value: ["Foo", "is equal", ""] },
     ]);
     expect.verifySteps([`bar and foo == ""`]);
 });
@@ -433,12 +433,12 @@ test("between operator", async () => {
         },
     });
     expect(getOperatorOptions()).toEqual([
-        "=",
-        "!=",
-        ">",
-        ">=",
-        "<",
-        "<=",
+        "is equal",
+        "is not equal",
+        "is greater",
+        "is greater or equal",
+        "is lower",
+        "is lower or equal",
         "is between",
         "is set",
         "is not set",

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -1239,7 +1239,7 @@ test("edit a filter", async () => {
     expect(SELECTORS.condition).toHaveCount(1);
     expect(queryAllTexts`.modal footer button`).toEqual(["Confirm", "Discard"]);
     expect(getCurrentPath()).toBe("Birthday");
-    expect(getCurrentOperator()).toBe(">=");
+    expect(getCurrentOperator()).toBe("is greater or equal");
     expect(getCurrentValue()).toBe("context_today()");
     expect(`.modal footer button`).toBeEnabled();
 
@@ -1250,12 +1250,12 @@ test("edit a filter", async () => {
     await contains(`.modal ${SELECTORS.addNewRule}`).click();
     expect(SELECTORS.condition).toHaveCount(1);
     expect(getCurrentPath()).toBe("Id");
-    expect(getCurrentOperator()).toBe("=");
+    expect(getCurrentOperator()).toBe("is equal");
     expect(getCurrentValue()).toBe("1");
 
     await contains(".modal footer button").click();
     expect(`.modal`).toHaveCount(0);
-    expect(getFacetTexts()).toEqual(["Bool", "Id = 1"]);
+    expect(getFacetTexts()).toEqual(["Bool", "Id is equal 1"]);
 });
 
 test("edit a filter with context: context is kept after edition", async () => {
@@ -1277,7 +1277,7 @@ test("edit a filter with context: context is kept after edition", async () => {
 
     await contains(".o_facet_with_domain .o_searchview_facet_label").click();
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual([`Foo = abc`]);
+    expect(getFacetTexts()).toEqual([`Foo is equal abc`]);
     expect(searchBar.env.searchModel.context.specialKey).toBe("abc");
 });
 
@@ -1470,7 +1470,9 @@ test("facets display with any / not any operator (with a complex path)", async f
     expect.verifySteps([`fields_get`]);
 
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Company ➔ Company matches ( Id = 1 ) or Bar = false"]);
+    expect(getFacetTexts()).toEqual([
+        "Company ➔ Company matches ( Id is equal 1 ) or Bar is equal false",
+    ]);
     expect.verifySteps([`/web/domain/validate`]);
 });
 
@@ -1499,7 +1501,7 @@ test("facets display with any / not any operator (with a or)", async function ()
     expect.verifySteps([`fields_get`]);
 
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Company matches ( Id = 1 ) or Bar = false"]);
+    expect(getFacetTexts()).toEqual(["Company matches ( Id is equal 1 ) or Bar is equal false"]);
     expect.verifySteps([`/web/domain/validate`]);
 });
 
@@ -1529,7 +1531,7 @@ test("facets display with any / not any operator (check brackets)", async functi
 
     await contains(".modal footer button").click();
     expect(getFacetTexts()).toEqual([
-        "Company matches ( Bar matches ( Bool is not set ) and Bar matches ( Bool is set ) ) or Bar = false",
+        "Company matches ( Bar matches ( Bool is not set ) and Bar matches ( Bool is set ) ) or Bar is equal false",
     ]);
     expect.verifySteps([`/web/domain/validate`]);
 });

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -702,9 +702,9 @@ test("Add a custom filter", async () => {
     await contains(".modal footer button").click();
     expect(getFacetTexts()).toEqual([
         "Filter",
-        "Id = 1",
-        "Id = 1",
-        "( Id = 1 and Id = 1 ) or Id is in ( 1 , 1 )",
+        "Id is equal 1",
+        "Id is equal 1",
+        "( Id is equal 1 and Id is equal 1 ) or Id is in ( 1 , 1 )",
     ]);
     expect(searchBar.env.searchModel.domain).toEqual([
         "&",
@@ -793,7 +793,7 @@ test("consistent display of ! in debug mode", async () => {
     expect(".o_tree_editor_row .dropdown-toggle").toHaveText("none");
 
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual([`! ( Foo = 1 or Id = 2 )`]);
+    expect(getFacetTexts()).toEqual([`! ( Foo is equal 1 or Id is equal 2 )`]);
     expect(searchBar.env.searchModel.domain).toEqual(["!", "|", ["foo", "=", 1], ["id", "=", 2]]);
 });
 
@@ -896,10 +896,10 @@ test("display names in facets", async () => {
     await contains(".modal footer button").click();
 
     expect(getFacetTexts()).toEqual([
-        "Bar = John",
+        "Bar is equal John",
         "Bar is in ( David , Inaccessible/missing record ID: 5555 )",
-        "Bar != false",
-        "Id = 2",
+        "Bar is not equal false",
+        "Id is equal 2",
     ]);
     expect(searchBar.env.searchModel.domain).toEqual([
         "&",
@@ -947,7 +947,7 @@ test("display names in facets (with a property)", async () => {
     );
     await contains(".modal footer button").click();
 
-    expect(getFacetTexts()).toEqual(["Properties \u2794 M2O = John"]);
+    expect(getFacetTexts()).toEqual(["Properties \u2794 M2O is equal John"]);
     expect(searchBar.env.searchModel.domain).toEqual([["properties.m2o", "=", 1]]);
 });
 


### PR DESCRIPTION
This commit renames the basic search operators (=, !=, <, >, <=, >=) into their names in full.

task-4416442
