### PR TITLE
[FIX] crm: incorrect value type in probability field in demo data

### DIFF
--- a/addons/crm/data/crm_team_demo.xml
+++ b/addons/crm/data/crm_team_demo.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="sales_team.team_sales_department" model="crm.team" forcecreate="False">
-            <field name="assignment_domain">[['probability', '>=', '20']]</field>
+            <field name="assignment_domain">[['probability', '>=', 20]]</field>
         </record>
 
         <record id="sales_team.crm_team_1" model="crm.team">


### PR DESCRIPTION
**Current behavior before PR:**

The `probability` field, defined as a float, had values in demo data assigned as strings. This caused errors during domain evaluation.

**Desired behavior after PR is merged:**

This update ensures the `probability` field in demo data uses values compatible with its float type.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
