### PR TITLE
[FIX] html_editor: opacity slider does not work in colorpicker

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -1,7 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
 import {
     isColorGradient,
-    rgbToHex,
+    rgbaToHex,
     hasColor,
     hasAnyNodesColor,
     TEXT_CLASSES_REGEX,
@@ -120,9 +120,9 @@ export class ColorPlugin extends Plugin {
         }
 
         this.selectedColors.color =
-            hasGradient && hasTextGradientClass ? backgroundImage : rgbToHex(elStyle.color);
+            hasGradient && hasTextGradientClass ? backgroundImage : rgbaToHex(elStyle.color);
         this.selectedColors.backgroundColor =
-            hasGradient && !hasTextGradientClass ? backgroundImage : rgbToHex(backgroundColor);
+            hasGradient && !hasTextGradientClass ? backgroundImage : rgbaToHex(backgroundColor);
     }
 
     /**
@@ -384,7 +384,7 @@ export class ColorPlugin extends Plugin {
         const usedCustomColors = new Set();
         for (const font of allFont) {
             if (isCSSColor(font.style[mode])) {
-                usedCustomColors.add(rgbToHex(font.style[mode]));
+                usedCustomColors.add(rgbaToHex(font.style[mode]));
             }
         }
         return usedCustomColors;

--- a/addons/html_editor/static/src/main/font/color_selector.xml
+++ b/addons/html_editor/static/src/main/font/color_selector.xml
@@ -76,7 +76,7 @@
                                 </div>
                                 <Colorpicker
                                     defaultColor="this.defaultColor"
-                                    onColorSelect.bind="(color) => this.applyColor(color.hex)"
+                                    onColorSelect.bind="(color) => this.applyColor(color.cssColor)"
                                     onColorPreview.bind="onColorPreview" />
                             </div>
                         </t>

--- a/addons/html_editor/static/src/main/font/gradient_picker.js
+++ b/addons/html_editor/static/src/main/font/gradient_picker.js
@@ -1,6 +1,6 @@
 import { Component, onWillUpdateProps, useState } from "@odoo/owl";
 import { Colorpicker } from "@web/core/colorpicker/colorpicker";
-import { isColorGradient, rgbToHex } from "@html_editor/utils/color";
+import { isColorGradient, rgbaToHex } from "@html_editor/utils/color";
 
 export class GradientPicker extends Component {
     static components = { Colorpicker };
@@ -39,14 +39,20 @@ export class GradientPicker extends Component {
             ...gradient.matchAll(
                 /(#[0-9a-f]{6}|rgba?\(\s*[0-9]+\s*,\s*[0-9]+\s*,\s*[0-9]+\s*[,\s*[0-9.]*]?\s*\)|[a-z]+)\s*([[0-9]+%]?)/g
             ),
-        ].filter((color) => rgbToHex(color[1]) !== "#");
+        ].filter((color) => rgbaToHex(color[1]) !== "#");
 
         if (colors.length !== 2) {
             return;
         }
 
-        this.colors[0] = { hex: rgbToHex(colors[0][1]), percentage: colors[0][2].replace("%", "") };
-        this.colors[1] = { hex: rgbToHex(colors[1][1]), percentage: colors[1][2].replace("%", "") };
+        this.colors[0] = {
+            hex: rgbaToHex(colors[0][1]),
+            percentage: colors[0][2].replace("%", ""),
+        };
+        this.colors[1] = {
+            hex: rgbaToHex(colors[1][1]),
+            percentage: colors[1][2].replace("%", ""),
+        };
 
         const isLinear = gradient.startsWith("linear-gradient(");
         if (isLinear) {
@@ -82,7 +88,8 @@ export class GradientPicker extends Component {
     }
 
     onColorChange(color) {
-        this.colors[this.state.currentColorIndex].hex = color.hex;
+        const hex = rgbaToHex(color.cssColor);
+        this.colors[this.state.currentColorIndex].hex = hex;
         this.onColorGradientChange();
     }
 

--- a/addons/html_editor/static/tests/utils/color.test.js
+++ b/addons/html_editor/static/tests/utils/color.test.js
@@ -1,9 +1,10 @@
-import { rgbToHex } from "@html_editor/utils/color";
+import { rgbToHex, rgbaToHex, blendColors } from "@html_editor/utils/color";
 import { expect, getFixture, test } from "@odoo/hoot";
 
-test("should convert an rgb color to hexadecimal", async () => {
+test("should convert an rgb and rgba color to hexadecimal", async () => {
     expect(rgbToHex("rgb(0, 0, 255)")).toBe("#0000ff");
     expect(rgbToHex("rgb(0,0,255)")).toBe("#0000ff");
+    expect(rgbaToHex("rgba(0, 0, 255, 0.5)")).toBe("#0000ff80");
 });
 
 test("should convert an rgba color to hexadecimal (background is hexadecimal)", async () => {
@@ -14,6 +15,7 @@ test("should convert an rgba color to hexadecimal (background is hexadecimal)", 
     parent.append(node);
     // white with 50% opacity over blue = light blue
     expect(rgbToHex("rgba(255, 255, 255, 0.5)", node)).toBe("#7f7fff");
+    expect(blendColors("rgba(255, 255, 255, 0.5)", node)).toBe("#8080ff");
 });
 
 test("should convert an rgba color to hexadecimal (background is color name)", async () => {
@@ -24,6 +26,7 @@ test("should convert an rgba color to hexadecimal (background is color name)", a
     parent.append(node);
     // white with 50% opacity over blue = light blue
     expect(rgbToHex("rgba(255, 255, 255, 0.5)", node)).toBe("#7f7fff");
+    expect(blendColors("rgba(255, 255, 255, 0.5)", node)).toBe("#8080ff");
 });
 
 test("should convert an rgba color to hexadecimal (background is rgb)", async () => {
@@ -34,6 +37,7 @@ test("should convert an rgba color to hexadecimal (background is rgb)", async ()
     parent.append(node);
     // white with 50% opacity over blue = light blue
     expect(rgbToHex("rgba(255, 255, 255, 0.5)", node)).toBe("#7f7fff");
+    expect(blendColors("rgba(255, 255, 255, 0.5)", node)).toBe("#8080ff");
     parent.remove();
 });
 
@@ -45,4 +49,5 @@ test("should convert an rgba color to hexadecimal (background is rgba)", async (
     parent.append(node);
     // white with 50% opacity over blue with 50% opacity over red = light purple
     expect(rgbToHex("rgba(255, 255, 255, 0.5)", node)).toBe("#bf7fbf");
+    expect(blendColors("rgba(255, 255, 255, 0.5)", node)).toBe("#c080c0");
 });

--- a/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
@@ -1,5 +1,5 @@
 import { isBlock } from "@html_editor/utils/blocks";
-import { rgbToHex } from "@html_editor/utils/color";
+import { blendColors } from "@html_editor/utils/color";
 import { getAdjacentPreviousSiblings } from "@html_editor/utils/dom_traversal";
 
 function parentsGet(node, root = undefined) {
@@ -576,7 +576,7 @@ export function classToStyle(element, cssRules) {
                                     .replace(RE_PADDING_MATCH, "")
                                     .replaceAll('"', "&quot;")}" ${
                         node.parentElement.style.textAlign === "center" ? 'align="center" ' : ""
-                    }bgcolor="${rgbToHex(node.style.backgroundColor)}">
+                    }bgcolor="${blendColors(node.style.backgroundColor)}">
                     `)
                 );
                 node.after(
@@ -1329,7 +1329,7 @@ export function normalizeColors(element) {
         for (const rgb of rgbaMatch || []) {
             node.setAttribute(
                 "style",
-                node.getAttribute("style").replace(rgb, rgbToHex(rgb, node))
+                node.getAttribute("style").replace(rgb, blendColors(rgb, node))
             );
         }
     }


### PR DESCRIPTION
**Current behavior before PR:**

- The opacity slider in the color picker did not apply the selected opacity to the text.

**Desired behavior after PR is merged:**

- Now, adjusting the opacity using the slider in the color picker correctly applies the selected opacity to the text.

task:4419805
