### PR TITLE
[MERGE] mail, various: cleanup notification values usage, docstrings, code bits

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5315,7 +5315,7 @@ class AccountMove(models.Model):
             else 'account.email_template_edi_invoice'
         )
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         groups = super()._notify_get_recipients_groups(message, model_description, msg_vals=msg_vals)
         self.ensure_one()
 
@@ -6104,7 +6104,7 @@ class AccountMove(models.Model):
                                                    force_email_company=False, force_email_lang=False):
         # EXTENDS mail mail.thread
         render_context = super()._notify_by_email_prepare_rendering_context(
-            message, msg_vals, model_description=model_description,
+            message, msg_vals=msg_vals, model_description=model_description,
             force_email_company=force_email_company, force_email_lang=force_email_lang
         )
         record = render_context['record']

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1921,7 +1921,7 @@ class CrmLead(models.Model):
     def _notify_by_email_prepare_rendering_context(self, message, msg_vals=False, model_description=False,
                                                    force_email_company=False, force_email_lang=False):
         render_context = super()._notify_by_email_prepare_rendering_context(
-            message, msg_vals, model_description=model_description,
+            message, msg_vals=msg_vals, model_description=model_description,
             force_email_company=force_email_company, force_email_lang=force_email_lang
         )
         if self.date_deadline:
@@ -1930,7 +1930,7 @@ class CrmLead(models.Model):
         return render_context
 
     def _notify_get_reply_to(self, default=None):
-        """ Override to set alias of lead and opportunities to their sales team if any. """
+        # Override to set alias of lead and opportunities to their sales team if any
         aliases = self.mapped('team_id').sudo()._notify_get_reply_to(default=default)
         res = {lead.id: aliases.get(lead.team_id.id) for lead in self}
         leftover = self.filtered(lambda rec: not rec.team_id)
@@ -1964,10 +1964,6 @@ class CrmLead(models.Model):
 
     @api.model
     def message_new(self, msg_dict, custom_values=None):
-        """ Overrides mail_thread message_new that is called by the mailgateway
-            through message_process.
-            This override updates the document according to the email.
-        """
         # remove default author when going through the mail gateway. Indeed we
         # do not want to explicitly set an user as responsible. We prefer that
         # assignment is done automatically (scoring) or manually. Otherwise it

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -108,7 +108,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'duration': 18,
         })
         partner_model = self.env.ref('base.model_res_partner')
-        with self.assertQueryCount(__system__=86):
+        with self.assertQueryCount(__system__=82):
             event = self.env['calendar.event'].create({
                 'name': "Event",
                 'start': datetime(2020, 1, 15, 8, 0),
@@ -125,7 +125,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
                 'res_id': partner.id,
             })
 
-        with self.assertQueryCount(__system__=38):
+        with self.assertQueryCount(__system__=27):
             event.unlink()
 
     def test_event_without_user(self):

--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -110,7 +110,7 @@ class TestOutOfOfficePerformance(TestHrHolidaysCommon, TransactionCaseWithUserDe
     @warmup
     def test_leave_im_status_performance_user_leave_offline(self):
         self.leave.write({'state': 'validate'})
-        with self.assertQueryCount(__system__=3, demo=3):
+        with self.assertQueryCount(__system__=2, demo=2):
             self.assertEqual(self.hr_user.im_status, 'leave_offline')
 
     @users('__system__', 'demo')

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -578,10 +578,6 @@ class HrApplicant(models.Model):
 
     @api.model
     def message_new(self, msg, custom_values=None):
-        """ Overrides mail_thread message_new that is called by the mailgateway
-            through message_process.
-            This override updates the document according to the email.
-        """
         # Remove default author when going through the mail gateway. Indeed, we
         # do not want to explicitly set user_id to False; however we do not
         # want the gateway user to be responsible if no other responsible is

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=117, admin=118):  # com 96/97
+        with self.assertQueryCount(__system__=108, admin=109):
             leave.action_validate()
         leave.action_refuse()
 
@@ -41,14 +41,14 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
     def test_performance_leave_write(self):
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=30, admin=38):
+        with self.assertQueryCount(__system__=10, admin=10):
             leave.date_to = datetime(2018, 1, 1, 19, 0)
         leave.action_refuse()
 
     @users('__system__', 'admin')
     @warmup
     def test_performance_leave_create(self):
-        with self.assertQueryCount(__system__=60, admin=60):
+        with self.assertQueryCount(__system__=53, admin=53):
             leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
         leave.action_refuse()
 

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -539,9 +539,9 @@ class DiscussChannel(models.Model):
                     ),
                 },
             )
-            devices, private_key, public_key = self._get_web_push_parameters(members.partner_id.ids)
+            devices, private_key, public_key = self._web_push_get_partners_parameters(members.partner_id.ids)
             if devices:
