### PR TITLE
[IMP] web: notify user when a required field is left empty

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -1,4 +1,4 @@
-import { AlertDialog, ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { unique } from "@web/core/utils/arrays";
 import { DataPoint } from "./datapoint";
@@ -319,11 +319,6 @@ export class DynamicList extends DataPoint {
             return false;
         }
         if (validSelection.length === 0) {
-            this.model.dialog.add(AlertDialog, {
-                body: _t("No valid record to save"),
-                confirm: () => this.leaveEditMode({ discard: true }),
-                dismiss: () => this.leaveEditMode({ discard: true }),
-            });
             return false;
         } else {
             const resIds = unique(validSelection.map((r) => r.resId));

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -1,5 +1,4 @@
 import { markRaw, markup, toRaw } from "@odoo/owl";
-import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { x2ManyCommands } from "@web/core/orm_service";
@@ -1085,7 +1084,11 @@ export class Record extends DataPoint {
                 this.data[fieldName]._abandonRecords();
             }
         }
-        if (!this._checkValidity({ displayNotification: true })) {
+        const notify =
+            this.isNew ||
+            !this.selected ||
+            (this.model.multiEdit && !this.isValid && !this._unsetRequiredFields.size);
+        if (!this._checkValidity({ displayNotification: notify })) {
             return false;
         }
         const changes = this._getChanges();
@@ -1249,20 +1252,6 @@ export class Record extends DataPoint {
         const canProceed = this.model.hooks.onWillSetInvalidField(this, fieldName);
         if (canProceed === false) {
             return;
-        }
-        if (
-            this.selected &&
-            this.model.multiEdit &&
-            this.model.root._recordToDiscard !== this &&
-            !this._invalidFields.has(fieldName)
-        ) {
-            await this.model.dialog.add(AlertDialog, {
-                body: _t("No valid record to save"),
-                confirm: async () => {
-                    await this.discard();
-                    this.switchMode("readonly");
-                },
-            });
         }
         this._invalidFields.add(fieldName);
     }

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -499,7 +499,10 @@ export class ListController extends Component {
             this.nextActionAfterMouseup = () => this.model.root.multiSave(editedRecord);
             return false;
         }
-        if (validSelectedRecords.length > 1) {
+        if (!editedRecord._checkValidity({ displayNotification: true })) {
+            return false;
+        }
+        if (validSelectedRecords.length > 1 || this.hasSelectedRecords > 1) {
             const { isDomainSelected, selection } = this.model.root;
             return new Promise((resolve) => {
                 const dialogProps = {

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -254,6 +254,11 @@ export class ListRenderer extends Component {
                     const column = this.cellToFocus.column;
                     const forward = this.cellToFocus.forward;
                     this.focusCell(column, forward);
+                } else if (this.editedRecord._invalidFields.size) {
+                    const columnIndex = this.columns.findIndex(
+                        (col) => col.name === [...this.editedRecord._invalidFields][0]
+                    );
+                    this.focusCell(this.columns[columnIndex]);
                 } else if (this.lastEditedCell) {
                     this.focusCell(this.lastEditedCell.column, true);
                 } else {


### PR DESCRIPTION
**Before this commit:**
- In the list view, if a user clears a required many2many field and attempts to save the record, the record is saved without notifying the user about the invalid field.

- Clearing other required fields triggered a dialog with the message "No valid record to save," which was not always helpful and could be perceived as annoying.

- Although there was an invalid field in a record, if no cell in the list was clicked(Global click), the first editable cell in the Listview would automatically gain focus.

**After this commit:**
- Now, if a user clears a required field and tries to save the record, then the record does not get saved, and the user receives a notification indicating the field is invalid.

- The intrusive dialog has been replaced with a more user-friendly notification, improving the user experience.

- Now, on a global click, the invalid cell will be focused if it exists.

Task-3981155

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
