### PR TITLE
[FIX] stock: prevent error while validating stock move

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -216,9 +216,13 @@ class StockMove(models.Model):
             bom = move._get_subcontract_bom()
             if not bom:
                 continue
+            company = move.company_id
+            subcontracting_location = \
+                move.picking_id.partner_id.with_company(company).property_stock_subcontractor \
+                or company.subcontracting_location_id
             move.write({
                 'is_subcontract': True,
-                'location_id': move.picking_id.partner_id.with_company(move.company_id).property_stock_subcontractor.id
+                'location_id': subcontracting_location.id
             })
         res = super()._action_confirm(merge=merge, merge_into=merge_into)
         for move in res:

--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -131,6 +131,9 @@ class StockPicking(models.Model):
         })
         product = subcontract_move.product_id
         warehouse = self._get_warehouse(subcontract_move)
+        subcontracting_location = \
+            subcontract_move.picking_id.partner_id.with_company(subcontract_move.company_id).property_stock_subcontractor \
+            or subcontract_move.company_id.subcontracting_location_id
         vals = {
             'company_id': subcontract_move.company_id.id,
             'procurement_group_id': group.id,
@@ -139,8 +142,8 @@ class StockPicking(models.Model):
             'product_id': product.id,
             'product_uom_id': subcontract_move.product_uom.id,
             'bom_id': bom.id,
-            'location_src_id': subcontract_move.picking_id.partner_id.with_company(subcontract_move.company_id).property_stock_subcontractor.id,
-            'location_dest_id': subcontract_move.picking_id.partner_id.with_company(subcontract_move.company_id).property_stock_subcontractor.id,
+            'location_src_id': subcontracting_location.id,
+            'location_dest_id': subcontracting_location.id,
             'product_qty': subcontract_move.product_uom_qty or subcontract_move.quantity,
             'picking_type_id': warehouse.subcontracting_type_id.id,
             'date_start': subcontract_move.date - relativedelta(days=bom.produce_delay)


### PR DESCRIPTION
Currently, an error occurs when validating stock moves without location.

Step to produce:

- Install the `mrp_subcontracting` module (make a debugger on).
- Create a product, add some quantities, and remove the value of 'Production Location' and 'Inventory Location' from it.
- Click on the 'Bills of Materials' button which is in the breadcrumbs of the product form view to create a bom of this product, And set a 'BoM Type' as Subcontracting and add an Administrator as 'Subcontractors'.
- Go to Inventory / Operations / Transfers / Receipts and create a new 'Receipts', add an Administrator as 'Receive From', and add product in 'Operations' which we created bom.
- Open a form view of 'Receive From' (res.partner) and remove value from 'Subcontractor Location' filed which is in the 'Sales & Purchase' tab.
- Again come to receipts form view and try to validate it.

`ValueError: Expected singleton: stock.location()`

This occurs because the system attempts to get 'location_id' from the stock move at [1], but it is not available.

Link [1]: https://github.com/odoo/odoo/blob/231952114ae730bb8d4671f4a61f738e8b6dd5b8/addons/stock/models/stock_move.py#L1566

To resolve this issue, add a condition to check if location_id is not available then use the company's subcontracting location as the default value.

Sentry-6156032937

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
