### PR TITLE
[FIX] hr: prevent error when computing avatar_128 for resource

### DIFF
--- a/addons/hr/models/resource.py
+++ b/addons/hr/models/resource.py
@@ -28,7 +28,10 @@ class ResourceResource(models.Model):
 
         for resource in self:
             employee = resource.employee_id
+            if not employee:
+                resource.avatar_128 = False
+                continue
             if is_hr_user:
-                resource.avatar_128 = employee and employee[0].avatar_128
+                resource.avatar_128 = employee[0].avatar_128
             else:
                 resource.avatar_128 = avatar_per_employee_id[employee[0].id]


### PR DESCRIPTION
Currently, a traceback is occurring when the `_compute_avatar_128` 
method triggers with resource having no employee.

Error:- 
```
IndexError: tuple index out of range
```

Here in resource employee_id is not a required field. 
So when the resource doesn't have any employee_id, it leads to the above traceback.

In the if condition we already checked the presence of employee, but the issue is 
occurring from the else condition.
https://github.com/odoo/odoo/blob/fb4d758ed78211a61ea797759e1fb3b02b51be60/addons/hr/models/resource.py#L30-L34

We can resolve this issue by making the avatar_128 field value False, if there is no employee_id.

sentry-6134007941
