### PR TITLE
[FIX] website_blog: fix some issue of website_blog 

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -956,7 +956,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
      * @private
      * @param {HTMLElement} editable
      */
-    async _saveCoverProperties($elementToSave) {
+    _saveCoverProperties($elementToSave) {
         var el = $elementToSave.closest('.o_record_cover_container')[0];
         if (!el) {
             return;
@@ -983,31 +983,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
         }
         this.__savedCovers[resModel].push(resID);
 
-        const imageEl = el.querySelector('.o_record_cover_image');
-        let cssBgImage = getComputedStyle(imageEl)["backgroundImage"];
-        if (imageEl.classList.contains("o_b64_image_to_save")) {
-            imageEl.classList.remove("o_b64_image_to_save");
-            const groups = cssBgImage.match(/url\("data:(?<mimetype>.*);base64,(?<imageData>.*)"\)/)?.groups;
-            if (!groups.imageData) {
-                // Checks if the image is in base64 format for RPC call. Relying
-                // only on the presence of the class "o_b64_image_to_save" is not
-                // robust enough.
-                return;
-            }
-            const modelName = await this.websiteService.getUserModelName(resModel);
-            const recordNameEl = imageEl.closest("body").querySelector(`[data-oe-model="${resModel}"][data-oe-id="${resID}"][data-oe-field="name"]`);
-            const recordName = recordNameEl ? `'${recordNameEl.textContent.replaceAll("/", "")}'` : resID;
-            const attachment = await this.rpc(
-                '/web_editor/attachment/add_data',
-                {
-                    name: `${modelName} ${recordName} cover image.${groups.mimetype.split("/")[1]}`,
-                    data: groups.imageData,
-                    is_image: true,
-                    res_model: 'ir.ui.view',
-                },
-            );
-            cssBgImage = `url(${attachment.image_src})`;
-        }
+        let cssBgImage = el.querySelector(".o_record_cover_image").style.backgroundImage;
         var coverProps = {
             'background-image': cssBgImage.replace(/"/g, '').replace(window.location.protocol + "//" + window.location.host, ''),
             'background_color_class': el.dataset.bgColorClass,

--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -113,6 +113,9 @@ $o-wblog-loader-size: 50px;
         a.oe_mail_expand {
             font-weight: bold;
         }
+        nav.breadcrumb > li:not(:last-child) {
+            flex-shrink: 0;
+        }
     }
 
     #o_wblog_post_content, .blog_header {


### PR DESCRIPTION
**Issue 1:**

Before this, the breadcrumb on the blog post page (`/blog/<blog>/<blogpost>`) was misaligned on mobile view when the blog post title is too long.

This commit introduces improved styles for the breadcrumb, ensuring proper alignment and better visual consistency.

**Issue 2:**

Steps to Reproduce:

1. Navigate to any blog and change its background image.
2. Save the changes.
3. Drag and drop any snippet, then modify its background image.
    Two same images appear with different filenames in attachment wizard.

When changing a blog’s cover image, an additional attachment record is created for the webp version of the image. This leads to duplicate image attachments with different file formats (original and webp).

This commit prevents the webp image from being saved as an attachment, ensuring only the original image is retained.

task-4353043