### PR TITLE
[IMP] core: implement dict update operations on views

### DIFF
--- a/addons/barcodes_gs1_nomenclature/views/barcodes_view.xml
+++ b/addons/barcodes_gs1_nomenclature/views/barcodes_view.xml
@@ -17,7 +17,7 @@
                 </xpath>
                 <!-- Rules table -->
                 <xpath expr="//field[@name='rule_ids']" position="attributes">
-                    <attribute name="context">{'is_gs1': is_gs1_nomenclature}</attribute>
+                    <attribute name="context" operation="update">{'is_gs1': is_gs1_nomenclature}</attribute>
                 </xpath>
                 <xpath expr="//field[@name='encoding']" position="attributes">
                     <attribute name="column_invisible">parent.is_gs1_nomenclature</attribute>

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -146,10 +146,7 @@
             </xpath>
 
             <xpath expr="//field[@name='contact_list_ids']" position="attributes">
-                <attribute name="context">
-                    {'mailing_sms' : context.get('mailing_sms'),
-                    'form_view_ref': 'mass_mailing.mailing_list_view_form_simplified'}
-                </attribute>
+                <attribute name="context" operation="update">{'mailing_sms' : context.get('mailing_sms')}</attribute>
             </xpath>
             <!-- Option page tweaks -->
             <xpath expr="//field[@name='email_from']" position="attributes">

--- a/addons/mrp/views/stock_move_views.xml
+++ b/addons/mrp/views/stock_move_views.xml
@@ -52,12 +52,7 @@
             <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree" />
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='lot_id']" position="attributes">
-		            <attribute name="context">{
-                        'active_mo_id': context.get('active_mo_id'),
-                        'active_picking_id': picking_id,
-                        'default_product_id': parent.product_id,
-                        }
-                    </attribute>
+                    <attribute name="context" operation="update">{'active_mo_id': context.get('active_mo_id')}</attribute>
                 </xpath>
             </field>
         </record>

--- a/addons/mrp_subcontracting_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/mrp_subcontracting_landed_costs/views/stock_landed_cost_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="mrp_landed_costs.view_mrp_landed_costs_form"/>
         <field name="arch" type="xml">
             <field name="mrp_production_ids" position="attributes">
-                <attribute name="context">{'search_view_ref': 'mrp_subcontracting.mrp_production_subcontracting_filter', 'list_view_ref': 'mrp_subcontracting.mrp_production_subcontracting_tree_view'}</attribute>
+                <attribute name="context" operation="update">{'search_view_ref': 'mrp_subcontracting.mrp_production_subcontracting_filter', 'list_view_ref': 'mrp_subcontracting.mrp_production_subcontracting_tree_view'}</attribute>
             </field>
             <field name="picking_ids" position="attributes">
                 <attribute name="domain">[('company_id', '=', company_id), '|', ('move_ids.stock_valuation_layer_ids', '!=', False), '&amp;', ('move_ids.is_subcontract', '!=', False), ('move_ids.state', '=', 'done')]</attribute>

--- a/addons/point_of_sale/views/product_combo_views.xml
+++ b/addons/point_of_sale/views/product_combo_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="product.product_combo_view_form"/>
         <field name="arch" type="xml">
             <field name="product_id" position="attributes">
-                <attribute name="context">{'default_available_in_pos': True}</attribute>
+                <attribute name="context" operation="update">{'default_available_in_pos': True}</attribute>
             </field>
         </field>
     </record>

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -97,7 +97,7 @@
         <field name="inherit_id" ref="product.product_template_only_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='attribute_line_ids']//field[@name='attribute_id']" position="attributes">
-                <attribute name="context">{'default_create_variant': context.get('create_variant_never', 'always')}</attribute>
+                <attribute name="context" operation="update">{'default_create_variant': context.get('create_variant_never', 'always')}</attribute>
             </xpath>
         </field>
     </record>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -516,8 +516,8 @@
                     <field name="product_template_variant_value_ids" widget="many2many_tags" readonly="1" invisible="not product_template_variant_value_ids" groups="product.group_product_variant"/>
                 </xpath>
                 <field name="product_tag_ids" position="attributes">
