### PR TITLE
[FIX] hr_holidays: resource leave should exist if not fully covered by public holiday

### DIFF
--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -81,6 +81,9 @@ class CalendarLeaves(models.Model):
             leave.write({'state': state})
             if leave.number_of_days == 0.0:
                 leaves_to_cancel |= leave
+            elif leave.state == 'validate':
+                # recreate the resource leave that were removed by writing state to draft
+                leave.sudo()._create_resource_leave()
 
         leaves_to_cancel._force_cancel(_("a new public holiday completely overrides this leave."), 'mail.mt_comment')
 


### PR DESCRIPTION
to reproduce:
=============
- create a leave for an employee of 3 days
- create a public holiday that happens to be in the middle of the employee leave
- check work entries for the employee on that period -> only work entries of the public holiday are created

Problem:
========
- when the public holiday was created, the leave was not split to take into account the public holiday

Solution:
=========
- split the leave to take into account the public holiday

opw-4353988

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
