### PR TITLE
[PERF] event_crm: add missing index on `event_id`

### DIFF
--- a/addons/event_crm/models/crm_lead.py
+++ b/addons/event_crm/models/crm_lead.py
@@ -8,7 +8,7 @@ class Lead(models.Model):
     _inherit = 'crm.lead'
 
     event_lead_rule_id = fields.Many2one('event.lead.rule', string="Registration Rule", help="Rule that created this lead")
-    event_id = fields.Many2one('event.event', string="Source Event", help="Event triggering the rule that created this lead")
+    event_id = fields.Many2one('event.event', string="Source Event", help="Event triggering the rule that created this lead", index='btree_not_null')
     registration_ids = fields.Many2many(
         'event.registration', string="Source Registrations",
         groups='event.group_event_registration_desk',


### PR DESCRIPTION
## Description
Integration between `event.event` <-> `crm.lead` heavily depends on the fkey `crm.lead.event_id`. There are multitude of `search`/ `read_group` just based on it.
Adding an index to avoid guaranteed `Seq.Scan` on `crm.lead`, as it's a table that tends to grow large on average.

## Reference
task-3977976

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
