### PR TITLE
[FIX] web_editor, website: prevent quotes carousel item removal

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -499,8 +499,13 @@ var SnippetEditor = publicWidget.Widget.extend({
                         // Consider layout-only elements (like bg-shapes) as empty
                         return el.matches(this.layoutElementsSelector);
                     }));
-                return isEmpty && !$el.hasClass('oe_structure')
-                    && !$el.parent().hasClass('carousel-item')
+                const notRemovableSelector =
+                    `.oe_structure,
+                    .carousel-item,
+                    .carousel-item > .container,
+                    .carousel-item > .container-fluid,
+                    .carousel-item > .o_container_small`;
+                return isEmpty && !$el[0].matches(notRemovableSelector)
                     && (!editor || editor.isTargetParentEditable)
                     && !isUnremovable($el[0]);
             };

--- a/addons/website/static/tests/tours/carousel_content_removal.js
+++ b/addons/website/static/tests/tours/carousel_content_removal.js
@@ -6,6 +6,7 @@ import {
     changeOption,
     clickOnSave,
     registerWebsitePreviewTour,
+    goBackToBlocks,
 } from '@website/js/tours/tour_utils';
 
 const carouselInnerSelector = ":iframe .carousel-inner";
@@ -29,6 +30,23 @@ registerWebsitePreviewTour("carousel_content_removal", {
 }, {
     trigger: ":iframe .carousel .carousel-item.active .container:not(:has(*)):not(:visible)",
     content: "Check for a carousel slide with an empty container tag",
+},
+    goBackToBlocks(),
+    ...insertSnippet({
+        id: "s_quotes_carousel",
+        name: "Blockquote",
+        groupName: "People",
+}), {
+    trigger: ":iframe .s_quotes_carousel_wrapper .carousel-item.active .s_blockquote",
+    content: "Select the blockquote.",
+    run: "click",
+}, {
+    trigger: ":iframe .oe_overlay.oe_active .oe_snippet_remove",
+    content: "Remove the blockquote from the carousel item.",
+    run: "click",
+}, {
+    trigger: ":iframe .s_quotes_carousel_wrapper .carousel-item.active:not(:has(.s_blockquote))",
+    content: "Check that the blockquote has been removed and the carousel item is empty.",
 }]);
 
 registerWebsitePreviewTour("snippet_carousel", {


### PR DESCRIPTION
Steps to reproduce:

- Enter website edit mode.
- In the right panel, click on the "Intro" category.
- Enter "quotes" in the "Search" input of the modal.
- Click on one of the two "quotes carousel" blocks.
- After the "quotes carousel" block is inserted on the page, click on its "Blockquote".
- Click the red "delete" button that appears above the "Blockquote".
- Bug: The carousel item is removed, and only the arrows to move the slide are shown on the screen. If you click on one of the arrows, a traceback will occur.

The exact same bug was previously fixed in commit [1], but since the modification of the "carousel quotes" snippet in commit [2], the fix no longer works.

There is a system that removes the parent of a snippet that gets deleted if this parent is empty after the deletion. This allows, for example, to remove a column if its content is emptied to avoid leaving an empty column on the page.

An exception to this rule was introduced by commit [1] for carousel items. Indeed, we don't want to remove a carousel item when it is empty.

This exception checks if the grandparent of the deleted element is a carousel item. It worked initially because when the content of a slide was deleted, the container still remained within the carousel item. But this is no longer the case for the "quotes" carousel since commit [2], where the intermediate "container" element is no longer present.

This commit also adds steps to the "carousel_content_removal" tour to prevent the issue from reappearing.

[1]: https://github.com/odoo/odoo/commit/3c194faa930b0d3a537ca8b893b2c0442b5464e7
[2]: https://github.com/odoo/odoo/commit/4357ce81ed89bd389eafe3756733758736bad6cb

opw-4417366
opw-4395645