### PR TITLE
[FIX] html_editor: properly convert self-closing tags

### DIFF
--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -2,7 +2,7 @@ import { MAIN_PLUGINS } from "./plugin_sets";
 import { removeClass } from "./utils/dom";
 import { isEmpty } from "./utils/dom_info";
 import { resourceSequenceSymbol, withSequence } from "./utils/resource";
-import { fixInvalidHTML, initElementForEdition } from "./utils/sanitize";
+import { initElementForEdition } from "./utils/sanitize";
 
 /**
  * @typedef { import("./plugin_sets").SharedMethods } SharedMethods
@@ -94,8 +94,7 @@ export class Editor {
         this.editable = editable;
         this.document = editable.ownerDocument;
         if (this.config.content) {
-            const content = fixInvalidHTML(this.config.content);
-            editable.innerHTML = content;
+            editable.innerHTML = this.config.content;
             if (isEmpty(editable)) {
                 editable.innerHTML = "<p><br></p>";
             }

--- a/addons/html_editor/static/src/utils/html.js
+++ b/addons/html_editor/static/src/utils/html.js
@@ -1,3 +1,5 @@
+import { fixInvalidHTML } from "./sanitize";
+
 /**
  * @param { Document } document
  * @param { string } html
@@ -27,7 +29,7 @@ export function parseHTML(document, html) {
  */
 export function normalizeHTML(content, cleanup = () => {}) {
     const parser = new document.defaultView.DOMParser();
-    const body = parser.parseFromString(content, "text/html").body;
+    const body = parser.parseFromString(fixInvalidHTML(content), "text/html").body;
     cleanup(body);
     return body.innerHTML;
 }


### PR DESCRIPTION
**Problem**:
Previously, self-closing tags were converted after parsing with `DOMParser`. However, when parsing with the content type `"text/html"`, all self-closing tags are converted to open tags without corresponding closing tags.

**Solution**:
Convert self-closing tags before parsing to ensure proper handling.

**Steps to reproduce**:
1. Open email templates.
2. Open a template containing self-closing tags like `t` (e.g., Sales: Order Confirmation).
3. Observe that the template is incorrect, with all self-closing tags converted to open but not closed tags.

opw-4394833

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
