### PR TITLE
[IMP] orm: rename get_domain_list to get_comodel_domain

### DIFF
--- a/addons/account/models/account_code_mapping.py
+++ b/addons/account/models/account_code_mapping.py
@@ -1,4 +1,5 @@
 from odoo import fields, models, api
+from odoo.fields import Domain
 from odoo.tools import Query
 
 COMPANY_OFFSET = 10000
@@ -45,14 +46,22 @@ class AccountCodeMapping(models.Model):
         return mappings
 
     def _search(self, domain, offset=0, limit=None, order=None) -> Query:
-        match domain:
-            case [('account_id', 'in', account_ids), *remaining_domain]:
-                return self.browse([
-                    account_id * COMPANY_OFFSET + company.id
-                    for account_id in account_ids
-                    for company in self.env.user.with_context(active_test=True).company_ids.sorted(lambda c: (c.sequence, c.name))
-                ]).filtered_domain(remaining_domain)._as_query()
-        raise NotImplementedError
+        account_ids = []
+
+        def get_accounts(condition):
+            if not account_ids and condition.field_expr == 'account_id' and condition.operator == 'in':
+                account_ids.extend(condition.value)
+                return Domain(bool(condition.value))
+            return condition
+
+        remaining_domain = Domain(domain).map_conditions(get_accounts)
+        if not account_ids:
+            raise NotImplementedError
+        return self.browse([
+            account_id * COMPANY_OFFSET + company.id
+            for account_id in account_ids
+            for company in self.env.user.with_context(active_test=True).company_ids.sorted(lambda c: (c.sequence, c.name))
+        ]).filtered_domain(remaining_domain)._as_query()
 
     def _compute_account_id(self):
         for record in self:

--- a/addons/account/models/account_root.py
+++ b/addons/account/models/account_root.py
@@ -20,7 +20,7 @@ class AccountRoot(models.Model):
         return super().browse(ids)
 
     def _search(self, domain, offset=0, limit=None, order=None) -> Query:
-        match domain:
+        match list(domain):
             case [('id', 'in', ids)]:
                 return self.browse(sorted(ids))._as_query()
             case [('id', 'parent_of', ids)]:

--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -4,8 +4,8 @@ from werkzeug import urls
 from werkzeug.exceptions import Forbidden, NotFound
 
 from odoo import http
+from odoo.fields import Domain
 from odoo.http import request
-from odoo.osv import expression
 from odoo.tools import consteq
 from odoo.addons.mail.controllers import mail
 from odoo.addons.mail.tools.discuss import Store
@@ -62,9 +62,9 @@ class PortalChatter(http.Controller):
         # extract domain from the 'website_message_ids' field
         model = request.env[thread_model]
         field = model._fields['website_message_ids']
