### PR TITLE
[REF] web: Kanban: make Compiler props mandatory

### DIFF
--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -13,6 +13,7 @@ import {
     useX2ManyCrud,
 } from "@web/views/fields/relational_utils";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { KanbanCompiler } from "@web/views/kanban/kanban_compiler";
 import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
 import { ListRenderer } from "@web/views/list/list_renderer";
 import { computeViewClassName } from "@web/views/utils";
@@ -197,6 +198,7 @@ export class X2ManyField extends Component {
         if (this.props.viewMode === "kanban") {
             const recordsDraggable = !this.props.readonly && archInfo.recordsDraggable;
             props.archInfo = { ...archInfo, recordsDraggable };
+            props.Compiler = KanbanCompiler;
             // TODO: apply same logic in the list case
             props.deleteRecord = (record) => {
                 if (this.isMany2Many) {

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -36,7 +36,7 @@ export class KanbanController extends Component {
         onSelectionChanged: { type: Function, optional: true },
         readonly: { type: Boolean, optional: true },
         showButtons: { type: Boolean, optional: true },
-        Compiler: { type: Function, optional: true }, // optional in stable for backward compatibility
+        Compiler: Function,
         Model: Function,
         Renderer: Function,
         buttonTemplate: String,
@@ -144,12 +144,10 @@ export class KanbanController extends Component {
         });
         useSetupAction({
             rootRef: this.rootRef,
-            getLocalState: () => {
-                return {
-                    activeBars: this.progressBarState?.activeBars,
-                    modelState: this.model.exportState(),
-                };
-            },
+            getLocalState: () => ({
+                activeBars: this.progressBarState?.activeBars,
+                modelState: this.model.exportState(),
+            }),
         });
         usePager(() => {
             const root = this.model.root;

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -184,7 +184,6 @@ export class KanbanRecord extends Component {
         "record",
         "progressBarState?",
     ];
-    static Compiler = KanbanCompiler;
     static KANBAN_CARD_ATTRIBUTE = KANBAN_CARD_ATTRIBUTE;
     static KANBAN_MENU_ATTRIBUTE = KANBAN_MENU_ATTRIBUTE;
     static menuTemplate = "web.KanbanRecordMenu";
@@ -197,7 +196,7 @@ export class KanbanRecord extends Component {
         this.notification = useService("notification");
 
         const { Compiler, archInfo } = this.props;
-        const ViewCompiler = Compiler || this.constructor.Compiler;
+        const ViewCompiler = Compiler || KanbanCompiler;
         const { templateDocs: templates } = archInfo;
 
         this.templates = useViewCompiler(ViewCompiler, templates);

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -46,7 +46,7 @@ export class KanbanRenderer extends Component {
     };
     static props = [
         "archInfo",
-        "Compiler?",
+        "Compiler",
         "list",
         "deleteRecord",
         "openRecord",

--- a/addons/web/static/src/views/kanban/kanban_view.js
+++ b/addons/web/static/src/views/kanban/kanban_view.js
@@ -20,11 +20,10 @@ export const kanbanView = {
         const { arch, relatedModels, resModel } = genericProps;
         const { ArchParser } = view;
         const archInfo = new ArchParser().parse(arch, relatedModels, resModel);
-
         return {
             ...genericProps,
             readonly: genericProps.readonly || !archInfo.activeActions?.edit,
-            // Compiler: view.Compiler, // don't pass it automatically in stable, for backward compat
+            Compiler: view.Compiler,
             Model: view.Model,
             Renderer: view.Renderer,
             buttonTemplate: view.buttonTemplate,

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -13155,16 +13155,9 @@ test("kanbans with basic and custom compiler, same arch", async () => {
             return compiledNode;
         }
     }
-    class MyKanbanRecord extends KanbanRecord {}
-    MyKanbanRecord.Compiler = MyKanbanCompiler;
-    class MyKanbanRenderer extends KanbanRenderer {}
-    MyKanbanRenderer.components = {
-        ...KanbanRenderer.components,
-        KanbanRecord: MyKanbanRecord,
-    };
     viewRegistry.add("my_kanban", {
         ...kanbanView,
-        Renderer: MyKanbanRenderer,
+        Compiler: MyKanbanCompiler,
     });
     after(() => viewRegistry.remove("my_kanban"));
 


### PR DESCRIPTION
Commit [1] made it possible to specify a custom Compiler in a kanban view. As this one done in stable, the props was made optional, with a todo for master to turn it mandatory.

This commit makes the props mandatory, which closes the gap between kanban and form views' APIs. If one wants to define a custom kanban view with its own compiler, the compiler class has to be set on the view itself (like the Renderer, Controller, ArchParser...), and the KanbanRecord will receives that Compiler in props.

[1] odoo/odoo@ea7ef13b0f76460f6fcf6dc02a3af3b4266cc0d2

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
