### PR TITLE
[FIX] project: show subtasks in project if converted into tasks

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1266,6 +1266,8 @@ class Task(models.Model):
                         if not project_link:
                             project_link = link_per_project_id[task.project_id.id] = task.project_id._get_html_link(title=task.project_id.display_name)
                         project_link_per_task_id[task.id] = project_link
+        if vals.get('parent_id') is False:
+            vals['display_in_project'] = True
         result = super().write(vals)
         if portal_can_write:
             super(Task, self_no_sudo).write(vals_no_sudo)

--- a/addons/project/tests/test_project_subtasks.py
+++ b/addons/project/tests/test_project_subtasks.py
@@ -542,3 +542,18 @@ class TestProjectSubtasks(TestProjectCommon):
             task_form.parent_id = Task
         self.assertEqual(task.project_id, self.task_1.project_id, "project_id should be affected")
         self.assertTrue(task.display_in_project, "display_in_project should be True when there is no parent task")
+
+    def test_invisible_subtask_became_visible_when_converted_to_task(self):
+        task = self.env['project.task'].create({
+            'name': 'Parent task',
+            'project_id': self.project_goats.id,
+            'child_ids': [Command.create({'name': 'Sub-task invisible', 'project_id': self.project_goats.id})],
+        })
+        invisible_subtask = task.child_ids
+
+        self.assertFalse(invisible_subtask.display_in_project)
+
+        with Form(invisible_subtask, view="project.project_task_convert_to_subtask_view_form") as subtask_form:
+            subtask_form.parent_id = self.env['project.task']
+
+        self.assertTrue(invisible_subtask.display_in_project)


### PR DESCRIPTION
Steps to reproduce:
1. Create a task, and a subtask
3. Open the subtask
4. From the gear icon, click "Convert to Task/Sub-Task"
5. Remove the parent task and click "Convert Task"
6. Go to the project dashboard > the subtask is not shown.

Why?
The above reproducing steps lead to the subtask having the `display_in_project` stored as `False`, hence it's not visible on the dashboard page. This is because `_compute_project_id` interrupted the computation flow of `display_in_project` by a call to `remove_to_compute` [1].

Fix:
In the `write` method, explicitly set `display_in_project` to `True` if the parent_id has been removed.

[1]: https://github.com/odoo/odoo/blob/9dec8329523d4966243c6491e7e556e643af6cdf/addons/project/models/project_task.py#L337

opw-4384222