### PR TITLE
[FIX] prevent creating a nested tax group from the child tax

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -15641,6 +15641,15 @@ msgstr ""
 
 #. module: account
 #. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid ""
+"You can't change this tax to a group of taxes because it is used in the "
+"following group(s) of taxes:%s"
+msgstr ""
+
+#. module: account
+#. odoo-python
 #: code:addons/account/models/account_payment.py:0
 #, python-format
 msgid ""


### PR DESCRIPTION
Nested group of taxes are not supported by Odoo. There are already some constraint to prevent adding a group of taxes to a group of taxes.

But there is still a way to end up with nested group of taxes:

1. Create a regular tax (any amount_type except 'group').
2. Create a group of taxes and add the tax from 1. to that group.
3. Edit the amount_type of the tax from 1. to 'group'. 
-> The group of taxes from 2. now contains a nested group of taxes.

This PR adds a constraint on the amount_type of the parent of a tax when you try to change its amount_type to 'group'.

The message of the error raised was also made to include the name of the parent tax groups, so the user do not have to manually look through all the taxes to find them.

opw-4414974