### PR TITLE
[FIX] mail: emoji search on only frequent should not show empty

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -981,6 +981,8 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields.selection,name:mail.selection__mail_activity_mixin__activity_exception_decoration__warning
 #: model:ir.model.fields.selection,name:mail.selection__mail_activity_type__decoration_type__warning
+#: model:ir.model.fields.selection,name:mail.selection__mail_test_activity__activity_exception_decoration__warning
+#: model:ir.model.fields.selection,name:mail.selection__mail_test_multi_company_with_activity__activity_exception_decoration__warning
 #: model:ir.model.fields.selection,name:mail.selection__res_partner__activity_exception_decoration__warning
 msgid "Alert"
 msgstr ""
@@ -3551,6 +3553,8 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_activity_schedule__error
 #: model:ir.model.fields.selection,name:mail.selection__mail_activity_mixin__activity_exception_decoration__danger
 #: model:ir.model.fields.selection,name:mail.selection__mail_activity_type__decoration_type__danger
+#: model:ir.model.fields.selection,name:mail.selection__mail_test_activity__activity_exception_decoration__danger
+#: model:ir.model.fields.selection,name:mail.selection__mail_test_multi_company_with_activity__activity_exception_decoration__danger
 #: model:ir.model.fields.selection,name:mail.selection__res_partner__activity_exception_decoration__danger
 msgid "Error"
 msgstr ""
@@ -6396,6 +6400,7 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/mail/static/src/core/web/message_patch.js:0
 #: model:ir.model.fields.selection,name:mail.selection__mail_activity_type__category__default
+#: model_terms:ir.ui.view,arch_db:mail.mail_notification_layout
 msgid "None"
 msgstr ""
 
@@ -6929,6 +6934,8 @@ msgstr ""
 #: code:addons/mail/static/src/core/web/activity_list_popover.xml:0
 #: model:ir.model.fields.selection,name:mail.selection__mail_activity__state__overdue
 #: model:ir.model.fields.selection,name:mail.selection__mail_activity_mixin__activity_state__overdue
+#: model:ir.model.fields.selection,name:mail.selection__mail_test_activity__activity_state__overdue
+#: model:ir.model.fields.selection,name:mail.selection__mail_test_multi_company_with_activity__activity_state__overdue
 #: model:ir.model.fields.selection,name:mail.selection__res_partner__activity_state__overdue
 #: model_terms:ir.ui.view,arch_db:mail.mail_activity_view_search
 msgid "Overdue"
@@ -7178,6 +7185,8 @@ msgstr ""
 #: code:addons/mail/static/src/core/web/activity_list_popover.xml:0
 #: model:ir.model.fields.selection,name:mail.selection__mail_activity__state__planned
 #: model:ir.model.fields.selection,name:mail.selection__mail_activity_mixin__activity_state__planned
+#: model:ir.model.fields.selection,name:mail.selection__mail_test_activity__activity_state__planned
+#: model:ir.model.fields.selection,name:mail.selection__mail_test_multi_company_with_activity__activity_state__planned
 #: model:ir.model.fields.selection,name:mail.selection__res_partner__activity_state__planned
 msgid "Planned"
 msgstr ""
@@ -9534,6 +9543,8 @@ msgstr ""
 #: code:addons/mail/static/src/core/web/activity_menu.xml:0
 #: model:ir.model.fields.selection,name:mail.selection__mail_activity__state__today
 #: model:ir.model.fields.selection,name:mail.selection__mail_activity_mixin__activity_state__today
+#: model:ir.model.fields.selection,name:mail.selection__mail_test_activity__activity_state__today
+#: model:ir.model.fields.selection,name:mail.selection__mail_test_multi_company_with_activity__activity_state__today
 #: model:ir.model.fields.selection,name:mail.selection__res_partner__activity_state__today
 #: model_terms:ir.ui.view,arch_db:mail.mail_activity_view_search
 msgid "Today"

--- a/addons/mail/static/tests/emoji/emoji.test.js
+++ b/addons/mail/static/tests/emoji/emoji.test.js
@@ -146,6 +146,25 @@ test("search emojis prioritize frequently used emojis", async () => {
     await contains(".o-EmojiPicker-content .o-Emoji:eq(0)", { text: "🤥" });
 });
 
