### PR TITLE
[FIX] point_of_sale: prevent NaN as login number in multi-company

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -62,7 +62,7 @@ class PosController(PortalAccount):
         session_info['fallback_nomenclature_id'] = pos_session._get_pos_fallback_nomenclature_id()
         context = {
             'session_info': session_info,
-            'login_number': pos_session.login(),
+            'login_number': pos_session.with_company(company).login(),
             'pos_session_id': pos_session.id,
             'pos_config_id': pos_session.config_id.id,
             'access_token': pos_session.config_id.access_token,


### PR DESCRIPTION
Before this commit, in a multi-company setup, logging into the PoS for the second company would result in the login number being NaN, such as 00337-NaN-0004.

opw-4425868

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