-        domain = expression.AND([
+        domain = Domain.AND([
             self._setup_portal_message_fetch_extra_domain(kw),
-            field.get_domain_list(model),
+            field.get_comodel_domain(model),
             [('res_id', '=', thread_id), '|', ('body', '!=', ''), ('attachment_ids', '!=', False),
              ("subtype_id", "=", request.env.ref("mail.mt_comment").id)]
         ])
@@ -79,7 +79,7 @@ class PortalChatter(http.Controller):
                 raise Forbidden()
             # Non-employee see only messages with not internal subtype (aka, no internal logs)
             if not request.env.user._is_internal():
-                domain = expression.AND([Message._get_search_domain_share(), domain])
+                domain = Domain.AND([Message._get_search_domain_share(), domain])
             Message = request.env["mail.message"].sudo()
         res = Message._message_fetch(domain, **(fetch_params or {}))
         messages = res.pop("messages")

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -480,7 +480,7 @@ class ProductProduct(models.Model):
     def _search(self, domain, offset=0, limit=None, order=None):
         # TDE FIXME: strange
         if self._context.get('search_default_categ_id'):
-            domain = domain.copy()
+            domain = list(domain)
             domain.append((('categ_id', 'child_of', self._context['search_default_categ_id'])))
         return super()._search(domain, offset, limit, order)
 

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -1256,19 +1256,30 @@ class Test_New_ApiModel_Many2one_Reference(models.Model):
 
     res_model = fields.Char('Resource Model')
     res_id = fields.Many2oneReference('Resource ID', model_field='res_model')
+    const = fields.Boolean(default=True)
 
 
 class Test_New_ApiInverse_M2o_Ref(models.Model):
     _name = 'test_new_api.inverse_m2o_ref'
     _description = 'dummy m2oref inverse model'
 
-    model_ids = fields.One2many('test_new_api.model_many2one_reference', 'res_id', string="Models")
+    model_ids = fields.One2many(
+        'test_new_api.model_many2one_reference', 'res_id',
+        string="Models", domain=[('const', '=', True)])
     model_ids_count = fields.Integer("Count", compute='_compute_model_ids_count')
+    model_computed_ids = fields.One2many(
+        'test_new_api.model_many2one_reference',
+        string="Models Computed",
+        compute='_compute_model_computed_ids',
+    )
 
     @api.depends('model_ids')
     def _compute_model_ids_count(self):
         for rec in self:
             rec.model_ids_count = len(rec.model_ids)
+
+    def _compute_model_computed_ids(self):
+        self.model_computed_ids = []
 
 
 class Test_New_ApiModel_Child_M2o(models.Model):

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -17,6 +17,7 @@ from odoo import models, fields, Command
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 from odoo.addons.base.tests.test_expression import TransactionExpressionCase
 from odoo.exceptions import AccessError, MissingError, UserError, ValidationError
+from odoo.fields import Domain
 from odoo.tests import TransactionCase, tagged, Form, users
 from odoo.tools import mute_logger, float_repr
 from odoo.tools.date_utils import add, subtract, start_of, end_of
@@ -597,6 +598,13 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         self.env.flush_all()
         self.registry.setup_models(self.cr)
         self.assertEqual(self.registry.field_depends[Model.full_name], ('name1', 'name2'))
+
+    def test_12_one2many_reference_domain(self):
+        model = self.env['test_new_api.inverse_m2o_ref']
+        o2m_field = model._fields['model_ids']
+        self.assertEqual(o2m_field.get_comodel_domain(model), Domain('const', '=', True) & Domain('res_model', '=', model._name))
+        o2m_field = model._fields['model_computed_ids']
+        self.assertEqual(o2m_field.get_comodel_domain(model), Domain.TRUE)
 
     def test_13_inverse(self):
         """ test inverse computation of fields """

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1142,7 +1142,7 @@ def _optimize_relational_name_search(condition, model):
         value = _value_to_ids(value, comodel, positive_operator)
     else:
         comodel = comodel.with_context(**field.context)
-        additional_domain = Domain(field.get_domain_list(model))
+        additional_domain = field.get_comodel_domain(model)
         value = _value_to_ids(value, comodel, positive_operator, additional_domain)
     if isinstance(value, OrderedSet):
         any_operator = 'in' if positive else 'not in'

--- a/odoo/orm/fields_reference.py
+++ b/odoo/orm/fields_reference.py
@@ -94,7 +94,7 @@ class Many2oneReference(Integer):
             if not records:
                 continue
             corecord = records.env[invf.model_name].browse(value)
-            records = records.filtered_domain(invf.get_domain_list(corecord))
+            records = records.filtered_domain(invf.get_comodel_domain(corecord))
             if not records:
                 continue
             ids0 = cache.get(corecord, invf, None)

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -73,13 +73,17 @@ class _Relational(Field[M], typing.Generic[M]):
             _logger.warning("Field %s with unknown comodel_name %r", self, self.comodel_name)
             self.comodel_name = '_unknown'
 
-    def get_domain_list(self, model):
-        """ Return a list domain from the domain parameter. """
-        # TODO rename and make it return a Domain
+    def get_comodel_domain(self, model: BaseModel) -> Domain:
+        """ Return a domain from the domain attribute. """
         domain = self.domain
         if callable(domain):
+            # the callable can return either a list, Domain or a string
             domain = domain(model)
-        return domain if isinstance(domain, list) else []
+        if not domain or isinstance(domain, str):
+            # if we don't have a domain or
+            # domain=str is used only for the client-side
+            return Domain.TRUE
+        return Domain(domain)
 
     @property
     def _related_domain(self):
@@ -100,8 +104,8 @@ class _Relational(Field[M], typing.Generic[M]):
     _description_relation = property(attrgetter('comodel_name'))
     _description_context = property(attrgetter('context'))
 
-    def _description_domain(self, env):
-        domain = self.domain(env[self.model_name]) if callable(self.domain) else self.domain  # pylint: disable=not-callable
+    def _description_domain(self, env) -> str | list:
+        domain = self._internal_description_domain_raw(env)
         if self.check_company:
             field_to_check = None
             if self.company_dependent:
@@ -130,6 +134,14 @@ class _Relational(Field[M], typing.Generic[M]):
                 no_company_domain = env[self.comodel_name]._check_company_domain(companies='')
                 return f"({field_to_check} and {company_domain} or {no_company_domain}) + ({domain or []})"
         return domain
+
+    def _internal_description_domain_raw(self, env) -> str | list:
+        domain = self.domain
+        if callable(domain):
+            domain = domain(env[self.model_name])
+        if isinstance(domain, Domain):
+            domain = list(domain)
+        return domain or []
 
 
 class Many2one(_Relational[M]):
@@ -362,7 +374,7 @@ class Many2one(_Relational[M]):
         cache = records.env.cache
         corecord = self.convert_to_record(value, records)
         for invf in records.pool.field_inverses[self]:
-            valid_records = records.filtered_domain(invf.get_domain_list(corecord))
+            valid_records = records.filtered_domain(invf.get_comodel_domain(corecord))
             if not valid_records:
                 continue
             ids0 = cache.get(corecord, invf, None)
@@ -568,11 +580,11 @@ class _RelationalMulti(_Relational[M], typing.Generic[M]):
 
     def get_depends(self, model):
         depends, depends_context = super().get_depends(model)
-        if not self.compute and isinstance(self.domain, list):
+        if not self.compute and isinstance(domain := self.domain, (list, Domain)):
+            domain = Domain(domain)
             depends = unique(itertools.chain(depends, (
-                self.name + '.' + arg[0]
-                for arg in self.domain
-                if isinstance(arg, (tuple, list)) and isinstance(arg[0], str)
+                self.name + '.' + condition.field_expr
+                for condition in domain.iter_conditions()
             )))
         return depends, depends_context
 
@@ -658,7 +670,7 @@ class _RelationalMulti(_Relational[M], typing.Generic[M]):
 
     def _get_query_for_condition_value(self, model: BaseModel, comodel: BaseModel, value: Domain | Query) -> Query:
         """ Return Query run on the comodel with the field.domain injected."""
-        field_domain = Domain(self.get_domain_list(model))
+        field_domain = self.get_comodel_domain(model)
         if isinstance(value, Domain):
             domain = value & field_domain
             comodel = comodel.with_context(**self.context)
@@ -746,13 +758,23 @@ class One2many(_RelationalMulti[M]):
                     comodel=self.comodel_name
                 ))
 
