### PR TITLE
[IMP] orm: Domain optimization transform '=' into 'in', optimize and redefine Fields.search

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -685,7 +685,7 @@ class AccountAccount(models.Model):
             raise UserError(_('Operation not supported'))
         domain = expression.OR([[('account_type', '=like', group)] for group in {
             self._get_internal_group(v) + '%'
-            for v in (value if isinstance(value, (list, tuple)) else [value])
+            for v in (value if operator in ('in', 'not in') else [value])
         }])
         if operator in ('!=', 'not in'):
             return ['!'] + expression.normalize_domain(domain)

--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 
 from odoo import api, fields, models, _, Command
 from odoo.exceptions import UserError
+from odoo.fields import Domain
 from odoo.tools.misc import formatLang
 
 
@@ -205,11 +206,9 @@ class AccountBankStatement(models.Model):
             stmt.problem_description = description
 
     def _search_is_valid(self, operator, value):
-        if operator not in ('=', '!=', '<>'):
-            raise UserError(_('Operation not supported'))
+        if operator != 'in':
+            return NotImplemented
         invalid_ids = self._get_invalid_statement_ids(all_statements=True)
-        if operator in ('!=', '<>') and value or operator == '=' and not value:
-            return [('id', 'in', invalid_ids)]
         return [('id', 'not in', invalid_ids)]
 
     # -------------------------------------------------------------------------

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1068,6 +1068,11 @@ class AccountMoveLine(models.Model):
             line.payment_date = line.discount_date if line.discount_date and date.today() <= line.discount_date else line.date_maturity
 
     def _search_payment_date(self, operator, value):
+        if operator == 'in':
+            # recursive call with operator '='
+            return Domain.OR(self._search_payment_date('=', v) for v in value)
+        if Domain.is_negative_operator(operator):
+            return NotImplemented
         if operator == '=':
             operator = '<='
         return [

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -9,6 +9,7 @@ from odoo.tools.misc import clean_context, formatLang
 from odoo.tools.translate import html_translate
 
 from collections import defaultdict
+from collections.abc import Iterable
 from markupsafe import Markup
 
 import ast
@@ -269,14 +270,15 @@ class AccountTax(models.Model):
             )
 
     def _search_price_include(self, operator, value):
