### PR TITLE
[PERF] mail: speedup GC when deleting ir.attachment

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -107,7 +107,7 @@ class MailThread(models.AbstractModel):
         'Number of errors', compute='_compute_message_has_error',
         help="Number of messages with delivery error")
     message_attachment_count = fields.Integer('Attachment Count', compute='_compute_message_attachment_count', groups="base.group_user")
-    message_main_attachment_id = fields.Many2one(string="Main Attachment", comodel_name='ir.attachment', copy=False)
+    message_main_attachment_id = fields.Many2one(string="Main Attachment", comodel_name='ir.attachment', copy=False, index='btree_not_null')
 
     @api.depends('message_follower_ids')
     def _compute_message_partner_ids(self):


### PR DESCRIPTION
##### This PR is a backport of https://github.com/odoo/odoo/pull/183302/commits/f9c2c8f382abbb1b18e5e2edb39c02c14819844b. It adds a index in the field message_main_attachment_id to reduce the time of deleting attachments due to Fkeys checks.
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
