### PR TITLE
[FIX]repair: `action_create_sale_order` for multiple repairs

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -348,9 +348,9 @@ class Repair(models.Model):
         sale_order_values_list = []
         for repair in self:
             sale_order_values_list.append({
-                "company_id": self.company_id.id,
-                "partner_id": self.partner_id.id,
-                "warehouse_id": self.picking_type_id.warehouse_id.id,
+                "company_id": repair.company_id.id,
+                "partner_id": repair.partner_id.id,
+                "warehouse_id": repair.picking_type_id.warehouse_id.id,
                 "repair_order_ids": [Command.link(repair.id)],
             })
         self.env['sale.order'].create(sale_order_values_list)
@@ -537,12 +537,19 @@ class Repair(models.Model):
         }
 
     def action_view_sale_order(self):
-        return {
+        sale_order_ids = self.mapped('sale_order_id.id')
+        action_window = {
             "type": "ir.actions.act_window",
             "res_model": "sale.order",
-            "views": [[False, "form"]],
-            "res_id": self.sale_order_id.id,
+            "name": _("Sales Order"),
         }
+        if len(sale_order_ids) == 1:
+            action_window["views"] = [[False, "form"]]
+            action_window["res_id"] = sale_order_ids[0]
+        else:
+            action_window["views"] = [[False, "tree"], [False, "form"]]
+            action_window["domain"] = [["id", "in", sale_order_ids]]
+        return action_window
 
     def print_repair_order(self):
         return self.env.ref('repair.action_report_repair_order').report_action(self)

--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -22,3 +22,4 @@ Bernat Puig bernat.puig@forgeflow.com https://github.com/BernatPForgeFlow
 Joan Sisquella joan.sisquella@forgeflow.com https://github.com/JoanSForgeFlow
 Laura Cazorla laura.cazorla@forgeflow.com https://github.com/LauraCForgeFlow
 Arnau Cruz arnau.cruz@forgeflow.com https://github.com/ArnauCForgeFlow
+Guillem Casassas guillem.casassas@forgeflow.com https://github.com/GuillemCForgeFlow


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

As the method is thought to be working with more than one repair (multi-record), when creating the Sales Orders, the values for `company_id`, `partner_id` and `warehouse_id` should be from the current `repair` within the iteration.

Also, for the case where Sales Orders are created from multiple Repair Orders, return the Window Action with the correct values: tree view if more than one record, form view only otherwise.

Current behavior before PR:

When creating Sales Orders from multiple Repair Orders, it may fail due to having different values on `company_id`, `partner_id` or `warehouse_id`.

Desired behavior after PR is merged:

If it is needed to create multiple Sales Order from more than one Repair Order, do not fail.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
