### PR TITLE
[FIX] core: onchange for mulitple X2many sibling

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3323,18 +3323,6 @@ class AccountMove(models.Model):
         for move in self:
             move.display_name = move._get_move_display_name(show_ref=True)
 
-    def onchange(self, values, field_names, fields_spec):
-        # Since only one field can be changed at the same time (the record is
-        # saved when changing tabs) we can avoid building the snapshots for the
-        # other field
-        if 'line_ids' in field_names:
-            values = {key: val for key, val in values.items() if key != 'invoice_line_ids'}
-            fields_spec = {key: val for key, val in fields_spec.items() if key != 'invoice_line_ids'}
-        elif 'invoice_line_ids' in field_names:
-            values = {key: val for key, val in values.items() if key != 'line_ids'}
-            fields_spec = {key: val for key, val in fields_spec.items() if key != 'line_ids'}
-        return super().onchange(values, field_names, fields_spec)
-
     # -------------------------------------------------------------------------
     # RECONCILIATION METHODS
     # -------------------------------------------------------------------------

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6897,3 +6897,12 @@ class StockMove(TransactionCase):
             {'location_id': subloc.id, 'lot_id': lots[1].id, 'package_id': pack.id},
             {'location_id': self.stock_location.id, 'lot_id': lots[2].id, 'package_id': False},
         ])
+
+    def test_change_dest_loc_after_sm_creation(self):
+        with Form(self.env['stock.picking'].with_context(restricted_picking_type_code="incoming")) as form:
+            with form.move_ids_without_package.new() as move:
+                move.product_id = self.product
+                move.product_uom_qty = 1
+            form.location_dest_id = self.customer_location
+        picking = form.save()
+        self.assertEqual(picking.move_ids.location_dest_id, self.customer_location, "Courage Rémy, la communauté croit en toi!")

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6372,6 +6372,16 @@ class BaseModel(metaclass=MetaModel):
                 # x2many fields should add self, while many2one fields should replace with self
                 for invf in self.pool.field_inverses[field]:
                     invf._update(inv_recs, self)
+                    # If multiple X2many target the same field, we need to patch
+                    # the values of the sibling ones
+                    if invf.type == 'one2many':
+                        continue
+                    for invf_invf in self.pool.field_inverses[invf]:
+                        if invf_invf == field:
+                            continue
+                        # TODO: the patch_and_set should filterout with the domain of the field
+                        for inv_rec in inv_recs:
+                            self.env.cache.patch(self, invf_invf, inv_rec.id)
 
     def _convert_to_record(self, values):
         """ Convert the ``values`` dictionary from the cache format to the


### PR DESCRIPTION
Some models have several One2many (some with a domain and another without by example) targeting the same Many2one. In this case, when we create a new record, add new line in one of this One2many and modifying any else that triggers onchange. The onchange will contains the line in one of the sibling one2many but not the other, and then during the `modified`, the ORM may used the one2many that doesn't contains any lines, and that's miss some compute to recompute....

To avoid this situation, we patch the sibling one2many when one of them contains the line during the all onchange process.
