### PR TITLE
[FIX] sale: fix catalog display price

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2185,7 +2185,7 @@ class SaleOrder(models.Model):
                 'product_uom_qty': quantity,
                 'sequence': ((self.order_line and self.order_line[-1].sequence + 1) or 10),  # put it at the end of the order
             })
-        return sol.price_unit
+        return sol.price_unit * (1-(sol.discount or 0.0)/100.0)
 
     #=== TOOLING ===#
 


### PR DESCRIPTION
Steps:
- install sale and activate pricelists
- activate discounts from setting
- create a product with price 100
- create a pricelist with of 2% discount on the product
- create a sale order with the new pricelist
- open the new product in catalog and add 1 quantity

Issue:
- the price for the product changes from 98 to 100 after adding quantity

Cause:
- the display price in catalog comes from either SOL price unit or computed from SO pricelist_id. When discounts setting is active the SOL price_unit is pricelist price without discount else with discount. Hence when first time the catalog is loaded it is computed from SO's pricelist and after adding a quantity it takes pricelist price without discount from SOL

Fix:
- Updated `_update_order_line_info` so it will always take the pricelist computed price and not SOL unit_price

opw - 4345503
opw - 4406373

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
