### PR TITLE
[FIX] l10n_sa_edi: setting tax scheme id to always be VAT

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -185,7 +185,10 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             the buyer VAT registration number or buyer group VAT registration number must not exist in the Invoice
         """
         if role != 'customer' or partner.country_id.code == 'SA':
-            return super()._get_partner_party_tax_scheme_vals_list(partner, role)
+            vals_list = super()._get_partner_party_tax_scheme_vals_list(partner, role)
+            for vals in vals_list:
+                vals['tax_scheme_vals'] = {'id': 'VAT'}
+            return vals_list
         return []
 
     def _apply_invoice_tax_filter(self, base_line, tax_values):

--- a/addons/l10n_sa_edi/tests/compliance/simplified/credit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/credit.xml
@@ -77,7 +77,7 @@
           </cac:Country>
         </cac:RegistrationAddress>
         <cac:TaxScheme>
-          <cbc:ID>NOT_EU_VAT</cbc:ID>
+          <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>

--- a/addons/l10n_sa_edi/tests/compliance/simplified/debit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/debit.xml
@@ -77,7 +77,7 @@
           </cac:Country>
         </cac:RegistrationAddress>
         <cac:TaxScheme>
-          <cbc:ID>NOT_EU_VAT</cbc:ID>
+          <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>

--- a/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
@@ -72,7 +72,7 @@
           </cac:Country>
         </cac:RegistrationAddress>
         <cac:TaxScheme>
-          <cbc:ID>NOT_EU_VAT</cbc:ID>
+          <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>

--- a/addons/l10n_sa_edi/tests/compliance/standard/credit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/credit.xml
@@ -71,7 +71,7 @@
                     </cac:Country>
                 </cac:RegistrationAddress>
                 <cac:TaxScheme>
-                    <cbc:ID>NOT_EU_VAT</cbc:ID>
+                    <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>

--- a/addons/l10n_sa_edi/tests/compliance/standard/debit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/debit.xml
@@ -71,7 +71,7 @@
                 </cac:Country>
                 </cac:RegistrationAddress>
                 <cac:TaxScheme>
-                    <cbc:ID>NOT_EU_VAT</cbc:ID>
+                    <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>

--- a/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
@@ -65,7 +65,7 @@
                     </cac:Country>
                 </cac:RegistrationAddress>
                 <cac:TaxScheme>
-                    <cbc:ID>NOT_EU_VAT</cbc:ID>
+                    <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
