### PR TITLE
[FIX] web: emoji picker navbar manages overflow better

### DIFF
--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -166,6 +166,7 @@ export class EmojiPicker extends Component {
 
     setup() {
         this.gridRef = useRef("emoji-grid");
+        this.navbarRef = useRef("navbar");
         this.ui = useState(useService("ui"));
         this.isMobileOS = isMobileOS();
         this.state = useState({
@@ -204,6 +205,9 @@ export class EmojiPicker extends Component {
                 : this.categories[0].sortId;
         });
         onMounted(() => {
+            this.navbarResizeObserver = new ResizeObserver(() => this.adaptNavbar());
+            this.navbarResizeObserver.observe(this.navbarRef.el);
+            this.adaptNavbar();
             if (this.emojis.length === 0) {
                 return;
             }
@@ -266,6 +270,7 @@ export class EmojiPicker extends Component {
             () => [this.searchTerm]
         );
         onWillUnmount(() => {
+            this.navbarResizeObserver.disconnect();
             if (!this.gridRef.el) {
                 return;
             }
@@ -273,6 +278,57 @@ export class EmojiPicker extends Component {
                 this.props.storeScroll.set(this.gridRef.el.scrollTop);
             }
         });
+    }
+
+    adaptNavbar() {
+        const computedStyle = getComputedStyle(this.navbarRef.el);
+        const availableWidth =
+            this.navbarRef.el.getBoundingClientRect().width -
+            parseInt(computedStyle.paddingLeft) -
+            parseInt(computedStyle.marginLeft) -
+            parseInt(computedStyle.paddingLeft) -
+            parseInt(computedStyle.marginLeft);
+        const itemWidth = this.navbarRef.el.querySelector(".o-Emoji").getBoundingClientRect().width;
+        const gapWidth = parseInt(computedStyle.gap);
+        const maxAvailableNavbarItemAmountAtOnce = Math.floor(
+            availableWidth / (itemWidth + gapWidth)
+        );
+        const repr = [];
+        let panel = [];
+        const allCategories = this.getAllCategories();
+        for (const category of allCategories) {
+            if (
+                panel.length === maxAvailableNavbarItemAmountAtOnce - 1 &&
+                category !== allCategories.at(-1)
+            ) {
+                panel.push("next");
+                repr.push(panel);
+                panel = [];
+                panel.push("previous");
+            }
+            panel.push(category.sortId);
+        }
+        if (panel.length > 0) {
+            if (repr.length > 0) {
+                panel.push(
+                    ...[...Array(maxAvailableNavbarItemAmountAtOnce - panel.length)].map(
+                        (_, idx) => "empty_" + idx
+                    )
+                );
+            }
+            repr.push(panel);
+        }
+        this.state.emojiNavbarRepr = repr;
+    }
+
+    get currentNavbarPanel() {
+        if (!this.state.emojiNavbarRepr) {
+            return this.getAllCategories().map((c) => c.sortId);
+        }
+        if (this.state.categoryId === null || Number.isNaN(this.state.categoryId)) {
+            return this.state.emojiNavbarRepr[0];
+        }
+        return this.state.emojiNavbarRepr.find((panel) => panel.includes(this.state.categoryId));
     }
 
     get searchTerm() {
@@ -308,6 +364,20 @@ export class EmojiPicker extends Component {
 
     onClick(ev) {
         markEventHandled(ev, "emoji.selectEmoji");
+    }
+
+    onClickToNextCategories() {
+        const panelIndex = this.state.emojiNavbarRepr.findIndex((p) =>
+            p.includes(this.state.categoryId)
+        );
+        this.selectCategory(this.state.emojiNavbarRepr[panelIndex + 1][1]);
+    }
+
+    onClickToPreviousCategories() {
+        const panelIndex = this.state.emojiNavbarRepr.findIndex((p) =>
+            p.includes(this.state.categoryId)
+        );
+        this.selectCategory(this.state.emojiNavbarRepr[panelIndex - 1].at(-2));
     }
 
     /**
@@ -407,6 +477,14 @@ export class EmojiPicker extends Component {
         }
     }
 
+    getAllCategories() {
+        const res = [...this.categories];
+        if (this.recentEmojis.length > 0) {
+            res.unshift(this.recentCategory);
+        }
+        return res;
+    }
+
     getEmojis() {
         let emojisToDisplay = [...this.emojis];
         const recentEmojis = this.recentEmojis;
@@ -428,10 +506,9 @@ export class EmojiPicker extends Component {
         return [...this.recentEmojis, ...this.getEmojis()];
     }
 
-    selectCategory(ev) {
-        const id = Number(ev.currentTarget.dataset.id);
+    selectCategory(categoryId) {
         this.searchTerm = "";
-        this.state.categoryId = id;
+        this.state.categoryId = categoryId;
         this.shouldScrollElem = true;
     }
 

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.scss
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.scss
@@ -1,6 +1,6 @@
 .popover .o-EmojiPicker {
-    width: 285px;
-    height: 350px;
+    width: 300px;
+    height: 365px;
 }
 
 .o-EmojiPicker-content {

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -52,13 +52,19 @@
                     <t t-set="itemIndex" t-value="itemIndex + 1"/>
                 </t>
             </div>
-            <div class="o-EmojiPicker-navbar d-flex flex-shrink-0 w-100 align-items-center overflow-auto px-2 gap-1 border-top border-secondary">
-                <t t-if="recentEmojis.length > 0" t-call="web.EmojiPicker.tab">
-                    <t t-set="category" t-value="recentCategory"/>
-                </t>
-                <t t-foreach="categories" t-as="category" t-key="category.sortId">
-                    <t t-call="web.EmojiPicker.tab">
-                        <t t-set="category" t-value="category"/>
+            <div class="o-EmojiPicker-navbar d-flex flex-shrink-0 w-100 align-items-center justify-content-center overflow-auto px-1 gap-1 border-top border-secondary" t-att-class="{ 'opacity-0': !state.emojiNavbarRepr }" t-ref="navbar">
+                <t t-if="currentNavbarPanel">
+                    <t t-set="allCategories" t-value="getAllCategories()"/>
+                    <t t-foreach="currentNavbarPanel" t-as="navbarItemId" t-key="navbarItemId">
+                        <t t-if="navbarItemId === 'next'" t-call="web.EmojiPicker.tabNext"/>
+                        <t t-elif="navbarItemId === 'previous'" t-call="web.EmojiPicker.tabPrev"/>
+                        <t t-elif="typeof navbarItemId === 'string' and navbarItemId.startsWith('empty')" t-call="web.EmojiPicker.tabEmpty"/>
+                        <t t-else="">
+                            <t t-set="category" t-value="allCategories.find(cat => cat.sortId === navbarItemId)"/>
+                            <t t-if="category" t-call="web.EmojiPicker.tab">
+                                <t t-set="category" t-value="category"/>
+                            </t>
+                        </t>
                     </t>
                 </t>
             </div>
@@ -67,13 +73,39 @@
 </t>
 
 <t t-name="web.EmojiPicker.tab">
-    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center" t-att-class="{'o-active': category.sortId === state.categoryId}" t-att-title="category.name" t-att-data-id="category.sortId" t-on-click="selectCategory">
+    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" t-att-class="{'o-active': category.sortId === state.categoryId}" t-att-title="category.name" t-att-data-id="category.sortId" t-on-click="() => this.selectCategory(category.sortId)">
         <span t-esc="category.title"/>
     </span>
 </t>
 
+<t t-name="web.EmojiPicker.tabNext">
+    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" title="To previous categories" t-on-click="onClickToNextCategories">
+        <span class="position-relative">
+            <i class="oi oi-chevron-right fa-fw smaller opacity-0"/>
+            <i class="oi oi-chevron-right fa-fw smaller position-absolute opacity-75" style="left: 3px; transform: translateY(75%);"/>
+            <i class="oi oi-chevron-right fa-fw smaller position-absolute opacity-75" style="left: -3px; transform: translateY(75%);"/>
+        </span>
+    </span>
+</t>
+
+<t t-name="web.EmojiPicker.tabPrev">
+    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" title="To next categories" t-on-click="onClickToPreviousCategories">
+        <span class="position-relative">
+            <i class="oi oi-chevron-left fa-fw smaller opacity-0"/>
+            <i class="oi oi-chevron-left fa-fw smaller position-absolute opacity-75" style="left: 3px; transform: translateY(75%);"/>
+            <i class="oi oi-chevron-left fa-fw smaller position-absolute opacity-75" style="left: -3px; transform: translateY(75%);"/>
+        </span>
+    </span>
+</t>
+
+<t t-name="web.EmojiPicker.tabEmpty">
+    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch opacity-0">
+        <span>🫥</span>
+    </span>
+</t>
+
 <t t-name="web.EmojiPicker.section">
-    <span class="w-100 fs-7 px-2 py-1 position-sticky top-0 bg-100" t-att-data-category="category.sortId"><span class="o-EmojiPicker-sectionIcon fs-5 opacity-50" t-esc="category.title"/><span class="ms-2 text-muted text-uppercase fs-7 opacity-50" t-esc="category.displayName"/></span>
+    <span class="w-100 fs-7 px-2 py-1 position-sticky top-0 bg-100 align-self-stretch" t-att-data-category="category.sortId"><span class="o-EmojiPicker-sectionIcon fs-5 opacity-50" t-esc="category.title"/><span class="ms-2 text-muted text-uppercase fs-7 opacity-50" t-esc="category.displayName"/></span>
     <span class="o-EmojiPicker-category opacity-100 fs-7 py-2" t-att-data-category="category.sortId"/>
 </t>
 


### PR DESCRIPTION
Before this commit, emoji navbar simply had `.overflow-auto`. The size of emoji category depends on browser/OS for the style of emoji, but browsers also differ in the way they render font unicodes. This means that overflow never happens on some configuration, and in a few of them it always occur.

The size of emoji picker container is good and we want to keep it fixed, as it plays nicely with the rest of UI. For the size of emojis, as long as we rely on font unicode, we have to live with the different sizing.

This commit suggests a new way to manage overflow which doesn't show a scroll bar while letting browser/OS choose their way to render emojis: we detect whether emoji tabs overflow, and when so it fills as most emoji it can without overflow. Navbar has many "panels", and switching to panels happen either manually (click on >> and << buttons) or with scrolling of emoji picker without any search.

Commit also makes the following minor improvements:
- category section position sticky was not completely hiding emoji list below (e.g. on Chrome macOS). This is fixed with a `.align-self-stretch` on the section
- emoji categories are centered with emoji picker

Task-4413819

-------------

_(note: size of emoji in navbar is artificially bigger to simulate some rendering in few browser/OS that have always overflow)_
Before / After
![before](https://github.com/user-attachments/assets/12375001-2c2d-4bfb-90c9-d4189c799370) ![after](https://github.com/user-attachments/assets/0d5e07ff-2d18-4f0b-93a8-a8b9aefe68b1)