### PR TITLE
[FIX] hr_attendance: null-safe record deletion

### DIFF
--- a/addons/hr_attendance/static/src/views/attendance_list_view.js
+++ b/addons/hr_attendance/static/src/views/attendance_list_view.js
@@ -22,9 +22,9 @@ export class AttendanceListModel extends listView.Model {
 
     /** @override **/
     async load(params = {}) {
-        const activeDomainParam = params.domain.some((index) => Array.isArray(index) && index[0] == "employee_id.active");
+        const activeDomainParam = params.domain?.some((index) => Array.isArray(index) && index[0] == "employee_id.active");
         if (!activeDomainParam) {
-            params.domain.push(["employee_id.active", "=", true]);
+            params.domain?.push(["employee_id.active", "=", true]);
         }
         return super.load(params);
     }

--- a/doc/cla/individual/yahia-soliman.md
+++ b/doc/cla/individual/yahia-soliman.md
@@ -1,0 +1,11 @@
+Egypt, 2024-12-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Yahia yn7599@gmail.com https://github.com/yahia-soliman


### PR DESCRIPTION
An error is thrown when deleting attendance records from the list view.


Steps to reproduce:
Attendances -> List View (Select some records) -> Actions -> Delete

Current behavior before PR:
```
TypeError: Cannot read properties of undefined (reading 'some')
    at Proxy.load (https://72301827-18-0-all.runbot171.odoo.com/web/assets/debug/web.assets_web.js:229101:49) (/hr_attendance/static/src/views/attendance_list_view.js:25)
    at Proxy._deleteRecords (https://72301827-18-0-all.runbot171.odoo.com/web/assets/debug/web.assets_web.js:55859:26) (/web/static/src/model/relational_model/dynamic_list.js:250)
    at async ConfirmationDialog.execButton (https://72301827-18-0-all.runbot171.odoo.com/web/assets/debug/web.assets_web.js:18747:31) (/web/static/src/core/confirmation_dialog/confirmation_dialog.js:79)
```


Desired behavior after PR is merged:
Deleting selected records without errors.

Cause:
The implementation of `DynamicList._deleteRecords` changed in v18.0 by fbb37ab363a6c729193f1ba1ba70775650140636 to call `model.load()` without `params`. Thus `params.domain` could possibly be undefined.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
