### PR TITLE
[FIX] account: cash basis use in invoicing

### DIFF
--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -185,7 +185,7 @@
                                            attrs="{'invisible': ['|', ('amount_type','=', 'group'), ('price_include', '=', True)]}"
                                            groups="base.group_no_one"/>
                                     <field name="hide_tax_exigibility" invisible="1"/>
-                                    <field name="tax_exigibility" widget="radio" attrs="{'invisible':['|', ('amount_type','=', 'group'), ('hide_tax_exigibility', '=', False)]}" groups="account.group_account_readonly"/>
+                                    <field name="tax_exigibility" widget="radio" attrs="{'invisible':['|', ('amount_type','=', 'group'), ('hide_tax_exigibility', '=', False)]}"/>
                                     <field name="cash_basis_transition_account_id" options="{'no_create': True}" attrs="{'invisible': [('tax_exigibility', '=', 'on_invoice')], 'required': [('tax_exigibility', '=', 'on_payment')]}" groups="account.group_account_readonly"/>
                                 </group>
                             </group>

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -120,8 +120,7 @@
                             </div>
                             <div class="col-12 col-lg-6 o_setting_box"
                                 id="tax_exigibility"
-                                title="Select this if the taxes should use cash basis, which will create an entry for such taxes on a given account during reconciliation."
-                                groups="account.group_account_user">
+                                title="Select this if the taxes should use cash basis, which will create an entry for such taxes on a given account during reconciliation.">
                                 <div class="o_setting_left_pane">
                                     <field name="tax_exigibility"/>
                                 </div>
@@ -131,7 +130,7 @@
                                     <div class="text-muted">
                                         Allow to configure taxes using cash basis
                                     </div>
-                                    <div class="content-group" attrs="{'invisible': [('tax_exigibility', '=', False)]}">
+                                    <div class="content-group" attrs="{'invisible': [('tax_exigibility', '=', False)]}" groups="account.group_account_user">
                                         <div class="row mt16">
                                             <label for="tax_cash_basis_journal_id" class="col-lg-3 o_light_label"/>
                                             <field name="tax_cash_basis_journal_id"/>


### PR DESCRIPTION
Before this commit, due to the group place on the setting, the cash basis option was not displayed to user with only invoicing. Now, we want the user (with only invoicing) to be able to see it but not modifying the account on the settings.

It will allow the users to choose the tax exigibility on the taxes, which for french user is important since depending on that the sentence "Option to pay tax on debits" will be displayed on the invoice.

task: 4342603




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
