### PR TITLE
[FIX] mail: make suggestions feel snappier

### DIFF
--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -1,13 +1,14 @@
-import { useSequential } from "@mail/utils/common/hooks";
 import { status, useComponent, useEffect, useState } from "@odoo/owl";
-
+import { ConnectionAbortedError } from "@web/core/network/rpc";
 import { useService } from "@web/core/utils/hooks";
+import { useDebounced } from "@web/core/utils/timing";
 
 class UseSuggestion {
     constructor(comp) {
         this.comp = comp;
+        this.fetchSuggestions = useDebounced(this.fetchSuggestions.bind(this), 250);
         useEffect(
-            (delimiter, position, term) => {
+            () => {
                 this.update();
                 if (this.search.position === undefined || !this.search.delimiter) {
                     return; // nothing else to fetch
@@ -15,51 +16,15 @@ class UseSuggestion {
                 if (this.composer.store.self.type !== "partner") {
                     return; // guests cannot access fetch suggestion method
                 }
-                this.sequential(async () => {
-                    if (
-                        this.search.delimiter !== delimiter ||
-                        this.search.position !== position ||
-                        this.search.term !== term
-                    ) {
-                        return; // ignore obsolete call
-                    }
-                    if (
-                        this.lastFetchedSearch?.count === 0 &&
-                        (!this.search.delimiter || this.isSearchMoreSpecificThanLastFetch)
-                    ) {
-                        return; // no need to fetch since this is more specific than last and last had no result
-                    }
-                    this.state.isFetching = true;
-                    try {
-                        await this.suggestionService.fetchSuggestions(this.search, {
-                            thread: this.thread,
-                        });
-                    } catch {
-                        this.lastFetchedSearch = null;
-                    } finally {
-                        this.state.isFetching = false;
-                    }
-                    if (status(comp) === "destroyed") {
-                        return;
-                    }
-                    this.update();
-                    this.lastFetchedSearch = {
-                        ...this.search,
-                        count: this.state.items?.suggestions.length ?? 0,
-                    };
-                    if (
-                        this.search.delimiter === delimiter &&
-                        this.search.position === position &&
-                        this.search.term === term &&
-                        !this.state.items?.suggestions.length
-                    ) {
-                        this.clearSearch();
-                    }
-                });
+                if (
+                    this.lastFetchedSearch?.count === 0 &&
+                    (!this.search.delimiter || this.isSearchMoreSpecificThanLastFetch)
+                ) {
+                    return; // no need to fetch since this is more specific than last and last had no result
+                }
+                this.fetchSuggestions();
             },
-            () => {
-                return [this.search.delimiter, this.search.position, this.search.term];
-            }
+            () => [this.search.delimiter, this.search.position, this.search.term]
         );
         useEffect(
             () => {
@@ -73,7 +38,6 @@ class UseSuggestion {
     get composer() {
         return this.comp.props.composer;
     }
-    sequential = useSequential();
     suggestionService = useService("mail.suggestion");
     state = useState({
         count: 0,
@@ -215,6 +179,40 @@ class UseSuggestion {
         const limit = 8;
         suggestions.length = Math.min(suggestions.length, limit);
         this.state.items = { type, suggestions };
+    }
+
+    async fetchSuggestions() {
+        let resetFetchingState = true;
+        try {
+            this.abortController?.abort();
+            this.abortController = new AbortController();
+            this.state.isFetching = true;
+            await this.suggestionService.fetchSuggestions(this.search, {
+                thread: this.thread,
+                abortSignal: this.abortController.signal,
+            });
+        } catch (e) {
+            if (e instanceof ConnectionAbortedError) {
+                resetFetchingState = false;
+                return;
+            }
+            this.lastFetchedSearch = null;
+        } finally {
+            if (resetFetchingState) {
+                this.state.isFetching = false;
+            }
+        }
+        if (status(this.comp) === "destroyed") {
+            return;
+        }
+        this.update();
+        this.lastFetchedSearch = {
+            ...this.search,
+            count: this.state.items?.suggestions.length ?? 0,
+        };
+        if (!this.state.items?.suggestions.length) {
+            this.clearSearch();
+        }
     }
 }
 

--- a/addons/project/static/src/project_sharing/chatter/suggestion_service_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/suggestion_service_patch.js
@@ -3,13 +3,14 @@ import { SuggestionService } from "@mail/core/common/suggestion_service";
 import { patch } from "@web/core/utils/patch";
 
 patch(SuggestionService.prototype, {
-    async fetchPartners(term, thread) {
+    async fetchPartners(term, thread, { abortSignal } = {}) {
         if (thread.model === "project.task") {
-            const suggestedPartners = await this.orm.silent.call(
+            const suggestedPartners = await this.makeOrmCall(
                 "project.task",
                 "get_mention_suggestions",
                 [thread.id],
-                { search: term }
+                { search: term },
+                { abortSignal }
             );
             this.store.insert(suggestedPartners);
             const suggestedPartnersIds = suggestedPartners["res.partner"].map(


### PR DESCRIPTION
Before this commit, suggestions were fetched sequentially, meaning that adding characters to the search would only take effect after the current RPC call finished. The intent was to provide initial results quickly, as the previous RPC had already started.

However, the first suggestion fetch is often based on very few characters, which can take a long time to process. This creates the impression that no item matches the search terms.

With more characters, the search becomes much faster. This commit adapts the behavior to cancel the previous fetch instead of waiting for it to finish. It also debounces the fetch to ensure it starts with as many characters as possible.
