### PR TITLE
[FIX] stock: allow lot to be used by branches

### DIFF
--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -124,7 +124,10 @@ class StockLot(models.Model):
     @api.depends('product_id.company_id')
     def _compute_company_id(self):
         for lot in self:
-            lot.company_id = lot.product_id.company_id
+            if self.env.company in lot.product_id.company_id.all_child_ids and lot.product_id.company_id not in self.env.companies:
+                lot.company_id = self.env.company
+            else:
+                lot.company_id = lot.product_id.company_id
 
     @api.depends('name')
     def _compute_display_complete(self):

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -698,10 +698,13 @@ class StockMoveLine(models.Model):
 
     def _prepare_new_lot_vals(self):
         self.ensure_one()
-        return {
+        vals =  {
             'name': self.lot_name,
             'product_id': self.product_id.id,
         }
+        if self.product_id.company_id and self.company_id in (self.product_id.company_id.all_child_ids | self.product_id.company_id):
+            vals['company_id'] = self.company_id.id
+        return vals
 
     def _create_and_assign_production_lot(self):
         """ Creates and assign new production lots for move lines."""


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a “Company A” and a “ branch 1” linked to this company
- Create a storable product “P1”:
    - limited to Company A

- Select only the branch 1 as current company
- Create a receipt for one unit of P1
- Mark it as to do.
- Try to create a lot or use lot created in Company A

Problem:
An acces error is raised:
`Incompatible companies on records:
- 'Product B' belongs to company 'Branch X' and 'Lot/Serial Number' (lot_id: 'sn_test') belongs to another company.`

opw-4415565