-                self._push_web_notification(devices, private_key, public_key, payload={
+                self._web_push_send_notification(devices, private_key, public_key, payload={
                     "title": "",
                     "options": {
                         "data": {

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -555,29 +555,20 @@ class DiscussChannel(models.Model):
     # MAILING
     # ------------------------------------------------------------
 
-    def _notify_get_recipients(self, message, msg_vals, **kwargs):
-        """ Override recipients computation as channel is not a standard
-        mail.thread document. Indeed there are no followers on a channel.
-        Instead of followers it has members that should be notified.
-
-        :param message: see ``MailThread._notify_get_recipients()``;
-        :param msg_vals: see ``MailThread._notify_get_recipients()``;
-        :param kwargs: see ``MailThread._notify_get_recipients()``;
-
-        :return recipients: structured data holding recipients data. See
-          ``MailThread._notify_thread()`` for more details about its content
-          and use;
-        """
-        # get values from msg_vals or from message if msg_vals doen't exists
-        message_type = msg_vals.get('message_type', 'comment') if msg_vals else message.message_type
-        pids = msg_vals.get('partner_ids', []) if msg_vals else message.partner_ids.ids
+    def _notify_get_recipients(self, message, msg_vals=False, **kwargs):
+        # Override recipients computation as channel is not a standard
+        # mail.thread document. Indeed there are no followers on a channel.
+        # Instead of followers it has members that should be notified.
+        msg_vals = msg_vals or {}
 
         # notify only user input (comment, whatsapp messages or incoming / outgoing emails)
+        message_type = msg_vals['message_type'] if 'message_type' in msg_vals else message.message_type
         if message_type not in ('comment', 'email', 'email_outgoing', 'whatsapp_message'):
             return []
 
         recipients_data = []
         author_id = msg_vals.get("author_id") or message.author_id.id
+        pids = msg_vals['partner_ids'] or [] if 'partner_ids' in msg_vals else message.partner_ids.ids
         if pids:
             email_from = tools.email_normalize(msg_vals.get('email_from') or message.email_from)
             self.env['res.partner'].flush_model(['active', 'email', 'partner_share'])
@@ -663,11 +654,11 @@ class DiscussChannel(models.Model):
             })
         return recipients_data
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
-        """ All recipients of a message on a channel are considered as partners.
-        This means they will receive a minimal email, without a link to access
-        in the backend. Mailing lists should indeed send minimal emails to avoid
-        the noise. """
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
+        # All recipients of a message on a channel are considered as partners.
+        # This means they will receive a minimal email, without a link to access
+        # in the backend. Mailing lists should indeed send minimal emails to avoid
+        # the noise.
         groups = super()._notify_get_recipients_groups(
             message, model_description, msg_vals=msg_vals
         )
@@ -694,9 +685,9 @@ class DiscussChannel(models.Model):
     def _notify_by_web_push_prepare_payload(self, message, msg_vals=False):
         payload = super()._notify_by_web_push_prepare_payload(message, msg_vals=msg_vals)
         payload['options']['data']['action'] = 'mail.action_discuss'
-        record_name = msg_vals.get('record_name') if msg_vals and 'record_name' in msg_vals else message.record_name
-        author_id = [msg_vals["author_id"]] if msg_vals and msg_vals.get("author_id") else message.author_id.ids
-        author = self.env["res.partner"].browse(author_id) or self.env["mail.guest"].browse(
+        record_name = msg_vals['record_name'] if 'record_name' in msg_vals else message.record_name
+        author_ids = [msg_vals["author_id"]] if msg_vals.get("author_id") else message.author_id.ids
+        author = self.env["res.partner"].browse(author_ids) or self.env["mail.guest"].browse(
             msg_vals.get("author_guest_id", message.author_guest_id.id)
         )
         if self.channel_type == 'chat':
@@ -719,7 +710,7 @@ class DiscussChannel(models.Model):
         super()._notify_thread_by_web_push(message, [r for r in recipients_data if r["notif"] == "web_push"], msg_vals=msg_vals, **kwargs)
 
     def _message_receive_bounce(self, email, partner):
-        """ Override bounce management to unsubscribe bouncing addresses """
+        # Override bounce management to unsubscribe bouncing addresses
         for p in partner:
             if p.message_bounce >= self.MAX_BOUNCE_LIMIT:
                 self._action_unfollow(p)
@@ -762,9 +753,7 @@ class DiscussChannel(models.Model):
         return super(DiscussChannel, self.with_context(mail_create_nosubscribe=True, mail_post_autofollow=False)).message_post(message_type=message_type, **kwargs)
 
     def _message_post_after_hook(self, message, msg_vals):
-        """
-        Automatically set the message posted by the current user as seen for themselves.
-        """
+        # Automatically set the message posted by the current user as seen for themselves.
         if (current_channel_member := self.env["discuss.channel.member"].search([
             ("channel_id", "=", self.id), ("is_self", "=", True)
         ])) and message.is_current_user_or_guest_author:
@@ -773,8 +762,7 @@ class DiscussChannel(models.Model):
         return super()._message_post_after_hook(message, msg_vals)
 
     def _check_can_update_message_content(self, message):
-        """ We don't call super in this override as we want to ignore the
-        mail.thread behavior completely """
+        # Don't call super in this override as we want to ignore the mail.thread behavior completely
         if not message.message_type == 'comment':
             raise UserError(_("Only messages type comment can have their content updated on model 'discuss.channel'"))
 
@@ -790,8 +778,7 @@ class DiscussChannel(models.Model):
         return attachments
 
     def _message_subscribe(self, partner_ids=None, subtype_ids=None, customer_ids=None):
-        """ Do not allow follower subscription on channels. Only members are
-        considered. """
+        # Do not allow follower subscription on channels. Only members are considered
         raise UserError(_('Adding followers on channels is not possible. Consider adding members instead.'))
 
     # ------------------------------------------------------------

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -462,7 +462,7 @@ class DiscussChannelMember(models.Model):
                     ),
                 },
             )
-            devices, private_key, public_key = self.channel_id._get_web_push_parameters(members.partner_id.ids)
+            devices, private_key, public_key = self.channel_id._web_push_get_partners_parameters(members.partner_id.ids)
             if devices:
                 if self.channel_id.channel_type != 'chat':
                     icon = f"/web/image/discuss.channel/{self.channel_id.id}/avatar_128"
@@ -502,7 +502,7 @@ class DiscussChannelMember(models.Model):
                             ]
                         }
                     }
