### PR TITLE
[FIX] stock_landed_costs: avoid uom user error from valid landed cost lines

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -345,6 +345,7 @@ class PurchaseOrderLine(models.Model):
         return moves
 
     def _get_po_line_invoice_lines_su(self):
+        #TODO remove in master: un-used
         return self.sudo().invoice_lines
 
     @api.depends('move_ids.state', 'move_ids.product_uom_qty', 'move_ids.product_uom')

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -49,15 +49,17 @@ class StockMove(models.Model):
             invoiced_layer = line.sudo().invoice_lines.stock_valuation_layer_ids
             # value on valuation layer is in company's currency, while value on invoice line is in order's currency
             receipt_value = 0
-            if move_layer:
-                receipt_value += sum(move_layer.mapped(lambda l: l.currency_id._convert(
-                    l.value, order.currency_id, order.company_id, l.create_date, round=False)))
+            for layer in move_layer:
+                if not layer._should_impact_price_unit_receipt_value():
+                    continue
+                receipt_value += layer.currency_id._convert(
+                    layer.value, order.currency_id, order.company_id, layer.create_date, round=False)
             if invoiced_layer:
                 receipt_value += sum(invoiced_layer.mapped(lambda l: l.currency_id._convert(
                     l.value, order.currency_id, order.company_id, l.create_date, round=False)))
             total_invoiced_value = 0
             invoiced_qty = 0
-            for invoice_line in line._get_po_line_invoice_lines_su():
+            for invoice_line in line.sudo().invoice_lines:
                 if invoice_line.move_id.state != 'posted':
                     continue
                 if invoice_line.tax_ids:

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -174,3 +174,7 @@ class StockValuationLayer(models.Model):
             new_valuation = unit_cost * new_valued_qty
 
         return new_valued_qty, new_valuation
+
+    def _should_impact_price_unit_receipt_value(self):
+        self.ensure_one()
+        return True

--- a/addons/stock_landed_costs/models/purchase.py
+++ b/addons/stock_landed_costs/models/purchase.py
@@ -9,6 +9,7 @@ class PurchaseOrderLine(models.Model):
         return res
 
     def _get_po_line_invoice_lines_su(self):
+        #TODO remove in master: un-used
         po_line_invoices_lines = super()._get_po_line_invoice_lines_su()
         move = self.sudo().invoice_lines.move_id
         if move.landed_costs_ids.filtered(lambda lc: lc.state == 'done'):

--- a/addons/stock_landed_costs/models/stock_valuation_layer.py
+++ b/addons/stock_landed_costs/models/stock_valuation_layer.py
@@ -8,3 +8,7 @@ class StockValuationLayer(models.Model):
     _inherit = 'stock.valuation.layer'
 
     stock_landed_cost_id = fields.Many2one('stock.landed.cost', 'Landed Cost')
+
+    def _should_impact_price_unit_receipt_value(self):
+        res = super()._should_impact_price_unit_receipt_value()
+        return res and not self.stock_landed_cost_id.vendor_bill_id

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -5,6 +5,7 @@ from odoo.addons.stock_landed_costs.tests.common import TestStockLandedCostsComm
 from odoo.addons.stock_landed_costs.tests.test_stockvaluationlayer import TestStockValuationLCCommon
 from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
 
+from odoo import fields
 from odoo.fields import Command, Date
 from odoo.tests import tagged, Form
 
@@ -431,6 +432,72 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         price_diff_aml = self.env['account.move.line'].search([('account_id', '=', stock_valuation_account.id), ('move_id', '=', move.id)])
         self.assertEqual(len(price_diff_aml), 0, "No line should have been generated in the stock valuation account about the price difference.")
 
