### PR TITLE
[FIX] web: fix active class on extra menu items

### DIFF
--- a/addons/web/static/src/legacy/js/core/menu.js
+++ b/addons/web/static/src/legacy/js/core/menu.js
@@ -177,7 +177,6 @@ export async function initAutoMoreMenu(el, options) {
                 if (navLink) {
                     navLink.classList.remove('nav-link');
                     navLink.classList.add('dropdown-item');
-                    navLink.classList.toggle('active', el.classList.contains('active'));
                 }
             } else {
                 const dropdownSubMenu = el.querySelector('.dropdown-menu');


### PR DESCRIPTION
Since [1], when an extra menu is displayed due to the top menu exceeding its maximum width, the active class is no longer applied correctly. This issue was introduced during the conversion from jQuery to vanilla JavaScript.

Steps to reproduce:

- Enter the Website in edit mode.
- Navigate to Site > Menu Editor.
- Add several menu items until the menu exceeds its maximum width.
- Ensure that one of the items in the extra menu redirects to "Contact Us".
- Click on the "Contact Us" menu item.
- Open the dropdown menu (via the "+" icon) and observe that the "Contact Us" entry is not highlighted.

This commit resolves the problem.

[1]: https://github.com/odoo/odoo/commit/0de634965a0dec4470b30154f3722a1e83b0e866

task-4428845
opw-4383641