-        if isinstance(value, bool):
-            tax_value = 'tax_included' if value else 'tax_excluded'
-            return [
-                '|', ('price_include_override', operator, tax_value),
-                    '&', ('price_include_override', '=', False),
-                         ('company_price_include', operator, tax_value),
-            ]
-        raise NotImplementedError()
+        if operator not in ('in', 'not in'):
+            return NotImplemented
+        assert list(value) == [True]
+        tax_value = 'tax_included' if operator == 'in' else 'tax_excluded'
+        return [
+            '|', ('price_include_override', '=', tax_value),
+                '&', ('price_include_override', '=', False),
+                        ('company_price_include', '=', tax_value),
+        ]
 
     def _hook_compute_is_used(self, tax_to_compute):
         '''
@@ -493,9 +495,11 @@ class AccountTax(models.Model):
         return super()._search(domain, offset, limit, order)
 
     def _search_name(self, operator, value):
-        if operator not in ("ilike", "like") or not isinstance(value, str):
-            return [('name', operator, value)]
-        return [('name', operator, AccountTax._parse_name_search(value))]
+        if isinstance(value, str):
+            value = AccountTax._parse_name_search(value)
+        elif isinstance(value, Iterable):
+            value = [AccountTax._parse_name_search(v) if isinstance(v, str) else v for v in value]
+        return [('name', operator, value)]
 
     def _check_repartition_lines(self, lines):
         self.ensure_one()

--- a/addons/analytic/models/analytic_line.py
+++ b/addons/analytic/models/analytic_line.py
@@ -5,7 +5,7 @@ from lxml.builder import E
 from odoo import api, fields, models, _
 from odoo.tools import date_utils
 from odoo.exceptions import ValidationError
-from odoo.osv.expression import OR
+from odoo.fields import Domain
 
 
 class AnalyticPlanFieldsMixin(models.AbstractModel):
@@ -42,8 +42,10 @@ class AnalyticPlanFieldsMixin(models.AbstractModel):
             line[line.auto_account_id.plan_id._column_name()] = line.auto_account_id
 
     def _search_auto_account(self, operator, value):
+        if Domain.is_negative_operator(operator):
+            return NotImplemented
         project_plan, other_plans = self.env['account.analytic.plan']._get_all_plans()
-        return OR([
+        return Domain.OR([
             [(plan._column_name(), operator, value)]
             for plan in project_plan + other_plans
         ])

--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -87,10 +87,6 @@ class AnalyticMixin(models.AbstractModel):
             # not ids found, just call super with an empty list
             return super()._condition_to_sql(alias, field_expr, operator, ids, query)
 
-        if isinstance(value, int) and operator in ('=', '!='):
-            value = [value]
-            operator = 'in' if operator == '=' else 'not in'
-
         # keys can be comma-separated ids, we will split those into an array and then make an array comparison with the list of ids to check
         analytic_accounts_query = self._query_analytic_accounts()
         ids = [str(id_) for id_ in ids if id_]  # list of ids -> list of string

--- a/addons/calendar/models/calendar_alarm.py
+++ b/addons/calendar/models/calendar_alarm.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
+from odoo.fields import Domain
 
 
 class CalendarAlarm(models.Model):
@@ -48,6 +49,14 @@ class CalendarAlarm(models.Model):
                 alarm.mail_template_id = False
 
     def _search_duration_minutes(self, operator, value):
+        if operator == 'in':
+            # recursive call with operator '='
+            return Domain.OR(self._search_duration_minutes('=', v) for v in value)
+        elif operator == '=':
+            if not value:
+                return Domain('duration', '=', False)
+        elif operator not in ('>=', '<=', '<', '>'):
+            return NotImplemented
         return [
             '|', '|',
             '&', ('interval', '=', 'minutes'), ('duration', operator, value),

--- a/addons/certificate/models/certificate.py
+++ b/addons/certificate/models/certificate.py
@@ -7,6 +7,7 @@ from cryptography.hazmat.primitives import constant_time, serialization
 from cryptography.hazmat.primitives.serialization import Encoding, pkcs12
 
 from odoo import _, api, fields, models
+from odoo.fields import Domain
 from .key import STR_TO_HASH, _get_formatted_value
 from odoo.exceptions import UserError
 from odoo.osv import expression
@@ -215,25 +216,15 @@ class CertificateCertificate(models.Model):
                 certificate.is_valid = date_start <= utc_now <= date_end
 
     def _search_is_valid(self, operator, value):
-        if operator not in ['=', '!='] or not isinstance(value, bool):
-            raise NotImplementedError("Operation not supported, only '=' and '!=' are allowed.")
+        if operator != 'in':
+            return NotImplemented
         utc_now = datetime.datetime.now(datetime.timezone.utc)
-        if (operator == '=' and value) or (operator == '!=' and not value):
-            return [
-                ('pem_certificate', '!=', False),
-                ('date_start', '<=', utc_now),
-                ('date_end', '>=', utc_now),
-                ('loading_error', '=', '')
-            ]
-        else:
-            return expression.OR([
-                [('pem_certificate', '=', False)],
-                [('date_start', '=', False)],
-                [('date_end', '=', False)],
-                [('date_start', '>', utc_now)],
-                [('date_end', '<', utc_now)],
-                [('loading_error', '!=', '')],
-            ])
+        return [
+            ('pem_certificate', '!=', False),
+            ('date_start', '<=', utc_now),
+            ('date_end', '>=', utc_now),
+            ('loading_error', '=', '')
+        ]
 
     @api.constrains('pem_certificate', 'private_key_id', 'public_key_id')
     def _constrains_certificate_key_compatibility(self):

--- a/addons/delivery_mondialrelay/models/delivery_carrier.py
+++ b/addons/delivery_mondialrelay/models/delivery_carrier.py
@@ -18,11 +18,9 @@ class DeliveryCarrier(models.Model):
             c.is_mondialrelay = c.product_id.default_code == "MR"
 
     def _search_is_mondialrelay(self, operator, value):
-        if operator not in ('=', '!=') or not isinstance(value, bool):
-            raise UserError(_("Operation not supported"))
-        if not value:
-            operator = '!=' if operator == '=' else '='
-        return [('product_id.default_code', operator, 'MR')]
+        if operator != 'in':
+            return NotImplemented
+        return [('product_id.default_code', '=', 'MR')]
 
     def fixed_get_tracking_link(self, picking):
         if self.is_mondialrelay:

--- a/addons/event_booth/models/event_booth.py
+++ b/addons/event_booth/models/event_booth.py
@@ -52,11 +52,10 @@ class EventBooth(models.Model):
         for booth in self:
             booth.is_available = booth.state == 'available'
 
-    def _search_is_available(self, operator, operand):
-        negative = operator in expression.NEGATIVE_TERM_OPERATORS
-        if (negative and operand) or not operand:
-            return [('state', '=', 'unavailable')]
-        return [('state', '=', 'available')]
+    def _search_is_available(self, operator, value):
+        if operator not in ('in', 'not in'):
+            return NotImplemented
+        return [('state', '=', 'available' if operator == 'in' else 'unavailable')]
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/event_booth_sale/models/sale_order_line.py
+++ b/addons/event_booth_sale/models/sale_order_line.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
+from odoo.fields import Domain
 
 
 class SaleOrderLine(models.Model):
@@ -42,6 +43,8 @@ class SaleOrderLine(models.Model):
             } for booth in selected_booths - existing_booths])
 
     def _search_event_booth_pending_ids(self, operator, value):
+        if Domain.is_negative_operator(operator):
+            return NotImplemented
         return [('event_booth_registration_ids.event_booth_id', operator, value)]
 
     @api.constrains('event_booth_registration_ids')

--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -43,11 +43,8 @@ class HrDepartment(models.Model):
             record.display_name = record.name
 
     def _search_has_read_access(self, operator, value):
-        supported_operators = ["="]
-        if operator not in supported_operators or not isinstance(value, bool):
-            raise NotImplementedError()
-        if not value:
-            return [(1, "=", 0)]
+        if operator != 'in':
+            return NotImplemented
         if self.env['hr.employee'].has_access('read'):
             return [(1, "=", 1)]
         departments_ids = self.env['hr.department'].sudo().search([('manager_id', 'in', self.env.user.employee_ids.ids)]).ids

--- a/addons/hr/report/hr_manager_department_report.py
+++ b/addons/hr/report/hr_manager_department_report.py
@@ -13,11 +13,8 @@ class HrManagerDepartmentReport(models.AbstractModel):
         compute="_compute_has_department_manager_access")
 
     def _search_has_department_manager_access(self, operator, value):
-        supported_operators = ["="]
-        if operator not in supported_operators or not isinstance(value, bool):
-            raise NotImplementedError()
-        if not value:
-            return [1, "=", 0]
+        if operator != 'in':
+            return NotImplemented
         department_ids = self.env['hr.department']._search([('manager_id', 'in', self.env.user.employee_ids.ids)])
         return [
             '|',

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -154,16 +154,10 @@ class TestHrEmployee(TestHrCommon):
         self.assertFalse(emp_parent.member_of_department)
         employees = emp + emp_sub + emp_sub_sub + emp_other + emp_parent
         self.assertEqual(
-            employees.filtered_domain(employees._search_part_of_department('=', True)),
+            employees.filtered_domain(employees._search_part_of_department('in', [True])),
             emp + emp_sub + emp_sub_sub)
         self.assertEqual(
-            employees.filtered_domain(employees._search_part_of_department('!=', False)),
-            emp + emp_sub + emp_sub_sub)
-        self.assertEqual(
-            employees.filtered_domain(employees._search_part_of_department('=', False)),
-            emp_other + emp_parent)
-        self.assertEqual(
-            employees.filtered_domain(employees._search_part_of_department('!=', True)),
+            employees.filtered_domain(['!'] + employees._search_part_of_department('in', [True])),
             emp_other + emp_parent)
 
     def test_employee_create_from_user(self):

--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -20,6 +20,8 @@ class HrEmployeePublic(models.Model):
         return super()._get_manager_only_fields() + ['first_contract_date']
 
     def _search_first_contract_date(self, operator, value):
+        if operator in expression.NEGATIVE_TERM_OPERATORS:
+            return NotImplemented
         employees = self.env['hr.employee'].sudo().search([('id', 'child_of', self.env.user.employee_id.ids), ('first_contract_date', operator, value)])
         return [('id', 'in', employees.ids)]
 

--- a/addons/hr_contract/models/resource.py
+++ b/addons/hr_contract/models/resource.py
@@ -53,18 +53,9 @@ class ResourceCalendar(models.Model):
 
     @api.model
     def _search_running_contracts_count(self, operator, value):
-        if operator not in ['=', '!=', '<', '>'] or not isinstance(value, int):
-            raise NotImplementedError(_('Operation not supported.'))
-        calendar_ids = self.env['resource.calendar'].search([])
-        if operator == '=':
-            calender = calendar_ids.filtered(lambda m: m.running_contracts_count == value)
-        elif operator == '!=':
-            calender = calendar_ids.filtered(lambda m: m.running_contracts_count != value)
-        elif operator == '<':
-            calender = calendar_ids.filtered(lambda m: m.running_contracts_count < value)
-        elif operator == '>':
-            calender = calendar_ids.filtered(lambda m: m.running_contracts_count > value)
-        return [('id', 'in', calender.ids)]
+        calendars = self.env['resource.calendar'].search_fetch([], ['running_contracts_count'])
+        calendars = calendars.filtered_domain([('running_contracts_count', operator, value)])
+        return [('id', 'in', calendars.ids)]
 
     def action_open_contracts(self):
         self.ensure_one()

--- a/addons/hr_fleet/models/employee.py
+++ b/addons/hr_fleet/models/employee.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, fields, models
+from odoo.fields import Domain
 from odoo.exceptions import ValidationError
 
 
@@ -37,8 +38,9 @@ class HrEmployee(models.Model):
                 employee.license_plate = ' '.join(employee.car_ids.filtered('license_plate').mapped('license_plate')) or employee.private_car_plate
 
     def _search_license_plate(self, operator, value):
-        employees = self.env['hr.employee'].search(['|', ('car_ids.license_plate', operator, value), ('private_car_plate', operator, value)])
-        return [('id', 'in', employees.ids)]
+        if Domain.is_negative_operator(operator):
+            return NotImplemented
+        return ['|', ('car_ids.license_plate', operator, value), ('private_car_plate', operator, value)]
 
     def _compute_employee_cars_count(self):
         rg = self.env['fleet.vehicle.assignation.log']._read_group([

--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -102,6 +102,8 @@ class HrLeaveReportCalendar(models.Model):
             leave.name += f": {leave.sudo().leave_id.duration_display}"
 
     def _search_name(self, operator, value):
+        if operator in expression.NEGATIVE_TERM_OPERATORS:
+            return NotImplemented
         query = self.env['hr.leave.report.calendar'].sudo()._search([('leave_id.duration_display', operator, value)])
         domain = ['|', ('employee_id.name', operator, value), ('id', 'in', query)]
         if self.env.user.has_group('hr_holidays.group_hr_holidays_user'):

--- a/addons/hr_org_chart/models/hr_org_chart_mixin.py
+++ b/addons/hr_org_chart/models/hr_org_chart_mixin.py
@@ -54,14 +54,10 @@ class HrEmployeeBase(models.AbstractModel):
                 employee.is_subordinate = employee in subordinates
 
     def _search_is_subordinate(self, operator, value):
-        if operator not in ('=', '!=') or not isinstance(value, bool):
-            raise UserError(_('Operation not supported'))
-        # Double negation
-        if not value:
-            operator = '!=' if operator == '=' else '='
-        if not self.env.user.employee_id.subordinate_ids:
-            return [('id', operator, self.env.user.employee_id.id)]
-        return (['!'] if operator == '!=' else []) + [('id', 'in', self.env.user.employee_id.subordinate_ids.ids)]
+        if operator != 'in':
+            return NotImplemented
+        subordinates = self.env.user.employee_id.subordinate_ids
+        return [('id', 'in', subordinates.ids)]
 
     def _compute_child_count(self):
         employee_read_group = self._read_group(

--- a/addons/hr_org_chart/tests/test_employee.py
+++ b/addons/hr_org_chart/tests/test_employee.py
@@ -27,8 +27,14 @@ class TestEmployee(TestHrCommon):
             self.employee_pierre.is_subordinate,
             'Pierre should not be a subordinate of the current user since Pierre has no manager.')
 
-        self.assertEqual(employees.filtered_domain(employees._search_is_subordinate('=', True)), self.employee_paul)
-        self.assertEqual(employees.filtered_domain(employees._search_is_subordinate('=', False)), self.employee_pierre)
+        def _filtered_is_subordinate(flag):
+            dom = employees._search_is_subordinate('in', [True])
+            if not flag:
+                dom = ['!', *dom]
+            return employees.filtered_domain(dom)
+
+        self.assertEqual(_filtered_is_subordinate(True), self.employee_paul)
+        self.assertEqual(_filtered_is_subordinate(False), self.employee_pierre)
 
         self.employee_pierre.parent_id = self.employee_paul
         self.assertTrue(
@@ -38,8 +44,8 @@ class TestEmployee(TestHrCommon):
             self.employee_pierre.is_subordinate,
             "Pierre should now be a subordinate of the current user since Paul is his manager and the current user is the Paul's manager.")
 
-        self.assertEqual(employees.filtered_domain(employees._search_is_subordinate('=', True)), employees)
-        self.assertFalse(employees.filtered_domain(employees._search_is_subordinate('=', False)))
+        self.assertEqual(_filtered_is_subordinate(True), employees)
+        self.assertFalse(_filtered_is_subordinate(False))
 
         self.employee_paul.parent_id = False
         employees._compute_is_subordinate()
@@ -51,8 +57,8 @@ class TestEmployee(TestHrCommon):
             self.employee_pierre.is_subordinate,
             "Pierre should not be a subordinate of the current user since Paul is his manager and the current user is not the Paul's manager.")
 
-        self.assertFalse(employees.filtered_domain(employees._search_is_subordinate('=', True)))
-        self.assertEqual(employees.filtered_domain(employees._search_is_subordinate('=', False)), employees)
+        self.assertFalse(_filtered_is_subordinate(True))
+        self.assertEqual(_filtered_is_subordinate(False), employees)
 
     def test_hierarchy_read(self):
         HrEmployee = self.env['hr.employee']

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -244,10 +244,9 @@ class TestRecruitment(TransactionCase):
         # Note: For some reason testing the search does not work if the compute
         #       is not tested first which is why these two tests are in one test.
         applicant = self.env["hr.applicant"]
-        in_pool_domain = applicant._search_is_applicant_in_pool("=", True)
-        out_of_pool_domain = applicant._search_is_applicant_in_pool(operator="=", value=False)
+        in_pool_domain = applicant._search_is_applicant_in_pool("in", [True])
         in_pool_applicants = applicant.search(Domain(in_pool_domain))
-        out_of_pool_applicants = applicant.search(Domain(out_of_pool_domain))
+        out_of_pool_applicants = applicant.search(~Domain(in_pool_domain))
         self.assertCountEqual(in_pool_applicants, A | B | C | D | E | G | H)
         self.assertCountEqual(out_of_pool_applicants, demo_applicants | F)
 

--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -56,20 +56,14 @@ class ProjectProject(models.Model):
 
     @api.model
     def _search_is_internal_project(self, operator, value):
-        if not isinstance(value, bool):
-            raise ValueError(_('Invalid value: %s', value))
-        if operator not in ['=', '!=']:
-            raise ValueError(_('Invalid operator: %s', operator))
+        if operator not in ('in', 'not in'):
+            return NotImplemented
 
         Company = self.env['res.company']
         sql = Company._where_calc(
             [('internal_project_id', '!=', False)], active_test=False
         ).subselect("internal_project_id")
-        if (operator == '=' and value is True) or (operator == '!=' and value is False):
-            operator_new = 'in'
-        else:
-            operator_new = 'not in'
-        return [('id', operator_new, sql)]
+        return [('id', operator, sql)]
 
     @api.depends('allow_timesheets', 'timesheet_ids.unit_amount', 'allocated_hours')
     def _compute_remaining_hours(self):
@@ -86,10 +80,8 @@ class ProjectProject(models.Model):
 
     @api.model
     def _search_is_project_overtime(self, operator, value):
-        if not isinstance(value, bool):
-            raise ValueError(_('Invalid value: %s', value))
-        if operator not in ['=', '!=']:
-            raise ValueError(_('Invalid operator: %s', operator))
+        if operator not in ('in', 'not in'):
+            return NotImplemented
 
         sql = SQL("""(
             SELECT Project.id
@@ -103,11 +95,7 @@ class ProjectProject(models.Model):
           GROUP BY Project.id
             HAVING Project.allocated_hours - SUM(Task.effective_hours) < 0
         )""")
-        if (operator == '=' and value is True) or (operator == '!=' and value is False):
-            operator_new = 'in'
-        else:
-            operator_new = 'not in'
-        return [('id', operator_new, sql)]
+        return [('id', operator, sql)]
 
     @api.constrains('allow_timesheets', 'account_id')
     def _check_allow_timesheet(self):

--- a/addons/hr_timesheet/models/project_task.py
+++ b/addons/hr_timesheet/models/project_task.py
@@ -110,7 +110,9 @@ class ProjectTask(models.Model):
 
     def _search_remaining_hours_percentage(self, operator, value):
         if operator not in OPERATOR_MAPPING:
-            raise NotImplementedError(_('This operator %s is not supported in this search method.', operator))
+            return NotImplemented
+        if operator in ('in', 'not in'):
+            value = tuple(value)
         sql = SQL("""(
             SELECT id
               FROM %s

--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -217,8 +217,8 @@ class LoyaltyReward(models.Model):
             reward.reward_product_ids = reward.reward_type == 'product' and products or self.env['product.product']
 
     def _search_reward_product_ids(self, operator, value):
-        if operator not in ('=', '!=', 'in'):
-            raise NotImplementedError("Unsupported search operator")
+        if operator != 'in':
+            return NotImplemented
         return [
             '&', ('reward_type', '=', 'product'),
             '|', ('reward_product_id', operator, value),

--- a/addons/lunch/models/lunch_alert.py
+++ b/addons/lunch/models/lunch_alert.py
@@ -71,10 +71,9 @@ class LunchAlert(models.Model):
             alert.available_today = alert.until > today if alert.until else True and alert[fieldname]
 
     def _search_available_today(self, operator, value):
-        if (not operator in ['=', '!=']) or (not value in [True, False]):
-            return []
+        if operator not in ('in', 'not in'):
+            return NotImplemented
 
-        searching_for_true = (operator == '=' and value) or (operator == '!=' and not value)
         today = fields.Date.context_today(self)
         fieldname = WEEKDAY_TO_NAME[today.weekday()]
 
@@ -82,7 +81,7 @@ class LunchAlert(models.Model):
             [(fieldname, operator, value)],
             expression.OR([
                 [('until', '=', False)],
-                [('until', '>' if searching_for_true else '<', today)],
+                [('until', '>' if operator == 'in' else '<', today)],
             ])
         ])
 

--- a/addons/lunch/models/lunch_product.py
+++ b/addons/lunch/models/lunch_product.py
@@ -84,17 +84,8 @@ class LunchProduct(models.Model):
             product.is_available_at = False
 
     def _search_is_available_at(self, operator, value):
-        supported_operators = ['in', 'not in', '=', '!=']
-
-        if not operator in supported_operators:
-            return expression.TRUE_DOMAIN
-
-        if isinstance(value, int):
-            value = [value]
-
-        if operator in expression.NEGATIVE_TERM_OPERATORS:
-            return expression.AND([[('supplier_id.available_location_ids', 'not in', value)], [('supplier_id.available_location_ids', '!=', False)]])
-
+        if operator != 'in':
+            return NotImplemented
         return expression.OR([[('supplier_id.available_location_ids', 'in', value)], [('supplier_id.available_location_ids', '=', False)]])
 
     def _sync_active_from_related(self):

--- a/addons/lunch/models/lunch_supplier.py
+++ b/addons/lunch/models/lunch_supplier.py
@@ -320,17 +320,16 @@ class LunchSupplier(models.Model):
                 supplier.order_deadline_passed = not supplier.available_today
 
     def _search_available_today(self, operator, value):
-        if (not operator in ['=', '!=']) or (not value in [True, False]):
-            return []
-
-        searching_for_true = (operator == '=' and value) or (operator == '!=' and not value)
+        if operator not in ('in', 'not in'):
+            return NotImplemented
 
         now = fields.Datetime.now().replace(tzinfo=pytz.UTC).astimezone(pytz.timezone(self.env.user.tz or 'UTC'))
         fieldname = WEEKDAY_TO_NAME[now.weekday()]
+        truth = operator == 'in'
 
         recurrency_domain = expression.OR([
             [('recurrency_end_date', '=', False)],
-            [('recurrency_end_date', '>' if searching_for_true else '<', now)]
+            [('recurrency_end_date', '>' if truth else '<', now)]
         ])
 
         return expression.AND([

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -219,7 +219,8 @@ class DiscussChannel(models.Model):
             channel.is_member = bool(channel.self_member_id)
 
     def _search_is_member(self, operator, operand):
-        is_in = (operator == '=' and operand) or (operator == '!=' and not operand)
+        if operator != 'in':
+            return NotImplemented
         # Separate query to fetch candidate channels because the sub-select that _search would
         # generate leads psql query plan to take bad decisions. When candidate ids are explicitly
         # given it doesn't need to make (incorrect) guess, at the cost of one extra but fast query.
@@ -234,7 +235,7 @@ class DiscussChannel(models.Model):
             channels = current_partner.sudo().channel_ids
         else:
             channels = self.env["discuss.channel"]
-        return [('id', "in" if is_in else "not in", channels.ids)]
+        return [('id', 'in', channels.ids)]
 
     @api.depends_context("uid", "guest")
     @api.depends("channel_member_ids")

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -100,33 +100,23 @@ class DiscussChannelMember(models.Model):
                 member.is_self = True
 
     def _search_is_self(self, operator, operand):
-        is_in = (operator == "=" and operand) or (operator == "!=" and not operand)
+        if operator != 'in':
+            return NotImplemented
         current_partner, current_guest = self.env["res.partner"]._get_current_persona()
-        if is_in:
-            return [
-                '|',
-                ("partner_id", "=", current_partner.id) if current_partner else expression.FALSE_LEAF,
-                ("guest_id", "=", current_guest.id) if current_guest else expression.FALSE_LEAF,
-            ]
-        else:
-            return [
-                ("partner_id", "!=", current_partner.id) if current_partner else expression.TRUE_LEAF,
-                ("guest_id", "!=", current_guest.id) if current_guest else expression.TRUE_LEAF,
-            ]
+        return [
+            '|',
+            ("partner_id", "=", current_partner.id) if current_partner else expression.FALSE_LEAF,
+            ("guest_id", "=", current_guest.id) if current_guest else expression.FALSE_LEAF,
+        ]
 
     def _search_is_pinned(self, operator, operand):
-        if (operator == "=" and operand) or (operator == "!=" and not operand):
-            return expression.OR([
-                [("unpin_dt", "=", False)],
-                [("last_interest_dt", ">=", self._field_to_sql(self._table, "unpin_dt"))],
-                [("channel_id.last_interest_dt", ">=", self._field_to_sql(self._table, "unpin_dt"))],
-            ])
-        else:
-            return [
-                ("unpin_dt", "!=", False),
-                ("last_interest_dt", "<", self._field_to_sql(self._table, "unpin_dt")),
-                ("channel_id.last_interest_dt", "<", self._field_to_sql(self._table, "unpin_dt")),
-            ]
+        if operator != 'in':
+            return NotImplemented
+        return expression.OR([
+            [("unpin_dt", "=", False)],
+            [("last_interest_dt", ">=", self._field_to_sql(self._table, "unpin_dt"))],
+            [("channel_id.last_interest_dt", ">=", self._field_to_sql(self._table, "unpin_dt"))],
+        ])
 
     @api.depends("channel_id.message_ids", "new_message_separator")
     def _compute_message_unread(self):

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime
@@ -7,8 +6,8 @@ import logging
 import pytz
 
 from odoo import api, fields, models
-from odoo.osv import expression
-from odoo.tools import SQL
+from odoo.fields import Domain
+from odoo.tools import partition, SQL
 
 _logger = logging.getLogger(__name__)
 
@@ -117,6 +116,8 @@ class MailActivityMixin(models.AbstractModel):
             record.activity_user_id = record.activity_ids[0].user_id if record.activity_ids else False
 
     def _search_activity_exception_decoration(self, operator, operand):
+        if Domain.is_negative_operator(operator):
+            return NotImplemented
         return [('activity_ids.activity_type_id.decoration_type', operator, operand)]
 
     @api.depends('activity_ids.state')
@@ -134,14 +135,12 @@ class MailActivityMixin(models.AbstractModel):
 
     def _search_activity_state(self, operator, value):
         all_states = {'overdue', 'today', 'planned', False}
-        if operator == '=':
-            search_states = {value}
-        elif operator == '!=':
-            search_states = all_states - {value}
-        elif operator == 'in':
+        if operator == 'in':
             search_states = set(value)
         elif operator == 'not in':
             search_states = all_states - set(value)
+        else:
+            return NotImplemented
 
         reverse_search = False
         if False in search_states:
@@ -198,22 +197,41 @@ class MailActivityMixin(models.AbstractModel):
             record.activity_date_deadline = next(iter(activities), activities).date_deadline
 
     def _search_activity_date_deadline(self, operator, operand):
-        if operator == '=' and not operand:
-            return [('activity_ids', '=', False)]
-        return [('activity_ids.date_deadline', operator, operand)]
+        if operator == 'in' and False in operand:
+            return Domain('activity_ids', '=', False) | Domain(self._search_activity_date_deadline('in', operand - {False}))
+        if Domain.is_negative_operator(operator):
+            return NotImplemented
+        return Domain('activity_ids.date_deadline', operator, operand)
 
     @api.model
     def _search_activity_user_id(self, operator, operand):
-        if isinstance(operand, bool) and ((operator == '=' and not operand) or (operator == '!=' and operand)):
-            return [('activity_ids', '=', False)]
-        return [('activity_ids', 'any', [('active', 'in', [True, False]), ('user_id', operator, operand)])]
+        # field supports comparison with any boolean
+        domain = Domain.FALSE
+        if Domain.is_negative_operator(operator):
+            return NotImplemented
+        if operator == 'in':
+            bools, values = partition(lambda v: isinstance(v, bool), operand)
+            if bools:
+                if True in bools:
+                    domain |= Domain('activity_ids', '!=', False)
+                if False in bools:
+                    domain |= Domain('activity_ids', '=', False)
+                if not values:
+                    return domain
+                operand = values
+        # basic case
+        return domain | Domain('activity_ids', 'any', [('active', 'in', [True, False]), ('user_id', operator, operand)])
 
     @api.model
     def _search_activity_type_id(self, operator, operand):
+        if Domain.is_negative_operator(operator):
+            return NotImplemented
         return [('activity_ids.activity_type_id', operator, operand)]
 
     @api.model
     def _search_activity_summary(self, operator, operand):
+        if Domain.is_negative_operator(operator):
+            return NotImplemented
         return [('activity_ids.summary', operator, operand)]
 
     @api.depends('activity_ids.date_deadline', 'activity_ids.user_id')
@@ -227,12 +245,13 @@ class MailActivityMixin(models.AbstractModel):
             ), False)
 
     def _search_my_activity_date_deadline(self, operator, operand):
-        activity_ids = self.env['mail.activity']._search([
+        if Domain.is_negative_operator(operator):
+            return NotImplemented
+        return [('activity_ids', 'any', [
             ('date_deadline', operator, operand),
             ('res_model', '=', self._name),
             ('user_id', '=', self.env.user.id)
-        ])
-        return [('activity_ids', 'in', activity_ids)]
+        ])]
 
     def write(self, vals):
         # Delete activities of archived record.
@@ -329,18 +348,18 @@ class MailActivityMixin(models.AbstractModel):
         if not any(activity_types_ids):
             return self.env['mail.activity']
 
-        domain = [
+        domain = Domain([
             ('res_model', '=', self._name),
             ('res_id', 'in', self.ids),
             ('activity_type_id', 'in', activity_types_ids)
-        ]
+        ])
 
         if only_automated:
-            domain = expression.AND([domain, [('automated', '=', True)]])
+            domain &= Domain('automated', '=', True)
         if user_id:
-            domain = expression.AND([domain, [('user_id', '=', user_id)]])
+            domain &= Domain('user_id', '=', user_id)
         if additional_domain:
-            domain = expression.AND([domain, additional_domain])
+            domain &= Domain(additional_domain)
 
         return self.env['mail.activity'].search(domain)
 

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -138,11 +138,8 @@ class MailTemplate(models.Model):
 
     @api.model
     def _search_template_category(self, operator, value):
-        if operator not in ['in', 'not in', '=', '!=']:
-            raise NotImplementedError(_('Operation not supported'))
-
-        value = [value] if isinstance(value, str) else value
-        operator = 'in' if operator in ("in", "=") else 'not in'
+        if operator != 'in':
+            return NotImplemented
 
         templates_with_xmlid = self.env['ir.model.data']._search([
             ('model', '=', 'mail.template'),
@@ -159,16 +156,7 @@ class MailTemplate(models.Model):
         if 'custom_template' in value:
             domain.append([('template_category', 'not in', ['base_template', 'hidden_template'])])
 
-        if operator == 'not in':
-            for dom in domain:
-                dom.insert(0, "!")
-
-        if len(domain) > 1:
-            domain = (expression.OR if operator == 'in' else expression.AND)(domain)
-        else:
-            domain = domain[0]
-
-        return domain
+        return expression.OR(domain)
 
     @api.onchange("model")
     def _onchange_model(self):

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -171,16 +171,14 @@ class MailThread(models.AbstractModel):
     @api.model
     def _search_message_partner_ids(self, operator, operand):
         """Search function for message_follower_ids"""
-        neg = ''
         if operator in expression.NEGATIVE_TERM_OPERATORS:
-            neg = 'not '
-            operator = expression.TERM_OPERATORS_NEGATION[operator]
+            return NotImplemented
         followers = self.env['mail.followers'].sudo()._search([
             ('res_model', '=', self._name),
             ('partner_id', operator, operand),
         ])
         # use `in` query to avoid reading thousands of potentially followed objects
-        return [('id', neg + 'in', followers.subselect('res_id'))]
+        return [('id', 'in', followers.subselect('res_id'))]
 
     @api.depends('message_follower_ids')
     def _compute_message_is_follower(self):
@@ -194,15 +192,14 @@ class MailThread(models.AbstractModel):
 
     @api.model
     def _search_message_is_follower(self, operator, operand):
-        followers = self.env['mail.followers'].sudo().search_fetch(
-            [('res_model', '=', self._name), ('partner_id', '=', self.env.user.partner_id.id)],
-            ['res_id'],
-        )
-        # Cases ('message_is_follower', '=', True) or  ('message_is_follower', '!=', False)
-        if (operator == '=' and operand) or (operator == '!=' and not operand):
-            return [('id', 'in', followers.mapped('res_id'))]
-        else:
-            return [('id', 'not in', followers.mapped('res_id'))]
+        if operator != 'in':
+            return NotImplemented
+        followers = self.env['mail.followers'].sudo()._search([
+            ('res_model', '=', self._name),
+            ('partner_id', operator, self.env.user.partner_id.ids),
+        ])
+        # use `in` query to avoid reading thousands of potentially followed objects
+        return [('id', 'in', followers.subselect('res_id'))]
 
     def _compute_has_message(self):
         self.env['mail.message'].flush_model()
@@ -217,11 +214,9 @@ class MailThread(models.AbstractModel):
             record.has_message = record.id in channel_ids
 
     def _search_has_message(self, operator, value):
-        if (operator == '=' and value is True) or (operator == '!=' and value is False):
-            operator_new = 'in'
-        else:
-            operator_new = 'not in'
-        return [('id', operator_new, SQL("(SELECT res_id FROM mail_message WHERE model = %s)", self._name))]
+        if operator != 'in':
+            return NotImplemented
+        return [('id', 'in', SQL("(SELECT res_id FROM mail_message WHERE model = %s)", self._name))]
 
     def _compute_message_needaction(self):
         res = dict.fromkeys(self.ids, 0)
@@ -266,8 +261,10 @@ class MailThread(models.AbstractModel):
 
     @api.model
     def _search_message_has_error(self, operator, operand):
-        message_ids = self.env['mail.message']._search([('has_error', operator, operand), ('author_id', '=', self.env.user.partner_id.id)])
-        return [('message_ids', 'in', message_ids)]
+        if operator != 'in':
+            return NotImplemented
+        message_domain = [('has_error', '=', True), ('author_id', '=', self.env.user.partner_id.id)]
+        return [('message_ids', 'any', message_domain)]
 
     def _compute_message_attachment_count(self):
         read_group_var = self.env['ir.attachment']._read_group([('res_id', 'in', self.ids), ('res_model', '=', self._name)],

--- a/addons/mail/models/mail_thread_blacklist.py
+++ b/addons/mail/models/mail_thread_blacklist.py
@@ -51,17 +51,13 @@ class MailThreadBlacklist(models.AbstractModel):
 
     @api.model
     def _search_is_blacklisted(self, operator, value):
-        # Assumes operator is '=' or '!=' and value is True or False
+        if operator not in ('in', 'not in'):
+            return NotImplemented
         self.flush_model(['email_normalized'])
         self.env['mail.blacklist'].flush_model(['email', 'active'])
         self._assert_primary_email()
-        if operator != '=':
-            if operator == '!=' and isinstance(value, bool):
-                value = not value
-            else:
-                raise NotImplementedError()
 
-        if value:
+        if operator == 'in':
             sql = SQL("""
                 SELECT m.id
                     FROM mail_blacklist bl

--- a/addons/mass_mailing/models/ir_model.py
+++ b/addons/mass_mailing/models/ir_model.py
@@ -18,17 +18,13 @@ class IrModel(models.Model):
             model.is_mailing_enabled = getattr(self.env[model.model], '_mailing_enabled', False)
 
     def _search_is_mailing_enabled(self, operator, value):
-        if operator not in ('=', '!='):
-            raise ValueError(_("Searching Mailing Enabled models supports only direct search using '='' or '!='."))
+        if operator not in ('in', 'not in'):
+            return NotImplemented
 
-        valid_models = self.env['ir.model']
-        for model in self.search([]):
-            if model.model not in self.env or model.is_transient():
-                continue
-            if getattr(self.env[model.model], '_mailing_enabled', False):
-                valid_models |= model
+        valid_models = self.search([]).filtered(
+            lambda model: model.model in self.env
+            and not model.is_transient()
+            and getattr(self.env[model.model], '_mailing_enabled', False)
+        )
 
-        search_is_mailing_enabled = (operator == '=' and value) or (operator == '!=' and not value)
-        if search_is_mailing_enabled:
-            return [('id', 'in', valid_models.ids)]
-        return [('id', 'not in', valid_models.ids)]
+        return [('id', operator, valid_models.ids)]

--- a/addons/mass_mailing/models/mailing_contact.py
+++ b/addons/mass_mailing/models/mailing_contact.py
@@ -60,18 +60,14 @@ class MailingContact(models.Model):
 
     @api.model
     def _search_opt_out(self, operator, value):
-        # Assumes operator is '=' or '!=' and value is True or False
-        if operator != '=':
-            if operator == '!=' and isinstance(value, bool):
-                value = not value
-            else:
-                raise NotImplementedError()
+        if operator != 'in':
+            return NotImplemented
 
         if 'default_list_ids' in self._context and isinstance(self._context['default_list_ids'], (list, tuple)) and len(self._context['default_list_ids']) == 1:
             [active_list_id] = self._context['default_list_ids']
             contacts = self.env['mailing.subscription'].search([('list_id', '=', active_list_id)])
-            return [('id', 'in', [record.contact_id.id for record in contacts if record.opt_out == value])]
-        return expression.FALSE_DOMAIN if value else expression.TRUE_DOMAIN
+            return [('id', 'in', [record.contact_id.id for record in contacts if record.opt_out])]
+        return expression.FALSE_DOMAIN
 
     @api.depends('first_name', 'last_name')
     def _compute_name(self):

--- a/addons/mrp_subcontracting/models/res_partner.py
+++ b/addons/mrp_subcontracting/models/res_partner.py
@@ -45,14 +45,11 @@ class ResPartner(models.Model):
             partner.picking_ids = picking_ids
 
     def _search_is_subcontractor(self, operator, value):
-        assert operator in ('=', '!=', '<>') and value in (True, False), 'Operation not supported'
+        if operator != 'in':
+            return NotImplemented
         subcontractor_ids = self.env['mrp.bom'].search(
             [('type', '=', 'subcontract')]).subcontractor_ids.ids
-        if (operator == '=' and value is True) or (operator in ('<>', '!=') and value is False):
-            search_operator = 'in'
-        else:
-            search_operator = 'not in'
-        return [('id', search_operator, subcontractor_ids)]
+        return [('id', 'in', subcontractor_ids)]
 
     def _compute_is_subcontractor(self):
         """ Determine whether the partner is a subcontractor (for giving sudo access) """

--- a/addons/mrp_subcontracting/models/stock_quant.py
+++ b/addons/mrp_subcontracting/models/stock_quant.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, _
-from odoo.exceptions import UserError
+from odoo import fields, models
 
 
 class StockQuant(models.Model):
@@ -11,7 +9,6 @@ class StockQuant(models.Model):
     is_subcontract = fields.Boolean(store=False, search='_search_is_subcontract')
 
     def _search_is_subcontract(self, operator, value):
-        if operator not in ['=', '!='] or not isinstance(value, bool):
-            raise UserError(_('Operation not supported'))
-
-        return [('location_id.is_subcontracting_location', operator, value)]
+        if operator != 'in':
+            return NotImplemented
+        return [('location_id.is_subcontracting_location', 'in', value)]

--- a/addons/payment/models/payment_method.py
+++ b/addons/payment/models/payment_method.py
@@ -114,12 +114,9 @@ class PaymentMethod(models.Model):
             payment_method.is_primary = not payment_method.primary_payment_method_id
 
     def _search_is_primary(self, operator, value):
-        if operator == '=' and value is True:
-            return [('primary_payment_method_id', '=', False)]
-        elif operator == '=' and value is False:
-            return [('primary_payment_method_id', '!=', False)]
-        else:
-            raise NotImplementedError(_("Operation not supported."))
+        if operator not in ('in', 'not in'):
+            return NotImplemented
+        return [('primary_payment_method_id', operator, [False])]
 
     #=== ONCHANGE METHODS ===#
 

--- a/addons/product/models/product_tag.py
+++ b/addons/product/models/product_tag.py
@@ -53,5 +53,5 @@ class ProductTag(models.Model):
 
     def _search_product_ids(self, operator, operand):
         if operator in expression.NEGATIVE_TERM_OPERATORS:
-            return [('product_template_ids.product_variant_ids', operator, operand), ('product_product_ids', operator, operand)]
+            return NotImplemented
         return ['|', ('product_template_ids.product_variant_ids', operator, operand), ('product_product_ids', operator, operand)]

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -69,9 +69,9 @@ class ProjectProject(models.Model):
 
     @api.model
     def _search_is_favorite(self, operator, value):
-        if operator not in ['=', '!='] or not isinstance(value, bool):
-            raise NotImplementedError(_('Operation not supported'))
-        return [('favorite_user_ids', 'in' if (operator == '=') == value else 'not in', self.env.uid)]
+        if operator != 'in':
+            return NotImplemented
+        return [('favorite_user_ids', 'in', [self.env.uid])]
 
     def _compute_is_favorite(self):
         for project in self:
@@ -321,10 +321,8 @@ class ProjectProject(models.Model):
 
     @api.model
     def _search_is_milestone_exceeded(self, operator, value):
-        if not isinstance(value, bool):
-            raise ValueError(_('Invalid value: %s', value))
-        if operator not in ['=', '!=']:
-            raise ValueError(_('Invalid operator: %s', operator))
+        if operator != 'in':
+            return NotImplemented
 
         sql = SQL("""(
             SELECT P.id
@@ -334,11 +332,7 @@ class ProjectProject(models.Model):
                AND P.allow_milestones IS true
                AND M.deadline <= CAST(now() AS date)
         )""")
-        if (operator == '=' and value is True) or (operator == '!=' and value is False):
-            operator_new = 'in'
-        else:
-            operator_new = 'not in'
-        return [('id', operator_new, sql)]
+        return [('id', 'any', sql)]
 
     @api.depends('collaborator_ids', 'privacy_visibility')
     def _compute_collaborator_count(self):

--- a/addons/project_timesheet_holidays/models/project_task.py
+++ b/addons/project_timesheet_holidays/models/project_task.py
@@ -26,8 +26,8 @@ class ProjectTask(models.Model):
         (self - timeoff_tasks).is_timeoff_task = False
 
     def _search_is_timeoff_task(self, operator, value):
-        if operator not in ['=', '!='] or not isinstance(value, bool):
-            raise NotImplementedError(_('Operation not supported'))
+        if operator not in ('in', 'not in'):
+            return NotImplemented
         timesheet_read_group = self.env['account.analytic.line']._read_group(
             [('task_id', '!=', False), '|', ('holiday_id', '!=', False), ('global_leave_id', '!=', False)],
             [],
@@ -36,6 +36,4 @@ class ProjectTask(models.Model):
         [timeoff_tasks] = timesheet_read_group[0]
         if self.env.company.leave_timesheet_task_id:
             timeoff_tasks |= self.env.company.leave_timesheet_task_id
-        if operator == '!=':
-            value = not value
-        return [('id', 'in' if value else 'not in', timeoff_tasks.ids)]
+        return [('id', operator, timeoff_tasks.ids)]

--- a/addons/purchase/models/product.py
+++ b/addons/purchase/models/product.py
@@ -97,8 +97,8 @@ class ProductProduct(models.Model):
             product.is_in_purchase_order = bool(data.get(product.id, 0))
 
     def _search_is_in_purchase_order(self, operator, value):
-        if operator not in ['=', '!='] or not isinstance(value, bool):
-            raise UserError(_("Operation not supported"))
+        if operator != 'in':
+            return NotImplemented
         product_ids = self.env['purchase.order.line'].search([
             ('order_id', 'in', [self.env.context.get('order_id', '')]),
         ]).product_id.ids

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -30,13 +30,11 @@ class StockPicking(models.Model):
 
     @api.model
     def _search_days_to_arrive(self, operator, value):
-        date_value = fields.Datetime.from_string(value)
-        return [('date_done', operator, date_value)]
+        return [('date_done', operator, value)]
 
     @api.model
     def _search_delay_pass(self, operator, value):
-        date_value = fields.Datetime.from_string(value)
-        return [('purchase_id.date_order', operator, date_value)]
+        return [('purchase_id.date_order', operator, value)]
 
 
 class StockWarehouse(models.Model):

--- a/addons/rating/models/mail_message.py
+++ b/addons/rating/models/mail_message.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
+from odoo.fields import Domain
 from odoo.addons.mail.tools.discuss import Store
 
 
@@ -26,11 +27,13 @@ class MailMessage(models.Model):
             message.rating_value = message.rating_id.rating if message.rating_id else 0.0
 
     def _search_rating_value(self, operator, operand):
-        ratings = self.env['rating.rating'].sudo().search([
+        if Domain.is_negative_operator(operator):
+            return NotImplemented
+        ratings = self.env['rating.rating'].sudo().search_fetch([
             ('rating', operator, operand),
             ('message_id', '!=', False),
             ("consumed", "=", True),
-        ])
+        ], ['message_id'])
         return [('id', 'in', ratings.mapped('message_id').ids)]
 
     def _to_store_defaults(self):

--- a/addons/rating/models/rating_data.py
+++ b/addons/rating/models/rating_data.py
@@ -20,8 +20,8 @@ RATING_TEXT = [
 ]
 
 OPERATOR_MAPPING = {
-    '=': operator.eq,
-    '!=': operator.ne,
+    'in': lambda elem, container: elem in container,
+    'not in': lambda elem, container: elem not in container,
     '<': operator.lt,
     '<=': operator.le,
     '>': operator.gt,

--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -58,15 +58,16 @@ class RatingMixin(models.AbstractModel):
             record.rating_avg = mapping.get(record.id, {}).get('rating_avg', 0)
 
     def _search_rating_avg(self, operator, value):
-        if operator not in rating_data.OPERATOR_MAPPING:
-            raise NotImplementedError('This operator %s is not supported in this search method.' % operator)
+        op = rating_data.OPERATOR_MAPPING.get(operator)
+        if not op:
+            return NotImplemented
         rating_read_group = self.env['rating.rating'].sudo()._read_group(
             [('res_model', '=', self._name), ('consumed', '=', True), ('rating', '>=', rating_data.RATING_LIMIT_MIN)],
             ['res_id'], ['rating:avg'])
         res_ids = [
             res_id
             for res_id, rating_avg in rating_read_group
-            if rating_data.OPERATOR_MAPPING[operator](float_compare(rating_avg, value, 2), 0)
+            if op(float_compare(rating_avg, value, 2), 0)
         ]
         return [('id', 'in', res_ids)]
 

--- a/addons/rating/models/rating_parent_mixin.py
+++ b/addons/rating/models/rating_parent_mixin.py
@@ -56,8 +56,9 @@ class RatingParentMixin(models.AbstractModel):
             record.rating_avg_percentage = record.rating_avg / 5
 
     def _search_rating_avg(self, operator, value):
-        if operator not in rating_data.OPERATOR_MAPPING:
-            raise NotImplementedError('This operator %s is not supported in this search method.' % operator)
+        op = rating_data.OPERATOR_MAPPING.get(operator)
+        if not op:
+            return NotImplemented
         domain = [('parent_res_model', '=', self._name), ('consumed', '=', True), ('rating', '>=', rating_data.RATING_LIMIT_MIN)]
         if self._rating_satisfaction_days:
             min_date = fields.Datetime.now() - timedelta(days=self._rating_satisfaction_days)
@@ -66,6 +67,6 @@ class RatingParentMixin(models.AbstractModel):
         parent_res_ids = [
             parent_res_id
             for parent_res_id, rating_avg in rating_read_group
-            if rating_data.OPERATOR_MAPPING[operator](float_compare(rating_avg, value, 2), 0)
+            if op(float_compare(rating_avg, value, 2), 0)
         ]
         return [('id', 'in', parent_res_ids)]

--- a/addons/repair/models/product.py
+++ b/addons/repair/models/product.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, _
@@ -18,16 +17,12 @@ class ProductProduct(models.Model):
         self.product_catalog_product_is_in_repair = False
 
     def _search_product_is_in_repair(self, operator, value):
-        if operator not in ['=', '!='] or not isinstance(value, bool):
-            raise UserError(_("Operation not supported"))
+        if operator != 'in':
+            return NotImplemented
         product_ids = self.env['repair.order'].search([
             ('id', 'in', [self.env.context.get('order_id', '')]),
         ]).move_ids.product_id.ids
-        if (operator == '!=' and value is True) or (operator == '=' and value is False):
-            domain_operator = 'not in'
-        else:
-            domain_operator = 'in'
-        return [('id', domain_operator, product_ids)]
+        return [('id', 'in', product_ids)]
 
     def _count_returned_sn_products_domain(self, sn_lot, or_domains):
         or_domains.append([

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -336,12 +336,9 @@ class RepairOrder(models.Model):
             )
 
     def _search_date_category(self, operator, value):
-        if operator != '=':
-            raise NotImplementedError(_('Operation not supported'))
-        search_domain = self.env['stock.picking'].date_category_to_domain(value)
-        return expression.AND([
-            [('schedule_date', operator, value)] for operator, value in search_domain
-        ])
+        if operator != 'in':
+            return NotImplemented
+        return self.env['stock.picking'].date_category_to_domain('scheduled_date', value)
 
     @api.onchange('product_uom')
     def onchange_product_uom(self):

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -152,13 +152,20 @@ class ResourceCalendar(models.Model):
 
     @api.model
     def _search_work_time_rate(self, operator, value):
-        if operator not in ['=', '!=', '<', '>'] or not isinstance(value, int):
-            raise NotImplementedError(_('Operation not supported.'))
+        if operator in ('in', 'not in'):
+            if not all(isinstance(v, int) for v in value):
+                return NotImplemented
+        elif operator in ('<', '>'):
+            if not isinstance(value, int):
+                return NotImplemented
+        else:
+            return NotImplemented
+
         calendar_ids = self.env['resource.calendar'].search([])
-        if operator == '=':
-            calender = calendar_ids.filtered(lambda m: m.work_time_rate == value)
-        elif operator == '!=':
-            calender = calendar_ids.filtered(lambda m: m.work_time_rate != value)
+        if operator == 'in':
+            calender = calendar_ids.filtered(lambda m: m.work_time_rate in value)
+        elif operator == 'not in':
+            calender = calendar_ids.filtered(lambda m: m.work_time_rate not in value)
         elif operator == '<':
             calender = calendar_ids.filtered(lambda m: m.work_time_rate < value)
         elif operator == '>':

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -66,11 +66,11 @@ class ProductProduct(models.Model):
             product.product_catalog_product_is_in_sale_order = bool(data.get(product.id, 0))
 
     def _search_product_is_in_sale_order(self, operator, value):
-        if operator not in ['=', '!='] or not isinstance(value, bool):
-            raise UserError(_("Operation not supported"))
-        product_ids = self.env['sale.order.line'].search([
+        if operator != 'in':
+            return NotImplemented
+        product_ids = self.env['sale.order.line'].search_fetch([
             ('order_id', 'in', [self.env.context.get('order_id', '')]),
-        ]).product_id.ids
+        ], ['product_id']).product_id.ids
         return [('id', 'in', product_ids)]
 
     @api.readonly

--- a/addons/sale_expense/models/sale_order.py
+++ b/addons/sale_expense/models/sale_order.py
@@ -20,18 +20,16 @@ class SaleOrder(models.Model):
     def _search_display_name(self, operator, value):
         """ For expense, we want to show all sales order but only their display_name (no ir.rule applied), this is the only way to do it. """
         if (
-            self._context.get('sale_expense_all_order')
+            self.env.context.get('sale_expense_all_order')
             and self.env.user.has_group('sales_team.group_sale_salesman')
             and not self.env.user.has_group('sales_team.group_sale_salesman_all_leads')
         ):
             if operator in expression.NEGATIVE_TERM_OPERATORS:
-                positive_operator = expression.TERM_OPERATORS_NEGATION[operator]
-            else:
-                positive_operator = operator
-            domain = super()._search_display_name(positive_operator, value)
+                return NotImplemented
+            domain = super()._search_display_name(operator, value)
             company_domain = ['&', ('state', '=', 'sale'), ('company_id', 'in', self.env.companies.ids)]
             query = self.sudo()._search(expression.AND([domain, company_domain]))
-            return [('id', 'in' if operator == positive_operator else 'not in', query)]
+            return [('id', 'in', query)]
         return super()._search_display_name(operator, value)
 
     @api.depends('expense_ids')

--- a/addons/sale_management/models/sale_order_option.py
+++ b/addons/sale_management/models/sale_order_option.py
@@ -131,9 +131,9 @@ class SaleOrderOption(models.Model):
             option.is_present = bool(option.order_id.order_line.filtered(lambda l: l.product_id == option.product_id))
 
     def _search_is_present(self, operator, value):
-        if (operator, value) in [('=', True), ('!=', False)]:
-            return [('line_id', '=', False)]
-        return [('line_id', '!=', False)]
+        if operator not in ('in', 'not in'):
+            return NotImplemented
+        return [('line_id', operator, [False])]
 
     @api.model
     def _product_id_domain(self):

--- a/addons/sale_project/models/project_task.py
+++ b/addons/sale_project/models/project_task.py
@@ -212,16 +212,15 @@ class ProjectTask(models.Model):
 
     @api.model
     def _search_task_to_invoice(self, operator, value):
+        if operator != 'in':
+            return NotImplemented
         sql = SQL("""(
             SELECT so.id
             FROM sale_order so
             WHERE so.invoice_status != 'invoiced'
                 AND so.invoice_status != 'no'
         )""")
-        operator_new = 'in'
-        if (bool(operator == '=') ^ bool(value)):
-            operator_new = 'not in'
-        return [('sale_order_id', operator_new, sql)]
+        return [('sale_order_id', 'in', sql)]
 
     @api.onchange('sale_line_id')
     def _onchange_partner_id(self):

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -3,9 +3,9 @@
 import ast
 from collections import defaultdict
 
-from odoo import api, fields, models, _, Command
+from odoo import api, fields, models, _
+from odoo.fields import Command, Domain
 from odoo.exceptions import UserError
-from odoo.osv.expression import AND, NEGATIVE_TERM_OPERATORS, TERM_OPERATORS_NEGATION
 from odoo.addons.project.models.project_task import CLOSED_STATES
 
 
@@ -60,13 +60,14 @@ class SaleOrder(models.Model):
 
     @api.model
     def _search_tasks_ids(self, operator, value):
-        if operator in NEGATIVE_TERM_OPERATORS:
-            positive_operator = TERM_OPERATORS_NEGATION[operator]
-        else:
-            positive_operator = operator
-        task_domain = [('display_name' if isinstance(value, str) else 'id', positive_operator, value), ('sale_order_id', '!=', False)]
+        if Domain.is_negative_operator(operator):
+            return NotImplemented
+        task_domain = [
+            ('display_name' if isinstance(value, str) else 'id', operator, value),
+            ('sale_order_id', '!=', False),
+        ]
         query = self.env['project.task']._search(task_domain)
-        return [('id', 'in' if positive_operator == operator else 'not in', query.subselect('sale_order_id'))]
+        return [('id', 'in', query.subselect('sale_order_id'))]
 
     @api.depends('order_line.product_id.project_id')
     def _compute_tasks_ids(self):
@@ -154,7 +155,7 @@ class SaleOrder(models.Model):
         project_ids = self.tasks_ids.project_id
         if len(project_ids) > 1:
             action = self.env['ir.actions.actions']._for_xml_id('project.action_view_task')
-            action['domain'] = AND([ast.literal_eval(action['domain']), self._tasks_ids_domain()])
+            action['domain'] = list(Domain.AND([ast.literal_eval(action['domain']), self._tasks_ids_domain()]))
             action['context'] = {}
         else:
             # Load top bar if all the tasks linked to the SO belong to the same project

--- a/addons/sale_timesheet/tests/test_project_pricing_type.py
+++ b/addons/sale_timesheet/tests/test_project_pricing_type.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.fields import Domain
 from odoo.tests import tagged
 
 from .common import TestCommonSaleTimesheet
@@ -19,18 +20,23 @@ class TestProjectPricingType(TestCommonSaleTimesheet):
             3) Set a customer and a SOL in the project and check if the pricing_type is equal to fixed_rate (project rate)
             4) Set a employee mapping and check if the pricing_type is equal to employee_rate
         """
-        # 1) Take a project non billable and check if the pricing_type is equal to False
         project = self.project_non_billable
+
+        def _search_pricing_type(operator, value):
+            # execute the optimization to transform the domain
+            return Domain('pricing_type', operator, value).optimize(project, full=True)
+
+        # 1) Take a project non billable and check if the pricing_type is equal to False
         self.assertFalse(project.allow_billable, 'The allow_billable should be false if the project is non billable.')
         self.assertFalse(project.pricing_type, 'The pricing type of this project should be equal to False since it is non billable.')
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', 'task_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', 'fixed_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', 'employee_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('=', False)))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', 'task_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', 'fixed_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', 'employee_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('!=', False)))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', 'task_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', 'fixed_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', 'employee_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('=', False)))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', 'task_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', 'fixed_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', 'employee_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('!=', False)))
 
         # 2) Set allow_billable to True and check if the pricing_type is equal to task_rate (if no SOL and no mappings)
         project.write({
@@ -42,14 +48,14 @@ class TestProjectPricingType(TestCommonSaleTimesheet):
         self.assertFalse(project.sale_line_id, 'The sales order item should be unset.')
         self.assertFalse(project.sale_line_employee_ids, 'The employee mappings should be empty.')
         self.assertEqual(project.pricing_type, 'task_rate', 'The pricing type should be equal to task_rate.')
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('=', 'task_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', 'fixed_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', 'employee_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', False)))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('!=', 'task_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', 'fixed_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', 'employee_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', False)))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('=', 'task_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', 'fixed_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', 'employee_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', False)))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('!=', 'task_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', 'fixed_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', 'employee_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', False)))
 
         # 3) Set a customer and a SOL in the project and check if the pricing_type is equal to fixed_rate (project rate)
         project.write({
@@ -60,14 +66,14 @@ class TestProjectPricingType(TestCommonSaleTimesheet):
         self.assertEqual(project.sale_order_id, self.so, 'The sales order should be equal to the one set in the project.')
         self.assertEqual(project.sale_line_id, self.so.order_line[0], 'The sales order item should be the one chosen.')
         self.assertEqual(project.pricing_type, 'fixed_rate', 'The pricing type should be equal to fixed_rate since the project has a sales order item.')
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', 'task_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('=', 'fixed_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', 'employee_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', False)))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', 'task_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('!=', 'fixed_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', 'employee_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', False)))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', 'task_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('=', 'fixed_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', 'employee_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', False)))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', 'task_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('!=', 'fixed_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', 'employee_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', False)))
 
         # 4) Set a employee mapping and check if the pricing_type is equal to employee_rate
         project.write({
@@ -79,14 +85,14 @@ class TestProjectPricingType(TestCommonSaleTimesheet):
 
         self.assertEqual(len(project.sale_line_employee_ids), 1, 'The project should have an employee mapping.')
         self.assertEqual(project.pricing_type, 'employee_rate', 'The pricing type should be equal to employee_rate since the project has an employee mapping.')
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', 'task_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', 'fixed_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('=', 'employee_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', False)))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', 'task_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', 'fixed_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('!=', 'employee_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', False)))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', 'task_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', 'fixed_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('=', 'employee_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', False)))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', 'task_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', 'fixed_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('!=', 'employee_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', False)))
 
         # Even if the project has no sales order item, since it has an employee mapping, the pricing type must be equal to employee_rate.
         project.write({
@@ -95,11 +101,11 @@ class TestProjectPricingType(TestCommonSaleTimesheet):
         self.assertFalse(project.sale_order_id, 'The sales order of the project should be empty.')
         self.assertFalse(project.sale_line_id, 'The sales order item of the project should be empty.')
         self.assertEqual(project.pricing_type, 'employee_rate', 'The pricing type should always be equal to employee_rate.')
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', 'task_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', 'fixed_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('=', 'employee_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('=', False)))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', 'task_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', 'fixed_rate')))
-        self.assertFalse(project.filtered_domain(project._search_pricing_type('!=', 'employee_rate')))
-        self.assertTrue(project.filtered_domain(project._search_pricing_type('!=', False)))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', 'task_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', 'fixed_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('=', 'employee_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('=', False)))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', 'task_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', 'fixed_rate')))
+        self.assertFalse(project.filtered_domain(_search_pricing_type('!=', 'employee_rate')))
+        self.assertTrue(project.filtered_domain(_search_pricing_type('!=', False)))

--- a/addons/sms/models/ir_model.py
+++ b/addons/sms/models/ir_model.py
@@ -25,6 +25,8 @@ class IrModel(models.Model):
             model.is_mail_thread_sms = False
 
     def _search_is_mail_thread_sms(self, operator, value):
+        if operator != 'in':
+            return NotImplemented
         thread_models = self.search([('is_mail_thread', '=', True)])
         valid_models = self.env['ir.model']
         for model in thread_models:
@@ -35,7 +37,4 @@ class IrModel(models.Model):
             if any(fname in ModelObject._fields for fname in potential_fields):
                 valid_models |= model
 
-        search_sms = (operator == '=' and value) or (operator == '!=' and not value)
-        if search_sms:
-            return [('id', 'in', valid_models.ids)]
-        return [('id', 'not in', valid_models.ids)]
+        return [('id', 'in', valid_models.ids)]

--- a/addons/sms/models/mail_message.py
+++ b/addons/sms/models/mail_message.py
@@ -24,6 +24,9 @@ class MailMessage(models.Model):
             message.has_sms_error = message in sms_error_from_notification
 
     def _search_has_sms_error(self, operator, operand):
-        if operator == '=' and operand:
-            return ['&', ('notification_ids.notification_status', '=', 'exception'), ('notification_ids.notification_type', '=', 'sms')]
-        raise NotImplementedError()
+        if operator != 'in':
+            return NotImplemented
+        return [('notification_ids', 'any', [
+            ('notification_status', '=', 'exception'),
+            ('notification_type', '=', 'sms'),
+        ])]

--- a/addons/sms/models/mail_thread.py
+++ b/addons/sms/models/mail_thread.py
@@ -40,7 +40,9 @@ class MailThread(models.AbstractModel):
 
     @api.model
     def _search_message_has_sms_error(self, operator, operand):
-        return ['&', ('message_ids.has_sms_error', operator, operand), ('message_ids.author_id', '=', self.env.user.partner_id.id)]
+        if operator != 'in':
+            return NotImplemented
+        return ['&', ('message_ids.has_sms_error', '=', True), ('message_ids.author_id', '=', self.env.user.partner_id.id)]
 
     def message_post(self, *args, body='', message_type='notification', **kwargs):
         # When posting an 'SMS' `message_type`, make sure that the body is used as-is in the sms,

--- a/addons/snailmail/models/mail_message.py
+++ b/addons/snailmail/models/mail_message.py
@@ -20,9 +20,9 @@ class MailMessage(models.Model):
             message.snailmail_error = message.letter_ids[0].state == 'error'
 
     def _search_snailmail_error(self, operator, operand):
-        if operator == '=' and operand:
-            return ['&', ('letter_ids.state', '=', 'error'), ('letter_ids.user_id', '=', self.env.user.id)]
-        return ['!', '&', ('letter_ids.state', '=', 'error'), ('letter_ids.user_id', '=', self.env.user.id)]
+        if operator != 'in':
+            return NotImplemented
+        return ['&', ('letter_ids.state', '=', 'error'), ('letter_ids.user_id', '=', self.env.user.id)]
 
     def cancel_letter(self):
         self.letter_ids.cancel()

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -3,10 +3,10 @@
 
 from collections import Counter, defaultdict
 
-from odoo import _, api, fields, tools, models, Command
+from odoo import _, api, fields, models
 from odoo.addons.web.controllers.utils import clean_action
 from odoo.exceptions import UserError, ValidationError
-from odoo.osv import expression
+from odoo.fields import Command, Domain
 from odoo.tools import OrderedSet, groupby
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
 
@@ -138,7 +138,9 @@ class StockMoveLine(models.Model):
                 line.location_dest_id = line.move_id.location_dest_id or line.picking_id.location_dest_id
 
     def _search_picking_type_id(self, operator, value):
-        return [('picking_id.picking_type_id', operator, value)]
+        if Domain.is_negative_operator(operator):
+            return NotImplemented
+        return Domain('picking_id.picking_type_id', operator, value)
 
     @api.depends('quant_id')
     def _compute_quantity(self):
@@ -304,17 +306,17 @@ class StockMoveLine(models.Model):
         dirty_move_lines = self.env['stock.move.line'].browse(dirty_move_line_ids)
         quants_data = []
         move_lines_data = []
-        domain = [("id", "in", dirty_quant_ids)]
-        for move_line in dirty_move_lines | deleted_move_lines:
-            move_line_domain = [
+        domain = Domain("id", "in", dirty_quant_ids) | Domain.OR(
+            Domain([
                 ("product_id", "=", move_line.product_id.id),
                 ("lot_id", "=", move_line.lot_id.id),
                 ("location_id", "=", move_line.location_id.id),
                 ("package_id", "=", move_line.package_id.id),
                 ("owner_id", "=", move_line.owner_id.id),
-            ]
-            domain = expression.OR([domain, move_line_domain])
-        if domain:
+            ])
+            for move_line in dirty_move_lines | deleted_move_lines
+        )
+        if not domain.is_false():
             quants = self.env['stock.quant'].search(domain)
             for quant in quants:
                 dirty_lines = dirty_move_lines.filtered(lambda ml: ml.product_id == quant.product_id

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -51,14 +51,13 @@ class StockValuationLayer(models.Model):
                 svl.warehouse_id = svl.stock_move_id.location_dest_id.warehouse_id.id
 
     def _search_warehouse_id(self, operator, value):
-        layer_ids = self.search([
+        return [
             '|',
             ('stock_move_id.location_dest_id.warehouse_id', operator, value),
             '&',
             ('stock_move_id.location_id.usage', '=', 'internal'),
             ('stock_move_id.location_id.warehouse_id', operator, value),
-        ]).ids
-        return [('id', 'in', layer_ids)]
+        ]
 
     def _validate_accounting_entries(self):
         am_vals = []

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -298,7 +298,7 @@ class WebsitePublishedMultiMixin(WebsitePublishedMixin):
     def _search_website_published(self, operator, value):
         if not isinstance(value, bool) or operator not in ('=', '!='):
             logger.warning('unsupported search on website_published: %s, %s', operator, value)
-            return [()]
+            return [(0, '=', 1)]
 
         if operator in expression.NEGATIVE_TERM_OPERATORS:
             value = not value

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -138,8 +138,6 @@ class WebsiteVisitor(models.Model):
             visitor.page_count = visitor_info['page_count']
 
     def _search_page_ids(self, operator, value):
-        if operator not in ('like', 'ilike', 'not like', 'not ilike', '=like', '=ilike', '=', '!='):
-            raise ValueError(_('This operator is not supported'))
         return [('website_track_ids.page_id.name', operator, value)]
 
     @api.depends('website_track_ids.page_id')

--- a/addons/website_event/models/website_visitor.py
+++ b/addons/website_event/models/website_visitor.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models
 from odoo.osv import expression
+from odoo.exceptions import UserError
 
 
 class WebsiteVisitor(models.Model):
@@ -61,8 +62,8 @@ class WebsiteVisitor(models.Model):
         """ Search visitors with terms on events within their event registrations. E.g. [('event_registered_ids',
         'in', [1, 2])] should return visitors having a registration on events 1, 2 as
         well as their children for notification purpose. """
-        if operator == "not in":
-            raise NotImplementedError("Unsupported 'Not In' operation on visitors registrations")
+        if operator in ('not in', 'not any'):
+            raise UserError(self.env._("Unsupported 'Not In' operation on visitors registrations"))
 
         all_registrations = self.env['event.registration'].sudo().search([
             ('event_id', operator, operand)

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -6,6 +6,7 @@ from pytz import utc
 from random import randint
 
 from odoo import api, fields, models, tools
+from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.tools.mail import email_normalize, is_html_empty
 from odoo.tools.translate import _, html_translate
@@ -360,8 +361,8 @@ class EventTrack(models.Model):
             track.wishlist_visitor_count = len(visitor_ids_map.get(track.id, []))
 
     def _search_wishlist_visitor_ids(self, operator, operand):
-        if operator == "not in":
-            raise NotImplementedError("Unsupported 'Not In' operation on track wishlist visitors")
+        if operator in ('not in', 'not any'):
+            raise UserError(self.env._("Unsupported 'Not In' operation on track wishlist visitors"))
 
         track_visitors = self.env['event.track.visitor'].sudo().search([
             ('visitor_id', operator, operand),

--- a/addons/website_event_track/models/website_visitor.py
+++ b/addons/website_event_track/models/website_visitor.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 from odoo.osv import expression
 
 
@@ -36,8 +37,8 @@ class WebsiteVisitor(models.Model):
     def _search_event_track_wishlisted_ids(self, operator, operand):
         """ Search visitors with terms on wishlisted tracks. E.g. [('event_track_wishlisted_ids',
         'in', [1, 2])] should return visitors having wishlisted tracks 1, 2. """
-        if operator == "not in":
-            raise NotImplementedError("Unsupported 'Not In' operation on track wishlist visitors")
+        if operator in ('not in', 'not any'):
+            raise UserError(self.env._("Unsupported 'Not In' operation on track wishlist visitors"))
 
         track_visitors = self.env['event.track.visitor'].sudo().search([
             ('track_id', operator, operand),

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -268,11 +268,8 @@ class ForumPost(models.Model):
             post.can_use_full_editor = is_admin or user.karma >= post.forum_id.karma_editor
 
     def _search_can_view(self, operator, value):
-        if operator not in ('=', '!=', '<>'):
-            raise ValueError('Invalid operator: %s' % (operator,))
-
-        if not value:
-            operator = '!=' if operator == '=' else '='
+        if operator != 'in':
+            return NotImplemented
 
         user = self.env.user
         # Won't impact sitemap, search() in converter is forced as public user
@@ -292,8 +289,7 @@ class ForumPost(models.Model):
                     and (p.active or p.create_uid = %(user_id)s)
                 )
         )""", user_id=user.id, karma=user.karma)
-        op = 'in' if operator == '=' else "not in"
-        return [('id', op, sql)]
+        return [('id', 'in', sql)]
 
     # EXTENDS WEBSITE.SEO.METADATA
 

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -982,11 +982,8 @@ class IrModuleModuleDependency(models.Model):
             dep.depend_id = name_mod.get(dep.name)
 
     def _search_depend(self, operator, value):
-        # support only `=` and `in`
-        if operator == '=':
-            value = [value]
-        else:
-            assert operator == 'in'
+        if operator not in ('in', 'any'):
+            return NotImplemented
         modules = self.env['ir.module.module'].browse(value)
         return [('name', 'in', modules.mapped('name'))]
 
@@ -1045,8 +1042,9 @@ class IrModuleModuleExclusion(models.Model):
             excl.exclusion_id = name_mod.get(excl.name)
 
     def _search_exclusion(self, operator, value):
-        assert operator == 'in'
-        modules = self.env['ir.module.module'].browse(set(value))
+        if operator not in ('in', 'any'):
+            return NotImplemented
+        modules = self.env['ir.module.module'].browse(value)
         return [('name', 'in', modules.mapped('name'))]
 
     @api.depends('exclusion_id.state')

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -2,6 +2,7 @@
 
 import logging
 import math
+from collections.abc import Iterable
 
 from odoo import api, fields, models, tools
 from odoo.exceptions import UserError, ValidationError
@@ -474,7 +475,10 @@ class ResCurrencyRate(models.Model):
 
     @api.model
     def _search_display_name(self, operator, value):
-        value = parse_date(self.env, value)
+        if isinstance(value, Iterable) and not isinstance(value, str):
+            value = [parse_date(self.env, v) for v in value]
+        else:
+            value = parse_date(self.env, value)
         return super()._search_display_name(operator, value)
 
     @api.model

--- a/odoo/addons/base/models/res_groups.py
+++ b/odoo/addons/base/models/res_groups.py
@@ -218,12 +218,8 @@ class ResGroups(models.Model):
 
     def _search_all_implied_ids(self, operator, value):
         """ Compute the search on the reflexive transitive closure of implied_ids. """
-        if isinstance(value, int):
-            value = [value]
-        elif isinstance(value, str):
-            raise NotImplementedError
-        if operator not in ('in', 'not in') or not isinstance(value, Collection):
-            raise NotImplementedError(f"_search_all_implied_ids with {operator!r} {value!r}")
+        if operator not in ('in', 'not in'):
+            return NotImplemented
         group_definitions = self._get_group_definitions()
         ids = [*value, *group_definitions.get_subset_ids(value)]
         return [('id', operator, ids)]
@@ -237,10 +233,8 @@ class ResGroups(models.Model):
 
     def _search_all_implied_by_ids(self, operator, value):
         """ Compute the search on the reflexive transitive closure of implied_by_ids. """
-        assert isinstance(value, (int, list, tuple))
-
-        if isinstance(value, int):
-            value = [value]
+        if operator not in ('in', 'not in'):
+            return NotImplemented
         group_definitions = self._get_group_definitions()
         ids = [*value, *group_definitions.get_superset_ids(value)]
 

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -176,6 +176,8 @@ class ResPartnerCategory(models.Model):
     def _search_display_name(self, operator, value):
         domain = super()._search_display_name(operator, value)
         if operator.endswith('like'):
+            if operator.startswith('not'):
+                return NotImplemented
             return [('id', 'child_of', tuple(self._search(domain)))]
         return domain
 

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -610,8 +610,10 @@ class ResUsers(models.Model):
     @api.model
     def _search_display_name(self, operator, value):
         domain = super()._search_display_name(operator, value)
-        if operator in ('=', 'ilike') and value:
-            name_domain = [('login', '=', value)]
+        if operator in ('in', 'ilike') and value:
+            name_domain = [('login', 'in', [value] if isinstance(value, str) else value)]
+            # avoid searching both by login and name because they reside in two different tables
+            # doing so prevents from using indexes and introduces a performance issue
             if users := self.search(name_domain):
                 domain = [('id', 'in', users.ids)]
         return domain

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -2625,8 +2625,10 @@ class TestPrettifyDomain(BaseCase):
 
 class TestAnyfy(TransactionCase):
     def _test_combine_anies(self, domain, expected):
-        anyfied_domain = list(Domain(domain).optimize(self.env['res.partner']))
-        return self.assertEqual(anyfied_domain, expected,
+        model = self.env['res.partner']
+        anyfied_domain = Domain(domain).optimize(model)
+        expected_domain = Domain(expected).map_conditions(lambda c: c.optimize(model))
+        return self.assertEqual(anyfied_domain, expected_domain,
                                 f'\nFor initial domain: {domain}\nBecame: {anyfied_domain}')
 
     def test_true_leaf_as_list(self):
@@ -2655,32 +2657,6 @@ class TestAnyfy(TransactionCase):
             ('child_ids.name', '=', 'Jack'),
         ], [
             ('child_ids', 'any', [('name', '=', 'Jack')]),
-        ])
-
-    def test_and_multiple_fields(self):
-        self._test_combine_anies([
-            '&', '&',
-                ('name', '=', 'Jack'),
-                ('name', '=', 'Sam'),
-                ('name', '=', 'Daniel'),
-        ], [
-            '&', '&',
-                ('name', '=', 'Jack'),
-                ('name', '=', 'Sam'),
-                ('name', '=', 'Daniel'),
-        ])
-
-    def test_or_multiple_fields(self):
-        self._test_combine_anies([
-            '|', '|',
-                ('name', '=', 'Jack'),
-                ('name', '=', 'Sam'),
-                ('name', '=', 'Daniel'),
-        ], [
-            '|', '|',
-                ('name', '=', 'Jack'),
-                ('name', '=', 'Sam'),
-                ('name', '=', 'Daniel'),
         ])
 
     def test_and_multiple_many2one_with_subfield(self):
@@ -2760,19 +2736,6 @@ class TestAnyfy(TransactionCase):
             '!', ('child_ids.name', '=', 'Jack')
         ], [
             ('child_ids', 'not any', [('name', '=', 'Jack')])
-        ])
-
-    def test_not_or_multiple_fields(self):
-        self._test_combine_anies([
-            '!', '|', '|',
-                ('name', '=', 'Jack'),
-                ('name', '=', 'Sam'),
-                ('name', '=', 'Daniel'),
-        ], [
-            '&', '&',
-                ('name', '!=', 'Jack'),
-                ('name', '!=', 'Sam'),
-                ('name', '!=', 'Daniel'),
         ])
 
     def test_not_and_multiple_many2one_field_with_subfield(self):

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1657,13 +1657,13 @@ class TestQueries(TransactionCase):
                 "res_partner"."active" IS TRUE
                 AND "res_partner"."name" LIKE %s
                 AND (
-                    "res_partner"."country_id" = %s OR (
-                        "res_partner"."ref" != %s OR
+                    "res_partner"."country_id" IN %s OR (
+                        "res_partner"."ref" NOT IN %s OR
                         "res_partner"."ref" IS NULL
                     )
                 )
             )
-            ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
+            ORDER BY "res_partner"."complete_name" ASC, "res_partner"."id" DESC
         ''']):
             Model.search(domain)
 
