### PR TITLE
[FIX]: account: fix psycopg2 error currency table

### DIFF
--- a/addons/account/models/res_currency.py
+++ b/addons/account/models/res_currency.py
@@ -216,7 +216,7 @@ class ResCurrency(models.Model):
             """,
             period_key=period_key,
             main_company_id=main_company.root_id.id,
-            fiscal_year_bounds_values=SQL(",").join(SQL("(%(fy_from)s,%(fy_to)s)", fy_from=fy_from, fy_to=fy_to) for fy_from, fy_to in fiscal_year_bounds),
+            fiscal_year_bounds_values=SQL(",").join(SQL("(%(fy_from)s::date,%(fy_to)s::date)", fy_from=fy_from, fy_to=fy_to) for fy_from, fy_to in fiscal_year_bounds),
             other_company_ids=tuple(other_companies.ids),
             date_to=date_to,
             main_company_unit_factor=main_company_unit_factor,


### PR DESCRIPTION
Steps:

- Have 2 companies with different currencies
- Select both in company selector
- Go to any report
- Traceback: `psycopg2.errors.UndefinedFunction: operator does not exist: text >= date`

Cause:

https://github.com/odoo/odoo/blob/686d098d59a6078e264c8b2633020b23c5902702/addons/account/models/res_currency.py#L211
this condition is never met because the NULL value is casted as a text,
therefore we ends up trying comparing 'NULL' to '<date>'.

Fix:

Casting both `date_from` and `date_to` into date format

opw-4367588
