### PR TITLE
[IMP] website_sale: fix spacing issue with contact us and price tags

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1438,7 +1438,7 @@
                             <t t-call="website_sale.product_accordion"/>
                             <div
                                 id="contact_us_wrapper"
-                                t-attf-class="{{'d-flex' if combination_info['prevent_zero_price_sale'] else 'd-none'}} oe_structure oe_structure_solo #{_div_classes}"
+                                t-attf-class="{{'d-flex' if combination_info['prevent_zero_price_sale'] else 'd-none'}} oe_structure oe_structure_solo mb-1 #{_div_classes}"
                             >
                                 <section
                                     class="s_text_block"


### PR DESCRIPTION
Steps to Reproduce:
Enable the "Prevent Sale of 0 Product" setting in eCommerce.
Create a product with:
->Zero price
->Price tags.

Issue :
When the "Prevent Sale of 0 Product" setting was enabled, there was a lack of
proper spacing between the "Contact Us" button and the product price tags,
resulting in a misaligned layout.

Fix:
Added a margin-bottom style to the "Contact Us" button container to ensure
proper spacing between the button and the price tags.

Affected Versions:
17.0

opw-4422462