### PR TITLE
[FIX] hr_recruitment: click on applicant_char widget

### DIFF
--- a/addons/hr_recruitment/__manifest__.py
+++ b/addons/hr_recruitment/__manifest__.py
@@ -52,6 +52,9 @@
             'hr_recruitment/static/src/**/*.xml',
             'hr_recruitment/static/src/js/tours/hr_recruitment.js',
         ],
+        'web.assets_unit_tests': [
+            'hr_recruitment/static/tests/**/*',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/hr_recruitment/static/src/applicant_char/applicant_char.js
+++ b/addons/hr_recruitment/static/src/applicant_char/applicant_char.js
@@ -15,11 +15,11 @@ export class ApplicantCharField extends CharField {
 
     onClick() {
         const record = this.props.record.data;
-        if (record.res_id !== undefined && record.res_model == 'hr.applicant') {
+        if (record.res_id && record.res_model == 'hr.applicant') {
             this.action.doAction({
                 type: 'ir.actions.act_window',
                 res_model: 'hr.applicant',
-                res_id: record.res_id,
+                res_id: record.res_id.resId,
                 views: [[false, "form"]],
                 view_mode: "form",
                 target: "current",

--- a/addons/hr_recruitment/static/tests/ir_attachments.test.js
+++ b/addons/hr_recruitment/static/tests/ir_attachments.test.js
@@ -1,0 +1,53 @@
+import {
+    click,
+    defineMailModels,
+    openView,
+    registerArchs,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+import { expect, test } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-mock";
+import { defineModels, models } from "@web/../tests/web_test_helpers";
+
+class HrApplicant extends models.ServerModel {
+    _name = "hr.applicant";
+    _records = [
+        {
+            id: 21,
+        },
+    ];
+    _views = {
+        "form,false": `<form><field name="id"/></form>`,
+        "search,false": `<search/>`,
+    };
+}
+defineMailModels();
+defineModels([HrApplicant]);
+
+const newArchs = {
+    "ir.attachment,false,list": `<list>
+             <field name="res_id"/>
+             <field name="res_model"/>
+             <field name="res_name" widget="applicant_char"/>
+         </list>`,
+};
+
+test("Recruitment applicant_char widget on ir.attachment", async () => {
+    const pyEnv = await startServer();
+    pyEnv["ir.attachment"]._fields.res_id.model_field = "res_model";
+    pyEnv["ir.attachment"].create([
+        { res_id: 21, res_model: "hr.applicant", res_name: "Someone" },
+        { res_id: false, res_model: "hr.applicant", res_name: "Nobody" },
+    ]);
+    registerArchs(newArchs);
+    await start();
+    await openView({ res_model: "ir.attachment", views: [[false, "list"]] });
+    await click(".o_field_applicant_char:last span");
+    await animationFrame();
+    expect(".o_field_applicant_char").toHaveCount(2);
+    await click(".o_field_applicant_char:first span");
+    await animationFrame();
+    expect(".o_field_applicant_char").toHaveCount(0);
+    expect('.o_field_widget[name="id"]:contains(21)').toHaveCount(1);
+});


### PR DESCRIPTION
Scenario:

- install hr_recruitment but not documents (to have the right view)
- go to Employee > Configuration > Recruitment | Job Positions
- choose a job positions with documents and click on Documents
- click on Applicant column on one of the rows

=> traceback shown:

OwlError: Invalid props for component 'FormController': 'resId' is not a number or boolean
  at Object.validateProps

Reason:

In saas-17.2 with a7586fdb4123481fd8794ef99fdc372e95de7459 merged in february 2024, many2one_reference was changed from a simple integer to either 0 if unset, or a object containing resId and displayName keys.

Fix:

Get the id with .resId and this should not happen, but test if the record is set with "if(res_id && ...)" in case res_id was 0.

Note: without the fix, the added test fails by opening the view if res_id was 0, and if not the next click would fail with:

OwlError: Invalid props for component 'FormController': 'resId' is not a number or boolean

opw-4384139

PR note: the test could be run without mails models, but then we would need to mock a lot of models for services (like `mail.ChatHub`) or a method like `prepareRegistry` [from studio](https://github.com/odoo/enterprise/blob/f5b7b53963829b351446e9b6f71e00f21291bc58/web_studio/static/tests/view_editor_tests_utils.js#L123-L153) that would remove all unnecessary services for the test.