### PR TITLE
[15.0][FIX] stock_account:  use uom of the move line when creating correction svl

### DIFF
--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -44,7 +44,7 @@ class StockMoveLine(models.Model):
                 if float_compare(vals['qty_done'], move_line.qty_done, precision_rounding=move.product_uom.rounding) == 0:
                     continue
                 rounding = move.product_id.uom_id.rounding
-                diff = move.product_uom._compute_quantity(vals['qty_done'] - move_line.qty_done, move.product_id.uom_id, rounding_method='HALF-UP')
+                diff = move.product_uom._compute_quantity(vals['qty_done'] - move_line.qty_done, move_line.product_uom_id, rounding_method='HALF-UP')
                 if float_is_zero(diff, precision_rounding=rounding):
                     continue
                 self._create_correction_svl(move, diff)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**  
When a stock move line has a different UoM (Unit of Measure) than the default UoM of the product, the correction Stock Valuation Layer (SVL) is created using the default product UoM instead of the UoM of the move line that is being corrected.

**Current behavior before PR:**  
- For example, if the default UoM of a product is "Units" but a receipt is made with 2 "Dozens" and later rectified to 1 "Dozen":  
  - The first SVL is created with +24 units (correct).  
  - The correction SVL, however, is created with -1 unit (incorrect, it should be -12 units to match the UoM used in the move line).

**Desired behavior after PR is merged:**  
- In the example above, the correction SVL would be created with -12 units (corresponding to 1 dozen), ensuring consistency and correctness.

---

I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](www.odoo.com/submit-pr).
