### PR TITLE
[IMP] website: fine-tune some snippets headings

### DIFF
--- a/addons/website/static/tests/builder/options/option_container.test.js
+++ b/addons/website/static/tests/builder/options/option_container.test.js
@@ -32,5 +32,5 @@ test("version control: replace outdated", async () => {
     await animationFrame();
     expect(".o_we_version_control").toHaveCount(0);
     expect(".we-bg-options-container:contains('Visibility'").toHaveCount(1);
-    expect(":iframe .s_title:contains('Your Site Title')").toHaveCount(1);
+    expect(":iframe .s_title:contains('Your section title')").toHaveCount(1);
 });

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -1084,19 +1084,19 @@ registerWebsitePreviewTour("website_form_editable_content", {
     },
     {
         content: "Click on the text inside the dropped form column",
-        trigger: ":iframe section.s_website_form h5.card-title",
+        trigger: ":iframe section.s_website_form h2.card-title",
         run: "dblclick",
     },
     {
         // Simulate a user interaction with the editable content.
         content: "Update the text inside the form column",
-        trigger: ":iframe section.s_website_form h5.card-title",
+        trigger: ":iframe section.s_website_form h2.card-title",
         run: "editor ABC",
     },
     {
         content: "Check that the new text value was correctly set",
-        trigger: ":iframe section.s_website_form h5:contains(/^ABC$/)",
-        run () {
+        trigger: ":iframe section.s_website_form h2:contains(/^ABC$/)",
+        run() {
             this.anchor.scrollIntoView();
         }
     },

--- a/addons/website/views/new_page_template_templates.xml
+++ b/addons/website/views/new_page_template_templates.xml
@@ -683,14 +683,14 @@ overridden by modules), because:
 <template id="new_page_template_s_three_columns" inherit_id="website.s_three_columns" primary="True"/>
 
 <template id="new_page_template_about_s_three_columns" inherit_id="website.new_page_template_s_three_columns" primary="True">
-    <xpath expr="//h3|//h4|//h5" position="replace">
-        <h3 class="card-title">Our Story</h3>
+    <xpath expr="//h2|//h3|//h4|//h5" position="replace">
+        <h2 class="card-title h5-fs">Our Story</h2>
     </xpath>
-    <xpath expr="(//h3|//h4|//h5)[2]" position="replace">
-        <h3 class="card-title">Our Mission</h3>
+    <xpath expr="(//h2|//h3|//h4|//h5)[2]" position="replace">
+        <h2 class="card-title h5-fs">Our Mission</h2>
     </xpath>
-    <xpath expr="(//h3|//h4|//h5)[3]" position="replace">
-        <h3 class="card-title">Our Values</h3>
+    <xpath expr="(//h2|//h3|//h4|//h5)[3]" position="replace">
+        <h2 class="card-title h5-fs">Our Values</h2>
     </xpath>
     <xpath expr="//p" position="replace">
         <p class="card-text">Step into our past and witness the transformation of a simple idea into an innovative force. Our journey, born in a garage, reflects the power of passion and hard work.</p>
@@ -706,14 +706,14 @@ overridden by modules), because:
 <template id="new_page_template_landing_s_three_columns" inherit_id="website.new_page_template_s_three_columns" primary="True"/>
 
 <template id="new_page_template_landing_2_s_three_columns" inherit_id="website.new_page_template_landing_s_three_columns" primary="True">
-    <xpath expr="//h3|//h4|//h5" position="replace">
-        <h3 class="card-title">Personalized Workouts</h3>
+    <xpath expr="//h2|//h3|//h4|//h5" position="replace">
+        <h2 class="card-title h5-fs">Personalized Workouts</h2>
     </xpath>
-    <xpath expr="(//h3|//h4|//h5)[2]" position="replace">
-        <h3 class="card-title">Nutritional Guidance</h3>
+    <xpath expr="(//h2|//h3|//h4|//h5)[2]" position="replace">
+        <h2 class="card-title h5-fs">Nutritional Guidance</h2>
     </xpath>
-    <xpath expr="(//h3|//h4|//h5)[3]" position="replace">
-        <h3 class="card-title">Progress Tracking</h3>
+    <xpath expr="(//h2|//h3|//h4|//h5)[3]" position="replace">
+        <h2 class="card-title h5-fs">Progress Tracking</h2>
     </xpath>
     <xpath expr="//p" position="replace">
         <p class="card-text">Our experienced fitness coaches design workouts that align with your goals, fitness level, and preferences.</p>
@@ -727,14 +727,14 @@ overridden by modules), because:
 </template>
 
 <template id="new_page_template_landing_3_s_three_columns" inherit_id="website.new_page_template_landing_s_three_columns" primary="True">
-    <xpath expr="//h3|//h4|//h5" position="replace">
-        <h3 class="card-title">Amazing Sound Quality</h3>
+    <xpath expr="//h2|//h3|//h4|//h5" position="replace">
+        <h2 class="card-title h5-fs">Amazing Sound Quality</h2>
     </xpath>
-    <xpath expr="(//h3|//h4|//h5)[2]" position="replace">
-        <h3 class="card-title">Wireless Freedom</h3>
+    <xpath expr="(//h2|//h3|//h4|//h5)[2]" position="replace">
+        <h2 class="card-title h5-fs">Wireless Freedom</h2>
     </xpath>
-    <xpath expr="(//h3|//h4|//h5)[3]" position="replace">
-        <h3 class="card-title">All-Day Comfort</h3>
+    <xpath expr="(//h2|//h3|//h4|//h5)[3]" position="replace">
+        <h2 class="card-title h5-fs">All-Day Comfort</h2>
     </xpath>
 </template>
 
@@ -742,14 +742,14 @@ overridden by modules), because:
 <template id="new_page_template_services_s_three_columns" inherit_id="website.new_page_template_s_three_columns" primary="True"/>
 
 <template id="new_page_template_services_0_s_three_columns" inherit_id="website.new_page_template_services_s_three_columns" primary="True">
-    <xpath expr="//h3|//h4|//h5" position="replace">
-        <h3 class="card-title">Wellness Coaching</h3>
+    <xpath expr="//h2|//h3|//h4|//h5" position="replace">
+        <h2 class="card-title h5-fs">Wellness Coaching</h2>
     </xpath>
-    <xpath expr="(//h3|//h4|//h5)[2]" position="replace">
-        <h3 class="card-title">Strength Training: </h3>
+    <xpath expr="(//h2|//h3|//h4|//h5)[2]" position="replace">
+        <h2 class="card-title h5-fs">Strength Training: </h2>
     </xpath>
-    <xpath expr="(//h3|//h4|//h5)[3]" position="replace">
-        <h3 class="card-title">Weight Loss Transformation</h3>
+    <xpath expr="(//h2|//h3|//h4|//h5)[3]" position="replace">
+        <h2 class="card-title h5-fs">Weight Loss Transformation</h2>
     </xpath>
     <xpath expr="//p" position="replace">
         <p class="card-text">Our Coaching combines personalized fitness plans with mindfulness practices, ensuring you achieve harmony in your body and peace in your mind.</p>
@@ -765,14 +765,14 @@ overridden by modules), because:
 <template id="new_page_template_team_s_three_columns" inherit_id="website.new_page_template_s_three_columns" primary="True"/>
 
 <template id="new_page_template_team_0_s_three_columns" inherit_id="website.new_page_template_team_s_three_columns" primary="True">
-    <xpath expr="//h3|//h4|//h5" position="replace">
-        <h3 class="card-title">Tony Fred, CEO</h3>
+    <xpath expr="//h2|//h3|//h4|//h5" position="replace">
+        <h2 class="card-title h5-fs">Tony Fred, CEO</h2>
     </xpath>
-    <xpath expr="(//h3|//h4|//h5)[2]" position="replace">
-        <h3 class="card-title">Mich Stark, COO</h3>
+    <xpath expr="(//h2|//h3|//h4|//h5)[2]" position="replace">
+        <h2 class="card-title h5-fs">Mich Stark, COO</h2>
     </xpath>
-    <xpath expr="(//h3|//h4|//h5)[3]" position="replace">
-        <h3 class="card-title">Aline Turner, CTO</h3>
+    <xpath expr="(//h2|//h3|//h4|//h5)[3]" position="replace">
+        <h2 class="card-title h5-fs">Aline Turner, CTO</h2>
     </xpath>
     <xpath expr="//div[hasclass('card')]//p|//div[hasclass('card-wrapper')]//p" position="replace">
         <p class="card-text">Founder and chief visionary, Tony is the driving force behind the company. He loves to keep his hands full by participating in the development of the software, marketing, and customer experience strategies.</p>
@@ -808,14 +808,14 @@ overridden by modules), because:
     <xpath expr="//section" position="attributes">
         <attribute name="data-snippet">s_three_columns</attribute>
     </xpath>
-    <xpath expr="//h3|//h4|//h5" position="replace">
-        <h3 class="card-title">Menu One</h3>
+    <xpath expr="//h2|//h3|//h4|//h5" position="replace">
+        <h2 class="card-title h5-fs">Menu One</h2>
     </xpath>
