### PR TITLE
[IMP] point_of_sale, pos_*: allow some settings to be modified during an open session

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -410,7 +410,7 @@ class PosConfig(models.Model):
             prepa_printers_menuitem.active = self.sudo().env['pos.config'].search_count([('is_order_printer', '=', True)], limit=1) > 0
 
     @api.depends('use_pricelist', 'pricelist_id', 'available_pricelist_ids', 'payment_method_ids', 'limit_categories',
-        'iface_available_categ_ids')
+        'iface_available_categ_ids', 'module_pos_hr', 'module_pos_discount', 'iface_tipproduct', 'default_preset_id')
     def _compute_local_data_integrity(self):
         self.last_data_change = self.env.cr.now()
 
@@ -420,7 +420,6 @@ class PosConfig(models.Model):
         if ('is_order_printer' in vals and not vals['is_order_printer']):
             vals['printer_ids'] = [fields.Command.clear()]
 
-        bypass_categories_forbidden_change = self.env.context.get('bypass_categories_forbidden_change', False)
         bypass_payment_method_ids_forbidden_change = self.env.context.get('bypass_payment_method_ids_forbidden_change', False)
 
         self._preprocess_x2many_vals_from_settings_view(vals)
@@ -430,40 +429,11 @@ class PosConfig(models.Model):
             forbidden_fields = []
             for key in self._get_forbidden_change_fields():
                 if key in vals.keys():
-                    if bypass_categories_forbidden_change and key in ('limit_categories', 'iface_available_categ_ids'):
-                        continue
                     if bypass_payment_method_ids_forbidden_change and key == 'payment_method_ids':
                         continue
-                    if key == 'use_pricelist' and vals[key]:
-                        continue
-                    if key == 'available_pricelist_ids':
-                        will_unlink_a_pricelist = \
-                            (
-                                (not isinstance(vals[key], list) or len(vals[key]) == 0)
-                                and self.available_pricelist_ids
-                            ) or (
-                                isinstance(vals[key], list) and any(
-                                    (
-                                        len(cmd) >= 1
-                                        and cmd[0] == Command.CLEAR
-                                        and self.available_pricelist_ids
-                                    ) or (
-                                        len(cmd) >= 2
-                                        and cmd[0] in {Command.UNLINK, Command.DELETE}
-                                        and cmd[1] in self.available_pricelist_ids.ids
-                                    ) or (
-                                        len(cmd) == 3
-                                        and cmd[0] == Command.SET
-                                        and set(self.available_pricelist_ids.ids) - set(cmd[2])
-                                    )
-                                    for cmd in vals[key]
-                                )
-                            )
-
-                        if not will_unlink_a_pricelist:
-                            continue
                     field_name = self._fields[key].get_description(self.env)["string"]
                     forbidden_fields.append(field_name)
