### PR TITLE
[FIX] core: fix header when converting to PDF/A-3

### DIFF
--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -419,7 +419,7 @@ class OdooPdfFileWriter(PdfFileWriter):
         # bytes, each of whose encoded byte values shall have a decimal value greater than 127 "
         self._header = b"%PDF-1.7\n"
         if submod == '._pypdf2_1':
-            self._header += b"\xDE\xAD\xBE\xEF"
+            self._header += b"%\xDE\xAD\xBE\xEF"
 
         # Add a document ID to the trailer. This is only needed when using encryption with regular PDF, but is required
         # when using PDF/A


### PR DESCRIPTION
**Issue:**
When converting a PDF file into a PDF/A compliant file, the result may generate the following error message when parsing it by a PDF/A-3 validator:
`The aforementioned EOL marker shall be immediately followed by a % (25h) character followed by at least four bytes, each of whose encoded byte values shall have a decimal value greater than 127 `

**Cause:**
A previous fix has moved the four bytes in a conditional operation, but the `%` character has been forgotten.

opw-4353108



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
