### PR TITLE
[FIX] iot_box_image: lightdm and cupsd causing /var saturation

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/DisplayInterface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/DisplayInterface_L.py
@@ -45,8 +45,11 @@ class DisplayInterface(Interface):
 
         try:
             os.environ['DISPLAY'] = ':0'
-            for x_screen, monitor in enumerate(screeninfo.get_monitors()):
-                display_devices[monitor.name] = self._add_device(monitor.name, x_screen)
+            display_devices = {
+                monitor.name: self._add_device(monitor.name, x_screen)
+                for x_screen, monitor in enumerate(screeninfo.get_monitors())
+                if "DUMMY" not in monitor.name
+            }
             return display_devices or dummy_display
         except screeninfo.common.ScreenInfoError:
             # If no display is connected, screeninfo raises an error, we return the distant display

--- a/addons/iot_box_image/overwrite_after_init/etc/X11/xorg.conf
+++ b/addons/iot_box_image/overwrite_after_init/etc/X11/xorg.conf
@@ -1,7 +1,41 @@
-Section "OutputClass"
-  Identifier "vc4"
-  MatchDriver "vc4"
-  Driver "modesetting"
-  Option "PrimaryGPU" "true"
-  Option "PageFlip" "false"
+Section "ServerLayout"
+    Identifier  "Multihead"
+    Screen      0 "Screen0" 0 0
+    Screen      1 "Screen1" RightOf "Screen0"
+EndSection
+
+Section "Monitor"
+    Identifier  "Monitor0"
+EndSection
+
+Section "Monitor"
+    Identifier  "Monitor1"
+EndSection
+
+Section "Device"
+    Identifier  "VC4"
+    Driver      "modesetting"
+EndSection
+
+Section "Device"
+    Identifier  "DummyDevice"
+    Driver      "dummy"
+EndSection
+
+Section "Screen"
+    Identifier  "Screen0"
+    Device      "VC4"
+    Monitor     "Monitor0"
+    SubSection "Display"
+        Modes   "1920x1080"
+    EndSubSection
+EndSection
+
+Section "Screen"
+    Identifier  "Screen1"
+    Device      "DummyDevice"
+    Monitor     "Monitor1"
+    SubSection "Display"
+        Modes   "1920x1080"
+    EndSubSection
 EndSection

--- a/addons/iot_box_image/overwrite_after_init/etc/lightdm/lightdm.conf
+++ b/addons/iot_box_image/overwrite_after_init/etc/lightdm/lightdm.conf
@@ -1,8 +1,7 @@
-
 [LightDM]
 user-authority-in-system-dir=true
 
-[SeatDefaults]
+[Seat:*]
 xserver-command=/usr/bin/X -s 0 -layout Multihead dpms -nolisten tcp
 greeter-hide-users=false
 autologin-user=odoo


### PR DESCRIPTION
Switching from framebuffers to vc4 driver on raspberry pis lead to a continuous
restart of X server when no display was connected to the IoT Box, as it couldn't
start the driver, resulting in saturating logs with `DEBUG` messages (default
logging level).
We added back the "layout" logic with one display using vc4 driver and one "dummy",
using `xserver-xorg-video-dummy` package.

Related Issue: [https://github.com/odoo/odoo/issues/191187](https://github.com/odoo/odoo/issues/191187)
opw-4420794
Task: 4420818