### PR TITLE
[FIX] web_editor: Prevent portal users from pasting images in the editor

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -5041,7 +5041,7 @@ export class OdooEditor extends EventTarget {
             if (fragment.hasChildNodes()) {
                 this._applyCommand('insert', fragment);
             }
-        } else if (files.length || clipboardHtml) {
+        } else if ((files.length || clipboardHtml) && this.options.allowCommandImage) {
             const clipboardElem = this._prepareClipboardData(clipboardHtml);
             // When copy pasting a table from the outside, a picture of the
             // table can be included in the clipboard as an image file. In that

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -429,6 +429,7 @@ export class Wysiwyg extends Component {
             getUnremovableElements: this.options.getUnremovableElements,
             defaultLinkAttributes: this.options.userGeneratedContent ? {rel: 'ugc' } : {},
             allowCommandVideo: this.options.allowCommandVideo,
+            allowCommandImage: this.options.allowCommandImage,
             allowInlineAtRoot: this.options.allowInlineAtRoot,
             getYoutubeVideoElement: getYoutubeVideoElement,
             getContextFromParentRect: options.getContextFromParentRect,


### PR DESCRIPTION
Portal users are not allowed to create attachments, yet they can still paste images into the editor.
Although the pasted image is not saved as an attachment, portal users should not be allowed to paste images at all.

The fix ensures that the system checksif the user has permissions to create attachments before allowing images to be pasted.

Steps to Reproduce:
1. Invite a portal user to edit Knowledge articles.
2. As a portal user, attempt to paste an image into the editor.

opw-4246752

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
