### PR TITLE
[IMP] website, website_payment, payment: add custom fields on donation form

### DIFF
--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -7,7 +7,7 @@ import { renderToMarkup } from '@web/core/utils/render';
 import publicWidget from '@web/legacy/js/public/public_widget';
 
 publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
-    selector: '#o_payment_form',
+    selector: '#o_payment_form, .o_payment_field_form',
     events: Object.assign({}, publicWidget.Widget.prototype.events, {
         'click [name="o_payment_radio"]': '_selectPaymentOption',
         'click [name="o_payment_delete_token"]': '_fetchTokenData',
@@ -512,7 +512,7 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
      * @return {Element | null} The inline form of the selected payment option, if any.
      */
     _getInlineForm(radio) {
-        const inlineFormContainer = radio.closest('[name="o_payment_option"]');
+        const inlineFormContainer = radio?.closest('[name="o_payment_option"]');
         return inlineFormContainer?.querySelector('[name="o_payment_inline_form"]');
     },
 

--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -125,6 +125,9 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
 
         const checkedRadio = this.el.querySelector('input[name="o_payment_radio"]:checked');
 
+        if (!checkedRadio) {
+            return;
+        }
         // Block the entire UI to prevent fiddling with other widgets.
         this._disableButton(true);
 

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -726,6 +726,16 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
     /**
      * @override
      */
+    _computeWidgetVisibility: function (widgetName, params) {
+        switch (widgetName) {
+            case "payment_form_opt":
+                return !this.$target[0].classList.contains("o_payment_field_form");
+        }
+        return this._super(...arguments);
+    },
+    /**
+     * @override
+     */
     _renderCustomXML: function (uiFragment) {
         if (this.modelCantChange) {
             return;

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -726,7 +726,7 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
     /**
      * @override
      */
-    _computeWidgetVisibility: function (widgetName, params) {
+    _computeWidgetVisibility(widgetName, params) {
         switch (widgetName) {
             case "payment_form_opt":
                 return !this.$target[0].classList.contains("o_payment_field_form");

--- a/addons/website_payment/__manifest__.py
+++ b/addons/website_payment/__manifest__.py
@@ -15,6 +15,7 @@ This is a bridge module that adds multi-website support for payment providers.
     ],
     'data': [
         'data/mail_templates.xml',
+        'data/payment_transaction_data.xml',
         'views/payment_form_templates.xml',
         'views/payment_provider.xml',
         'views/res_config_settings_views.xml',

--- a/addons/website_payment/controllers/portal.py
+++ b/addons/website_payment/controllers/portal.py
@@ -60,7 +60,6 @@ class PaymentPortal(payment_portal.PaymentPortal):
             amount=amount, currency_id=currency_id, partner_id=partner_id, **kwargs
         )
         tx_sudo.is_donation = True
-        breakpoint()
         if use_public_partner:
             fields = tx_sudo._fields
             for key, value in kwargs['partner_details'].items():
@@ -117,7 +116,21 @@ class PaymentPortal(payment_portal.PaymentPortal):
             countries = request.env['res.country'].sudo().search([])
             descriptions = request.httprequest.form.getlist('donation_descriptions')
 
+            # When we click the edit button, the donation_options reset.
+            # We need to set the default values for the donation options
+            # to avoid errors in the template.
             donation_options = json_safe.loads(donation_options) if donation_options else {}
+            donation_options.setdefault('prefilledOptions', "true")
+            donation_options.setdefault('donationAmounts', '["10", "25", "50", "100"]')
+            donation_options.setdefault('descriptions', 'true')
+            if not descriptions:
+                descriptions = [
+                    'A year of cultural awakening.',
+                    'Caring for a baby for 1 month.',
+                    'One year in elementary school.',
+                    'One year in high school.'
+                ]
+
             donation_amounts = json_safe.loads(donation_options.get('donationAmounts', '[]'))
 
             rendering_context.update({

--- a/addons/website_payment/controllers/portal.py
+++ b/addons/website_payment/controllers/portal.py
@@ -61,11 +61,16 @@ class PaymentPortal(payment_portal.PaymentPortal):
         )
         tx_sudo.is_donation = True
         if use_public_partner:
-            tx_sudo.update({
-                'partner_name': details['name'],
-                'partner_email': details['email'],
-                'partner_country_id': int(details['country_id']),
-            })
+            fields = tx_sudo._fields
+            for key, value in kwargs['partner_details'].items():
+                # Find matching field key
+                match_key = f'partner_{key}' if f'partner_{key}' in fields else key
+                if match_key in fields:
+                    # Type conversion for specific fields
+                    if key.endswith('_id'):
+                        tx_sudo.update({match_key: int(value)})
+                    else:
+                        tx_sudo.update({match_key: value})
         elif not tx_sudo.partner_country_id:
             tx_sudo.partner_country_id = int(kwargs['partner_details']['country_id'])
         # the user can change the donation amount on the payment page,

--- a/addons/website_payment/controllers/portal.py
+++ b/addons/website_payment/controllers/portal.py
@@ -60,6 +60,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
             amount=amount, currency_id=currency_id, partner_id=partner_id, **kwargs
         )
         tx_sudo.is_donation = True
+        breakpoint()
         if use_public_partner:
             fields = tx_sudo._fields
             for key, value in kwargs['partner_details'].items():

--- a/addons/website_payment/data/payment_transaction_data.xml
+++ b/addons/website_payment/data/payment_transaction_data.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="payment.model_payment_transaction" model="ir.model">
+        <field name="website_form_key">Donation</field>
+        <field name="website_form_access">True</field>
+        <field name="website_form_label">Donate</field>
+    </record>
+</odoo>

--- a/addons/website_payment/models/payment_transaction.py
+++ b/addons/website_payment/models/payment_transaction.py
@@ -30,12 +30,13 @@ class PaymentTransaction(models.Model):
             msg = [_('Payment received from donation with following details:')]
             for field in field_names:
                 match_key = f'partner_{field}' if f'partner_{field}' in donation_tx._fields else field
-                field_name = donation_tx._fields[match_key].string
-                value = donation_tx[match_key]
-                if value:
-                    if hasattr(value, 'name'):
-                        value = value.name
-                    msg.append(Markup('<br/>- %s: %s') % (field_name, value))
+                if match_key in donation_tx._fields:
+                    field_name = donation_tx._fields[match_key].string
+                    value = donation_tx[match_key]
+                    if value:
+                        if hasattr(value, 'name'):
+                            value = value.name
+                        msg.append(Markup('<br/>- %s: %s') % (field_name, value))
             donation_tx.payment_id._message_log(body=Markup().join(msg))
 
     def _send_donation_email(self, is_internal_notification=False, comment=None, recipient_email=None):

--- a/addons/website_payment/static/src/js/payment_form.js
+++ b/addons/website_payment/static/src/js/payment_form.js
@@ -52,7 +52,7 @@ PaymentForm.include({
     async _initiatePaymentFlow(providerCode, paymentOptionId, paymentMethodCode, flow) {
         if (document.querySelector('.o_donation_payment_form')) {
             const errorFields = {};
-            if (!this.el.querySelector('input[name="email"]').checkValidity()) {
+            if (!document.querySelector('input[name="email"]').checkValidity()) {
                 errorFields['email'] = _t("Email is invalid");
             }
             const mandatoryFields = {
@@ -61,7 +61,7 @@ PaymentForm.include({
                 'country_id': _t('Country'),
             };
             for (const id in mandatoryFields) {
-                const fieldEl = this.el.querySelector(`input[name="${id}"],select[name="${id}"]`);
+                const fieldEl = document.querySelector(`input[name="${id}"],select[name="${id}"]`);
                 fieldEl.classList.remove('is-invalid');
                 Popover.getOrCreateInstance(fieldEl)?.dispose();
                 if (!fieldEl.value.trim()) {
@@ -70,7 +70,7 @@ PaymentForm.include({
             }
             if (Object.keys(errorFields).length) {
                 for (const id in errorFields) {
-                    const fieldEl = this.el.querySelector(
+                    const fieldEl = document.querySelector(
                         `input[name="${id}"],select[name="${id}"]`
                     );
                     fieldEl.classList.add('is-invalid');
@@ -100,6 +100,23 @@ PaymentForm.include({
      */
     _prepareTransactionRouteParams() {
         const transactionRouteParams = this._super(...arguments);
+        this.getFormData = (formSelector) => {
+            const form = document.querySelector(formSelector);
+            if (!form) {
+                return {};
+            }
+            const formData = new FormData(form)
+
+            const partnerDetails = {};
+
+            formData.forEach((value, key) => {
+                partnerDetails[key] = value;
+            });
+
+            return partnerDetails;
+        };
+
+        const partnerDetails = this.getFormData(".o_payment_field_form");
         return document.querySelector('.o_donation_payment_form')
             ? {
             ...transactionRouteParams,
@@ -107,13 +124,9 @@ PaymentForm.include({
             currency_id: this.paymentContext['currencyId']
                     ? parseInt(this.paymentContext['currencyId']) : null,
             reference_prefix:this.paymentContext['referencePrefix']?.toString(),
-            partner_details: {
-                name: this.el.querySelector('input[name="name"]').value,
-                email: this.el.querySelector('input[name="email"]').value,
-                country_id: this.el.querySelector('select[name="country_id"]').value,
-            },
-            donation_comment: this.el.querySelector('#donation_comment').value,
-            donation_recipient_email: this.el.querySelector(
+            partner_details: partnerDetails,
+            donation_comment: document.querySelector('#donation_comment').value,
+            donation_recipient_email: document.querySelector(
                 'input[name="donation_recipient_email"]'
             ).value,
         } : transactionRouteParams;

--- a/addons/website_payment/static/src/js/payment_form.js
+++ b/addons/website_payment/static/src/js/payment_form.js
@@ -63,6 +63,16 @@ PaymentForm.include({
                 'email': _t('Email'),
                 'country_id': _t('Country'),
             };
+
+            // This code is added here because setting a custom field as required
+            // in the form does not work. So, we are manually checking if the field is mandatory.
+            document.querySelectorAll('.s_website_form_required').forEach((field) => {
+                const inputEl = field.querySelector('input, select');
+                if (inputEl && inputEl.name) {
+                    mandatoryFields[inputEl.name] = field.textContent.trim();
+                }
+            });
+
             for (const id in mandatoryFields) {
                 const fieldEl = document.querySelector(`input[name="${id}"],select[name="${id}"]`);
                 fieldEl.classList.remove('is-invalid');
@@ -109,23 +119,20 @@ PaymentForm.include({
         transactionRouteParams.amount = parseFloat(
             document.querySelector(".o_payment_form").dataset.amount
         );
-        this.getFormData = (formSelector) => {
+        const getFormData = (formSelector) => {
             const form = document.querySelector(formSelector);
             if (!form) {
                 return {};
             }
             const formData = new FormData(form)
-
             const partnerDetails = {};
-
             formData.forEach((value, key) => {
                 partnerDetails[key] = value;
             });
-
             return partnerDetails;
         };
 
-        const partnerDetails = this.getFormData(".o_payment_field_form");
+        const partnerDetails = getFormData(".o_payment_field_form");
         return document.querySelector('.o_donation_payment_form')
             ? {
             ...transactionRouteParams,

--- a/addons/website_payment/static/src/js/payment_form.js
+++ b/addons/website_payment/static/src/js/payment_form.js
@@ -22,6 +22,9 @@ PaymentForm.include({
     _updateAmount(ev) {
         if (ev.target.value >= 0) {
             this.paymentContext.amount = ev.target.value;
+            // Update paymentContext of second form as amount is mentioned
+            // on second's dataset.
+            document.querySelector(".o_payment_form").dataset.amount = ev.target.value;
             const otherAmountEl = this.el.querySelector("#other_amount");
             if (ev.target.id === "other_amount_value" && otherAmountEl) {
                 otherAmountEl.value = ev.target.value;
@@ -100,6 +103,12 @@ PaymentForm.include({
      */
     _prepareTransactionRouteParams() {
         const transactionRouteParams = this._super(...arguments);
+        //To update the amount after change it from form.
+        //The paymentContext['amount'] is in second form. So, The amount
+        //doesn't get updated after we change it through form.
+        transactionRouteParams.amount = parseFloat(
+            document.querySelector(".o_payment_form").dataset.amount
+        );
         this.getFormData = (formSelector) => {
             const form = document.querySelector(formSelector);
             if (!form) {

--- a/addons/website_payment/views/payment_form_templates.xml
+++ b/addons/website_payment/views/payment_form_templates.xml
@@ -130,12 +130,9 @@
         </form>
     </template>
 
-    <template id="website_signup_form_options" inherit_id="website.snippet_options">
+    <template id="website_payment_form_options" inherit_id="website.snippet_options">
         <xpath expr="//div[@data-js='WebsiteFormEditor']//we-row//we-select" position="attributes">
             <attribute name="data-name" add="payment_form_opt" />
-        </xpath>
-        <xpath expr="//div[@data-js='AddFieldForm']" position="attributes">
-            <attribute name="data-exclude" add=".o_payment_form_container" />
         </xpath>
     </template>
 

--- a/addons/website_payment/views/payment_form_templates.xml
+++ b/addons/website_payment/views/payment_form_templates.xml
@@ -62,7 +62,7 @@
                     <span class="s_website_form_label_content">Country</span>
                     <span class="s_website_form_mark"> *</span>
                 </label>
-                <select t-att-disabled="'1' if country_id and partner_id else None" id="country_id" name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}">
+                <select t-att-disabled="'1' if country_id and partner_id else None" id="country_id" name="country_id" t-attf-class="form-select s_website_form_input #{error.get('country_id') and 'is-invalid' or ''}">
                     <option value="">Country...</option>
                     <t t-foreach="countries" t-as="c">
                         <option t-att-value="c.id" t-att-selected="c.id == (country_id or -1)">

--- a/addons/website_payment/views/payment_form_templates.xml
+++ b/addons/website_payment/views/payment_form_templates.xml
@@ -57,12 +57,12 @@
                 <input t-att-readonly="'1' if 'email' in partner_details and partner_id else None" type="email" name="email"  data-fill-with="email" t-attf-class="form-control s_website_form_input #{error.get('email') and 'is-invalid' or ''}" t-att-value="partner_details.get('email')" />
             </div>
             <t t-set="country_id" t-value="partner_details.get('country_id')"/>
-            <div  data-name="Field" t-attf-class="s_website_form_field s_website_form_custom mb-3 #{error.get('country_id') and 'o_has_error' or ''} col-lg-6 div_country">
+            <div data-name="Field" t-attf-class="s_website_form_field s_website_form_custom mb-3 #{error.get('country_id') and 'o_has_error' or ''} col-lg-6 div_country" data-type="many2one">
                 <label class="s_website_form_label col-form-label fw-bold" for="country_id">
                     <span class="s_website_form_label_content">Country</span>
                     <span class="s_website_form_mark"> *</span>
                 </label>
-                <select t-att-disabled="'1' if country_id and partner_id else None" id="country_id" name="country_id" t-attf-class="form-select s_website_form_input #{error.get('country_id') and 'is-invalid' or ''}">
+                <select t-att-disabled="'1' if country_id and partner_id else None" name="country_id" t-attf-class="form-select s_website_form_input #{error.get('country_id') and 'is-invalid' or ''}">
                     <option value="">Country...</option>
                     <t t-foreach="countries" t-as="c">
                         <option t-att-value="c.id" t-att-selected="c.id == (country_id or -1)">

--- a/addons/website_payment/views/payment_form_templates.xml
+++ b/addons/website_payment/views/payment_form_templates.xml
@@ -3,9 +3,9 @@
 
     <!-- Insert the donation form inside the payment form's <form/> element. -->
     <template id="website_payment.payment_form" inherit_id="payment.form">
-        <xpath expr="//div[@id='o_payment_form_options']" position="before">
-            <div class="mb-3" t-if="is_donation">
-                <t t-call="website_payment.donation_information"/>
+        <xpath expr="//form[@id='o_payment_form']" position="before">
+            <div t-if="is_donation" class="s_website_form o_payment_form_container mb-3" data-vcss="001" data-snippet="s_website_form" data-name="Form" t-ignore="True">
+                <t t-call="website_payment.website_payment_fields_form"/>
             </div>
         </xpath>
     </template>
@@ -40,23 +40,26 @@
 
     <template id="website_payment.donation_information" name="Donation Information">
         <h3 class="o_page_header mt16 mb4">Donation</h3>
-        <div class="row">
-            <div t-attf-class="mb-3 #{error.get('name') and 'o_has_error' or ''} col-lg-12 div_name">
-                <label class="col-form-label fw-bold" for="name">Name
+        <div class="s_website_form_rows row">
+            <div data-type="char" data-name="Field" t-attf-class="s_website_form_field s_website_form_custom mb-3 s_website_form_required #{error.get('name') and 'o_has_error' or ''} col-lg-12 div_name">
+                <label class="s_website_form_label col-form-label fw-bold" for="name">
+                    <span class="s_website_form_label_content">Name</span>
                     <span class="s_website_form_mark"> *</span>
                 </label>
-                <input t-att-readonly="'1' if 'name' in partner_details and partner_id else None" type="text" name="name" t-attf-class="form-control #{error.get('name') and 'is-invalid' or ''}" t-att-value="partner_details.get('name')" />
+                <input t-att-readonly="'1' if 'name' in partner_details and partner_id else None" type="text" name="name" data-fill-with="name" t-attf-class="form-control s_website_form_input #{error.get('name') and 'is-invalid' or ''}" t-att-value="partner_details.get('name')" />
             </div>
             <div class="w-100"/>
-            <div t-attf-class="mb-3 #{error.get('email') and 'o_has_error' or ''} col-lg-6" id="div_email">
-                <label class="col-form-label fw-bold" for="email">Email
+            <div data-name="Field" t-attf-class="s_website_form_field s_website_form_custom mb-3 s_website_form_required #{error.get('email') and 'o_has_error' or ''} col-lg-6" id="div_email" data-type="char">
+                <label class="s_website_form_label col-form-label fw-bold" for="email">
+                    <span class="s_website_form_label_content">Email</span>
                     <span class="s_website_form_mark"> *</span>
                 </label>
-                <input t-att-readonly="'1' if 'email' in partner_details and partner_id else None" type="email" name="email" t-attf-class="form-control #{error.get('email') and 'is-invalid' or ''}" t-att-value="partner_details.get('email')" />
+                <input t-att-readonly="'1' if 'email' in partner_details and partner_id else None" type="email" name="email"  data-fill-with="email" t-attf-class="form-control s_website_form_input #{error.get('email') and 'is-invalid' or ''}" t-att-value="partner_details.get('email')" />
             </div>
             <t t-set="country_id" t-value="partner_details.get('country_id')"/>
-            <div t-attf-class="mb-3 #{error.get('country_id') and 'o_has_error' or ''} col-lg-6 div_country">
-                <label class="col-form-label fw-bold" for="country_id">Country
+            <div  data-name="Field" t-attf-class="s_website_form_field s_website_form_custom mb-3 #{error.get('country_id') and 'o_has_error' or ''} col-lg-6 div_country">
+                <label class="s_website_form_label col-form-label fw-bold" for="country_id">
+                    <span class="s_website_form_label_content">Country</span>
                     <span class="s_website_form_mark"> *</span>
                 </label>
                 <select t-att-disabled="'1' if country_id and partner_id else None" id="country_id" name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}">
@@ -119,6 +122,21 @@
             <div class="w-100"/>
         </div>
         <h3 class="o_page_header mt16 mb4">Payment Details</h3>
+    </template>
+
+    <template id="website_payment_fields_form">
+        <form class="o_payment_field_form" data-model_name="payment.transaction" hide-change-model="true">
+            <t t-call="website_payment.donation_information" />
+        </form>
+    </template>
+
+    <template id="website_signup_form_options" inherit_id="website.snippet_options">
+        <xpath expr="//div[@data-js='WebsiteFormEditor']//we-row//we-select" position="attributes">
+            <attribute name="data-name" add="payment_form_opt" />
+        </xpath>
+        <xpath expr="//div[@data-js='AddFieldForm']" position="attributes">
+            <attribute name="data-exclude" add=".o_payment_form_container" />
+        </xpath>
     </template>
 
     <template id="website_payment.donation_input" name="Donation input">


### PR DESCRIPTION
With this commit, Now user can easily add custom fields which they want in donation form. Fields added by user will be logged in chatter of  `account.payment.form`.

task-3114722
