### PR TITLE
[FIX] point_of_sale: keep product serial number in refund order

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -288,7 +288,10 @@ export class TicketScreen extends Component {
                 discount: refundLine.discount,
                 tax_ids: refundLine.tax_ids.map((tax) => ["link", tax]),
                 refunded_orderline_id: refundLine,
-                pack_lot_ids: refundLine.pack_lot_ids.map((packLot) => ["link", packLot]),
+                pack_lot_ids: refundLine.pack_lot_ids.map((packLot) => [
+                    "create",
+                    { lot_name: packLot.lot_name },
+                ]),
                 price_type: "automatic",
             });
             lines.push(line);

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1050,7 +1050,9 @@ export class PosStore extends Reactive {
 
                 if (refundedOrderLine) {
                     const order = refundedOrderLine.order_id;
-                    delete order.uiState.lineToRefund[refundedOrderLine.uuid];
+                    if (order) {
+                        delete order.uiState.lineToRefund[refundedOrderLine.uuid];
+                    }
                     refundedOrderLine.refunded_qty += Math.abs(line.qty);
                 }
             }


### PR DESCRIPTION
Previously, when refunding a product with a serial number, the serial number was not being properly set in the refund order. This caused issues in inventory management as the POS transfer was not automatically validated.

After this commit, the serial number of the refunded product is correctly assigned in the refund order and the POS transfer is automatically validated.

opw-4387411

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
