### PR TITLE
[REF] web: remove bannerRoute from viewProps and config

### DIFF
--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1069,13 +1069,11 @@ export class SearchModel extends EventBus {
             domain
         );
         const result = groupBy(Object.values(definitions), (definition) => definition.record_id);
-        return Object.entries(result).map(([recordId, definitions]) => {
-            return {
-                definitionRecordId: parseInt(recordId),
-                definitionRecordName: definitions[0]?.record_name,
-                definitions,
-            };
-        });
+        return Object.entries(result).map(([recordId, definitions]) => ({
+            definitionRecordId: parseInt(recordId),
+            definitionRecordName: definitions[0]?.record_name,
+            definitions,
+        }));
     }
 
     /**
@@ -1222,15 +1220,13 @@ export class SearchModel extends EventBus {
      * Add filters of type 'filter' determined by the key array dynamicFilters.
      */
     _createGroupOfDynamicFilters(dynamicFilters) {
-        const pregroup = dynamicFilters.map((filter) => {
-            return {
-                groupNumber: this.nextGroupNumber,
-                description: filter.description,
-                domain: filter.domain,
-                isDefault: "is_default" in filter ? filter.is_default : true,
-                type: "filter",
-            };
-        });
+        const pregroup = dynamicFilters.map((filter) => ({
+            groupNumber: this.nextGroupNumber,
+            description: filter.description,
+            domain: filter.domain,
+            isDefault: "is_default" in filter ? filter.is_default : true,
+            type: "filter",
+        }));
         this.nextGroupNumber++;
         this._createGroupOfSearchItems(pregroup);
     }
@@ -1496,14 +1492,13 @@ export class SearchModel extends EventBus {
      */
     _getDisplay(display = {}) {
         const { viewTypes } = this.searchPanelInfo;
-        const { bannerRoute, viewType } = this.env.config;
+        const { viewType } = this.env.config;
         return {
             controlPanel: "controlPanel" in display ? display.controlPanel : {},
             searchPanel:
                 this.sections.size &&
                 (!viewType || viewTypes.includes(viewType)) &&
                 ("searchPanel" in display ? display.searchPanel : true),
-            banner: Boolean(bannerRoute),
         };
     }
 

--- a/addons/web/static/src/views/standard_view_props.js
+++ b/addons/web/static/src/views/standard_view_props.js
@@ -16,7 +16,6 @@ export const standardViewProps = {
     },
     resModel: String,
     arch: { type: Element },
-    bannerRoute: { type: String, optional: true },
     className: { type: String, optional: true },
     context: { type: Object },
     createRecord: { type: Function, optional: true },


### PR DESCRIPTION
This commit is a followup of [1] which removes the OnboardingBanner feature. We forgot to clean up bannerRoute references at a few places.

[1] odoo/odoo@92f56f1c398e1a25882d6b25ffd2e886f8cdfee2

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
