### PR TITLE
[PERF] hr_expense: add missing index on `sheet_id`

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -103,6 +103,7 @@ class HrExpense(models.Model):
         domain="[('employee_id', '=', employee_id), ('company_id', '=', company_id)]",
         readonly=True,
         copy=False,
+        index=True,
     )
     approved_by = fields.Many2one(comodel_name='res.users', string="Approved By", related='sheet_id.user_id', tracking=False)
     approved_on = fields.Datetime(string="Approved On", related='sheet_id.approval_date')


### PR DESCRIPTION
## Why
- Inverse of the One2many `expense_line_ids`, the ORM will search on it to resolve the read on the field
- Used as a traversable dependency of a few compute methods (`@api. depends('sheet_id.xxx')`), index will be hit when ORM resolves the computation of dependencies to know what compute method to call when the dependency changed.
- Frequently used as the traversal field of related fields, index will be hit when reading on the field in SQL in `_traverse_related_sql`.
- Using Full index, as there aren't many `NULL`/`False` entries, as it's moslty pending expense lines that are pending for reporting. So a search on the NULL criteria (done in `get_expenses_to_submit`) will hit the index.

## Reference
task-3977983

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
