### PR TITLE
[FIX] sale, sale_expense: prevent creation of tax line

### DIFF
--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -37,7 +37,7 @@ class AccountMoveLine(models.Model):
                         move_to_reinvoice |= move_line
 
         # insert the sale line in the create values of the analytic entries
-        if move_to_reinvoice.filtered(lambda aml: not aml.move_id.reversed_entry_id):  # only if the move line is not a reversal one
+        if move_to_reinvoice.filtered(lambda aml: not aml.move_id.reversed_entry_id and aml.product_id):  # only if the move line is not a reversal one
             map_sale_line_per_move = move_to_reinvoice._sale_create_reinvoice_sale_line()
             for values in values_list:
                 sale_line = map_sale_line_per_move.get(values.get('move_line_id'))

--- a/addons/sale_expense/tests/test_reinvoice.py
+++ b/addons/sale_expense/tests/test_reinvoice.py
@@ -459,3 +459,102 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
                 'is_expense': True,
             },
         ])
+
+    def test_expense_reinvoice_tax_multine_line(self):
+        """
+        Tests that when a tax has multine distribution, the creation of an expense can go forward without issues
+        """
+        multi_distribution_tax = self.env['account.tax'].create({
+            'name': 'Tax 10.00%',
+            'amount': 10.00,
+            'amount_type': 'percent',
+            'type_tax_use': 'purchase',
+            'invoice_repartition_line_ids': [
+                Command.create({
+                    'repartition_type': 'base',
+                    'use_in_tax_closing': False,
+                }),
+                Command.create({
+                    'repartition_type': 'tax',
+                    'factor_percent': 70,
+                    'use_in_tax_closing': False,
+                }),
+                Command.create({
+                    'repartition_type': 'tax',
+                    'factor_percent': 30,
+                    'account_id': self.company_data['default_account_tax_purchase'].id,
+                    'use_in_tax_closing': True,
+                }),
+            ],
+            'refund_repartition_line_ids': [
+                Command.create({
+                    'repartition_type': 'base',
+                    'use_in_tax_closing': False,
+                }),
+                Command.create({
+                    'repartition_type': 'tax',
+                    'factor_percent': 70,
+                    'use_in_tax_closing': False,
+                }),
+                Command.create({
+                    'repartition_type': 'tax',
+                    'factor_percent': 30,
+                    'account_id': self.company_data['default_account_tax_purchase'].id,
+                    'use_in_tax_closing': True,
+                }),
+            ],
+        })
+        (self.company_data['product_order_sales_price'] + self.company_data['product_delivery_sales_price']).write({
+            'can_be_expensed': True,
+        })
+
+        # create SO line and confirm SO (with only one line)
+        sale_order = self.env['sale.order'].with_context(mail_notrack=True, mail_create_nolog=True).create({
+            'partner_id': self.partner_a.id,
+            'partner_invoice_id': self.partner_a.id,
+            'partner_shipping_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'name': self.company_data['product_order_sales_price'].name,
+                'product_id': self.company_data['product_order_sales_price'].id,
+                'product_uom_qty': 1.0,
+                'price_unit': 1000.0,
+            })],
+        })
+        sale_order.action_confirm()
+
+        expense_sheet = self.env['hr.expense.sheet'].create({
+            'name': 'First Expense for employee',
+            'employee_id': self.expense_employee.id,
+            'journal_id': self.company_data['default_journal_purchase'].id,
+            'accounting_date': '2017-01-01',
+            'expense_line_ids': [
+                Command.create({
+                    'name': 'expense_1',
+                    'date': '2016-01-01',
+                    'product_id': self.company_data['product_order_sales_price'].id,
+                    'quantity': 1,
+                    'employee_id': self.expense_employee.id,
+                    'sale_order_id': sale_order.id,
+                    'tax_ids': multi_distribution_tax.ids,
+                }),
+            ],
+        })
+
+        expense_sheet.approve_expense_sheets()
+        expense_sheet.action_sheet_move_create()
+
+        self.assertRecordValues(sale_order.order_line, [
+            # Original SO line:
+            {
+                'qty_delivered': 0.0,
+                'product_uom_qty': 1.0,
+                'is_expense': False,
+            },
+            # Expense lines:
+            {
+                'qty_delivered': 1.0,
+                'product_uom_qty': 1.0,
+                'is_expense': True,
+            },
+        ])
+


### PR DESCRIPTION
Steps to reproduce:
[l10n_dk]
- create and confirm a sale order
- create an expense for a new employee and use a product set with reinvoice at cost and a tax with multiple repartition lines
- confirm and process the expense
- post journal entries

Issue:
Missing required fields on accountable sale order line.

Cause:
We want to reinvoice the tax line that no product on it

opw-4378714
