### PR TITLE
[FIX] web: memory leak in Hoot tests

### DIFF
--- a/addons/web/static/tests/_framework/env_test_helpers.js
+++ b/addons/web/static/tests/_framework/env_test_helpers.js
@@ -7,6 +7,7 @@ import { pick } from "@web/core/utils/objects";
 import { patch } from "@web/core/utils/patch";
 import { makeEnv, startServices } from "@web/env";
 import { MockServer, makeMockServer } from "./mock_server/mock_server";
+import { allowedFns } from "@web/core/py_js/py_interpreter";
 
 /**
  * @typedef {Record<keyof Services, any>} Dependencies
@@ -102,6 +103,14 @@ export async function makeMockEnv(partialEnv, { makeNew = false } = {}) {
             }
             translatedTerms[translationLoaded] = false;
         }
+
+        // Ideally: should be done in a patch of the company service, but this
+        // is less intrusive for now.
+        allowedFns.forEach((fn) => {
+            if (fn.name === "has") {
+                allowedFns.delete(fn);
+            }
+        });
     });
     Object.assign(currentEnv, partialEnv, createDebugContext(currentEnv)); // This is needed if the views are in debug mode
 


### PR DESCRIPTION
Since [1], the company service adds the `has` function to the list of allowed functions for the Python interpreter each time it starts.
The problem with this is that each test will start all services, for independence reasons. This means that the function is added multiple times without a proper clean-up.

This commit removes the `has` function from the allowed functions for the Python interpreter after each test has finished.

Note that, the side effects of the localization services are removed on the same way.
