### PR TITLE
[FIX] hw_posbox_homepage: mistyped indentifier resulting in duplicated foreach key

### DIFF
--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -147,7 +147,7 @@ class IotBoxOwlHomePage(http.Controller):
             'name': device.device_name,
             'value': str(device.data['value']),
             'type': device.device_type,
-            'identifer': device.device_identifier
+            'identifier': device.device_identifier
         } for device in iot_devices.values()]
         device_type_key = lambda device: device['type']
         grouped_devices = {


### PR DESCRIPTION
OWL dev mode adds foreach key unicity check. An error in the name 'identifier' was leading to duplicate keys (`undefined`) in dev mode.
