### PR TITLE
[IMP] mail: minor discuss style improvements

### DIFF
--- a/addons/hr_holidays/static/tests/channel_member_list.test.js
+++ b/addons/hr_holidays/static/tests/channel_member_list.test.js
@@ -1,6 +1,6 @@
 import { describe, test } from "@odoo/hoot";
 import { Command, serverState } from "@web/../tests/web_test_helpers";
-import { contains, click, openDiscuss, start, startServer } from "@mail/../tests/mail_test_helpers";
+import { contains, openDiscuss, start, startServer } from "@mail/../tests/mail_test_helpers";
 import { defineHrHolidaysModels } from "@hr_holidays/../tests/hr_holidays_test_helpers";
 
 describe.current.tags("desktop");
@@ -26,7 +26,6 @@ test("on leave members are categorised correctly in online/offline", async () =>
     });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Members']");
     await contains(".o-discuss-ChannelMemberList h6", { text: "Online - 3" });
     await contains(".o-discuss-ChannelMemberList h6", { text: "Offline - 1" });
 });

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -44,10 +44,6 @@
     width: $o-mail-Avatar-sizeSmall;
 }
 
-.o-mail-ChatWindow-quickActions {
-    gap: map-get($spacers, 1) / 2;
-}
-
 .o-mail-ChatWindow-typing {
     font-size: $small-font-size * 0.9;
     z-index: $o-mail-NavigableList-zIndex - 2;

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -78,7 +78,7 @@
             <div t-if="thread and thread.importantCounter > 0" class="o-mail-ChatWindow-counter mx-1 badge rounded-pill fw-bold o-discuss-badge" t-ref="needactionCounter">
                 <t t-out="thread.importantCounter"/>
             </div>
-            <div class="o-mail-ChatWindow-quickActions d-flex flex-shrink-0 me-2">
+            <div class="o-mail-ChatWindow-quickActions d-flex flex-shrink-0 me-2 o-gap-0_5">
                 <t t-foreach="partitionedActions.quick.slice(0, ui.isSmall ? 2 : 4).reverse()" t-as="action" t-key="action.id" t-call="mail.ChatWindow.quickAction">
                     <t t-if="action_last" t-set="itemClass" t-value="ui.isSmall ? 'mx-2' : ''"/>
                 </t>

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -11,7 +11,7 @@
                     'pb-2': extended and !props.composer.message,
                     'o-extended': extended,
                     'o-isUiSmall': ui.isSmall,
-                    'p-3': normal,
+                    'px-3 pb-2': normal,
                     'o-hasSelfAvatar': !env.inChatWindow and thread,
                     'o-focused': props.composer.isFocused,
                     'o-editing': props.composer.message,

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -49,6 +49,15 @@ $o-discuss-talkingColor: lighten($success, 5%);
     min-width: 0;
 }
 
+.o-gap-0_5 {
+    gap: map-get($spacers, 1) / 2;
+}
+
+.o-py-0_5 {
+    padding-top: map-get($spacers, 1) / 2;
+    padding-bottom: map-get($spacers, 1) / 2;
+}
+
 .o-hover-text-underline:hover {
     text-decoration: underline;
 }

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -238,6 +238,12 @@ export class Message extends Record {
                 time: this.datetime.toLocaleString(DateTime.TIME_24_SIMPLE, userLocale),
             });
         }
