### PR TITLE
[FIX] account: Account Journal Late Bills Count

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -543,7 +543,7 @@ class account_journal(models.Model):
                 SQL("account_move_line.journal_id"),
                 SQL("account_move_line.company_id"),
                 SQL("account_move_line.currency_id AS currency"),
-                SQL("account_move_line.date_maturity < %s AS late", fields.Date.context_today(self)),
+                SQL("CASE WHEN account_move_line.date_maturity < %s AND account_move_line.amount_residual != 0 THEN TRUE ELSE FALSE END AS late", fields.Date.context_today(self)),
                 SQL("SUM(account_move_line.amount_residual) AS amount_total_company"),
                 SQL("SUM(account_move_line.amount_residual_currency) AS amount_total"),
                 SQL("COUNT(*)"),


### PR DESCRIPTION
**[FIX] account: Account Journal Late Bills Count**

This fix mitigates an issue when a line of a Bill is paid but appears in the late Bills count in the dashboard.

**Steps to reproduce:**

1. Create a payment term to pay in installemts.
2. Create a bill an X amount back in the past to have one installment as late. 3 - Pay the late installment

**Issue**: The paid installment will still be counted as late in the dashboard.

**Fix**: filter out line with residual amount different than zero.

_opw-4327227_


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
