### PR TITLE
[FIX] website_forum: fix spam search with multiple nodes

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -9,7 +9,7 @@ import publicWidget from "@web/legacy/js/public/public_widget";
 import { session } from "@web/session";
 import { escape } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
-import { renderToElement } from "@web/core/utils/render";
+import { renderToFragment } from "@web/core/utils/render";
 
 publicWidget.registry.websiteForum = publicWidget.Widget.extend({
     selector: '.website_forum',
@@ -654,7 +654,7 @@ publicWidget.registry.websiteForumSpam = publicWidget.Widget.extend({
             Object.values(o).forEach((r) => {
                 r.content = $('<p>' + $(r.content).html() + '</p>').text().substring(0, 250);
             });
-            self.$('div.post_spam').empty().append(renderToElement('website_forum.spam_search_name', {
+            self.$('div.post_spam').empty().append(renderToFragment('website_forum.spam_search_name', {
                 posts: o,
             }));
         });


### PR DESCRIPTION
Since render.qweb was replaced by renderToElement, the spam input search crashes if more than one post meets the search. This commit renders a fragment instead of an element to bypass this limitation.

Steps to reproduce:
- Connect as Admin
- Flag 2 posts on the forum ("..." at the bottom of a post > Flag)
- Go to the flagged posts in the moderation tools (left bar)
- Click on "Filter Tool"
- Select the "Text" tab
- Type "e" (to select both posts) => Traceback.

(No linked task)