### PR TITLE
[PERF] iap_crm, website_crm_iap_reveal: missing index on `reveal_id`

### DIFF
--- a/addons/iap_crm/models/crm_lead.py
+++ b/addons/iap_crm/models/crm_lead.py
@@ -7,7 +7,7 @@ from odoo import fields, models
 class Lead(models.Model):
     _inherit = 'crm.lead'
 
-    reveal_id = fields.Char(string='Reveal ID') # Technical ID of reveal request done by IAP
+    reveal_id = fields.Char(string='Reveal ID', index='btree_not_null') # Technical ID of reveal request done by IAP
 
     def _merge_get_fields(self):
         return super(Lead, self)._merge_get_fields() + ['reveal_id']

--- a/addons/website_crm_iap_reveal/models/crm_reveal_rule.py
+++ b/addons/website_crm_iap_reveal/models/crm_reveal_rule.py
@@ -362,7 +362,7 @@ class CRMRevealRule(models.Model):
             return False
         if not result['clearbit_id']:
             return False
-        already_created_lead = self.env['crm.lead'].search([('reveal_id', '=', result['clearbit_id'])])
+        already_created_lead = self.env['crm.lead'].search_count([('reveal_id', '=', result['clearbit_id'])], limit=1)
         if already_created_lead:
             _logger.info('Existing lead for this clearbit_id [%s]', result['clearbit_id'])
             # Does not create a lead if the reveal_id is already known


### PR DESCRIPTION
## Description
ir_cron_crm_reveal_lead (executed by OdooBot)
⤷ _process_lead_generation
  ⤷ _perform_reveal_service
    ⤷ _create_lead_from_response
      ⤷ `already_created_lead = self.env['crm.lead'].search([
     ('reveal_id', '=', result['clearbit_id'])])`
         ⤷ `Seq.Scan` on `crm.lead`

Also `search(...)` -> `search_count(..., limit=1)` as it's just an existence check, searching for all instances is not necessary.

## Benchmark
On a database with over 8-digits count of `crm.lead`:

|               | Before | After    |
|---------------|--------|----------|
| Timings (hot) | 6.4 s  | 0.041 ms |
| Buffers usage | 2.6 GB | 32KB     |

## Reference
task-3977976

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
