### PR TITLE
[FIX] website_sale: fix overlapping terms & conditions

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -812,13 +812,10 @@ a.no-decoration {
     // bottom of the page.
     @include media-breakpoint-down(lg){
         .o_cta_navigation_container {
+            top: 100%;
+            bottom: auto !important;
             padding: 0 calc(var(--gutter-x) * .5);
         }
-    }
-
-    // TODO This height is arbitrary and the calculation should be improved.
-    .o_cta_navigation_placeholder {
-        height: o-to-rem(111px) + map-get($spacers, 4) + 2rem;
     }
 
     a.disabled {

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1776,7 +1776,7 @@
             - xmlid: The id of the xml templated rendered by the controller.
         -->
         <t t-set="step_specific_values" t-value="website._get_checkout_steps(xmlid)"/>
-        <div t-attf-class="#{_container_classes} d-flex #{_form_send_navigation and 'flex-column flex-lg-row align-items-lg-center' or 'flex-column'} pt-4">
+        <div t-attf-class="#{_container_classes} d-flex #{_form_send_navigation and 'flex-column flex-lg-row align-items-lg-center' or 'flex-column'} mb-5 mb-lg-0 pt-4">
             <t t-if="website_sale_order and website_sale_order.website_order_line">
                 <t t-if="xmlid == 'website_sale.payment'">
                     <div t-if="not errors and not website_sale_order.amount_total"
@@ -2340,7 +2340,7 @@
                         <!-- This div serves as an anchor for the navigation buttons on the mobile
                              view. -->
                         <div t-if="not show_shorter_cart_summary and show_navigation_button"
-                             class="o_cta_navigation_placeholder d-block d-lg-none order-lg-4"/>
+                             class="o_cta_navigation_placeholder d-block d-none d-lg-none order-lg-4"/>
                     </div>
                 </div>
                 <!-- This is the drag-and-drop area for website building blocs at the end of each


### PR DESCRIPTION
This PR fixes an issues about the terms & conditions overlapping the rest of the content on the `website_sale` payment page.

Prior to this PR, the terms & conditions was positioned using a `position-absolute` with a `bottom-0`, resulting in the element extending to the topside if its content is very long. This led to some overlapping issues with the others elements of the view.

To prevent this issue to happen, we position the element with a `top-100` and remove the `<div>` that aimed to handle the spacing at the bottom. We now manage this spacing with a utility class.

opw-4373853

| 17.0 | This PR |
|--------|--------|
| <img width="472" alt="image" src="https://github.com/user-attachments/assets/6b4b768f-9764-45aa-84b8-94fcab059f30" /> | <img width="461" alt="image" src="https://github.com/user-attachments/assets/5cd8548e-9b8f-4036-84dd-3f224779af27" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
