### PR TITLE
[FIX] sale: take line discount in global discount calculation

### DIFF
--- a/addons/sale/tests/test_sale_order_discount.py
+++ b/addons/sale/tests/test_sale_order_discount.py
@@ -107,3 +107,19 @@ class TestSaleOrderDiscount(SaleCommon):
     def test_percent_discount_above_100(self):
         with self.assertRaises(ValidationError):
             self.wizard.write({'discount_percentage': 1.1, 'discount_type': 'sol_discount'})
+
+    def test_line_and_global_discount(self):
+        solines = self.sale_order.order_line
+        amount_before_discount = self.sale_order.amount_untaxed
+        self.assertEqual(len(solines), 2)
+
+        solines.discount = 10
+        self.assertEqual(self.sale_order.amount_untaxed, amount_before_discount * 0.9)
+        amount_with_line_discount = self.sale_order.amount_untaxed
+
+        self.wizard.write({
+            'discount_percentage': 0.1,  # 10%
+            'discount_type': 'so_discount',
+        })
+        self.wizard.action_apply_discount()
+        self.assertEqual(self.sale_order.amount_untaxed, amount_with_line_discount * 0.9)

--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -104,8 +104,8 @@ class SaleOrderDiscount(models.TransientModel):
             for line in self.sale_order_id.order_line:
                 if not line.product_uom_qty or not line.price_unit:
                     continue
-
-                total_price_per_tax_groups[line.tax_id] += (line.price_unit * line.product_uom_qty)
+                discounted_price = line.price_unit * (1 - (line.discount or 0.0)/100)
+                total_price_per_tax_groups[line.tax_id] += (discounted_price * line.product_uom_qty)
 
             if not total_price_per_tax_groups:
                 # No valid lines on which the discount can be applied


### PR DESCRIPTION
If discount was appplied to sale order line and user applied global discount, it would have been calculated based on unsdicounted amount resulting in too high global discount as global discount should be calculated based on price after line discount.

opw-4349320

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
