### PR TITLE
[FIX] web_editor: update code view after saving images

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -397,6 +397,10 @@ export class HtmlField extends Component {
                     await this.updateValue();
                 }
                 await saveModifiedImagesPromise;
+                if (this.state.showCodeView) {
+                    const codeViewEl = this._getCodeViewEl();
+                    codeViewEl.value = this.wysiwyg.getValue();
+                }
                 if (this.props.isInlineStyle) {
                     await toInlinePromise;
                 }


### PR DESCRIPTION
**Problem**:
When in `codeview`, calling `saveModifiedImagesPromise` creates the attachments and updates the DOM but does not update the `codeview`. As a result, the non-urgent save (`this.updateValue()`) uses outdated content from the `codeview`.

**Solution**:
Ensure that the `codeview` content is updated after saving attachments to reflect the latest changes.

**Steps to reproduce**:
1. Add an Image-Text snippet.
2. Save the snippet.
3. Resize the image.
4. Switch to code view.
5. Save.
6. Observe that the class `o_modified_image_to_save` is not removed from the image.

opw-4406195

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
