### PR TITLE
[FIX] web: MultiRecordSelector should pass domain to SelectCreateDialog

### DIFF
--- a/addons/web/static/src/core/record_selectors/record_autocomplete.js
+++ b/addons/web/static/src/core/record_selectors/record_autocomplete.js
@@ -94,6 +94,7 @@ export class RecordAutocomplete extends Component {
         this.addDialog(SelectCreateDialog, {
             title: _t("Search: %s", fieldString),
             dynamicFilters,
+            domain: this.getDomain(),
             resModel,
             noCreate: true,
             multiSelect,


### PR DESCRIPTION
When using MultiRecordSelector with domain, the domain will not automatically apply to SelectCreateDialog.

See odoo/enterprise#68484

closes odoo/odoo#176850

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
