### PR TITLE
[FIX] sale: allow multiple companies in recordsets when creating product.template records

### DIFF
--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from collections import defaultdict
+
 import json
 import logging
 
@@ -64,19 +66,28 @@ class ProductTemplate(models.Model):
     def _check_sale_product_company(self):
         """Ensure the product is not being restricted to a single company while
         having been sold in another one in the past, as this could cause issues."""
-        target_company = self.company_id
-        if target_company:  # don't prevent writing `False`, should always work
-            product_data = self.env['product.product'].sudo().with_context(active_test=False).search_read([('product_tmpl_id', 'in', self.ids)], fields=['id'])
-            product_ids = list(map(lambda p: p['id'], product_data))
-            so_lines = self.env['sale.order.line'].sudo().search_read([('product_id', 'in', product_ids), ('company_id', '!=', target_company.id)], fields=['id', 'product_id'])
-            used_products = list(map(lambda sol: sol['product_id'][1], so_lines))
+        products_by_company = defaultdict(lambda: self.env['product.template'])
+        for product in self:
+            if not product.product_variant_ids or not product.company_id:
+                # No need to check if the product has just being created (`product_variant_ids` is
+                # still empty) or if we're writing `False` on its company (should always work.)
+                continue
+            products_by_company[product.company_id] |= product
+
+        for target_company, products in products_by_company.items():
+            subquery_products = self.env['product.product'].sudo().with_context(active_test=False)._search([('product_tmpl_id', 'in', products.ids)])
+            so_lines = self.env['sale.order.line'].sudo().search_read(
+                [('product_id', 'in', subquery_products), ('company_id', '!=', target_company.id)],
+                fields=['id', 'product_id']
+            )
             if so_lines:
+                used_products = [sol['product_id'][1] for sol in so_lines]
                 raise ValidationError(_('The following products cannot be restricted to the company'
-                                        ' %s because they have already been used in quotations or '
-                                        'sales orders in another company:\n%s\n'
+                                        ' %(company)s because they have already been used in quotations or '
+                                        'sales orders in another company:\n%(used_products)s\n'
                                         'You can archive these products and recreate them '
                                         'with your company restriction instead, or leave them as '
-                                        'shared product.') % (target_company.name, ', '.join(used_products)))
+                                        'shared product.', company=target_company.name, used_products=', '.join(used_products)))
 
     def action_view_sales(self):
         action = self.env["ir.actions.actions"]._for_xml_id("sale.report_all_channels_sales_action")

--- a/addons/sale/tests/test_onchange.py
+++ b/addons/sale/tests/test_onchange.py
@@ -68,3 +68,20 @@ class TestSaleOnchanges(TransactionCase):
         })
 
         self.assertFalse(sale_order_line.product_id.id)
+
+    def test_create_products_in_different_companies(self):
+        """ Ensures the product's constrain on `company_id` doesn't block the creation of multiple
+        products in different companies (see `product.template` `_check_sale_product_company`.)
+        """
+        company_a = self.env['res.company'].create({'name': 'Company A'})
+        company_b = self.env['res.company'].create({'name': 'Company B'})
+        products = self.env['product.template'].create([
+            {'name': "Product Test 1", 'company_id': company_a.id},
+            {'name': "Product Test 2", 'company_id': company_b.id},
+            {'name': "Product Test 3", 'company_id': False},
+        ])
+        self.assertRecordValues(products, [
+            {'company_id': company_a.id},
+            {'company_id': company_b.id},
+            {'company_id': False},
+        ])


### PR DESCRIPTION
Backport commit 454f861

Versions affected:
- 16.0
- 17.0

Before this commit, the `product.template` constrains `_check_sale_product_company` didn't work if the recordset contains products from different companies, causing a traceback.

How to reproduce:
- Create multiple products at once in different companies. For example, in the shell of a newly created DB: - company_b, company_a = self.env["res.company"].search([]) - products = self.env["product.product"].create([ {'name': "prod1", 'company_id': company_a.id}, {'name': "prod2", 'company_id': company_b.id}]) -> Traceback.

To fix this issue, this commit groups products by their company in `_check_sale_product_company`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
