### PR TITLE
[REF] im_livechat: allow arbitrary users when forwarding to operator

### DIFF
--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -325,13 +325,17 @@ class ChatbotScriptStep(models.Model):
             return self._process_step_forward_operator(discuss_channel)
         return discuss_channel._chatbot_post_message(self.chatbot_script_id, plaintext2html(self.message))
 
-    def _process_step_forward_operator(self, discuss_channel):
+    def _process_step_forward_operator(self, discuss_channel, users=None):
         """ Special type of step that will add a human operator to the conversation when reached,
         which stops the script and allow the visitor to discuss with a real person.
 
         In case we don't find any operator (e.g: no-one is available) we don't post any messages.
         The script will continue normally, which allows to add extra steps when it's the case
-        (e.g: ask for the visitor's email and create a lead). """
+        (e.g: ask for the visitor's email and create a lead).
+
+        When specific available users are not provided, the currently available users of the
+        livechat channel are used as candidates.
+        """
 
         human_operator = False
         posted_message = self.env["mail.message"]
@@ -345,6 +349,7 @@ class ChatbotScriptStep(models.Model):
                 else None,
                 country_id=discuss_channel.country_id.id,
                 expertises=self.operator_expertise_ids,
+                users=users,
             )
 
         # handle edge case where we found yourself as available operator -> don't do anything

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -1,10 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import common
+from odoo.addons.mail.tests.common import MailCommon
 
 
-class ChatbotCase(common.HttpCase):
+class ChatbotCase(MailCommon, common.HttpCase):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/im_livechat/tests/test_get_operator.py
+++ b/addons/im_livechat/tests/test_get_operator.py
@@ -433,3 +433,25 @@ class TestGetOperator(MailCommon, HttpCase):
                 livechat_channels[1]: self.env["res.users"],
             },
         )
+
+    @users("employee")
+    def test_get_non_member_operator(self):
+        """Test _get_operator works with a given list of operators that are not members of the
+        livechat channel"""
+        operator_1 = self._create_operator(lang_code="fr_FR")
+        operator_2 = self._create_operator(lang_code="en_US")
+        all_operators = operator_1 + operator_2
+        livechat_channel_data = {"name": "Livechat Channel 2"}
+        livechat_channel = self.env["im_livechat.channel"].sudo().create(livechat_channel_data)
+        self.assertFalse(livechat_channel._get_operator())
+        self.assertFalse(
+            livechat_channel._get_operator(previous_operator_id=operator_1.partner_id.id)
+        )
+        self.assertEqual(livechat_channel._get_operator(users=all_operators), operator_1)
+        self.assertEqual(
+            livechat_channel._get_operator(previous_operator_id=operator_2.partner_id.id, users=all_operators),
+            operator_2,
+        )
+        self.assertEqual(
+            livechat_channel._get_operator(lang="en_US", users=all_operators), operator_2
+        )


### PR DESCRIPTION
In a follow up commit, crm team members will be assigned to specific live chat sessions.

This PR allows passing any users as candidate to `_process_step_forward_operator`, even if they are not member of the live chat channel (or if they are not live chat user at all).

Part of task-4354325

See https://github.com/odoo/odoo/pull/190364 (or https://github.com/odoo/odoo/pull/191076 for an updated version)