### PR TITLE
[IMP] hw_posbox_homepage: ui while access point mode

### DIFF
--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -117,7 +117,7 @@ export class Homepage extends Component {
             <div class="d-flex mb-4 flex-column align-items-center justify-content-center">
                 <h4 class="text-center m-0">IoT Box - <t t-esc="state.data.hostname" /></h4>
             </div>
-            <div t-if="this.store.advanced" t-att-class="'alert ' + (state.data.is_certificate_ok === true ? 'alert-info' : 'alert-warning')" role="alert">
+            <div t-if="store.advanced" t-att-class="'alert ' + (state.data.is_certificate_ok === true ? 'alert-info' : 'alert-warning')" role="alert">
                 <p class="m-0 fw-bold">HTTPS Certificate</p>
                 <small>
                     <t t-if="state.data.is_certificate_ok === true">Status: </t>
@@ -125,35 +125,39 @@ export class Homepage extends Component {
                     <t t-esc="state.data.certificate_details" />
                 </small>
             </div>
+            <div t-if="store.base.is_access_point_up" class="alert alert-info" role="alert">
+                <p class="m-0 fw-bold">Access Point Mode</p>
+                <small>Please connect your IoT Box to a Wi-Fi network (or plug an ethernet cable in) in order to connect it to an Odoo database.</small>
+            </div>
             <SingleData name="'Name'" value="state.data.hostname" icon="'fa-id-card'">
 				<t t-set-slot="button">
 					<ServerDialog t-if="this.store.isLinux" />
 				</t>
 			</SingleData>
-            <SingleData t-if="this.store.advanced" name="'Version'" value="state.data.version" icon="'fa-microchip'">
+            <SingleData t-if="store.advanced and !store.base.is_access_point_up" name="'Version'" value="state.data.version" icon="'fa-microchip'">
                 <t t-set-slot="button">
                     <UpdateDialog t-if="this.store.isLinux" />
                 </t>
             </SingleData>
-            <SingleData t-if="this.store.advanced" name="'IP address'" value="state.data.ip" icon="'fa-globe'" />
-            <SingleData t-if="this.store.advanced" name="'MAC address'" value="state.data.mac.toUpperCase()" icon="'fa-address-card'" />
-            <SingleData t-if="this.store.isLinux" name="'Internet Status'" value="networkStatus" icon="'fa-wifi'">
+            <SingleData t-if="store.advanced" name="'IP address'" value="state.data.ip" icon="'fa-globe'" />
+            <SingleData t-if="store.advanced" name="'MAC address'" value="state.data.mac.toUpperCase()" icon="'fa-address-card'" />
+            <SingleData t-if="store.isLinux" name="'Internet Status'" value="networkStatus" icon="'fa-wifi'">
                 <t t-set-slot="button">
                     <WifiDialog />
                 </t>
             </SingleData>
-            <SingleData name="'Odoo database connected'" value="state.data.server_status" icon="'fa-link'">
+            <SingleData t-if="!store.base.is_access_point_up" name="'Odoo database connected'" value="state.data.server_status" icon="'fa-link'">
 				<t t-set-slot="button">
 					<ServerDialog />
 				</t>
 			</SingleData>
-            <SingleData t-if="state.data.pairing_code" name="'Pairing Code'" value="state.data.pairing_code" icon="'fa-code'"/>
-            <SingleData  t-if="this.store.advanced" name="'Six terminal'" value="state.data.six_terminal" icon="'fa-money'">
+            <SingleData t-if="state.data.pairing_code and !this.store.base.is_access_point_up" name="'Pairing Code'" value="state.data.pairing_code" icon="'fa-code'"/>
+            <SingleData  t-if="store.advanced and !store.base.is_access_point_up" name="'Six terminal'" value="state.data.six_terminal" icon="'fa-money'">
                 <t t-set-slot="button">
                     <SixDialog />
                 </t>
             </SingleData>
-            <SingleData name="'Devices'" value="numDevices + ' devices'" icon="'fa-plug'">
+            <SingleData t-if="!this.store.base.is_access_point_up" name="'Devices'" value="numDevices + ' devices'" icon="'fa-plug'">
                 <t t-set-slot="button">
                     <DeviceDialog />
                 </t>

--- a/addons/hw_posbox_homepage/static/src/app/components/FooterButtons.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/FooterButtons.js
@@ -21,8 +21,12 @@ export class FooterButtons extends Component {
 
     static template = xml`
     <div class="w-100 d-flex flex-wrap align-items-cente gap-2 justify-content-center">
-        <a t-if="this.store.isLinux" class="btn btn-primary btn-sm" t-att-href="'http://' + this.store.base.ip + '/status'" target="_blank">Status Display</a>
-        <a t-if="this.store.isLinux" class="btn btn-primary btn-sm" t-att-href="'http://' + this.store.base.ip + ':631'" target="_blank">Printer Server</a>
+        <a t-if="store.isLinux and !store.base.is_access_point_up" class="btn btn-primary btn-sm" t-att-href="'http://' + this.store.base.ip + '/status'" target="_blank">
+            Status Display
+        </a>
+        <a t-if="store.isLinux and !store.base.is_access_point_up" class="btn btn-primary btn-sm" t-att-href="'http://' + this.store.base.ip + ':631'" target="_blank">
+            Printer Server
+        </a>
         <RemoteDebugDialog t-if="this.store.advanced and this.store.isLinux" />
         <CredentialDialog t-if="this.store.advanced" />
         <HandlerDialog t-if="this.store.advanced" />

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/DeviceDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/DeviceDialog.js
@@ -5,7 +5,7 @@ import { BootstrapDialog } from "./BootstrapDialog.js";
 
 const { Component, xml } = owl;
 
-const DEVICE_ICONS = {
+export const DEVICE_ICONS = {
     camera: "fa-camera",
     device: "fa-plug",
     display: "fa-desktop",

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/WifiDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/WifiDialog.js
@@ -80,7 +80,7 @@ export class WifiDialog extends Component {
     static template = xml`
         <LoadingFullScreen t-if="this.state.waitRestart">
             <t t-set-slot="body">
-                Processing your request please wait...
+                Updating Wi-Fi configuration, please wait...
             </t>
         </LoadingFullScreen>
 

--- a/addons/hw_posbox_homepage/static/src/app/css/status_display.css
+++ b/addons/hw_posbox_homepage/static/src/app/css/status_display.css
@@ -33,3 +33,7 @@ body {
 .device-type {
     text-transform: capitalize;
 }
+
+ul {
+    padding-left: 18px;
+}

--- a/addons/hw_posbox_homepage/static/src/app/status.js
+++ b/addons/hw_posbox_homepage/static/src/app/status.js
@@ -1,4 +1,5 @@
 /* global owl */
+import { DEVICE_ICONS } from "./components/dialog/DeviceDialog.js";
 
 const { Component, mount, xml, useState } = owl;
 
@@ -7,6 +8,7 @@ class StatusPage extends Component {
 
     setup() {
         this.state = useState({ data: {}, loading: true });
+        this.icons = DEVICE_ICONS;
 
         this.loadInitialData();
         setInterval(() => {
@@ -28,7 +30,6 @@ class StatusPage extends Component {
     <div t-if="!state.loading" class="container-fluid">
         <div class="text-center pt-5">
             <img class="odoo-logo" src="/web/static/img/logo2.png" alt="Odoo logo"/>
-            <p class="iotbox-name mt-3">IoT Box: <t t-out="state.data.hostname"/></p>
         </div>
         <div class="status-display-boxes">
             <div t-if="state.data.pairing_code" class="status-display-box">
@@ -36,36 +37,45 @@ class StatusPage extends Component {
                 <hr/>
                 <h4 t-out="state.data.pairing_code" class="text-center mb-3"/>
             </div>
+            <div t-if="state.data.is_access_point_up" class="status-display-box">
+                <h4 class="text-center mb-3">Access Point Mode</h4>
+                <hr/>
+                <p class="mb-3">
+                    Please connect your IoT Box to a Wi-Fi network (or plug an ethernet cable in) in order to connect it to an Odoo database.
+                </p>
+            </div>
             <div class="status-display-box">
                 <h4 class="text-center mb-3">Status display</h4>
-                <h5 class="text-center mb-1">IoT Interfaces</h5>
+                
+                <h5 class="mb-1">General</h5>
                 <table class="table table-hover table-sm">
-                    <thead>
-                        <tr>
-                            <th>Type</th>
-                            <th>IP</th>
-                        </tr>
-                    </thead>
                     <tbody>
-                        <tr t-foreach="state.data.network_interfaces" t-as="interface" t-key="interface.id">
-                            <td><i t-att-class="'me-1 fa fa-fw fa-' + (interface.is_wifi ? 'wifi' : 'sitemap')"/><t t-out="interface.is_wifi ? interface.ssid : 'Ethernet'"/></td>
-                            <td t-out="interface.ip"/>
+                        <tr>
+                            <td class="col-3"><i class="me-1 fa fa-fw fa-id-card"/>Name</td>
+                            <td class="col-3" t-out="state.data.hostname"/>
                         </tr>
                     </tbody>
                 </table>
+                
+                <h5 class="mb-1">Interfaces</h5>
+                <table class="table table-hover table-sm">
+                    <tbody>
+                        <tr t-foreach="state.data.network_interfaces" t-as="interface" t-key="interface.id">
+                            <td class="col-3"><i t-att-class="'me-1 fa fa-fw fa-' + (interface.is_wifi ? 'wifi' : 'sitemap')"/><t t-out="interface.is_wifi ? interface.ssid : 'Ethernet'"/></td>
+                            <td class="col-3" t-out="interface.ip"/>
+                        </tr>
+                    </tbody>
+                </table> 
                 <div t-if="Object.keys(state.data.devices).length > 0">
-                    <h5 class="text-center mb-1">IoT Devices</h5>
+                    <h5 class="mb-1">Devices</h5>
                     <table class="table table-hover table-sm">
-                        <thead>
-                            <tr>
-                                <th>Type</th>
-                                <th>Devices</th>
-                            </tr>
-                        </thead>
                         <tbody>
                             <tr t-foreach="Object.keys(state.data.devices)" t-as="deviceType" t-key="deviceType">
-                                <td t-out="deviceType.replaceAll('_', ' ') + 's'" class="device-type"/>
-                                <td>
+                                <td class="device-type col-3">
+                                    <i t-att-class="'me-1 fa fa-fw fa- ' + icons[deviceType]"/>
+                                    <t t-out="deviceType.replaceAll('_', ' ') + 's'" />
+                                </td>
+                                <td class="col-3">
                                     <ul>
                                         <li t-foreach="state.data.devices[deviceType].slice(0, 10)" t-as="device" t-key="device.identifier">
                                             <t t-out="device.name"/>


### PR DESCRIPTION
Since the refactor to use OWL instead of jinja, we do not display a specific page when the IoT Box is in access point mode.
We added more conditions to display less elements on the homepage for the user to know that he needs to configure a Wi-Fi network on the IoT Box.

Task: 4403617

![image](https://github.com/user-attachments/assets/ceee99bc-1d68-4631-8c3d-2d246b59112a)
![image](https://github.com/user-attachments/assets/0e8769fb-1c5a-4aca-999d-5e753f327951)