### PR TITLE
[FIX] payment_worldline: various fixes

### DIFF
--- a/addons/payment_worldline/models/payment_transaction.py
+++ b/addons/payment_worldline/models/payment_transaction.py
@@ -268,7 +268,7 @@ class PaymentTransaction(models.Model):
 
         # Update the provider reference.
         payment_data = notification_data['payment']
-        self.provider_reference = payment_data.get('id', '').removesuffix('_0')
+        self.provider_reference = payment_data.get('id', '').rsplit('_', 1)[0]
 
         # Update the payment method.
         payment_output = payment_data.get('paymentOutput', {})

--- a/addons/payment_worldline/models/payment_transaction.py
+++ b/addons/payment_worldline/models/payment_transaction.py
@@ -102,7 +102,7 @@ class PaymentTransaction(models.Model):
         return_url = f'{urls.url_join(base_url, return_route)}?{return_url_params}'
         payload = {
             'hostedCheckoutSpecificInput': {
-                'locale': self.partner_lang,
+                'locale': self.partner_lang or '',
                 'returnUrl': return_url,
                 'showResultPage': False,
             },
@@ -113,15 +113,15 @@ class PaymentTransaction(models.Model):
                 },
                 'customer': {  # required to create a token and for some redirected payment methods
                     'billingAddress': {
-                        'city': self.partner_city,
-                        'countryCode': self.partner_country_id.code,
-                        'state': self.partner_state_id.name,
-                        'street': self.partner_address,
-                        'zip': self.partner_zip,
+                        'city': self.partner_city or '',
+                        'countryCode': self.partner_country_id.code or '',
+                        'state': self.partner_state_id.name or '',
+                        'street': self.partner_address or '',
+                        'zip': self.partner_zip or '',
                     },
                     'contactDetails': {
-                        'emailAddress': self.partner_email,
-                        'phoneNumber': self.partner_phone,
+                        'emailAddress': self.partner_email or '',
+                        'phoneNumber': self.partner_phone or '',
                     },
                 },
                 'references': {

--- a/addons/payment_worldline/models/payment_transaction.py
+++ b/addons/payment_worldline/models/payment_transaction.py
@@ -100,6 +100,7 @@ class PaymentTransaction(models.Model):
         return_route = WorldlineController._return_url
         return_url_params = urls.url_encode({'provider_id': str(self.provider_id.id)})
         return_url = f'{urls.url_join(base_url, return_route)}?{return_url_params}'
+        first_name, last_name = payment_utils.split_partner_name(self.partner_name)
         payload = {
             'hostedCheckoutSpecificInput': {
                 'locale': self.partner_lang or '',
@@ -122,6 +123,12 @@ class PaymentTransaction(models.Model):
                     'contactDetails': {
                         'emailAddress': self.partner_email or '',
                         'phoneNumber': self.partner_phone or '',
+                    },
+                    'personalInformation': {
+                        'name': {
+                            'firstName': first_name or '',
+                            'surname': last_name or '',
+                        },
                     },
                 },
                 'references': {


### PR DESCRIPTION
Fixup of 65b273681db8277493ee399b3addc96fd284e100

Some transactions references are suffixed by a higher number than 0. For instance: _1, _2, ...

We now also manage that case.

----------------------------

Avoid sending False to the API

---------------------------

Send the customer's name to Worldline