### PR TITLE
[FIX] web_editor: remove listeners on destroy

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5977,6 +5977,11 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
         this._deactivateLinkTool = this._deactivateLinkTool.bind(this);
     },
 
+    destroy: function () {
+        this._clearListeners();
+        return this._super(...arguments);
+    },
+
     /**
      * @override
      */
@@ -5991,8 +5996,7 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
      * @override
      */
     onBlur() {
-        this.options.wysiwyg.odooEditor.removeEventListener('activate_image_link_tool', this._activateLinkTool);
-        this.options.wysiwyg.odooEditor.removeEventListener('deactivate_image_link_tool', this._deactivateLinkTool);
+        this._clearListeners();
     },
 
     //--------------------------------------------------------------------------
@@ -6097,6 +6101,13 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
         } else {
             this._requestUserValueWidgets('media_link_opt')[0].enable();
         }
+    },
+    /**
+     * @private
+     */
+    _clearListeners() {
+        this.options.wysiwyg.odooEditor.removeEventListener('activate_image_link_tool', this._activateLinkTool);
+        this.options.wysiwyg.odooEditor.removeEventListener('deactivate_image_link_tool', this._deactivateLinkTool);
     },
     /**
      * @private


### PR DESCRIPTION
**Problem**:
When destroying a snippet, listeners are not cleared. As a result, when focusing on a new instance of `ReplaceMedia`, the previous listeners remain active with stale context (old `$target`), which no longer has a parent since it was removed during the `img` change.

**Solution**:
Clear listeners during the `destroy` process.

**Steps to reproduce**:
1. Open the website.
2. Add items.
3. Change an image.
4. Unlink that image.
5. Observe a traceback.

opw-4412300

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