@@ -1746,7 +1746,7 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT COUNT(*)
             FROM "res_country"
-            WHERE "res_country"."id" = %s
+            WHERE "res_country"."id" IN %s
         ''']):
             Model.search_count([('id', '=', 1)])
 
@@ -1771,7 +1771,7 @@ class TestQueries(TransactionCase):
             LEFT JOIN "res_partner" AS "res_users__partner_id" ON
                 ("res_users"."partner_id" = "res_users__partner_id"."id")
             WHERE "res_users"."active" IS TRUE
-            AND ("res_users"."id" = %s AND "res_users__partner_id"."id" = %s)
+            AND ("res_users"."id" IN %s AND "res_users__partner_id"."id" IN %s)
             ORDER BY "res_users__partner_id"."name", "res_users"."login"
         ''']):
             Model.search([])
@@ -1844,7 +1844,7 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."company_id" = %s
+            WHERE "res_partner"."company_id" IN %s
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id', '=', self.company.id)])
@@ -2278,7 +2278,7 @@ class TestOne2many(TransactionCase):
                             AND "res_partner_bank"."sanitized_acc_number" LIKE %s
                         )
                     )
-                    AND ("res_partner"."name" != %s OR "res_partner"."name" IS NULL)
+                    AND ("res_partner"."name" NOT IN %s OR "res_partner"."name" IS NULL)
                     AND "res_partner"."parent_id" IS NOT NULL
                 )
             )

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -430,7 +430,8 @@ class Test_New_ApiBar(models.Model):
             bar.foo = self.env['test_new_api.foo'].search([('name', '=', bar.name)], limit=1)
 
     def _search_foo(self, operator, value):
