### PR TITLE
[FIX] website_sale: video uploads

### DIFF
--- a/addons/website_sale/views/product_image_views.xml
+++ b/addons/website_sale/views/product_image_views.xml
@@ -41,6 +41,7 @@
         <field name="model">product.image</field>
         <field name="arch" type="xml">
             <kanban string="Product Images" default_order="sequence">
+                <field name="video_url" invisible="1"/>
                 <field name="sequence" widget="handle"/>
                 <templates>
                     <t t-name="card" class="p-0 border-0">


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a product template.
2. Press the "Add Media" button in the "Sale" tab of the product form.
3. Try to add a video by pasting the URL.
4. Pressing "Add" displays multiple error messages, one on top of each other.

Issue
-----
Impossible to add a video as extra media for a product.

Cause
-----
The `video_url` field is not loaded by the Kanban view, which is used by the `X2ManyMediaViewer` to display the `product.image`. Therefore, updating the `video_url` caused a series of “ field not found” bugs.

Solution
--------
Add the `video_url` to the Kanban view of the `product.image` model.

opw-4391126

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
