### PR TITLE
[IMP] l10n_es_edi_tbai: allow for more than one original vendor bill

### DIFF
--- a/addons/l10n_es_edi_tbai/views/account_move_view.xml
+++ b/addons/l10n_es_edi_tbai/views/account_move_view.xml
@@ -12,9 +12,10 @@
                         <field name="l10n_es_tbai_chain_index" groups="base.group_no_one"/>
                         <field name="l10n_es_tbai_refund_reason"
                             attrs="{
-                            'readonly': [('state', '!=', 'draft')], 
-                            'invisible': [('l10n_es_tbai_refund_reason', '=', False)]
+                            'readonly': [('state', '!=', 'draft')],
+                            'invisible': [('move_type', 'not in', ('in_refund', 'out_refund'))]
                         }"/>
+                        <field name="reversed_entry_id" attrs="{'invisible': [('move_type', '!=', 'in_refund')]}"/>
                     </group>
                 </xpath>
             </field>

--- a/addons/l10n_es_edi_tbai_multi_refund/__init__.py
+++ b/addons/l10n_es_edi_tbai_multi_refund/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/l10n_es_edi_tbai_multi_refund/__manifest__.py
+++ b/addons/l10n_es_edi_tbai_multi_refund/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "TicketBAI multi refund",
+    "summary": "Link one refund with multiple invoices",
+    "version": "1.0",
+    "category": "Accounting/Localizations/EDI",
+    "license": "LGPL-3",
+    "auto_install": True,
+    "depends": [
+        "l10n_es_edi_tbai",
+    ],
+    "data": [
+        "data/template_LROE_bizkaia.xml",
+        "views/account_move_view.xml",
+    ],
+}

--- a/addons/l10n_es_edi_tbai_multi_refund/data/template_LROE_bizkaia.xml
+++ b/addons/l10n_es_edi_tbai_multi_refund/data/template_LROE_bizkaia.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<data>
+    <template id="template_LROE_240_inner_recibidas" inherit_id="l10n_es_edi_tbai.template_LROE_240_inner_recibidas">
+        <xpath expr="//FacturasRectificadasSustituidas" position="attributes">
+            <attribute name="t-if" value="credit_note_invoices"/>
+        </xpath>
+
+        <xpath expr="//IDFacturaRectificadaSustituida" position="attributes">
+            <attribute name="t-foreach" value="credit_note_invoices"/>
+            <attribute name="t-as" value="credit_note_invoice"/>
+        </xpath>
+    </template>
+</data>

--- a/addons/l10n_es_edi_tbai_multi_refund/i18n/es.po
+++ b/addons/l10n_es_edi_tbai_multi_refund/i18n/es.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_es_edi_tbai_multi_refund
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-02 09:47+0000\n"
+"PO-Revision-Date: 2025-01-02 09:50+0000\n"
+"Last-Translator: Jairo Llopis <jairo@moduon.team>\n"
+"Language-Team: \n"
+"Language: es_ES\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.4\n"
+
+#. module: l10n_es_edi_tbai_multi_refund
+#: model:ir.model,name:l10n_es_edi_tbai_multi_refund.model_account_edi_format
+msgid "EDI format"
+msgstr "Formato EDI"
+
+#. module: l10n_es_edi_tbai_multi_refund
+#: model:ir.model.fields,help:l10n_es_edi_tbai_multi_refund.field_account_bank_statement_line__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,help:l10n_es_edi_tbai_multi_refund.field_account_move__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,help:l10n_es_edi_tbai_multi_refund.field_account_payment__l10n_es_tbai_reversed_ids
+msgid ""
+"In the case where a vendor refund has multiple original invoices, you can "
+"set them here. "
+msgstr ""
+"Si una rectificación de facturas de proveedor tiene múltiples facturas "
+"originales, puede indicarlas aquí."
+
+#. module: l10n_es_edi_tbai_multi_refund
+#: model:ir.model,name:l10n_es_edi_tbai_multi_refund.model_account_move
+msgid "Journal Entry"
+msgstr "Asiento contable"
+
+#. module: l10n_es_edi_tbai_multi_refund
+#: model:ir.model.fields,field_description:l10n_es_edi_tbai_multi_refund.field_account_bank_statement_line__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,field_description:l10n_es_edi_tbai_multi_refund.field_account_move__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,field_description:l10n_es_edi_tbai_multi_refund.field_account_payment__l10n_es_tbai_reversed_ids
+msgid "Refunded Vendor Bills"
+msgstr "Facturas de proveedor rectificadas"

