### PR TITLE
[FIX] account_peppol,*: Peppol miscellaneous fixes

### DIFF
--- a/addons/account_edi_ubl_cii/i18n/account_edi_ubl_cii.pot
+++ b/addons/account_edi_ubl_cii/i18n/account_edi_ubl_cii.pot
@@ -166,7 +166,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/ar.po
+++ b/addons/account_edi_ubl_cii/i18n/ar.po
@@ -176,7 +176,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/az.po
+++ b/addons/account_edi_ubl_cii/i18n/az.po
@@ -170,7 +170,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/bg.po
+++ b/addons/account_edi_ubl_cii/i18n/bg.po
@@ -175,7 +175,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/ca.po
+++ b/addons/account_edi_ubl_cii/i18n/ca.po
@@ -177,7 +177,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/cs.po
+++ b/addons/account_edi_ubl_cii/i18n/cs.po
@@ -175,7 +175,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/da.po
+++ b/addons/account_edi_ubl_cii/i18n/da.po
@@ -172,7 +172,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/de.po
+++ b/addons/account_edi_ubl_cii/i18n/de.po
@@ -177,7 +177,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/de.po
+++ b/addons/account_edi_ubl_cii/i18n/de.po
@@ -126,7 +126,7 @@ msgstr "BIS3 DE (XRechnung)"
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0208
 msgid "Belgium CBE - 0208"
-msgstr ""
+msgstr "Belgien ZDU - 0208"
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__9925

--- a/addons/account_edi_ubl_cii/i18n/el.po
+++ b/addons/account_edi_ubl_cii/i18n/el.po
@@ -170,7 +170,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/es.po
+++ b/addons/account_edi_ubl_cii/i18n/es.po
@@ -177,7 +177,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/es_419.po
+++ b/addons/account_edi_ubl_cii/i18n/es_419.po
@@ -178,7 +178,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/et.po
+++ b/addons/account_edi_ubl_cii/i18n/et.po
@@ -175,7 +175,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/fi.po
+++ b/addons/account_edi_ubl_cii/i18n/fi.po
@@ -177,7 +177,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/fr.po
+++ b/addons/account_edi_ubl_cii/i18n/fr.po
@@ -176,7 +176,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/fr.po
+++ b/addons/account_edi_ubl_cii/i18n/fr.po
@@ -125,7 +125,7 @@ msgstr "BIS3 DE (XRechnung)"
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0208
 msgid "Belgium CBE - 0208"
-msgstr ""
+msgstr "Belgique BCE - 0208"
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__9925

--- a/addons/account_edi_ubl_cii/i18n/he.po
+++ b/addons/account_edi_ubl_cii/i18n/he.po
@@ -173,7 +173,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/hi.po
+++ b/addons/account_edi_ubl_cii/i18n/hi.po
@@ -166,7 +166,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/hr.po
+++ b/addons/account_edi_ubl_cii/i18n/hr.po
@@ -170,7 +170,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/hu.po
+++ b/addons/account_edi_ubl_cii/i18n/hu.po
@@ -172,7 +172,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/id.po
+++ b/addons/account_edi_ubl_cii/i18n/id.po
@@ -177,7 +177,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/it.po
+++ b/addons/account_edi_ubl_cii/i18n/it.po
@@ -176,7 +176,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/ja.po
+++ b/addons/account_edi_ubl_cii/i18n/ja.po
@@ -175,7 +175,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/ko.po
+++ b/addons/account_edi_ubl_cii/i18n/ko.po
@@ -176,7 +176,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/lt.po
+++ b/addons/account_edi_ubl_cii/i18n/lt.po
@@ -174,7 +174,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/lv.po
+++ b/addons/account_edi_ubl_cii/i18n/lv.po
@@ -172,7 +172,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/mn.po
+++ b/addons/account_edi_ubl_cii/i18n/mn.po
@@ -171,7 +171,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/nb.po
+++ b/addons/account_edi_ubl_cii/i18n/nb.po
@@ -172,7 +172,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/nl.po
+++ b/addons/account_edi_ubl_cii/i18n/nl.po
@@ -127,7 +127,7 @@ msgstr "BIS3 DE (XRechnung)"
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0208
 msgid "Belgium CBE - 0208"
-msgstr ""
+msgstr "België KBO - 0208"
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__9925

