### PR TITLE
 [FIX] web: don't apply col span on small screen 

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -491,6 +491,10 @@
             &.o_form_fw_labels {
                 grid-template-columns: 150px 1fr;
             }
+
+            .o_cell_custom {
+                grid-column: span var(--o-grid-column-span, 1);
+            }
         }
     }
 

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -45,6 +45,7 @@
 
     @include media-breakpoint-down(md) {
         .o_cell:has(+ :is(.o_wrap_label, .o_wrap_field_boolean)),
+        .o_cell.o_wrap_input,
         .o_wrap_field_boolean,
         .o_cell_custom:not(.o_wrap_label),
         .o_cell:first-child:last-child {

--- a/addons/web/static/src/views/form/form_group/form_group.xml
+++ b/addons/web/static/src/views/form/form_group/form_group.xml
@@ -26,7 +26,7 @@
                 <t t-else="">
                     <div
                         class="o_cell o_cell_custom"
-                        t-attf-style="{{ cell.itemSpan > 1 ? 'grid-column: span ' + cell.itemSpan + ';' : '' }}"
+                        t-attf-style="{{ cell.itemSpan > 1 ? '--o-grid-column-span: ' + cell.itemSpan + ';' : '' }}"
                         t-attf-class="{{ cell.subType === 'label' ? 'o_wrap_label text-break text-900' : null }}"
                         t-if="cell.isVisible">
                         <t t-slot="{{ cell.name }}" />

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -8468,9 +8468,15 @@ test(`form rendering with groups with col/colspan`, async () => {
 
     // Verify .group_4 content
     expect(`.group_4 > div.o_cell`).toHaveCount(4);
-    expect(`.group_4 > div.o_cell:first-child`).toHaveAttribute("style", "grid-column: span 3;");
-    expect(`.group_4 > div.o_cell:nth-child(2)`).toHaveAttribute("style", "grid-column: span 2;");
-    expect(`.group_4 > div.o_cell:last-child`).toHaveAttribute("style", "grid-column: span 4;");
+    expect(`.group_4 > div.o_cell:first-child`).toHaveAttribute(
+        "style",
+        "--o-grid-column-span: 3;"
+    );
+    expect(`.group_4 > div.o_cell:nth-child(2)`).toHaveAttribute(
+        "style",
+        "--o-grid-column-span: 2;"
+    );
+    expect(`.group_4 > div.o_cell:last-child`).toHaveAttribute("style", "--o-grid-column-span: 4;");
 
     // Verify .group_3 content
     expect(`.group_3 > *`).toHaveCount(3);


### PR DESCRIPTION
This commit avoids setting the `grid-column: span 2;` CSS rules (inline)
in form view when we are on small screen.

Before the removal of d-contents it was not an issue as it was not a
grid but a flex on small screen.

Steps to reproduce:
* Open Odoo on small Screen
* Go to Contact
* Select a Company
* Go to the "Sales & Purchase" pane
* The "Purchase" group has 2 grid columns and the render is ugly => BUG

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
