### PR TITLE
[FIX] l10n_in_edi_ewaybill: fix e-invoicing of credit note

### DIFF
--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -371,7 +371,7 @@ class AccountEdiFormat(models.Model):
 
     def _get_l10n_in_edi_saler_buyer_party(self, move):
         res = super()._get_l10n_in_edi_saler_buyer_party(move)
-        if move.is_outbound():
+        if move.is_outbound() and self.code == 'in_ewaybill_1_03':
             res = {
                 "seller_details":  move.partner_id,
                 "dispatch_details": move.partner_shipping_id or move.partner_id,

--- a/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
+++ b/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
@@ -7,7 +7,12 @@ from odoo.tests import tagged
 class TestEdiEwaybillJson(TestEdiJson):
 
     def test_edi_json(self):
-        (self.invoice + self.invoice_full_discount + self.invoice_zero_qty).write({
+        self.env['account.move'].browse((
+            self.invoice.id,
+            self.invoice_full_discount.id,
+            self.invoice_zero_qty.id,
+            self.invoice_reverse.id,
+        )).write({
             "l10n_in_type_id": self.env.ref("l10n_in_edi_ewaybill.type_tax_invoice_sub_type_supply"),
             "l10n_in_distance": 20,
             "l10n_in_mode": "1",
@@ -75,6 +80,36 @@ class TestEdiEwaybillJson(TestEdiJson):
             "totInvValue": 1999.59
         }
         self.assertDictEqual(json_value, expected, "Indian EDI send json value is not matched")
+
+        # =================================== Credit Note Test =============================================
+        credit_note_expected = expected.copy()
+        credit_note_expected.update({
+            'docDate': '25/12/2023',
+            'docNo': 'RINV/2023/00001',
+            'supplyType': 'I',
+            "fromGstin": expected['toGstin'],
+            "fromTrdName": expected['toTrdName'],
+            "fromAddr1": expected['toAddr1'],
+            "fromAddr2": expected['toAddr2'],
+            "fromPlace": expected['toPlace'],
+            "fromPincode": expected['toPincode'],
+            "fromStateCode": expected['toStateCode'],
+            "actFromStateCode": expected['actToStateCode'],
+            "toGstin": expected['fromGstin'],
+            "toTrdName": expected['fromTrdName'],
+            "toAddr1": expected['fromAddr1'],
+            "toAddr2": expected['fromAddr2'],
+            "toPlace": expected['fromPlace'],
+            "toPincode": expected['fromPincode'],
+            "toStateCode": expected['fromStateCode'],
+            "actToStateCode": expected['actFromStateCode'],
+        })
+        self.assertDictEqual(
+            self.env.ref(
+                'l10n_in_edi_ewaybill.edi_in_ewaybill_json_1_03'
+            )._l10n_in_edi_ewaybill_generate_json(self.invoice_reverse),
+            credit_note_expected,
+        )
 
         #=================================== Full discount test =====================================
         json_value = self.env["account.edi.format"]._l10n_in_edi_ewaybill_generate_json(self.invoice_full_discount)


### PR DESCRIPTION
Issue introduced at https://github.com/odoo/odoo/commit/ce92dedea0fd3cdc73da6366c20b8052bb04f7e9 ,

While doing the fix for ewaybill, now it's causing issue for `E-Invoice`, because the partner buyer details were changed from Purchase Document to Move type being a Outbound

In this fix we only change Buyer-Seller Details only if it's for e-waybill

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