-    <xpath expr="(//h3|//h4|//h5)[2]" position="replace">
-        <h3 class="card-title">Menu Two</h3>
+    <xpath expr="(//h2|//h3|//h4|//h5)[2]" position="replace">
+        <h2 class="card-title h5-fs">Menu Two</h2>
     </xpath>
-    <xpath expr="(//h3|//h4|//h5)[3]" position="replace">
-        <h3 class="card-title">All You Can Eat</h3>
+    <xpath expr="(//h2|//h3|//h4|//h5)[3]" position="replace">
+        <h2 class="card-title h5-fs">All You Can Eat</h2>
     </xpath>
     <xpath expr="//p" position="replace">
         <p class="card-text">Vegetable Salad, Beef Burger and Mango Ice Cream</p>
@@ -843,13 +843,13 @@ overridden by modules), because:
 <template id="new_page_template_s_showcase" inherit_id="website.s_showcase" primary="True"/>
 
 <template id="new_page_template_landing_s_showcase" inherit_id="website.new_page_template_s_showcase" primary="True">
-    <xpath expr="//h5" position="replace" mode="inner">
+    <xpath expr="//h3" position="replace" mode="inner">
         Intuitive Touch Controls
     </xpath>
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Secure and Comfortable Fit
     </xpath>
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         On-the-Go Charging
     </xpath>
     <xpath expr="//p" position="replace">

--- a/addons/website/views/snippets/s_attributes_horizontal.xml
+++ b/addons/website/views/snippets/s_attributes_horizontal.xml
@@ -16,7 +16,7 @@
                                 />
                         </div>
                         <div class="col-10 col-lg-9 d-flex flex-column pe-0">
-                            <h6>Easy returns</h6>
+                            <h2 class="h6-fs">Easy returns</h2>
                             <small class="text-muted">Free 30-day returns with quick refunds or easy exchanges and no stress.</small>
                         </div>
                     </div>
@@ -32,7 +32,7 @@
                                 />
                         </div>
                         <div class="col-10 col-lg-9 d-flex flex-column pe-0">
-                            <h6>Free shipping</h6>
+                            <h2 class="h6-fs">Free shipping</h2>
                             <small class="text-muted">Enjoy fast, free shipping on all orders, no minimum, no hidden fees.</small>
                         </div>
                     </div>
@@ -48,7 +48,7 @@
                                 />
                         </div>
                         <div class="col-10 col-lg-9 d-flex flex-column pe-0">
-                            <h6>Secure payment</h6>
+                            <h2 class="h6-fs">Secure payment</h2>
                             <small class="text-muted">Your information is protected with encrypted checkout and trusted payment methods.</small>
                         </div>
                     </div>
@@ -64,7 +64,7 @@
                                 />
                         </div>
                         <div class="col-10 col-lg-9 d-flex flex-column pe-0">
-                            <h6>Quality assured</h6>
+                            <h2 class="h6-fs">Quality assured</h2>
                             <small class="text-muted">Every product is carefully tested to meet high standards of durability and performance.</small>
                         </div>
                     </div>

--- a/addons/website/views/snippets/s_call_to_action.xml
+++ b/addons/website/views/snippets/s_call_to_action.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-9">
-                    <h3>50,000+ companies run Odoo to grow their businesses.</h3>
+                    <h2 class="h3-fs">50,000+ companies run Odoo to grow their businesses.</h2>
                     <p class="lead">Join us and make your company a better place.</p>
                 </div>
                 <div class="col-lg-3">

--- a/addons/website/views/snippets/s_card.xml
+++ b/addons/website/views/snippets/s_card.xml
@@ -7,7 +7,7 @@
             <img class="o_card_img card-img-top" src="/web/image/website.s_card_default_image_1" alt=""/>
         </figure>
         <div class="card-body">
-            <h5 class="card-title">Card title</h5>
+            <h3 class="card-title h5-fs">Card title</h3>
             <p class="card-text">A card is a flexible and extensible content container. It includes options for headers and footers, a wide variety of content, contextual background colors, and powerful display options.</p>
             <a t-att-href="cta_btn_href">Discover</a>
         </div>

--- a/addons/website/views/snippets/s_card_offset.xml
+++ b/addons/website/views/snippets/s_card_offset.xml
@@ -9,7 +9,7 @@
                     <img src="/web/image/website.s_card_offset_default_image" class="img img-fluid mx-auto rounded" alt=""/>
                 </div>
                 <div class="o_grid_item g-height-7 g-col-lg-5 col-lg-5 offset-1 offset-lg-0 col-10 rounded o_colored_level o_cc o_cc1 shadow" style="z-index: 2; grid-area: 1 / 7 / 8 / 12; --grid-item-padding-y: 40px; --grid-item-padding-x: 32px; box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 10px !important;">
-                    <h3>Why Our Product is the Future of Innovation</h3>
+                    <h2 class="h3-fs">Why Our Product is the Future of Innovation</h2>
                     <p class="lead">Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers.</p>
                     <p class="lead">Start with the customer – find out what they want and give it to them.</p>
                 </div>

--- a/addons/website/views/snippets/s_cards_grid.xml
+++ b/addons/website/views/snippets/s_cards_grid.xml
@@ -4,7 +4,7 @@
 <template id="s_cards_grid" name="Cards Grid">
     <section class="s_cards_grid o_colored_level o_cc o_cc2 pt64 pb64">
         <div class="container">
-            <h3>Features that set us apart</h3>
+            <h2 class="h3-fs">Features that set us apart</h2>
             <div class="row">
                 <div data-name="Card" class="col-lg-6">
                     <div class="s_card o_card_img_horizontal o_cc o_cc1 card flex-lg-row" data-vxml="001" data-snippet="s_card" data-name="Card" style="--card-img-size-h: 25%;">
@@ -12,7 +12,7 @@
                             <img class="o_card_img rounded-start" src="/web/image/website.s_key_images_default_image_1" alt=""/>
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">Quality and Excellence</h5>
+                            <h3 class="card-title h5-fs">Quality and Excellence</h3>
                             <p class="card-text">We provide personalized solutions to meet your unique needs. Our team works with you to ensure optimal results from start to finish.</p>
                         </div>
                     </div>
@@ -23,7 +23,7 @@
                             <img class="o_card_img rounded-start" src="/web/image/website.s_key_images_default_image_2" alt=""/>
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">Expertise and Knowledge</h5>
+                            <h3 class="card-title h5-fs">Expertise and Knowledge</h3>
                             <p class="card-text">Customer satisfaction is our priority. Our support team is always ready to assist, ensuring you have a smooth and successful experience.</p>
                         </div>
                     </div>
@@ -34,7 +34,7 @@
                             <img class="o_card_img rounded-start" src="/web/image/website.s_key_images_default_image_3" alt=""/>
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">Eco-Friendly Solutions</h5>
+                            <h3 class="card-title h5-fs">Eco-Friendly Solutions</h3>
                             <p class="card-text">We offer cutting-edge products and services to tackle modern challenges. Leveraging the latest technology, we help you achieve your goals.</p>
                         </div>
                     </div>
@@ -45,7 +45,7 @@
                             <img class="o_card_img rounded-start" src="/web/image/website.s_key_images_default_image_4" alt=""/>
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">Tailored Solutions</h5>
+                            <h3 class="card-title h5-fs">Tailored Solutions</h3>
                             <p class="card-text">With extensive experience and deep industry knowledge, we provide insights and solutions that keep you ahead of the curve.</p>
                         </div>
                     </div>

--- a/addons/website/views/snippets/s_cards_soft.xml
+++ b/addons/website/views/snippets/s_cards_soft.xml
@@ -10,7 +10,7 @@
                 <div data-name="Card" class="col-lg-4 pt16 pb16">
                     <div class="s_card card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
                         <div class="card-body">
-                            <h5 class="card-title">Innovative Ideas</h5>
+                            <h3 class="card-title h5-fs">Innovative Ideas</h3>
                             <p class="card-text">Our creativity is at the forefront of everything we do, delivering innovative solutions that make your project stand out while maintaining a balance between originality and functionality.</p>
                             <img class="img img-fluid rounded" src="/web/image/website.s_three_columns_default_image_1" alt=""/>
                         </div>
@@ -19,7 +19,7 @@
                 <div data-name="Card" class="col-lg-4 pt16 pb16">
                     <div class="s_card card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
                         <div class="card-body">
-                            <h5 class="card-title">Comprehensive Support</h5>
+                            <h3 class="card-title h5-fs">Comprehensive Support</h3>
                             <p class="card-text">From the initial stages to completion, we offer support every step of the way, ensuring you feel confident in your choices and that your project is a success.</p>
                             <img class="img img-fluid rounded" src="/web/image/website.s_three_columns_default_image_2" alt=""/>
                         </div>
@@ -28,7 +28,7 @@
                 <div data-name="Card" class="col-lg-4 pt16 pb16">
                     <div class="s_card card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
                         <div class="card-body">
