### PR TITLE
[FIX] web_editor: font-size not computed correctly

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -2204,7 +2204,7 @@ export function isColorGradient(value) {
  */
 export function getFontSizeDisplayValue(sel, getCSSVariableValue, convertNumericToUnit) {
     const tagNameRelatedToFontSize = ["h1", "h2", "h3", "h4", "h5", "h6"];
-    const styleClassesRelatedToFontSize = ["display-1", "display-2", "display-3", "display-4"];
+    const styleClassesRelatedToFontSize = ["display-1", "display-2", "display-3", "display-4", "lead"];
     const closestStartContainerEl = closestElement(sel.getRangeAt(0).startContainer);
     const closestFontSizedEl = closestStartContainerEl.closest(`
         [style*='font-size'],
@@ -2239,11 +2239,7 @@ export function getFontSizeDisplayValue(sel, getCSSVariableValue, convertNumeric
         }
         remValue = parseFloat(getCSSVariableValue(`${fsName}-font-size`));
     }
-    // It's default font size (no font size class / style).
-    if (remValue === undefined) {
-        remValue = parseFloat(getCSSVariableValue("font-size-base"));
-    }
-    const pxValue = convertNumericToUnit(remValue, "rem", "px");
+    const pxValue = remValue && convertNumericToUnit(remValue, "rem", "px");
     return pxValue || parseFloat(getComputedStyle(closestStartContainerEl).fontSize);
 }
 

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -91,6 +91,7 @@
     @include print-variable('h6-font-size', $h6-font-size);
     @include print-variable('font-size-base', $font-size-base);
     @include print-variable('small-font-size', $small-font-size);
+    @include print-variable('lead-font-size', $lead-font-size);
 }
 
 html, body {


### PR DESCRIPTION
**Behaviour before PR:**

In website, in some snippets font-size of paragraph like elements is not displayed correctly in toolbar. This issue happens because in `getFontSizeDisplayValue` method if there is no font-size class applied to element then it will set the value of `--font-size-base` css variable which is `16px`.

**Behaviour after PR is merged:**

Now, `getFontSizeDisplayValue` method will set font-size using `getComputedStyle` if there is no font related class is applied to that element.

task-4420329




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
