### PR TITLE
[FIX] pos_stripe: fix error string and log to console detailed error

### DIFF
--- a/addons/pos_stripe/static/src/app/payment_stripe.js
+++ b/addons/pos_stripe/static/src/app/payment_stripe.js
@@ -56,6 +56,7 @@ export class PaymentStripe extends PaymentInterface {
                 }
             }
         } catch (error) {
+            console.error(error);
             this._showError(error);
             return false;
         }
@@ -96,6 +97,7 @@ export class PaymentStripe extends PaymentInterface {
                     this.pos.connectedReader = this.payment_method_id.stripe_serial_number;
                     return true;
                 } catch (error) {
+                    console.error(error);
                     if (error.error) {
                         this._showError(error.error.message, error.code);
                     } else {
@@ -267,7 +269,8 @@ export class PaymentStripe extends PaymentInterface {
                 return await this.collectPayment(line.amount);
             }
         } catch (error) {
-            this._showError(error);
+            console.error(error);
+            this._showError(String(error));
             return false;
         }
     }


### PR DESCRIPTION
Before this commit:

1. Install pos_stripe & pos_restaurant
2. Create a PoS payment method wish Stripe Terminal setup with dummy (wrong) value. ! Purposfully DON'T set up the Stripe account (so let it as deactivate)
3. Add the payment method to the bar PoS
4. Open the bar PoS, make an order and try to pay by the stripe payment method

=> JS error
```js
undefined

undefined

OwlError: Invalid props for component 'AlertDialog': 'body' is not a string
    Error: Invalid props for component 'AlertDialog': 'body' is not a string
        at Object.validateProps (http://127.0.0.1:8069/web/assets/debug/point_of_sale.assets_prod.js:11392:19) (/web/static/lib/owl/owl.js:3160)
        at DialogWrapper.template (eval at compile (http://127.0.0.1:8069/web/assets/debug/point_of_sale.assets_prod.js:13846:20), <anonymous>:10:13) (/web/static/lib/owl/owl.js:5614)
        at Fiber._render (http://127.0.0.1:8069/web/assets/debug/point_of_sale.assets_prod.js:9961:38) (/web/static/lib/owl/owl.js:1729)
        at Fiber.render (http://127.0.0.1:8069/web/assets/debug/point_of_sale.assets_prod.js:9953:18) (/web/static/lib/owl/owl.js:1721)
        at ComponentNode.initiateRender (http://127.0.0.1:8069/web/assets/debug/point_of_sale.assets_prod.js:10633:23) (/web/static/lib/owl/owl.js:2401)
```
This error hide the real error as the error dialog expect to receive a string while it receive an Error object

After this commit:
The (real) error is logged to the console:
```js
payment_stripe.js:272 SyntaxError: "undefined" is not valid JSON
    at JSON.parse (<anonymous>)
    at Proxy.connectReader (payment_stripe.js:87:1)
    at Proxy.checkReader (payment_stripe.js:79:1)
    at Proxy.send_payment_request (payment_stripe.js:268:1)
    at async Proxy.pay (pos_payment.js:74:1)
    at async PaymentScreen.sendPaymentRequest (payment_screen.js:545:1)
```
and the error dialog shows with the string of the error, here: `SyntaxError: "undefined" is not valid JSON`

We will not have the traceback in the client message as I didn't find a way to do so except letting the error propagate. But this might have side effects so I didn't used this option.

opw-4375876