+
             if len(forbidden_fields) > 0:
                 raise UserError(_(
                     "Unable to modify this PoS Configuration because you can't modify %s while a session is open.",
@@ -532,10 +502,7 @@ class PosConfig(models.Model):
         return new_vals
 
     def _get_forbidden_change_fields(self):
-        forbidden_keys = ['module_pos_hr', 'module_pos_restaurant', 'available_pricelist_ids',
-                          'limit_categories', 'iface_available_categ_ids', 'use_pricelist', 'module_pos_discount',
-                          'payment_method_ids', 'iface_tipproduct', 'use_presets', 'default_preset_id']
-        return forbidden_keys
+        return ['module_pos_restaurant', 'payment_method_ids', 'use_presets', 'default_preset_id']
 
     def unlink(self):
         # Delete the pos.config records first then delete the sequences linked to them

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -110,7 +110,7 @@
                                 </div>
                             </setting>
                             <setting id="iface_tipproduct" title="This product is used as reference on customer receipts." string="Tips" help="Accept customer tips or convert their change to a tip" documentation="/applications/sales/point_of_sale/restaurant/tips.html">
-                                <field name="pos_iface_tipproduct" readonly="pos_has_active_session"/>
+                                <field name="pos_iface_tipproduct"/>
                                 <div class="content-group" invisible="not pos_iface_tipproduct">
                                     <div class="row mt16" id="tip_product">
                                         <label string="Tip Product" for="pos_tip_product_id" class="col-lg-3 o_light_label "/>
@@ -124,7 +124,7 @@
                                 There is no Chart of Accounts configured on the company. Please go to the invoicing settings to install a Chart of Accounts.
                             </div>
                             <setting id="multiple_employee_session" title="Employees can scan their badge or enter a PIN to log in to a PoS session. These credentials are configurable in the *HR Settings* tab of the employee form." string="Log in with Employees" help="Allow to log and switch between selected Employees" documentation="/applications/sales/point_of_sale/employee_login.html">
-                                <field name="pos_module_pos_hr" readonly="pos_has_active_session"/>
+                                <field name="pos_module_pos_hr"/>
                                 <div class="content-group mt16" invisible="not pos_module_pos_hr">
                                     <div class="text-warning" id="warning_text_employees">
                                         Save this page and come back here to set up the feature.
@@ -160,9 +160,9 @@
                         </block>
                         <block id="product_and_category_block" title="Product &amp; PoS categories">
                             <setting help="Pick which product PoS categories are available">
-                                <field name="pos_limit_categories" readonly="pos_has_active_session"/>
+                                <field name="pos_limit_categories"/>
                                 <div class="content-group mt16" invisible="not pos_limit_categories">
-                                    <field name="pos_iface_available_categ_ids" widget="many2many_tags" readonly="pos_has_active_session"/>
+                                    <field name="pos_iface_available_categ_ids" widget="many2many_tags"/>
                                 </div>
                                 <div class="content-group mt16" invisible="not pos_limit_categories">
                                     <button name="%(product_pos_category_action)d" icon="oi-arrow-right" type="action" string="PoS Product Categories" class="btn-link"/>
@@ -241,11 +241,11 @@
 
                         <block title="Pricing" id="pos_pricing_section">
                             <setting id="multiple_prices_setting" string="Flexible Pricelists" help="Set multiple prices per product, automated discounts, etc." documentation="/applications/sales/point_of_sale/pricing/pricelists.html">
-                                <field name="pos_use_pricelist" readonly="pos_has_active_session"/>
+                                <field name="pos_use_pricelist"/>
                                 <div class="content-group" invisible="not pos_use_pricelist">
                                     <div class="row mt16">
                                         <label string="Available" for="pos_available_pricelist_ids" class="col-lg-3 o_light_label"/>
-                                        <field name="pos_available_pricelist_ids" widget="many2many_tags" domain="['|',('company_id', '=', company_id),('company_id', '=', False)]" readonly="pos_has_active_session"/>
+                                        <field name="pos_available_pricelist_ids" widget="many2many_tags" domain="['|',('company_id', '=', company_id),('company_id', '=', False)]"/>
                                     </div>
                                     <div class="row mt16">
                                         <label string="Default" for="pos_pricelist_id" class="col-lg-3 o_light_label"/>
@@ -269,7 +269,7 @@
                                 <field name="pos_manual_discount"/>
                             </setting>
                             <setting help="Adds a button to set a global discount" documentation="/applications/sales/point_of_sale/pricing/discounts.html">
-                                <field name="pos_module_pos_discount" readonly="pos_has_active_session"/>
+                                <field name="pos_module_pos_discount"/>
                                 <div class="content-group mt16" invisible="not pos_module_pos_discount">
                                     <div class="text-warning mb4" id="warning_text_pos_discount" >
                                         Save this page and come back here to set up the feature.

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -140,3 +140,7 @@ class PosConfig(models.Model):
             existing_session = self.env.ref('pos_restaurant.pos_closed_session_3', raise_if_not_found=False)
             if not existing_session:
                 convert.convert_file(self.env, 'pos_restaurant', 'data/restaurant_session_floor.xml', None, noupdate=True, mode='init', kind='data')
+
+    @api.depends('set_tip_after_payment', 'module_pos_restaurant_appointment')
+    def _compute_local_data_integrity(self):
+       super()._compute_local_data_integrity()


### PR DESCRIPTION
 '*'  pos_restaurant

Previously, some settings (Table booking: appointment type, Tips, Login with employees, Restrict categories, Flexible procelists, Global discount) could not be modified while a session was open.
With this commit, these settings can now be modified, and the POS will resynchronize after reloading

task-4380609


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