-                            <h5 class="card-title">Timeless Quality</h5>
+                            <h3 class="card-title h5-fs">Timeless Quality</h3>
                             <p class="card-text">Our services are built to last, ensuring that every solution we provide is of the highest quality, bringing lasting value to your investment and ultimate customer satisfaction.</p>
                             <img class="img img-fluid rounded" src="/web/image/website.s_three_columns_default_image_3" alt=""/>
                         </div>

--- a/addons/website/views/snippets/s_carousel.xml
+++ b/addons/website/views/snippets/s_carousel.xml
@@ -42,8 +42,8 @@
                     <div class="container oe_unremovable">
                         <div class="row">
                             <div class="carousel-content col-lg-6 offset-lg-6 pb24 pt24">
-                                <h3>Edit this title</h3>
-                                <h6>Good writing is simple, but not simplistic.</h6>
+                                <h2 class="h3-fs">Edit this title</h2>
+                                <p>Good writing is simple, but not simplistic.</p>
                                 <p><br/></p>
                                 <p class="lead">Good copy starts with understanding how your product or service helps your customers. Simple words communicate better than big words and pompous language.</p>
                             </div>

--- a/addons/website/views/snippets/s_carousel_cards.xml
+++ b/addons/website/views/snippets/s_carousel_cards.xml
@@ -14,7 +14,7 @@
                             <img class="o_card_img h-100" src="/web/image/website.s_carousel_cards_default_image_1" alt=""/>
                         </figure>
                         <div class="card-body">
-                            <h3 class="card-title">Slide title</h3>
+                            <h2 class="card-title h3-fs">Slide title</h2>
                             <p class="card-text">A card is a flexible and extensible content container. It includes colors and powerful display options.</p>
                             <a href="#" class="btn btn-secondary">Read More</a>
                         </div>
@@ -27,7 +27,7 @@
                             <img class="o_card_img h-100" src="/web/image/website.s_carousel_cards_default_image_2" alt=""/>
                         </figure>
                         <div class="card-body">
-                            <h3 class="card-title">Slide title</h3>
+                            <h2 class="card-title h3-fs">Slide title</h2>
                             <p class="card-text">A card is a flexible and extensible content container. It includes colors and powerful display options.</p>
                             <a href="#" class="btn btn-secondary">Read More</a>
                         </div>
@@ -40,7 +40,7 @@
                             <img class="o_card_img h-100" src="/web/image/website.s_carousel_cards_default_image_3" alt=""/>
                         </figure>
                         <div class="card-body">
-                            <h3 class="card-title">Slide title</h3>
+                            <h2 class="card-title h3-fs">Slide title</h2>
                             <p class="card-text">A card is a flexible and extensible content container. It includes colors and powerful display options.</p>
                             <a href="#" class="btn btn-secondary">Read More</a>
                         </div>

--- a/addons/website/views/snippets/s_company_team.xml
+++ b/addons/website/views/snippets/s_company_team.xml
@@ -4,7 +4,7 @@
 <template id="s_company_team" name="Team">
     <section class="s_company_team pt48 pb48">
         <div class="container">
-            <h3>Meet our team</h3>
+            <h2 class="h3-fs">Meet our team</h2>
             <p class="lead">Dedicated professionals driving our success</p>
             <div class="row">
                 <div class="col-lg-6 pt32 pb32" data-name="Team Member">
@@ -13,7 +13,7 @@
                             <img alt="" src="/web/image/website.s_company_team_image_1" class="img-fluid rounded-circle o_editable_media w-lg-100 mx-lg-auto"/>
                         </div>
                         <div class="col-lg-9">
-                            <h4 class="h5-fs">Tony Fred</h4>
+                            <h3 class="h5-fs">Tony Fred</h3>
                             <p class="text-muted mb-3">Chief Executive Officer</p>
                             <p>
                                 Founder and chief visionary, Tony is the driving force behind the company. He loves
@@ -29,7 +29,7 @@
                             <img alt="" src="/web/image/website.s_company_team_image_2" class="img-fluid rounded-circle o_editable_media w-lg-100 mx-lg-auto"/>
                         </div>
                         <div class="col-lg-9">
-                            <h4 class="h5-fs">Mich Stark</h4>
+                            <h3 class="h5-fs">Mich Stark</h3>
                             <p class="text-muted mb-3">Chief Commercial Officer</p>
                             <p>Mich loves taking on challenges. With his multi-year experience as Commercial Director in the software industry, Mich has helped the company to get where it is today. Mich is among the best minds.</p>
                         </div>
@@ -41,7 +41,7 @@
                             <img alt="" src="/web/image/website.s_company_team_image_3" class="img-fluid rounded-circle o_editable_media w-lg-100 mx-lg-auto"/>
                         </div>
                         <div class="col-lg-9">
-                            <h4 class="h5-fs">Aline Turner</h4>
+                            <h3 class="h5-fs">Aline Turner</h3>
                             <p class="text-muted mb-3">Chief Technical Officer</p>
                             <p>Aline is one of the iconic people in life who can say they love what they do. She mentors 100+ in-house developers and looks after the community of thousands of developers.</p>
                         </div>
@@ -53,7 +53,7 @@
                             <img alt="" src="/web/image/website.s_company_team_image_4" class="img-fluid rounded-circle o_editable_media w-lg-100 mx-lg-auto"/>
                         </div>
                         <div class="col-lg-9">
-                            <h4 class="h5-fs">Iris Joe</h4>
+                            <h3 class="h5-fs">Iris Joe</h3>
                             <p class="text-muted mb-3">Chief Financial Officer</p>
                             <p>Iris, with her international experience, helps us easily understand the numbers and improves them. She is determined to drive success and delivers her professional acumen to bring the company to the next level.</p>
                         </div>

--- a/addons/website/views/snippets/s_company_team_basic.xml
+++ b/addons/website/views/snippets/s_company_team_basic.xml
@@ -4,35 +4,35 @@
 <template id="s_company_team_basic" name="Team Basic">
     <section class="s_company_team_basic o_cc o_cc1 pt96 pb64">
         <div class="container">
-            <h3 style="text-align: center;">Discover our executive team</h3>
+            <h2 class="h3-fs" style="text-align: center;">Discover our executive team</h2>
             <p><br/></p>
             <div class="row">
                 <div class="col-lg-3 col-6 pb32" data-name="Team Member">
                     <p class="o_not_editable" contenteditable="false" style="text-align: center;">
                         <img alt="" class="o_editable_media img-fluid rounded-circle me-auto float-start" src="/web/image/website.s_company_team_image_1" style="width: 100% !important; padding: 20px"/>
                     </p>
-                    <h4 class="h5-fs" style="text-align: center;">Tony Fred, CEO</h4>
+                    <h3 class="h5-fs" style="text-align: center;">Tony Fred, CEO</h3>
                     <p class="o_small-fs text-muted" style="text-align: center;">Chief Executive Officer</p>
                 </div>
                 <div class="col-lg-3 col-6 pb32" data-name="Team Member">
                     <p class="o_not_editable" contenteditable="false" style="text-align: center;">
                         <img alt="" class="o_editable_media img-fluid rounded-circle me-auto float-start" src="/web/image/website.s_company_team_image_2" style="width: 100% !important; padding: 20px"/>
                     </p>
-                    <h4 class="h5-fs" style="text-align: center;">Mich Stark, COO</h4>
+                    <h3 class="h5-fs" style="text-align: center;">Mich Stark, COO</h3>
                     <p class="o_small-fs text-muted" style="text-align: center;">Chief Operational Officer</p>
                 </div>
                 <div class="col-lg-3 col-6 pb32" data-name="Team Member">
                     <p class="o_not_editable" contenteditable="false" style="text-align: center;">
                         <img alt="" class="o_editable_media img-fluid rounded-circle me-auto float-start" src="/web/image/website.s_company_team_image_3" style="width: 100% !important; padding: 20px"/>
                     </p>
-                    <h4 class="h5-fs" style="text-align: center;">Aline Turner, CTO</h4>
+                    <h3 class="h5-fs" style="text-align: center;">Aline Turner, CTO</h3>
                     <p class="o_small-fs text-muted" style="text-align: center;">Chief Technical Officer</p>
                 </div>
                 <div class="col-lg-3 col-6 pb32" data-name="Team Member">
                     <p class="o_not_editable" contenteditable="false" style="text-align: center;">
                         <img alt="" class="o_editable_media img-fluid rounded-circle me-auto float-start" src="/web/image/website.s_company_team_image_4" style="width: 100% !important; padding: 20px"/>
                     </p>
-                    <h4 class="h5-fs" style="text-align: center;">Iris Joe, CFO</h4>
+                    <h3 class="h5-fs" style="text-align: center;">Iris Joe, CFO</h3>
                     <p class="o_small-fs text-muted" style="text-align: center;">Chief Financial Officer</p>
                 </div>
             </div>

--- a/addons/website/views/snippets/s_company_team_detail.xml
+++ b/addons/website/views/snippets/s_company_team_detail.xml
@@ -4,14 +4,14 @@
 <template id="s_company_team_detail" name="Team Detail">
     <section class="s_company_team_detail o_cc o_cc1 pt64 pb64">
         <div class="container">