-                self.channel_id._push_web_notification(devices, private_key, public_key, payload_by_lang=payload_by_lang)
+                self.channel_id._web_push_send_notification(devices, private_key, public_key, payload_by_lang=payload_by_lang)
         return members
 
     def _mark_as_read(self, last_message_id, sync=False):

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -947,7 +947,7 @@ class MailMessage(models.Model):
             )
         return field_names
 
-    def _to_store(self, store: Store, fields, *, format_reply=True, msg_vals=None,
+    def _to_store(self, store: Store, fields, *, format_reply=True, msg_vals=False,
                   for_current_user=False, add_followers=False, followers=None):
         """Add the messages to the given store.
 
@@ -1229,15 +1229,14 @@ class MailMessage(models.Model):
             message_id = tools.mail.generate_tracking_message_id('private')
         return message_id
 
-    def _is_thread_message(self, vals=None, thread=None):
+    def _is_thread_message(self, vals=False, thread=None):
         """ Tool method to compute thread validity in notification methods. """
-        if vals is None:
-            vals = {}
+        vals = vals or {}
         res_model = vals['model'] if 'model' in vals else thread._name if thread else self.model
         res_id = vals['res_id'] if 'res_id' in vals else thread.ids[0] if thread and thread.ids else self.res_id
         return bool(res_id) if (res_model and res_model != 'mail.thread') else False
 
-    def _is_thread_message_visible(self, vals=None, thread=None):
+    def _is_thread_message_visible(self, vals=False, thread=None):
         """ In addition to being a thread message, it should not be a user specific
         notification that is recipient-specific. Used mainly for ACL purpose. """
         is_thread = self._is_thread_message(vals=vals, thread=thread)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3183,8 +3183,7 @@ class MailThread(models.AbstractModel):
             restricting_names=self._get_notify_valid_parameters()
         )
 
-        msg_vals = msg_vals if msg_vals else {}
-        recipients_data = self._notify_get_recipients(message, msg_vals, **kwargs)
+        recipients_data = self._notify_get_recipients(message, msg_vals=msg_vals, **kwargs)
         if not recipients_data:
             return recipients_data
         # cache data fetched by manual query to avoid extra queries when reading user.partner_id
@@ -3452,9 +3451,7 @@ class MailThread(models.AbstractModel):
             record_wlang = self.with_context(lang=lang)
             lang_model_description = model_description
             if not lang_model_description:
-                lang_model_description = record_wlang._get_model_description(
-                    msg_vals['model'] if msg_vals and msg_vals.get('model') else message.model
-                )
+                lang_model_description = record_wlang._get_model_description(msg_vals and msg_vals.get('model') or message.model)
             recipients_groups_list = record_wlang._notify_get_recipients_classify(
                 message,
                 lang_recipients_data,
@@ -3514,17 +3511,17 @@ class MailThread(models.AbstractModel):
 
         :return: dictionary of values used when rendering notification layout;
         """
-        if msg_vals is False:
-            msg_vals = {}
+        msg_vals = msg_vals or {}
+
         lang = force_email_lang if force_email_lang else self.env.lang
         record_wlang = self.with_context(lang=lang)
 
         # compute send user and its related signature; try to use self.env.user instead of browsing
         # user_ids if they are the author will give a sudo user, improving access performances and cache usage.
         signature = ''
-        email_add_signature = msg_vals.get('email_add_signature') if msg_vals and 'email_add_signature' in msg_vals else message.email_add_signature
+        email_add_signature = msg_vals['email_add_signature'] if 'email_add_signature' in msg_vals else message.email_add_signature
         if email_add_signature:
-            author = message.env['res.partner'].browse(msg_vals.get('author_id')) if 'author_id' in msg_vals else message.author_id
+            author = message.env['res.partner'].browse(msg_vals['author_id']) if 'author_id' in msg_vals else message.author_id
             author_user = self.env.user if self.env.user.partner_id == author else author.user_ids[0] if author and author.user_ids else False
             if author_user:
                 signature = author_user.signature
@@ -3542,10 +3539,8 @@ class MailThread(models.AbstractModel):
 
         # record, model
         if not model_description:
-            model_description = record_wlang._get_model_description(
-                msg_vals.get('model') if 'model' in msg_vals else message.model
-            )
-        record_name = msg_vals.get('record_name') if 'record_name' in msg_vals else message.record_name
+            model_description = record_wlang._get_model_description(msg_vals['model'] if 'model' in msg_vals else message.model)
+        record_name = msg_vals['record_name'] if 'record_name' in msg_vals else message.record_name
 
         # tracking: in case of missing value, perform search (skip only if sure we don't have any)
         check_tracking = msg_vals.get('tracking_value_ids', True) if msg_vals else bool(self)
@@ -3564,7 +3559,7 @@ class MailThread(models.AbstractModel):
                 ) for fmt_vals in tracking_values._tracking_value_format()
             ]
 
