### PR TITLE
[FIX] project: allow default search in portal

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -380,7 +380,7 @@ class ProjectCustomerPortal(CustomerPortal):
         elif search_in in self._task_get_searchbar_inputs(milestones_allowed, project):
             return [(search_in, 'ilike', search)]
         else:
-            return FALSE_DOMAIN
+            return ['|', ('name', 'ilike', search), ('id', 'ilike', search)]
 
     def _prepare_tasks_values(self, page, date_begin, date_end, sortby, search, search_in, groupby, url="/my/tasks", domain=None, su=False, project=False):
         values = self._prepare_portal_layout_values()
@@ -510,7 +510,7 @@ class ProjectCustomerPortal(CustomerPortal):
         return searchbar_filters
 
     @http.route(['/my/tasks', '/my/tasks/page/<int:page>'], type='http', auth="user", website=True)
-    def portal_my_tasks(self, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, search=None, search_in='content', groupby=None, **kw):
+    def portal_my_tasks(self, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, search=None, search_in='name', groupby=None, **kw):
         searchbar_filters = self._get_my_tasks_searchbar_filters()
 
         if not filterby:


### PR DESCRIPTION
Steps to reproduce:
--------------------

 - Go my account
 - Click on tasks
 - Search

Issue:
------

The client when searching without selecting a scope cannot search. This is direct incidence of the [changes](https://github.com/odoo/odoo/commit/2a0ff2ae7bd46666) Since the default search_in was set to content that has been removed.

Fix:
---

Setting the search_in defaulting to name. (Name is the closest to what content did)

opw-4396491

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
