### PR TITLE
 [FIX] account: some list inside the form not taking all space

### DIFF
--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -154,10 +154,10 @@
                             <div invisible="amount_type == 'group'">
                                 <field name="country_code" invisible="1"/>
                                 <group string="Distribution for Invoices" class="mw-100">
-                                    <field name="invoice_repartition_line_ids" nolabel="1"/>
+                                    <field name="invoice_repartition_line_ids" nolabel="1" colspan="2"/>
                                 </group>
                                 <group string="Distribution for Refunds" class="mw-100">
-                                    <field name="refund_repartition_line_ids" nolabel="1"/>
+                                    <field name="refund_repartition_line_ids" nolabel="1" colspan="2"/>
                                 </group>
                             </div>
                             <field name="children_tax_ids" invisible="amount_type != 'group' or type_tax_use == 'none'" domain="[('type_tax_use','in',('none',type_tax_use)), ('amount_type','!=','group')]">


### PR DESCRIPTION
This commit fixes some ARCH to fixes some visual issue.

Inside a group (grid) there will be always two columns:
* one smaller on the left (max 150px)
* one taking all the remaining space on the right.

When we add only one element with `nolabel="1"` it will take one part of
the grid to take all the space we need to specify it with `colspan="2"`.

Steps to reproduce:
* Go to Accounting App
* Go to menu Configuration -> Taxes
* Select a Taxes
  The list view inside the form not taking all space => BUG

task-4416643

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