-                    <attribute name="options">{'no_open': True}</attribute>
-                    <attribute name="context">{'product_template_id': product_tmpl_id}</attribute>
+                    <attribute name="options" operation="update">{'no_open': True}</attribute>
+                    <attribute name="context" operation="update">{'product_template_id': product_tmpl_id}</attribute>
                 </field>
                 <field name="product_tag_ids" position="after">
                     <field name="additional_product_tag_ids" widget="many2many_tags"/>

--- a/addons/project/views/rating_rating_views.xml
+++ b/addons/project/views/rating_rating_views.xml
@@ -145,7 +145,7 @@
                 </filter>
             </xpath>
             <xpath expr="//filter[@name='month']" position="attributes">
-                <attribute name="context">{'group_by':'write_date:month'}</attribute>
+                <attribute name="context" operation="update">{'group_by':'write_date:month'}</attribute>
             </xpath>
         </field>
     </record>

--- a/addons/project_account/views/project_project_views.xml
+++ b/addons/project_account/views/project_project_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="project.view_project"/>
         <field name="arch" type="xml">
             <field name="partner_id" position="attributes">
-                <attribute name="context">{'res_partner_search_mode': 'customer'}</attribute>
+                <attribute name="context" operation="update">{'res_partner_search_mode': 'customer'}</attribute>
             </field>
         </field>
     </record>
@@ -18,7 +18,7 @@
         <field name="inherit_id" ref="project.edit_project"/>
         <field name="arch" type="xml">
             <field name="partner_id" position="attributes">
-                <attribute name="context">{'res_partner_search_mode': 'customer'}</attribute>
+                <attribute name="context" operation="update">{'res_partner_search_mode': 'customer'}</attribute>
             </field>
         </field>
     </record>

--- a/addons/project_account/views/project_sharing_project_task_views.xml
+++ b/addons/project_account/views/project_sharing_project_task_views.xml
@@ -7,13 +7,13 @@
         <field name="inherit_id" ref="project.project_sharing_project_task_view_form"/>
         <field name="arch" type="xml">
             <field name="partner_id" position="attributes">
-                <attribute name="context">{'res_partner_search_mode': 'customer'}</attribute>
+                <attribute name="context" operation="update">{'res_partner_search_mode': 'customer'}</attribute>
             </field>
             <xpath expr="//field[@name='child_ids']/list/field[@name='partner_id']" position="attributes">
-                <attribute name="context">{'res_partner_search_mode': 'customer'}</attribute>
+                <attribute name="context" operation="update">{'res_partner_search_mode': 'customer'}</attribute>
             </xpath>
             <xpath expr="//field[@name='depend_on_ids']/list/field[@name='partner_id']" position="attributes">
-                <attribute name="context">{'res_partner_search_mode': 'customer'}</attribute>
+                <attribute name="context" operation="update">{'res_partner_search_mode': 'customer'}</attribute>
             </xpath>
         </field>
     </record>

--- a/addons/project_account/views/project_task_views.xml
+++ b/addons/project_account/views/project_task_views.xml
@@ -7,13 +7,13 @@
         <field name="inherit_id" ref="project.view_task_form2"/>
         <field name="arch" type="xml">
             <field name="partner_id" position="attributes">
-                <attribute name="context">{'res_partner_search_mode': 'customer'}</attribute>
+                <attribute name="context" operation="update">{'res_partner_search_mode': 'customer'}</attribute>
             </field>
             <xpath expr="//field[@name='child_ids']/list/field[@name='partner_id']" position="attributes">
-                <attribute name="context">{'res_partner_search_mode': 'customer'}</attribute>
+                <attribute name="context" operation="update">{'res_partner_search_mode': 'customer'}</attribute>
             </xpath>
             <xpath expr="//field[@name='depend_on_ids']/list/field[@name='partner_id']" position="attributes">
-                <attribute name="context">{'res_partner_search_mode': 'customer'}</attribute>
+                <attribute name="context" operation="update">{'res_partner_search_mode': 'customer'}</attribute>
             </xpath>
         </field>
     </record>
@@ -24,7 +24,7 @@
         <field name="inherit_id" ref="project.project_task_view_tree_base"/>
         <field name="arch" type="xml">
             <field name="partner_id" position="attributes">
-                <attribute name="context">{'res_partner_search_mode': 'customer'}</attribute>
+                <attribute name="context" operation="update">{'res_partner_search_mode': 'customer'}</attribute>
             </field>
         </field>
     </record>