-        subtype_id = msg_vals.get('subtype_id') if msg_vals and 'subtype_id' in msg_vals else message.subtype_id.id
+        subtype_id = msg_vals['subtype_id'] if 'subtype_id' in msg_vals else message.subtype_id.id
         is_discussion = subtype_id == self.env['ir.model.data']._xmlid_to_res_id('mail.mt_comment')
 
         return {
@@ -3614,8 +3609,9 @@ class MailThread(models.AbstractModel):
         """
         if render_values is None:
             render_values = {}
+        msg_vals = msg_vals or {}
 
-        email_layout_xmlid = msg_vals.get('email_layout_xmlid') if msg_vals else message.email_layout_xmlid
+        email_layout_xmlid = msg_vals['email_layout_xmlid'] if 'email_layout_xmlid' in msg_vals else message.email_layout_xmlid
         template_xmlid = email_layout_xmlid if email_layout_xmlid else 'mail.mail_notification_layout'
 
         render_values = {**render_values, **recipients_group}
@@ -3711,8 +3707,7 @@ class MailThread(models.AbstractModel):
           directly. It lessens query count in some optimized use cases by avoiding
           access message content in db;
         """
-        msg_vals = dict(msg_vals or {})
-        partner_ids = self._extract_partner_ids_for_notifications(message, msg_vals, recipients_data)
+        partner_ids = self._extract_partner_ids_for_notifications(message, recipients_data, msg_vals=msg_vals)
         devices, private_key, public_key = self._get_web_push_parameters(partner_ids)
         if not devices:
             return
@@ -3780,32 +3775,26 @@ class MailThread(models.AbstractModel):
         This info will be delivered to a browser device via its recorded endpoint.
         REM: It is having a limit of 4000 bytes (4kb)
         """
-        if msg_vals:
-            author_id = [msg_vals.get('author_id')]
-            author_name = self.env['res.partner'].browse(author_id).name
-            model = msg_vals.get('model')
-            title = msg_vals.get('record_name') or msg_vals.get('subject')
-            res_id = msg_vals.get('res_id')
-            body = msg_vals.get('body')
-            if not model and body:
-                model, res_id = self._extract_model_and_id(msg_vals)
-        else:
-            author_id = message.author_id.ids
-            author_name = self.env['res.partner'].browse(author_id).name
-            model = message.model
-            title = message.record_name or message.subject
-            res_id = message.res_id
-            body = message.body
+        msg_vals = msg_vals or {}
+        author_id = msg_vals['author_id'] if 'author_id' in msg_vals else message.author_id.id
+        model = msg_vals['model'] if 'model' in msg_vals else message.model
+        title = msg_vals['record_name'] if 'record_name' in msg_vals else message.model
+        res_id = msg_vals['res_id'] if 'res_id' in msg_vals else message.res_id
+        body = msg_vals['body'] if 'body' in msg_vals else message.body
+        if not model and body:
+            model, res_id = self._extract_model_and_id(body)
 
-        icon = '/web/static/img/odoo-icon-192x192.png'
-
-        if author_name:
+        if author_id:
+            author_name = self.env['res.partner'].browse(author_id).name
             title = "%s: %s" % (author_name, title)
-            icon = "/web/image/res.partner/%d/avatar_128" % author_id[0]
+            icon = "/web/image/res.partner/%d/avatar_128" % author_id
+        else:
+            icon = '/web/static/img/odoo-icon-192x192.png'
 
-        payload = {
+        return {
             'title': title,
             'options': {
+                'body': html2plaintext(body) + self._generate_tracking_message(message),
                 'icon': icon,
                 'data': {
                     'model': model if model else '',
@@ -3813,12 +3802,8 @@ class MailThread(models.AbstractModel):
                 }
             }
         }
-        payload['options']['body'] = html2plaintext(body)
-        payload['options']['body'] += self._generate_tracking_message(message)
 
-        return payload
-
-    def _notify_get_recipients(self, message, msg_vals, **kwargs):
+    def _notify_get_recipients(self, message, msg_vals=False, **kwargs):
         """ Compute recipients to notify based on subtype and followers. This
         method returns data structured as expected for ``_notify_recipients``.
 
@@ -3862,11 +3847,13 @@ class MailThread(models.AbstractModel):
             'ushare': are users shared (if users, all users are shared);
           }, {...}]
         """
+        msg_vals = msg_vals or {}
         msg_sudo = message.sudo()
+
         # get values from msg_vals or from message if msg_vals doen't exists
-        pids = msg_vals.get('partner_ids', []) if msg_vals else msg_sudo.partner_ids.ids
-        message_type = msg_vals.get('message_type') if msg_vals else msg_sudo.message_type
-        subtype_id = msg_vals.get('subtype_id') if msg_vals else msg_sudo.subtype_id.id
+        pids = msg_vals['partner_ids'] if 'partner_ids' in msg_vals else msg_sudo.partner_ids.ids
+        message_type = msg_vals['message_type'] if 'message_type' in msg_vals else msg_sudo.message_type
+        subtype_id = msg_vals['subtype_id'] if 'subtype_id' in msg_vals else msg_sudo.subtype_id.id
         # is it possible to have record but no subtype_id ?
         recipients_data = []
 
@@ -3907,7 +3894,7 @@ class MailThread(models.AbstractModel):
 
         return recipients_data
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         """ Return groups used to classify recipients of a notification email.
         Groups is a list of tuple (group_name, group_func, group_data) where
 
