### PR TITLE
[16.0][FIX] web: login page should not be cached

### DIFF
--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -126,6 +126,7 @@ class Home(http.Controller):
             values['disable_database_manager'] = True
 
         response = request.render('web.login', values)
+        response.headers['Cache-Control'] = 'no-cache'
         response.headers['X-Frame-Options'] = 'SAMEORIGIN'
         response.headers['Content-Security-Policy'] = "frame-ancestors 'self'"
         return response


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When odoo is deployed with Reverse Proxy , like cloudflare, and cache rule is enabled. 
The login page is cached by cloudflare,  "Cf-Cache-Status" is set to "HIT" in the reponse header
![image](https://github.com/user-attachments/assets/51187a2e-476b-414b-a396-4af15ed26df7)

But in the html content, csrf_token is unavailable.
![image](https://github.com/user-attachments/assets/6a8d81e6-3270-466a-b292-789a9473657e)

Error when try to login.
![image](https://github.com/user-attachments/assets/f8cd7fa1-f08e-49af-adc6-7109f24bca17)

**Current behavior before PR:**
User can not login.

**Desired behavior after PR is merged:**
User can login.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
