### PR TITLE
[FIX] html_editor: preserve font style on typing after ctrl+A selection

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -1151,9 +1151,9 @@ export class DeletePlugin extends Plugin {
 
     onBeforeInputInsertText(ev) {
         if (ev.inputType === "insertText") {
-            const selection = this.dependencies.selection.getEditableSelection();
+            const selection = this.dependencies.selection.getSelectionData().deepEditableSelection;
             if (!selection.isCollapsed) {
-                this.deleteSelection();
+                this.deleteSelection(selection);
             }
             // Default behavior: insert text and trigger input event
         }

--- a/addons/html_editor/static/tests/insert/text.test.js
+++ b/addons/html_editor/static/tests/insert/text.test.js
@@ -3,6 +3,7 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { deleteBackward, insertText } from "../_helpers/user_actions";
 import { getContent } from "../_helpers/selection";
 import { execCommand } from "../_helpers/userCommands";
+import { press } from "@odoo/hoot-dom";
 
 describe("collapsed selection", () => {
     test("should insert a char into an empty span without removing the zws", async () => {
@@ -42,6 +43,17 @@ describe("collapsed selection", () => {
                 await insertText(editor, "x");
             },
             contentAfter: "<p>abx[]cd</p>",
+        });
+    });
+
+    test("should insert text within heading after selecting a heading using ctrl+A", async () => {
+        await testEditor({
+            contentBefore: "<h1>abc[]</h1><p>def</p>",
+            stepFunction: async (editor) => {
+                await press(["ctrl", "a"]);
+                await insertText(editor, "x");
+            },
+            contentAfter: "<h1>x[]<br></h1>",
         });
     });
 });


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

Previously, typing after selecting all text using Ctrl+A would reset the font style of the anchorNode of the selection.

Desired behavior after PR is merged:

Typing after selecting all text using Ctrl+A keeps the font style of the anchorNode of the selection.

task-4426710

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
