### PR TITLE
[FIX] l10n_test_pos_qr_payment: only load one product for test

### DIFF
--- a/addons/l10n_test_pos_qr_payment/tests/common.py
+++ b/addons/l10n_test_pos_qr_payment/tests/common.py
@@ -10,6 +10,9 @@ class TestPosQrCommon(AccountTestInvoicingHttpCommon):
         super().setUpClass()
         cls.company_data['company'].qr_code = True
 
+        cls.env['product.combo.item'].search([]).unlink()
+        cls.env['product.product'].search([]).write({'available_in_pos': False})
+
         cls.product_1 = cls.env['product.product'].create({
             'name': 'Hand Bag',
             'available_in_pos': True,


### PR DESCRIPTION
Prevent random runbot error by making sure only the Hand Bag product is available.

