### PR TITLE
[FIX] *: basic receipt print

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
@@ -11,7 +11,7 @@
 
     <t t-name="l10n_fr_pos_cert.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
         <xpath expr="//Orderline" position="inside">
-            <t t-if="line.order_id.l10n_fr_hash !== false and line.price_type === 'manual' and !line.config.basic_receipt">
+            <t t-if="line.order_id.l10n_fr_hash !== false and line.price_type === 'manual' and !props.basic_receipt">
                 <div class="pos-receipt-right-padding">
                     Old unit price:
                     <span class="oldPrice">

--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.js
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.js
@@ -10,12 +10,14 @@ export class Orderline extends Component {
         showTaxGroupLabels: { type: Boolean, optional: true },
         showTaxGroup: { type: Boolean, optional: true },
         mode: { type: String, optional: true }, // display, receipt
+        basic_receipt: { type: Boolean, optional: true },
     };
     static defaultProps = {
         showImage: false,
         showTaxGroupLabels: false,
         showTaxGroup: false,
         mode: "display",
+        basic_receipt: false,
     };
 
     formatCurrency(amount) {

--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
@@ -18,7 +18,7 @@
                         <span class="text-wrap" t-esc="line.getFullProductName()"/>
                         <t t-slot="product-name" />
                     </div>
-                    <div t-if="!line.config.basic_receipt" t-esc="line.getPriceString()" class="product-price price fw-bolder"/>
+                    <div t-if="!props.basic_receipt" t-esc="line.getPriceString()" class="product-price price fw-bolder"/>
                     <div t-if="props.showTaxGroup" t-esc="this.taxGroup" class="text-end" style="width: 2rem"/>
                 </div>
                 <ul class="info-list d-flex flex-column">

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
@@ -18,6 +18,10 @@ export class OrderReceipt extends Component {
     };
     static props = {
         order: Object,
+        basic_receipt: { type: Boolean, optional: true },
+    };
+    static defaultProps = {
+        basic_receipt: false,
     };
 
     get header() {

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -6,14 +6,14 @@
             <ReceiptHeader order="order" />
             <OrderDisplay order="order" t-slot-scope="scope" mode="'receipt'">
                 <t t-set="line" t-value="scope.line"/>
-                <Orderline line="line" showTaxGroup="showTaxGroupLabels" mode="'receipt'">
+                <Orderline line="line" showTaxGroup="showTaxGroupLabels" mode="'receipt'" basic_receipt="props.basic_receipt">
                     <li t-if="line.customerNote" class="customer-note w-100 p-2 my-1 rounded text-break">
                         <i class="fa fa-sticky-note me-1" role="img" aria-label="Customer Note" title="Customer Note"/>
                         <t t-esc="line.customerNote" />
                     </li>
                 </Orderline>
             </OrderDisplay>
-            <t t-if="!order.config.basic_receipt">
+            <t t-if="!props.basic_receipt">
                 <t t-set="taxTotals" t-value="order.taxTotals"/>
                 <div t-if="taxTotals and taxTotals.has_tax_groups" class="pos-receipt-taxes">
                     <div class="text-center">--------------------------------</div>

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1432,6 +1432,7 @@ export class PosStore extends WithLazyGetterTrap {
             OrderReceipt,
             {
                 order,
+                basic_receipt: basic,
             },
             { webPrintFallback: true }
         );

--- a/addons/pos_loyalty/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_loyalty/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
@@ -22,9 +22,9 @@
                     </t>
                 </div>
             </t>
-            <t t-if="order.parnter_id">
+            <t t-if="order.partner_id">
                 <br/>
-                <div>Customer <span t-esc='order.parnter_id.name' class='pos-receipt-right-align'/></div>
+                <div>Customer <span t-esc='order.partner_id.name' class='pos-receipt-right-align'/></div>
             </t>
             <t t-if="order.new_coupon_info and order.new_coupon_info.length !== 0">
                 <div class="pos-coupon-rewards">


### PR DESCRIPTION
*: point_of_sale, l10n_fr_pos_cert, pos_loyalty

Before this commit:
==========
- When the basic receipt option is enabled in the configuration, only basic receipts are printed, even when the full receipt option is selected. Additionally, the receipt screen displays only basic receipts.
- Customer details were not visible on the receipt.

After this commit:
==========
- The basic receipt functionality has been refined for a seamless experience. Both printing and screen display behaviors now align with the expected workflow.
- Customer details are now correctly displayed on the receipt.

task-4430207