### PR TITLE
[FIX] event: can't go back to event when in registration desk

### DIFF
--- a/addons/event/static/src/client_action/event_barcode.js
+++ b/addons/event/static/src/client_action/event_barcode.js
@@ -78,23 +78,8 @@ export class EventScanView extends Component {
 
     onClickBackToEvents() {
         if (this.isMultiEvent) {
-            // define action from scratch instead of using existing 'action_event_view' to avoid
-            // messing with menu bar
-            this.actionService.doAction({
-                type: "ir.actions.act_window",
-                name: _t("Events"),
-                res_model: "event.event",
-                views: [
-                    [false, "kanban"],
-                    [false, "calendar"],
-                    [false, "list"],
-                    [false, "gantt"],
-                    [false, "form"],
-                    [false, "pivot"],
-                    [false, "graph"],
-                    [false, "map"],
-                ],
-                target: "main",
+            this.actionService.doAction("event.action_event_view", {
+                clearBreadcrumbs: true,
             });
         } else {
             this.actionService.doAction({


### PR DESCRIPTION
* STEP TO REPRODUCE: install event (only CE code), go to Registration
Desk then hit button < to go back -> The system warning there are no
gantt view
* Solution: using existing action `action_event_view` with
`clearBreacrumbs` which will help display the menu correctly

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
