### PR TITLE
[FIX] hr_attendance: kiosk images out of box

### DIFF
--- a/addons/hr_attendance/static/src/components/manual_selection/manual_selection.xml
+++ b/addons/hr_attendance/static/src/components/manual_selection/manual_selection.xml
@@ -17,7 +17,7 @@
     </t>
     <t t-name="hr_attendance.public_kiosk_manual_selection">
         <t t-if="!this.props.displayBackButton">
-            <button t-on-click="() => this.props.onClickBack()" class="o_hr_attendance_back_button o_hr_attendance_back_button_md btn btn-secondary d-none d-md-inline-flex align-items-center position-absolute top-0 start-0 rounded-circle">
+            <button t-on-click="() => this.props.onClickBack()" class="o_hr_attendance_back_button o_hr_attendance_back_button_md btn btn-secondary d-none d-md-inline-flex align-items-center position-absolute top-0 start-0 rounded-circle m-5">
             <i class="oi fa-2x fa-fw oi-chevron-left me-1" role="img" aria-label="Go back" title="Go back"/>
         </button>
         </t>

--- a/addons/hr_attendance/static/src/components/pin_code/pin_code.xml
+++ b/addons/hr_attendance/static/src/components/pin_code/pin_code.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="hr_attendance.EmployeeBadge">
-    <div class="o_hr_attendance_user_badge o_attendance_background d-flex align-items-end justify-content-center flex-grow-1 pt-5 pt-md-4 bg-odoo">
+    <div class="o_attendance_background d-flex align-items-end justify-content-center flex-grow-1 pt-5 pt-md-4 bg-odoo">
         <img class="o_hr_attendance_employee_badge img rounded-circle" t-attf-src="data:image/png;base64,{{employeeAvatar}}" height="80"/>
     </div>
 </t>
@@ -14,7 +14,7 @@
         <t t-call="hr_attendance.EmployeeBadge">
             <t t-set="employeeAvatar" t-value="this.props.employeeData.employee_avatar"/>
         </t>
-        <button t-on-click="() => this.props.onClickBack()" class="o_hr_attendance_back_button o_hr_attendance_back_button_md btn btn-secondary d-none d-md-inline-flex align-items-center position-absolute top-0 start-0 rounded-circle">
+        <button t-on-click="() => this.props.onClickBack()" class="o_hr_attendance_back_button o_hr_attendance_back_button_md btn btn-secondary d-none d-md-inline-flex align-items-center position-absolute top-0 start-0 rounded-circle m-5">
             <i class="oi fa-2x fa-fw oi-chevron-left me-1" role="img" aria-label="Go back" title="Go back"/>
         </button>
 

--- a/addons/hr_attendance/static/src/hr_attendance.scss
+++ b/addons/hr_attendance/static/src/hr_attendance.scss
@@ -21,10 +21,6 @@
 .o_hr_attendance_kiosk_mode {
     @include media-breakpoint-up(md) {
         min-width: map-get($grid-breakpoints, 'md') * .6;
-
-        .o_hr_attendance_user_badge {
-            @include o-position-absolute(auto, $border-width * -1, 100%, $border-width * -1); // Compensate card's border
-        }
     }
 
     .o_hr_attendance_back_button_md {


### PR DESCRIPTION
Issue:
When using the kiosk in versions 17.0 & 17.2, 2 visual issues arise:
- when trying to identify manually, the "Go back" arrow is cropped out of its' container
- when identified, the user's profile picture is cropped out of the greeting container

Steps to reproduce:
- Install the attendance module
- Go to Kiosk Mode
- Identify Manually

Cause:
For the "Go back arrow", its' position in the container is set to the top left corner (absolute 0;0). The problem is that these coordinates are set for the center of the button and not its' top-left end. For the profile pictures, there is some V16 styling still present that wrongly sets the image's absolute position.

Notes:
I also changed the back button on the PIN screen since it had the same problem. It isn't pretty but everything is visible now...
![image](https://github.com/user-attachments/assets/6eee3958-e12c-44a8-bd8c-42d2f36119f6)


Ticket:
opw-4366047