-    def get_domain_list(self, records):
-        comodel = records.env.registry[self.comodel_name]
-        inverse_field = comodel._fields[self.inverse_name]
-        domain = super(One2many, self).get_domain_list(records)
-        if inverse_field.type == 'many2one_reference':
-            domain = domain + [(inverse_field.model_field, '=', records._name)]
-        return domain
+    def _additional_domain(self, env) -> Domain:
+        if self.comodel_name and self.inverse_name:
+            comodel = env.registry[self.comodel_name]
+            inverse_field = comodel._fields[self.inverse_name]
+            if inverse_field.type == 'many2one_reference':
+                return Domain(inverse_field.model_field, '=', self.model_name)
+        return Domain.TRUE
+
+    def get_comodel_domain(self, model) -> Domain:
+        return super().get_comodel_domain(model) & self._additional_domain(model.env)
+
+    def _internal_description_domain_raw(self, env) -> str | list:
+        domain = super()._internal_description_domain_raw(env)
+        additional_domain = self._additional_domain(env)
+        if additional_domain.is_true():
+            return domain
+        return f"({domain}) + ({additional_domain})"
 
     def __get__(self, records, owner=None):
         if records is not None and self.inverse_name is not None:
@@ -772,7 +794,7 @@ class One2many(_RelationalMulti[M]):
         inverse_field = comodel._fields[inverse]
 
         # optimization: fetch the inverse and active fields with search()
