### PR TITLE
[FIX] web_editor: blend the bg color when selecting a table cell

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
@@ -34,7 +34,8 @@
         background-color: transparent !important;
     }
     .o_selected_td {
-        background-color: rgba(117, 167, 249, 0.5) !important; /* #bad3fc equivalent when over white*/
+        box-shadow: 0 0 0 100vmax rgba(117, 167, 249, 0.5) inset; /* #bad3fc equivalent when over white, overlaying on the bg color*/
+        border-collapse: separate;
         cursor: pointer !important;
     }
 }


### PR DESCRIPTION
Before this commit: the bg color of a table cell is set to a fixed value when selected

After this commit: the selection will have a blue overlay color effect on the selected cells with bg color

task-4398980




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
