### PR TITLE
[FIX] mail: fix non-deterministic public page tours

### DIFF
--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -1,5 +1,5 @@
 import { registry } from "@web/core/registry";
-import { click, contains, inputFiles } from "@web/../tests/utils";
+import { contains, click, inputFiles } from "@web/../tests/utils";
 
 registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
     steps: () => [
@@ -108,8 +108,8 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             run: "hover && click .o-mail-Message [title='Add a Reaction']",
         },
         {
-            trigger: ".o-mail-QuickReactionMenu [title='Toggle Emoji Picker']",
-            run: "click",
+            trigger: ".o-mail-QuickReactionMenu",
+            run: () => click("[title='Toggle Emoji Picker']"),
         },
         {
             trigger: ".o-EmojiPicker .o-Emoji:contains('🙂')",


### PR DESCRIPTION

Before this PR, the discuss public page tours would occasionally fail.
The failure was caused by the quick reaction not being considered
visible.

This issue occurs because the tour engine forces the `visible` option
of the `queryFirst` hoot helper which considers `opacity: 0` as
insisible.

The quick reaction menu has a small animation to animate it's opacity
from 0 to 1. The tour mutation observer cannot detect this change. As
a result, although the menu was visually present, it was not
recognized as visible, leading to intermittent test failures.

This PR replaces this trigger by the `click` method which does not
consider opacity in order to detect the quick reaction item
consitently.

runbot-110592,110541