-            <h3>Meet our team</h3>
+            <h2 class="h3-fs">Meet our team</h2>
             <p class="lead">Dedicated professionals driving our success</p>
             <div class="row">
                 <div class="col-lg-4 pt32 pb32" data-name="Team Member">
                     <div class="o_not_editable" contenteditable="false">
                         <img class="o_editable_media img img-fluid rounded-circle" src="/web/image/website.s_company_team_image_1" alt="" style="width: 25% !important;"/>
                     </div>
-                    <h4 class="h5-fs"><br/>James Mitchell</h4>
+                    <h3 class="h5-fs"><br/>James Mitchell</h3>
                     <p class="text-muted">Chief Technical Officer</p>
                     <p>James leads the tech strategy and innovation efforts at the company.</p>
                     <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media">
@@ -31,11 +31,11 @@
                     <div class="o_not_editable" contenteditable="false">
                         <img class="o_editable_media img img-fluid rounded-circle" src="/web/image/website.s_company_team_image_6" alt="" style="width: 25% !important;"/>
                     </div>
-                    <h4 class="h5-fs"><br/>Sophia Benett</h4>
+                    <h3 class="h5-fs"><br/>Sophia Benett</h3>
                     <p class="text-muted">Financial Analyst</p>
                     <p>Sophia evaluates financial data and provides strategic insights.</p>
                     <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media">
-                        <h5 class="s_social_media_title d-none">Social Media</h5>
+                        <h4 class="s_social_media_title d-none h5-fs">Social Media</h4>
                         <a href="/website/social/github" class="s_social_media_github" target="_blank" aria-label="GitHub">
                             <i class="fa fa-github o_editable_media fa-stack"/>
                         </a>
@@ -51,11 +51,11 @@
                     <div class="o_not_editable" contenteditable="false">
                         <img class="o_editable_media img img-fluid rounded-circle" src="/web/image/website.s_company_team_image_3" alt="" style="width: 25% !important;"/>
                     </div>
-                    <h4 class="h5-fs"><br/>Olivia Reed</h4>
+                    <h3 class="h5-fs"><br/>Olivia Reed</h3>
                     <p class="text-muted">Product Manager</p>
                     <p>Olivia oversees product development from concept to launch.</p>
                     <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media">
-                        <h5 class="s_social_media_title d-none">Social Media</h5>
+                        <h4 class="s_social_media_title d-none h5-fs">Social Media</h4>
                         <a href="/website/social/github" class="s_social_media_github" target="_blank" aria-label="GitHub">
                             <i class="fa fa-github o_editable_media fa-stack"/>
                         </a>
@@ -71,11 +71,11 @@
                     <div class="o_not_editable" contenteditable="false">
                         <img class="o_editable_media img img-fluid rounded-circle" src="/web/image/website.s_company_team_image_4" alt="" style="width: 25% !important;"/>
                     </div>
-                    <h4 class="h5-fs"><br/>Emily Carter</h4>
+                    <h3 class="h5-fs"><br/>Emily Carter</h3>
                     <p class="text-muted">Human Resources Manager</p>
                     <p>Emily manages talent acquisition and workplace culture.</p>
                     <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media">
-                        <h5 class="s_social_media_title d-none">Social Media</h5>
+                        <h4 class="s_social_media_title d-none h5-fs">Social Media</h4>
                         <a href="/website/social/github" class="s_social_media_github" target="_blank" aria-label="GitHub">
                             <i class="fa fa-github o_editable_media fa-stack"/>
                         </a>
@@ -91,11 +91,11 @@
                     <div class="o_not_editable" contenteditable="false">
                         <img class="o_editable_media img img-fluid rounded-circle" src="/web/image/website.s_company_team_image_5" alt="" style="width: 25% !important;"/>
                     </div>
-                    <h4 class="h5-fs"><br/>Alexander Rivera</h4>
+                    <h3 class="h5-fs"><br/>Alexander Rivera</h3>
                     <p class="text-muted">Marketing Director</p>
                     <p>Alexander drives our marketing campaigns and brand presence.</p>
                     <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media">
-                        <h5 class="s_social_media_title d-none">Social Media</h5>
+                        <h4 class="s_social_media_title d-none h5-fs">Social Media</h4>
                         <a href="/website/social/github" class="s_social_media_github" target="_blank" aria-label="GitHub">
                             <i class="fa fa-github o_editable_media fa-stack"/>
                         </a>
@@ -111,11 +111,11 @@
                     <div class="o_not_editable" contenteditable="false">
                         <img class="o_editable_media img img-fluid rounded-circle" src="/web/image/website.s_company_team_image_2" alt="" style="width: 25% !important;"/>
                     </div>
-                    <h4 class="h5-fs"><br/>Daniel Foster</h4>
+                    <h3 class="h5-fs"><br/>Daniel Foster</h3>
                     <p class="text-muted">Operations Manager</p>
                     <p>Daniel ensures efficient daily operations and process optimization.</p>
                     <div class="s_social_media o_not_editable text-start no_icon_color" data-snippet="s_social_media" data-name="Social Media">
-                        <h5 class="s_social_media_title d-none">Social Media</h5>
+                        <h4 class="s_social_media_title d-none h5-fs">Social Media</h4>
                         <a href="/website/social/github" class="s_social_media_github" target="_blank" aria-label="GitHub">
                             <i class="fa fa-github o_editable_media fa-stack"/>
                         </a>

--- a/addons/website/views/snippets/s_company_team_spotlight.xml
+++ b/addons/website/views/snippets/s_company_team_spotlight.xml
@@ -13,7 +13,7 @@
                             <img class="o_card_img card-img-top" src="/web/image/website.s_company_team_image_1"/>
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">Tony Fred</h5>
+                            <h3 class="card-title h5-fs">Tony Fred</h3>
                             <p class="card-text">Chief Executive Officer</p>
                         </div>
                     </div>
@@ -24,7 +24,7 @@
                             <img class="o_card_img card-img-top" src="/web/image/website.s_company_team_image_2"/>
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">Mich Stark</h5>
+                            <h3 class="card-title h5-fs">Mich Stark</h3>
                             <p class="card-text">Chief Technical Manager</p>
                         </div>
                     </div>
@@ -35,7 +35,7 @@
                             <img class="o_card_img card-img-top" src="/web/image/website.s_company_team_image_3"/>
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">Aline Turner</h5>
+                            <h3 class="card-title h5-fs">Aline Turner</h3>
                             <p class="card-text">Chief Financial Officer</p>
                         </div>
                     </div>
@@ -46,7 +46,7 @@
                             <img class="o_card_img card-img-top" src="/web/image/website.s_company_team_image_4"/>
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">Iris Joe</h5>
+                            <h3 class="card-title h5-fs">Iris Joe</h3>
                             <p class="card-text">Chief Operational Officer</p>
                         </div>
                     </div>

--- a/addons/website/views/snippets/s_comparisons.xml
+++ b/addons/website/views/snippets/s_comparisons.xml
@@ -5,14 +5,14 @@
     <section class="s_comparisons pt48 pb48" data-vxml="001" data-vcss="001">
         <div class="container">
             <div class="mb-4">
-                <h3>Competitive pricing</h3>
+                <h2 class="h3-fs">Competitive pricing</h2>
                 <p class="lead">Listing your product pricing helps potential customers quickly determine if it fits their budget and needs.</p>
             </div>
             <div class="row gap-4 gap-lg-0">
                 <div class="col-lg-4" data-name="Plan">
                     <div class="s_card card o_cc o_cc1 h-100 my-0" data-vxml="001" data-snippet="s_card" data-name="Card">
                         <div class="card-body">
-                            <h5 class="card-title">Beginner</h5>
+                            <h3 class="card-title h5-fs">Beginner</h3>
                             <div class="my-2">
                                 <strong class="h2-fs">$ 15.00</strong>
                                 <small class="text-muted">/ month</small>
@@ -34,7 +34,7 @@
                 <div class="col-lg-4" data-name="Plan">
                     <div class="s_card card o_cc o_cc1 h-100 my-0" data-vxml="001" data-snippet="s_card" data-name="Card">
                         <div class="card-body">
-                            <h5 class="card-title">Professional</h5>
+                            <h3 class="card-title h5-fs">Professional</h3>
                             <div class="my-2">
                                 <strong class="h2-fs">$ 25.00</strong>
                                 <small class="text-muted">/ month</small>
@@ -56,7 +56,7 @@
                 <div class="col-lg-4" data-name="Plan">
                     <div class="s_card card o_cc o_cc1 h-100 my-0" data-vxml="001" data-snippet="s_card" data-name="Card">
                         <div class="card-body">
-                            <h5 class="card-title">Expert</h5>
+                            <h3 class="card-title h5-fs">Expert</h3>
                             <div class="my-2">
                                 <strong class="h2-fs">$ 45.00</strong>
                                 <small class="text-muted">/ month</small>

--- a/addons/website/views/snippets/s_cta_card.xml
+++ b/addons/website/views/snippets/s_cta_card.xml
@@ -13,7 +13,7 @@
                 <div class="col-lg-4">
                     <div class="s_card card o_cc o_cc1 mx-auto shadow" data-snippet="s_card" data-name="Card" data-vxml="001" style="border-width: 0px !important; max-width: 50%">
                         <div class="card-body p-4">
