### PR TITLE
[FIX] website_sale_loyalty: validate rewards before payment

### DIFF
--- a/addons/website_sale_loyalty/i18n/website_sale_loyalty.pot
+++ b/addons/website_sale_loyalty/i18n/website_sale_loyalty.pot
@@ -38,6 +38,13 @@ msgid "Available on Website"
 msgstr ""
 
 #. module: website_sale_loyalty
+#. odoo-python
+#: code:addons/website_sale_loyalty/controllers/main.py:0
+#, python-format
+msgid "Cannot process payment: applied reward was changed or has expired."
+msgstr ""
+
+#. module: website_sale_loyalty
 #: model_terms:ir.ui.view,arch_db:website_sale_loyalty.modify_code_form
 msgid "Claim"
 msgstr ""

--- a/addons/website_sale_loyalty/tests/__init__.py
+++ b/addons/website_sale_loyalty/tests/__init__.py
@@ -1,5 +1,8 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from . import test_apply_pending_coupon
-from . import test_sale_coupon_multiwebsite
-from . import test_shop_sale_coupon
 from . import test_free_product_reward
+from . import test_sale_coupon_multiwebsite
+from . import test_shop_loyalty_payment
 from . import test_shop_multi_reward
+from . import test_shop_sale_coupon

--- a/addons/website_sale_loyalty/tests/test_shop_loyalty_payment.py
+++ b/addons/website_sale_loyalty/tests/test_shop_loyalty_payment.py
@@ -1,0 +1,74 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import date, timedelta
+from freezegun import freeze_time
+
+from odoo import Command
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+from odoo.addons.payment.tests.http_common import PaymentHttpCommon
+from odoo.addons.sale_loyalty.tests.common import TestSaleCouponCommon
+
+
+@tagged('post_install', '-at_install')
+class TestShopLoyaltyTransaction(PaymentHttpCommon, TestSaleCouponCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.website = cls.env.company.website_id
+        if not cls.website:
+            cls.website = cls.env.ref('website.default_website')
+            cls.website.company_id = cls.env.company
+
+    @mute_logger('odoo.http')
+    def test_expired_reward_validation(self):
+        """Ensure payments don't process if any applied reward is no longer valid."""
+        order = self.empty_order
+        program = self.program_gift_card
+
+        program.date_to = date.today()  # set program to expire after today
+        self.product_a.type = 'service'  # prevent need for delivery method
+
+        self.env['loyalty.generate.wizard'].with_context(active_id=program.id).create({
+            'coupon_qty': 1,
+            'points_granted': 100,
+        }).generate_coupons()
+
+        order.write({
+            'partner_id': self.portal_partner.id,
+            'website_id': self.website.id,
+            'message_partner_ids': self.portal_partner.ids,
+            'order_line': [Command.create({
+                'product_id': self.product_a.id,
+            })],
+        })
+        self._apply_promo_code(order, program.coupon_ids.code)
+
+        with freeze_time(program.date_to + timedelta(days=1)):
+            self.authenticate(self.portal_user.login, self.portal_user.login)
+            tx_response = self._make_json_rpc_request(
+                self._build_url(f'/shop/payment/transaction/{order.id}'),
+                {
+                    'order_id': order.id,
+                    'access_token': None,
+                    'amount': order.amount_total,
+                    'currency_id': order.currency_id.id,
+                    'payment_option_id': self.provider.id,
+                    'flow': 'direct',
+                    'tokenization_requested': False,
+                    'landing_route': order.get_portal_url(),
+                },
+            ).json()
+
+        self.assertIn(
+            'error',
+            tx_response,
+            "Attempting to initate payment with an expired reward should raise an error.",
+        )
+        self.assertEqual(
+            tx_response['error']['data']['message'],
+            "Cannot process payment: applied reward was changed or has expired.",
+        )


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Have a payment provider like Demo published;
2. create a discount program that expired yesterday;
3. change time of PC to yesterday;
4. go to eCommerce, add product to cart, go to checkout;
5. follow steps until you get to the "Pay Now" button;
6. change time of PC to today;
7. finalize payment.

Issue
-----
The payment transaction proceeds, but doesn't cover the entire amount, as the promotion was removed afterwards.

Cause
-----
When initiating payment, there's check on whether the applied rewards are still valid.

Solution
--------
Add an override for `_validate_transaction_for_order`, which compares the order amount before and after updating programs & rewards.

If they don't match, raise a `ValidationError`, forcing the user reload the order without expired programs & rewards.

opw-4304241