### PR TITLE
[FIX] website_mail: `mail` translations available in frontend

### DIFF
--- a/addons/website_mail/models/__init__.py
+++ b/addons/website_mail/models/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import ir_http
 from . import update

--- a/addons/website_mail/models/ir_http.py
+++ b/addons/website_mail/models/ir_http.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        mods = super()._get_translation_frontend_modules_name()
+        return mods + ['mail']


### PR DESCRIPTION
Portal chatter now uses discuss, thus it relies on translation of Discuss in `mail` module.

Frontend translations need to be available, they aren't by default unless the module is prefixed by `website`. This isn't the case for `mail`, and the module `website_mail` does not share the translations.

This commit fixes the issue by enabling `mail` in the translations of available translations in the frontend

Task-4423556