### PR TITLE
[IMP] mrp: add feedback notification for scrap action

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2208,7 +2208,8 @@ class MrpProduction(models.Model):
             'type': 'ir.actions.act_window',
             'context': {'default_production_id': self.id,
                         'product_ids': (self.move_raw_ids.filtered(lambda x: x.state not in ('done', 'cancel')) | self.move_finished_ids.filtered(lambda x: x.state == 'done')).mapped('product_id').ids,
-                        'default_company_id': self.company_id.id
+                        'default_company_id': self.company_id.id,
+                        'from_shop_floor': self.env.context.get('from_shop_floor'),
                         },
             'target': 'new',
         }

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -754,7 +754,9 @@ class MrpWorkorder(models.Model):
             'context': {'default_company_id': self.production_id.company_id.id,
                         'default_workorder_id': self.id,
                         'default_production_id': self.production_id.id,
-                        'product_ids': (self.production_id.move_raw_ids.filtered(lambda x: x.state not in ('done', 'cancel')) | self.production_id.move_finished_ids.filtered(lambda x: x.state == 'done')).mapped('product_id').ids},
+                        'product_ids': (self.production_id.move_raw_ids.filtered(lambda x: x.state not in ('done', 'cancel')) | self.production_id.move_finished_ids.filtered(lambda x: x.state == 'done')).mapped('product_id').ids,
+                        'from_shop_floor': self.env.context.get('from_shop_floor'),
+                        },
             'target': 'new',
         }
 

--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -161,6 +161,11 @@ class StockScrap(models.Model):
             scrap.date_done = fields.Datetime.now()
             if scrap.should_replenish:
                 scrap.do_replenish()
+        if self.env.context.get('from_shop_floor'):
+            self.env.user._bus_send('simple_notification', {
+                'type': 'success',
+                'message': _("The scrap order has successfully been registered."),
+            })
         return True
 
     def do_replenish(self, values=False):


### PR DESCRIPTION
Before Commit:
------------------------------
- No feedback or notifications were provided after executing the Scrap action on the shopfloor, leaving users uncertain about its success.

After Commit:
-------------------------------
- Feedback notification is now triggered after executing the Scrap action, providing users with immediate, clear confirmation of success.

task-4403621