### PR TITLE
[FIX] core: adapt_version support for non-digit major version

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -452,11 +452,14 @@ def adapt_version(version: str) -> str:
     version_str_parts = version.split('.')
     if not (2 <= len(version_str_parts) <= 5):
         raise ValueError(f"Invalid version {version!r}, must have between 2 and 5 parts")
+    serie = release.major_version
+    if version.startswith(serie) and not version_str_parts[0].isdigit():
+        # keep only digits for parsing
+        version_str_parts[0] = ''.join(c for c in version_str_parts[0] if c.isdigit())
     try:
         version_parts = [int(v) for v in version_str_parts]
     except ValueError as e:
         raise ValueError(f"Invalid version {version!r}") from e
-    serie = release.major_version
     if len(version_parts) <= 3 and not version.startswith(serie):
         # prefix the version with serie
         return f"{serie}.{version}"

--- a/odoo/release.py
+++ b/odoo/release.py
@@ -12,6 +12,7 @@ RELEASE_LEVELS_DISPLAY = {ALPHA: ALPHA,
 # properly comparable using normal operators, for example:
 #  (6,1,0,'beta',0) < (6,1,0,'candidate',1) < (6,1,0,'candidate',2)
 #  (6,1,0,'candidate',2) < (6,1,0,'final',0) < (6,1,2,'final',0)
+# NOTE: during release, the MAJOR version can become an arbitrary string ('saas~xx')
 version_info = (18, 2, 0, ALPHA, 1, '')
 version = '.'.join(str(s) for s in version_info[:2]) + RELEASE_LEVELS_DISPLAY[version_info[3]] + str(version_info[4] or '') + version_info[5]
 series = serie = major_version = '.'.join(str(s) for s in version_info[:2])


### PR DESCRIPTION
During release of itermediary versions, the majsor version may not be an integer. Accept it when parsing the serie.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
