### PR TITLE
[FIX] point_of_sale: customer display "get" action

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
@@ -155,7 +155,9 @@ export class ClosePosPopup extends Component {
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
-                    action: "close",
+                    params: {
+                        action: "close",
+                    },
                 }),
             }).catch(() => {
                 console.log("Failed to send data to customer display");

--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -126,9 +126,11 @@ export class Navbar extends Component {
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
-                    action: "open",
-                    access_token: this.pos.config.access_token,
-                    id: this.pos.config.id,
+                    params: {
+                        action: "open",
+                        access_token: this.pos.config.access_token,
+                        id: this.pos.config.id,
+                    },
                 }),
             })
                 .then(() => {

--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -71,8 +71,10 @@ export class Chrome extends Component {
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
-                    action: "set",
-                    data: selectedOrder.getCustomerDisplayData(),
+                    params: {
+                        action: "set",
+                        data: selectedOrder.getCustomerDisplayData(),
+                    },
                 }),
             }).catch(() => {
                 console.log("Failed to send data to customer display");

--- a/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
@@ -3,11 +3,10 @@ import { deduceUrl, getOnNotified } from "@point_of_sale/utils";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 import { _t } from "@web/core/l10n/translation";
-import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
 export const CustomerDisplayDataService = {
-    dependencies: ["bus_service", "dialog"],
-    async start(env, { bus_service, dialog }) {
+    dependencies: ["bus_service", "notification"],
+    async start(env, { bus_service, notification }) {
         const data = reactive({});
         if (session.type === "local") {
             new BroadcastChannel("UPDATE_CUSTOMER_DISPLAY").onmessage = (event) => {
@@ -34,20 +33,24 @@ export const CustomerDisplayDataService = {
                                 "Content-Type": "application/json",
                             },
                             body: JSON.stringify({
-                                action: "get",
+                                params: {
+                                    action: "get",
+                                },
                             }),
                         }
                     );
                     const payload = await response.json();
                     Object.assign(data, payload.result.data);
                 } catch (error) {
-                    dialog.add(AlertDialog, {
-                        title: _t("IoT customer display error"),
-                        body: _t(
-                            "Error: %s.\nMake sure there is an IoT Box subscription associated with your Odoo database, then restart the IoT Box.",
-                            error
+                    notification.add(
+                        _t(
+                            "Make sure there is an IoT Box subscription associated with your Odoo database, then restart the IoT Box."
                         ),
-                    });
+                        {
+                            title: _t("IoT Customer Display Error"),
+                            type: "danger",
+                        }
+                    );
                     console.error("Error fetching data for the IoT customer display: %s", error);
                     clearInterval(intervalId);
                 }


### PR DESCRIPTION
Customer display "get" action was missing `params` key, required for the IoT Box to understand the request correctly.
