### PR TITLE
[FIX] website: fix scroll to anchor when animations

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2081,10 +2081,19 @@ input[value*="data-oe-translation-source-sha"] {
     visibility: visible;
 }
 .o_wanim_overflow_xy_hidden {
-    // "overflow-x: hidden" is added to the "body" and not to "html" because if
+    // "overflow-x: clip" is added to the "body" and not to "html" because if
     // it's added to "html", when a popup opens, the page scrolls to the top.
     > body {
-        overflow-x: hidden !important;
+        // We use clip instead of hidden to prevent scroll animations to an
+        // anchor from stopping working.
+        overflow-x: clip !important;
+        // For supporting browsers not updated since around 2021-2022.
+        @supports not (overflow-x: clip) {
+            overflow-x: hidden !important;
+        }
+        // Create a new formatting context. Without this, elements inside <body>
+        // may still overflow (e.g. animated elements in Firefox).
+        display: flow-root;
     }
     &.o_rtl, .o_rtl {
         // Fix for Chrome and Edge bug: resolves slow/stuck scrolling during


### PR DESCRIPTION
Steps to reproduce the bug:

- Go to the website edit mode.
- Drag and drop a "Text - Image" block onto the page.
- Drag and drop a "Media List" block at the bottom of the page.
- Drag and drop a "Text" block at the bottom of the page.
- Click on the "Text" block.
- In the "Text" block options, click the "Create a link to target this section" button.
- Click on the "Button" inside the "Text - Image" block.
- In the options, paste the "link" to the anchor copied to the clipboard into the URL input of the button.
- In the "Column" options, add an "On Scroll" animation to the column.
- Save the page.
- Click the "Text - Image" button.
- Bug: the page doesn't scroll to the "Text" block.

This bug was introduced by commit [1], where the "overflow-x: hidden" CSS rule, used to prevent a horizontal scrollbar during animations caused by overflowing content on the right side of the page, was moved from the HTML element to the body element.

The bug appeared because when the code triggering the scroll animation to the anchor runs after clicking the button, it checks which element is scrollable. At that moment, the body has "overflow-x: hidden," which causes its "overflow-y" to become "auto" instead of "visible" (browser behavior, see https://developer.mozilla.org/en-US/docs/Web/CSS/overflow). The body element is then considered scrollable, even though it isn't. This is why the scroll animation doesn't work.

To fix this, we replace "overflow-x: hidden" with "overflow-x: clip". This is more appropriate in this context and prevents "overflow-y" from becoming "auto".

We also add "display: flow-root;" in combination with "overflow: clip" because without it, "overflow: clip" alone may not be sufficient to prevent elements inside "body" from overflowing, particularly animated elements in Firefox.
This creates a new formatting context, preventing unexpected overflow behavior across different browsers.

[1]: https://github.com/odoo/odoo/commit/fece9cb85761e6cb3fe3642f947661464402363b

opw-4393527