### PR TITLE
[FIX] point_of_sale: Fix show selected partner on top

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -90,6 +90,8 @@ export class PartnerList extends Component {
                   .toSorted((a, b) =>
                       this.props.partner?.id === a.id
                           ? -1
+                          : this.props.partner?.id === b.id
+                          ? 1
                           : (a.name || "").localeCompare(b.name || "")
                   );
 


### PR DESCRIPTION
Steps to reproduce:
1.Install ``point_of_sale`` in odoo 18.0
2.Open point of sale session and left side there is customer button select the customer.
3.selected partner will show at the top of all partner in chrome but in firefox browser selected partner is not showing at top

For fixing it
 making sorting(compartor) more acurate.

opw-4408218

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
