### PR TITLE
[FIX] web: DateTimePicker tests in en-non-US environments

### DIFF
--- a/addons/web/static/tests/core/components/datetime/datetime_picker.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_picker.test.js
@@ -2,9 +2,9 @@ import { beforeEach, expect, test } from "@odoo/hoot";
 import { click, queryAllTexts, resize, select } from "@odoo/hoot-dom";
 import { animationFrame, mockDate } from "@odoo/hoot-mock";
 import { Component, useState, xml } from "@odoo/owl";
-import { defineParams, mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { DateTimePicker } from "@web/core/datetime/datetime_picker";
 import { ensureArray } from "@web/core/utils/arrays";
+import { defineParams, mountWithCleanup, makeMockEnv, serverState } from "@web/../tests/web_test_helpers";
 import { assertDateTimePicker, getPickerCell } from "../../datetime/datetime_test_helpers";
 
 const { DateTime } = luxon;
@@ -70,6 +70,10 @@ test("default params", async () => {
 });
 
 test("minDate: correct days/month/year/decades are disabled", async () => {
+    serverState.lang = "en-US";
+    // necessary to configure the lang before minDate/maxDate are created
+    await makeMockEnv();
+
     await mountWithCleanup(DateTimePicker, {
         props: {
             minDate: DateTime.fromISO("2023-04-20T00:00:00.000"),
@@ -305,6 +309,10 @@ test("maxDate: correct days/month/year/decades are disabled", async () => {
 });
 
 test("min+max date: correct days/month/year/decades are disabled", async () => {
+    serverState.lang = "en-US";
+    // necessary to configure the lang before minDate/maxDate are created
+    await makeMockEnv();
+
     await mountWithCleanup(DateTimePicker, {
         props: {
             minDate: DateTime.fromISO("2023-04-20T00:00:00.000"),


### PR DESCRIPTION
If the `en` locale of the system is aliased to something other than en-US, some of the months may be formatted differently than expected, leading to a test failure (for instance `en-GB` formats september as `"Sept"` rather than `"Sep"` on at least some systems).

Fix by forcing the locale to `en-US` specificially. This requires an explicit `makeMockEnv` to take effect because the `*Date` props carry the locale from the time of their creation so although `mountWithCleanup` will `makeMockEnv` internally by the time that runs `minDate` and `maxDate` will already have been created with the original and possibly incompatible locale.
