### PR TITLE
 [IMP] crm, *: add new chatbot script step to create lead and forward

### DIFF
--- a/addons/crm_livechat/models/__init__.py
+++ b/addons/crm_livechat/models/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import chatbot_script
 from . import chatbot_script_step
+from . import crm_team
 from . import discuss_channel

--- a/addons/crm_livechat/models/chatbot_script_step.py
+++ b/addons/crm_livechat/models/chatbot_script_step.py
@@ -1,23 +1,37 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, models, fields
+from odoo import models, fields
 
 
 class ChatbotScriptStep(models.Model):
     _inherit = 'chatbot.script.step'
 
     step_type = fields.Selection(
-        selection_add=[('create_lead', 'Create Lead')], ondelete={'create_lead': 'cascade'})
+        selection_add=[
+            ("create_lead", "Create Lead"),
+            ("create_lead_and_forward", "Create Lead & Forward"),
+        ],
+        ondelete={"create_lead": "cascade", "create_lead_and_forward": "cascade"},
+    )
     crm_team_id = fields.Many2one(
-        'crm.team', string='Sales Team', ondelete='set null',
+        'crm.team', string='Sales Team', ondelete='set null', index="btree_not_null",
         help="Used in combination with 'create_lead' step type in order to automatically "
              "assign the created lead/opportunity to the defined team")
 
