### PR TITLE
[FIX] analytic: qunit value suggestion test under new headless

### DIFF
--- a/addons/analytic/static/tests/analytic_distribution_tests.js
+++ b/addons/analytic/static/tests/analytic_distribution_tests.js
@@ -381,11 +381,13 @@ QUnit.module("Analytic", (hooks) => {
         // fill internal
         triggerHotkey("Tab");  // new line
         await nextTick();
-        triggerHotkey("arrowdown");
-        await nextTick();
-        triggerHotkey("arrowdown");
-        await nextTick();
-        triggerHotkey("Enter");  // choose Operating Costs
+        const autocomplete = document.activeElement.parentNode;
+        // choose Operating Costs
+        while (autocomplete.querySelector("a[aria-selected='true']")?.textContent !== "Operating Costs") {
+            triggerHotkey("arrowdown");
+            await nextTick();
+        }
+        triggerHotkey("Enter");  // validate
         await nextTick();
         triggerHotkey("Escape");  // close the popup
         await nextTick();


### PR DESCRIPTION
Apparently on new headless mode a single arrowdown doesn't work to open the autocomplete menu (or possibly the setup takes longer on the new headless mode so the first arrowdown is missed).

Anyway, if we loop on `arrowdown` until the correct element is selected, we end up with the correct element selected on both old and new headless modes.
