### PR TITLE
18.0 opw 4370090 validate timeoff azey

### DIFF
--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard_views.xml
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard_views.xml
@@ -6,7 +6,7 @@
             <form string="Generate time off for multiple employees">
                 <group>
                     <group>
-                        <field name="holiday_status_id"/>
+                        <field name="holiday_status_id" domain="[('requires_allocation', '=', 'no')]"/>
                         <field name="allocation_mode" string="Mode"/>
                         <field name="employee_ids" invisible="allocation_mode != 'employee'" required="allocation_mode == 'employee'" widget="many2many_avatar_user"/>
                         <field name="company_id" invisible="allocation_mode != 'company'"/>


### PR DESCRIPTION
In previous versions, when dealing with multiple time-off requests,
only time-off types that do not require allocations were listed for selection. 

This behavior has been restored by restricting the `holiday_status_id` field
to show only non-allocation time-off types in the multi-request wizard.

opw-4370090

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
