### PR TITLE
[FIX] project: rely on access rules for task count in portal

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -23,7 +23,7 @@ class ProjectCustomerPortal(CustomerPortal):
             values['project_count'] = request.env['project.project'].search_count([]) \
                 if request.env['project.project'].check_access_rights('read', raise_exception=False) else 0
         if 'task_count' in counters:
-            values['task_count'] = request.env['project.task'].sudo().search_count([('project_id', '!=', False), ('message_partner_ids', 'in', request.env.user.partner_id.ids), ('project_privacy_visibility', '=', 'portal')]) \
+            values['task_count'] = request.env['project.task'].search_count([('project_id', '!=', False)])\
                 if request.env['project.task'].check_access_rights('read', raise_exception=False) else 0
         return values
 


### PR DESCRIPTION
## Issue:
- Child contacts of followers were unable to access the tasks menu in the portal home, despite having access according to the access rules.

## Steps to reproduce:
1. Create a parent contact with a child contact.
2. Grant the child contact portal access.
3. Create a task with the parent contact as the customer.
4. Add the parent contact as a follower or send a message in the task chatter.
5. Log in as the child contact in the portal.
6. Notice the tasks menu is unavailable.

## Solution:
- The issue originated in `_prepare_home_portal_values`, where the task count was computed with a restrictive domain and sudo instead of relying on the access rules.
- Removed the unnecessary domain filter to let the access rules handle it.

opw-4306834



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