-        assert operator in ('=', 'in')
+        if operator not in ('in', 'any'):
+            return NotImplemented
         records = self.env['test_new_api.foo'].browse(value)
         return [('name', 'in', records.mapped('name'))]
 

--- a/odoo/addons/test_new_api/tests/test_domain.py
+++ b/odoo/addons/test_new_api/tests/test_domain.py
@@ -538,7 +538,7 @@ class TestDomainOptimize(TransactionCase):
         model = self.env['test_new_api.message']
         self.assertEqual(
             Domain('discussion', 'like', '').optimize(model),
-            Domain('discussion', '!=', False),
+            Domain('discussion', 'not in', OrderedSet([False])),
             "Matching anything in relation",
         )
         query = model.discussion._search([('display_name', 'like', 'ok')])
@@ -561,7 +561,7 @@ class TestDomainOptimize(TransactionCase):
         )
         self.assertEqual(
             Domain('important', '=', True).optimize(model),
-            Domain('important', '=', True),
+            Domain('important', 'in', OrderedSet([True])),
         )
         self.assertEqual(
             list(Domain('important', 'not in', [True, False]).optimize(model)),
@@ -598,15 +598,15 @@ class TestDomainOptimize(TransactionCase):
         model = self.env['test_new_api.mixed']
         self.assertEqual(
             Domain('date', '=', date(2024, 1, 5)).optimize(model),
-            Domain('date', '=', date(2024, 1, 5)),
+            Domain('date', 'in', OrderedSet([date(2024, 1, 5)])),
         )
         self.assertEqual(
             Domain('date', '=', datetime(2024, 1, 5, 12, 0, 0)).optimize(model),
-            Domain('date', '=', date(2024, 1, 5)),
+            Domain('date', 'in', OrderedSet([date(2024, 1, 5)])),
         )
         self.assertEqual(
             Domain('date', '=', '2024-01-05').optimize(model),
-            Domain('date', '=', date(2024, 1, 5)),
+            Domain('date', 'in', OrderedSet([date(2024, 1, 5)])),
         )
         self.assertEqual(
             Domain('date', '=like', '2024%').optimize(model),
@@ -631,12 +631,12 @@ class TestDomainOptimize(TransactionCase):
     def test_condition_optimize_datetime(self):
         model = self.env['test_new_api.mixed']
         self.assertEqual(
-            Domain('moment', '=', datetime(2024, 1, 5)).optimize(model),
-            Domain('moment', '=', datetime(2024, 1, 5)),
+            Domain('moment', '=', date(2024, 1, 5)).optimize(model),
+            Domain('moment', 'in', OrderedSet([datetime(2024, 1, 5)])),
         )
         self.assertEqual(
             Domain('moment', '=', '2024-01-05').optimize(model),
-            Domain('moment', '=', datetime(2024, 1, 5)),
+            Domain('moment', 'in', OrderedSet([datetime(2024, 1, 5)])),
         )
         self.assertEqual(
             Domain('moment', '=like', '2024%').optimize(model),
@@ -723,9 +723,9 @@ class TestDomainOptimize(TransactionCase):
             ]).optimize(model),
             Domain.AND([
                 Domain('comment1', 'like', 'ok'),
-                Domain('date', '!=', False),
+                Domain('date', 'not in', OrderedSet([False])),
                 Domain('date', 'like', "2024"),
-                Domain('number', '=', 5),
+                Domain('number', 'in', OrderedSet([5])),
                 Domain('number', '<', 99),
             ]),
             "Optimization sorts by field and operator",

--- a/odoo/addons/test_new_api/tests/test_domain.py
+++ b/odoo/addons/test_new_api/tests/test_domain.py
@@ -564,8 +564,9 @@ class TestDomainOptimize(TransactionCase):
             Domain('important', '=', True),
         )
         self.assertEqual(
-            len(list(Domain('important', 'not in', [True, False]).optimize(model).iter_conditions())),
-            1, "the condition should not be reduced to a constant"
+            list(Domain('important', 'not in', [True, False]).optimize(model)),
+            [('important', 'not in', [True, False])],
+            "the condition should not be reduced to a constant"
         )
         self.assertEqual(
             Domain('important', 'not in', [True, False]).optimize(model, full=True),
@@ -581,6 +582,15 @@ class TestDomainOptimize(TransactionCase):
         )
         self.assertEqual(
             Domain('important', 'in', [0, 2]).optimize(model, full=True),
+            Domain.TRUE,
+        )
+        self.assertEqual(
+            list(Domain('active', 'in', [True, False]).optimize(model)),
+            [('active', 'in', [True, False])],
+            "the condition should not be reduced to a constant for active record"
+        )
+        self.assertEqual(
+            Domain('active', 'in', [True, False]).optimize(model, full=True),
             Domain.TRUE,
         )
 

