### PR TITLE
[FIX] website_sale: resolve product reorder issue in shop editor

### DIFF
--- a/addons/website_sale_product_configurator/data/demo.xml
+++ b/addons/website_sale_product_configurator/data/demo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
     <record id="sale_product_configurator.product_product_1_product_template" model="product.template">
-            <field name="website_sequence">9980</field>
+            <field name="website_sequence">9985</field>
             <field name="is_published" eval="True"/>
         </record>
     <record id="product.product_product_4_product_template" model="product.template">


### PR DESCRIPTION
**Steps to Reproduce:**
- Navigate to /shop .
- Open editor mode and select a product.
- Use the reorder widget from the editor panel to change the product's position.
- Notice the product jumps 2 positions instead of 1 when reordered.

**Issue:**
- Two products, 'Warranty' and 'Chair Floor Protection', have the same website_sequence. This causes the reorder logic to malfunction, making products jump 2 positions when one is placed in front or behind these two.

**Fix:**
- Updated the website_sequence of conflicting products to ensure all products have unique values.

**Affected Versions:** 16.0~master
opw-4150099