### PR TITLE
[FIX] web: some table overflow in Form on small screen

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -16,7 +16,7 @@
 @mixin form-break-table() {
     --fieldWidget-margin-bottom: 0;
 
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     margin-bottom: $o-form-spacing-unit * 4;
 
     .o_cell {


### PR DESCRIPTION
This commit changes the `1fr` with `minmax(O, 1fr)` to avoid some content with a min-with bigger than the grid itself to overflow.

See this commit[1] for more info

Steps to reproduce:
* Open Odoo on small screen
* Open Sale App
* Go to Product Menu
* Select a Product
* Activate the `Rental` checkbox
* Go to `Rental prices` pane The list inside the panel overflow => BUG

[1]: odoo/odoo@dbf1794799f2be54e0a0da7719cde3e5069fcdd9

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
