### PR TITLE
[FIX] account_peppol: fix peppol installation crash

### DIFF
--- a/addons/account_peppol/__init__.py
+++ b/addons/account_peppol/__init__.py
@@ -5,6 +5,10 @@ from . import models
 from . import wizard
 from . import tools
 
+def _account_peppol_pre_init(env):
+    view = env.ref('account_edi_ubl_cii.view_partner_property_form')
+    if "peppol_address" not in view.arch:
+        view.reset_arch(mode='hard')
 
 def _account_peppol_post_init(env):
     for company in env['res.company'].sudo().search([]):

--- a/addons/account_peppol/__manifest__.py
+++ b/addons/account_peppol/__manifest__.py
@@ -38,6 +38,7 @@
     'demo': [
         'demo/account_peppol_demo.xml',
     ],
+    'pre_init_hook': '_account_peppol_pre_init',
     'post_init_hook': '_account_peppol_post_init',
     'license': 'LGPL-3',
     'assets': {


### PR DESCRIPTION
The aim of this commit is to ensure a smooth installation of account_peppol.

Context:
Commit 171b4ae657bc86bba1b113f0aed7a4ba4a154ed9 introduced the div with id peppol_address in stable. That same id is referenced by account_peppol for inheritance.

Before the commit:
Customer already having the `account_edi_ubl_cii` module installed will face a crash when installing peppol.
To be able to to install peppol, they will need to update `account_edi_ubl_cii`.

After the commit:
Peppol installation goes smoothly, even if the div isn't there yet.

task-id: None