+test("search matches only frequently used emojis", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "" });
+    await start();
+    await openDiscuss(channelId);
+    await click("button[aria-label='Emojis']");
+    await contains(".o-EmojiPicker-navbar [title='Frequently used']", { count: 0 });
+    await click(".o-EmojiPicker-content .o-Emoji", { text: "🥦" });
+    await click("button[aria-label='Emojis']");
+    await contains(".o-EmojiPicker-navbar [title='Frequently used']");
+    await insertText("input[placeholder='Search emoji']", "brocoli");
+    await contains(".o-EmojiPicker-sectionIcon", { count: 0 }); // await search performed
+    await contains(".o-EmojiPicker-content .o-Emoji:eq(0)", { text: "🥦" });
+    await contains(".o-EmojiPicker-content .o-Emoji", { count: 1 });
+    await contains(".o-EmojiPicker-content", { text: "No emoji matches your search", count: 0 });
+    await insertText("input[placeholder='Search emoji']", "2");
+    await contains(".o-EmojiPicker-content", { text: "No emoji matches your search" });
+});
+
 test("emoji usage amount orders frequent emojis", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "" });

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -424,6 +424,10 @@ export class EmojiPicker extends Component {
         return emojisToDisplay;
     }
 
+    getEmojisFromSearch() {
+        return [...this.recentEmojis, ...this.getEmojis()];
+    }
+
     selectCategory(ev) {
         const id = Number(ev.currentTarget.dataset.id);
         this.searchTerm = "";

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -18,10 +18,11 @@
                 </span>
             </div>
             <t t-set="itemIndex" t-value="0"/>
-            <div class="o-EmojiPicker-content overflow-auto d-flex flex-grow-1 w-100 flex-wrap align-items-center user-select-none mt-1" t-att-class="getEmojis().length === 0 ? 'flex-column justify-content-center' : 'align-content-start'" t-ref="emoji-grid" t-on-scroll="highlightActiveCategory">
-                <t t-if="searchTerm and getEmojis().length === 0" class="d-flex flex-column">
+            <t t-set="emojisFromSearch" t-value="getEmojisFromSearch()"/>
+            <div class="o-EmojiPicker-content overflow-auto d-flex flex-grow-1 w-100 flex-wrap align-items-center user-select-none mt-1" t-att-class="emojisFromSearch.length === 0 ? 'flex-column justify-content-center' : 'align-content-start'" t-ref="emoji-grid" t-on-scroll="highlightActiveCategory">
+                <t t-if="searchTerm and emojisFromSearch.length === 0" class="d-flex flex-column">
                     <span class="o-EmojiPicker-empty">😢</span>
-                    <span class="fs-5 text-muted">No emoji match your search</span>
+                    <span class="fs-5 text-muted">No emoji matches your search</span>
                 </t>
                 <t t-if="recentEmojis.length > 0">
                     <t t-if="!searchTerm" t-call="web.EmojiPicker.section">


### PR DESCRIPTION
Before this commit, when a search in emoji picker matches only frequently used emojis, it was showing "No emoji" screen.

Steps to reproduce:
- add 🥦 in frequently used emoji picker (click on it in emoji picker at least once)
- open any emoji picker
- search for "brocoli"

=> It shows "No emoji match your search"

The recent emojis were shown and clickable, but the empty screen being visible is a mistake. This happens because the screen was relying on emptiness on non-frequently used emojis. This means if all matches were frequently used emojis, then the screen was mistakenly displayed. The function `getEmojis()` is filtering non-recent emojis when there's an active search: `recentEmojis()` takes search term into account so it must be used to put a priority on frequent emojis.

This commit fixes the issue by showing screen only when there's no emoji match, including frequently used emojis.

Also reword the screen "No emoji match your search" to "No emoji matches your search".

Task-4415147

Before / After
<img width="307" alt="Screenshot 2024-12-18 at 16 05 28" src="https://github.com/user-attachments/assets/a61283c7-3304-46d3-bf1e-e707686470e2" /> <img width="311" alt="Screenshot 2024-12-18 at 16 05 07" src="https://github.com/user-attachments/assets/bab33944-a456-456b-b99f-c6a1aa430f0c" />

