### PR TITLE
[FIX] web: fix FormView's labels spacing

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -47,7 +47,7 @@
         .o_cell:has(+ :is(.o_wrap_label, .o_wrap_field_boolean)),
         .o_wrap_field_boolean,
         .o_cell:first-child:last-child {
-            margin-bottom: map-get($spacers, 3);
+            margin-bottom: map-get($spacers, 4);
         }
     }
 }
@@ -462,7 +462,7 @@
 
     .o_inner_group {
         --columns: 1;
-        gap: map-get($spacers, 2) $o-horizontal-padding;
+        gap: 0 $o-horizontal-padding;
         margin-bottom: map-get($spacers, 2);
 
         span, .o_field_boolean, .oe_avatar, .o_form_uri {
@@ -969,7 +969,7 @@
             margin-top: 0;
 
             .o_inner_group {
-                margin-bottom: 0 !important;
+                margin-bottom: map-get($spacers, 4 ) !important;
 
                 div[name="carrier_selection"] {
                     > div:not(.alert) {


### PR DESCRIPTION
This PR aims to fix an issue about the spacing of our labels within the FormView being visually centered between their related input and the next one.

| Master | This PR |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/01297197-cc6e-4478-8183-19f262e64669) | ![image](https://github.com/user-attachments/assets/eea9ddf2-798a-4f58-864f-b460ba226cdb) | 

Before Commit[^1], the labels within our FormView were directly following the input. We used a `div.o_wrap_field` as a container form the input and label, and this `<div>` was receiving the gap from the grid.

After Commit[^1], since this div doesn't exist anymore, the grid gap affects every elements, meaning we have no way to control the spacing for the labels only.

To do so, we remove the grid gap, and rely on the bottom margin that was already there. We increase its value to `24px`, which replicates the old implementation `mb-3` + `gap-2`

task-4419604

[^1]: https://github.com/odoo/odoo/pull/187996/commits/ed4afaa8b6694914f2a344816834e54504e46b64


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
