### PR TITLE
[IMP] orm: Domain add "not =like" operator as standard

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -777,8 +777,8 @@ class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
         self.assertIs(Domain(simple), simple, "Domain(Domain) should return the instance")
 
         # negative and nary
-        neg_domain = ~Domain('foo', '=like', 'bar')
-        self.assertEqual(list(neg_domain), ['!', ('foo', '=like', 'bar')], "Internal test that we are inversing a domain")
+        neg_domain = ~Domain('foo.x', '>', 'bar')
+        self.assertEqual(list(neg_domain), ['!', ('foo.x', '>', 'bar')], "Internal test that we are inversing a domain")
         and_domain = simple & Domain('bar', '=', 'baz')
 
         # bool
@@ -1000,14 +1000,20 @@ class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
         self.assertEqual(helen, self._search(Model, [('name', '=ilike', 'hél%')]))
         self.assertNotIn(helen, self._search(Model, [('name', 'not ilike', 'Helene')]))
         self.assertNotIn(helen, self._search(Model, [('name', 'not ilike', 'hélène')]))
+        self.assertNotIn(helen, self._search(Model, [('name', 'not ilike', 'ele')]))
+        self.assertNotIn(helen, self._search(Model, [('name', 'not ilike', 'élè')]))
+        self.assertNotIn(helen, self._search(Model, [('name', 'not =ilike', 'Hel%')]))
+        self.assertNotIn(helen, self._search(Model, [('name', 'not =ilike', 'hél%')]))
 
         # =like and like should be case and accent sensitive
         self.assertEqual(helen, self._search(Model, [('name', '=like', 'Hél%')]))
         self.assertNotIn(helen, self._search(Model, [('name', '=like', 'Hel%')]))
         self.assertEqual(helen, self._search(Model, [('name', 'like', 'élè')]))
         self.assertNotIn(helen, self._search(Model, [('name', 'like', 'ele')]))
-        self.assertNotIn(helen, self._search(Model, [('name', 'not ilike', 'ele')]))
-        self.assertNotIn(helen, self._search(Model, [('name', 'not ilike', 'élè')]))
+        self.assertIn(helen, self._search(Model, [('name', 'not like', 'ele')]))
+        self.assertNotIn(helen, self._search(Model, [('name', 'not like', 'élè')]))
+        self.assertNotIn(helen, self._search(Model, [('name', 'not =like', 'Hél%')]))
+        self.assertIn(helen, self._search(Model, [('name', 'not =like', 'Hel%')]))
 
         hermione, nicostratus = Model.create([
             {'name': 'Hermione', 'parent_id': helen.id},

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -76,9 +76,8 @@ STANDARD_CONDITION_OPERATORS = frozenset([
     '<', '>', '<=', '>=',
     'like', 'not like',
     'ilike', 'not ilike',
-    '=like',
-    '=ilike',
-    # TODO "not =like"?
+    '=like', 'not =like',
+    '=ilike', 'not =ilike',
 ])
 """List of standard operators for conditions.
 This should be supported in the framework at all levels.
@@ -119,6 +118,8 @@ NEGATIVE_CONDITION_OPERATORS = {
     'not in': 'in',
     'not like': 'like',
     'not ilike': 'ilike',
+    'not =like': '=like',
+    'not =ilike': '=ilike',
     '!=': '=',
     '<>': '=',
 }
@@ -131,6 +132,8 @@ _INVERSE_OPERATOR = {
     'not in': 'in',
     'not like': 'like',
     'not ilike': 'ilike',
+    'not =like': '=like',
+    'not =ilike': '=ilike',
     '!=': '=',
     '<>': '=',
     # positive to negative
@@ -138,6 +141,8 @@ _INVERSE_OPERATOR = {
     'in': 'not in',
     'like': 'not like',
     'ilike': 'not ilike',
+    '=like': 'not =like',
+    '=ilike': 'not =ilike',
     '=': '!=',
     # inequalities
     '<': '>=',

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -6332,7 +6332,7 @@ class BaseModel(metaclass=MetaModel):
                 if comparator in ('any', 'not any') and isinstance(value, Query):
                     comparator = 'in' if comparator == 'any' else 'not in'
                     value = set(value)
-                if comparator in ('like', 'ilike', '=like', '=ilike', 'not ilike', 'not like'):
+                if comparator.endswith('like'):
                     if comparator.endswith('ilike'):
                         # ilike uses unaccent and lower-case comparison
                         # we may get something which is not a string
@@ -6363,7 +6363,7 @@ class BaseModel(metaclass=MetaModel):
                             yield '$'
                         # no need to match r'.*' in else because we only use .match()
 
-                    like_regex = re.compile("".join(build_like_regex(unaccent(value), comparator.startswith("="))))
+                    like_regex = re.compile("".join(build_like_regex(unaccent(value), '=' in comparator)))
                 falsy_value = field.falsy_value
                 if falsy_value is not None and comparator in ('=', '!=') and not value and falsy_value is not False:
                     comparator = 'in' if comparator == '=' else 'not in'
@@ -6425,7 +6425,7 @@ class BaseModel(metaclass=MetaModel):
                             ok = any(x is not False and x is not None and inequality(x, value) for x in data)
                         else:
                             ok = any(inequality(x or falsy_value, value) for x in data)
-                    elif comparator in ('like', 'ilike', '=like', '=ilike', 'not ilike', 'not like'):
+                    elif comparator.endswith('like'):
                         ok = any(like_regex.match(unaccent(x)) for x in data)
                         if comparator.startswith('not'):
                             ok = not ok

--- a/odoo/orm/utils.py
+++ b/odoo/orm/utils.py
@@ -58,6 +58,8 @@ SQL_OPERATORS = {
     "=ilike": SQL(" ILIKE "),
     "not like": SQL(" NOT LIKE "),
     "not ilike": SQL(" NOT ILIKE "),
+    "not =like": SQL(" NOT LIKE "),
+    "not =ilike": SQL(" NOT ILIKE "),
 }
 
 


### PR DESCRIPTION
Adding the complement of `=like` and `=ilike`. This is mainly for completeness sake, but it also allows to avoid some NOT nodes in the AST of domains.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