+        if (this.datetime?.year === DateTime.now().year) {
+            return this.datetime.toLocaleString(
+                { ...DateTime.DATETIME_MED, hourCycle: "h23", year: undefined },
+                userLocale
+            );
+        }
         return this.datetime.toLocaleString(
             { ...DateTime.DATETIME_MED, hourCycle: "h23" },
             userLocale

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -159,8 +159,14 @@ function transformAction(component, id, action) {
          * */
         open({ keepPrevious } = {}) {
             if (this.toggle) {
-                if (component.threadActions.activeAction && keepPrevious) {
-                    component.threadActions.actionStack.push(component.threadActions.activeAction);
+                if (component.threadActions.activeAction) {
+                    if (keepPrevious) {
+                        component.threadActions.actionStack.push(
+                            component.threadActions.activeAction
+                        );
+                    } else {
+                        component.threadActions.activeAction.close();
+                    }
                 }
                 component.threadActions.activeAction = this;
             }

--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -94,6 +94,23 @@ export class Discuss extends Component {
         }
         onMounted(() => (this.store.discuss.isActive = true));
         onWillUnmount(() => (this.store.discuss.isActive = false));
+        useEffect(
+            (memberListAction) => {
+                if (!memberListAction) {
+                    return;
+                }
+                if (this.store.discuss.isMemberPanelOpenByDefault) {
+                    if (!this.threadActions.activeAction) {
+                        memberListAction.open();
+                    } else if (this.threadActions.activeAction === memberListAction) {
+                        return; // no-op (already open)
+                    } else {
+                        this.store.discuss.isMemberPanelOpenByDefault = false;
+                    }
+                }
+            },
+            () => [this.threadActions.actions.find((a) => a.id === "member-list")]
+        );
     }
 
     get thread() {

--- a/addons/mail/static/src/core/public_web/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app_model.js
@@ -48,6 +48,21 @@ export class DiscussApp extends Record {
     activeTab = "main";
     searchTerm = "";
     isActive = false;
+    isMemberPanelOpenByDefault = Record.attr(true, {
+        compute() {
+            return (
+                browser.localStorage.getItem("mail.user_setting.no_members_default_open") !== "true"
+            );
+        },
+        /** @this {import("models").DiscussApp} */
+        onUpdate() {
+            if (this.isMemberPanelOpenByDefault) {
+                browser.localStorage.removeItem("mail.user_setting.no_members_default_open");
+            } else {
+                browser.localStorage.setItem("mail.user_setting.no_members_default_open", "true");
+            }
+        },
+    });
     isSidebarCompact = Record.attr(false, {
         compute() {
             return (

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebar">
-        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 border-end border-secondary z-1 o-mail-discussSidebarBgColor gap-1" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
+        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 border-end border-secondary z-1 o-mail-discussSidebarBgColor o-gap-0_5" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
             <div class="o-mail-DiscussSidebar-top position-sticky justify-content-center top-0 z-2 o-mail-discussSidebarBgColor" t-att-class="{ 'pt-2 pb-1': !store.inPublicPage, 'pt-1': store.inPublicPage }">
                 <div class="d-flex align-items-center justify-content-center" t-att-class="{ 'flex-column gap-2': store.discuss.isSidebarCompact }">
                     <t name="options-btn">

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -12,7 +12,7 @@
             'ps-3 pe-2 py-2': !ui.isSmall,
             'o-active': props.isActive,
         }">
-            <span class="o-mail-NotificationItem-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': props.muted, 'opacity-50': !props.muted }"><i class="fa fa-circle"/></span>
+            <span class="o-mail-NotificationItem-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': props.muted, 'opacity-75': !props.muted }"><i class="fa fa-circle"/></span>
             <div class="o-mail-NotificationItem-avatarContainer position-relative bg-inherit flex-shrink-0 align-self-start" t-att-class="{ 'o-small': ui.isSmall }">
                 <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.scss
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.scss
@@ -1,4 +1,4 @@
-.o-mail-Mailbox {
+.o-mail-Mailbox.o-compact {
     padding-top: map-get($spacers, 2) + map-get($spacers, 1) / 2; // so that button is square like other items
     padding-bottom: map-get($spacers, 2) + map-get($spacers, 1) / 2; // so that buton is square like other items
 }

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.DiscussSidebarMailboxes">
-        <div class="d-flex flex-column flex-grow-0 gap-1 mt-2">
+        <div class="d-flex flex-column flex-grow-0 o-gap-0_5 mt-2">
             <Mailbox mailbox="store.inbox"/>
             <Mailbox mailbox="store.starred"/>
             <Mailbox mailbox="store.history"/>
@@ -27,8 +27,8 @@
             t-att-class="{
                 'bg-inherit': mailbox.notEq(store.discuss.thread),
                 'o-active': mailbox.eq(store.discuss.thread),
-                'mx-2 justify-content-center position-relative': store.discuss.isSidebarCompact,
-                'mx-3 py-0': !store.discuss.isSidebarCompact,
+                'mx-2 justify-content-center position-relative o-compact': store.discuss.isSidebarCompact,
+                'mx-3 o-py-0_5': !store.discuss.isSidebarCompact,
                 'o-unread': mailbox.counter,
             }"
             t-on-click="(ev) => this.openThread(ev)"

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -126,6 +126,16 @@ threadActionsRegistry
         icon: "fa fa-fw fa-users",
         iconLarge: "fa fa-fw fa-lg fa-users",
         name: _t("Members"),
+        close(component) {
+            if (component.env.inDiscussApp) {
+                component.store.discuss.isMemberPanelOpenByDefault = false;
+            }
+        },
+        open(component) {
+            if (component.env.inDiscussApp) {
+                component.store.discuss.isMemberPanelOpenByDefault = true;
+            }
+        },
         sequence: 30,
         sequenceGroup: 10,
         toggle: true,

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -18,18 +18,18 @@ const threadPatch = {
         this.onlineMembers = Record.many("ChannelMember", {
             /** @this {import("models").Thread} */
             compute() {
-                return this.channelMembers.filter((member) =>
-                    this.store.onlineMemberStatuses.includes(member.persona.im_status)
-                );
-            },
-            sort(m1, m2) {
-                return this.store.sortMembers(m1, m2);
+                return this.channelMembers
+                    .filter((member) =>
+                        this.store.onlineMemberStatuses.includes(member.persona.im_status)
+                    )
+                    .sort((m1, m2) => this.store.sortMembers(m1, m2)); // FIXME: sort are prone to infinite loop (see test "Display livechat custom name in typing status")
             },
         });
         this.offlineMembers = Record.many("ChannelMember", {
-            compute: this._computeOfflineMembers,
-            sort(m1, m2) {
-                return this.store.sortMembers(m1, m2);
+            compute() {
+                return this._computeOfflineMembers().sort(
+                    (m1, m2) => this.store.sortMembers(m1, m2) // FIXME: sort are prone to infinite loop (see test "Display livechat custom name in typing status")
+                );
             },
         });
     },

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -81,7 +81,6 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
 .o-mail-DiscussSidebar-unreadIndicator {
     font-size: 0.35rem;
     left: 6px;
-    opacity: 35%;
 
     &.o-compact {
         left: 1px;

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -21,7 +21,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebarQuickSearchInput">
-        <div class="o-mail-DiscussSidebarQuickSearchInput d-flex align-items-center justify-content-center rounded gap-1" t-att-class="{ 'o-active': state.quickSearchVal.length, 'mx-3 mt-1': !store.discuss.isSidebarCompact }">
+        <div class="o-mail-DiscussSidebarQuickSearchInput d-flex align-items-center justify-content-center rounded gap-1" t-att-class="{ 'o-active': state.quickSearchVal.length, 'mx-3 mt-2 mb-1': !store.discuss.isSidebarCompact }">
             <input class="form-control rounded-3 border-0" placeholder="Quick search…" t-model="state.quickSearchVal" t-ref="root"/>
             <button t-if="state.quickSearchVal.length" class="btn btn-light p-1 rounded-0" t-on-click="() => state.quickSearchVal = ''"><i class="oi oi-close" title="Clear quick search"/></button>
         </div>
@@ -74,10 +74,10 @@
 
     <t t-name="mail.DiscussSidebarCategory.actions">
         <div class="d-flex">
-            <div class="o-mail-DiscussSidebarCategory-actions" t-att-class="{ 'd-flex flex-column align-items-start pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm mx-1': !store.discuss.isSidebarCompact }">
+            <div class="o-mail-DiscussSidebarCategory-actions" t-att-class="{ 'd-flex flex-column align-items-start pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm mx-1 o-gap-0_5': !store.discuss.isSidebarCompact }">
                 <t name="action-group">
                     <t t-foreach="actions" t-as="action" t-key="action_index">
-                        <button class="btn w-100 opacity-50 opacity-100-hover" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-circle p-0': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">
+                        <button class="btn w-100 opacity-50 opacity-100-hover" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">
                             <i role="img" class="fa-fw" t-att-class="action.icon"/>
                             <span t-if="store.discuss.isSidebarCompact" class="text-muted" t-esc="action.label"/>
                         </button>
@@ -88,7 +88,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebarChannel">
-        <div class="o-mail-DiscussSidebarChannel-container d-flex flex-column mx-2 bg-inherit" t-att-class="attClassContainer">
+        <div class="o-mail-DiscussSidebarChannel-container d-flex flex-column mx-2 bg-inherit o-py-0_5" t-att-class="attClassContainer">
             <t name="root">
                 <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
                     <t t-call="mail.DiscussSidebarChannel.main"/>
@@ -152,7 +152,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebar.unreadIndicator">
-        <span class="o-mail-DiscussSidebar-unreadIndicator position-absolute" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
+        <span class="o-mail-DiscussSidebar-unreadIndicator position-absolute opacity-50" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
     </t>
 
     <t t-name="mail.DiscussSidebarChannel.main">
@@ -188,10 +188,14 @@
     </t>
 
     <t t-name="mail.DiscussSidebarChannel.commands">
-        <div class="o-mail-DiscussSidebarChannel-commands" t-att-class="{ 'd-none mx-1': !store.discuss.isSidebarCompact }">
-            <div t-att-class="{ 'd-flex flex-column align-items-start ps-1 pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm gap-1': !store.discuss.isSidebarCompact }">
+        <div class="o-mail-DiscussSidebarChannel-commands" t-att-class="{
+            'd-none': !store.discuss.isSidebarCompact,
+            'mx-1': !store.discuss.isSidebarCompact and thread.importantCounter === 0,
+            'ms-1': !store.discuss.isSidebarCompact and thread.importantCounter > 0,
+        }">
+            <div t-att-class="{ 'd-flex flex-column align-items-start ps-1 pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm o-gap-0_5': !store.discuss.isSidebarCompact }">
                 <t t-foreach="sortedCommands" t-as="command" t-key="command_index">
-                    <button class="btn opacity-50 opacity-100-hover" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light rounded-circle p-0': !store.discuss.isSidebarCompact }" t-on-click.stop="() => command.onSelect()" t-att-title="store.discuss.isSidebarCompact ? '' : command.label">
+                    <button class="btn opacity-50 opacity-100-hover" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light rounded-3 p-0': !store.discuss.isSidebarCompact }" t-on-click.stop="() => command.onSelect()" t-att-title="store.discuss.isSidebarCompact ? '' : command.label">
                         <i role="img" class="fa-fw" t-att-class="command.icon"/>
                         <span t-if="store.discuss.isSidebarCompact" t-esc="command.label"/>
                     </button>

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -480,7 +480,6 @@ test("Can handle leave notification from unknown member", async () => {
     await withUser(userId, () =>
         getService("orm").call("discuss.channel", "action_unfollow", [channelId])
     );
-    await click("button[title='Members']");
     await contains(".o-discuss-ChannelMember", { text: "Mitchell Admin" });
     await contains(".o-discuss-ChannelMember", { count: 0, text: "Dobby" });
 });

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -41,6 +41,9 @@ test("should show member list when clicking on member list button in thread view
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // open by default
+    await click("[title='Members']");
+    await contains(".o-discuss-ChannelMemberList", { count: 0 });
     await click("[title='Members']");
     await contains(".o-discuss-ChannelMemberList");
 });
@@ -58,7 +61,6 @@ test("should have correct members in member list", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Members']");
     await contains(".o-discuss-ChannelMember", { count: 2 });
     await contains(".o-discuss-ChannelMember", { text: serverState.partnerName });
     await contains(".o-discuss-ChannelMember", { text: "Demo" });
@@ -82,7 +84,6 @@ test("members should be correctly categorised into online/offline", async () => 
     });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Members']");
     await contains(".o-discuss-ChannelMemberList h6", { text: "Online - 2" });
     await contains(".o-discuss-ChannelMemberList h6", { text: "Offline - 1" });
 });
@@ -101,7 +102,6 @@ test("chat with member should be opened after clicking on channel member", async
     });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Members']");
     await click(".o-discuss-ChannelMember.cursor-pointer", { text: "Demo" });
     await contains(".o_avatar_card .o_card_user_infos", { text: "Demo" });
     await click(".o_avatar_card button", { text: "Send message" });
@@ -123,8 +123,10 @@ test("should show a button to load more members if they are not all loaded", asy
     await start();
     await openDiscuss(channelId);
     pyEnv["discuss.channel"].write([channelId], { channel_member_ids });
-    await click("[title='Members']");
-    await contains("button", { text: "Load more" });
+    await contains(
+        ".o-mail-ActionPanel:has(.o-mail-ActionPanel-header:contains('Members')) button",
+        { text: "Load more" }
+    );
 });
 
 test("Load more button should load more members", async () => {
@@ -142,8 +144,9 @@ test("Load more button should load more members", async () => {
     await start();
     await openDiscuss(channelId);
     pyEnv["discuss.channel"].write([channelId], { channel_member_ids });
-    await click("[title='Members']");
-    await click("[title='Load more']");
+    await click(
+        ".o-mail-ActionPanel:has(.o-mail-ActionPanel-header:contains('Members')) [title='Load more']"
+    );
     await contains(".o-discuss-ChannelMember", { count: 102 });
 });
 
@@ -154,7 +157,6 @@ test("Channel member count update after user joined", async () => {
     pyEnv["res.partner"].create({ name: "Harry", user_ids: [userId] });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Members']");
     await contains(".o-discuss-ChannelMemberList h6", { text: "Offline - 1" });
     await click("[title='Invite People']");
     await click(".o-discuss-ChannelInvitation-selectable", { text: "Harry" });
@@ -177,7 +179,6 @@ test("Channel member count update after user left", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Members']");
     await contains(".o-discuss-ChannelMember", { count: 2 });
     await withUser(userId, () =>
         getService("orm").call("discuss.channel", "action_unfollow", [channelId])
@@ -211,7 +212,6 @@ test("Members are partitioned by online/offline", async () => {
     pyEnv["res.partner"].write([serverState.partnerId], { im_status: "online" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Members']");
     await contains(".o-discuss-ChannelMember", { count: 3 });
     await contains("h6", { text: "Online - 2" });
     await contains("h6", { text: "Offline - 1" });

--- a/addons/mail/static/tests/discuss/core/crosstab.test.js
+++ b/addons/mail/static/tests/discuss/core/crosstab.test.js
@@ -19,7 +19,6 @@ test("Add member to channel", async () => {
     pyEnv["res.partner"].create({ name: "Harry", user_ids: [userId] });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Members']");
     await contains(".o-discuss-ChannelMember", { text: "Mitchell Admin" });
     await click("[title='Invite People']");
     await click(".o-discuss-ChannelInvitation-selectable", { text: "Harry" });
@@ -45,7 +44,6 @@ test("Remove member from channel", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Members']");
     await contains(".o-discuss-ChannelMember", { text: "Harry" });
     withUser(userId, () =>
         getService("orm").call("discuss.channel", "action_unfollow", [channelId])

--- a/addons/mail/static/tests/discuss/core/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss.test.js
@@ -22,8 +22,7 @@ test("Member list and Pinned Messages Panel menu are exclusive", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Members']");
-    await contains(".o-discuss-ChannelMemberList");
+    await contains(".o-discuss-ChannelMemberList"); // member list open by default
     await click("[title='Pinned Messages']");
     await contains(".o-discuss-PinnedMessagesPanel");
     await contains(".o-discuss-ChannelMemberList", { count: 0 });

--- a/addons/mail/static/tests/discuss/typing/typing.test.js
+++ b/addons/mail/static/tests/discuss/typing/typing.test.js
@@ -373,7 +373,6 @@ test("show typing in member list", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Members']");
     await contains(".o-discuss-ChannelMember", { count: 2 });
     withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -335,7 +335,7 @@ test("mark channel as fetched when a new message is loaded", async () => {
 test.tags("focus required");
 test("mark channel as fetched when a new message is loaded and thread is focused", async () => {
     const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({});
+    const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
     const userId = pyEnv["res.users"].create({ partner_id: partnerId });
     const channelId = pyEnv["discuss.channel"].create({
         name: "test",


### PR DESCRIPTION
Some style tweaks to discuss for improved readability and usability:

1. Slightly more vertical spacing between discuss sidebar items.
   -> Motivation: discuss sidebar felt too crowded, which was a bit hard to see group of avatar and related conversation name.
2. `.rounded-3` on category and channel actions rather than `.rounded-circle`
   -> Motivation: rounded square match rest of UI better, and makes hover effect slightly more visible.
3. Consistent spacing in-between category and channel actions, less spacing when next to badge counter.
   -> Motivation: spacing was too big and inconsistent.
4. Composer in discuss app is slightly lower.
   -> Motivation: felt too high compared to other chat apps
5. Member list is open by default in discuss app. Its default opening state is saved in local storage, thus preserved when open.
   -> Motivation: better visual of online members, incite for more communication between members, and also discuss feels more feature-complete.
6. Discuss sidebar unread indicator (small dot) is slightly more visible (opacity 35% => 50%).
   messaging menu important indicator is more visible (opacity 50% => 75%)
   -> Motivation: more visible while still not too distracting, the new opacity fits more with the rest of UI.
7. Message datetime does not show year if same as current year
   -> Motivation: reduces UI noise a bit for 2 days-old messages.

https://github.com/odoo/enterprise/pull/75971

Discuss app, before
![before-1](https://github.com/user-attachments/assets/91db23f9-cc64-49a1-ad80-0cdfdc5a9983)
Discuss app, after
![Screenshot 2024-12-20 at 13 44 34](https://github.com/user-attachments/assets/46e9f0ae-86ab-4389-803d-8bec63dbd496)


Messaging menu item, before (important bullet opacity 50%)
![before-2](https://github.com/user-attachments/assets/bea0ca66-1104-4a7a-a7fa-cdb86641eea5)

Messaging menu item, after (important bullet opacity 75%)
![after-2](https://github.com/user-attachments/assets/a81689f7-aa64-493e-abc0-5f594026e4c5)