@@ -3988,7 +3975,7 @@ class MailThread(models.AbstractModel):
             ],
         ]
 
-    def _notify_get_recipients_groups_fillup(self, groups, model_description, msg_vals=None):
+    def _notify_get_recipients_groups_fillup(self, groups, model_description, msg_vals=False):
         """ Iterate on recipients groups (see '_notify_get_recipients_groups')
         and fill up the result with default values, allowing to compute links or
         titles once.
@@ -4024,7 +4011,7 @@ class MailThread(models.AbstractModel):
         return groups
 
     def _notify_get_recipients_classify(self, message, recipients_data,
-                                        model_description, msg_vals=None):
+                                        model_description, msg_vals=False):
         """ Classify recipients to be notified of a message in groups to have
         specific rendering depending on their group. For example users could
         have access to buttons customers should not have in their emails.
@@ -4130,7 +4117,7 @@ class MailThread(models.AbstractModel):
         return hm
 
     @api.model
-    def _extract_model_and_id(self, msg_vals):
+    def _extract_model_and_id(self, html_content):
         """
         Return the model and the id when is present in a link (HTML)
 
@@ -4139,13 +4126,14 @@ class MailThread(models.AbstractModel):
         :return: a dict empty if no matches and a dict with these keys if match : model and res_id
         """
         regex = r"<a.+model=(?P<model>[\w.]+).+res_id=(?P<id>\d+).+>[\s\w\/\\.]+<\/a>"
-        matches = re.finditer(regex, msg_vals['body'])
+        matches = re.finditer(regex, html_content)
 
         for match in matches:
             return match['model'], match['id']
         return None, None
 
-    def _extract_partner_ids_for_notifications(self, message, msg_vals, recipients_data):
+    def _extract_partner_ids_for_notifications(self, message, recipients_data, msg_vals=None):
+        msg_vals = msg_vals or {}
         notif_pids = []
         no_inbox_pids = []
         for recipient in recipients_data:
@@ -4159,13 +4147,13 @@ class MailThread(models.AbstractModel):
 
         msg_sudo = message.sudo()
         msg_type = msg_vals.get('message_type') or msg_sudo.message_type
-        author_id = [msg_vals.get('author_id')] if 'author_id' in msg_vals else msg_sudo.author_id.ids
+        author_ids = [msg_vals.get('author_id') or msg_sudo.author_id.id]
         # never send to author and to people outside Odoo (email), except comments
         pids = set()
         if msg_type in {'comment', 'whatsapp_message'}:
-            pids = set(notif_pids) - set(author_id)
+            pids = set(notif_pids) - set(author_ids)
         elif msg_type in ('notification', 'user_notification', 'email'):
-            pids = (set(notif_pids) - set(author_id) - set(no_inbox_pids))
+            pids = (set(notif_pids) - set(author_ids) - set(no_inbox_pids))
         return list(pids)
 
     @api.model

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3779,8 +3779,6 @@ class MailThread(models.AbstractModel):
         title = msg_vals['record_name'] if 'record_name' in msg_vals else message.model
         res_id = msg_vals['res_id'] if 'res_id' in msg_vals else message.res_id
         body = msg_vals['body'] if 'body' in msg_vals else message.body
-        if not model and body:
-            model, res_id = self._extract_model_and_id(body)
 
         if author_id:
             author_name = self.env['res.partner'].browse(author_id).name
@@ -4133,20 +4131,6 @@ class MailThread(models.AbstractModel):
         token = '%s?%s' % (base_link, ' '.join('%s=%s' % (key, params[key]) for key in sorted(params)))
         hm = hmac.new(secret.encode('utf-8'), token.encode('utf-8'), hashlib.sha1).hexdigest()
         return hm
-
-    @api.model
-    def _extract_model_and_id(self, html_content):
-        """
-        Return the model and the id when is present in a link (HTML)
-        :param msg_vals: see :meth:`._notify_thread_by_web_push`
-        :return: a dict empty if no matches and a dict with these keys if match : model and res_id
-        """
-        regex = r"<a.+model=(?P<model>[\w.]+).+res_id=(?P<id>\d+).+>[\s\w\/\\.]+<\/a>"
-        matches = re.finditer(regex, html_content)
-
-        for match in matches:
-            return match['model'], match['id']
-        return None, None
 
     @api.model
     def _generate_tracking_message(self, message, return_line='\n'):

--- a/addons/mail/models/mail_thread_cc.py
+++ b/addons/mail/models/mail_thread_cc.py
@@ -31,7 +31,7 @@ class MailThreadCc(models.AbstractModel):
         return super().message_new(msg_dict, cc_values)
 
     def message_update(self, msg_dict, update_vals=None):
-        '''Adds cc email to self.email_cc while trying to keep email as raw as possible but unique'''
+        # Adds cc email to self.email_cc while trying to keep email as raw as possible but unique
         if update_vals is None:
             update_vals = {}
         cc_values = {}

--- a/addons/mass_mailing/models/mail_thread.py
+++ b/addons/mass_mailing/models/mail_thread.py
@@ -15,9 +15,9 @@ class MailThread(models.AbstractModel):
 
     @api.model
     def _message_route_process(self, message, message_dict, routes):
