### PR TITLE
[FIX] sale_loyalty: fixed taxes not paid by gift card

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -172,9 +172,14 @@ class SaleOrder(models.Model):
                 product=line.product_id,
                 partner=line.order_partner_id,
             )
-            # To compute the discountable amount we get the subtotal and add
-            # non-fixed tax totals. This way fixed taxes will not be discounted
-            taxes = line.tax_id.filtered(lambda t: t.amount_type != 'fixed')
+            if reward.program_id.is_payment_program:
+                # In case of payment programs (Gift Card, e-Wallet) the order can be totally
+                # paid with the card balance
+                taxes = line.tax_id
+            else:
+                # To compute the discountable amount we get the subtotal and add
+                # non-fixed tax totals. This way fixed taxes will not be discounted
+                taxes = line.tax_id.filtered(lambda t: t.amount_type != 'fixed')
             discountable += tax_data['total_excluded'] + sum(
                 tax['amount'] for tax in tax_data['taxes']
                 if (


### PR DESCRIPTION
Users may give gift cards to their customers. Acting like a payment
method, gift cards will lower the total amount of a sale order up to 0.
Currently, in case of fixed tax applied in the order, the tax amount
cannot be covered with the card balance

Steps to reproduce
- Generate a Gift Card of 100$
- Create a Sale Order with a product having:
  - price: 90$
  - quantity: 1
  - A fixed tax of 10$
- Add the gift card to the order

Issue: Fixed tax amount will be left uncovered.
This is an issue because when using the gift card (or anyhow having the total 0),
it means the fixed tax cost is supported by the merchant so it should be
covered by the gift card

opw-4422678