### PR TITLE
[FIX] account: make account uninstall possible

### DIFF
--- a/addons/account/models/ir_module.py
+++ b/addons/account/models/ir_module.py
@@ -103,7 +103,11 @@ class IrModule(models.Model):
 
     def module_uninstall(self):
         unlinked_templates = [code for template in self.mapped('account_templates') for code in template]
-        self.env['res.company'].search([
-            ('chart_template', 'in', unlinked_templates),
-        ]).chart_template = False
+        if unlinked_templates:
+            companies = self.env['res.company'].search([
+                ('chart_template', 'in', unlinked_templates),
+            ])
+            companies.chart_template = False
+            companies.flush_recordset()
+
         return super().module_uninstall()


### PR DESCRIPTION
Currently, an error is generated when the user tries to uninstall ``account`` module after installing ``account_inter_company_rules`` module.

Steps to reproduce:
---
- Install ``account_inter_company_rules`` module
- Uninstall ``account`` module

Traceback:
---
``KeyError: 'res.company.intercompany_purchase_journal_id'``

When we uninstall the account module, we set all associated fields related to 'account' (e.g., chart_template) to 'False'.

Change:
---
Force a recomputation by flushing the records.


sentry-6054886854

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
