### PR TITLE
[FIX] payment_authorize: stop logging authentication data

### DIFF
--- a/addons/payment_authorize/models/authorize_request.py
+++ b/addons/payment_authorize/models/authorize_request.py
@@ -3,11 +3,12 @@
 import json
 import logging
 import pprint
+
 from uuid import uuid4
 
-from odoo.addons.payment import utils as payment_utils
-
 import requests
+
+from odoo.addons.payment import utils as payment_utils
 
 _logger = logging.getLogger(__name__)
 
@@ -49,8 +50,9 @@ class AuthorizeAPI:
                 **(data or {})
             }
         }
+        logged_request = {operation: data or {}}
 
-        _logger.info("sending request to %s:\n%s", self.url, pprint.pformat(request))
+        _logger.info("sending request to %s:\n%s", self.url, pprint.pformat(logged_request))
         response = requests.post(self.url, json.dumps(request), timeout=60)
         response.raise_for_status()
         response = json.loads(response.content)


### PR DESCRIPTION
Authentication data was accidentally logged when sending requests to the Authorize API. This change stops logging such data to avoid security breaches.

opw-4311870