### PR TITLE
[FIX] account_peppol: do not mingle Peppol with Italy EDI for requests

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -22,8 +22,14 @@ class AccountEdiProxyClientUser(models.Model):
     # HELPER METHODS
     # -------------------------------------------------------------------------
 
-    @handle_demo
+
     def _make_request(self, url, params=False):
+        if self.proxy_type == 'peppol':
+            return self._make_request_peppol(url, params=params)
+        return super()._make_request(url, params=params)
+
+    @handle_demo
+    def _make_request_peppol(self, url, params=False):
         # extends account_edi_proxy_client to update peppol_proxy_state
         # of archived users
         try:

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -184,7 +184,7 @@ def _mock_check_company_on_peppol(func, self, *args, **kwargs):
 
 
 _demo_behaviour = {
-    '_make_request': _mock_make_request,
+    '_make_request_peppol': _mock_make_request,
     'button_account_peppol_check_partner_endpoint': _mock_button_verify_partner_endpoint,
     '_get_peppol_verification_state': _mock_get_peppol_verification_state,
     '_peppol_migrate_registration': _mock_migrate_participant,


### PR DESCRIPTION
The problem was that the decorator would be triggered if Peppol is in demo mode, but also for the requests made by the Italian EDI which does not have the same information which results in a traceback.

opw-4421483

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
