### PR TITLE
[FIX] l10n_es_pos_tbai: Add refund reason in pos

### DIFF
--- a/addons/l10n_es_pos_tbai/__manifest__.py
+++ b/addons/l10n_es_pos_tbai/__manifest__.py
@@ -11,6 +11,9 @@
         'point_of_sale._assets_pos': [
             'l10n_es_pos_tbai/static/src/**/*',
         ],
+        'web.assets_tests': [
+            'l10n_es_pos_tbai/static/tests/**/*',
+        ],
     },
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/l10n_es_pos_tbai/models/__init__.py
+++ b/addons/l10n_es_pos_tbai/models/__init__.py
@@ -1,1 +1,2 @@
 from . import pos_order
+from . import account_move

--- a/addons/l10n_es_pos_tbai/models/account_move.py
+++ b/addons/l10n_es_pos_tbai/models/account_move.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    @api.model
+    def get_refund_reason_list(self):
+        return self.env['account.move']._fields['l10n_es_tbai_refund_reason']._description_selection(self.env)

--- a/addons/l10n_es_pos_tbai/models/pos_order.py
+++ b/addons/l10n_es_pos_tbai/models/pos_order.py
@@ -27,3 +27,15 @@ class PosOrder(models.Model):
             return super(PosOrder, self.with_context(skip_account_edi_cron_trigger=True))._generate_pos_order_invoice()
         else:
             return super()._generate_pos_order_invoice()
+
+    def _process_order(self, order, draft, existing_order):
+        if'l10n_es_tbai_refund_reason' in order['data']:
+            return super(PosOrder, self.with_context(l10n_es_tbai_refund_reason=order['data']['l10n_es_tbai_refund_reason']))._process_order(order, draft, existing_order)
+        else:
+            return super()._process_order(order, draft, existing_order)
+
+    def _prepare_invoice_vals(self):
+        res = super()._prepare_invoice_vals()
+        if self.env.context.get('l10n_es_tbai_refund_reason'):
+            res['l10n_es_tbai_refund_reason'] = self.env.context.get('l10n_es_tbai_refund_reason')
+        return res

--- a/addons/l10n_es_pos_tbai/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/l10n_es_pos_tbai/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -1,0 +1,27 @@
+/** @odoo-module */
+
+import { patch } from "@web/core/utils/patch";
+import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
+import { SelectionPopup } from "@point_of_sale/app/utils/input_popups/selection_popup";
+import { _t } from "@web/core/l10n/translation";
+
+patch(TicketScreen.prototype, {
+    //@override
+    async addAdditionalRefundInfo(order, destinationOrder) {
+        if (this.pos.config.is_spanish && order.state == "invoiced") {
+            let selectionList = await this.orm.call("account.move", "get_refund_reason_list", []);
+            selectionList = selectionList.map((el) => {
+                return { 'id': el[0], 'label': el[1], 'item': el[0]}
+            })
+            const { confirmed, payload } = await this.popup.add(SelectionPopup, {
+                title: _t("Select the refund reason"),
+                list: selectionList,
+            });
+            if (payload && confirmed) {
+                destinationOrder.l10n_es_tbai_refund_reason = payload;
+                destinationOrder.to_invoice = true;
+            }
+        }
+        super.addAdditionalRefundInfo(...arguments);
+    },
+});

--- a/addons/l10n_es_pos_tbai/static/src/overrides/models/order.js
+++ b/addons/l10n_es_pos_tbai/static/src/overrides/models/order.js
@@ -11,4 +11,11 @@ patch(Order.prototype, {
             l10n_es_pos_tbai_qrsrc: this.l10n_es_pos_tbai_qrsrc,
         };
     },
+    export_as_JSON() {
+        const json = super.export_as_JSON(...arguments);
+        if (this.pos.config.is_spanish) {
+            json["l10n_es_tbai_refund_reason"] = this.l10n_es_tbai_refund_reason
+        }
+        return json;
+    },
 });

--- a/addons/l10n_es_pos_tbai/static/tests/tours/spanish_tbai_pos_tour.js
+++ b/addons/l10n_es_pos_tbai/static/tests/tours/spanish_tbai_pos_tour.js
@@ -1,0 +1,35 @@
+/** @odoo-module */
+
+import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
+import * as ReceiptScreen from "@point_of_sale/../tests/tours/helpers/ReceiptScreenTourMethods";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/helpers/PaymentScreenTourMethods";
+import * as TicketScreen from "@point_of_sale/../tests/tours/helpers/TicketScreenTourMethods";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("spanish_pos_tbai_tour", {
+    test: true,
+    steps: () => [
+        ProductScreen.confirmOpeningPopup(),
+        ProductScreen.clickHomeCategory(),
+        ProductScreen.clickDisplayedProduct("Desk Pad"),
+        ProductScreen.clickPayButton(),
+        PaymentScreen.clickPaymentMethod("Bank"),
+        PaymentScreen.remainingIs("0.00"),
+        PaymentScreen.clickValidate(),
+        ReceiptScreen.isShown(),
+        ReceiptScreen.clickNextOrder(),
+        ProductScreen.clickRefund(),
+        TicketScreen.selectOrder("-0001"),
+        ProductScreen.pressNumpad("1"),
+        TicketScreen.toRefundTextContains("To Refund: 1.00"),
+        TicketScreen.confirmRefund(),
+        {
+            trigger: 'button:contains("R1")',
+        },
+        ProductScreen.isShown(),
+        ProductScreen.clickPayButton(),
+        PaymentScreen.clickPaymentMethod("Bank"),
+        PaymentScreen.clickValidate(),
+        ReceiptScreen.isShown(),
+    ].flat(),
+});

--- a/addons/l10n_es_pos_tbai/tests/__init__.py
+++ b/addons/l10n_es_pos_tbai/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_frontend

--- a/addons/l10n_es_pos_tbai/tests/test_frontend.py
+++ b/addons/l10n_es_pos_tbai/tests/test_frontend.py
@@ -1,0 +1,27 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+
+
+@odoo.tests.tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUi(TestPointOfSaleHttpCommon):
+    @classmethod
+    def _get_main_company(cls):
+        cls.company_data["company"].country_id = cls.env.ref("base.es").id
+        cls.company_data["company"].currency_id = cls.env.ref("base.EUR").id
+        cls.company_data["company"].vat = "ESA12345674"
+        return cls.company_data["company"]
+
+    def test_spanish_tbai_pos(self):
+        simp = self.env['account.journal'].create({
+            'name': 'Simplified Invoice Journal',
+            'type': 'sale',
+            'company_id': self._get_main_company().id,
+            'code': 'SIMP',
+        })
+        self.main_pos_config.l10n_es_simplified_invoice_journal_id = simp
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", "spanish_pos_tbai_tour", login="pos_user")
+        order = self.env['pos.order'].search([], order='id desc', limit=1)
+        self.assertEqual(order.account_move.l10n_es_tbai_refund_reason, 'R1')


### PR DESCRIPTION
Refund order in spain require a refund reason.

Steps to reproduce:
-------------------
* Install l10n_es_pos_tbai module
* Open PoS
* Make an order and try to refund it
> Observation: You get an error message saying that you need to add a
refund reason

opw-4282586