--- a/addons/account_edi_ubl_cii/i18n/nl.po
+++ b/addons/account_edi_ubl_cii/i18n/nl.po
@@ -178,7 +178,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/pl.po
+++ b/addons/account_edi_ubl_cii/i18n/pl.po
@@ -177,7 +177,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/pt_BR.po
+++ b/addons/account_edi_ubl_cii/i18n/pt_BR.po
@@ -177,7 +177,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/ro.po
+++ b/addons/account_edi_ubl_cii/i18n/ro.po
@@ -175,7 +175,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/ru.po
+++ b/addons/account_edi_ubl_cii/i18n/ru.po
@@ -175,7 +175,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/sl.po
+++ b/addons/account_edi_ubl_cii/i18n/sl.po
@@ -170,7 +170,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/sv.po
+++ b/addons/account_edi_ubl_cii/i18n/sv.po
@@ -179,7 +179,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/th.po
+++ b/addons/account_edi_ubl_cii/i18n/th.po
@@ -175,7 +175,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/tr.po
+++ b/addons/account_edi_ubl_cii/i18n/tr.po
@@ -176,7 +176,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/uk.po
+++ b/addons/account_edi_ubl_cii/i18n/uk.po
@@ -175,7 +175,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/vi.po
+++ b/addons/account_edi_ubl_cii/i18n/vi.po
@@ -176,7 +176,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/zh_CN.po
+++ b/addons/account_edi_ubl_cii/i18n/zh_CN.po
@@ -174,7 +174,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/i18n/zh_TW.po
+++ b/addons/account_edi_ubl_cii/i18n/zh_TW.po
@@ -173,7 +173,7 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #: model:ir.model.fields.selection,name:account_edi_ubl_cii.selection__res_partner__peppol_eas__0201
-msgid "Codice Univoco UnitÃ  Organizzativa iPA - 0201"
+msgid "Codice Univoco Unità Organizzativa iPA - 0201"
 msgstr ""
 
 #. module: account_edi_ubl_cii

--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -109,7 +109,7 @@ class ResPartner(models.Model):
             ('0142', "SECETI Object Identifiers - 0142"),
             ('0193', "UBL.BE party identifier - 0193"),
             ('0199', "Legal Entity Identifier (LEI) - 0199"),
-            ('0201', "Codice Univoco UnitÃ  Organizzativa iPA - 0201"),
+            ('0201', "Codice Univoco Unità Organizzativa iPA - 0201"),
             ('0202', "Indirizzo di Posta Elettronica Certificata - 0202"),
             ('0209', "GS1 identification keys - 0209"),
             ('0210', "Codice Fiscale - 0210"),

--- a/addons/account_peppol/i18n/account_peppol.pot
+++ b/addons/account_peppol/i18n/account_peppol.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-16 13:39+0000\n"
-"PO-Revision-Date: 2024-12-16 13:39+0000\n"
+"POT-Creation-Date: 2024-12-23 10:41+0000\n"
+"PO-Revision-Date: 2024-12-23 10:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -776,6 +776,12 @@ msgstr ""
 
 #. module: account_peppol
 #. odoo-python
+#: code:addons/account_peppol/wizard/peppol_registration.py:0
+msgid "Registered as a receiver."
+msgstr ""
+
+#. module: account_peppol
+#. odoo-python
 #: code:addons/account_peppol/tools/demo_utils.py:0
 msgid "Registered as a sender (demo)."
 msgstr ""
@@ -1039,14 +1045,18 @@ msgstr ""
 
 #. module: account_peppol
 #. odoo-python
-#: code:addons/account_peppol/tools/demo_utils.py:0
-msgid "You can now send invoices in demo mode."
+#: code:addons/account_peppol/wizard/peppol_registration.py:0
+msgid "You can now send and receive electronic invoices via Peppol"
 msgstr ""
 
 #. module: account_peppol
-#. odoo-python
 #: code:addons/account_peppol/wizard/peppol_registration.py:0
-msgid "You can now send invoices via Peppol."
+msgid "You can now send electronic invoices via Peppol."
+msgstr ""
+
+#. module: account_peppol
+#: code:addons/account_peppol/tools/demo_utils.py:0
+msgid "You can now send invoices in demo mode."
 msgstr ""
 
 #. module: account_peppol

