### PR TITLE
[IMP] mail, web, *: `useService()` with auto-`useState()`

### DIFF
--- a/addons/bus/static/src/components/bus_connection_alert.js
+++ b/addons/bus/static/src/components/bus_connection_alert.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 
@@ -11,7 +11,7 @@ export class BusConnectionAlert extends Component {
     static props = {};
 
     setup() {
-        this.busMonitoring = useState(useService("bus.monitoring_service"));
+        this.busMonitoring = useService("bus.monitoring_service");
     }
 
     /**

--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
@@ -15,7 +15,7 @@ export class ActivityMenu extends Component {
     static template = "hr_attendance.attendance_menu";
 
     setup() {
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.employee = false;
         this.state = useState({
             checkedIn: false,

--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.js
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.js
@@ -14,7 +14,7 @@ patch(ChatWindow.prototype, {
     setup() {
         super.setup(...arguments);
         this.livechatService = useService("im_livechat.livechat");
-        this.chatbotService = useState(useService("im_livechat.chatbot"));
+        this.chatbotService = useService("im_livechat.chatbot");
         this.livechatState = useState({ showCloseConfirmation: false });
     },
 

--- a/addons/im_livechat/static/src/embed/common/livechat_button.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_button.js
@@ -14,9 +14,9 @@ export class LivechatButton extends Component {
     static DEBOUNCE_DELAY = 500;
 
     setup() {
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         /** @type {import('@im_livechat/embed/common/livechat_service').LivechatService} */
-        this.livechatService = useState(useService("im_livechat.livechat"));
+        this.livechatService = useService("im_livechat.livechat");
         this.onClick = debounce(this.onClick.bind(this), LivechatButton.DEBOUNCE_DELAY, {
             leading: true,
         });

--- a/addons/im_livechat/static/src/embed/common/thread_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_patch.js
@@ -1,13 +1,11 @@
 import { Thread } from "@mail/core/common/thread";
 
-import { useState } from "@odoo/owl";
-
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 
 patch(Thread.prototype, {
     setup() {
         super.setup();
-        this.chatbotService = useState(useService("im_livechat.chatbot"));
+        this.chatbotService = useService("im_livechat.chatbot");
     },
 });

--- a/addons/im_livechat/static/src/views/livechat_view_controller_mixin.js
+++ b/addons/im_livechat/static/src/views/livechat_view_controller_mixin.js
@@ -1,5 +1,3 @@
-import { useState } from "@odoo/owl";
-
 import { useService } from "@web/core/utils/hooks";
 import { _t } from "@web/core/l10n/translation";
 
@@ -7,8 +5,8 @@ export const LivechatViewControllerMixin = (ViewController) =>
     class extends ViewController {
         setup() {
             super.setup(...arguments);
-            this.store = useState(useService("mail.store"));
-            this.ui = useState(useService("ui"));
+            this.store = useService("mail.store");
+            this.ui = useService("ui");
         }
 
         async openRecord(record) {

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -25,7 +25,7 @@ export class Chatter extends Component {
     static defaultProps = { composer: true, threadId: false, twoColumns: false };
 
     setup() {
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.state = useState({
             jumpThreadPresent: 0,
             /** @type {import("models").Thread} */

--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
@@ -37,7 +37,7 @@ export class AttachmentList extends Component {
 
     setup() {
         super.setup();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         // Arbitrary high value, this is effectively a max-width.
         this.imagesWidth = 1920;
         this.dialog = useService("dialog");

--- a/addons/mail/static/src/core/common/attachment_view.js
+++ b/addons/mail/static/src/core/common/attachment_view.js
@@ -20,7 +20,7 @@ class AbstractAttachmentView extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.uiService = useService("ui");
         this.iframeViewerPdfRef = useRef("iframeViewerPdf");
         this.state = useState({

--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -36,7 +36,7 @@ export class ChatBubble extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         const popoverRef = useChildRef();
         this.popover = usePopover(ChatBubblePreview, {
             animation: false,

--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -20,9 +20,9 @@ export class ChatHub extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
-        this.ui = useState(useService("ui"));
-        this.busMonitoring = useState(useService("bus.monitoring_service"));
+        this.store = useService("mail.store");
+        this.ui = useService("ui");
+        this.busMonitoring = useService("bus.monitoring_service");
         this.bubblesHover = useHover("bubbles");
         this.moreHover = useHover(["more-button", "more-menu*"], {
             onHover: () => (this.more.isOpen = true),

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -45,7 +45,7 @@ export class ChatWindow extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.messageEdition = useMessageEdition();
         this.messageHighlight = useMessageHighlight();
         this.messageToReplyTo = useMessageToReplyTo();
@@ -56,7 +56,7 @@ export class ChatWindow extends Component {
             editingGuestName: false,
             editingName: false,
         });
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.contentRef = useRef("content");
         this.threadActions = useThreadActions();
         this.actionsMenuButtonHover = useHover("actionsMenuButton");

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -100,12 +100,12 @@ export class Composer extends Component {
                     .join(" + "),
             })
         );
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.attachmentUploader = useAttachmentUploader(
             this.thread ?? this.props.composer.message.thread,
             { composer: this.props.composer }
         );
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.ref = useRef("textarea");
         this.fakeTextarea = useRef("fakeTextarea");
         this.inputContainerRef = useRef("input-container");
@@ -151,10 +151,15 @@ export class Composer extends Component {
             { capture: true }
         );
         if (this.props.dropzoneRef) {
-            useCustomDropzone(this.props.dropzoneRef, MailAttachmentDropzone, {
-                extraClass: "o-mail-Composer-dropzone",
-                onDrop: this.onDropFile,
-            }, () => this.allowUpload);
+            useCustomDropzone(
+                this.props.dropzoneRef,
+                MailAttachmentDropzone,
+                {
+                    extraClass: "o-mail-Composer-dropzone",
+                    onDrop: this.onDropFile,
+                },
+                () => this.allowUpload
+            );
         }
         if (this.props.messageEdition) {
             this.props.messageEdition.composerOfThread = this;
@@ -524,8 +529,9 @@ export class Composer extends Component {
             mentionedPartners: this.props.composer.mentionedPartners,
         });
         const signature = this.store.self.signature;
-        const default_body = await prettifyMessageContent(body, validMentions) +
-            ((this.props.composer.emailAddSignature && signature) ? ("<br>" + signature) : "");
+        const default_body =
+            (await prettifyMessageContent(body, validMentions)) +
+            (this.props.composer.emailAddSignature && signature ? "<br>" + signature : "");
         const context = {
             default_attachment_ids: attachmentIds,
             default_body,
@@ -735,12 +741,12 @@ export class Composer extends Component {
         if (editable) {
             Object.assign(config, {
                 emailAddSignature: false,
-                text: editable.innerText.replace(/(\t|\n)+/g, "\n")
+                text: editable.innerText.replace(/(\t|\n)+/g, "\n"),
             });
         } else {
             Object.assign(config, {
                 emailAddSignature: true,
-                text: composer.text
+                text: composer.text,
             });
         }
         browser.localStorage.setItem(composer.localId, JSON.stringify(config));
@@ -756,6 +762,6 @@ export class Composer extends Component {
             }
         } catch {
             browser.localStorage.removeItem(composer.localId);
-        };
+        }
     }
 }

--- a/addons/mail/static/src/core/common/link_preview_confirm_delete.js
+++ b/addons/mail/static/src/core/common/link_preview_confirm_delete.js
@@ -1,5 +1,5 @@
 import { rpc } from "@web/core/network/rpc";
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { useService } from "@web/core/utils/hooks";
@@ -18,7 +18,7 @@ export class LinkPreviewConfirmDelete extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
     }
 
     get message() {

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -121,10 +121,10 @@ export class Message extends Component {
         this.hasTouch = hasTouch;
         this.messageBody = useRef("body");
         this.messageActions = useMessageActions();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.shadowBody = useRef("shadowBody");
         this.dialog = useService("dialog");
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.openReactionMenu = this.openReactionMenu.bind(this);
         this.optionsDropdown = useDropdownState();
         useChildSubEnv({

--- a/addons/mail/static/src/core/common/message_action_menu_mobile.js
+++ b/addons/mail/static/src/core/common/message_action_menu_mobile.js
@@ -1,4 +1,4 @@
-import { Component, onMounted, onWillUnmount, useState } from "@odoo/owl";
+import { Component, onMounted, onWillUnmount } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { useMessageActions } from "./message_actions";
 import { useChildRef, useService } from "@web/core/utils/hooks";
@@ -18,7 +18,7 @@ export class MessageActionMenuMobile extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.modalRef = useChildRef();
         this.messageActions = useMessageActions();
         this.onClickModal = this.onClickModal.bind(this);

--- a/addons/mail/static/src/core/common/message_card_list.js
+++ b/addons/mail/static/src/core/common/message_card_list.js
@@ -1,7 +1,7 @@
 import { Message } from "@mail/core/common/message";
 import { useVisible } from "@mail/utils/common/hooks";
 
-import { Component, useState, useSubEnv } from "@odoo/owl";
+import { Component, useSubEnv } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
@@ -35,7 +35,7 @@ export class MessageCardList extends Component {
 
     setup() {
         super.setup();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         useSubEnv({ messageCard: true });
         useVisible("load-more", (isVisible) => {
             if (isVisible) {

--- a/addons/mail/static/src/core/common/message_in_reply.js
+++ b/addons/mail/static/src/core/common/message_in_reply.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 import { url } from "@web/core/utils/urls";
@@ -9,7 +9,7 @@ export class MessageInReply extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
     }
 
     get authorAvatarUrl() {

--- a/addons/mail/static/src/core/common/message_reaction_list.js
+++ b/addons/mail/static/src/core/common/message_reaction_list.js
@@ -15,7 +15,7 @@ export class MessageReactionList extends Component {
     setup() {
         super.setup();
         this.loadEmoji = loadEmoji;
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.ui = useService("ui");
         this.preview = useDropdownState();
         this.hover = useHover(["reactionButton", "reactionList*"], {

--- a/addons/mail/static/src/core/common/message_reaction_menu.js
+++ b/addons/mail/static/src/core/common/message_reaction_menu.js
@@ -22,8 +22,8 @@ export class MessageReactionMenu extends Component {
     setup() {
         super.setup();
         this.root = useRef("root");
-        this.store = useState(useService("mail.store"));
-        this.ui = useState(useService("ui"));
+        this.store = useService("mail.store");
+        this.ui = useService("ui");
         this.state = useState({
             emojiLoaded: Boolean(loader.loaded),
             reaction: this.props.initialReaction

--- a/addons/mail/static/src/core/common/message_reactions.js
+++ b/addons/mail/static/src/core/common/message_reactions.js
@@ -1,4 +1,4 @@
-import { Component, useRef, useState } from "@odoo/owl";
+import { Component, useRef } from "@odoo/owl";
 
 import { MessageReactionList } from "@mail/core/common/message_reaction_list";
 import { useService } from "@web/core/utils/hooks";
@@ -11,7 +11,7 @@ export class MessageReactions extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.ui = useService("ui");
         this.addRef = useRef("add");
         this.emojiPicker = useEmojiPicker(this.addRef, {

--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -25,7 +25,7 @@ export class QuickReactionMenu extends Component {
 
     setup() {
         this.toggle = useRef("toggle");
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.picker = useEmojiPicker(
             null,
             { onSelect: this.toggleReaction.bind(this), class: "overflow-hidden rounded-2" },
@@ -35,7 +35,7 @@ export class QuickReactionMenu extends Component {
             }
         );
         this.dropdown = useState(useDropdownState());
-        this.frequentEmojiService = useState(useService("web.frequent.emoji"));
+        this.frequentEmojiService = useService("web.frequent.emoji");
         this.state = useState({ emojiLoaded: Boolean(loader.loaded) });
         if (!loader.loaded) {
             loader.onEmojiLoaded(() => (this.state.emojiLoaded = true));

--- a/addons/mail/static/src/core/common/search_messages_panel.js
+++ b/addons/mail/static/src/core/common/search_messages_panel.js
@@ -1,4 +1,4 @@
-import { Component, useState, onWillUpdateProps } from "@odoo/owl";
+import { Component, onWillUpdateProps } from "@odoo/owl";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
@@ -17,7 +17,7 @@ export class SearchMessagesPanel extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.messageSearch = useMessageSearch(this.props.thread);
         onWillUpdateProps((nextProps) => {
             if (this.props.thread.notEq(nextProps.thread)) {

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -446,8 +446,14 @@ export class Store extends BaseStore {
      * Get the parameters to pass to the message post route.
      */
     async getMessagePostParams({ body, postData, thread }) {
-        const { attachments, cannedResponseIds, emailAddSignature, isNote, mentionedChannels, mentionedPartners } =
-            postData;
+        const {
+            attachments,
+            cannedResponseIds,
+            emailAddSignature,
+            isNote,
+            mentionedChannels,
+            mentionedPartners,
+        } = postData;
         const subtype = isNote ? "mail.mt_note" : "mail.mt_comment";
         const validMentions = this.getMentionsFromText(body, {
             mentionedChannels,
@@ -619,6 +625,7 @@ Store.register();
 
 export const storeService = {
     dependencies: ["bus_service", "ui"],
+    stateful: true,
     /**
      * @param {import("@web/env").OdooEnv} env
      * @param {import("services").ServiceFactories} services

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -71,7 +71,7 @@ export class Thread extends Component {
         this.applyScroll = this.applyScroll.bind(this);
         this.saveScroll = this.saveScroll.bind(this);
         this.registerMessageRef = this.registerMessageRef.bind(this);
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.state = useState({
             isReplyingTo: false,
             mountedAndLoaded: false,

--- a/addons/mail/static/src/core/common/thread_icon.js
+++ b/addons/mail/static/src/core/common/thread_icon.js
@@ -1,6 +1,6 @@
 import { useService } from "@web/core/utils/hooks";
 
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { Thread } from "./thread_model";
 import { _t } from "@web/core/l10n/translation";
 
@@ -25,7 +25,7 @@ export class ThreadIcon extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
     }
 
     get correspondent() {

--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -49,7 +49,7 @@ export class Discuss extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.messageHighlight = useMessageHighlight();
         this.messageEdition = useMessageEdition();
         this.messageToReplyTo = useMessageToReplyTo();
@@ -58,7 +58,7 @@ export class Discuss extends Component {
         this.state = useState({ jumpThreadPresent: 0 });
         this.orm = useService("orm");
         this.effect = useService("effect");
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         useSubEnv({
             inDiscussApp: true,
             messageHighlight: this.messageHighlight,

--- a/addons/mail/static/src/core/public_web/discuss_client_action.js
+++ b/addons/mail/static/src/core/public_web/discuss_client_action.js
@@ -1,6 +1,6 @@
 import { Discuss } from "@mail/core/public_web/discuss";
 
-import { Component, onWillStart, onWillUpdateProps, useState } from "@odoo/owl";
+import { Component, onWillStart, onWillUpdateProps } from "@odoo/owl";
 
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
@@ -21,7 +21,7 @@ export class DiscussClientAction extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         onWillStart(() => {
             // bracket to avoid blocking rendering with restore promise
             this.restoreDiscussThread(this.props);

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.js
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 
@@ -18,7 +18,7 @@ export class DiscussSidebar extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
     }
 
     get discussSidebarItems() {

--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -21,9 +21,9 @@ export class MessagingMenu extends Component {
     setup() {
         super.setup();
         this.discussSystray = useDiscussSystray();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.hasTouch = hasTouch;
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.state = useState({
             activeIndex: null,
             adding: false,

--- a/addons/mail/static/src/core/public_web/notification_item.js
+++ b/addons/mail/static/src/core/public_web/notification_item.js
@@ -2,7 +2,7 @@ import { ImStatus } from "@mail/core/common/im_status";
 import { isToday } from "@mail/utils/common/dates";
 import { useHover } from "@mail/utils/common/hooks";
 
-import { Component, useRef, useState } from "@odoo/owl";
+import { Component, useRef } from "@odoo/owl";
 
 import { ActionSwiper } from "@web/core/action_swiper/action_swiper";
 import { useService } from "@web/core/utils/hooks";
@@ -37,7 +37,7 @@ export class NotificationItem extends Component {
         super.setup();
         this.isToday = isToday;
         this.DateTime = DateTime;
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.markAsReadRef = useRef("markAsRead");
         this.rootHover = useHover("root");
     }

--- a/addons/mail/static/src/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/core/public_web/thread_actions.js
@@ -1,5 +1,5 @@
 import { threadActionsRegistry } from "@mail/core/common/thread_actions";
-import { useComponent, useState } from "@odoo/owl";
+import { useComponent } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
@@ -15,6 +15,6 @@ threadActionsRegistry.add("leave", {
     sequenceGroup: 40,
     setup() {
         const component = useComponent();
-        component.ui = useState(useService("ui"));
+        component.ui = useService("ui");
     },
 });

--- a/addons/mail/static/src/core/web/activity_list_popover.js
+++ b/addons/mail/static/src/core/web/activity_list_popover.js
@@ -1,7 +1,7 @@
 import { ActivityListPopoverItem } from "@mail/core/web/activity_list_popover_item";
 import { compareDatetime } from "@mail/utils/common/misc";
 
-import { Component, onWillUpdateProps, useState } from "@odoo/owl";
+import { Component, onWillUpdateProps } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 
@@ -32,7 +32,7 @@ export class ActivityListPopover extends Component {
     setup() {
         super.setup();
         this.orm = useService("orm");
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.updateFromProps(this.props);
         onWillUpdateProps((props) => this.updateFromProps(props));
     }

--- a/addons/mail/static/src/core/web/activity_mail_template.js
+++ b/addons/mail/static/src/core/web/activity_mail_template.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 import { _t } from "@web/core/l10n/translation";
@@ -19,7 +19,7 @@ export class ActivityMailTemplate extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
     }
 
     /**

--- a/addons/mail/static/src/core/web/activity_menu.js
+++ b/addons/mail/static/src/core/web/activity_menu.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 import { useDiscussSystray } from "@mail/utils/common/hooks";
 import { Dropdown } from "@web/core/dropdown/dropdown";
@@ -16,10 +16,10 @@ export class ActivityMenu extends Component {
     setup() {
         super.setup();
         this.discussSystray = useDiscussSystray();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.action = useService("action");
         this.userId = user.userId;
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.dropdown = useDropdownState();
     }
 

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.js
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.js
@@ -2,7 +2,7 @@ import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { discussSidebarItemsRegistry } from "@mail/core/public_web/discuss_sidebar";
 import { useHover } from "@mail/utils/common/hooks";
 
-import { Component, useRef, useState } from "@odoo/owl";
+import { Component, useRef } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 
@@ -16,7 +16,7 @@ export class Mailbox extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.hover = useHover(["root", "floating*"], {
             onHover: () => (this.floating.isOpen = true),
             onAway: () => (this.floating.isOpen = false),
@@ -48,7 +48,7 @@ export class DiscussSidebarMailboxes extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
     }
 }
 

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.js
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.js
@@ -1,7 +1,6 @@
 import { patch } from "@web/core/utils/patch";
 import { DiscussSidebar } from "../public_web/discuss_sidebar";
 import { _t } from "@web/core/l10n/translation";
-import { useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { useHover } from "@mail/utils/common/hooks";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
@@ -9,7 +8,7 @@ import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 patch(DiscussSidebar.prototype, {
     setup() {
         super.setup();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.meetingHover = useHover(["meeting-btn", "meeting-floating*"], {
             onHover: () => (this.meetingFloating.isOpen = true),
             onAway: () => (this.meetingFloating.isOpen = false),

--- a/addons/mail/static/src/core/web/follower_list.js
+++ b/addons/mail/static/src/core/web/follower_list.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { FollowerSubtypeDialog } from "./follower_subtype_dialog";
@@ -21,7 +21,7 @@ export class FollowerList extends Component {
     setup() {
         super.setup();
         this.action = useService("action");
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         useVisible("load-more", (isVisible) => {
             if (isVisible) {
                 this.props.thread.loadMoreFollowers();

--- a/addons/mail/static/src/core/web/follower_subtype_dialog.js
+++ b/addons/mail/static/src/core/web/follower_subtype_dialog.js
@@ -26,7 +26,7 @@ export class FollowerSubtypeDialog extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.state = useState({
             /** @type {SubtypeData[]} */
             subtypes: [],

--- a/addons/mail/static/src/core/web/mail_composer_attachment_list.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_list.js
@@ -1,9 +1,8 @@
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-import { useState } from "@odoo/owl";
 import {
     many2ManyBinaryField,
-    Many2ManyBinaryField
+    Many2ManyBinaryField,
 } from "@web/views/fields/many2many_binary/many2many_binary_field";
 
 export class MailComposerAttachmentList extends Many2ManyBinaryField {
@@ -11,7 +10,7 @@ export class MailComposerAttachmentList extends Many2ManyBinaryField {
     /** @override */
     setup() {
         super.setup();
-        this.mailStore = useState(useService("mail.store"));
+        this.mailStore = useService("mail.store");
         this.attachmentUploadService = useService("mail.attachment_upload");
     }
     /**

--- a/addons/mail/static/src/core/web/mention_list.js
+++ b/addons/mail/static/src/core/web/mention_list.js
@@ -25,7 +25,7 @@ export class MentionList extends Component {
             isFetching: false,
         });
         this.orm = useService("orm");
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.suggestionService = useService("mail.suggestion");
         this.sequential = useSequential();
         this.ref = useAutofocus({ mobile: true });

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -1,6 +1,6 @@
 import { MessagingMenu } from "@mail/core/public_web/messaging_menu";
 import { onExternalClick } from "@mail/utils/common/hooks";
-import { useEffect, useState } from "@odoo/owl";
+import { useEffect } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
@@ -13,8 +13,8 @@ patch(MessagingMenu.prototype, {
     setup() {
         super.setup();
         this.action = useService("action");
-        this.pwa = useState(useService("pwa"));
-        this.notification = useState(useService("mail.notification.permission"));
+        this.pwa = useService("pwa");
+        this.notification = useService("mail.notification.permission");
         Object.assign(this.state, {
             searchOpen: false,
         });

--- a/addons/mail/static/src/core/web/messaging_menu_quick_search.js
+++ b/addons/mail/static/src/core/web/messaging_menu_quick_search.js
@@ -1,5 +1,5 @@
 import { onExternalClick } from "@mail/utils/common/hooks";
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 
 import { useAutofocus, useService } from "@web/core/utils/hooks";
@@ -11,7 +11,7 @@ export class MessagingMenuQuickSearch extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         useAutofocus();
         onExternalClick("search", () => this.props.onClose());
     }

--- a/addons/mail/static/src/core/web/recipient_list.js
+++ b/addons/mail/static/src/core/web/recipient_list.js
@@ -1,5 +1,5 @@
 import { useVisible } from "@mail/utils/common/hooks";
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { _t } from "@web/core/l10n/translation";
 import { sprintf } from "@web/core/utils/strings";
@@ -16,7 +16,7 @@ export class RecipientList extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.loadMoreState = useVisible("load-more", () => {
             if (this.loadMoreState.isVisible) {
                 this.props.thread.loadMoreRecipients();

--- a/addons/mail/static/src/core/web/thread_actions.js
+++ b/addons/mail/static/src/core/web/thread_actions.js
@@ -1,5 +1,5 @@
 import { threadActionsRegistry } from "@mail/core/common/thread_actions";
-import { useComponent, useState } from "@odoo/owl";
+import { useComponent } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
@@ -31,7 +31,7 @@ threadActionsRegistry
         sequence: 2,
         setup() {
             const component = useComponent();
-            component.store = useState(useService("mail.store"));
+            component.store = useService("mail.store");
         },
         text: _t("Unstar all"),
     })

--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -42,7 +42,7 @@ export class Call extends Component {
         super.setup();
         this.grid = useRef("grid");
         this.notification = useService("notification");
-        this.rtc = useState(useService("discuss.rtc"));
+        this.rtc = useService("discuss.rtc");
         this.state = useState({
             isFullscreen: false,
             sidebar: false,
@@ -53,7 +53,7 @@ export class Call extends Component {
             /** @type {CardData|undefined} */
             insetCard: undefined,
         });
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         onMounted(() => {
             this.resizeObserver = new ResizeObserver(() => this.arrangeTiles());
             this.resizeObserver.observe(this.grid.el);
@@ -120,19 +120,16 @@ export class Call extends Component {
                 });
             }
         }
-        raisingHandCards.sort((c1, c2) => {
-            return c1.session.raisingHand - c2.session.raisingHand;
-        });
-        sessionCards.sort((c1, c2) => {
-            return (
+        raisingHandCards.sort((c1, c2) => c1.session.raisingHand - c2.session.raisingHand);
+        sessionCards.sort(
+            (c1, c2) =>
                 c1.session.channel_member_id?.persona?.name?.localeCompare(
                     c2.session.channel_member_id?.persona?.name
                 ) ?? 1
-            );
-        });
-        invitationCards.sort((c1, c2) => {
-            return c1.member.persona?.name?.localeCompare(c2.member.persona?.name) ?? 1;
-        });
+        );
+        invitationCards.sort(
+            (c1, c2) => c1.member.persona?.name?.localeCompare(c2.member.persona?.name) ?? 1
+        );
         return raisingHandCards.concat(sessionCards, invitationCards);
     }
 

--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 import { isMobileOS } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
@@ -14,8 +14,8 @@ export class CallActionList extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
-        this.rtc = useState(useService("discuss.rtc"));
+        this.store = useService("mail.store");
+        this.rtc = useService("discuss.rtc");
         this.callActions = useCallActions();
     }
 

--- a/addons/mail/static/src/discuss/call/common/call_context_menu.js
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.js
@@ -17,8 +17,8 @@ export class CallContextMenu extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
-        this.rtc = useState(useService("discuss.rtc"));
+        this.store = useService("mail.store");
+        this.rtc = useService("discuss.rtc");
         this.state = useState({
             downloadStats: {},
             uploadStats: {},

--- a/addons/mail/static/src/discuss/call/common/call_invitation.js
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.js
@@ -9,7 +9,7 @@ export class CallInvitation extends Component {
     setup() {
         super.setup();
         this.rtc = useService("discuss.rtc");
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.state = useState({ videoStream: null });
         this.videoRef = useRef("video");
         onWillUnmount(() => {

--- a/addons/mail/static/src/discuss/call/common/call_invitations.js
+++ b/addons/mail/static/src/discuss/call/common/call_invitations.js
@@ -1,6 +1,6 @@
 import { CallInvitation } from "@mail/discuss/call/common/call_invitation";
 
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
@@ -12,8 +12,8 @@ export class CallInvitations extends Component {
 
     setup() {
         super.setup();
-        this.rtc = useState(useService("discuss.rtc"));
-        this.store = useState(useService("mail.store"));
+        this.rtc = useService("discuss.rtc");
+        this.store = useService("mail.store");
     }
 }
 

--- a/addons/mail/static/src/discuss/call/common/call_menu.js
+++ b/addons/mail/static/src/discuss/call/common/call_menu.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
@@ -9,7 +9,7 @@ export class CallMenu extends Component {
     static template = "discuss.CallMenu";
     setup() {
         super.setup();
-        this.rtc = useState(useService("discuss.rtc"));
+        this.rtc = useService("discuss.rtc");
         this.callActions = useCallActions();
     }
 

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -29,9 +29,9 @@ export class CallParticipantCard extends Component {
         this.contextMenuAnchorRef = useRef("contextMenuAnchor");
         this.root = useRef("root");
         this.popover = usePopover(CallContextMenu);
-        this.rtc = useState(useService("discuss.rtc"));
-        this.store = useState(useService("mail.store"));
-        this.ui = useState(useService("ui"));
+        this.rtc = useService("discuss.rtc");
+        this.store = useService("mail.store");
+        this.ui = useService("ui");
         this.rootHover = useHover("root");
         this.state = useState({ drag: false, dragPos: undefined });
         onMounted(() => {

--- a/addons/mail/static/src/discuss/call/common/call_participant_video.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_video.js
@@ -1,4 +1,4 @@
-import { Component, onMounted, onPatched, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, onMounted, onPatched, useExternalListener, useRef } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
 /**
@@ -12,7 +12,7 @@ export class CallParticipantVideo extends Component {
 
     setup() {
         super.setup();
-        this.rtc = useState(useService("discuss.rtc"));
+        this.rtc = useService("discuss.rtc");
         this.root = useRef("root");
         onMounted(() => this._update());
         onPatched(() => this._update());

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -19,13 +19,13 @@ export class CallSettings extends Component {
     setup() {
         super.setup();
         this.notification = useService("notification");
-        this.store = useState(useService("mail.store"));
-        this.rtc = useState(useService("discuss.rtc"));
+        this.store = useService("mail.store");
+        this.rtc = useService("discuss.rtc");
         this.microphoneVolume = useMicrophoneVolume();
         this.state = useState({
             userDevices: [],
         });
-        this.pttExtService = useState(useService("discuss.ptt_extension"));
+        this.pttExtService = useService("discuss.ptt_extension");
         this.saveBackgroundBlurAmount = debounce(() => {
             browser.localStorage.setItem(
                 "mail_user_setting_background_blur_amount",

--- a/addons/mail/static/src/discuss/call/common/ptt_ad_banner.js
+++ b/addons/mail/static/src/discuss/call/common/ptt_ad_banner.js
@@ -10,8 +10,8 @@ export class PttAdBanner extends Component {
 
     setup() {
         super.setup();
-        this.pttExtService = useState(useService("discuss.ptt_extension"));
-        this.store = useState(useService("mail.store"));
+        this.pttExtService = useService("discuss.ptt_extension");
+        this.store = useService("mail.store");
         this.state = useState({
             wasDiscarded: browser.localStorage.getItem(PttAdBanner.LOCAL_STORAGE_KEY),
         });

--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -1,7 +1,7 @@
 import { threadActionsRegistry } from "@mail/core/common/thread_actions";
 import { CallSettings } from "@mail/discuss/call/common/call_settings";
 
-import { useComponent, useState } from "@odoo/owl";
+import { useComponent } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
@@ -23,7 +23,7 @@ threadActionsRegistry
         sequenceQuick: 30,
         setup() {
             const component = useComponent();
-            component.rtc = useState(useService("discuss.rtc"));
+            component.rtc = useService("discuss.rtc");
         },
     })
     .add("camera-call", {
@@ -42,7 +42,7 @@ threadActionsRegistry
         sequenceQuick: (component) => (component.env.inDiscussApp ? 25 : 35),
         setup() {
             const component = useComponent();
-            component.rtc = useState(useService("discuss.rtc"));
+            component.rtc = useService("discuss.rtc");
         },
     })
     .add("settings", {
@@ -63,7 +63,7 @@ threadActionsRegistry
         sequenceGroup: 30,
         setup() {
             const component = useComponent();
-            component.rtc = useState(useService("discuss.rtc"));
+            component.rtc = useService("discuss.rtc");
         },
         toggle: true,
     });

--- a/addons/mail/static/src/discuss/call/public/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/call/public/discuss_client_action_patch.js
@@ -1,5 +1,4 @@
 import { DiscussClientAction } from "@mail/core/public_web/discuss_client_action";
-import { useState } from "@odoo/owl";
 import "@mail/discuss/core/public/discuss_client_action_patch";
 
 import { browser } from "@web/core/browser/browser";
@@ -9,7 +8,7 @@ import { patch } from "@web/core/utils/patch";
 patch(DiscussClientAction.prototype, {
     setup() {
         super.setup(...arguments);
-        this.rtc = useState(useService("discuss.rtc"));
+        this.rtc = useService("discuss.rtc");
     },
     async joinCallWithWelcomeSettings() {
         if (this.store.discuss_public_thread.default_display_mode !== "video_full_screen") {

--- a/addons/mail/static/src/discuss/call/public_web/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_client_action_patch.js
@@ -1,5 +1,4 @@
 import { DiscussClientAction } from "@mail/core/public_web/discuss_client_action";
-import { useState } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
@@ -7,7 +6,7 @@ import { patch } from "@web/core/utils/patch";
 patch(DiscussClientAction.prototype, {
     setup() {
         super.setup(...arguments);
-        this.rtc = useState(useService("discuss.rtc"));
+        this.rtc = useService("discuss.rtc");
     },
     /**
      * Checks if we are in a client action and if we have a query parameter requesting to join a call,

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.js
@@ -1,7 +1,7 @@
 import { Thread } from "@mail/core/common/thread_model";
 import { discussSidebarChannelIndicatorsRegistry } from "@mail/discuss/core/public_web/discuss_sidebar_categories";
 
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
 /**
@@ -16,8 +16,8 @@ export class DiscussSidebarCallIndicator extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
-        this.rtc = useState(useService("discuss.rtc"));
+        this.store = useService("mail.store");
+        this.rtc = useService("discuss.rtc");
     }
 }
 

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
@@ -20,8 +20,8 @@ export class DiscussSidebarCallParticipants extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
-        this.rtc = useState(useService("discuss.rtc"));
+        this.store = useService("mail.store");
+        this.rtc = useService("discuss.rtc");
         this.hover = useHover(["root", "floating*"], {
             onHover: () => (this.floating.isOpen = true),
             onAway: () => (this.floating.isOpen = false),

--- a/addons/mail/static/src/discuss/core/common/action_panel.js
+++ b/addons/mail/static/src/discuss/core/common/action_panel.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { ResizablePanel } from "@web/core/resizable_panel/resizable_panel";
 import { useService } from "@web/core/utils/hooks";
 
@@ -16,7 +16,7 @@ export class ActionPanel extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
     }
 
     get classNames() {

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -23,7 +23,7 @@ export class ChannelInvitation extends Component {
     setup() {
         super.setup();
         this.orm = useService("orm");
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.notification = useService("notification");
         this.suggestionService = useService("mail.suggestion");
         this.ui = useService("ui");

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -1,7 +1,7 @@
 import { ImStatus } from "@mail/core/common/im_status";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 
-import { Component, onWillUpdateProps, onWillStart, useState } from "@odoo/owl";
+import { Component, onWillUpdateProps, onWillStart } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 
 import { useService } from "@web/core/utils/hooks";
@@ -13,7 +13,7 @@ export class ChannelMemberList extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         onWillStart(() => {
             if (this.props.thread.fetchMembersState === "not_fetched") {
                 this.props.thread.fetchChannelMembers();

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings.js
@@ -6,7 +6,7 @@ export class DiscussNotificationSettings extends Component {
     static template = "mail.DiscussNotificationSettings";
 
     setup() {
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.state = useState({
             selectedDuration: false,
         });

--- a/addons/mail/static/src/discuss/core/common/notification_settings.js
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.js
@@ -1,4 +1,4 @@
-import { Component, useState, xml } from "@odoo/owl";
+import { Component, xml } from "@odoo/owl";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
@@ -22,7 +22,7 @@ export class NotificationSettings extends Component {
     static template = "discuss.NotificationSettings";
 
     setup() {
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.dialog = useService("dialog");
     }
 

--- a/addons/mail/static/src/discuss/core/public/welcome_page.js
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.js
@@ -12,8 +12,8 @@ export class WelcomePage extends Component {
     setup() {
         super.setup();
         this.isClosed = false;
-        this.store = useState(useService("mail.store"));
-        this.ui = useState(useService("ui"));
+        this.store = useService("mail.store");
+        this.ui = useService("ui");
         this.state = useState({
             userName: this.store.self.name || _t("Guest"),
             audioStream: null,

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -23,7 +23,7 @@ class CreateChatDialog extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.invitePeopleState = useState({
             selectablePartners: [],
             selectedPartners: [],
@@ -53,7 +53,7 @@ class CreateChannelDialog extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.orm = useService("orm");
         this.state = useState({ name: this.props.name || "", isInvalid: false });
     }
@@ -97,8 +97,8 @@ class DiscussCommand extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
-        this.ui = useState(useService("ui"));
+        this.store = useService("mail.store");
+        this.ui = useService("ui");
     }
 }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
@@ -75,7 +75,6 @@ export class DiscussCorePublicWeb {
 
 export const discussCorePublicWeb = {
     dependencies: ["bus_service", "discuss.rtc", "mail.store", "notification"],
-
     /**
      * @param {import("@web/env").OdooEnv} env
      * @param {import("services").ServiceFactories} services

--- a/addons/mail/static/src/discuss/core/public_web/discuss_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_patch.js
@@ -1,6 +1,5 @@
 import { Discuss } from "@mail/core/public_web/discuss";
 import { Call } from "@mail/discuss/call/common/call";
-import { useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
 import { patch } from "@web/core/utils/patch";
@@ -10,6 +9,6 @@ Object.assign(Discuss.components, { Call });
 patch(Discuss.prototype, {
     setup() {
         super.setup(...arguments);
-        this.rtc = useState(useService("discuss.rtc"));
+        this.rtc = useService("discuss.rtc");
     },
 });

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -4,7 +4,7 @@ import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { discussSidebarItemsRegistry } from "@mail/core/public_web/discuss_sidebar";
 import { useHover } from "@mail/utils/common/hooks";
 
-import { Component, useState, useSubEnv } from "@odoo/owl";
+import { Component, useSubEnv } from "@odoo/owl";
 
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
@@ -24,7 +24,7 @@ export class DiscussSidebarSubchannel extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.hover = useHover(["root", "floating*"], {
             onHover: () => (this.floating.isOpen = true),
             onAway: () => (this.floating.isOpen = false),
@@ -69,7 +69,7 @@ export class DiscussSidebarChannel extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.hover = useHover(["root", "floating*"], {
             onHover: () => (this.floating.isOpen = true),
             onAway: () => (this.floating.isOpen = false),
@@ -154,8 +154,8 @@ export class DiscussSidebarCategory extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
-        this.discusscorePublicWebService = useState(useService("discuss.core.public.web"));
+        this.store = useService("mail.store");
+        this.discusscorePublicWebService = useService("discuss.core.public.web");
         this.hover = useHover(["root", "floating*"], {
             onHover: () => this.onHover(true),
             onAway: () => this.onHover(false),
@@ -200,10 +200,10 @@ export class DiscussSidebarCategories extends Component {
 
     setup() {
         super.setup();
-        this.store = useState(useService("mail.store"));
-        this.discusscorePublicWebService = useState(useService("discuss.core.public.web"));
+        this.store = useService("mail.store");
+        this.discusscorePublicWebService = useService("discuss.core.public.web");
         this.orm = useService("orm");
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.command = useService("command");
         this.searchHover = useHover(["search-btn", "search-floating*"], {
             onHover: () => (this.searchFloating.isOpen = true),

--- a/addons/mail/static/src/discuss/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/discuss/core/web/messaging_menu_patch.js
@@ -1,12 +1,11 @@
 import { MessagingMenu } from "@mail/core/public_web/messaging_menu";
 import { patch } from "@web/core/utils/patch";
-import { useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
 patch(MessagingMenu.prototype, {
     setup() {
         super.setup();
-        this.command = useState(useService("command"));
+        this.command = useService("command");
     },
     beforeOpen() {
         const res = super.beforeOpen(...arguments);
@@ -33,12 +32,8 @@ patch(MessagingMenu.prototype, {
                   ).length;
         // Needactions are already counted in the super call, but we want to discard them for channel so that there is only +1 per channel.
         const channelsNeedactionCounter = Object.values(this.store.Thread.records).reduce(
-            (acc, thread) => {
-                return (
-                    acc +
-                    (thread.model === "discuss.channel" ? thread.message_needaction_counter : 0)
-                );
-            },
+            (acc, thread) =>
+                acc + (thread.model === "discuss.channel" ? thread.message_needaction_counter : 0),
             0
         );
         return count + channelsContribution - channelsNeedactionCounter;

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
@@ -1,7 +1,7 @@
 import { Composer } from "@mail/core/common/composer";
 import { markEventHandled } from "@web/core/utils/misc";
 
-import { useRef, useState } from "@odoo/owl";
+import { useRef } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
@@ -11,7 +11,7 @@ const composerPatch = {
     setup() {
         this.gifButton = useRef("gif-button");
         super.setup();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
     },
     get pickerSettings() {
         const setting = super.pickerSettings;

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
@@ -57,7 +57,7 @@ export class GifPicker extends Component {
     setup() {
         super.setup();
         this.orm = useService("orm");
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
         this.sequential = useSequential();
         useAutofocus();
         useOnBottomScrolled(

--- a/addons/mail/static/src/discuss/voice_message/common/voice_recorder.js
+++ b/addons/mail/static/src/discuss/voice_message/common/voice_recorder.js
@@ -41,7 +41,7 @@ export function useVoiceRecorder() {
     });
     /** @type {ReturnType<typeof import("@web/core/notifications/notification_service").notificationService.start>} */
     const notification = useService("notification");
-    const store = useState(useService("mail.store"));
+    const store = useService("mail.store");
     const config = { bitRate: 128 }; // 128 or 160 kbit/s – mid-range bitrate quality
     onWillUnmount(() => {
         if (state.recording) {

--- a/addons/mail/static/src/discuss/web/bus_connection_alert_patch.js
+++ b/addons/mail/static/src/discuss/web/bus_connection_alert_patch.js
@@ -1,12 +1,11 @@
 import { patch } from "@web/core/utils/patch";
 import { BusConnectionAlert } from "@bus/components/bus_connection_alert";
-import { useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
 patch(BusConnectionAlert.prototype, {
     setup() {
         super.setup(...arguments);
-        this.store = useState(useService("mail.store"));
+        this.store = useService("mail.store");
     },
 
     get showBorderOnFailure() {

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -379,7 +379,7 @@ export function useMicrophoneVolume() {
 }
 
 export function useSelection({ refName, model, preserveOnClickAwayPredicate = () => false }) {
-    const ui = useState(useService("ui"));
+    const ui = useService("ui");
     const ref = useRef(refName);
     function onSelectionChange() {
         const activeElement = ref.el?.getRootNode().activeElement;
@@ -531,7 +531,7 @@ export function useSequential() {
 }
 
 export function useDiscussSystray() {
-    const ui = useState(useService("ui"));
+    const ui = useService("ui");
     return {
         class: "o-mail-DiscussSystray-class",
         get contentClass() {

--- a/addons/mail/static/src/views/web/activity/activity_controller.js
+++ b/addons/mail/static/src/views/web/activity/activity_controller.js
@@ -28,7 +28,7 @@ export class ActivityController extends Component {
         this.dialog = useService("dialog");
         this.action = useService("action");
         this.store = useService("mail.store");
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         usePager(() => {
             const { count, hasLimitedCount, limit, offset } = this.model.root;
             return {
@@ -85,12 +85,9 @@ export class ActivityController extends Component {
     }
 
     scheduleActivity() {
-        this.dialog.add(
-            SelectCreateDialog,
-            this.getSelectCreateDialogProps,
-            {
-                onClose: () => this.model.load(this.getSearchProps()),
-            });
+        this.dialog.add(SelectCreateDialog, this.getSelectCreateDialogProps, {
+            onClose: () => this.model.load(this.getSearchProps()),
+        });
     }
 
     openActivityFormView(resId, activityTypeId) {

--- a/addons/point_of_sale/static/src/app/components/navbar/cashier_name/cashier_name.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/cashier_name/cashier_name.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { useService } from "@web/core/utils/hooks";
 
@@ -9,7 +9,7 @@ export class CashierName extends Component {
 
     setup() {
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
     }
     get avatar() {
         const user_id = this.pos.getCashierUserId();

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -39,7 +39,7 @@ export class Navbar extends Component {
     static props = {};
     setup() {
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.state = useState({ searchBarOpen: false });
         this.debug = useService("debug");
         this.dialog = useService("dialog");

--- a/addons/point_of_sale/static/src/app/components/navbar/proxy_status/proxy_status.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/proxy_status/proxy_status.js
@@ -10,7 +10,7 @@ export class ProxyStatus extends Component {
 
     setup() {
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         const hardwareProxy = useService("hardware_proxy");
         this.connectionInfo = useState(hardwareProxy.connectionInfo);
     }

--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
@@ -1,6 +1,6 @@
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { useService } from "@web/core/utils/hooks";
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { ListContainer } from "@point_of_sale/app/components/list_container/list_container";
 
 export class OrderTabs extends Component {
@@ -17,7 +17,7 @@ export class OrderTabs extends Component {
     };
     setup() {
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.dialog = useService("dialog");
     }
     async newFloatingOrder() {

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -35,7 +35,7 @@ export class ClosePosPopup extends Component {
         this.report = useService("report");
         this.hardwareProxy = useService("hardware_proxy");
         this.dialog = useService("dialog");
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.state = useState(this.getInitialState());
         this.confirm = useAsyncLockedMethod(this.confirm);
     }

--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
@@ -122,7 +122,7 @@ export class ProductConfiguratorPopup extends Component {
             computeProductProduct: this.computeProductProduct.bind(this),
         });
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.inputArea = useRef("input-area");
         this.state = useState({
             productTemplate: this.props.productTemplate,

--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
@@ -18,7 +18,7 @@ export class ProductInfoBanner extends Component {
     setup() {
         this.pos = usePos();
         this.fetchStock = useTrackedAsync((pt, p) => this.pos.getProductInfo(pt, 1, 0, p));
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.state = useState({
             other_warehouses: [],
             available_quantity: 0,

--- a/addons/point_of_sale/static/src/app/hooks/pos_hook.js
+++ b/addons/point_of_sale/static/src/app/hooks/pos_hook.js
@@ -1,9 +1,8 @@
-import { useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
 /**
  * @returns {import("@point_of_sale/app/services/pos_store").PosStore}
  */
 export function usePos() {
-    return useState(useService("pos"));
+    return useService("pos");
 }

--- a/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.js
@@ -1,6 +1,6 @@
 import { registry } from "@web/core/registry";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { useTime } from "@point_of_sale/app/hooks/time_hook";
 import { _t } from "@web/core/l10n/translation";
@@ -12,7 +12,7 @@ export class LoginScreen extends Component {
     setup() {
         this.pos = usePos();
         this.dialog = useService("dialog");
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.time = useTime();
     }
 

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -23,7 +23,7 @@ export class PartnerList extends Component {
 
     setup() {
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.notification = useService("notification");
         this.dialog = useService("dialog");
 

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.js
@@ -1,7 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { NumberPopup } from "@point_of_sale/app/components/popups/number_popup/number_popup";
 import { useService } from "@web/core/utils/hooks";
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { parseFloat } from "@web/views/fields/parsers";
 import { enhancedButtons } from "@point_of_sale/app/components/numpad/numpad";
@@ -21,7 +21,7 @@ export class PaymentScreenPaymentLines extends Component {
     };
 
     setup() {
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.pos = usePos();
         this.dialog = useService("dialog");
     }

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -12,7 +12,7 @@ import { ConnectionLostError, RPCError } from "@web/core/network/rpc";
 import { PaymentScreenPaymentLines } from "@point_of_sale/app/screens/payment_screen/payment_lines/payment_lines";
 import { PaymentScreenStatus } from "@point_of_sale/app/screens/payment_screen/payment_status/payment_status";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
-import { Component, useState, onMounted } from "@odoo/owl";
+import { Component, onMounted } from "@odoo/owl";
 import { Numpad, enhancedButtons } from "@point_of_sale/app/components/numpad/numpad";
 import { floatIsZero, roundPrecision } from "@web/core/utils/numbers";
 import { ask, makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
@@ -33,7 +33,7 @@ export class PaymentScreen extends Component {
 
     setup() {
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.dialog = useService("dialog");
         this.invoiceService = useService("account_move");
         this.notification = useService("notification");

--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.js
@@ -1,5 +1,5 @@
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { SelectPartnerButton } from "@point_of_sale/app/screens/product_screen/control_buttons/select_partner_button/select_partner_button";
 import { useService } from "@web/core/utils/hooks";
 import { BackButton } from "@point_of_sale/app/screens/product_screen/action_pad/back_button/back_button";
@@ -20,6 +20,6 @@ export class ActionpadWidget extends Component {
 
     setup() {
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -1,4 +1,4 @@
-import { Component, useState, xml } from "@odoo/owl";
+import { Component, xml } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { Dialog } from "@web/core/dialog/dialog";
 import { SelectionPopup } from "@point_of_sale/app/components/popups/selection_popup/selection_popup";
@@ -21,7 +21,7 @@ export class ControlButtons extends Component {
     };
     setup() {
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.dialog = useService("dialog");
         this.notification = useService("notification");
     }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/select_partner_button/select_partner_button.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/select_partner_button/select_partner_button.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { useService } from "@web/core/utils/hooks";
 
@@ -7,6 +7,6 @@ export class SelectPartnerButton extends Component {
     static props = ["partner?"];
     setup() {
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -43,7 +43,7 @@ export class ProductScreen extends Component {
     setup() {
         super.setup();
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.dialog = useService("dialog");
         this.notification = useService("notification");
         this.numberBuffer = useService("number_buffer");

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -16,7 +16,7 @@ export class ReceiptScreen extends Component {
         super.setup();
         this.pos = usePos();
         useErrorHandlers();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.renderer = useService("renderer");
         this.notification = useService("notification");
         this.dialog = useService("dialog");

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/search_bar/search_bar.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/search_bar/search_bar.js
@@ -33,7 +33,7 @@ export class SearchBar extends Component {
     };
 
     setup() {
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         useAutofocus();
         useExternalListener(window, "click", this._hideOptions);
         this.filterOptionsList = [...this.props.config.filter.options.keys()];

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -58,7 +58,7 @@ export class TicketScreen extends Component {
 
     setup() {
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.dialog = useService("dialog");
         this.numberBuffer = useService("number_buffer");
         this.doPrint = useTrackedAsync((_selectedSyncedOrder) =>

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1,7 +1,7 @@
 /* global waitForWebfonts */
 
 import { Mutex } from "@web/core/utils/concurrency";
-import { markRaw } from "@odoo/owl";
+import { markRaw, reactive } from "@odoo/owl";
 import { floatIsZero } from "@web/core/utils/numbers";
 import { renderToElement } from "@web/core/utils/render";
 import { registry } from "@web/core/registry";
@@ -58,7 +58,9 @@ export class PosStore extends WithLazyGetterTrap {
     ];
     constructor({ traps, env, deps }) {
         super({ traps });
-        this.ready = this.setup(env, deps).then(() => this);
+        const reactiveSelf = reactive(this);
+        reactiveSelf.ready = reactiveSelf.setup(env, deps).then(() => reactiveSelf);
+        return reactiveSelf;
     }
     // use setup instead of constructor because setup can be patched.
     async setup(

--- a/addons/point_of_sale/static/src/customer_display/customer_display.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.js
@@ -1,4 +1,4 @@
-import { Component, useState, whenReady } from "@odoo/owl";
+import { Component, whenReady } from "@odoo/owl";
 import { OdooLogo } from "@point_of_sale/app/components/odoo_logo/odoo_logo";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { session } from "@web/session";
@@ -13,7 +13,7 @@ export class CustomerDisplay extends Component {
     setup() {
         this.session = session;
         this.dialog = useService("dialog");
-        this.order = useState(useService("customer_display_data"));
+        this.order = useService("customer_display_data");
     }
 
     get netWeight() {

--- a/addons/pos_loyalty/static/src/app/components/popups/manage_giftcard_popup/manage_giftcard_popup.js
+++ b/addons/pos_loyalty/static/src/app/components/popups/manage_giftcard_popup/manage_giftcard_popup.js
@@ -21,7 +21,7 @@ export class ManageGiftCardPopup extends Component {
     };
 
     setup() {
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.state = useState({
             inputValue: this.props.startingValue,
             amountValue: "",

--- a/addons/pos_restaurant/static/src/app/components/numpad_dropdown/numpad_dropdown.js
+++ b/addons/pos_restaurant/static/src/app/components/numpad_dropdown/numpad_dropdown.js
@@ -17,7 +17,7 @@ export class NumpadDropdown extends Component {
 
     setup() {
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.numberBuffer = useService("number_buffer");
         this.numberBuffer.use({
             triggerAtEnter: () => this.pos.searchOrder(this.state.buffer),

--- a/addons/pos_restaurant/static/src/app/screens/bill_screen/bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/bill_screen/bill_screen.js
@@ -1,6 +1,6 @@
 import { Dialog } from "@web/core/dialog/dialog";
 import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { useService } from "@web/core/utils/hooks";
 
@@ -12,7 +12,7 @@ export class BillScreen extends Component {
     };
     setup() {
         this.pos = usePos();
-        this.printer = useState(useService("printer"));
+        this.printer = useService("printer");
     }
     async print() {
         await this.pos.printReceipt({

--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
@@ -14,7 +14,7 @@ export class SplitBillScreen extends Component {
 
     setup() {
         this.pos = usePos();
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.qtyTracker = useState({});
         this.priceTracker = useState({});
 

--- a/addons/pos_self_order/static/src/app/router.js
+++ b/addons/pos_self_order/static/src/app/router.js
@@ -1,4 +1,4 @@
-import { Component, onWillRender, useState, xml } from "@odoo/owl";
+import { Component, onWillRender, xml } from "@odoo/owl";
 import { escapeRegExp } from "@web/core/utils/strings";
 import { zip } from "@web/core/utils/arrays";
 import { useService } from "@web/core/utils/hooks";
@@ -24,7 +24,7 @@ export class Router extends Component {
     static template = xml`<t t-slot="{{activeSlot}}" t-props="slotProps"/>`;
 
     setup() {
-        this.router = useState(useService("router"));
+        this.router = useService("router");
         this.activeSlot = "default";
         this.slotProps = {};
         this.routes = {};

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -3,7 +3,7 @@ import { ConnectionLostError, RPCError, rpc } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { formatCurrency as webFormatCurrency } from "@web/core/currency";
 import { attributeFormatter } from "@pos_self_order/app/utils";
-import { useState, markup } from "@odoo/owl";
+import { markup } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { cookie } from "@web/core/browser/cookie";
@@ -967,5 +967,5 @@ registry.category("services").add("printer", printerService);
 registry.category("services").add("self_order", selfOrderService);
 
 export function useSelfOrder() {
-    return useState(useService("self_order"));
+    return useService("self_order");
 }

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -94,14 +94,14 @@ export class EmojiPicker extends Component {
     setup() {
         this.gridRef = useRef("emoji-grid");
         this.navbarRef = useRef("navbar");
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         this.isMobileOS = isMobileOS();
         this.state = useState({
             activeEmojiIndex: 0,
             categoryId: null,
             searchTerm: "",
         });
-        this.frequentEmojiService = useState(useService("web.frequent.emoji"));
+        this.frequentEmojiService = useService("web.frequent.emoji");
         useAutofocus();
         onWillStart(async () => {
             const { categories, emojis } = await loadEmoji();
@@ -469,7 +469,7 @@ export function usePicker(PickerComponent, ref, props, options = {}) {
     const component = useComponent();
     const targets = [];
     const state = useState({ isOpen: false });
-    const ui = useState(useService("ui"));
+    const ui = useService("ui");
     const dialog = useService("dialog");
     let remove;
     const newOptions = {

--- a/addons/web/static/src/core/file_viewer/file_viewer.js
+++ b/addons/web/static/src/core/file_viewer/file_viewer.js
@@ -56,7 +56,7 @@ export class FileViewer extends Component {
             scale: 1,
             angle: 0,
         });
-        this.ui = useState(useService("ui"));
+        this.ui = useService("ui");
         useEffect(
             (el) => {
                 if (el) {

--- a/addons/web/static/src/core/install_scoped_app/install_scoped_app.js
+++ b/addons/web/static/src/core/install_scoped_app/install_scoped_app.js
@@ -10,7 +10,7 @@ export class InstallScopedApp extends Component {
     static template = "web.InstallScopedApp";
     static components = { Dropdown };
     setup() {
-        this.pwa = useState(useService("pwa"));
+        this.pwa = useService("pwa");
         this.state = useState({ manifest: {}, showInstallUI: false });
         this.isDisplayStandalone = isDisplayStandalone();
         // BeforeInstallPrompt event can take while before the browser triggers it. Some will display

--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -1,6 +1,6 @@
 import { hasTouch, isMobileOS } from "@web/core/browser/feature_detection";
 
-import { status, useComponent, useEffect, useRef, onWillUnmount } from "@odoo/owl";
+import { status, useComponent, useEffect, useRef, onWillUnmount, useState, toRaw } from "@odoo/owl";
 
 /**
  * This file contains various custom hooks.
@@ -136,17 +136,20 @@ export function useService(serviceName) {
         throw new Error(`Service ${serviceName} is not available`);
     }
     const service = services[serviceName];
-    if (serviceName in SERVICES_METADATA) {
+    if (SERVICES_METADATA[serviceName]) {
         if (service instanceof Function) {
             return _protectMethod(component, service);
         } else {
-            const methods = SERVICES_METADATA[serviceName];
+            const methods = SERVICES_METADATA[serviceName] ?? [];
             const result = Object.create(service);
             for (const method of methods) {
                 result[method] = _protectMethod(component, service[method]);
             }
             return result;
         }
+    }
+    if (toRaw(service) !== service) {
+        return useState(service);
     }
     return service;
 }


### PR DESCRIPTION
Before this commit, when a component uses service "mail.store", it has to wrap in a `useState()` to make sure any change to store is observed. This is the behaviour that essentially all `useService("mail.store")` want. If they omit it, it can fail to re-render store changed, which is painful to debug.

This commit improves by automatically wrapping `useState()` on services that are stateful. Stateful services return a reactive. Using stateful services becomes the same as non-stateful one: just put `useService(serviceName)`.

https://github.com/odoo/enterprise/pull/76058