### PR TITLE
[REF] web: listView and standardViewProps cleanup

### DIFF
--- a/addons/web/static/src/views/list/list_view.js
+++ b/addons/web/static/src/views/list/list_view.js
@@ -6,20 +6,20 @@ import { ListRenderer } from "./list_renderer";
 
 export const listView = {
     type: "list",
+
     Controller: ListController,
     Renderer: ListRenderer,
     ArchParser: ListArchParser,
     Model: RelationalModel,
-    buttonTemplate: "web.ListView.Buttons",
-    canOrderByCount: true,
 
-    limit: 80,
+    buttonTemplate: "web.ListView.Buttons",
+
+    canOrderByCount: true,
 
     props: (genericProps, view) => {
         const { ArchParser } = view;
         const { arch, relatedModels, resModel } = genericProps;
         const archInfo = new ArchParser().parse(arch, relatedModels, resModel);
-
         return {
             ...genericProps,
             Model: view.Model,

--- a/addons/web/static/src/views/standard_view_props.js
+++ b/addons/web/static/src/views/standard_view_props.js
@@ -1,15 +1,3 @@
-// TODO: add this in info props description
-
-// breadcrumbs: { type: Array, optional: true },
-// __getLocalState__: { type: CallbackRecorder, optional: true },
-// __getContext__: { type: CallbackRecorder, optional: true },
-// displayName: { type: String, optional: true },
-// noContentHelp: { type: String, optional: true },
-// searchViewId: { type: [Number, false], optional: true },
-// viewId: { type: [Number, false], optional: true },
-// views: { type: Array, element: Array, optional: true },
-// viewSwitcherEntries: { type: Array, optional: true },
-
 export const standardViewProps = {
     info: {
         type: Object,


### PR DESCRIPTION
This commit removes the limit attribute from the listView, as it is not used (it was meant to be given in props to the Controller, but we don't, so...). If a limit is set in the action, the Controller receives that limit in props. If not, a default limit is defined in the RelationalModel (80).

We also remove very old comment in standardViewProps, which we wrote when converting the views to wowl. Props that needed to be defined have been defined.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