-                            <h5 class="card-title">What you will get</h5>
+                            <h3 class="card-title h5-fs">What you will get</h3>
                             <br/>
                             <p><i class="fa fa-check text-o-color-1" role="img"/>&#160;&#160;Wonderful experience</p>
                             <p><i class="fa fa-check text-o-color-1" role="img"/>&#160;&#160;Quick support</p>

--- a/addons/website/views/snippets/s_cta_mobile.xml
+++ b/addons/website/views/snippets/s_cta_mobile.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row o_grid_mode" data-row-count="8">
                 <div class="o_grid_item g-height-6 g-col-lg-12 col-lg-12 o_cc o_cc2 rounded" style="grid-area: 3 / 1 / 9 / 13; z-index: 1; --grid-item-padding-y: 80px; --grid-item-padding-x: 64px;">
-                    <h3>50,000+ companies trust Odoo.</h3>
+                    <h2 class="h3-fs">50,000+ companies trust Odoo.</h2>
                     <p class="lead">Join us and make your company a better place.<br/><br/></p>
                     <a href="https://www.apple.com/app-store/"><img src="/web/image/website.app_store_image" class="img img-fluid" alt="App Store"/></a>
                     <a href="https://play.google.com/store/"><img src="/web/image/website.google_play_image" class="img img-fluid" alt="Google Play"/></a>

--- a/addons/website/views/snippets/s_cta_mockups.xml
+++ b/addons/website/views/snippets/s_cta_mockups.xml
@@ -9,7 +9,7 @@
                     <img src="web_editor/image_shape/website.s_cta_mockups_default_image/web_editor/devices/macbook_front.svg" class="img img-fluid" data-shape="html_builder/devices/macbook_front" data-format-mimetype="image/webp" data-file-name="s_cta_mockups.webp" alt=""/>
                 </div>
                 <div class="o_grid_item g-height-6 g-col-lg-4 col-lg-4" style="grid-area: 3 / 1 / 9 / 5; z-index: 2;">
-                    <h3>50,000+ companies trust Odoo.</h3>
+                    <h2 class="h3-fs">50,000+ companies trust Odoo.</h2>
                     <p class="lead">Join us and make your company a better place.</p>
                     <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-out="cta_btn_text">Contact us</t></a>
                 </div>

--- a/addons/website/views/snippets/s_faq_collapse.xml
+++ b/addons/website/views/snippets/s_faq_collapse.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row align-items-start s_nb_column_fixed">
                 <div class="col-lg-4 pt16">
-                    <h3>Frequently asked questions</h3>
+                    <h2 class="h3-fs">Frequently asked questions</h2>
                     <p class="lead">Here are some common questions about our company.</p>
                 </div>
                 <div class="col-lg-7 offset-lg-1 s_col_no_bgcolor" data-name="Accordion Box">

--- a/addons/website/views/snippets/s_faq_list.xml
+++ b/addons/website/views/snippets/s_faq_list.xml
@@ -4,32 +4,32 @@
 <template id="s_faq_list" name="FAQ List">
     <section class="s_faq_list pt56 pb64">
         <div class="container">
-            <h3>Need help?</h3>
+            <h2 class="h3-fs">Need help?</h2>
             <p class="lead">In this section, you can address common questions efficiently.</p>
             <p><br/></p>
             <div class="row">
                 <div class="col-lg-4 pt16 pb16">
-                    <h6><strong>What sets us apart?</strong></h6>
+                    <h3 class="h6-fs"><strong>What sets us apart?</strong></h3>
                     <p>We deliver personalized solutions, ensuring that every customer receives top-tier service tailored to their needs.</p>
                 </div>
                 <div class="col-lg-4 pt16 pb16">
-                    <h6><strong>Is the website user-friendly?</strong></h6>
+                    <h3 class="h6-fs"><strong>Is the website user-friendly?</strong></h3>
                     <p>Our website is designed for easy navigation, allowing you to find the information you need quickly and efficiently.</p>
                 </div>
                 <div class="col-lg-4 pt16 pb16">
-                    <h6><strong>Can you trust our partners?</strong></h6>
+                    <h3 class="h6-fs"><strong>Can you trust our partners?</strong></h3>
                     <p>We collaborate with trusted, high-quality partners to bring you reliable and top-notch products and services.</p>
                 </div>
                 <div class="col-lg-4 pt16 pb16">
-                    <h6><strong>What support do we offer?</strong></h6>
+                    <h3 class="h6-fs"><strong>What support do we offer?</strong></h3>
                     <p>We provide 24/7 support through various channels, including live chat, email, and phone, to assist with any queries.</p>
                 </div>
                 <div class="col-lg-4 pt16 pb16">
-                    <h6><strong>How is your data secured?</strong></h6>
+                    <h3 class="h6-fs"><strong>How is your data secured?</strong></h3>
                     <p>Your data is protected by advanced encryption and security protocols, keeping your personal information safe.</p>
                 </div>
                 <div class="col-lg-4 pt16 pb16">
-                    <h6><strong>Are links to other websites approved?</strong></h6>
+                    <h3 class="h6-fs"><strong>Are links to other websites approved?</strong></h3>
                     <p>Although this Website may be linked to other websites, we are not, directly or indirectly, implying any approval.</p>
                 </div>
             </div>

--- a/addons/website/views/snippets/s_features.xml
+++ b/addons/website/views/snippets/s_features.xml
@@ -4,7 +4,7 @@
 <template id="s_features" name="Features">
     <section class="s_features pt64 pb64">
         <div class="container">
-            <h3>Everything you need</h3>
+            <h2 class="h3-fs">Everything you need</h2>
             <p class="lead">List and describe the key features of your solution or service.</p>
             <div class="row">
                 <div class="col-lg-4">

--- a/addons/website/views/snippets/s_features_grid.xml
+++ b/addons/website/views/snippets/s_features_grid.xml
@@ -9,7 +9,7 @@
                     <div class="row">
                         <div class="col-lg-12" data-name="Box">
                             <h2 class="h3-fs">Core Features</h2>
-                            <h5 class="lead">Essential tools for your success.</h5>
+                            <p class="lead h5-fs">Essential tools for your success.</p>
                             <div class="s_hr pt32 pb-2">
                                 <hr class="w-100 mx-auto"/>
                             </div>
@@ -17,21 +17,21 @@
                         <div class="col-lg-12 py-3" data-name="Box">
                             <i class="fa fa-flag-o rounded bg-o-color-3 s_features_grid_icon float-start flex-shrink-0" role="img"/>
                             <div class="s_features_grid_content mb-0 d-flex flex-column">
-                                <h4 class="h5-fs">Change Icons</h4>
+                                <h3 class="h5-fs">Change Icons</h3>
                                 <p>Double click an icon to replace it with one of your choice.</p>
                             </div>
                         </div>
                         <div class="col-lg-12 py-3" data-name="Box">
                             <i class="fa fa-files-o rounded bg-o-color-3 s_features_grid_icon float-start flex-shrink-0" role="img"/>
                             <div class="s_features_grid_content d-flex flex-column">
-                                <h4 class="h5-fs">Duplicate</h4>
+                                <h3 class="h5-fs">Duplicate</h3>
                                 <p>Duplicate blocks and columns to add more features.</p>
                             </div>
                         </div>
                         <div class="col-lg-12 py-3" data-name="Box">
                             <i class="fa fa-trash-o rounded bg-o-color-3 s_features_grid_icon float-start flex-shrink-0" role="img"/>
                             <div class="s_features_grid_content d-flex flex-column">
-                                <h4 class="h5-fs">Delete Blocks</h4>
+                                <h3 class="h5-fs">Delete Blocks</h3>
                                 <p>Select and delete blocks to remove features.</p>
                             </div>
                         </div>
@@ -41,7 +41,7 @@
                     <div class="row">
                         <div class="col-lg-12" data-name="Box">
                             <h2 class="h3-fs">Foundation Package</h2>
-                            <h5 class="lead">Everything you need to get started.</h5>
+                            <p class="lead h5-fs">Everything you need to get started.</p>
                             <div class="s_hr pt32 pb-2">
                                 <hr class="w-100 mx-auto"/>
                             </div>
@@ -49,21 +49,21 @@
                         <div class="col-lg-12 py-3" data-name="Box">
                             <i class="fa fa-magic rounded bg-o-color-3 s_features_grid_icon float-start flex-shrink-0" role="img"/>
                             <div class="s_features_grid_content d-flex flex-column">
-                                <h4 class="h5-fs">Great Value</h4>
+                                <h3 class="h5-fs">Great Value</h3>
                                 <p>Turn every feature into a benefit for your reader.</p>
                             </div>
                         </div>
                         <div class="col-lg-12 py-3" data-name="Box">
                             <i class="fa fa-eyedropper rounded bg-o-color-3 s_features_grid_icon float-start flex-shrink-0" role="img"/>
                             <div class="s_features_grid_content d-flex flex-column">
