### PR TITLE
[PERF] sale_expense: add missing index on `sale_order_id`

### DIFF
--- a/addons/sale_expense/models/hr_expense.py
+++ b/addons/sale_expense/models/hr_expense.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models
 class Expense(models.Model):
     _inherit = "hr.expense"
 
-    sale_order_id = fields.Many2one('sale.order', compute='_compute_sale_order_id', store=True, string='Customer to Reinvoice', readonly=False, tracking=True,
+    sale_order_id = fields.Many2one('sale.order', compute='_compute_sale_order_id', store=True, index='btree_not_null', string='Customer to Reinvoice', readonly=False, tracking=True,
         # NOTE: only confirmed SO can be selected, but this domain in activated throught the name search with the `sale_expense_all_order`
         # context key. So, this domain is not the one applied.
         domain="[('state', '=', 'sale'), ('company_id', '=', company_id)]",


### PR DESCRIPTION
## Description
`sale.order._compute_expense_count` does a `_read_group` with a domain only based on `sale_order_id`, which is an unindexed FKey, leading to a guaranteed `Seq.Scan`. This `_compute_expense_count` is used to compute the count of related expenses for a `sale.order`, shown as a smart button on the form view, which is a frequent operation.

## Reference
task-3977983

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
