### PR TITLE
[IMP] livechat: hide welcome bot message

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -297,3 +297,7 @@ class DiscussChannel(models.Model):
             self.sudo().livechat_active = False
             self._bus_send_store(Store(self, "livechat_active"))
         super()._action_unfollow(partner, guest)
+
+    def _post_leave_notification(self, member):
+        if member.partner_id != self.chatbot_current_step_id.chatbot_script_id.operator_partner_id:
+            super()._post_leave_notification(member)

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -174,7 +174,7 @@ class ChatbotCase(chatbot_common.ChatbotCase):
         def get_forward_op_bus_params():
             messages = self.env["mail.message"].search([], order="id desc", limit=3)
             # only data relevant to the test are asserted for simplicity
-            transfer_message_data = Store(messages[2]).get_result()
+            transfer_message_data = Store(messages[1]).get_result()
             transfer_message_data["mail.message"][0].update(
                 {
                     "author": {"id": self.chatbot_script.operator_partner_id.id, "type": "partner"},
@@ -185,7 +185,7 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                 }
             )
             transfer_message_data["mail.thread"][0]["display_name"] = "Testing Bot"
-            joined_message_data = Store(messages[1]).get_result()
+            joined_message_data = Store(messages[0]).get_result()
             joined_message_data["mail.message"][0].update(
                 {
                     "author": {"id": self.partner_employee.id, "type": "partner"},
@@ -196,17 +196,6 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                 }
             )
             joined_message_data["mail.thread"][0]["display_name"] = "Testing Bot"
-            left_message_data = Store(messages[0]).get_result()
-            left_message_data["mail.message"][0].update(
-                {
-                    "author": {"id": self.chatbot_script.operator_partner_id.id, "type": "partner"},
-                    "body": '<div class="o_mail_notification">left the channel</div>',
-                    # thread not renamed yet at this step
-                    "default_subject": "Testing Bot",
-                    "record_name": "Testing Bot",
-                }
-            )
-            left_message_data["mail.thread"][0]["display_name"] = "Testing Bot"
             member_emp = discuss_channel.channel_member_ids.filtered(
                 lambda m: m.partner_id == self.partner_employee
             )
@@ -218,8 +207,8 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                     ).get_result()
                 )
             )
-            channel_data_join["discuss.channel"][0]["chatbot"]["currentStep"]["message"] = messages[2].id
-            channel_data_join["discuss.channel"][0]["chatbot"]["steps"][0]["message"] = messages[2].id
+            channel_data_join["discuss.channel"][0]["chatbot"]["currentStep"]["message"] = messages[1].id
+            channel_data_join["discuss.channel"][0]["chatbot"]["steps"][0]["message"] = messages[1].id
             channel_data_join["discuss.channel"][0]["is_pinned"] = True
             channel_data_join["discuss.channel"][0]["livechat_operator_id"] = {
                 "id": self.chatbot_script.operator_partner_id.id,
@@ -263,8 +252,6 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                     (self.cr.dbname, "discuss.channel", discuss_channel.id, "members"),
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
-                    (self.cr.dbname, "discuss.channel", discuss_channel.id, "members"),
-                    (self.cr.dbname, "discuss.channel", discuss_channel.id),
                     (self.cr.dbname, "res.partner", self.chatbot_script.operator_partner_id.id),
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
@@ -297,7 +284,7 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                                     "id": member_emp.id,
                                     "message_unread_counter": 0,
                                     "message_unread_counter_bus_id": 0,
-                                    "new_message_separator": messages[0].id,
+                                    "new_message_separator": messages[0].id + 1,
                                     "persona": {"id": self.partner_employee.id, "type": "partner"},
                                     "syncUnread": True,
                                     "thread": {
@@ -349,14 +336,14 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                                     "create_date": fields.Datetime.to_string(
                                         member_emp.create_date
                                     ),
-                                    "fetched_message_id": messages[1].id,
+                                    "fetched_message_id": messages[0].id,
                                     "id": member_emp.id,
                                     "is_bot": False,
                                     "last_seen_dt": fields.Datetime.to_string(
                                         member_emp.last_seen_dt
                                     ),
                                     "persona": {"id": self.partner_employee.id, "type": "partner"},
-                                    "seen_message_id": messages[1].id,
+                                    "seen_message_id": messages[0].id,
                                     "thread": {
                                         "id": discuss_channel.id,
                                         "model": "discuss.channel",
@@ -383,16 +370,6 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                                 }
                             ),
                         },
-                    },
-                    {
-                        "type": "mail.record/insert",
-                        "payload": {
-                            "discuss.channel": [{"id": discuss_channel.id, "is_pinned": True}]
-                        },
-                    },
-                    {
-                        "type": "discuss.channel/new_message",
-                        "payload": {"data": left_message_data, "id": discuss_channel.id},
                     },
                     {
                         "type": "discuss.channel/leave",

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -438,6 +438,15 @@ class DiscussChannel(models.Model):
     def action_unfollow(self):
         self._action_unfollow(self.env.user.partner_id)
 
+    def _post_leave_notification(self, member):
+        notification = Markup('<div class="o_mail_notification">%s</div>') % _(
+            "left the channel"
+        )
+        # sudo: mail.message - post as sudo since the user just unsubscribed from the channel
+        member.channel_id.sudo().message_post(
+            body=notification, subtype_xmlid="mail.mt_comment", author_id=member.partner_id.id
+        )
+
     def _action_unfollow(self, partner=None, guest=None):
         self.ensure_one()
         self.message_unsubscribe(partner.ids)
@@ -452,13 +461,7 @@ class DiscussChannel(models.Model):
             target = partner or guest
             target._bus_send_store(custom_store, notification_type="discuss.channel/leave")
             return
-        notification = Markup('<div class="o_mail_notification">%s</div>') % _(
-            "left the channel"
-        )
-        # sudo: mail.message - post as sudo since the user just unsubscribed from the channel
-        member.channel_id.sudo().message_post(
-            body=notification, subtype_xmlid="mail.mt_comment", author_id=partner.id
-        )
+        self._post_leave_notification(member)
         # send custom store after message_post to avoid is_pinned reset to True
         member._bus_send_store(custom_store, notification_type="discuss.channel/leave")
         member.unlink()


### PR DESCRIPTION
**Current behavior before PR:**

prior to this PR when Welcome bot leave after fw to operator it posts
notification message like `Welcome bot left the channel` which is unnecessary.

**Desired behavior after PR is merged:**

now it will not post any messages regarding `Welcome bot left the channel` .

task-4410808

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
