### PR TITLE
[FIX] website_sale_slides: fix allow course product issue

### DIFF
--- a/addons/website_sale_slides/models/product_product.py
+++ b/addons/website_sale_slides/models/product_product.py
@@ -9,6 +9,15 @@ class Product(models.Model):
 
     channel_ids = fields.One2many('slide.channel', 'product_id', string='Courses')
 
+    def _is_add_to_cart_allowed(self):
+        """Override to allow published course related products to the cart regardless of product's rules."""
+        self.ensure_one()
+        res = super()._is_add_to_cart_allowed()
+        return res or bool(self.env['slide.channel'].sudo().search_count([
+            ('product_id', '=', self.id),
+            ('website_published', '=', True),
+        ], limit=1))
+
     def get_product_multiline_description_sale(self):
         payment_channels = self.channel_ids.filtered(lambda course: course.enroll == 'payment')
 


### PR DESCRIPTION
Steps:
- Install E-learning app and E-commerce app.
- Go to E-commerce setting and make Ecommerce access to logged in user.
- Try to add a course with on payment setting with out login.

Issue:
User can't able to add course in cart.

Cause:
- No specific condition to allow adding course type product into cart.

Fix:
- Add condition to allow course product add into account even with Ecommerce access is `logged in user`.

opw-4384616