--- a/addons/account_peppol/i18n/account_peppol.pot
+++ b/addons/account_peppol/i18n/account_peppol.pot
@@ -355,6 +355,12 @@ msgid "EDI user"
 msgstr ""
 
 #. module: account_peppol
+#. odoo-python
+#: code:addons/account_peppol/models/account_edi_proxy_user.py:0
+msgid "EDI user should be of type Peppol"
+msgstr ""
+
+#. module: account_peppol
 #: model:ir.model.fields,field_description:account_peppol.field_res_config_settings__account_peppol_edi_identification
 msgid "Edi Identification"
 msgstr ""

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -41,7 +41,7 @@ def _get_notification_message(proxy_state):
 # MOCKED FUNCTIONS
 # -------------------------------------------------------------------------
 
-def _mock_make_request(func, self, *args, **kwargs):
+def _mock_call_peppol_proxy(func, self, *args, **kwargs):
 
     def _mock_get_all_documents(user, args, kwargs):
         if not user.env['account.move'].search_count([
@@ -184,7 +184,7 @@ def _mock_check_company_on_peppol(func, self, *args, **kwargs):
 
 
 _demo_behaviour = {
-    '_make_request_peppol': _mock_make_request,
+    '_call_peppol_proxy': _mock_call_peppol_proxy,
     'button_account_peppol_check_partner_endpoint': _mock_button_verify_partner_endpoint,
     '_get_peppol_verification_state': _mock_get_peppol_verification_state,
     '_peppol_migrate_registration': _mock_migrate_participant,

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -5,9 +5,6 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='account_peppol_install']" position="attributes">
-                <attribute name="invisible">account_peppol_proxy_state not in ('not_registered', 'in_verification')</attribute>
-            </xpath>
             <xpath expr="//div[@id='account_peppol_install']" position="replace">
                 <div id="account_peppol" class="col-12 o_setting_box">
                     <div class="o_setting_right_pane border-0">

--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -269,17 +269,25 @@ class PeppolRegistration(models.TransientModel):
                 self.button_deregister_peppol_participant()
                 raise
 
-            if self.company_id.account_peppol_proxy_state == 'smp_registration':
-                return self._action_send_notification(
-                    title=_("Registered to receive documents via Peppol."),
-                    message=_(
-                        "Your registration on Peppol network should be activated within a day. The updated status will be visible in Settings."),
-                )
-            return self._action_open_peppol_form()
-
+        # success
+        notifications = {
+            'sender': {
+                'title': _('Registered as a sender.'),
+                'message': _('You can now send electronic invoices via Peppol.'),
+            },
+            'smp_registration': {  # TODO remove in master
+                'title': _('Registered to receive documents via Peppol.'),
+                'message': _('Your registration on Peppol network should be activated within a day. The updated status will be visible in Settings.'),
+            },
+            'receiver': {
+                'title': _('Registered as a receiver.'),
+                'message': _('You can now send and receive electronic invoices via Peppol'),
+            },
+        }
+        state = self.company_id.account_peppol_proxy_state
         return self._action_send_notification(
-            title=_("Registered as a sender."),
-            message=_("You can now send invoices via Peppol."),
+            title=notifications[state]['title'],
+            message=notifications[state]['message'],
         )
 
     @handle_demo


### PR DESCRIPTION
### Commit 1: [FIX] account_peppol: Remove useless div
The div is replaced few lines below, so no need to make it
visible/invisible.

task-no

### Commit 2: [FIX] account_edi_ubl_cii: add belgian EAS translation
task-no

### Commit 3: [FIX] account_edi_ubl_cii: fix typo in EAS
task-no

### Commit 4: [FIX] account_peppol: clean calls to proxy
Before this commit, when calling our Peppol proxy, here is what the call
graph would look like (prefixed by the module the method belongs to):
`account_peppol._call_peppol_proxy`
-> `account_peppol._make_request`
--> `account_peppol._call_peppol_proxy`
---> `account_edi_proxy_client._make_request`

We simplify this to:
`account_peppol._call_peppol_proxy`
-> `account_edi_proxy_client._make_request`

task-no

### Commit 5: [FIX] account_peppol: fix reopening of Print & Send wizard
With previous commit [1], we broke the flow when registering to Peppol
coming from the Print & Send wizard. The Print & Send wizard was not
reopening after successful registration.

task-no