### PR TITLE
[FIX] website_payment: fix s_donation slider for RTL languages

### DIFF
--- a/addons/website_payment/static/src/snippets/s_donation/000.js
+++ b/addons/website_payment/static/src/snippets/s_donation/000.js
@@ -75,7 +75,7 @@ publicWidget.registry.DonationSnippet = publicWidget.Widget.extend({
         }).replaceWith(val);
 
         // Sorta magic numbers based on size of the native UI thumb (source: https://css-tricks.com/value-bubbles-for-range-inputs/)
-        $bubble[0].style.left = `calc(${newVal}% + (${tipOffsetLow}px))`;
+        $bubble[0].style.insetInlineStart = `calc(${newVal}% + (${tipOffsetLow}px))`;
     },
     /**
      * @private


### PR DESCRIPTION
This commit uses the `inset-inline-start` CSS property instead of `left` to account for RTL languages.

(No linked task)