+    def test_lc_with_avco_ordered_qty_backorder(self):
+        """ Make sure the landed cost added in invoices are taken into account to compute product
+        cost even in 'Ordered Quantity' invoice policy. """
+        self.env.company.anglo_saxon_accounting = True
+        self.landed_cost.split_method_landed_cost = 'by_quantity'
+        product2 = self.env['product.product'].create({
+            'name': 'product2',
+            'type': 'product',
+            'categ_id': self.stock_account_product_categ.id,
+        })
+        products = self.product1 | product2
+        products.purchase_method = 'purchase'
+        products.categ_id.write({
+            'property_stock_account_input_categ_id': self.company_data['default_account_stock_in'].id,
+            'property_stock_account_output_categ_id': self.company_data['default_account_stock_out'].id,
+            'property_stock_valuation_account_id': self.company_data['default_account_stock_valuation'].id,
+            'property_valuation': 'real_time',
+            'property_cost_method': 'average',
+        })
+        self.landed_cost.categ_id = products.categ_id.id
+
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': self.product1.id,
+                'product_qty': 100000,
+                'price_unit': 1,
+            }), Command.create({
+                'product_id': product2.id,
+                'product_qty': 50000,
+                'price_unit': 3,
+            })],
+        })
+        purchase_order.button_confirm()
+        purchase_order.action_create_invoice()
+        bill = purchase_order.invoice_ids[0]
+        receipt = purchase_order.picking_ids[0]
+        receipt.picking_type_id.create_backorder = 'always'
+        receipt.move_ids[0].quantity_done = 50000
+        receipt.move_ids[1].quantity_done = 25000
+        receipt.button_validate()
+        self.assertEqual(self.product1.standard_price, 1)
+        self.assertEqual(product2.standard_price, 3)
+
+        bill.invoice_date = fields.Date.today()
+        with Form(bill) as bill_form:
+            with bill_form.invoice_line_ids.new() as inv_line:
+                inv_line.product_id = self.landed_cost
+                inv_line.price_unit = 75000
+                inv_line.is_landed_costs_line = True
+        bill.action_post()
+        action = bill.button_create_landed_costs()
+        lc_form = Form(self.env[action['res_model']].browse(action['res_id']))
+        lc_form.picking_ids.add(receipt)
+        lc = lc_form.save()
+        lc.button_validate()
+        self.assertEqual(self.product1.standard_price, 2)
+        self.assertEqual(product2.standard_price, 4)
+
+        receipt2 = purchase_order.picking_ids.filtered(lambda p: p.state == 'assigned')
+        for move in receipt2.move_ids:
+            move.quantity_done = move.product_qty
+        receipt2.button_validate()
+        self.assertEqual(self.product1.standard_price, 1.5)
+        self.assertEqual(product2.standard_price, 3.5)
+
     def test_invoice_after_lc_amls(self):
         self.env.company.anglo_saxon_accounting = True
         self.landed_cost.landed_cost_ok = True
@@ -514,6 +581,7 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         })
         self.landed_cost.categ_id = self.product1.categ_id.id
         product = self.product1
+        product.uom_id = self.env.ref("uom.product_uom_kgm")
 
         purchase_order = self.env['purchase.order'].create({
             'partner_id': self.partner_a.id,


### PR DESCRIPTION
Issue 1
---
Trying to validate a receipt related to a landed cost account line for
a product using a uom from a different uom category will raise a
userError that do not allow you to validate the receipt.

### Steps to reproduce:

- Create a product:
    - real time property valuation
    - average cost method
    - on ordered quantities control policy
    - UOM from an other category han "Unit" e.g. kg
- Create and confirm a PO for 100 k units at 1.35 each
- Create an invoice for 23 k, receive 23k units and backorder
- Create a landed cost on the invoice for 23k units in the company currency units
- Post the invoice
- Create a second invoice for 27k units and post it
- Try to validate the receipt of the 27k units more units
> UserError: The unit of measure Units defined on the order line doesn't belong to the same category as the unit of measure kg > defined on the product.

### Cause of the issue:

Since Commit 32543ce9356f228d087d17a0ead1e0a80449e5de The landed_cost account lines related to a given stock move are also considered in the `_get_price_unit` call of stock moves:
https://github.com/odoo/odoo/blob/1b999e4b358eabe80cb3d636cd7bc348c5b85a1b/addons/purchase_stock/models/stock_move.py#L60
https://github.com/odoo/odoo/blob/1b999e4b358eabe80cb3d636cd7bc348c5b85a1b/addons/stock_landed_costs/models/purchase.py#L11-L16
However, the uom related to the landed cost account line might not match the uom category of the product related to the move. As such, this line will raise a UserError:
https://github.com/odoo/odoo/blob/da1f44c2296486c0267a7bdbbe3a314ada3aa679/addons/purchase_stock/models/stock_move.py#L70
https://github.com/odoo/odoo/blob/da1f44c2296486c0267a7bdbbe3a314ada3aa679/addons/uom/models/uom_uom.py#L223-L227

Issue 2
---
### Steps to reproduce

- Create a product invoiced on ordered quantities
- Create a PO and a bill for it, post the bill
- Receipt half the quantity
- Add a landed cost product on the PO, create a second bill for this landed cost product. Create and validate the landed cost.
- Receipt the second half quantity.

### Issue:

The valuation of the second transfer is too low

### Cause of the Issue 2:

To get the price unit for "on ordered qty" policy, We compute the ratio  of already receipt value on already invoiced value:
https://github.com/odoo/odoo/blob/4f6353ec8a7306fbf63e95e8e02248d72f413aa3/addons/purchase_stock/models/stock_move.py#L84
The issue is the receipt value is increase by the landed costs value  because the receipt valuation layer is linked to the landed cost  valuation layer. But the product invoice line is not linked to the  landed costs invoice line. Resulting in a invoice value under valuated.

This commit will ingnore the receipt values coming from landed costs so that the landed costs value will be added to the total invoiced value and not removed from the value here:
https://github.com/odoo/odoo/blob/cfb7a3593c5a4b313bdfd8628fe1b0dfe7e73823/addons/purchase_stock/models/stock_move.py#L72
*if* the landed cost has it's own invoice line.

Revert Commit 32543ce9356f228d087d17a0ead1e0a80449e5de
Authored-by: Whenrow <whe@odoo.com>

Issue 1: opw-4389366
Issue 2: opw-4354498
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