--- a/addons/project_mrp/views/mrp_production_views.xml
+++ b/addons/project_mrp/views/mrp_production_views.xml
@@ -17,8 +17,7 @@
         <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
         <field name="arch" type="xml">
             <field name="bom_id" position="attributes">
-                <attribute name="context">{
-                    'default_product_tmpl_id': product_tmpl_id,
+                <attribute name="context" operation="update">{
                     'default_project_id': project_id,
                 }</attribute>
             </field>

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -92,10 +92,10 @@
             <field name="inherit_id" ref="product.product_normal_form_view"/>
             <field name="arch" type="xml">
                 <field name="seller_ids" position="attributes">
-                    <attribute name="context">{'default_product_tmpl_id': product_tmpl_id, 'product_template_invisible_variant': True, 'list_view_ref':'purchase.product_product_supplierinfo_tree_view2'}</attribute>
+                    <attribute name="context" operation="update">{'default_product_tmpl_id': product_tmpl_id, 'list_view_ref':'purchase.product_product_supplierinfo_tree_view2'}</attribute>
                 </field>
                 <field name="variant_seller_ids" position="attributes">
-                    <attribute name="context">{'model': 'product.product', 'active_id': id, 'list_view_ref':'purchase.product_product_supplierinfo_tree_view2'}</attribute>
+                    <attribute name="context" operation="update">{'model': 'product.product', 'list_view_ref':'purchase.product_product_supplierinfo_tree_view2'}</attribute>
                 </field>
             </field>
         </record>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -151,7 +151,7 @@
         <field name="inherit_id" ref="project.quick_create_task_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='project_id']" position="attributes">
-                <attribute name="context">{'default_allow_billable': True, 'default_type_ids': [(4, context.get('default_stage_id', False))]}
+                <attribute name="context" operation="update">{'default_allow_billable': True, 'default_type_ids': [(4, context.get('default_stage_id', False))]}
                 </attribute>
             </xpath>
         </field>
@@ -236,7 +236,7 @@
                 <attribute name="invisible">not allow_billable</attribute>
             </xpath>
             <field name="project_id" position="attributes">
-                <attribute name="context">{'default_allow_billable': True}</attribute>
+                <attribute name="context" operation="update">{'default_allow_billable': True}</attribute>
             </field>
         </field>
     </record>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -6,12 +6,6 @@
         <field name="model">project.project</field>
         <field name="inherit_id" ref="hr_timesheet.project_invoice_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_view_sos'][1]" position="attributes">
-                <attribute name="context">{'create_for_project_id': id, 'default_project_id': id, 'default_partner_id': partner_id}</attribute>
-            </xpath>
-            <xpath expr="//button[@name='action_view_sos'][2]" position="attributes">
-                <attribute name="context">{'create_for_project_id': id, 'default_project_id': id, 'default_partner_id': partner_id}</attribute>
-            </xpath>
             <xpath expr="//page[@name='settings']" position="after">
                 <page name="billing_employee_rate" string="Invoicing" invisible="not allow_billable or not partner_id">
                     <field name="sale_line_employee_ids" mode="list,kanban" context="{'default_sale_line_id': sale_line_id}">
@@ -228,14 +222,7 @@
             <field name="inherit_id" ref="sale_project.view_sale_project_inherit_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='sale_line_id'][2]" position="attributes">
-                    <attribute name="context">{
-                        'create': False, 'edit': False, 'delete': False,
-                        'with_price_unit': True,
-                        'with_remaining_hours': True,
-                        'form_view_ref': 'sale_project.sale_order_line_view_form_editable',
-                        'default_partner_id': partner_id,
-                        'default_company_id': company_id,
-                    }</attribute>
+                    <attribute name="context" operation="update">{'with_remaining_hours': True}</attribute>
                 </xpath>
             </field>
         </record>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -386,9 +386,7 @@
                         </t>
                     </div>
                     <xpath expr="//button[@name='%(action_open_routes)d']" position="attributes">
-                        <attribute name="context">
-                            {'default_product_id': id}
-                        </attribute>
+                        <attribute name="context" operation="update">{'default_product_id': id}</attribute>
                     </xpath>
                 </data>
             </field>

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -197,7 +197,7 @@
     <field name="inherit_id" ref="base.view_view_form"/>
     <field name="arch" type="xml">
         <field name="inherit_id" position="attributes">
-            <attribute name="context">{'display_website': True}</attribute>
+            <attribute name="context" operation="update">{'display_website': True}</attribute>
         </field>
         <field name="model_id" position="before">
             <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -180,7 +180,7 @@
             <field name="inherit_id" ref="base.reset_view_arch_wizard_view"/>
             <field name="arch" type="xml">
                 <field name="compare_view_id" position="attributes">
-                    <attribute name="context">{'display_website': True}</attribute>
+                    <attribute name="context" operation="update">{'display_website': True}</attribute>
                 </field>
             </field>
         </record>

--- a/addons/website_event/views/event_event_views.xml
+++ b/addons/website_event/views/event_event_views.xml
@@ -26,7 +26,7 @@
                 </div>
             </xpath>
             <xpath expr="//field[@name='tag_ids']" position="attributes">
-                <attribute name="context">{'default_website_id': website_id}</attribute>
+                <attribute name="context" operation="update">{'default_website_id': website_id}</attribute>
                 <attribute name="groups">website.group_multi_website</attribute>
             </xpath>
             <xpath expr="//button[@name='%(event.event_registration_action_stats_from_event)d']" position="before">

--- a/addons/website_sale/views/sale_order_views.xml
+++ b/addons/website_sale/views/sale_order_views.xml
@@ -178,12 +178,7 @@
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
             <field name="partner_id" position="attributes">
-                <attribute name="context">{
-                    'display_website': True,
-                    'res_partner_search_mode': 'customer',
-                    'show_address': 1,
-                    'show_vat': True,
-                }</attribute>
+                <attribute name="context" operation="update">{'display_website': True}</attribute>
             </field>
             <field name="team_id" position="after">
                 <field name="website_id" invisible="not website_id" groups="website.group_multi_website"/>

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -2,6 +2,7 @@
 # ruff: noqa: F401
 
 from . import constants
+from .ast import *
 from .parse_version import parse_version
 from .barcode import check_barcode_encoding
 from .cache import ormcache, ormcache_context

--- a/odoo/tools/ast.py
+++ b/odoo/tools/ast.py
@@ -1,0 +1,40 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import ast
+
+
+__all__ = ['merge_ast_dicts']
+
+
+def merge_ast_dicts(*ast_dicts: ast.Dict) -> ast.Dict:
+    """Merge multiple ast.Dict objects into a single ast.Dict
+
+    Combining all their keys and values similar to the python operation
+    ``result = {**dict1, **dict2, ...}``.
+
+    :returns: A new ast.Dict with all the keys and values from the input dicts
+    """
+
+    def ast_key_eq(k1, k2):
+        if type(k1) is not type(k2):
+            return False
+        elif isinstance(k1, ast.Constant):
+            return k1.value == k2.value
+        else:
+            raise NotImplementedError("Unsupported key type: %s", type(k1))
+
+    result = ast.Dict([], [])
+    for ast_dict in ast_dicts:
+        to_add_idx = []
+        # Update values in result dict, for matching keys
+        for update_idx, update_key in enumerate(ast_dict.keys):
+            for result_idx, result_key in enumerate(result.keys):
+                if ast_key_eq(result_key, update_key):
+                    result.values[result_idx] = ast_dict.values[update_idx]
+                    break
+            else:
+                to_add_idx.append(update_idx)
+        # Add the missing keys and values
+        for update_idx in to_add_idx:
+            result.keys.append(ast_dict.keys[update_idx])
+            result.values.append(ast_dict.values[update_idx])
+    return result


### PR DESCRIPTION
In the same spirit than https://github.com/odoo/odoo/commit/46dc040d8ee484783b9666ea9818584ece0f9471, this PR implements a dictionary update operation for attributes in views.

The use case is to prevent the complete overwrite of attributes like `context` or `options` in view inheritance, when only a few keys need to be updated.

IMHO, one should almost always use this operation when modifying `context`, `options`, `t-options` through inheritance.  The exception would be cases when one truly wants to replace the previous values.

This helps in writing more meaningful and maintainable code, where two separate modules can actually inject their own keys to the same view element without fighting each other.. 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
