### PR TITLE
[IMP] hr, *: use the companies key from the evaluation context

### DIFF
--- a/addons/base_setup/models/res_config_settings.py
+++ b/addons/base_setup/models/res_config_settings.py
@@ -44,7 +44,6 @@ class ResConfigSettings(models.TransientModel):
     language_count = fields.Integer('Number of Languages', compute="_compute_language_count")
     company_name = fields.Char(related="company_id.display_name", string="Company Name")
     company_informations = fields.Text(compute="_compute_company_informations")
-    company_country_code = fields.Char(related="company_id.country_id.code", string="Company Country Code", readonly=True)
     profiling_enabled_until = fields.Datetime("Profiling enabled until", config_parameter='base.profiling_enabled_until')
     module_product_images = fields.Boolean("Get product pictures using barcode")
 

--- a/addons/hr/models/res_company.py
+++ b/addons/hr/models/res_company.py
@@ -13,3 +13,10 @@ class ResCompany(models.Model):
     hr_presence_control_email = fields.Boolean(string="Based on number of emails sent")
     hr_presence_control_ip = fields.Boolean(string="Based on IP Address")
     hr_presence_control_attendance = fields.Boolean(string="Based on attendances")
+
+    def _get_session_info(self, allowed_company_ids):
+        res = super()._get_session_info(allowed_company_ids)
+        res.update({
+            'country_code': self.country_id.code
+        })
+        return res

--- a/addons/l10n_fr_hr_holidays/views/res_config_settings_views.xml
+++ b/addons/l10n_fr_hr_holidays/views/res_config_settings_views.xml
@@ -7,8 +7,7 @@
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <block name="work_organization_setting_container" position="after">
-                <field name="company_country_code" invisible="1"/>
-                <block title="French Time Off Localization" invisible="company_country_code != 'FR'">
+                <block title="French Time Off Localization" invisible="not companies.has(companies.active_id,'country_code','FR')">
                     <setting company_dependent="1" help="Set the time off type used as the company Paid Time Off to compute part-timers leave duration">
                         <field name="l10n_fr_reference_leave_type"
                             class="o_light_label"

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -18,16 +18,16 @@ class TestPerfSessionInfo(common.HttpCase):
         self.authenticate(user.login, "info")
 
         self.env.registry.clear_all_caches()
-        # cold ormcache (only web: 42, all module: 113)
-        with self.assertQueryCount(113):
+        # cold ormcache (only web: 42, all module: 114)
+        with self.assertQueryCount(114):
             self.url_open(
                 "/web/session/get_session_info",
                 data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),
                 headers={"Content-Type": "application/json"},
             )
 
-        # cold fields cache - warm ormcache (only web: 6, all module: 23)
-        with self.assertQueryCount(23):
+        # cold fields cache - warm ormcache (only web: 6, all module: 25)
+        with self.assertQueryCount(25):
             self.url_open(
                 "/web/session/get_session_info",
                 data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),


### PR DESCRIPTION
* = [base_setup, hr, l10n_fr_hr_holidays, web]

Since [1], a new `companies` key has been added to the evaluation context,  and a new mechanism for adding company information to the `session_info` has also been added.

This commit uses the new `companies` key and removes the `company_country_code` field from the settings.

[1]: https://github.com/odoo/odoo/commit/22e9d822e8cab08114c006eb8c4054c4de0c40f2