--- a/odoo/addons/test_new_api/tests/test_domain.py
+++ b/odoo/addons/test_new_api/tests/test_domain.py
@@ -793,6 +793,35 @@ class TestDomainOptimize(TransactionCase):
             OrderedSet, "Check we can optimize something else than OrderedSet"
         )
 
+    def test_nary_optimize_in_relational(self):
+        model = self.env['test_new_api.discussion']
+
+        # check when the optimizations are applied, the results are checked
+        # by the previous test function
+        with self.subTest(field_type='many2one'):
+            d1 = Domain('moderator', 'in', [1]).optimize(model)
+            d2 = Domain('moderator', 'in', [1, 2]).optimize(model)
+            self.assertEqual((d1 & d2).optimize(model), d1)
+            self.assertEqual((d1 | d2).optimize(model), d2)
+            self.assertEqual((~d1 & ~d2).optimize(model), ~d2)
+            self.assertEqual((~d1 | ~d2).optimize(model), ~d1)
+
+        with self.subTest(field_type='one2many'):
+            d1 = Domain('messages', 'in', [1]).optimize(model)
+            d2 = Domain('messages', 'in', [1, 2]).optimize(model)
+            self.assertEqual((d1 & d2).optimize(model), (d1 & d2))
+            self.assertEqual((d1 | d2).optimize(model), d2)
+            self.assertEqual((~d1 & ~d2).optimize(model), ~d2)
+            self.assertEqual((~d1 | ~d2).optimize(model), ~d1 | ~d2)
+
+        with self.subTest(field_type='many2many'):
+            d1 = Domain('categories', 'in', [1]).optimize(model)
+            d2 = Domain('categories', 'in', [1, 2]).optimize(model)
+            self.assertEqual((d1 & d2).optimize(model), (d1 & d2))
+            self.assertEqual((d1 | d2).optimize(model), d2)
+            self.assertEqual((~d1 & ~d2).optimize(model), ~d2)
+            self.assertEqual((~d1 | ~d2).optimize(model), ~d1 | ~d2)
+
     def test_nary_optimize_any(self):
         model = self.env['test_new_api.discussion']
 

