### PR TITLE
[FIX] account: test file in Test_preserving_manually_added_attachments

### DIFF
--- a/addons/account/tests/test_account_move_attachment.py
+++ b/addons/account/tests/test_account_move_attachment.py
@@ -19,7 +19,7 @@ class TestAccountMoveAttachment(HttpCase):
                 "thread_id": invoice.id,
                 "thread_model": "account.move",
             },
-            files={"ufile": b""},
+            files={'ufile': ('salut.txt', b"Salut !\n", 'text/plain')},
         )
         self.assertEqual(response.status_code, 200)
         self.assertTrue(invoice.attachment_ids)


### PR DESCRIPTION
test file in test_preserving_manually_added_attachments function is being created empty, and because of that some of the tests are breaking. This commit fixes the issue.

[link to broken builds](https://runbot.odoo.com/odoo/action-573/110710)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