-        domain = self.get_domain_list(records) + [(inverse, 'in', records.ids)]
+        domain = self.get_comodel_domain(records) & Domain(inverse, 'in', records.ids)
         field_names = [inverse]
         if comodel._active_name:
             field_names.append(comodel._active_name)
@@ -861,8 +883,7 @@ class One2many(_RelationalMulti[M]):
                         flush()
                         # assign the given lines to the last record only
                         lines = comodel.browse(line_ids)
-                        domain = self.get_domain_list(model) + \
-                            [(inverse, 'in', recs.ids), ('id', 'not in', lines.ids)]
+                        domain = self.get_comodel_domain(model) & Domain(inverse, 'in', recs.ids) & Domain('id', 'not in', lines.ids)
                         unlink(comodel.search(domain))
                         lines[inverse] = recs[-1]
 
@@ -1192,7 +1213,7 @@ class Many2many(_RelationalMulti[M]):
         comodel = records.env[self.comodel_name].with_context(**context)
 
         # make the query for the lines
-        domain = self.get_domain_list(records)
+        domain = self.get_comodel_domain(records)
         query = comodel._where_calc(domain)
         comodel._apply_ir_rules(query, 'read')
         query.order = comodel._order_to_sql(comodel._order, query)
@@ -1321,7 +1342,7 @@ class Many2many(_RelationalMulti[M]):
                 y_to_xs[y].add(x)
                 modified_corecord_ids.add(y)
             for invf in records.pool.field_inverses[self]:
-                domain = invf.get_domain_list(comodel)
+                domain = invf.get_comodel_domain(comodel)
                 valid_ids = set(records.filtered_domain(domain)._ids)
                 if not valid_ids:
                     continue
@@ -1450,7 +1471,7 @@ class Many2many(_RelationalMulti[M]):
                 y_to_xs[y].add(x)
                 modified_corecord_ids.add(y)
             for invf in records.pool.field_inverses[self]:
-                domain = invf.get_domain_list(comodel)
+                domain = invf.get_comodel_domain(comodel)
                 valid_ids = set(records.filtered_domain(domain)._ids)
                 if not valid_ids:
                     continue

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -5504,8 +5504,8 @@ class BaseModel(metaclass=MetaModel):
                 to_flush[model._name].add(fname)
                 if field.type == 'one2many' and field.inverse_name:
                     to_flush[field.comodel_name].add(field.inverse_name)
-                    field_domain = field.get_domain_list(model)
-                    if field_domain:
+                    field_domain = field.get_comodel_domain(model)
+                    if not field_domain.is_true():
                         collect_from_domain(self.env[field.comodel_name], field_domain)
                 # DLE P111: `test_message_process_email_partner_find`
                 # Search on res.users with email_normalized in domain


### PR DESCRIPTION
The function now returns a `Domain` which indicates a more specific type
and simplifies some code.
Fix usages in relational fields: the domain for inverses is not always
correct and may crash for computed fields. Resolve the `get_depends`
using the `get_domain_list` whenever possible.
Update `_description_domain` to also use `get_comodel_domain`.

task-4380712
odoo/enterprise#75983

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
