### PR TITLE
[FIX] hr: remove duplicate field in dep. form

### DIFF
--- a/addons/hr/views/hr_department_views.xml
+++ b/addons/hr/views/hr_department_views.xml
@@ -25,7 +25,7 @@
                         </div>
                         <group>
                             <group>
-                                <field name="name"/>
+                                <field name="name" invisible="1"/> <!-- Remove in master -->
                                 <field name="manager_id" widget="many2one_avatar_employee"/>
                                 <field name="parent_id"/>
                                 <field name="child_ids" invisible="1"/>


### PR DESCRIPTION
Before this commit, the "name" field was present 2 times in the department views.