--- a/odoo/addons/test_new_api/tests/test_search.py
+++ b/odoo/addons/test_new_api/tests/test_search.py
@@ -398,7 +398,7 @@ class TestSubqueries(TransactionCase):
             WHERE "test_new_api_related"."foo_id" IN (
                 SELECT "test_new_api_related_foo"."id"
                 FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."name" = %s
+                WHERE "test_new_api_related_foo"."name" IN %s
             )
             ORDER BY "test_new_api_related"."id"
         """]):
@@ -410,7 +410,7 @@ class TestSubqueries(TransactionCase):
             WHERE "test_new_api_related"."foo_id" IN (
                 SELECT "test_new_api_related_foo"."id"
                 FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."name" = %s
+                WHERE "test_new_api_related_foo"."name" IN %s
                 AND "test_new_api_related_foo"."id" < %s
             )
             ORDER BY "test_new_api_related"."id"
@@ -446,7 +446,7 @@ class TestSubqueries(TransactionCase):
                 WHERE "test_new_api_related_foo"."bar_id" IN (
                     SELECT "test_new_api_related_bar"."id"
                     FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" = %s
+                    WHERE "test_new_api_related_bar"."name" IN %s
                 )
             )
             ORDER BY "test_new_api_related"."id"
@@ -462,7 +462,7 @@ class TestSubqueries(TransactionCase):
                 WHERE "test_new_api_related_foo"."bar_id" IN (
                     SELECT "test_new_api_related_bar"."id"
                     FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" = %s
+                    WHERE "test_new_api_related_bar"."name" IN %s
                     AND "test_new_api_related_bar"."id" < %s
                 )
                 AND "test_new_api_related_foo"."id" < %s
@@ -480,7 +480,7 @@ class TestSubqueries(TransactionCase):
                 WHERE "test_new_api_related_foo"."bar_id" IN (
                     SELECT "test_new_api_related_bar"."id"
                     FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" = %s
+                    WHERE "test_new_api_related_bar"."name" IN %s
                     AND "test_new_api_related_bar"."id" < %s
                 )
                 AND "test_new_api_related_foo"."id" < %s
@@ -498,7 +498,7 @@ class TestSubqueries(TransactionCase):
                 WHERE "test_new_api_related_foo"."bar_id" IN (
                     SELECT "test_new_api_related_bar"."id"
                     FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" = %s
+                    WHERE "test_new_api_related_bar"."name" IN %s
                     AND "test_new_api_related_bar"."id" < %s
                 )
                 AND "test_new_api_related_foo"."id" < %s
@@ -517,7 +517,7 @@ class TestSubqueries(TransactionCase):
                 WHERE "test_new_api_related_foo"."bar_id" IN (
                     SELECT "test_new_api_related_bar"."id"
                     FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" = %s
+                    WHERE "test_new_api_related_bar"."name" IN %s
                     AND "test_new_api_related_bar"."id" < %s
                 )
             )
@@ -546,7 +546,7 @@ class TestSubqueries(TransactionCase):
             WHERE "test_new_api_related"."foo_id" IN (
                 SELECT "test_new_api_related_foo"."id"
                 FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."name" = %s
+                WHERE "test_new_api_related_foo"."name" IN %s
             )
             ORDER BY "test_new_api_related"."id"
         """]):
