### PR TITLE
[FIX] web_editor: unreliable test in recent chrome

### DIFF
--- a/addons/web_editor/static/tests/banner_tests.js
+++ b/addons/web_editor/static/tests/banner_tests.js
@@ -140,6 +140,8 @@ QUnit.module(
             insertText(editor, 'Test2');
             triggerEvent(editor.editable, "keydown", { key: "a", ctrlKey: true });
             await nextTick();
+            await nextTick();
+            await nextTick();
             triggerEvent(editor.editable, "input", { inputType: "deleteContentBackward" });
             await nextTick();
             assert.strictEqual(


### PR DESCRIPTION
This seems to affect both old and new headless modes, ctrl-a seems to just not be stable after a single `nextTick`, leading to the content not being deleted on `deleteContentBackward`.

Inspecting the selections to try and suss out a divergence didn't reveal anything, in both success and failure case the selection encompasses the entire editable, element, so I can only assume that there's *some* part of the selection operation that's internal and may take more than a tick to sync up, but not knowing how to detect this issue...
