### PR TITLE
[FIX] l10n_ch: avoid to print QR code when not a Swiss company

### DIFF
--- a/addons/l10n_ch/models/account_invoice.py
+++ b/addons/l10n_ch/models/account_invoice.py
@@ -40,8 +40,11 @@ class AccountMove(models.Model):
     @api.depends('partner_id', 'currency_id')
     def _compute_l10n_ch_qr_is_valid(self):
         for move in self:
-            move.l10n_ch_is_qr_valid = move.move_type == 'out_invoice' \
-                                       and move.partner_bank_id._eligible_for_qr_code('ch_qr', move.partner_id, move.currency_id, raises_error=False)
+            move.l10n_ch_is_qr_valid = (
+                move.move_type == 'out_invoice'
+                and move.partner_bank_id._eligible_for_qr_code('ch_qr', move.partner_id, move.currency_id, raises_error=False)
+                and move.company_id.country_id.code == 'CH'
+            )
 
     @api.depends('partner_bank_id.l10n_ch_isr_subscription_eur', 'partner_bank_id.l10n_ch_isr_subscription_chf')
     def _compute_l10n_ch_isr_subscription(self):


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_ch" and switch to a Belgian company, for example "My Belgian Company"
- Create an invoice and set the partner to "CH Company"
- In the page "Other info", make sure the "recipient Bank" is filled
- Confirm and Send
- The generated PDF has a QR code even though the sending company is not from Switzerland

### Cause:
The QR code generation depends on the field `l10n_ch_is_qr_valid` of the invoice. This field does not take the sending company into account in its compute method.

### Solution:
Change the compute method to check the company.

opw-4380520