### PR TITLE
[IMP] base_vat: Issue with RUT validation (UY)

### DIFF
--- a/addons/base_vat/i18n/base_vat.pot
+++ b/addons/base_vat/i18n/base_vat.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-30 14:40+0000\n"
-"PO-Revision-Date: 2024-10-30 14:40+0000\n"
+"POT-Creation-Date: 2024-12-23 21:07+0000\n"
+"PO-Revision-Date: 2024-12-23 21:07+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -114,6 +114,14 @@ msgstr ""
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "DO1-01-85004-3 or 101850043"
+msgstr ""
+
+#. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid ""
+"Example: '219999830019' (format: 12 digits, all numbers, valid check digit)"
 msgstr ""
 
 #. module: base_vat

--- a/addons/base_vat/i18n/es.po
+++ b/addons/base_vat/i18n/es.po
@@ -1,26 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* base_vat
-# 
-# Translators:
-# Martin Trigaux, 2022
-# Pedro M. Baeza <pedro.baeza@tecnativa.com>, 2024
-# Wil Odoo, 2024
-# Larissa Manderfeld, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-30 14:40+0000\n"
-"PO-Revision-Date: 2022-09-22 05:45+0000\n"
-"Last-Translator: Larissa Manderfeld, 2024\n"
-"Language-Team: Spanish (https://app.transifex.com/odoo/teams/41243/es/)\n"
+"POT-Creation-Date: 2024-12-23 21:10+0000\n"
+"PO-Revision-Date: 2024-12-23 21:10+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: \n"
 
 #. module: base_vat
 #. odoo-python
@@ -127,6 +120,14 @@ msgstr "DE123456788 o 12/345/67890"
 #, python-format
 msgid "DO1-01-85004-3 or 101850043"
 msgstr "DO1-01-85004-3 o 101850043"
+
+#. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid ""
+"Example: '219999830019' (format: 12 digits, all numbers, valid check digit)"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_account_fiscal_position

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -106,6 +106,24 @@ class TestStructure(TransactionCase):
         with self.assertRaises(ValidationError):
             test_partner.write({'vat': "136695978"})
 
+    def test_rut_uy(self):
+        test_partner = self.env["res.partner"].create({"name": "UY Company", "country_id": self.env.ref("base.uy").id})
+        # Set a valid Number
+        test_partner.vat = "215521750017"
+        test_partner.vat = "220018800014"
+        test_partner.vat = "21-55217500-17"
+        test_partner.vat = "21 55217500 17"
+        test_partner.vat = "UY215521750017"
+
+        # Test invalid VAT (should raise a ValidationError)
+        msg = "The VAT number.*does not seem to be valid"
+        with self.assertRaisesRegex(ValidationError, msg):
+            test_partner.vat = "215521750018"
+        with self.assertRaisesRegex(ValidationError, msg):
+            test_partner.vat = "21.55217500.17"
+        with self.assertRaisesRegex(ValidationError, msg):
+            test_partner.vat = "2155 ABC 21750017"
+
     def test_soap_client_for_vies_loads(self):
         # Test of stdnum get_soap_client monkeypatch. This test is mostly to
         # see that no unexpected import errors are thrown and not caught.


### PR DESCRIPTION
- Implemented proper validation logic for Uruguayan VAT numbers (RUT).
- Now supports VAT numbers starting with '22', addressing previous validation issues.
- Corrections in l10n_uy tests due to changes in logic.

Task: 1292
adhoc-task-side: 45613




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
