### PR TITLE
[FIX] im_livechat: fix live chat name after forwarding to operator

### DIFF
--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -377,7 +377,17 @@ class ChatbotScriptStep(models.Model):
                 lambda m: m.partner_id == self.chatbot_script_id.operator_partner_id
             ):
                 channel_sudo._action_unfollow(partner=bot_member.partner_id)
-            channel_sudo.name = (human_operator.livechat_username or human_operator.name,)
+            # finally, rename the channel to include the operator's name
+            channel_sudo.name = " ".join(
+                [
+                    self.env.user.display_name
+                    if not self.env.user._is_public()
+                    else discuss_channel.anonymous_name,
+                    human_operator.livechat_username
+                    if human_operator.livechat_username
+                    else human_operator.name,
+                ]
+            )
             channel_sudo._broadcast(human_operator.partner_id.ids)
             discuss_channel.channel_pin(pinned=True)
 


### PR DESCRIPTION
When a chat bot forwards the conversation to a human operator, the
live chat name is updated to reflect this change. However, the way
the name is updated changed in [1] while it was not intended.

This name is used by live chat managers to review session history.
Both the operator and visitor names are important in this context.
This PR restores the original naming: "{operator_name, visitor_name}".

[1]: https://github.com/odoo/odoo/pull/189456