-                                <h4 class="h5-fs">Edit Styles</h4>
+                                <h3 class="h5-fs">Edit Styles</h3>
                                 <p>You can edit colors and backgrounds to highlight features.</p>
                             </div>
                         </div>
                         <div class="col-lg-12 py-3" data-name="Box">
                             <i class="fa fa-picture-o rounded bg-o-color-3 s_features_grid_icon float-start flex-shrink-0" role="img"/>
                             <div class="s_features_grid_content d-flex flex-column">
-                                <h4 class="h5-fs">Sample Icons</h4>
+                                <h3 class="h5-fs">Sample Icons</h3>
                                 <p>All these icons are completely free for commercial use.</p>
                             </div>
                         </div>

--- a/addons/website/views/snippets/s_features_wave.xml
+++ b/addons/website/views/snippets/s_features_wave.xml
@@ -5,7 +5,7 @@
     <section class="s_features_wave o_cc o_cc5 pt64 pb88" data-oe-shape-data="{'shape':'web_editor/Wavy/11_001','colors':{'c5':'o-color-1'}, 'showOnMobile':true}">
         <div class="o_we_shape o_web_editor_Wavy_11_001 o_shape_show_mobile" style="background-image: url('/web_editor/shape/web_editor/Wavy/11_001.svg?c5=o-color-1');"/>
         <div class="container">
-            <h3 style="text-align: center;">Everything you need</h3>
+            <h2 class="h3-fs" style="text-align: center;">Everything you need</h2>
             <p class="lead" style="text-align: center;">List and describe the key features of your solution or service.</p>
             <p><br/></p>
             <div class="row">

--- a/addons/website/views/snippets/s_image_frame.xml
+++ b/addons/website/views/snippets/s_image_frame.xml
@@ -9,7 +9,7 @@
                     <img src="/web/image/website.s_image_frame_default_image" class="img img-fluid mx-auto" style="padding: 16px;" alt=""/>
                 </div>
                 <div class="o_grid_item g-height-4 g-col-lg-5 col-10 offset-1 col-lg-5 offset-lg-0 order-lg-0 rounded o_cc o_cc1" style="z-index: 1; grid-area: 7 / 7 / 11 / 12; --grid-item-padding-x: 32px; order: 0;">
-                    <h3>Product highlight</h3>
+                    <h2 class="h3-fs">Product highlight</h2>
                     <p class="lead">Choose a vibrant image and write an inspiring paragraph about it. It does not have to be long, but it should reinforce your image.</p>
                 </div>
             </div>

--- a/addons/website/views/snippets/s_image_text_box.xml
+++ b/addons/website/views/snippets/s_image_text_box.xml
@@ -10,7 +10,7 @@
                     <img src="/web/image/website.s_text_cover_default_image" class="img img-fluid rounded order-lg-0" alt=""/>
                 </div>
                 <div class="o_grid_item o_cc o_cc2 g-col-lg-6 g-height-10 col-lg-6 rounded order-lg-0" style="grid-area: 1 / 7 / 11 / 13; z-index: 2; --grid-item-padding-y: 140px; --grid-item-padding-x: 48px; order:1;">
-                    <h3>Learn about our offerings</h3>
+                    <h2 class="h3-fs">Learn about our offerings</h2>
                     <p>Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers.</p>
                     <p>Start with the customer – find out what they want and give it to them.</p>
                     <p class="mb-0"><a href="#" class="btn btn-primary o_translate_inline">Learn more</a></p>

--- a/addons/website/views/snippets/s_masonry_block.xml
+++ b/addons/website/views/snippets/s_masonry_block.xml
@@ -21,19 +21,19 @@ Use t-snippet-call and fill it with its inner grid-mode row.
                 <img src="/web/image/website.s_masonry_block_default_image_1" class="img img-fluid mx-auto" alt=""/>
             </div>
             <div class="o_grid_item o_cc o_cc2 g-height-4 g-col-lg-3 col-lg-3 justify-content-end order-lg-0 rounded-4" data-name="Block" style="order: 2; --grid-item-padding-y: 20px; --grid-item-padding-x: 20px; z-index: 2; grid-area: 1 / 6 / 5 / 9;">
-                <h3>Key <br class="d-none d-lg-inline"/>Milestone</h3>
+                <h2 class="h3-fs">Key <br class="d-none d-lg-inline"/>Milestone</h2>
                 <p>Reaching new heights</p>
             </div>
             <div class="o_grid_item o_cc o_cc3 g-height-4 g-col-lg-4 col-lg-4 justify-content-end order-lg-0 rounded-4" data-name="Block" style="order: 1; --grid-item-padding-y: 20px; --grid-item-padding-x: 20px; z-index: 3; grid-area: 1 / 9 / 5 / 13; background-image: linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-2) 100%);">
-                <h3>Greater <br class="d-none d-lg-inline"/>Impact</h3>
+                <h2 class="h3-fs">Greater <br class="d-none d-lg-inline"/>Impact</h2>
                 <p>Making a difference every day</p>
             </div>
             <div class="o_grid_item o_cc o_cc4 g-height-4 g-col-lg-4 col-lg-4 justify-content-end order-lg-0 rounded-4" data-name="Block" style="order: 3; --grid-item-padding-y: 20px; --grid-item-padding-x: 20px; z-index: 4; grid-area: 5 / 6 / 9 / 10; background-image: linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-1) 100%);">
-                <h3>Innovation <br class="d-none d-lg-inline"/>Hub</h3>
+                <h2 class="h3-fs">Innovation <br class="d-none d-lg-inline"/>Hub</h2>
                 <p>Where ideas come to life</p>
             </div>
             <div class="o_grid_item o_cc o_cc2 g-height-4 g-col-lg-3 col-lg-3 justify-content-end order-lg-0 rounded-4" data-name="Block" style="order: 4; --grid-item-padding-y: 20px; --grid-item-padding-x: 20px; z-index: 5; grid-area: 5 / 10 / 9 / 13;">
-                <h3>Community <br class="d-none d-lg-inline"/>Focus</h3>
+                <h2 class="h3-fs">Community <br class="d-none d-lg-inline"/>Focus</h2>
                 <p>Building connections</p>
             </div>
         </div>
@@ -46,22 +46,22 @@ Use t-snippet-call and fill it with its inner grid-mode row.
         <div class="row o_grid_mode" data-row-count="10">
             <div class="o_grid_item o_cc o_cc3 g-height-5 g-col-lg-3 col-lg-3 justify-content-center text-center" data-name="Block"
                 style="grid-area: 1 / 1 / 6 / 4; z-index: 1; background-image: linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-2) 100%);">
-                <h3>Greater <br class="d-none d-lg-inline"/>Impact</h3>
+                <h2 class="h3-fs">Greater <br class="d-none d-lg-inline"/>Impact</h2>
                 <p>Making a difference every day</p>
             </div>
             <div class="o_grid_item o_cc o_cc2 g-height-5 g-col-lg-3 col-lg-3 justify-content-center text-center" data-name="Block"
                 style="grid-area: 1 / 4 / 6 / 7; z-index: 2;">
-                <h3>Key <br class="d-none d-lg-inline"/>Milestone</h3>
+                <h2 class="h3-fs">Key <br class="d-none d-lg-inline"/>Milestone</h2>
                 <p>Reaching new heights together</p>
             </div>
             <div class="o_grid_item o_cc o_cc2 g-height-5 g-col-lg-3 col-lg-3 justify-content-center text-center" data-name="Block"
                 style="grid-area: 6 / 1 / 11 / 4; z-index: 3;">
-                <h3>Innovation <br class="d-none d-lg-inline"/>Hub</h3>
+                <h2 class="h3-fs">Innovation <br class="d-none d-lg-inline"/>Hub</h2>
                 <p>Where ideas come to life</p>
             </div>
             <div class="o_grid_item o_cc o_cc4 g-height-5 g-col-lg-3 col-lg-3 justify-content-center text-center" data-name="Block"
                 style="grid-area: 6 / 4 / 11 / 7; z-index: 4; background-image: linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-1) 100%);">
-                <h3>Community <br class="d-none d-lg-inline"/>Focus</h3>
+                <h2 class="h3-fs">Community <br class="d-none d-lg-inline"/>Focus</h2>
                 <p>Building connections</p>
             </div>
             <div class="o_grid_item o_grid_item_image g-height-10 g-col-lg-6 col-lg-6 text-center" data-name="Block"
@@ -77,12 +77,12 @@ Use t-snippet-call and fill it with its inner grid-mode row.
         <div class="row o_grid_mode" data-row-count="8" style="gap: 16px;">
             <div class="o_grid_item o_cc o_cc5 g-height-8 g-col-lg-6 col-lg-6 justify-content-start shadow rounded-3 oe_img_bg o_bg_img_center" data-name="Block" style="z-index: 1; grid-area: 1 / 1 / 9 / 7; background-image: url(/web/image/website.s_masonry_block_default_image_2); --grid-item-padding-y: 30px; --grid-item-padding-x: 30px;">
                 <div class="o_we_bg_filter bg-black-50"/>
