### PR TITLE
[FIX] website_sale_loyalty: prevent reload cycle on multi tax discounts

### DIFF
--- a/addons/website_sale_loyalty/controllers/delivery.py
+++ b/addons/website_sale_loyalty/controllers/delivery.py
@@ -24,8 +24,8 @@ class WebsiteSaleLoyaltyDelivery(Delivery):
                 shipping_discount, order.currency_id
             )
         res['discount_reward_amounts'] = [
-            to_html(line.price_subtotal)
-            for line in order.order_line
-            if line.reward_id.reward_type == 'discount'
+            to_html(sum(lines.mapped('price_subtotal')))
+            for reward, lines in order.order_line.grouped('reward_id').items()
+            if reward.reward_type == 'discount'
         ]
         return res


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Create a deliverable product with sales tax;
2. create another product without sales tax;
3. publish both to eCommerce;
4. create a discount program;
5. add both products to shopping cart;
6. apply discount;
7. go to delivery selection step.

Issue
-----
Endless browser reload cycle.

Cause
-----
The reload is supposed to sync the discount lines in the back-end with the discount lines displayed during checkout. If the number of lines don't match, a reload is triggered.

The issue is that on the back-end, discounts are counted per line, while in eCommerce, the discounts are displayed per reward. This difference matters when a discount is applied on products with different sales taxes, creating a separate discount line for every sales tax.

Solution
--------
When iterating over discount lines in the controller, group them per `reward_id`, and sum up their subtotals.

opw-4343959