--- a/addons/l10n_es_edi_tbai_multi_refund/i18n/l10n_es_edi_tbai_multi_refund.pot
+++ b/addons/l10n_es_edi_tbai_multi_refund/i18n/l10n_es_edi_tbai_multi_refund.pot
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_es_edi_tbai_multi_refund
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-02 09:47+0000\n"
+"PO-Revision-Date: 2025-01-02 09:47+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_es_edi_tbai_multi_refund
+#: model:ir.model,name:l10n_es_edi_tbai_multi_refund.model_account_edi_format
+msgid "EDI format"
+msgstr ""
+
+#. module: l10n_es_edi_tbai_multi_refund
+#: model:ir.model.fields,help:l10n_es_edi_tbai_multi_refund.field_account_bank_statement_line__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,help:l10n_es_edi_tbai_multi_refund.field_account_move__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,help:l10n_es_edi_tbai_multi_refund.field_account_payment__l10n_es_tbai_reversed_ids
+msgid ""
+"In the case where a vendor refund has multiple original invoices, you can "
+"set them here. "
+msgstr ""
+
+#. module: l10n_es_edi_tbai_multi_refund
+#: model:ir.model,name:l10n_es_edi_tbai_multi_refund.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_es_edi_tbai_multi_refund
+#: model:ir.model.fields,field_description:l10n_es_edi_tbai_multi_refund.field_account_bank_statement_line__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,field_description:l10n_es_edi_tbai_multi_refund.field_account_move__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,field_description:l10n_es_edi_tbai_multi_refund.field_account_payment__l10n_es_tbai_reversed_ids
+msgid "Refunded Vendor Bills"
+msgstr ""

--- a/addons/l10n_es_edi_tbai_multi_refund/models/__init__.py
+++ b/addons/l10n_es_edi_tbai_multi_refund/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_edi_format
+from . import account_move

--- a/addons/l10n_es_edi_tbai_multi_refund/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai_multi_refund/models/account_edi_format.py
@@ -1,0 +1,12 @@
+from odoo import models
+
+
+class AccountEdiFormat(models.Model):
+    _inherit = 'account.edi.format'
+
+    def _l10n_es_tbai_get_in_invoice_values_batuz(self, invoice):
+        values = super()._l10n_es_tbai_get_in_invoice_values_batuz(invoice)
+        credit_notes = values.pop('credit_note_invoice', self.env['account.move']) | invoice.l10n_es_tbai_reversed_ids
+        if credit_notes:
+            values['credit_note_invoices'] = credit_notes
+        return values

--- a/addons/l10n_es_edi_tbai_multi_refund/models/account_move.py
+++ b/addons/l10n_es_edi_tbai_multi_refund/models/account_move.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    l10n_es_tbai_reversed_ids = fields.Many2many(
+        'account.move', 'account_move_tbai_reversed_moves', 'refund_id', 'reversed_move_id',
+        string="Refunded Vendor Bills",
+        domain="[('move_type', '=', 'in_invoice'), ('commercial_partner_id', '=', commercial_partner_id)]",
+        help="In the case where a vendor refund has multiple original invoices, you can set them here. ",
+    )

--- a/addons/l10n_es_edi_tbai_multi_refund/views/account_move_view.xml
+++ b/addons/l10n_es_edi_tbai_multi_refund/views/account_move_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.form.inherit.l10n_es_edi_tbai_multi_refund</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <field name="l10n_es_tbai_refund_reason" position='after'>
+                <field name="l10n_es_tbai_reversed_ids" attrs="{'invisible': [('move_type', '!=', 'in_refund')]}" widget="many2many_tags"/>
+            </field>
+        </field>
+    </record>
+</data>


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/166533:

> For the Bizkaia tax agency in Bask country, we also need to send vendor bills and vendor bill refunds.  In Odoo standard however, we only have a link towards one original vendor bill for a vendor bill refund.
> 
> The problem however is that your vendor can send you a vendor refund for multiple original vendor bills and that for the moment, you do not really have a good way to encode it.
> 
> So, we added a field to put the other original vendor bills as a many2many.
> 
> We also updated the translations.
> 
> opw-3719158


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@moduon MT-4966