-        """ Override to update the parent mailing traces. The parent is found
-        by using the References header of the incoming message and looking for
-        matching message_id in mailing.trace. """
+        # Override to update the parent mailing traces. The parent is found
+        # by using the References header of the incoming message and looking for
+        # matching message_id in mailing.trace.
         if routes:
             # even if 'reply_to' in ref (cfr mail/mail_thread) that indicates a new thread redirection
             # (aka bypass alias configuration in gateway) consider it as a reply for statistics purpose
@@ -46,14 +46,14 @@ class MailThread(models.AbstractModel):
 
     @api.model
     def _routing_handle_bounce(self, email_message, message_dict):
-        """ In addition, an auto blacklist rule check if the email can be blacklisted
-        to avoid sending mails indefinitely to this email address.
-        This rule checks if the email bounced too much. If this is the case,
-        the email address is added to the blacklist in order to avoid continuing
-        to send mass_mail to that email address. If it bounced too much times
-        in the last month and the bounced are at least separated by one week,
-        to avoid blacklist someone because of a temporary mail server error,
-        then the email is considered as invalid and is blacklisted."""
+        # In addition, an auto blacklist rule check if the email can be blacklisted
+        # to avoid sending mails indefinitely to this email address.
+        # This rule checks if the email bounced too much. If this is the case,
+        # the email address is added to the blacklist in order to avoid continuing
+        # to send mass_mail to that email address. If it bounced too much times
+        # in the last month and the bounced are at least separated by one week,
+        # to avoid blacklist someone because of a temporary mail server error,
+        # then the email is considered as invalid and is blacklisted.
         super(MailThread, self)._routing_handle_bounce(email_message, message_dict)
 
         bounced_email = message_dict['bounced_email']
@@ -76,10 +76,6 @@ class MailThread(models.AbstractModel):
 
     @api.model
     def message_new(self, msg_dict, custom_values=None):
-        """ Overrides mail_thread message_new that is called by the mailgateway
-            through message_process.
-            This override updates the document according to the email.
-        """
         defaults = {}
 
         if isinstance(self, self.pool['utm.mixin']):

--- a/addons/portal/models/mail_thread.py
+++ b/addons/portal/models/mail_thread.py
@@ -17,7 +17,7 @@ class MailThread(models.AbstractModel):
         auto_join=True,
         help="Website communication history")
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         groups = super()._notify_get_recipients_groups(
             message, model_description, msg_vals=msg_vals
         )

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -659,7 +659,7 @@ class ProjectProject(models.Model):
                 res -= waiting_subtype
         return res
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         """ Give access to the portal user/customer if the project visibility is portal. """
         groups = super()._notify_get_recipients_groups(message, model_description, msg_vals=msg_vals)
         if not self:

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -457,7 +457,7 @@ class ProjectTask(models.Model):
                 personal_stage_by_user[user_id].sudo().write({'stage_id': stage.id})
 
     def message_subscribe(self, partner_ids=None, subtype_ids=None):
-        """ Set task notification based on project notification preference if user follow the project"""
+        # Set task notification based on project notification preference if user follow the project
         if not subtype_ids:
             project_followers = self.project_id.message_follower_ids.filtered(lambda f: f.partner_id.id in partner_ids)
             for project_follower in project_followers:
@@ -1464,7 +1464,7 @@ class ProjectTask(models.Model):
     def _notify_by_email_prepare_rendering_context(self, message, msg_vals=False, model_description=False,
                                                    force_email_company=False, force_email_lang=False):
         render_context = super()._notify_by_email_prepare_rendering_context(
-            message, msg_vals, model_description=model_description,
+            message, msg_vals=msg_vals, model_description=model_description,
             force_email_company=force_email_company, force_email_lang=force_email_lang
         )
         if self.stage_id:
@@ -1592,11 +1592,11 @@ class ProjectTask(models.Model):
                 res -= waiting_subtype
         return res
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
-        """ Handle project users and managers recipients that can assign
-        tasks and create new one directly from notification emails. Also give
-        access button to portal users and portal customers. If they are notified
-        they should probably have access to the document. """
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
+        # Handle project users and managers recipients that can assign
+        # tasks and create new one directly from notification emails. Also give
+        # access button to portal users and portal customers. If they are notified
+        # they should probably have access to the document.
         groups = super()._notify_get_recipients_groups(
             message, model_description, msg_vals=msg_vals
         )
@@ -1628,7 +1628,7 @@ class ProjectTask(models.Model):
         return groups
 
     def _notify_get_reply_to(self, default=None):
-        """ Override to set alias of tasks to their project if any. """
+        # Override to set alias of tasks to their project if any
         aliases = self.sudo().mapped('project_id')._notify_get_reply_to(default=default)
         res = {task.id: aliases.get(task.project_id.id) for task in self}
         leftover = self.filtered(lambda rec: not rec.project_id)
@@ -1653,10 +1653,6 @@ class ProjectTask(models.Model):
 
     @api.model
     def message_new(self, msg, custom_values=None):
-        """ Overrides mail_thread message_new that is called by the mailgateway
-            through message_process.
-            This override updates the document according to the email.
-        """
         # remove default author when going through the mail gateway. Indeed we
         # do not want to explicitly set user_id to False; however we do not
         # want the gateway user to be responsible if no other responsible is
@@ -1687,7 +1683,6 @@ class ProjectTask(models.Model):
         return task
 
     def message_update(self, msg, update_vals=None):
