### PR TITLE
[FIX] pos_self_order: fix `self_order_product_info` tour

### DIFF
--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -78,7 +78,8 @@ registry.category("web_tour.tours").add("self_order_product_info", {
     steps: () => [
         Utils.clickBtn("Order Now"),
         {
-            trigger: ".self_order_product_card .product-information-tag",
+            trigger:
+                ".self_order_product_card:contains('Product Info Test') .product-information-tag",
             run: "click",
         },
         {


### PR DESCRIPTION
**Problem**:
The product created during the tour test was not explicitly selected. It was selected implicitly because it appeared first in the product list.

**Solution**:
Explicitly select the product created during the test in the tour to ensure proper functionality and remove dependency on list order.

runbot-110904

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
