### PR TITLE
[IMP] mail: set full mail composer values from macros

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -534,11 +534,12 @@ export class Composer extends Component {
             mentionedPartners: this.props.composer.mentionedPartners,
         });
         const signature = this.store.self.signature;
-        const default_body = await prettifyMessageContent(body, validMentions) +
+        const defaultBody = await prettifyMessageContent(body, validMentions) +
+            (ev.detail?.body || '') +
             ((this.props.composer.emailAddSignature && signature) ? ("<br>" + signature) : "");
         const context = {
             default_attachment_ids: attachmentIds,
-            default_body: "<div>" + default_body + "</div>", // as to not wrap in <p> by html_sanitize,
+            default_body: "<div>" + defaultBody + "</div>", // as to not wrap in <p> by html_sanitize,
             default_email_add_signature: false,
             default_model: this.thread.model,
             default_partner_ids:


### PR DESCRIPTION
When a user is viewing a page, clicks on the Knowledge Book icon, opens an article, and selects the "Send As Message" button in a Knowledge Clipboard block, the macro system performs several actions: it restores the initial view, opens the full mail composer, and inserts the clipboard block's text at the very end of the editor.

Recent updates introduced automatic inclusion of the user's signature in the email body when the full mail composer is opened. As a result, the clipboard text is inserted after the user signature, which is undesirable because users must manually adjust the message to position the signature correctly.

To insert text before the user signature but after the user text, the clipboard macro will now trigger a "click" event on the button opening the full mail composer and set on that event the text to insert. The chatter will then read that value and insert the text at the right place.

Task-4428445

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
