### PR TITLE
[FIX] mrp: variant assignation warning

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -1274,6 +1274,15 @@ msgid "Change Quantity To Produce"
 msgstr ""
 
 #. module: mrp
+#. odoo-python
+#: code:addons/mrp/models/mrp_bom.py:0
+#, python-format
+msgid ""
+"Changing the product or variant will permanently reset all previously "
+"encoded variant-related data."
+msgstr ""
+
+#. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_production_form_view
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_production_tree_view
 msgid "Check availability"


### PR DESCRIPTION
Issue
-----
When selecting a variant for the bom, all of the component lines lose the "Apply on variants" info. This is intended behaviour but can lead to big data losses for larger boms.

Discussed it with PO and we went with a simple user warning when this happens.

Steps to reproduce
-----
- Create product "A" with variant "A1" and product "B"
- Create a bom for A
- Create a bom line with "Apply on variants" set to A1
- Save the bom
- Change the bom product from A to B
- Save the bom / Leave the page

Ticket:
opw-4182384
