### PR TITLE
[FIX] l10n_in_ewaybill: hide create button in case of entry

### DIFF
--- a/addons/l10n_in_ewaybill/views/account_move_views.xml
+++ b/addons/l10n_in_ewaybill/views/account_move_views.xml
@@ -10,7 +10,7 @@
                         string="Create e-Waybill"
                         class="oe_highlight"
                         type="object"
-                        invisible="country_code != 'IN' or state != 'posted' or l10n_in_ewaybill_ids"
+                        invisible="country_code != 'IN' or state != 'posted' or l10n_in_ewaybill_ids or move_type == 'entry'"
                         groups="account.group_account_invoice"
                         data-hotkey="e"/>
             </xpath>
@@ -19,7 +19,7 @@
                         class="oe_stat_button"
                         icon="fa-truck"
                         type="object"
-                        invisible="country_code != 'IN' or not l10n_in_ewaybill_ids"
+                        invisible="country_code != 'IN' or not l10n_in_ewaybill_ids or move_type == 'entry'"
                         groups="account.group_account_invoice">
                         <div class="o_stat_info">
                             <span class="o_stat_text">e-Waybill</span>


### PR DESCRIPTION
Before this commit:
Whenever user posted a journal entry,
`Create E-waybill` button is visible but practically it's not possible to have E-waybill for a journal entry

In this commit:
We hide the E-waybill button whenever a move
type is an entry


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
