### PR TITLE
[FIX] mail: fix failing sub channel tour

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -166,5 +166,5 @@ a.o-discuss-mention {
 
 .o-mail-Discuss-threadActionPopover {
     width: Min(95vw, 400px);
-    max-height: Min(calc(100vh - 140px), 530px);
+    max-height: Min(50vh, 530px);
 }


### PR DESCRIPTION
Before this PR, the `test_04_sub_channel_panel_search` test was always failing when chrome version is greater than 123 or in watch mode.

This occurs because the sub channel search panel is overflowing, falsing the assertion related to the thread being scrolled to the bottom.

The search panel popover is restricted to `Min(100vh, 500px)` which does not take into account the space between the top of the window and the popover.

This PR fixes the issue by reducing the vh allowed for the popover in order to keep it visible as much as possible.
