### PR TITLE
[FIX] modules: allow hyphen in external_dependencies

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -28,7 +28,7 @@ except ImportError:
 
     class Requirement:
         def __init__(self, pydep):
-            if not re.fullmatch(r'\w+', pydep):  # check that we have no versions or marker in pydep
+            if not re.fullmatch(r'[\w\-]+', pydep):  # check that we have no versions or marker in pydep
                 msg = f"Package `packaging` is required to parse `{pydep}` external dependency and is not installed"
                 raise Exception(msg)
             self.marker = None


### PR DESCRIPTION
Some modules may have python packages with hyphen in the external_dependies (google-auth-oauthlib, ...)

Those module cannot be installed anymore.

Fixing the regex to allow hyphen in external dependencies when packaging is not installed. 