+    _create_lead_and_forward_has_sales_team = models.Constraint(
+        "CHECK(step_type != 'create_lead_and_forward' or crm_team_id IS NOT NULL)",
+        "Create Lead & Forward steps must have a sales team defined.",
+    )
+
+    def _compute_is_forward_operator(self):
+        super()._compute_is_forward_operator()
+        self.filtered(lambda s: s.step_type == "create_lead_and_forward").is_forward_operator = True
+
     def _chatbot_crm_prepare_lead_values(self, discuss_channel, description):
         return {
+            "company_id": self.crm_team_id.company_id.id,
             'description': description + discuss_channel._get_channel_history(),
-            'name': _("%s's New Lead", self.chatbot_script_id.title),
+            "name": self.env._("%s's New Lead", self.chatbot_script_id.title),
             'source_id': self.chatbot_script_id.source_id.id,
             'team_id': self.crm_team_id.id,
             'type': 'lead' if self.crm_team_id.use_leads else 'opportunity',
@@ -26,12 +40,11 @@ class ChatbotScriptStep(models.Model):
 
     def _process_step(self, discuss_channel):
         self.ensure_one()
-
+        if self.step_type == "create_lead_and_forward":
+            return self._process_step_create_lead_and_forward(discuss_channel)
         posted_message = super()._process_step(discuss_channel)
-
         if self.step_type == 'create_lead':
             self._process_step_create_lead(discuss_channel)
-
         return posted_message
 
     def _process_step_create_lead(self, discuss_channel):
@@ -44,7 +57,6 @@ class ChatbotScriptStep(models.Model):
         The whole conversation history will be saved into the lead's description for reference.
         This also allows having a question of type 'free_input_multi' to let the visitor explain
         their interest / needs before creating the lead. """
-
         customer_values = self._chatbot_prepare_customer_values(
             discuss_channel, create_partner=False, update_partner=True)
         if self.env.user._is_public():
@@ -58,8 +70,27 @@ class ChatbotScriptStep(models.Model):
                 'partner_id': partner.id,
                 'company_id': partner.company_id.id,
             }
-
         create_values.update(self._chatbot_crm_prepare_lead_values(
             discuss_channel, customer_values['description']))
+        return self.env["crm.lead"].create(create_values)
 
-        self.env['crm.lead'].create(create_values)
+    def _process_step_create_lead_and_forward(self, discuss_channel):
+        lead = self._process_step_create_lead(discuss_channel)
+        assignable_user_ids = [
+            member.user_id.id
+            for member in lead.team_id.crm_team_member_ids
+            if not member.assignment_optout and member._get_assignment_quota() > 0
+        ]
+        # sudo: im_livechat.channel - getting available operators is acceptable
+        users = discuss_channel.livechat_channel_id.sudo()._get_available_operators_by_livechat_channel(
+            self.env["res.users"].browse(assignable_user_ids)
+        )[discuss_channel.livechat_channel_id]
+        message = self._process_step_forward_operator(discuss_channel, users=users)
+        operator_partner = discuss_channel.livechat_operator_id
+        if operator_partner != self.chatbot_script_id.operator_partner_id:
+            lead.user_id = next(user for user in users if user.partner_id == operator_partner)
+            # Call flush_recordset() now (as sudo), otherwise flush_all() is called at the end of
+            # the request with a non-sudo env, which fails (as public user) to compute some crm.lead
+            # fields having dependencies on assigned user_id.
+            lead.flush_recordset()
+        return message

--- a/addons/crm_livechat/models/crm_team.py
+++ b/addons/crm_livechat/models/crm_team.py
@@ -1,0 +1,30 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.exceptions import UserError
+from odoo.tools.i18n import format_list
+
+
+class CrmTeam(models.Model):
+    _inherit = "crm.team"
+
+    def write(self, values):
+        if not values.get("active", True):
+            self._ensure_no_forward_chatbot_step()
+        return super().write(values)
+
+    def unlink(self):
+        self._ensure_no_forward_chatbot_step()
+        return super().unlink()
+
+    def _ensure_no_forward_chatbot_step(self):
+        domain = [("crm_team_id", "in", self.ids), ("step_type", "=", "create_lead_and_forward")]
+        # sudo: chatbot.script.step - leaking chatbot name related to specific sales team is acceptable
+        if steps := self.env["chatbot.script.step"].sudo().search(domain):
+            raise UserError(
+                self.env._(
+                    "These sales team cannot be archived or deleted because they are connected to the following chatbots: %(chatbots)s.\n"
+                    "To proceed, update the “Create Lead & Forward” steps of these chatbots to use a different sales team.",
+                    chatbots=format_list(self.env, steps.chatbot_script_id.mapped("title")),
+                )
+            )

--- a/addons/crm_livechat/tests/chatbot_common.py
+++ b/addons/crm_livechat/tests/chatbot_common.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.addons.im_livechat.tests.chatbot_common import ChatbotCase
 from odoo.addons.mail.tests.common import mail_new_test_user
 
@@ -9,37 +9,25 @@ class CrmChatbotCase(ChatbotCase):
 
     @classmethod
     def setUpClass(cls):
-        super(CrmChatbotCase, cls).setUpClass()
-
-        cls.company_id = cls.env['res.company'].create({
-            'name': 'Test Company',
-            'country_id': cls.env.ref('base.be').id,
-        })
-
-        cls.user_public = mail_new_test_user(
-            cls.env, login='user_public', groups='base.group_public', name='Public User')
-        cls.user_portal = mail_new_test_user(
-            cls.env, login='user_portal', groups='base.group_portal', name='Portal User',
-            company_id=cls.company_id.id, email='portal@example.com')
-        # update company_id on partner since the user's company is not propagated
-        cls.user_portal.partner_id.write({'company_id': cls.company_id.id})
-
-        cls.sale_team = cls.env['crm.team'].create({
-            'name': 'Test Sale Team 1',
-            'company_id': cls.company_id.id,
-        })
-
-        cls.sale_team_with_lead = cls.env['crm.team'].create({
-            'name': 'Test Sale Team 2',
-            'use_leads': True,
-            'company_id': cls.company_id.id,
-        })
-
+        super().setUpClass()
+        cls._create_portal_user()
+        teams_data = [
+            {
+                "company_id": cls.company_admin.id,
+                "crm_team_member_ids": [Command.create({"user_id": cls.user_employee.id})],
+                "name": "Test Sale Team 1",
+            },
+            {
+                "company_id": cls.company_admin.id,
+                "name": "Test Sale Team 2",
+                "use_leads": True,
+            },
+        ]
+        cls.sale_team, cls.sale_team_with_lead = cls.env["crm.team"].create(teams_data)
         cls.step_dispatch_create_lead = cls.env['chatbot.script.answer'].sudo().create({
             'name': 'Create a lead',
             'script_step_id': cls.step_dispatch.id,
         })
-
         [
             cls.step_create_lead_email,
             cls.step_create_lead_phone,

--- a/addons/crm_livechat/views/chatbot_script_step_views.xml
+++ b/addons/crm_livechat/views/chatbot_script_step_views.xml
@@ -7,8 +7,12 @@
         <field name="inherit_id" ref="im_livechat.chatbot_script_step_view_form"/>
         <field name="arch" type="xml">
             <field name="step_type" position="after">
-                <field name="crm_team_id" invisible="step_type != 'create_lead'"
-                    options="{'no_open': True}"/>
+                <field
+                    name="crm_team_id"
+                    invisible="step_type not in ['create_lead', 'create_lead_and_forward']"
+                    options="{'no_open': True}"
+                    required="step_type == 'create_lead_and_forward'"
+                />
             </field>
         </field>
     </record>

--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -110,7 +110,7 @@ class LivechatController(http.Controller):
 
     @http.route('/im_livechat/get_session', methods=["POST"], type="jsonrpc", auth='public')
     @add_guest_to_context
-    def get_session(self, channel_id, anonymous_name, previous_operator_id=None, chatbot_script_id=None, persisted=True, **kwargs):
+    def get_session(self, channel_id, anonymous_name, previous_operator_id=None, chatbot_script_id=None, persisted=True):
         store = Store()
         user_id = None
         country_id = None

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -329,11 +329,7 @@ class ChatbotScriptStep(models.Model):
         Those will have a dedicated processing method with specific docstrings.
 
         Returns the mail.message posted by the chatbot's operator_partner_id. """
-
         self.ensure_one()
-        # sudo: discuss.channel - updating current step on the channel is allowed
-        discuss_channel.sudo().chatbot_current_step_id = self.id
-
         if self.step_type == 'forward_operator':
             return self._process_step_forward_operator(discuss_channel)
         return discuss_channel._chatbot_post_message(self.chatbot_script_id, plaintext2html(self.message))
@@ -346,8 +342,9 @@ class ChatbotScriptStep(models.Model):
         The script will continue normally, which allows to add extra steps when it's the case
         (e.g: ask for the visitor's email and create a lead).
 
-        When specific available users are not provided, the currently available users of the
-        livechat channel are used as candidates.
+        :param discuss_channel: channel on which to execute the step
+        :param users: recordset of candidate operators, if not provided the currently available
+            users of the livechat channel are used as candidates instead.
         """
 
         human_operator = False

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -338,13 +338,17 @@ class ChatbotScriptStep(models.Model):
             return self._process_step_forward_operator(discuss_channel)
         return discuss_channel._chatbot_post_message(self.chatbot_script_id, plaintext2html(self.message))
 
-    def _process_step_forward_operator(self, discuss_channel):
+    def _process_step_forward_operator(self, discuss_channel, users=None):
         """ Special type of step that will add a human operator to the conversation when reached,
         which stops the script and allow the visitor to discuss with a real person.
 
         In case we don't find any operator (e.g: no-one is available) we don't post any messages.
         The script will continue normally, which allows to add extra steps when it's the case
-        (e.g: ask for the visitor's email and create a lead). """
+        (e.g: ask for the visitor's email and create a lead).
+
+        When specific available users are not provided, the currently available users of the
+        livechat channel are used as candidates.
+        """
 
         human_operator = False
         posted_message = self.env["mail.message"]
@@ -358,6 +362,7 @@ class ChatbotScriptStep(models.Model):
                 else None,
                 country_id=discuss_channel.country_id.id,
                 expertises=self.operator_expertise_ids,
+                users=users,
             )
 
         # handle edge case where we found yourself as available operator -> don't do anything

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -155,9 +155,11 @@ class DiscussChannel(models.Model):
         """
         Converting message body back to plaintext for correct data formatting in HTML field.
         """
-        return Markup('').join(
-            Markup('%s: %s<br/>') % (message.author_id.name or self.anonymous_name, html2plaintext(message.body))
-            for message in self.message_ids.sorted('id')
+        return Markup("").join(
+            Markup("%s: %s<br/>")
+            % (message.author_id.name or self.anonymous_name, html2plaintext(message.body))
+            # sudo: discuss.channel: can read all previous messages when converting to lead
+            for message in self.sudo().message_ids.sorted("id")
         )
 
     # =======================

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -216,7 +216,6 @@ export class LivechatService {
                     ? this.thread.chatbot?.script.id
                     : this.rule.chatbotScript?.id,
                 previous_operator_id: expirableStorage.getItem(OPERATOR_STORAGE_KEY),
-                temporary_id: this.thread?.id,
                 persisted: persist,
             },
             { shadow: true }

--- a/addons/im_livechat/static/tests/embed/livechat_service.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service.test.js
@@ -110,7 +110,6 @@ test("Only necessary requests are made when creating a new chat", async () => {
             channel_id: livechatChannelId,
             anonymous_name: "Visitor",
             previous_operator_id: operatorPartnerId,
-            temporary_id: -1,
             persisted: true,
         })}`,
         `/mail/data - ${JSON.stringify({

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -143,13 +143,29 @@ class ChatbotCase(MailCommon, common.HttpCase):
             })]
         })
 
-    @classmethod
-    def _post_answer_and_trigger_next_step(cls, discuss_channel, answer, chatbot_script_answer=False):
-        mail_message = discuss_channel.message_post(body=answer)
+    def _post_answer_and_trigger_next_step(
+        self, discuss_channel, body=None, email=None, chatbot_script_answer=None
+    ):
+        data = self.make_jsonrpc_request(
+            "/mail/message/post",
+            {
+                "thread_model": "discuss.channel",
+                "thread_id": discuss_channel.id,
+                "post_data": {"body": body or email or chatbot_script_answer.name},
+            },
+        )
+        if email:
+            self.make_jsonrpc_request(
+                "/chatbot/step/validate_email", {"channel_id": discuss_channel.id}
+            )
         if chatbot_script_answer:
-            cls.env['chatbot.message'].search([
-                ('mail_message_id', '=', mail_message.id)
-            ], limit=1).user_script_answer_id = chatbot_script_answer.id
-
-        next_step = discuss_channel.chatbot_current_step_id._process_answer(discuss_channel, mail_message.body)
-        next_step._process_step(discuss_channel)
+            message = self.env["mail.message"].browse(data["mail.message"][0]["id"])
+            self.make_jsonrpc_request(
+                "/chatbot/answer/save",
+                {
+                    "channel_id": discuss_channel.id,
+                    "message_id": message.id,
+                    "selected_answer_id": chatbot_script_answer.id,
+                },
+            )
+        self.make_jsonrpc_request("/chatbot/step/trigger", {"channel_id": discuss_channel.id})

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -1,10 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import common
+from odoo.addons.mail.tests.common import MailCommon
 
 
-class ChatbotCase(common.HttpCase):
+class ChatbotCase(MailCommon, common.HttpCase):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -1,8 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.im_livechat.tests import chatbot_common
-from odoo.exceptions import ValidationError
-from odoo.tests.common import tagged
+from odoo.tests.common import JsonRpcException, tagged
+
 
 @tagged("post_install", "-at_install")
 class ChatbotCase(chatbot_common.ChatbotCase):
@@ -54,16 +54,14 @@ class ChatbotCase(chatbot_common.ChatbotCase):
         self.assertEqual(discuss_channel.chatbot_current_step_id, self.step_dispatch)
 
         self._post_answer_and_trigger_next_step(
-            discuss_channel,
-            self.step_dispatch_buy_software.name,
-            chatbot_script_answer=self.step_dispatch_buy_software
+            discuss_channel, chatbot_script_answer=self.step_dispatch_buy_software
         )
         self.assertEqual(discuss_channel.chatbot_current_step_id, self.step_email)
 
-        with self.assertRaises(ValidationError, msg="Should raise an error since it's not a valid email"):
-            self._post_answer_and_trigger_next_step(discuss_channel, 'test')
+        with self.assertRaises(JsonRpcException, msg='odoo.exceptions.ValidationError'):
+            self._post_answer_and_trigger_next_step(discuss_channel, email="test")
 
-        self._post_answer_and_trigger_next_step(discuss_channel, 'test@example.com')
+        self._post_answer_and_trigger_next_step(discuss_channel, email="test@example.com")
         self.assertEqual(discuss_channel.chatbot_current_step_id, self.step_email_validated)
 
     def test_chatbot_steps_sequence(self):

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -36,7 +36,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     'anonymous_name': 'Visitor 22',
                     'previous_operator_id': operator.partner_id.id,
                     'channel_id': self.livechat_channel.id,
-                    'country_id': belgium.id,
                 },
             )
         channel_info = data["discuss.channel"][0]
@@ -88,7 +87,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         data = self.make_jsonrpc_request('/im_livechat/get_session', {
             'anonymous_name': 'whatever',
             'previous_operator_id': operator.partner_id.id,
-            'user_id': test_user.id,
             'channel_id': self.livechat_channel.id,
         })
         channel_info = data["discuss.channel"][0]
@@ -180,7 +178,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         data = self.make_jsonrpc_request('/im_livechat/get_session', {
             'anonymous_name': 'whatever',
             'previous_operator_id': operator.partner_id.id,
-            'user_id': operator.id,
             'channel_id': self.livechat_channel.id,
         })
         channel_info = data["discuss.channel"][0]

--- a/addons/im_livechat/tests/test_get_operator.py
+++ b/addons/im_livechat/tests/test_get_operator.py
@@ -433,3 +433,25 @@ class TestGetOperator(MailCommon, HttpCase):
                 livechat_channels[1]: self.env["res.users"],
             },
         )
+
+    @users("employee")
+    def test_get_non_member_operator(self):
+        """Test _get_operator works with a given list of operators that are not members of the
+        livechat channel"""
+        operator_1 = self._create_operator(lang_code="fr_FR")
+        operator_2 = self._create_operator(lang_code="en_US")
+        all_operators = operator_1 + operator_2
+        livechat_channel_data = {"name": "Livechat Channel 2"}
+        livechat_channel = self.env["im_livechat.channel"].sudo().create(livechat_channel_data)
+        self.assertFalse(livechat_channel._get_operator())
+        self.assertFalse(
+            livechat_channel._get_operator(previous_operator_id=operator_1.partner_id.id)
+        )
+        self.assertEqual(livechat_channel._get_operator(users=all_operators), operator_1)
+        self.assertEqual(
+            livechat_channel._get_operator(previous_operator_id=operator_2.partner_id.id, users=all_operators),
+            operator_2,
+        )
+        self.assertEqual(
+            livechat_channel._get_operator(lang="en_US", users=all_operators), operator_2
+        )

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -65,7 +65,6 @@ class TestImLivechatMessage(HttpCase, MailCommon):
                 {
                     "anonymous_name": "anon 1",
                     "previous_operator_id": self.users[0].partner_id.id,
-                    "country_id": self.env.ref("base.in").id,
                     "channel_id": im_livechat_channel.id,
                 },
             )["discuss.channel"][0]["id"]
@@ -168,7 +167,6 @@ class TestImLivechatMessage(HttpCase, MailCommon):
                 {
                     "anonymous_name": "anon 1",
                     "previous_operator_id": self.users[0].partner_id.id,
-                    "country_id": self.env.ref("base.in").id,
                     "channel_id": im_livechat_channel.id,
                 },
             )["discuss.channel"][0]["id"]

--- a/addons/website_livechat/controllers/main.py
+++ b/addons/website_livechat/controllers/main.py
@@ -65,9 +65,9 @@ class WebsiteLivechat(LivechatController):
         return _('Visitor #%d', visitor_sudo.id) if visitor_sudo else super()._get_guest_name()
 
     @http.route()
-    def get_session(self, channel_id, anonymous_name, previous_operator_id=None, chatbot_script_id=None, persisted=True, **kwargs):
+    def get_session(self, channel_id, anonymous_name, previous_operator_id=None, chatbot_script_id=None, persisted=True):
         """ Override to use visitor name instead of 'Visitor' whenever a visitor start a livechat session. """
         visitor_sudo = request.env['website.visitor']._get_visitor_from_request()
         if visitor_sudo:
             anonymous_name = _('Visitor #%s', visitor_sudo.id)
-        return super(WebsiteLivechat, self).get_session(channel_id, anonymous_name, previous_operator_id=previous_operator_id, chatbot_script_id=chatbot_script_id, persisted=persisted, **kwargs)
+        return super().get_session(channel_id, anonymous_name, previous_operator_id=previous_operator_id, chatbot_script_id=chatbot_script_id, persisted=persisted)


### PR DESCRIPTION
\* = im_livechat, crm_livechat

This commit introduces a new chatbot script step 'create lead & forward'.

On selection, the chatbot will:

1. Create a new lead.
2. Assign the lead and forward the conversation to a salesperson based on the assignment rules configured for the selected sales team, provided a salesperson is available.

Main PR is https://github.com/odoo/odoo/pull/190364
This is rebased on https://github.com/odoo/odoo/pull/190966 and https://github.com/odoo/odoo/pull/191055

https://github.com/odoo/enterprise/pull/75886