### PR TITLE
[FIX] l10n_br_website_sale: missing city selection in address form

### DIFF
--- a/addons/l10n_br_website_sale/controllers/main.py
+++ b/addons/l10n_br_website_sale/controllers/main.py
@@ -14,7 +14,7 @@ class L10nBRWebsiteSale(WebsiteSale):
             and request.website.sudo().company_id.account_fiscal_country_id.code == 'BR'
         ):
             mandatory_fields |= {
-                'vat', 'l10n_latam_identification_type_id', 'street_name', 'street2', 'street_number', 'zip', 'city_id', 'state_id', 'country_id'
+                'street_name', 'street2', 'street_number', 'zip', 'city_id', 'state_id', 'country_id'
             }
             mandatory_fields -= {'street', 'city'}  # Brazil uses the base_extended_address fields added above
 
@@ -39,15 +39,17 @@ class L10nBRWebsiteSale(WebsiteSale):
         rendering_values = super()._prepare_address_form_values(
             order_sudo, partner_sudo, *args, address_type=address_type, **kwargs
         )
-        if (kwargs.get('use_delivery_as_billing') and address_type == 'delivery' or address_type == 'billing') and request.website.sudo().company_id.account_fiscal_country_id.code == 'BR':
-            can_edit_vat = rendering_values['can_edit_vat']
-            LatamIdentificationType = request.env['l10n_latam.identification.type'].sudo()
-            rendering_values.update({
-                'identification_types': LatamIdentificationType.search([
-                    '|', ('country_id', '=', False), ('country_id.code', '=', 'BR'),
-                ]) if can_edit_vat else LatamIdentificationType,
-            })
+        if request.website.sudo().company_id.account_fiscal_country_id.code == 'BR':
             rendering_values['city_sudo'] = partner_sudo.city_id
             rendering_values['cities_sudo'] = request.env['res.city'].sudo().search([('country_id.code', '=', 'BR')])
-            rendering_values['vat_label'] = _lt('Number')
+
+            if (kwargs.get('use_delivery_as_billing') and address_type == 'delivery') or address_type == 'billing':
+                can_edit_vat = rendering_values['can_edit_vat']
+                LatamIdentificationType = request.env['l10n_latam.identification.type'].sudo()
+                rendering_values.update({
+                    'identification_types': LatamIdentificationType.search([
+                        '|', ('country_id', '=', False), ('country_id.code', '=', 'BR'),
+                    ]) if can_edit_vat else LatamIdentificationType,
+                    'vat_label': _lt('Number'),
+                })
         return rendering_values


### PR DESCRIPTION
In BR localization, when a logged user tries to edit the delivery
address during checkout it may occur that the city field is missing the
selection list, causing the form to always return a validation error

Steps to reproduce (with a BR company setup)
- In Website > Configuration > Settings, set BR company as owner of website
- Log in as new user
- Add an item to the cart
- Go to checkout and add all the address info
- In the addresses selection page, uncheck 'Same as delivery address'
  and add a new delivery address

Issue: City selection list will be empty

This occurs because, when user is editing the delivery address without
'Save as delivery address' the system won't provide the city list.
Moreover it will attempt to validate VAT info (fields `vat` and
`l10n_latam_identification_type_id`) for delivery addresses

opw-4411470