-                <h3 class="display-4-fs">Key <br class="d-none d-lg-inline"/>Milestone</h3>
+                <h2 class="display-4-fs">Key <br class="d-none d-lg-inline"/>Milestone</h2>
                 <p class="lead">Reaching new heights together</p>
             </div>
             <div class="o_grid_item o_cc o_cc5 g-height-8 g-col-lg-6 col-lg-6 justify-content-start shadow rounded-3 oe_img_bg o_bg_img_center" data-name="Block" style="z-index: 2; grid-area: 1 / 7 / 9 / 13; background-image: url(/web/image/website.s_masonry_block_default_image_1); --grid-item-padding-y: 30px; --grid-item-padding-x: 30px;">
                 <div class="o_we_bg_filter bg-black-50"/>
-                <h3 class="display-4-fs">Innovation <br class="d-none d-lg-inline"/>Hub</h3>
+                <h2 class="display-4-fs">Innovation <br class="d-none d-lg-inline"/>Hub</h2>
                 <p class="lead">Where ideas come to life</p>
             </div>
         </div>
@@ -93,11 +93,11 @@ Use t-snippet-call and fill it with its inner grid-mode row.
     <t t-snippet-call="website.s_masonry_block">
         <div class="row o_grid_mode" data-row-count="10" style="gap: 16px;">
             <div class="o_grid_item o_cc o_cc3 g-height-3 g-col-lg-3 col-lg-3 justify-content-start order-lg-0 rounded-3" data-name="Block" style="order: 1; z-index: 1; --grid-item-padding-y: 20px; --grid-item-padding-x: 20px; grid-area: 1 / 1 / 4 / 4; linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-2) 100%);">
-                <h3>Innovation</h3>
+                <h2 class="h3-fs">Innovation</h2>
                 <p>How ideas come to life</p>
             </div>
             <div class="o_grid_item o_cc o_cc2 g-height-3 g-col-lg-3 col-lg-3 justify-content-start order-lg-0 rounded-3" data-name="Block" style="order: 2; z-index: 2; --grid-item-padding-y: 20px; --grid-item-padding-x: 20px; grid-area: 1 / 4 / 4 / 7;">
-                <h3>Focus</h3>
+                <h2 class="h3-fs">Focus</h2>
                 <p>Building connections</p>
             </div>
             <div class="o_grid_item o_grid_item_image g-height-7 g-col-lg-6 col-lg-6 rounded-3 text-center order-lg-0" data-name="Block" style="order: 0; z-index: 3; grid-area: 1 / 7 / 8 / 13;">
@@ -107,11 +107,11 @@ Use t-snippet-call and fill it with its inner grid-mode row.
                 <img src="/web/image/website.s_masonry_block_default_image_1" class="img img-fluid mx-auto" alt=""/>
             </div>
             <div class="o_grid_item o_cc o_cc2 g-height-3 g-col-lg-3 col-lg-3 justify-content-center text-center order-lg-0 rounded-3" data-name="Block" style="order: 4; z-index: 5; --grid-item-padding-y: 20px; --grid-item-padding-x: 20px; grid-area: 8 / 7 / 11 / 10;">
-                <h3 class="display-1-fs">22%</h3>
+                <h2 class="display-1-fs">22%</h2>
                 <p>Reaching new heights</p>
             </div>
             <div class="o_grid_item o_cc o_cc4 g-height-3 g-col-lg-3 col-lg-3 justify-content-center text-center order-lg-0 rounded-3" data-name="Block" style="order: 5; z-index: 6; --grid-item-padding-y: 20px; --grid-item-padding-x: 20px; grid-area: 8 / 10 / 11 / 13; linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-1) 100%);">
-                <h3 class="display-1-fs">+12</h3>
+                <h2 class="display-1-fs">+12</h2>
                 <p>Mark the difference</p>
             </div>
         </div>
@@ -122,14 +122,14 @@ Use t-snippet-call and fill it with its inner grid-mode row.
     <t t-snippet-call="website.s_masonry_block">
         <div class="row o_grid_mode" data-row-count="4" style="gap: 16px;">
             <div class="o_grid_item o_cc o_cc2 g-height-4 g-col-lg-3 col-lg-3 justify-content-start rounded" data-name="Block" style="z-index: 1; grid-area: 1 / 1 / 5 / 4; --grid-item-padding-y: 20px; --grid-item-padding-x: 20px;">
-                <h3 class="h4-fs">Incredible <br class="d-none d-lg-inline"/>Features</h3>
+                <h2 class="h4-fs">Incredible <br class="d-none d-lg-inline"/>Features</h2>
                 <p>&#160;</p>
             </div>
             <div class="o_grid_item o_grid_item_image g-height-4 g-col-lg-3 col-lg-3 rounded" data-name="Block" style="z-index: 2; grid-area: 1 / 4 / 5 / 7;">
                 <img src="/web/image/website.s_masonry_block_default_image_1" class="img img-fluid mx-auto" alt=""/>
             </div>
             <div class="o_grid_item o_cc o_cc2 g-height-4 g-col-lg-3 col-lg-3 justify-content-start rounded" data-name="Block" style="z-index: 3; grid-area: 1 / 7 / 5 / 10; --grid-item-padding-y: 20px; --grid-item-padding-x: 20px;">
-                <h3 class="h4-fs">Advanced <br class="d-none d-lg-inline"/>Capabilities</h3>
+                <h2 class="h4-fs">Advanced <br class="d-none d-lg-inline"/>Capabilities</h2>
                 <p>&#160;</p>
             </div>
             <div class="o_grid_item o_grid_item_image g-height-4 g-col-lg-3 col-lg-3 rounded" data-name="Block" style="z-index: 4; grid-area: 1 / 10 / 5 / 13;">
@@ -148,7 +148,7 @@ Use t-snippet-call and fill it with its inner grid-mode row.
             </div>
             <div class="o_grid_item o_cc o_cc2 g-height-10 g-col-lg-3 col-lg-3 justify-content-center text-center" data-name="Block" style="grid-area: 1 / 4 / 11 / 7; z-index: 2; position: relative;" data-oe-shape-data="{'shape':'web_editor/Rainy/06','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}">
                 <div class="o_we_shape o_web_editor_Rainy_06"/>
-                <h3 class="h2-fs">Innovation Hub</h3>
+                <h2>Innovation Hub</h2>
                 <p>Where ideas come to life</p>
             </div>
             <div class="o_grid_item o_grid_item_image g-height-10 g-col-lg-3 col-lg-3 text-center" data-name="Block" style="grid-area: 1 / 7 / 11 / 10; z-index: 3;">
@@ -156,7 +156,7 @@ Use t-snippet-call and fill it with its inner grid-mode row.
             </div>
             <div class="o_grid_item o_cc o_cc2 g-height-10 g-col-lg-3 col-lg-3 justify-content-center text-center" data-name="Block" style="grid-area: 1 / 10 / 11 / 13; z-index: 4; position: relative;" data-oe-shape-data="{'shape':'web_editor/Floats/01','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0','animated':'true'}">
                 <div class="o_we_shape o_web_editor_Floats_01 o_we_animated"/>
-                <h3 class="h2-fs">Key Milestone</h3>
+                <h2>Key Milestone</h2>
                 <p>Reaching new heights together</p>
             </div>
         </div>

--- a/addons/website/views/snippets/s_numbers.xml
+++ b/addons/website/views/snippets/s_numbers.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row s_nb_column_fixed">
                 <div class="col-lg-5">
-                    <h3 class="mb-3 h4">Key Metrics of<br/>Company's Achievements</h3>
+                    <h2 class="mb-3 h4-fs">Key Metrics of<br/>Company's Achievements</h2>
                     <p class="lead">Analyzing the numbers behind our success: <br class="d-none d-xxl-inline"/>an in-depth look at the key metrics driving our company's achievements</p>
                 </div>
                 <div class="col-lg-2 offset-lg-1">

--- a/addons/website/views/snippets/s_numbers_charts.xml
+++ b/addons/website/views/snippets/s_numbers_charts.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row o_grid_mode" data-row-count="12">
                 <div class="o_grid_item g-col-lg-6 g-height-5 col-lg-6" style="grid-area: 1 / 1 / 6 / 7; z-index: 1">
-                    <h3>Key Metrics of Company's<br/>Achievements</h3>
+                    <h2 class="h3-fs">Key Metrics of Company's<br/>Achievements</h2>
                     <p class="lead">Our key metrics, from revenue growth to customer retention and market expansion, highlight our strategic prowess and commitment to sustainable business success.</p>
                 </div>
                 <div class="o_grid_item g-col-lg-5 g-height-3 col-lg-5" style="grid-area: 6 / 1 / 9 / 6; z-index: 3">

--- a/addons/website/views/snippets/s_numbers_list.xml
+++ b/addons/website/views/snippets/s_numbers_list.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row s_nb_column_fixed">
                 <div class="col-lg-5 pb32">
