### PR TITLE
[FIX] stock_account: resolve SVL rounding issue

### DIFF
--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -574,6 +574,23 @@ class TestStockValuationAVCO(TestStockValuationCommon):
         self.assertEqual(self.product1.quantity_svl, 0)
         self.assertEqual(self.product1.value_svl, 0)
 
+    def test_rounding_svl_5(self):
+        self.product1.categ_id.property_cost_method = 'average'
+        self._make_in_move(self.product1, 10, unit_cost=16.83)
+        self._make_in_move(self.product1, 10, unit_cost=20)
+        self.assertEqual(self.product1.standard_price, 18.42)
+
+        self._make_out_move(self.product1, 10)
+        out_move = self._make_out_move(self.product1, 9)
+        self.assertEqual(out_move.stock_valuation_layer_ids[0].value, -165.73)
+
+        self.assertEqual(self.product1.value_svl, 18.42)
+        self.assertEqual(self.product1.quantity_svl, 1)
+
+        self._make_out_move(self.product1, 1)
+        self.assertEqual(self.product1.value_svl, 0)
+        self.assertEqual(self.product1.quantity_svl, 0)
+
     def test_return_delivery_2(self):
         self.product1.write({"standard_price": 1})
         move1 = self._make_out_move(self.product1, 10, create_picking=True, force_assign=True)


### PR DESCRIPTION
Problem with stock valuation rounding.

Steps to reproduce:
- Create a product with automated valuation in AVCO
- Set the product cost to 16.83
- Update the quantity to 10
- Make a purchase order with this product: quantity 10 and unit price 20
- Receive the product
- On the product, reduce the quantity to: 10 (-10), then 1 (-9), then 0 (-1)
- Check the valuation, it will remain -0.05 with a quantity of 0

This commit improves the previous commit:
https://github.com/odoo/odoo/commit/795ce6760c11fc8424819b468d62e2e6b4412113 by using float_compare to check if the rounding error should be considered a rounding issue.

opw-4387534
