### PR TITLE
[FIX] web_editor: prevent adding videos for html_field from studio

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -694,11 +694,6 @@ export const htmlField = {
         name: "snippets",
         type: "string"
     }, {
-        label: _t("No videos"),
-        name: "noVideos",
-        type: "boolean",
-        default: true
-    }, {
         label: _t("Resizable"),
         name: "resizable",
         type: "boolean",


### PR DESCRIPTION
**Problem**:
Enabling the addition of videos from Studio is not supported. This
option should be removed.

**Steps to Reproduce**:
1. In Studio, focus on any HTML field.
2. Under "Properties," there should be no "videos" option.

opw-4405801
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
