### PR TITLE
[FIX] website: do not auto hide empty navbar

### DIFF
--- a/addons/website/static/src/js/content/auto_hide_menu.js
+++ b/addons/website/static/src/js/content/auto_hide_menu.js
@@ -9,11 +9,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     const header = document.querySelector('header#top');
     if (header) {
         const topMenu = header.querySelector('#top_menu');
-        if (header.classList.contains('o_no_autohide_menu')) {
+        const unfoldable = ".divider, .divider ~ li, .o_no_autohide_item, .js_language_selector";
+        if (!topMenu.querySelector(`:scope > :not(${unfoldable})`)
+                || header.classList.contains("o_no_autohide_menu")) {
             topMenu.classList.remove('o_menu_loading');
             return;
         }
-        const unfoldable = '.divider, .divider ~ li, .o_no_autohide_item, .js_language_selector';
         const excludedImagesSelector = '.o_mega_menu, .o_offcanvas_logo_container, .o_lang_flag';
         const excludedImages = [...header.querySelectorAll(excludedImagesSelector)];
         const images = [...header.querySelectorAll('img')].filter((img) => {


### PR DESCRIPTION
Before this commit, even if no foldable link items were present in the navbar of a website header, the function to check if items needed to be hidden was still executed.

After this commit, if no foldable items are present in the navbar, the function is not executed.

Running the function when no items are present can, in rare cases, cause errors (e.g., starting from version 17.0, if the "sales 1" header template contains no links and the page is zoomed). This is why we addressed this issue in this commit.

opw-4390661
