### PR TITLE
[IMP] web: align "Delete" button to the right on M2M dialog

### DIFF
--- a/addons/web/static/src/views/fields/relational_utils.xml
+++ b/addons/web/static/src/views/fields/relational_utils.xml
@@ -70,7 +70,8 @@
         <button class="btn btn-secondary o_form_button_cancel" t-on-click="discard" data-hotkey="j">Discard</button>
 
         <t t-if="props.delete and displayDeleteButton">
-            <button class="btn btn-secondary o_btn_remove" t-on-click="remove" data-hotkey="k">
+            <button class="btn btn-secondary d-flex flex-nowrap align-items-center justify-content-center gap-1 ms-md-auto o_btn_remove" t-on-click="remove" data-hotkey="k">
+                <i class="fa fa-trash"/>
                 <t t-if="props.deleteButtonLabel" t-out="props.deleteButtonLabel"/>
                 <t t-else="">Remove</t>
             </button>


### PR DESCRIPTION
This commit pushes the Delete button to the right on M2M dialog.

task-4367567

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
