### PR TITLE
[IMP] hr_expense: split invoice button

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -144,6 +144,11 @@ class HrExpense(models.Model):
     duplicate_expense_ids = fields.Many2many(comodel_name='hr.expense', compute='_compute_duplicate_expense_ids')  # Used to trigger warnings
     same_receipt_expense_ids = fields.Many2many(comodel_name='hr.expense', compute='_compute_same_receipt_expense_ids')  # Used to trigger warnings
 
+    split_expense_origin_id = fields.Many2one(
+        comodel_name='hr.expense',
+        string="Origin Split Expense",
+        help="Original expense from a split.",
+    )
     # Amount fields
     tax_amount_currency = fields.Monetary(
         string="Tax amount in Currency",
@@ -683,7 +688,7 @@ class HrExpense(models.Model):
     def _compute_same_receipt_expense_ids(self):
         self.same_receipt_expense_ids = [Command.clear()]
 
-        expenses_with_attachments = self.filtered(lambda expense: expense.attachment_ids)
+        expenses_with_attachments = self.filtered(lambda expense: expense.attachment_ids and not expense.split_expense_origin_id)
         if not expenses_with_attachments:
             return
 
@@ -1088,6 +1093,11 @@ class HrExpense(models.Model):
     # ----------------------------------------
     # Actions
     # ----------------------------------------
+
+    def action_open_split_expense(self):
+        self.ensure_one()
+        split_expense_ids = self.search([('split_expense_origin_id', '=', self.split_expense_origin_id.id)])
+        return split_expense_ids._get_records_action(name=_("Split Expenses"))
 
     def action_submit(self):
         """ Submit a draft expense to an approve, may skip to the approval step if no approver on the employee nor the expense """
@@ -1768,3 +1778,8 @@ class HrExpense(models.Model):
             partner = self.employee_id.sudo().work_contact_id.with_company(self.company_id)
             account_dest = partner.property_account_payable_id or partner.parent_id.property_account_payable_id
         return account_dest.id
+
+    def _creation_message(self):
+        if self.env.context.get('from_split_wizard'):
+            return _("Expense created from a split.")
+        return super()._creation_message()

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -281,6 +281,7 @@ class TestExpenses(TestExpenseCommon):
                 'tax_amount_currency': 0.00,
                 'untaxed_amount_currency': 200.00,
                 'analytic_distribution': False,
+                'split_expense_origin_id': expense.id,
             }, {
                 'name': expense.name,
                 'employee_id': expense.employee_id.id,
@@ -290,6 +291,7 @@ class TestExpenses(TestExpenseCommon):
                 'tax_amount_currency': 39.13,
                 'untaxed_amount_currency': 260.87,
                 'analytic_distribution': {str(self.analytic_account_1.id): 100},
+                'split_expense_origin_id': expense.id,
             }, {
                 'name': expense.name,
                 'employee_id': expense.employee_id.id,
@@ -299,6 +301,7 @@ class TestExpenses(TestExpenseCommon):
                 'tax_amount_currency': 115.38,
                 'untaxed_amount_currency': 384.62,
                 'analytic_distribution': {str(self.analytic_account_2.id): 100},
+                'split_expense_origin_id': expense.id,
             }
         ])
 

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -164,6 +164,15 @@
                 </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
+                        <button name="action_open_split_expense"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                            invisible="not split_expense_origin_id"
+                            string="Split"
+                        />
+                    </div>
+                    <div class="oe_button_box" name="button_box">
                         <button name="action_open_account_move"
                             class="oe_stat_button"
                             icon="fa-bars"


### PR DESCRIPTION
This commit will add a button when splitting an expense to easily find them.
It also deals with split loop so that if you have an expense that you split in
two, and then split again one of the two. The split button will show all
split expense.

task: 4418348




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
