### PR TITLE
[FIX] account: change shortcut for Upload Button to Alt+Shift+I to avoid conflict

### DIFF
--- a/addons/account/static/src/components/account_file_uploader/account_file_uploader.xml
+++ b/addons/account/static/src/components/account_file_uploader/account_file_uploader.xml
@@ -10,7 +10,7 @@
     <t t-name="account.AccountViewUploadButton">
         <AccountFileUploader>
             <t t-set-slot="toggler">
-                <button type="button" class="btn btn-secondary o_button_upload_bill" data-hotkey="b">
+                <button type="button" class="btn btn-secondary o_button_upload_bill" data-hotkey="shift+i">
                     Upload
                 </button>
             </t>

--- a/addons/account/static/src/components/document_file_uploader/document_file_uploader.xml
+++ b/addons/account/static/src/components/document_file_uploader/document_file_uploader.xml
@@ -17,7 +17,7 @@
     <t t-name="account.DocumentViewUploadButton">
         <DocumentFileUploader resModel="props.resModel">
             <t t-set-slot="toggler">
-                <button type="button" class="btn btn-secondary" data-hotkey="b">
+                <button type="button" class="btn btn-secondary" data-hotkey="shift+i">
                     Upload
                 </button>
             </t>


### PR DESCRIPTION
Before this PR:
- The Upload Button was assigned the shortcut Alt+B.
- This caused a conflict with Odoo's default shortcut for navigating backward.

After this PR:
- The shortcut for the Upload Button is now updated to Alt+Shift+I.
- This resolves the conflict and ensures smooth navigation and functionality.

Task ID:-4417310

