### PR TITLE
[FIX] point_of_sale: removed forgotten gitignore in posbox

### DIFF
--- a/addons/point_of_sale/tools/posbox/.gitignore
+++ b/addons/point_of_sale/tools/posbox/.gitignore
@@ -1,4 +1,0 @@
-raspios.img
-iotbox.img
-root_mount/
-overwrite_before_init/usr/bin/ngrok


### PR DESCRIPTION
We previously moved `point_of_sale/tools/posbox` to a new `iot_box_image` module but forgot to remove the `.gitignore` file from the old path. This is now fixed.
