### PR TITLE
[FIX] sale,website_sale: pricelist valid dates not applied

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -456,7 +456,7 @@ class SaleOrderLine(models.Model):
                     line.product_id,
                     quantity=line.product_uom_qty or 1.0,
                     uom=line.product_uom,
-                    date=line.order_id.date_order,
+                    date=line._get_order_date(),
                 )
 
     @api.depends('product_id', 'product_uom', 'product_uom_qty')
@@ -479,6 +479,10 @@ class SaleOrderLine(models.Model):
                     ),
                     fiscal_position=line.order_id.fiscal_position_id,
                 )
+
+    def _get_order_date(self):
+        self.ensure_one()
+        return self.order_id.date_order
 
     def _get_display_price(self):
         """Compute the displayed unit price for a given line.
@@ -518,7 +522,7 @@ class SaleOrderLine(models.Model):
             product=self.product_id.with_context(**self._get_product_price_context()),
             quantity=self.product_uom_qty or 1.0,
             uom=self.product_uom,
-            date=self.order_id.date_order,
+            date=self._get_order_date(),
             currency=self.currency_id,
         )
 
@@ -542,7 +546,7 @@ class SaleOrderLine(models.Model):
             'pricelist': self.order_id.pricelist_id.id,
             'uom': self.product_uom.id,
             'quantity': self.product_uom_qty,
-            'date': self.order_id.date_order,
+            'date': self._get_order_date(),
         }
 
     def _get_pricelist_price_before_discount(self):
@@ -558,7 +562,7 @@ class SaleOrderLine(models.Model):
             product=self.product_id.with_context(**self._get_product_price_context()),
             quantity=self.product_uom_qty or 1.0,
             uom=self.product_uom,
-            date=self.order_id.date_order,
+            date=self._get_order_date(),
             currency=self.currency_id,
         )
 

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -47,6 +47,14 @@ class SaleOrderLine(models.Model):
     def get_description_following_lines(self):
         return self.name.splitlines()[1:]
 
+    def _get_order_date(self):
+        self.ensure_one()
+        if self.order_id.website_id and self.state == 'draft':
+            # cart prices must always be computed based on the current time, not on the order
+            # creation date.
+            return fields.Datetime.now()
+        return super()._get_order_date()
+
     def _get_pricelist_price_before_discount(self):
         """On ecommerce orders, the base price must always be the sales price."""
         self.ensure_one()
@@ -57,7 +65,7 @@ class SaleOrderLine(models.Model):
                 product=self.product_id.with_context(**self._get_product_price_context()),
                 quantity=self.product_uom_qty or 1.0,
                 uom=self.product_uom,
-                date=self.order_id.date_order,
+                date=self._get_order_date(),
                 currency=self.currency_id,
             )
 


### PR DESCRIPTION
If you create a pricelist rule with a discount that has a valid date range, that discount is only applied if the SO was created in that range. Even if it is confirmed within the valid date range.

Fix:
For website_sale orders we consider the date to be the current time when computing the price.

opw-4375643


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
