### PR TITLE
[FIX] web: fix record_selector_tests

### DIFF
--- a/addons/web/static/tests/core/record_selectors/record_selector_tests.js
+++ b/addons/web/static/tests/core/record_selectors/record_selector_tests.js
@@ -16,21 +16,7 @@ QUnit.module("Web Components", (hooks) => {
     QUnit.module("RecordSelector");
 
     let target;
-    const serverData = {
-        models: {
-            partner: {
-                fields: {
-                    display_name: { string: "Display name", type: "char" },
-                },
-                records: [
-                    { id: 1, display_name: "Alice" },
-                    { id: 2, display_name: "Bob" },
-                    { id: 3, display_name: "Charlie" },
-                ],
-            },
-        },
-    };
-
+    let serverData;
     async function makeRecordSelector(props, { mockRPC } = {}) {
         class Parent extends Component {
             setup() {
@@ -60,6 +46,20 @@ QUnit.module("Web Components", (hooks) => {
 
     hooks.beforeEach(async () => {
         target = getFixture();
+        serverData = {
+            models: {
+                partner: {
+                    fields: {
+                        display_name: { string: "Display name", type: "char" },
+                    },
+                    records: [
+                        { id: 1, display_name: "Alice" },
+                        { id: 2, display_name: "Bob" },
+                        { id: 3, display_name: "Charlie" },
+                    ],
+                },
+            },
+        };
         registry.category("services").add("hotkey", hotkeyService);
         registry.category("services").add("dialog", dialogService);
         registry.category("services").add("name", nameService);
@@ -199,6 +199,9 @@ QUnit.module("Web Components", (hooks) => {
             },
             {
                 mockRPC: (route, args) => {
+                    if (args.method === "has_group") {
+                        return true;
+                    }
                     if (args.method === "web_search_read") {
                         assert.step("web_search_read");
                         assert.deepEqual(args.kwargs.domain, [


### PR DESCRIPTION
Because of odoo/odoo@dd1dfbc1f2075c8f4b414fc6fe5287f6e0bf76c3 the test suite crashed when studio was not installed because the route has_group was called with no virtual endpoint.

After this commit, this is fixed

runbot-error-110790

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