@@ -561,7 +561,7 @@ class TestSubqueries(TransactionCase):
                     SELECT "test_new_api_related_foo"."id"
                     FROM "test_new_api_related_foo"
                     WHERE (
-                        "test_new_api_related_foo"."name" != %s
+                        "test_new_api_related_foo"."name" NOT IN %s
                         OR "test_new_api_related_foo"."name" IS NULL
                     )
                 )
@@ -578,7 +578,7 @@ class TestSubqueries(TransactionCase):
                 OR "test_new_api_related"."foo_id" IN (
                     SELECT "test_new_api_related_foo"."id"
                     FROM "test_new_api_related_foo"
-                    WHERE ("test_new_api_related_foo"."name" = %s OR "test_new_api_related_foo"."name" IS NULL)
+                    WHERE ("test_new_api_related_foo"."name" IN %s OR "test_new_api_related_foo"."name" IS NULL)
                 )
             )
             ORDER BY "test_new_api_related"."id"
@@ -591,7 +591,7 @@ class TestSubqueries(TransactionCase):
             WHERE "test_new_api_related"."foo_id" IN (
                 SELECT "test_new_api_related_foo"."id"
                 FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."name" != %s
+                WHERE "test_new_api_related_foo"."name" NOT IN %s
             )
             ORDER BY "test_new_api_related"."id"
         """]):
@@ -670,7 +670,7 @@ class TestSubqueries(TransactionCase):
                         OR "test_new_api_related_foo"."bar_id" IN (
                             SELECT "test_new_api_related_bar"."id"
                             FROM "test_new_api_related_bar"
-                            WHERE ("test_new_api_related_bar"."name" = %s OR "test_new_api_related_bar"."name" IS NULL)
+                            WHERE ("test_new_api_related_bar"."name" IN %s OR "test_new_api_related_bar"."name" IS NULL)
                         )
                     )
                 )
@@ -688,7 +688,7 @@ class TestSubqueries(TransactionCase):
                 WHERE "test_new_api_related_foo"."bar_id" IN (
                     SELECT "test_new_api_related_bar"."id"
                     FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" != %s
+                    WHERE "test_new_api_related_bar"."name" NOT IN %s
                 )
             )
             ORDER BY "test_new_api_related"."id"
@@ -726,7 +726,7 @@ class TestSubqueries(TransactionCase):
             FROM "test_new_api_related_inherits"
             LEFT JOIN "test_new_api_related" AS "test_new_api_related_inherits__base_id"
                 ON ("test_new_api_related_inherits"."base_id" = "test_new_api_related_inherits__base_id"."id")
-            WHERE "test_new_api_related_inherits__base_id"."name" = %s
+            WHERE "test_new_api_related_inherits__base_id"."name" IN %s
             AND "test_new_api_related_inherits__base_id"."id" < %s
             ORDER BY "test_new_api_related_inherits"."id"
         """]):
@@ -741,7 +741,7 @@ class TestSubqueries(TransactionCase):
             WHERE "test_new_api_related_inherits__base_id"."foo_id" IN (
                 SELECT "test_new_api_related_foo"."id"
                 FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."name" = %s
+                WHERE "test_new_api_related_foo"."name" IN %s
             )
             AND "test_new_api_related_inherits__base_id"."id" < %s
             ORDER BY "test_new_api_related_inherits"."id"
@@ -756,7 +756,7 @@ class TestSubqueries(TransactionCase):
             WHERE "test_new_api_related_inherits__base_id"."foo_id" IN (
                 SELECT "test_new_api_related_foo"."id"
                 FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."name" = %s
+                WHERE "test_new_api_related_foo"."name" IN %s
                 AND "test_new_api_related_foo"."id" < %s
             )
             AND "test_new_api_related_inherits__base_id"."id" < %s
@@ -775,7 +775,7 @@ class TestSubqueries(TransactionCase):
                 WHERE "test_new_api_related_foo"."bar_id" IN (
                     SELECT "test_new_api_related_bar"."id"
                     FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" = %s
+                    WHERE "test_new_api_related_bar"."name" IN %s
                 )
             )
             AND "test_new_api_related_inherits__base_id"."id" < %s
@@ -794,7 +794,7 @@ class TestSubqueries(TransactionCase):
                 WHERE "test_new_api_related_foo"."bar_id" IN (
                     SELECT "test_new_api_related_bar"."id"
                     FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" = %s
+                    WHERE "test_new_api_related_bar"."name" IN %s
                     AND "test_new_api_related_bar"."id" < %s
                 )
                 AND "test_new_api_related_foo"."id" < %s
@@ -990,7 +990,7 @@ class TestFlushSearch(TransactionCase):
         ''', '''
             SELECT "test_new_api_city"."id"
             FROM "test_new_api_city"
