### PR TITLE
[FIX] account: do not consider reversed move as overdue

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -57,7 +57,7 @@ class PortalAccount(CustomerPortal):
         return [
             ('state', 'not in', ('cancel', 'draft')),
             ('move_type', 'in', ('out_invoice', 'out_receipt')),
-            ('payment_state', 'not in', ('in_payment', 'paid')),
+            ('payment_state', 'not in', ('in_payment', 'paid', 'reversed')),
             ('invoice_date_due', '<', fields.Date.today()),
             ('partner_id', '=', partner_id or request.env.user.partner_id.id),
         ]


### PR DESCRIPTION
We should never consider 'reversed' move as overdue, otherwise the user might get a warning when it connect to its portal and are encouraged to pay it whereas it should not be paid.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