-        """ Override to update the task according to the email. """
         email_list = self.task_email_split(msg)
         partner_ids = [p.id for p in self.env['mail.thread']._mail_find_partner_from_emails(email_list, records=self, force_create=False) if p]
         self.message_subscribe(partner_ids)

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -387,9 +387,8 @@ class PurchaseOrder(models.Model):
             kwargs['notify_author'] = self.env.user.partner_id.id in (kwargs.get('partner_ids') or [])
         return super(PurchaseOrder, self.with_context(**po_ctx)).message_post(**kwargs)
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
-        """ Tweak 'view document' button for portal customers, calling directly
-        routes for confirm specific to PO model. """
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
+        # Tweak 'view document' button for portal customers, calling directly routes for confirm specific to PO model.
         groups = super()._notify_get_recipients_groups(
             message, model_description, msg_vals=msg_vals
         )
@@ -414,7 +413,7 @@ class PurchaseOrder(models.Model):
     def _notify_by_email_prepare_rendering_context(self, message, msg_vals=False, model_description=False,
                                                    force_email_company=False, force_email_lang=False):
         render_context = super()._notify_by_email_prepare_rendering_context(
-            message, msg_vals, model_description=model_description,
+            message, msg_vals=msg_vals, model_description=model_description,
             force_email_company=force_email_company, force_email_lang=force_email_lang
         )
         subtitles = [render_context['record'].name]

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1675,10 +1675,10 @@ class SaleOrder(models.Model):
             kwargs['notify_author'] = self.env.user.partner_id.id in (kwargs.get('partner_ids') or [])
         return super(SaleOrder, self.with_context(**so_ctx)).message_post(**kwargs)
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
-        """ Give access button to users and portal customer as portal is integrated
-        in sale. Customer and portal group have probably no right to see
-        the document so they don't have the access button. """
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
+        # Give access button to users and portal customer as portal is integrated
+        # in sale. Customer and portal group have probably no right to see
+        # the document so they don't have the access button.
         groups = super()._notify_get_recipients_groups(
             message, model_description, msg_vals=msg_vals
         )
@@ -1726,7 +1726,7 @@ class SaleOrder(models.Model):
     def _notify_by_email_prepare_rendering_context(self, message, msg_vals=False, model_description=False,
                                                    force_email_company=False, force_email_lang=False):
         render_context = super()._notify_by_email_prepare_rendering_context(
-            message, msg_vals, model_description=model_description,
+            message, msg_vals=msg_vals, model_description=model_description,
             force_email_company=force_email_company, force_email_lang=force_email_lang
         )
         lang_code = render_context.get('lang')

--- a/addons/sms/models/mail_thread.py
+++ b/addons/sms/models/mail_thread.py
@@ -219,7 +219,7 @@ class MailThread(models.AbstractModel):
     def _notify_thread(self, message, msg_vals=False, **kwargs):
         # Main notification method. Override to add support of sending OCN notifications.
         scheduled_date = self._is_notification_scheduled(kwargs.get('scheduled_date'))
-        recipients_data = super(MailThread, self)._notify_thread(message, msg_vals=msg_vals, **kwargs)
+        recipients_data = super()._notify_thread(message, msg_vals=msg_vals, **kwargs)
         if not scheduled_date:
             self._notify_thread_by_sms(message, recipients_data, msg_vals=msg_vals, **kwargs)
         return recipients_data
