### PR TITLE
[FIX] stock_account: branch accounts configuration ignored

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -266,9 +266,8 @@ class AccountMoveLine(models.Model):
             and line.move_id.is_purchase_document()
         ))
         for line in input_lines:
-            line = line.with_company(line.move_id.journal_id.company_id)
             fiscal_position = line.move_id.fiscal_position_id
-            accounts = line.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=fiscal_position)
+            accounts = line.with_company(line.company_id).product_id.product_tmpl_id.get_product_accounts(fiscal_pos=fiscal_position)
             if accounts['stock_input']:
                 line.account_id = accounts['stock_input']
 

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -366,3 +366,29 @@ class TestAccountMove(TestAccountMoveStockCommon):
 
         cogs_line = move.line_ids.filtered(lambda l: l.account_id == self.product_A.property_account_expense_id)
         self.assertEqual(cogs_line.analytic_distribution, {str(analytic_account.id): 100})
+
+    def test_cogs_account_branch_company(self):
+        """Check branch company accounts are selected"""
+        branch = self.branch_a['company']
+        test_account = self.env['account.account'].create({
+            'name': '10001 Test Account',
+            'code': 'STCKIN',
+            'reconcile': True,
+            'account_type': 'asset_current',
+            'company_id': branch.id,
+        })
+        self.auto_categ.with_company(branch.id).property_valuation = "real_time"
+        self.auto_categ.with_company(branch.id).property_stock_account_input_categ_id = test_account
+
+        bill = self.env['account.move'].with_company(branch.id).with_context(default_move_type='in_invoice').create({
+            'partner_id': self.partner_a.id,
+            'invoice_date': fields.Date.today(),
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_A.id,
+                    'price_unit': 100,
+                }),
+            ],
+        })
+
+        self.assertEqual(bill.invoice_line_ids.account_id, test_account)


### PR DESCRIPTION
User of a branch company may change accounts configuration product categories,
but currently this settings is ignored, as accounts are fetched from the main
company instead

Steps to reproduce:
- Create a branch company
- Open a product category [CATEG] (i.e. Office Furniture) and set
  - 'Inventory valuation': 'Automated'
  - 'Stock Input Account': [Account]
- Assign product category [CATEG] to a product [PROD]
- Create a Vendor bill with [PROD] and Save
- Check Journal items tab

Issue: Product line account is not [Account] but it is taken from the
main company settings
This occurs due to a fix [1] done to have `stock_account` in sync with the
base method in `account`. However, the forced company in base method was changed
in a refactor [2]

[1] https://github.com/odoo/odoo/commit/0b07210fe1f1c451eb648deff74c3ab37c8c09bd
[2] https://github.com/odoo/odoo/commit/d8d47f9ff8554f4b39487fd2f13c153c7d6f958d

opw-4297203