### PR TITLE
[FIX] project_todo: set by default project to False in todo

### DIFF
--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -246,7 +246,7 @@
         <field name="domain">[('user_ids', 'in', [uid]), ('project_id', '=', False), ('parent_id', '=', False)]</field>
         <field name="view_mode">kanban,form,tree,activity</field>
         <field name="search_view_id" ref="project_task_view_todo_search"/>
-        <field name="context">{'search_default_open_tasks': 1, 'tree_view_ref': 'project_todo.project_task_view_todo_tree'}</field>
+        <field name="context">{'search_default_open_tasks': 1, 'tree_view_ref': 'project_todo.project_task_view_todo_tree', 'default_project_id': False}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No to-do found. Let's create one!


### PR DESCRIPTION
Before this commit, when the user sets a project as a default value for his tasks, that default value will also be applied inside To-Do app because a to-do is in fact a private task (that is, a task without any project set).

This commit adds a default value inside the context of the main action used in To-Do to make sure the default value for `project_id` field in To-Do is false and nothing else.

Steps to reproduce
==================

1. Install Project app
2. Go to Project app
3. Select/create a project
4. Select/create and edit a task inside
5. Enable the debug mode
6. Click on debug menu and select `Set Default Values`
7. Apply `project = <your project selected/created>` and save
8. Go to To-Do app
9. Create a to-do

Expected Behavior
-----------------

A to-do should be created without any issue in the kanban view.

Current Behavior
----------------

A form view will be displayed inside a modal to create the to-do but the form view is in fact the one used in Project app and the project set is the one set as default value instead of having no project since the user is creating a to-do and not a task inside that project.
