### PR TITLE
[FIX] sale,website_sale: fix configurable products in combo configurator

### DIFF
--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -60,7 +60,7 @@ export class ComboConfiguratorDialog extends Component {
         // Use up-to-date selected PTAVs and custom values to populate the product configurator.
         comboItem = this.getSelectedOrProvidedComboItem(comboId, comboItem);
         let product = comboItem.product;
-        if (product.hasNoVariantPtals) {
+        if (comboItem.is_configurable) {
             this.dialog.add(ProductConfiguratorDialog, {
                 productTemplateId: product.product_tmpl_id,
                 ptavIds: product.selectedPtavIds,
@@ -165,7 +165,7 @@ export class ComboConfiguratorDialog extends Component {
      */
     _initSelectedComboItems() {
         for (const combo of this.props.combos) {
-            const comboItem = combo.selectedComboItem ?? combo.preselectedComboItem;
+            const comboItem = combo.selectedComboItem;
             if (comboItem) {
                 this.state.selectedComboItems.set(combo.id, comboItem.deepCopy());
             }

--- a/addons/sale/static/src/js/models/product_combo.js
+++ b/addons/sale/static/src/js/models/product_combo.js
@@ -20,13 +20,4 @@ export class ProductCombo {
     get selectedComboItem() {
         return this.combo_items.find(item => item.is_selected);
     }
-
-    /**
-     * Return the preselected combo item, if any.
-     *
-     * @return {ProductComboItem|undefined} The preselected combo item, if any.
-     */
-    get preselectedComboItem() {
-        return this.combo_items.find(item => item.is_preselected);
-    }
 }

--- a/addons/sale/static/src/js/models/product_combo_item.js
+++ b/addons/sale/static/src/js/models/product_combo_item.js
@@ -5,14 +5,14 @@ export class ProductComboItem {
      * @param {number} id
      * @param {number} extra_price
      * @param {boolean} is_selected
-     * @param {boolean} is_preselected
+     * @param {boolean} is_configurable
      * @param {ProductProduct|object} product
      */
-    constructor({id, extra_price, is_selected, is_preselected, product}) {
+    constructor({id, extra_price, is_selected, is_configurable, product}) {
         this.id = id;
         this.extra_price = extra_price;
         this.is_selected = is_selected;
-        this.is_preselected = is_preselected;
+        this.is_configurable = is_configurable;
         this.product = new ProductProduct(product);
     }
 

--- a/addons/sale/static/src/js/models/product_product.js
+++ b/addons/sale/static/src/js/models/product_product.js
@@ -31,15 +31,6 @@ export class ProductProduct {
     }
 
     /**
-     * Check whether this product has `no_variant` PTALs.
-     *
-     * @return {Boolean} Whether this product has `no_variant` PTALs.
-     */
-    get hasNoVariantPtals() {
-        return this.noVariantPtals.length > 0;
-    }
-
-    /**
      * Return the extra price of the selected `no_variant` PTAVs.
      *
      * @return {Number} The extra price of the selected `no_variant` PTAVs.

--- a/addons/sale/static/src/js/product/product.js
+++ b/addons/sale/static/src/js/product/product.js
@@ -6,6 +6,7 @@ import {
     ProductTemplateAttributeLine as PTAL
 } from "../product_template_attribute_line/product_template_attribute_line";
 import { QuantityButtons } from '../quantity_buttons/quantity_buttons';
+import { getSelectedCustomPtav } from "../sale_utils";
 
 export class Product extends Component {
     static components = { PTAL, QuantityButtons };
@@ -67,6 +68,8 @@ export class Product extends Component {
      * @return {Boolean} Whether the PTAL should be shown.
      */
     shouldShowPtal(ptal) {
-        return this.env.canChangeVariant || ptal.create_variant === 'no_variant' ;
+        return this.env.canChangeVariant
+            || ptal.create_variant === 'no_variant'
+            || !!getSelectedCustomPtav(ptal);
     }
 }

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.js
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.js
@@ -2,6 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import { Component } from "@odoo/owl";
 import { formatCurrency } from "@web/core/currency";
 import { BadgeExtraPrice } from "../badge_extra_price/badge_extra_price";
+import { getSelectedCustomPtav } from "../sale_utils";
 
 export class ProductTemplateAttributeLine extends Component {
     static components = { BadgeExtraPrice };
@@ -126,14 +127,13 @@ export class ProductTemplateAttributeLine extends Component {
      * @return {Boolean} - Whether the selected ptav is custom or not.
      */
     isSelectedPTAVCustom() {
-        return this.props.attribute_values.find(
-            ptav => this.props.selected_attribute_value_ids.includes(ptav.id)
-        )?.is_custom;
+        return !!getSelectedCustomPtav(this.props);
     }
 
     get showValuesChoice() {
-        return this.props.attribute_values.length > 1
-            || this.props.attribute.display_type == 'multi'
+        return (this.env.canChangeVariant || this.props.create_variant === 'no_variant') && (
+            this.props.attribute_values.length > 1 || this.props.attribute.display_type === 'multi'
+        )
     }
 
     get customValuePlaceholder() {

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
@@ -9,8 +9,7 @@
              template are rendered. -->
             <div class="d-flex flex-column flex-lg-row gap-2 mb-2">
                 <label
-                    t-if="showValuesChoice || (
-                        this.props.attribute_values.length === 1 &amp;&amp; isSelectedPTAVCustom())"
+                    t-if="showValuesChoice || isSelectedPTAVCustom()"
                     t-out="this.props.attribute.name"
                     t-attf-class="fw-bold text-break #{this.props.attribute_values.length === 1
                         &amp;&amp; hasPTAVCustom() ? '' : 'col-lg-3'}"/>

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -16,7 +16,7 @@ import { ProductConfiguratorDialog } from "./product_configurator_dialog/product
 import { uuid } from "@web/views/utils";
 import { ComboConfiguratorDialog } from "./combo_configurator_dialog/combo_configurator_dialog";
 import { ProductCombo } from "./models/product_combo";
-import { getLinkedSaleOrderLines, serializeComboItem } from "./sale_utils";
+import { getLinkedSaleOrderLines, serializeComboItem, getSelectedCustomPtav } from "./sale_utils";
 
 async function applyProduct(record, product) {
     // handle custom values & no variants
@@ -24,9 +24,7 @@ async function applyProduct(record, product) {
         x2ManyCommands.set([]),  // Command.clear isn't supported in static_list/_applyCommands
     ];
     for (const ptal of product.attribute_lines) {
-        const selectedCustomPTAV = ptal.attribute_values.find(
-            ptav => ptav.is_custom && ptal.selected_attribute_value_ids.includes(ptav.id)
-        );
+        const selectedCustomPTAV = getSelectedCustomPtav(ptal);
         if (selectedCustomPTAV) {
             customAttributesCommands.push(
                 x2ManyCommands.create(undefined, {

--- a/addons/sale/static/src/js/sale_utils.js
+++ b/addons/sale/static/src/js/sale_utils.js
@@ -48,3 +48,18 @@ export function serializeComboItem(comboItem) {
         ),
     }
 }
+
+/**
+ * Get the selected custom PTAV in the provided PTAL, if any.
+ *
+ * Note: a PTAL can have at most one selected custom PTAV, by design.
+ *
+ * @param {ProductTemplateAttributeLine.props} ptal The PTAL in which to look for the selected
+ *     custom PTAV.
+ * @return {Object|undefined} The selected custom PTAV, if any.
+ *
+ */
+export function getSelectedCustomPtav(ptal) {
+    const selectedPtavIds = new Set(ptal.selected_attribute_value_ids);
+    return ptal.attribute_values.find(ptav => ptav.is_custom && selectedPtavIds.has(ptav.id));
+}

--- a/addons/sale/static/src/js/tours/combo_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/combo_configurator_tour_utils.js
@@ -19,7 +19,7 @@ function comboItemSelector(comboItemName, extraClasses=[]) {
 function assertComboCount(count) {
     return {
         content: `Assert that there are ${count} combos`,
-        trigger:'.sale-combo-configurator-dialog',
+        trigger: '.sale-combo-configurator-dialog',
         run: () => queryAll(
             '.sale-combo-configurator-dialog [name="sale_combo_configurator_title"]'
         ).length === count,
@@ -31,7 +31,17 @@ function assertComboItemCount(comboName, count) {
         content: `Assert that there are ${count} combo items in combo ${comboName}`,
         trigger: comboSelector(comboName),
         run: () => queryAll(
-            `${comboSelector(comboName)} .combo-item-grid .product-card`
+            `${comboSelector(comboName)} + .combo-item-grid .product-card`
+        ).length === count,
+    };
+}
+
+function assertSelectedComboItemCount(count) {
+    return {
+        content: `Assert that there are ${count} selected combo items`,
+        trigger: '.sale-combo-configurator-dialog',
+        run: () => queryAll(
+            `.sale-combo-configurator-dialog .combo-item-grid .product-card.selected`
         ).length === count,
     };
 }
@@ -147,7 +157,7 @@ function saveConfigurator() {
             run: 'click',
         }, {
             content: "Wait until the modal is closed",
-            trigger: 'body:not(:has(.modal))',
+            trigger: 'body:not(:has(.sale-combo-configurator-dialog))',
         },
     ];
 }
@@ -157,6 +167,7 @@ export default {
     comboItemSelector,
     assertComboCount,
     assertComboItemCount,
+    assertSelectedComboItemCount,
     selectComboItem,
     assertComboItemSelected,
     increaseQuantity,

--- a/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
@@ -199,18 +199,18 @@ function assertProductNameContains(productName) {
 function assertFooterButtonsDisabled() {
     return {
         content: "Assert that the footer buttons are disabled",
-        trigger: 'footer.modal-footer button:disabled',
+        trigger: '.o_sale_product_configurator_dialog footer.modal-footer button:disabled',
     };
 }
 
 function saveConfigurator() {
     return [
         {
-            trigger: '.modal button:contains(Confirm)',
+            trigger: '.o_sale_product_configurator_dialog button:contains(Confirm)',
             run: 'click',
         }, {
             content: "Wait until the modal is closed",
-            trigger: 'body:not(:has(.modal))',
+            trigger: 'body:not(:has(.o_sale_product_configurator_dialog))',
         }
     ];
 }

--- a/addons/sale/static/tests/tours/sale_combo_configurator.js
+++ b/addons/sale/static/tests/tours/sale_combo_configurator.js
@@ -35,15 +35,11 @@ registry
             comboConfiguratorTourUtils.selectComboItem("Product A2"),
             comboConfiguratorTourUtils.selectComboItem("Product B2"),
             comboConfiguratorTourUtils.assertConfirmButtonEnabled(),
-            // Assert that the product configurator is opened when a product with `no_variant` PTALs
-            // is selected.
+            // Assert that the product configurator is opened when a product with configurable
+            // `no_variant` PTALs is selected.
             comboConfiguratorTourUtils.selectComboItem("Product A1"),
             productConfiguratorTourUtils.selectAttribute("Product A1", "No variant attribute", "A"),
-            {
-                content: "Confirm the product configurator",
-                trigger: 'button[name="sale_product_configurator_confirm_button"]',
-                run: 'click',
-            },
+            ...productConfiguratorTourUtils.saveConfigurator(),
             // Assert that the extra price of a combo item is applied correctly.
             comboConfiguratorTourUtils.assertPrice('90.00'),
             // Assert that the extra price of a `no_variant` PTAV is applied correctly.
@@ -51,11 +47,7 @@ registry
             ...productConfiguratorTourUtils.selectAndSetCustomAttribute(
                 "Product A1", "No variant attribute", "B", "Some custom value"
             ),
-            {
-                content: "Confirm the product configurator",
-                trigger: 'button[name="sale_product_configurator_confirm_button"]',
-                run: 'click',
-            },
+            ...productConfiguratorTourUtils.saveConfigurator(),
             comboConfiguratorTourUtils.assertPrice('93.00'),
             // Assert that the order's content is correct.
             ...comboConfiguratorTourUtils.saveConfigurator(),

--- a/addons/sale/static/tests/tours/sale_combo_configurator_preconfigure_unconfigurable_ptals.js
+++ b/addons/sale/static/tests/tours/sale_combo_configurator_preconfigure_unconfigurable_ptals.js
@@ -1,0 +1,37 @@
+import { registry } from '@web/core/registry';
+import { stepUtils } from '@web_tour/tour_service/tour_utils';
+import comboConfiguratorTourUtils from '@sale/js/tours/combo_configurator_tour_utils';
+import productConfiguratorTourUtils from '@sale/js/tours/product_configurator_tour_utils';
+import tourUtils from '@sale/js/tours/tour_utils';
+
+registry
+    .category('web_tour.tours')
+    .add('sale_combo_configurator_preconfigure_unconfigurable_ptals', {
+        url: '/odoo',
+        steps: () => [
+            ...stepUtils.goToAppSteps('sale.sale_menu_root', "Open the sales app"),
+            ...tourUtils.createNewSalesOrder(),
+            ...tourUtils.selectCustomer("Test Partner"),
+            ...tourUtils.addProduct("Combo product"),
+            {
+                content: "Verify that unconfigurable ptals are preconfigured",
+                trigger: `${comboConfiguratorTourUtils.comboItemSelector("Test product")}:contains("Attribute A: A")`,
+            },
+            {
+                content: "Verify that configurable ptals aren't preconfigured",
+                trigger: `${comboConfiguratorTourUtils.comboItemSelector("Test product")}:not(:contains("Attribute B: B"))`,
+            },
+            comboConfiguratorTourUtils.selectComboItem("Test product"),
+            productConfiguratorTourUtils.selectAttribute(
+                "Test product", "Attribute B", "B", 'multi'
+            ),
+            ...productConfiguratorTourUtils.saveConfigurator(),
+            {
+                content: "Verify that configurable ptals are now configured",
+                trigger: `${comboConfiguratorTourUtils.comboItemSelector("Test product")}:contains("Attribute B: B")`,
+            },
+            ...comboConfiguratorTourUtils.saveConfigurator(),
+            // Don't end the tour with a form in edition mode.
+            ...stepUtils.saveForm(),
+        ],
+    });

--- a/addons/sale/static/tests/tours/sale_combo_configurator_preselect_single_unconfigurable_items.js
+++ b/addons/sale/static/tests/tours/sale_combo_configurator_preselect_single_unconfigurable_items.js
@@ -1,0 +1,36 @@
+import { registry } from '@web/core/registry';
+import { stepUtils } from '@web_tour/tour_service/tour_utils';
+import comboConfiguratorTourUtils from '@sale/js/tours/combo_configurator_tour_utils';
+import productConfiguratorTourUtils from '@sale/js/tours/product_configurator_tour_utils';
+import tourUtils from '@sale/js/tours/tour_utils';
+
+registry
+    .category('web_tour.tours')
+    .add('sale_combo_configurator_preselect_single_unconfigurable_items', {
+        url: '/odoo',
+        steps: () => [
+            ...stepUtils.goToAppSteps('sale.sale_menu_root', "Open the sales app"),
+            ...tourUtils.createNewSalesOrder(),
+            ...tourUtils.selectCustomer("Test Partner"),
+            ...tourUtils.addProduct("Combo product"),
+            // Assert that only single unconfigurable items are preselected.
+            comboConfiguratorTourUtils.assertSelectedComboItemCount(2),
+            comboConfiguratorTourUtils.assertComboItemSelected("Product A"),
+            comboConfiguratorTourUtils.assertComboItemSelected("Product C"),
+            comboConfiguratorTourUtils.assertConfirmButtonDisabled(),
+            // Configure the remaining combos.
+            comboConfiguratorTourUtils.selectComboItem("Product B"),
+            productConfiguratorTourUtils.selectAttribute("Product B", "Attribute B", "B", 'multi'),
+            ...productConfiguratorTourUtils.saveConfigurator(),
+            comboConfiguratorTourUtils.selectComboItem("Product D"),
+            productConfiguratorTourUtils.setCustomAttribute(
+                "Product D", "Attribute D", "Test D"
+            ),
+            ...productConfiguratorTourUtils.saveConfigurator(),
+            comboConfiguratorTourUtils.selectComboItem("Product E1"),
+            comboConfiguratorTourUtils.assertConfirmButtonEnabled(),
+            ...comboConfiguratorTourUtils.saveConfigurator(),
+            // Don't end the tour with a form in edition mode.
+            ...stepUtils.saveForm(),
+        ],
+    });

--- a/addons/sale/tests/test_sale_combo_configurator.py
+++ b/addons/sale/tests/test_sale_combo_configurator.py
@@ -55,3 +55,118 @@ class TestSaleComboConfigurator(HttpCase, SaleCommon):
             ],
         )
         self.start_tour('/', 'sale_combo_configurator', login='salesman')
+
+    def test_sale_combo_configurator_preselect_single_unconfigurable_items(self):
+        if self.env['ir.module.module']._get('sale_management').state != 'installed':
+            self.skipTest("Sale App is not installed, Sale menu is not accessible.")
+
+        unconfigurable_no_variant_attribute = self.env['product.attribute'].create({
+            'name': "Attribute A",
+            'create_variant': 'no_variant',
+            'value_ids': [Command.create({'name': "A"})],
+        })
+        configurable_no_variant_attribute = self.env['product.attribute'].create({
+            'name': "Attribute B",
+            'create_variant': 'no_variant',
+            'display_type': 'multi',
+            'value_ids': [Command.create({'name': "B"})],
+        })
+        unconfigurable_always_attribute = self.env['product.attribute'].create({
+            'name': "Attribute C",
+            'create_variant': 'always',
+            'value_ids': [Command.create({'name': "C"})],
+        })
+        configurable_always_attribute = self.env['product.attribute'].create({
+            'name': "Attribute D",
+            'create_variant': 'always',
+            'value_ids': [Command.create({'name': "D", 'is_custom': True})],
+        })
+        unconfigurable_no_variant_combo = self._create_combo_from_attribute(
+            unconfigurable_no_variant_attribute, "Product A", "Combo A"
+        )
+        configurable_no_variant_combo = self._create_combo_from_attribute(
+            configurable_no_variant_attribute, "Product B", "Combo B"
+        )
+        unconfigurable_always_combo = self._create_combo_from_attribute(
+            unconfigurable_always_attribute, "Product C", "Combo C"
+        )
+        configurable_always_combo = self._create_combo_from_attribute(
+            configurable_always_attribute, "Product D", "Combo D"
+        )
+        combo_with_multiple_unconfigurable_items = self.env['product.combo'].create({
+            'name': "Combo E",
+            'combo_item_ids': [
+                Command.create({'product_id': self._create_product(name="Product E1").id}),
+                Command.create({'product_id': self._create_product(name="Product E2").id}),
+            ],
+        })
+        self._create_product(
+            name="Combo product",
+            type='combo',
+            combo_ids=[
+                Command.link(unconfigurable_no_variant_combo.id),
+                Command.link(configurable_no_variant_combo.id),
+                Command.link(unconfigurable_always_combo.id),
+                Command.link(configurable_always_combo.id),
+                Command.link(combo_with_multiple_unconfigurable_items.id),
+            ],
+        )
+        self.start_tour(
+            '/', 'sale_combo_configurator_preselect_single_unconfigurable_items', login='salesman'
+        )
+
+    def test_sale_combo_configurator_preconfigure_unconfigurable_ptals(self):
+        if self.env['ir.module.module']._get('sale_management').state != 'installed':
+            self.skipTest("Sale App is not installed, Sale menu is not accessible.")
+
+        unconfigurable_no_variant_attribute = self.env['product.attribute'].create({
+            'name': "Attribute A",
+            'create_variant': 'no_variant',
+            'value_ids': [Command.create({'name': "A"})],
+        })
+        configurable_no_variant_attribute = self.env['product.attribute'].create({
+            'name': "Attribute B",
+            'create_variant': 'no_variant',
+            'display_type': 'multi',
+            'value_ids': [Command.create({'name': "B"})],
+        })
+        product = self.env['product.template'].create({
+            'name': "Test product",
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': unconfigurable_no_variant_attribute.id,
+                    'value_ids': [Command.set(unconfigurable_no_variant_attribute.value_ids.ids)],
+                }),
+                Command.create({
+                    'attribute_id': configurable_no_variant_attribute.id,
+                    'value_ids': [Command.set(configurable_no_variant_attribute.value_ids.ids)],
+                }),
+            ],
+        })
+        combo = self.env['product.combo'].create({
+            'name': "Test combo",
+            'combo_item_ids': [Command.create({'product_id': product.product_variant_id.id})],
+        })
+        self._create_product(
+            name="Combo product",
+            type='combo',
+            combo_ids=[Command.link(combo.id)],
+        )
+        self.start_tour(
+            '/', 'sale_combo_configurator_preconfigure_unconfigurable_ptals', login='salesman'
+        )
+
+    def _create_combo_from_attribute(self, attribute, product_name, combo_name):
+        product = self.env['product.template'].create({
+            'name': product_name,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': attribute.id,
+                    'value_ids': [Command.set(attribute.value_ids.ids)],
+                }),
+            ],
+        })
+        return self.env['product.combo'].create({
+            'name': combo_name,
+            'combo_item_ids': [Command.create({'product_id': product.product_variant_id.id})],
+        })

--- a/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
+++ b/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
@@ -17,11 +17,7 @@ registry
             ...productConfiguratorTourUtils.selectAndSetCustomAttribute(
                 "Product A1", "No variant attribute", "B", "Some custom value"
             ),
-            {
-                content: "Confirm the product configurator",
-                trigger: 'button[name="sale_product_configurator_confirm_button"]',
-                run: 'click',
-            },
+            ...productConfiguratorTourUtils.saveConfigurator(),
             comboConfiguratorTourUtils.selectComboItem("Product B2"),
             comboConfiguratorTourUtils.assertFooterButtonsEnabled(),
             // Assert that the cart's content is correct.


### PR DESCRIPTION
The combo configurator works with `product.product` records, so previously, we
only allowed to configure `no_variant` PTALs. However, we should also allow to
configure the `product.product`'s custom PTAVs (which can be `always` or
`dynamic`).

Moreover, we always allowed to configure `no_variant` PTALs, even if they
weren't configurable (i.e. PTALs with a single, non-custom, non-multicheckbox
PTAV). However, such PTAVs should be preselected and non-configurable in the
combo configurator.