### PR TITLE
[FIX] website_sale: hide delivery row only on the /cart

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1658,6 +1658,7 @@
         <t t-call="website_sale.checkout_layout">
             <t t-set="show_shorter_cart_summary" t-value="True"/>
             <t t-set="show_footer" t-value="True"/>
+            <t t-set="hide_delivery_row" t-value="not website_sale_order.carrier_id"/>
             <t t-set="oe_structure">
                 <!-- This is the drag-and-drop area for website building blocs at the end of each
                      checkout page. This is append at the of the page in `checkout_layout`. The
@@ -2478,7 +2479,7 @@
         <div id="cart_total" t-if="website_sale_order and website_sale_order.website_order_line" t-att-class="_cart_total_classes">
             <table class="table mb-0">
                 <tr
-                    t-if="website_sale_order._has_deliverable_products() and website_sale_order.carrier_id"
+                    t-if="not hide_delivery_row and website_sale_order._has_deliverable_products()"
                     id="order_delivery"
                 >
                     <td


### PR DESCRIPTION
The fix da95d25 introduced an issue in /checkout. Steps to reproduce:
1) Activate 2 delivery methods: one which fails and not available in /checkout and a valid one
2) Make sure the failed one comes first
3) Add a storable product to the cart, go to checkout
4) Observe that the delivery method is not chosen and delivery row in cart summary is not present
5) Select the available delivery method and observe the traceback

Reason: Cart summary fails to update delivery row. After this PR: we will hide a delivery row only for the /cart page and show it for the others.

opw-4397672

