### PR TITLE
[IMP] web: remove display_switch_company_menu from session_info

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -170,7 +170,6 @@ class IrHttp(models.AbstractModel):
                     },
                 },
                 "show_effect": True,
-                "display_switch_company_menu": user.has_group('base.group_multi_company') and len(user_company_ids) > 1,
             })
         return session_info
 

--- a/addons/web/static/src/views/form/form_label.js
+++ b/addons/web/static/src/views/form/form_label.js
@@ -1,8 +1,8 @@
 import { fieldVisualFeedback } from "@web/views/fields/field";
-import { session } from "@web/session";
 import { getTooltipInfo } from "@web/views/fields/field_tooltip";
 import { _t } from "@web/core/l10n/translation";
 import { Component } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
 
 export class FormLabel extends Component {
     static template = "web.FormLabel";
@@ -16,6 +16,9 @@ export class FormLabel extends Component {
         notMuttedLabel: { type: Boolean, optional: true },
     };
 
+    setup() {
+        this.company = useService("company");
+    }
     get className() {
         const { invalid, empty, readonly } = fieldVisualFeedback(
             this.props.fieldInfo.field,
@@ -43,7 +46,7 @@ export class FormLabel extends Component {
     get tooltipHelp() {
         const field = this.props.record.fields[this.props.fieldName];
         let help = this.props.fieldInfo.help || field.help || "";
-        if (field.company_dependent && session.display_switch_company_menu) {
+        if (field.company_dependent && this.company.isMultiCompany) {
             help += (help ? "\n\n" : "") + _t("Values set here are company-specific.");
         }
         return help;

--- a/addons/web/static/src/views/form/setting/setting.js
+++ b/addons/web/static/src/views/form/setting/setting.js
@@ -1,7 +1,7 @@
-import { session } from "@web/session";
 import { Component } from "@odoo/owl";
 import { FormLabel } from "../form_label";
 import { DocumentationLink } from "@web/views/widgets/documentation_link/documentation_link";
+import { useService } from "@web/core/utils/hooks";
 
 export class Setting extends Component {
     static template = "web.Setting";
@@ -26,6 +26,7 @@ export class Setting extends Component {
     };
 
     setup() {
+        this.company = useService("company");
         if (this.props.fieldName) {
             this.fieldType = this.props.record.fields[this.props.fieldName].type;
             if (this.props.fieldInfo.readonly === "True") {
@@ -47,9 +48,7 @@ export class Setting extends Component {
     }
 
     get displayCompanyDependentIcon() {
-        return (
-            this.labelString && this.props.companyDependent && session.display_switch_company_menu
-        );
+        return this.labelString && this.props.companyDependent && this.company.isMultiCompany;
     }
 
     get labelString() {

--- a/addons/web/static/src/webclient/company_service.js
+++ b/addons/web/static/src/webclient/company_service.js
@@ -90,6 +90,10 @@ export const companyService = {
                 return allowedCompanies[activeCompanyIds[0]];
             },
 
+            get isMultiCompany() {
+                return Object.values(allowedCompanies).length > 1;
+            },
+
             getCompany(companyId) {
                 return allowedCompaniesWithAncestors[companyId];
             },

--- a/addons/web/static/tests/_framework/mock_session.hoot.js
+++ b/addons/web/static/tests/_framework/mock_session.hoot.js
@@ -32,7 +32,6 @@ const makeSession = ({
     },
     can_insert_in_spreadsheet: true,
     db,
-    display_switch_company_menu: false,
     home_action_id: false,
     is_admin: true,
     is_internal_user: true,

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -58,7 +58,6 @@ import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { SIZES } from "@web/core/ui/ui_service";
 import { useBus, useService } from "@web/core/utils/hooks";
-import { session } from "@web/session";
 import { CharField } from "@web/views/fields/char/char_field";
 import { DateTimeField } from "@web/views/fields/datetime/datetime_field";
 import { Field } from "@web/views/fields/field";
@@ -10384,7 +10383,11 @@ test(`company_dependent field in form view, in multi company group`, async () =>
         help: "this is a tooltip",
     });
 
-    patchWithCleanup(session, { display_switch_company_menu: true });
+    serverState.companies = [
+        { id: 1, name: "Company 1", sequence: 1, parent_id: false, child_ids: [] },
+        { id: 2, name: "Company 2", sequence: 2, parent_id: false, child_ids: [] },
+        { id: 3, name: "Company 3", sequence: 3, parent_id: false, child_ids: [] },
+    ];
     await mountView({
         resModel: "partner",
         type: "form",
@@ -10417,7 +10420,10 @@ test(`company_dependent field in form view, not in multi company group`, async (
         help: "this is a tooltip",
     });
 
-    patchWithCleanup(session, { display_switch_company_menu: false });
+    serverState.companies = [
+        { id: 1, name: "Company 1", sequence: 1, parent_id: false, child_ids: [] },
+    ];
+
     await mountView({
         resModel: "partner",
         type: "form",
@@ -11200,9 +11206,11 @@ test(`setting : boolean field`, async () => {
 });
 
 test(`setting : char field`, async () => {
-    patchWithCleanup(session, {
-        display_switch_company_menu: true,
-    });
+    serverState.companies = [
+        { id: 1, name: "Company 1", sequence: 1, parent_id: false, child_ids: [] },
+        { id: 2, name: "Company 2", sequence: 2, parent_id: false, child_ids: [] },
+        { id: 3, name: "Company 3", sequence: 3, parent_id: false, child_ids: [] },
+    ];
 
     await mountView({
         resModel: "partner",


### PR DESCRIPTION
This commit removes the display_switch_company_menu from the session, and uses the company service. Note that, the company service already has the information about the allowed companies.

part-of task-id 2224776
