### PR TITLE
[FIX] base: website is not shown in the contact qweb widget

### DIFF
--- a/odoo/addons/base/tests/test_qweb_field.py
+++ b/odoo/addons/base/tests/test_qweb_field.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 from odoo.tests import common
 
 
@@ -56,3 +57,27 @@ class TestQwebFieldInteger(common.TransactionCase):
             self.value_to_html(125125, {'format_decimalized_number': True, 'precision_digits': 3}),
             "125.125k"
         )
+
+class TestQwebFieldContact(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
+        cls.partner = cls.env.ref("base.res_partner_1")
+
+    def test_value_to_html_with_website_and_phone(self):
+        Contact = self.env["ir.qweb.field.contact"]
+        result = Contact.value_to_html(self.partner, {"fields": ["phone", "website"]})
+        self.assertIn('itemprop="website"', result)
+        self.assertIn(self.partner.website, result)
+        self.assertIn('itemprop="telephone"', result)
+        self.assertIn(self.partner.phone, result)
+        self.assertNotIn('itemprop="email"', result)
+
+    def test_value_to_html_without_phone(self):
+        Contact = self.env["ir.qweb.field.contact"]
+        result = Contact.value_to_html(self.partner, {"fields": ["name", "website"]})
+        self.assertIn('itemprop="website"', result)
+        self.assertIn(self.partner.website, result)
+        self.assertNotIn(self.partner.phone, result)
+        self.assertIn('itemprop="telephone"', result, "Empty telephone itemprop should be added to prevent issue with iOS Safari")

--- a/odoo/addons/base/views/ir_qweb_widget_templates.xml
+++ b/odoo/addons/base/views/ir_qweb_widget_templates.xml
@@ -37,7 +37,7 @@
             <div t-if="phone and 'phone' in fields"><i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-phone fa-fw' role="img" aria-label="Phone" title="Phone"/> <span class="o_force_ltr" itemprop="telephone" t-esc="phone"/></div>
             <div t-if="mobile and 'mobile' in fields"><i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-mobile fa-fw' role="img" aria-label="Mobile" title="Mobile"/> <span class="o_force_ltr" itemprop="telephone" t-esc="mobile"/></div>
             <!-- Prevent issue with iOS Safari parsing of schema data without telephone itemprops -->
-            <div t-elif="not (phone and 'phone' in fields)" itemprop="telephone"/>
+            <div t-if="not (phone and 'phone' in fields) and not (mobile and 'mobile' in fields)" itemprop="telephone"/>
             <div t-if="website and 'website' in fields">
                 <i t-if="not options.get('no_marker')" class='fa fa-globe' role="img" aria-label="Website" title="Website"/>
                 <a t-att-href="website and '%s%s' % ('http://' if '://' not in website else '',website)"><span itemprop="website" t-esc="website"/></a>


### PR DESCRIPTION
**Affects**
16.0+

**Steps to reproduce:**

- Render the Contact qweb widget with fields ["phone", "website"]

```py
Contact = self.env["ir.qweb.field.contact"]
partner = self.env["res.partner"].create(
    {
        "name": "Test Partner",
        "phone": "1234567890",
        "website": "https://www.example.com",
    }
)
result = Contact.value_to_html(partner, {"fields": ["phone", "website"]})
```

**Result:**

- The website is not shown

---

This is a regression introduced in 9e53aea9, in combination with some buggy behavior in the qweb compilation.

Somehow the `t-elif` condition is applying on the next element instead on itself, hiding the website item. I did not investigate this further.


ping @lvsz @ryv-odoo

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
