### PR TITLE
[FIX] sale_pdf_quote_builder: quote builder tab not visible immediately

### DIFF
--- a/addons/sale_pdf_quote_builder/models/sale_order.py
+++ b/addons/sale_pdf_quote_builder/models/sale_order.py
@@ -81,7 +81,8 @@ class SaleOrder(models.Model):
                     'files': [{
                         'name': doc.name.rstrip('.pdf'),
                         'id': doc.id,
-                        'is_selected': doc in line.product_document_ids,
+                        'is_selected': doc in line.sudo().product_document_ids, # User should be
+                        # able to access all product documents even without sales access
                         'custom_form_fields': [{
                             'name': custom_form_field.name,
                             'value': existing_mapping.get('line', {}).get(str(line.id), {}).get(

--- a/addons/sale_pdf_quote_builder/models/sale_order_line.py
+++ b/addons/sale_pdf_quote_builder/models/sale_order_line.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class SaleOrderLine(models.Model):
@@ -11,6 +11,7 @@ class SaleOrderLine(models.Model):
         comodel_name='product.document',
         relation='available_sale_order_line_product_document_rel',
         compute='_compute_available_product_document_ids',
+        compute_sudo=True, # To access attached_on_sale
     )
     product_document_ids = fields.Many2many(
         string="Product Documents",
@@ -23,6 +24,7 @@ class SaleOrderLine(models.Model):
 
     # === COMPUTE METHODS === #
 
+    @api.depends('product_id', 'product_template_id')
     def _compute_available_product_document_ids(self):
         for line in self:
             line.available_product_document_ids = self.env['product.document'].search([

--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -7,13 +7,13 @@ from odoo import Command
 from odoo.tests import tagged
 from odoo.tools.misc import file_open
 
-from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.addons.base.tests.common import BaseUsersCommon
 from odoo.addons.sale.tests.common import SaleCommon
 from .files import forms_pdf, plain_pdf
 
 
 @tagged('-at_install', 'post_install')
-class TestPDFQuoteBuilder(HttpCaseWithUserDemo, SaleCommon):
+class TestPDFQuoteBuilder(BaseUsersCommon, SaleCommon):
 
     @classmethod
     def setUpClass(cls):
@@ -146,21 +146,13 @@ class TestPDFQuoteBuilder(HttpCaseWithUserDemo, SaleCommon):
             self.assertEqual(result, expected[form_field.name])
 
     def test_product_document_dialog_params_access(self):
-        sale_order_user_demo = self.sale_order.copy({'user_id': self.user_demo.id})
-        dialog_param = sale_order_user_demo.with_user(
-            self.user_demo.id
+        sale_order_user_internal = self.sale_order.copy({'user_id': self.user_internal.id})
+        dialog_param = sale_order_user_internal.with_user(
+            self.user_internal.id
         ).get_update_included_pdf_params()
+        # should return all document data regardless of access
         self.assertEqual('Header', dialog_param['headers']['files'][0]['name'])
-        # Line product document should only be accessible by sales user
-        self.assertFalse(dialog_param['lines'])
-
-        self.user_demo.groups_id += self.env.ref('sales_team.group_sale_salesman')
-        dialog_param = sale_order_user_demo.with_user(
-            self.user_demo.id
-        ).get_update_included_pdf_params()
-        # should return all document data for sale own document user
-        self.assertEqual('Header', dialog_param['headers']['files'][0]['name'])
-        self.assertTrue('Product > Test Product', dialog_param['lines'][0]['name'])
+        self.assertEqual('Product > Test Product', dialog_param['lines'][0]['name'])
 
     def _test_custom_content_kanban_like(self):
         # TODO VCR finish tour and uncomment


### PR DESCRIPTION
Steps to Reproduce:
- Ensure no headers or footers are in Configuration > Headers/Footers.
- Create a new Sale Order (SO).
- Add a partner to the SO.
- Add a product to the SO that has a document linked to it.
- The `Quote Builder` tab does not appear until the SO is saved and reopened.

Issue:
The `Quote Builder` tab did not appear immediately after adding a product with linked documents. This required saving and reopening the SO to make the tab visible, causing inconvenience to users.

Cause:
The `_compute_available_product_document_ids` method lacked an `@api.depends` decorator for fields `product_id` and `product_template_id`. As a result, the dependent field `is_pdf_quote_builder_available` was not updated dynamically.

Fix:
Added the `@api.depends` decorator to `_compute_available_product_document_ids`, ensuring the computation is triggered immediately when `product_id` or `product_template_id` changes. This ensures that
`is_pdf_quote_builder_available` is recalculated dynamically, making the `Quote Builder` tab visible immediately.

- Also added `compute_sudo` on `available_product_document_ids` field to ensure
available documents consistancy even though users have different access.

opw-4364152