### PR TITLE
[IMP] mail: store incoming email_{cc,to} on mail.message

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Discuss',
-    'version': '1.18',
+    'version': '1.19',
     'category': 'Productivity/Discuss',
     'sequence': 145,
     'summary': 'Chat, mail gateway and private channels',

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -57,6 +57,9 @@ class MailMail(models.Model):
     is_notification = fields.Boolean('Notification Email', help='Mail has been created to notify people of an existing mail.message')
     # recipients: include inactive partners (they may have been archived after
     # the message was sent, but they should remain visible in the relation)
+    # note that email_{cc,to} are different from mail.message fields as mail.mail
+    # are also used for outgoing emails sharing the same mail_message_id but with
+    # different recipients
     email_to = fields.Text('To', help='Message recipients (emails)')
     email_cc = fields.Char('Cc', help='Carbon copy message recipients')
     recipient_ids = fields.Many2many('res.partner', string='To (Partners)',

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -144,6 +144,9 @@ class MailMessage(models.Model):
     # recipients: include inactive partners (they may have been archived after
     # the message was sent, but they should remain visible in the relation)
     partner_ids = fields.Many2many('res.partner', string='Recipients', context={'active_test': False})
+    # email recipients of incoming emails: comma separated list of emails (not necessarily normalized)
+    incoming_email_to = fields.Text('Emails To')
+    incoming_email_cc = fields.Char('Emails Cc')
     # list of partner having a notification. Caution: list may change over time because of notif gc cron.
     # mainly usefull for testing
     notified_partner_ids = fields.Many2many(

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1348,9 +1348,15 @@ class MailThread(models.AbstractModel):
                 else:
                     subtype_id = self.env['ir.model.data']._xmlid_to_res_id('mail.mt_comment')
 
-            post_params = dict(subtype_id=subtype_id, partner_ids=partner_ids, **message_dict)
+            post_params = dict(
+                incoming_email_cc=message_dict.pop('cc', False),
+                incoming_email_to=message_dict.pop('to', False),
+                subtype_id=subtype_id,
+                partner_ids=partner_ids,
+                **message_dict,
+            )
             # remove computational values not stored on mail.message and avoid warnings when creating it
-            for x in ('from', 'to', 'cc', 'recipients', 'references', 'in_reply_to', 'x_odoo_message_id',
+            for x in ('from', 'recipients', 'references', 'in_reply_to', 'x_odoo_message_id',
                       'is_bounce', 'bounced_email', 'bounced_message', 'bounced_msg_ids', 'bounced_partner'):
                 post_params.pop(x, None)
             new_msg = False

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2124,7 +2124,8 @@ class MailThread(models.AbstractModel):
     def message_post(self, *,
                      body='', subject=None, message_type='notification',
                      email_from=None, author_id=None, parent_id=False,
-                     subtype_xmlid=None, subtype_id=False, partner_ids=None,
+                     subtype_xmlid=None, subtype_id=False,
+                     partner_ids=None, incoming_email_to=False, incoming_email_cc=False,
                      attachments=None, attachment_ids=None, body_is_html=False,
                      **kwargs):
         """ Post a new message in an existing thread, returning the new mail.message.
@@ -2145,6 +2146,10 @@ class MailThread(models.AbstractModel):
             notification mechanism;
         :param list(int) partner_ids: partner_ids to notify in addition to partners
             computed based on subtype / followers matching;
+        :param str incoming_email_to: comma-separated list of emails, already notified
+            by incoming email;
+        :param str incoming_email_cc: comma-separated list of emails, already notified
+            by incoming email;
         :param list(tuple(str,str), tuple(str,str, dict)) attachments : list of attachment
             tuples in the form ``(name,content)`` or ``(name,content, info)`` where content
             is NOT base64 encoded;
@@ -2252,6 +2257,8 @@ class MailThread(models.AbstractModel):
             'subtype_id': subtype_id,
             # recipients
             'partner_ids': partner_ids,
+            'incoming_email_to': incoming_email_to,
+            'incoming_email_cc': incoming_email_cc,
         })
         # add default-like values afterwards, to avoid useless queries
         if 'record_alias_domain_id' not in msg_values:
@@ -2505,7 +2512,7 @@ class MailThread(models.AbstractModel):
         # preliminary value safety check
         self._raise_for_invalid_parameters(
             set(kwargs.keys()),
-            forbidden_names={'body', 'composition_mode', 'model', 'res_id', 'values'}
+            forbidden_names={'body', 'composition_mode', 'incoming_email_cc', 'incoming_email_to', 'model', 'res_id', 'values'}
         )
 
         # with a view, render bodies in batch (template is managed by composer)
@@ -2581,7 +2588,7 @@ class MailThread(models.AbstractModel):
         # preliminary value safety check
         self._raise_for_invalid_parameters(
             set(kwargs.keys()),
-            forbidden_names={'body', 'composition_mode', 'model', 'res_id', 'values'}
+            forbidden_names={'body', 'composition_mode', 'incoming_email_cc', 'incoming_email_to', 'model', 'res_id', 'values'}
         )
 
         # with a view, render bodies in batch (template is managed by composer)
@@ -2677,7 +2684,7 @@ class MailThread(models.AbstractModel):
         # preliminary value safety check
         self._raise_for_invalid_parameters(
             set(kwargs.keys()),
-            forbidden_names={'message_id', 'message_type', 'parent_id'}
+            forbidden_names={'incoming_email_cc', 'incoming_email_to', 'message_id', 'message_type', 'parent_id'}
         )
         if attachments:
             # attachments should be a list (or tuples) of 3-elements list (or tuple)
@@ -2771,7 +2778,7 @@ class MailThread(models.AbstractModel):
         """
         self._raise_for_invalid_parameters(
             set(kwargs.keys()),
-            forbidden_names={'body', 'bodies'}
+            forbidden_names={'body', 'bodies', 'incoming_email_cc', 'incoming_email_to'}
         )
 
         # with a view, render bodies in batch (template is managed by composer)
@@ -2972,6 +2979,8 @@ class MailThread(models.AbstractModel):
             'email_add_signature',
             'email_from',
             'email_layout_xmlid',
+            'incoming_email_cc',
+            'incoming_email_to',
             'is_internal',
             'mail_activity_type_id',
             'mail_server_id',

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -736,10 +736,18 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         call with a dictionary of expected values. """
         for fname, fvalue in fields_values.items():
             with self.subTest(fname=fname, fvalue=fvalue):
-                self.assertEqual(
-                    message[fname], fvalue,
-                    f'Message: expected {fvalue} for {fname}, got {message[fname]}',
-                )
+                # email_{cc, to} are lists, hence order is not important
+                if fname in {'incoming_email_cc', 'incoming_email_to'}:
+                    self.assertEqual(
+                        sorted(tools.mail.email_split_and_format_normalize(message[fname])),
+                        sorted(tools.mail.email_split_and_format_normalize(fvalue)),
+                        f'Message: expected {fvalue} for {fname}, got {message[fname]}',
+                    )
+                else:
+                    self.assertEqual(
+                        message[fname], fvalue,
+                        f'Message: expected {fvalue} for {fname}, got {message[fname]}',
+                    )
 
     def assertNoMail(self, recipients, mail_message=None, author=None):
         """ Check no mail.mail and email was generated during gateway mock. """

--- a/addons/test_mail/tests/test_mail_flow.py
+++ b/addons/test_mail/tests/test_mail_flow.py
@@ -132,6 +132,8 @@ class TestMailFlow(MailCommon, TestRecipients):
                     'message_values': {
                         'author_id': self.env['res.partner'],
                         'email_from': self.test_emails[0],
+                        'incoming_email_cc': email_cc,
+                        'incoming_email_to': email_to,
                         'mail_server_id': self.env['ir.mail_server'],
                         'parent_id': self.env['mail.message'],
                         'notified_partner_ids': self.env['res.partner'],
@@ -239,6 +241,8 @@ class TestMailFlow(MailCommon, TestRecipients):
                     'message_values': {
                         'author_id': self.partner_employee,
                         'email_from': self.partner_employee.email_formatted,
+                        'incoming_email_cc': False,
+                        'incoming_email_to': False,
                         'mail_server_id': self.env['ir.mail_server'],
                         'notified_partner_ids': external_partners + self.partner_employee_2,
                         'parent_id': incoming_email,
@@ -283,6 +287,8 @@ class TestMailFlow(MailCommon, TestRecipients):
                     'message_values': {
                         'author_id': partner_sylvie,
                         'email_from': partner_sylvie.email_formatted,
+                        'incoming_email_cc': f'{self.test_emails[3]}, {self.test_emails[4]}',
+                        'incoming_email_to': expected_chatter_reply_to,  # reply_all not already implemented, hence just alias
                         'mail_server_id': self.env['ir.mail_server'],
                         # notified: followers, behaves like classic post
                         'notified_partner_ids': internal_partners + self.partner_portal,

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -754,6 +754,9 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
                         'author_id': self.partner_employee,
                         'body': '<p>Body</p>',
                         'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                        # incoming_email_cc/_to are informative and do not trigger any notification
+                        'incoming_email_cc': '"Leo Pol" <leo@test.example.com>, fab@test.example.com',
+                        'incoming_email_to': '"Gaby Tlair" <gab@test.example.com>, ted@test.example.com',
                         'is_internal': False,
                         'message_type': 'comment',
                         'model': test_record._name,
@@ -766,6 +769,8 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
             ):
             new_message = test_record.message_post(
                 body='Body',
+                incoming_email_cc='"Leo Pol" <leo@test.example.com>, fab@test.example.com',
+                incoming_email_to='"Gaby Tlair" <gab@test.example.com>, ted@test.example.com',
                 message_type='comment',
                 subtype_xmlid='mail.mt_comment',
                 partner_ids=[self.partner_employee_2.id],


### PR DESCRIPTION
Add fields holding email recipients on message, in addition to partners.
It is going to be used to store information about recipients that are
not partners, mainly for mailgateway and incoming emails.

We decided to differentiate mail.mail fields from mail.message fields
as mail.mail are also used for outgoing emails. Several mail.mail
can be linked to a single mail.message, each with their own recipients.
It is therefore easier to have different fields, as their definition
and usage vary on the two model.

Propagate from 'message_post' to message creation. Prevent using those
fields in other main posting API, as it is currently intended for
mailgateway and email flows.

Propagate from mailgateway to message_post.

This PR belongs to a group of PRs that aim at improving mail flow
in Odoo so that it looks more like traditional email flows:
 * odoo/odoo#184824
 * odoo/odoo#187024
 * odoo/odoo#191213
 * odoo/odoo#185240
 * odoo/odoo#191358
 * odoo/odoo#188642 : Final branch

Task-4286232: [mail] Store email{cc/to} on mail.message
Prepares Task-4273479: [mail] Email-like recipients