-            WHERE "test_new_api_city"."id" = %s AND "test_new_api_city"."name" LIKE %s
+            WHERE "test_new_api_city"."id" IN %s AND "test_new_api_city"."name" LIKE %s
             ORDER BY "test_new_api_city"."id"
         ''']):
             self.brussels.name = "Bruxelles"
@@ -1007,7 +1007,7 @@ class TestFlushSearch(TransactionCase):
         ''', '''
             SELECT "test_new_api_city"."id"
             FROM "test_new_api_city"
-            WHERE "test_new_api_city"."id" = %s
+            WHERE "test_new_api_city"."id" IN %s
             ORDER BY "test_new_api_city"."name", "test_new_api_city"."id"
         ''']):
             self.brussels.name = "Bruxelles"
@@ -1026,7 +1026,7 @@ class TestFlushSearch(TransactionCase):
             FROM "test_new_api_city"
             LEFT JOIN "test_new_api_country" AS "test_new_api_city__country_id"
                 ON ("test_new_api_city"."country_id" = "test_new_api_city__country_id"."id")
-            WHERE "test_new_api_city"."id" = %s
+            WHERE "test_new_api_city"."id" IN %s
             ORDER BY "test_new_api_city__country_id"."name",
                     "test_new_api_city__country_id"."id",
                     "test_new_api_city"."id"
@@ -1046,7 +1046,7 @@ class TestFlushSearch(TransactionCase):
             FROM "test_new_api_city"
             LEFT JOIN "test_new_api_country" AS "test_new_api_city__country_id"
                 ON ("test_new_api_city"."country_id" = "test_new_api_city__country_id"."id")
-            WHERE "test_new_api_city"."id" = %s
+            WHERE "test_new_api_city"."id" IN %s
             ORDER BY "test_new_api_city__country_id"."name",
                     "test_new_api_city__country_id"."id",
                     "test_new_api_city"."id"
@@ -1058,7 +1058,7 @@ class TestFlushSearch(TransactionCase):
         with self.assertQueries(['''
             SELECT "test_new_api_city"."id", "test_new_api_city"."name"
             FROM "test_new_api_city"
-            WHERE "test_new_api_city"."id" = %s
+            WHERE "test_new_api_city"."id" IN %s
             ORDER BY "test_new_api_city"."id"
         '''], flush=False):
             self.brussels.name = "Bruxelles"
@@ -1091,7 +1091,7 @@ class TestFlushSearch(TransactionCase):
         ''', '''
             SELECT "test_new_api_city"."id", "test_new_api_city"."name"
             FROM "test_new_api_city"
-            WHERE "test_new_api_city"."id" = %s
+            WHERE "test_new_api_city"."id" IN %s
             ORDER BY "test_new_api_city"."name"
         '''], flush=False):
             self.brussels.name = "Brüsel"
@@ -1152,7 +1152,7 @@ class TestDatePartNumber(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_person"."id"
             FROM "test_new_api_person"
-            WHERE date_part(%s, "test_new_api_person"."birthday") = %s
+            WHERE date_part(%s, "test_new_api_person"."birthday") IN %s
             ORDER BY "test_new_api_person"."id"
         """]):
             result = Person.search([('birthday.month_number', '=', '2')])
@@ -1161,7 +1161,7 @@ class TestDatePartNumber(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_person"."id"
             FROM "test_new_api_person"
-            WHERE date_part(%s, "test_new_api_person"."birthday") = %s
+            WHERE date_part(%s, "test_new_api_person"."birthday") IN %s
             ORDER BY "test_new_api_person"."id"
         """]):
             result = Person.search([('birthday.quarter_number', '=', '1')])
@@ -1170,7 +1170,7 @@ class TestDatePartNumber(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_person"."id"
             FROM "test_new_api_person"
-            WHERE date_part(%s, "test_new_api_person"."birthday") = %s
+            WHERE date_part(%s, "test_new_api_person"."birthday") IN %s
             ORDER BY "test_new_api_person"."id"
         """]):
             result = Person.search([('birthday.iso_week_number', '=', '6')])

--- a/odoo/addons/test_new_api/tests/test_search.py
+++ b/odoo/addons/test_new_api/tests/test_search.py
@@ -556,15 +556,11 @@ class TestSubqueries(TransactionCase):
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
             WHERE (
-                "test_new_api_related"."foo_id" IS NULL
-                OR "test_new_api_related"."foo_id" IN (
+                "test_new_api_related"."foo_id" NOT IN (
                     SELECT "test_new_api_related_foo"."id"
                     FROM "test_new_api_related_foo"
-                    WHERE (
-                        "test_new_api_related_foo"."name" NOT IN %s
-                        OR "test_new_api_related_foo"."name" IS NULL
-                    )
-                )
+                    WHERE "test_new_api_related_foo"."name" IN %s
+                ) OR "test_new_api_related"."foo_id" IS NULL
             )
             ORDER BY "test_new_api_related"."id"
         """]):
@@ -613,15 +609,11 @@ class TestSubqueries(TransactionCase):
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
             WHERE (
-                "test_new_api_related"."foo_id" IS NULL
-                OR "test_new_api_related"."foo_id" IN (
+                "test_new_api_related"."foo_id" NOT IN (
                     SELECT "test_new_api_related_foo"."id"
                     FROM "test_new_api_related_foo"
-                    WHERE (
-                        "test_new_api_related_foo"."name" NOT IN %s
-                        OR "test_new_api_related_foo"."name" IS NULL
-                    )
-                )
+                    WHERE "test_new_api_related_foo"."name" IN %s
+                ) OR "test_new_api_related"."foo_id" IS NULL
             )
             ORDER BY "test_new_api_related"."id"
         """]):

--- a/odoo/addons/test_read_group/tests/test_private_read_group.py
+++ b/odoo/addons/test_read_group/tests/test_private_read_group.py
@@ -1153,7 +1153,7 @@ class TestPrivateReadGroup(common.TransactionCase):
                     AND "test_read_group_related_foo__bar_id__base_ids"."test_read_group_related_base_id" IN (
                         SELECT "test_read_group_related_base"."id"
                         FROM "test_read_group_related_base"
-                        WHERE "test_read_group_related_base"."id" = %s
+                        WHERE "test_read_group_related_base"."id" IN %s
                     )
                 )
             GROUP BY "test_read_group_related_foo__bar_id__base_ids"."test_read_group_related_base_id"

--- a/odoo/addons/test_read_group/tests/test_private_read_group.py
+++ b/odoo/addons/test_read_group/tests/test_private_read_group.py
@@ -910,7 +910,7 @@ class TestPrivateReadGroup(common.TransactionCase):
                     AND "test_read_group_task__user_ids"."user_id" IN (
                         SELECT "test_read_group_user"."id"
                         FROM "test_read_group_user"
-                        WHERE "test_read_group_user"."id" = %s
+                        WHERE "test_read_group_user"."id" IN %s
                     )
                 )
             GROUP BY "test_read_group_task__user_ids"."user_id"

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -181,7 +181,7 @@ class Domain:
     # because we overwrite __new__ so typechecking for abstractmethod is incorrect.
     # We do this so that we can use the Domain as both a factory for multiple
     # types of domains, while still having `isinstance` working for it.
-    __slots__ = '_opt_level'
+    __slots__ = ('_opt_level',)
     _opt_level: OptimizationLevel
 
     def __new__(cls, *args):
@@ -410,7 +410,7 @@ class DomainBool(Domain):
     It is NOT considered as a condition and these constants are removed
     from nary domains.
     """
-    __slots__ = 'value'
+    __slots__ = ('value',)
     value: bool
 
     def __new__(cls, value: bool):
@@ -461,7 +461,7 @@ class DomainNot(Domain):
     """Negation domain, contains a single child"""
     OPERATOR = '!'
 
-    __slots__ = 'child'
+    __slots__ = ('child',)
     child: Domain
 
     def __new__(cls, child: Domain):
@@ -504,7 +504,7 @@ class DomainNary(Domain):
     OPERATOR_SQL: SQL = SQL(" ??? ")
     ZERO: DomainBool = _FALSE_DOMAIN  # default for lint checks
 
-    __slots__ = 'children'
+    __slots__ = ('children',)
     children: list[Domain]
 
     def __new__(cls, children: list[Domain]):

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -727,6 +727,9 @@ class DomainCondition(Domain):
             isinstance(other, DomainCondition)
             and self.field_expr == other.field_expr
             and self.operator == other.operator
+            # we want stricter equality than this: `OrderedSet([x]) == {x}`
+            # to ensure that optimizations always return OrderedSet values
+            and self.value.__class__ is other.value.__class__
             and self.value == other.value
         )
 

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1215,12 +1215,6 @@ class Field(typing.Generic[T]):
         can_be_null = self not in model.env.registry.not_null_fields
 
         # operator: in (equality)
-        equal_operator = None
-        if operator in ('=', '!='):
-            equal_operator = operator
-            operator = 'in' if operator == '=' else 'not in'
-            value = [value]
-
         if operator in ('in', 'not in'):
             assert isinstance(value, COLLECTION_TYPES), \
                 f"condition_to_sql() 'in' operator expects a collection, not a {value!r}"
@@ -1236,11 +1230,7 @@ class Field(typing.Generic[T]):
 
             sql = None
             if params:
-                if equal_operator:
-                    assert len(params) == 1
-                    sql = SQL("%s%s%s", sql_field, SQL_OPERATORS[equal_operator], params[0])
-                else:
-                    sql = SQL("%s%s%s", sql_field, SQL_OPERATORS[operator], params)
+                sql = SQL("%s%s%s", sql_field, SQL_OPERATORS[operator], params)
 
             if (operator == 'in') == null_in_condition:
                 # field in {val, False} => field IN vals OR field IS NULL

--- a/odoo/orm/fields_binary.py
+++ b/odoo/orm/fields_binary.py
@@ -226,7 +226,7 @@ class Binary(Field):
             return super().condition_to_sql(field_expr, operator, value, model, alias, query)
         # check permission
         model._check_field_access(self, 'read')
-        assert (operator in ('in', 'not in') and set(value) == {False}) or (operator in ('=', '!=') and not value), "Should have been done in Domain optimization"
+        assert operator in ('in', 'not in') and set(value) == {False}, "Should have been done in Domain optimization"
         return SQL(
             "%s%s(SELECT res_id FROM ir_attachment WHERE res_model = %s AND res_field = %s)",
             model._field_to_sql(alias, 'id', query),

--- a/odoo/orm/fields_misc.py
+++ b/odoo/orm/fields_misc.py
@@ -40,7 +40,7 @@ class Boolean(Field[bool]):
         return bool(value)
 
     def _condition_to_sql(self, field_expr: str, operator: str, value, model: BaseModel, alias: str, query: Query) -> SQL:
-        if operator not in ('in', 'not in', '=', '!='):
+        if operator not in ('in', 'not in'):
             return super()._condition_to_sql(field_expr, operator, value, model, alias, query)
 
         # get field and check access
@@ -48,8 +48,6 @@ class Boolean(Field[bool]):
 
         # express all conditions as (field_expr, 'in', possible_values)
         possible_values = (
-            {bool(value)} if operator == '=' else
-            {(not value)} if operator == '!=' else
             {bool(v) for v in value} if operator == 'in' else
             {True, False} - {bool(v) for v in value}  # operator == 'not in'
         )

--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -592,9 +592,6 @@ class Properties(Field):
         raw_sql_field = model._field_to_sql(alias, fname, query)
         sql_left = model._field_to_sql(alias, field_expr, query)
 
-        if operator in ('=', '!='):
-            operator = 'in' if operator == '=' else 'not in'
-            value = [value]
         if operator in ('in', 'not in'):
             assert isinstance(value, COLLECTION_TYPES)
             if len(value) == 1 and True in value:

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -678,9 +678,6 @@ class _RelationalMulti(_Relational[M], typing.Generic[M]):
         comodel = model.env[self.comodel_name]
 
         # update the operator to 'any'
-        if operator in ('=', '!='):
-            operator = 'in' if operator == '=' else 'not in'
-            value = [value]
         if operator in ('in', 'not in'):
             operator = 'any' if operator == 'in' else 'not any'
         assert operator in ('any', 'not any'), \

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -318,7 +318,7 @@ class BaseString(Field[str | typing.Literal[False]]):
         if (
             self.translate
             and value
-            and operator in ('=', 'in', 'like', 'ilike', '=like', '=ilike')
+            and operator in ('in', 'like', 'ilike', '=like', '=ilike')
             and self.index == 'trigram'
             and model.pool.has_trigram
             and (
@@ -328,9 +328,6 @@ class BaseString(Field[str | typing.Literal[False]]):
         ):
             # a prefilter using trigram index to speed up '=', 'like', 'ilike'
             # '!=', '<=', '<', '>', '>=', 'in', 'not in', 'not like', 'not ilike' cannot use this trick
-            if operator == '=':
-                operator = 'in'
-                value = [value]
             if operator == 'in' and len(value) == 1:
                 value = value_to_translated_trigram_pattern(next(iter(value)))
             elif operator != 'in':


### PR DESCRIPTION
## Details are in the commit messages.

### Optimize 'in' conditions
Merge multiple 'in' domain conditions in a single one. This results in simpler domains.

### Replace '=' operator with 'in'
In order to use the 'in' optimization more frequently and to simply code, transform all '=' conditions into 'in' conditions. With this change, all equality domains always use 'in'.

### Refactor `Field.search`
Since most of the methods are implemented using '=' that gets transformed, we need to review them. At the same time, writing search methods is not easy today because of all operators that need to be supported and negative operators are sometimes not (or incorrectly) handled.
We simplify by first applying basic optimizations and then calling the search method so that most of base cases are already handled. A function not supporting the operator should raise `NotImplementedError`. If a negative operator, such as `not in` is not supported, we will call  the method with the operator `in` and complement the result automatically.
For boolean searchable fields (which are quite common), we always call them with `'in'/'not in', [True]` which further simplifies their implementation.


## References

task-4150178
odoo/enterprise#76079


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
