### PR TITLE
[FIX] point_of_sale: use payment method Intermediary Account

### DIFF
--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -96,10 +96,8 @@ class PosPayment(models.Model):
             is_split_transaction = payment.payment_method_id.split_transactions
             if is_split_transaction and is_reverse:
                 reversed_move_receivable_account_id = accounting_partner.with_company(order.company_id).property_account_receivable_id.id
-            elif is_reverse:
-                reversed_move_receivable_account_id = payment.payment_method_id.receivable_account_id.id or self.company_id.account_default_pos_receivable_account_id.id
             else:
-                reversed_move_receivable_account_id = self.company_id.account_default_pos_receivable_account_id.id
+                reversed_move_receivable_account_id = payment.payment_method_id.receivable_account_id.id or self.company_id.account_default_pos_receivable_account_id.id
             debit_line_vals = pos_session._debit_amounts({
                 'account_id': reversed_move_receivable_account_id,
                 'move_id': payment_move.id,


### PR DESCRIPTION
Before this commit, in the payment move for a normal order, the Default Temporary Account was used while it should use the payment method Intermediary Account.

opw-4404557

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
