### PR TITLE
[FIX] pos_self_order: disable auto loading

### DIFF
--- a/addons/pos_self_order/static/src/app/data_service.js
+++ b/addons/pos_self_order/static/src/app/data_service.js
@@ -31,4 +31,7 @@ patch(PosData.prototype, {
             ? await super.loadIndexedDBData(...arguments)
             : {};
     },
+    async missingRecursive(recordMap) {
+        return recordMap;
+    },
 });


### PR DESCRIPTION
Before this commit, auto loading could run in self ordering, which resulted in error as the necessary permissions to operate the read were not available. Additionally, auto loading was not needed since all required data is loaded at the beginning.

opw-4422124

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
