### PR TITLE
[FIX] base_import: display error on reading faulty xlsx file

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -511,7 +511,7 @@ class Base_ImportImport(models.TransientModel):
         for rowx, row in enumerate(sheet.rows, 1):
             values = []
             for colx, cell in enumerate(row, 1):
-                if cell.data_type is types.TYPE_ERROR:
+                if cell.data_type == types.TYPE_ERROR:
                     raise ValueError(
                         _("Invalid cell value at row %(row)s, column %(col)s: %(cell_value)s", row=rowx, col=colx, cell_value=cell.value)
                     )


### PR DESCRIPTION
Previously when we try to import a faulty xlsx file on master 
runbot build (which is working on python version-3.12) it was 
not displaying any error but the error was occurring in our 
localhost (which is working on python version-3.10).

After this commit the error will be displayed on reading faulty 
xlsx file even in python-3.12 version.

Related Task- 4024315

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