-                    <h3>Key Metrics of Company's Achievements</h3>
+                    <h2 class="h3-fs">Key Metrics of Company's Achievements</h2>
                     <p><br/>From revenue growth to customer retention and market expansion, our key metrics of company achievements underscore our strategic prowess and dedication to driving sustainable business success.</p>
                 </div>
                 <div class="col-12 col-lg-3 offset-lg-1">

--- a/addons/website/views/snippets/s_showcase.xml
+++ b/addons/website/views/snippets/s_showcase.xml
@@ -9,27 +9,27 @@
                 <div class="col-lg-6">
                     <div class="row">
                         <div class="col-12 pb32">
-                            <h3>Features showcase</h3>
+                            <h2 class="h3-fs">Features showcase</h2>
                             <p class="lead">A features section highlights your product’s key attributes, engaging visitors and boosting conversions.</p>
                         </div>
                         <div class="col-12 pt8 pb8" data-name="Feature">
                             <i class="s_showcase_icon fa fa-star-o me-auto rounded float-start bg-o-color-3" role="img"/>
                             <div class="d-flex flex-column">
-                                <h5 class="s_showcase_title">Highlights Key Attributes</h5>
+                                <h3 class="s_showcase_title h5-fs">Highlights Key Attributes</h3>
                                 <p>A feature section allows you to clearly showcase the main benefits and unique aspects of your product.</p>
                             </div>
                         </div>
                         <div class="col-12 pt8 pb8" data-name="Feature">
                             <i class="s_showcase_icon fa fa-user-o me-auto rounded float-start bg-o-color-3" role="img"/>
                             <div class="d-flex flex-column">
-                                <h5 class="s_showcase_title">Engages Visitors</h5>
+                                <h3 class="s_showcase_title h5-fs">Engages Visitors</h3>
                                 <p>It captures your visitors' attention and helps them quickly understand the value of your product.</p>
                             </div>
                         </div>
                         <div class="col-12 pt8 pb8" data-name="Feature">
                             <i class="s_showcase_icon fa fa-heart-o me-auto rounded float-start bg-o-color-3" role="img"/>
                             <div class="d-flex flex-column">
-                                <h5 class="s_showcase_title">Boosts Conversions</h5>
+                                <h3 class="s_showcase_title h5-fs">Boosts Conversions</h3>
                                 <p>Organizing and presenting key information effectively increases the likelihood of turning your visitors into customers.</p>
                             </div>
                         </div>

--- a/addons/website/views/snippets/s_table_of_content.xml
+++ b/addons/website/views/snippets/s_table_of_content.xml
@@ -16,7 +16,7 @@
                 <div class="col-lg-9 s_table_of_content_main oe_structure oe_empty" data-name="Content">
                     <section class="s_text_block pt0 pb64" data-snippet="s_text_block" data-name="Section">
                         <div class="container s_allow_columns">
-                            <h2 id="table_of_content_heading_1_1" class="h3" data-anchor="true">Intuitive system</h2>
+                            <h2 id="table_of_content_heading_1_1" class="h3-fs" data-anchor="true">Intuitive system</h2>
                             <div class="s_hr pt8 pb24" data-snippet="s_hr" data-name="Separator">
                                 <hr class="w-100 mx-auto"/>
                             </div>
@@ -25,13 +25,13 @@
                             </p>
                             <br/>
                             <br/>
-                            <h4 class="h5">What you see is what you get</h4>
+                            <h3 class="h5-fs">What you see is what you get</h3>
                             <p>
                                 Insert text styles like headers, bold, italic, lists, and fonts with a simple WYSIWYG editor. Flexible and easy to use, it lets you design and format documents in real time. No coding knowledge is needed, making content creation straightforward and enjoyable for everyone.
                             </p>
                             <br/>
                             <br/>
-                            <h4 class="h5">Customization tool</h4>
+                            <h3 class="h5-fs">Customization tool</h3>
                             <p>
                                 Click and change content directly from the front-end, avoiding complex backend processes. This tool allows quick updates to text, images, and elements right on the page, streamlining your workflow and maintaining control over your content.
                             </p>
@@ -39,7 +39,7 @@
                     </section>
                     <section class="s_text_block pt0 pb64" data-snippet="s_text_block" data-name="Section">
                         <div class="container s_allow_columns">
-                            <h2 id="table_of_content_heading_1_2" class="h3" data-anchor="true">Design features</h2>
+                            <h2 id="table_of_content_heading_1_2" class="h3-fs" data-anchor="true">Design features</h2>
                             <div class="s_hr pt8 pb24" data-snippet="s_hr" data-name="Separator">
                                 <hr class="w-100 mx-auto"/>
                             </div>
@@ -48,13 +48,13 @@
                             </p>
                             <br/>
                             <br/>
-                            <h4 class="h5">Building blocks system</h4>
+                            <h3 class="h5-fs">Building blocks system</h3>
                             <p>
                                 Create pages from scratch by dragging and dropping customizable building blocks. This system simplifies web design, making it accessible to all skill levels. Combine headers, images, and text sections to build cohesive layouts quickly and efficiently.
                             </p>
                             <br/>
                             <br/>
-                            <h4 class="h5">Bootstrap-Based Templates</h4>
+                            <h3 class="h5-fs">Bootstrap-Based Templates</h3>
                             <p>
                                 Design Odoo templates easily with clean HTML and Bootstrap CSS. These templates offer a responsive, mobile-first design, making them simple to customize and perfect for any web project, from corporate sites to personal blogs.
                             </p>

--- a/addons/website/views/snippets/s_text_highlight.xml
+++ b/addons/website/views/snippets/s_text_highlight.xml
@@ -4,7 +4,7 @@
 <template name="Text Highlight" id="s_text_highlight">
     <div class="s_text_highlight o_colored_level o_cc o_cc3 my-3 text-center w-100">
         <div class="container">
-            <h3>Text Highlight</h3>
+            <h2 class="h3-fs">Text Highlight</h2>
             <p>Put the focus on what you have to say!</p>
         </div>
     </div>

--- a/addons/website/views/snippets/s_three_columns.xml
+++ b/addons/website/views/snippets/s_three_columns.xml
@@ -11,7 +11,7 @@
                             <img class="o_card_img card-img-top" src="/web/image/website.s_three_columns_default_image_1" alt=""/>
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">Feature One</h5>
+                            <h2 class="card-title h5-fs">Feature One</h2>
                             <p class="card-text">Adapt these three columns to fit your design need. To duplicate, delete or move columns, select the column and use the top icons to perform your action.</p>
                         </div>
                     </div>
@@ -22,7 +22,7 @@
                             <img class="o_card_img card-img-top" src="/web/image/website.s_three_columns_default_image_2" alt=""/>
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">Feature Two</h5>
+                            <h2 class="card-title h5-fs">Feature Two</h2>
                             <p class="card-text">To add a fourth column, reduce the size of these three columns using the right icon of each block. Then, duplicate one of the columns to create a new one as a copy.</p>
                         </div>
                     </div>
@@ -33,7 +33,7 @@
                             <img class="o_card_img card-img-top" src="/web/image/website.s_three_columns_default_image_3" alt=""/>
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">Feature Three</h5>
+                            <h2 class="card-title h5-fs">Feature Three</h2>
                             <p class="card-text">Delete the above image or replace it with a picture that illustrates your message. Click on the picture to change its <em>rounded corner</em> style.</p>
                         </div>
                     </div>

--- a/addons/website/views/snippets/s_title.xml
+++ b/addons/website/views/snippets/s_title.xml
@@ -4,7 +4,7 @@
 <template id="s_title" name="Title">
     <section class="s_title pt40 pb40" data-vcss="001">
         <div class="container s_allow_columns">
-            <h2 class="display-3-fs" style="text-align: center;">Your Site Title</h2>
+            <h2 class="display-3-fs" style="text-align: center;">Your section title</h2>
         </div>
     </section>
 </template>


### PR DESCRIPTION
Requires : 
- https://github.com/odoo/enterprise/pull/92978
- https://github.com/odoo/design-themes/pull/1043

----------

Complete list of snippets :
s_attributes_horizontal, s_call_to_action, s_card, s_card_offset, s_card_offset, s_cards_grid, s_cards_soft, s_carousel, s_carousel_cards, s_company_team, s_company_team_basic, s_company_team_detail,
s_company_team_spotlight, s_comparisons, s_cta_card, s_cta_mobile, s_cta_mockups, s_faq_collapse, s_faq_list, s_features, s_features_grid, s_features_wave, s_image_frame, s_image_text_box, s_masonry_block, s_numbers, s_numbers_charts, s_numbers_list, s_showcase, s_table_of_content, s_text_highlight, s_three_columns, s_title


Some snippets in website were using inconsistent heading levels (e.g. h2 directly followed by h6), which harmed both accessibility and SEO. This PR standardizes the heading hierarchy inside snippets to ensure a logical structure.

This improves:

1. Natural SEO ranking by providing clearer semantic signals to search engines.

2. Accessibility for screen readers that rely on a consistent heading order.

3. Overall readability and maintainability of the themes.

Note that the we preserved the design by applying a `.h*-fs` class that matches the old heading tag in use.

We also fixed selectors inside tests and adapted the new page templates

task-4349019

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
