### PR TITLE
[FIX] website_sale: fix display of not available for sale

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -197,7 +197,6 @@
                             </del>
                         </t>
                         <span class="h6 mb-0" t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale" t-esc="template_price_vals['price_reduce']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
-                        <span class="h6 mb-0" t-elif="any(ptav.price_extra for ptav in product.attribute_line_ids.product_template_value_ids)">&amp;nbsp;</span>
                         <span class="h6 mb-0" t-else="" t-field="website.prevent_zero_price_sale_text"/>
                         <span itemprop="price" style="display:none;" t-esc="template_price_vals['price_reduce']" />
                         <span itemprop="priceCurrency" style="display:none;" t-esc="website.currency_id.name" />


### PR DESCRIPTION
**Steps to Reproduce:**
- Configure eCommerce to "Prevent Sale of 0 Product" by enabling the setting.
- Create a "Zero" price list and apply to the shop
- Create a product with:
   - Attributes and extra prices on those attributes.
   - Ensure one product has no attributes or attributes with no extra price.

**Issue:**
- Products with zero prices and extra-priced attributes did not display the "Not Available for Sale" message.

**Fix:**
- Reverted the [previous commit](8a3922428f464866abda41f51f23a9b455be1fab) as the updated behavior now ensures that the "Add to Cart" option is no longer available for such products. Also, the "Contact Us" button is displayed for the further flow. This ensures compliance with the "Prevent Sale of 0 Product" setting.

**Affected Versions:** 16.0~master
**opw**-4409441