### PR TITLE
[FIX] core: test file tag

### DIFF
--- a/odoo/tests/tag_selector.py
+++ b/odoo/tests/tag_selector.py
@@ -61,7 +61,7 @@ class TagsSelector(object):
             (tag, module, klass, method, file_path) = test_filter
             if tag and tag not in test_tags:
                 return False
-            elif file_path and not file_path.endswith(test_module_path):
+            elif file_path and not test_module_path.endswith(file_path):
                 return False
             elif not file_path and module and module != test_module:
                 return False


### PR DESCRIPTION
Restore the behaviour where running using a tag "/test_xx.py" executes that test file in any module. Right now, only an exact path relative from odoo.addons to the file works ("/mymodule/tests/test_xx.py").


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
