### PR TITLE
[FIX] point_of_sale: ensure sufficient products are shown in search

### DIFF
--- a/addons/point_of_sale/static/src/app/store/db.js
+++ b/addons/point_of_sale/static/src/app/store/db.js
@@ -592,7 +592,7 @@ export class PosDB {
             return [];
         }
         var results = [];
-        for (var i = 0; i < this.limit; i++) {
+        while (results.length < this.limit) {
             var r = re.exec(this.category_search_string[category_id]);
             if (r) {
                 var id = Number(r[1]);


### PR DESCRIPTION
Before this commit, the search functionality might not retrieve the desired number of products due to the loop condition. This fix ensures that the search retrieves up to the specified limit of products if there are enough available.

opw-4426797

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