@@ -250,13 +250,14 @@ class MailThread(models.AbstractModel):
         :param put_in_queue: use cron to send queued SMS instead of sending them
           directly;
         """
+        msg_vals = msg_vals or {}
         sms_pid_to_number = sms_pid_to_number if sms_pid_to_number is not None else {}
         sms_numbers = sms_numbers if sms_numbers is not None else []
         sms_create_vals = []
         sms_all = self.env['sms.sms'].sudo()
 
         # pre-compute SMS data
-        body = sms_content or html2plaintext(msg_vals['body'] if msg_vals and 'body' in msg_vals else message.body)
+        body = sms_content or html2plaintext(msg_vals['body'] if 'body' in msg_vals else message.body)
         sms_base_vals = {
             'body': body,
             'mail_message_id': message.id,

--- a/addons/test_mail/models/mail_test_ticket.py
+++ b/addons/test_mail/models/mail_test_ticket.py
@@ -39,9 +39,8 @@ class MailTestTicket(models.Model):
             } for record in self
         }
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
-        """ Activate more groups to test query counters notably (and be backward
-        compatible for tests). """
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
+        # Activate more groups to test query counters notably (and be backward compatible for tests)
         groups = super()._notify_get_recipients_groups(
             message, model_description, msg_vals=msg_vals
         )
@@ -188,9 +187,8 @@ class MailTestContainer(models.Model):
             } for record in self
         }
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
-        """ Activate more groups to test query counters notably (and be backward
-        compatible for tests). """
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
+        # Activate more groups to test query counters notably (and be backward compatible for tests)
         groups = super()._notify_get_recipients_groups(
             message, model_description, msg_vals=msg_vals
         )

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -72,13 +72,10 @@ class MailTestLang(models.Model):
     def _mail_get_partner_fields(self, introspect_fields=False):
         return ['customer_id']
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         groups = super()._notify_get_recipients_groups(
             message, model_description, msg_vals=msg_vals
         )
-
-        local_msg_vals = dict(msg_vals or {})
-
         for group in [g for g in groups if g[0] in('follower', 'customer')]:
             group_options = group[2]
             group_options['has_button_access'] = True

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -91,8 +91,6 @@ class MailTestGateway(models.Model):
 
     @api.model
     def message_new(self, msg_dict, custom_values=None):
-        """ Check override of 'message_new' allowing to update record values
-        base on incoming email. """
         defaults = {
             'email_from': msg_dict.get('from'),
         }

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -432,7 +432,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 composer_form.attachment_ids.add(attachment)
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=49, employee=59):  # tm 48/48
+        with self.assertQueryCount(admin=49, employee=49):  # tm 48/48
             composer._action_send_mail()
 
         # notifications

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -288,8 +288,7 @@ class BlogPost(models.Model):
             'res_id': self.id,
         }
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
-        """ Add access button to everyone if the document is published. """
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         groups = super()._notify_get_recipients_groups(
             message, model_description, msg_vals=msg_vals
         )
@@ -304,11 +303,10 @@ class BlogPost(models.Model):
         return groups
 
     def _notify_thread_by_inbox(self, message, recipients_data, msg_vals=False, **kwargs):
-        """ Override to avoid keeping all notified recipients of a comment.
-        We avoid tracking needaction on post comments. Only emails should be
-        sufficient. """
-        if msg_vals is None:
-            msg_vals = {}
+        # Override to avoid keeping all notified recipients of a comment.
+        # We avoid tracking needaction on post comments. Only emails should be
+        # sufficient.
+        msg_vals = msg_vals or {}
         if msg_vals.get('message_type', message.message_type) == 'comment':
             return
         return super(BlogPost, self)._notify_thread_by_inbox(message, recipients_data, msg_vals=msg_vals, **kwargs)

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -738,8 +738,7 @@ class ForumPost(models.Model):
                     raise AccessError(_('%d karma required to edit a post.', post.karma_edit))
         return super()._get_mail_message_access(res_ids, operation, model_name=model_name)
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
-        """ Add access button to everyone if the document is active. """
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         groups = super()._notify_get_recipients_groups(
             message, model_description, msg_vals=msg_vals
         )
@@ -775,11 +774,10 @@ class ForumPost(models.Model):
         return super().message_post(message_type=message_type, **kwargs)
 
     def _notify_thread_by_inbox(self, message, recipients_data, msg_vals=False, **kwargs):
-        """ Override to avoid keeping all notified recipients of a comment.
-        We avoid tracking needaction on post comments. Only emails should be
-        sufficient. """
-        if msg_vals is None:
-            msg_vals = {}
+        # Override to avoid keeping all notified recipients of a comment.
+        # We avoid tracking needaction on post comments. Only emails should be
+        # ufficient.
+        msg_vals = msg_vals or {}
         if msg_vals.get('message_type', message.message_type) == 'comment':
             return
         return super()._notify_thread_by_inbox(message, recipients_data, msg_vals=msg_vals, **kwargs)

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -548,8 +548,7 @@ class SaleOrder(models.Model):
         sent_orders.write({'cart_recovery_email_sent': True})
 
     def _message_mail_after_hook(self, mails):
-        """ After sending recovery cart emails, update orders to avoid sending
-        it again. """
+        # After sending recovery cart emails, update orders to avoid sending it again
         if self.env.context.get('website_sale_send_recovery_email'):
             self.filtered_domain([
                 ('cart_recovery_email_sent', '=', False),
@@ -558,15 +557,14 @@ class SaleOrder(models.Model):
         return super()._message_mail_after_hook(mails)
 
     def _message_post_after_hook(self, message, msg_vals):
-        """ After sending recovery cart emails, update orders to avoid sending
-        it again. """
+        # After sending recovery cart emails, update orders to avoid sending it again
         if self.env.context.get('website_sale_send_recovery_email'):
             self.cart_recovery_email_sent = True
         return super()._message_post_after_hook(message, msg_vals)
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
-        """ In case of cart recovery email, update link to redirect directly
-        to the cart (like ``mail_template_sale_cart_recovery`` template). """
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
+        # In case of cart recovery email, update link to redirect directly
+        # to the cart (like ``mail_template_sale_cart_recovery`` template).
         groups = super()._notify_get_recipients_groups(
             message, model_description, msg_vals=msg_vals
         )

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -734,8 +734,7 @@ class SlideSlide(models.Model):
             }
         return super()._get_access_action(access_uid=access_uid, force_website=force_website)
 
-    def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):
-        """ Add access button to everyone if the document is active. """
+    def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         groups = super()._notify_get_recipients_groups(
             message, model_description, msg_vals=msg_vals
         )

--- a/addons/website_slides/tests/test_gamification_karma.py
+++ b/addons/website_slides/tests/test_gamification_karma.py
@@ -147,7 +147,7 @@ class TestKarmaGain(common.SlidesCase):
             self.assertEqual(user_trackings[1].origin_ref, self.channel)
 
         # now, remove the membership in batch, on multiple users - karma should not move as we only archive membership
-        with self.assertQueryCount(10):
+        with self.assertQueryCount(8):
             (self.channel | self.channel_2)._remove_membership(users.partner_id.ids)
 
         for user in users:


### PR DESCRIPTION
Consider 'msg_vals' propagated through layers of notification is False
by default, not sometimes None or False. Add fallback to avoid trying
to access keys of False/None. Correctly update some old writing. Be
sure to use a writing that allows to skip message access in simple
cases, as it was build to avoid useless queries.

Update overrides docstrings: use comments to avoid overriding the base
docstring.

Rename / remove outdated code. Update some left query counters.

Prepares Task-4273479: [mail] Email-like recipients