### PR TITLE
[FIX] pdf: don't erase existing flags

### DIFF
--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -176,9 +176,12 @@ def fill_form_fields_pdf(writer, form_fields):
         for raw_annot in page.get('/Annots', []):
             annot = raw_annot.getObject()
             for field in form_fields:
-                # Mark filled fields as readonly to avoid the blue overlay:
+                # Modifying the form flags to force  all text fields read-only
                 if annot.get('/T') == field:
-                    annot.update({NameObject("/Ff"): NumberObject(1)})
+                    form_flags = annot.get('/Ff', 0)
+                    readonly_flag = 1  # 1st bit sets readonly
+                    new_flags = form_flags | readonly_flag
+                    annot.update({NameObject("/Ff"): NumberObject(new_flags)})
 
 
 def rotate_pdf(pdf):


### PR DESCRIPTION
Partly backporting 3731550474dc90819fa1667385f35f4a22ee4f11

Currently, to ensure the filled forms are set as readonly, we erase all the existing flags. Instead, we now only force the readonly flag.

