### PR TITLE
[FIX] web: show selected option during keyboard navigation

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.scss
+++ b/addons/web/static/src/core/autocomplete/autocomplete.scss
@@ -10,6 +10,14 @@
     }
 
     .ui-menu-item {
+        > a.ui-state-active {
+            margin: 0;
+            border: none;
+            font-weight: $font-weight-normal;
+            color: $dropdown-link-hover-color;
+            background-color: $dropdown-link-hover-bg;
+        }
+
         &.o_m2o_dropdown_option, &.o_m2o_start_typing, &.o_m2o_no_result {
             text-indent: $o-dropdown-hpadding * .5;
         }
@@ -28,6 +36,10 @@
             a.ui-menu-item-wrapper, a.ui-state-active, a.ui-state-active:hover {
                 background: none;
             }
+        }
+
+        &.o_m2o_start_typing > a.ui-state-active {
+            color: $dropdown-link-color;
         }
     }
 }


### PR DESCRIPTION
- Previously, navigating through dropdown options using the keyboard's up and down arrow keys would highlight the selected value in the dropdown. However, this functionality was inadvertently removed in this commit https://github.com/odoo/odoo/commit/6d77fb2d823688fcdd3085cd15c7a28771e783b6, 
resulting in the selected record not being visible during keyboard navigation.

- This fix restores the original behavior, ensuring that the selected option is properly highlighted and visible when navigating with the keyboard.

Task-4402580

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
