### PR TITLE
[FIX] mrp: fix traceback on onchange of product uom qty in stock move

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -331,9 +331,9 @@ class StockMove(models.Model):
                 move.display_import_lot = False
                 move.display_assign_serial = False
 
-    @api.onchange('product_uom_qty')
+    @api.onchange('product_uom_qty', 'product_uom')
     def _onchange_product_uom_qty(self):
-        if self.raw_material_production_id and self.has_tracking == 'none':
+        if self.product_uom and self.raw_material_production_id and self.has_tracking == 'none':
             mo = self.raw_material_production_id
             new_qty = float_round((mo.qty_producing - mo.qty_produced) * self.unit_factor, precision_rounding=self.product_uom.rounding)
             self.quantity = new_qty


### PR DESCRIPTION
Currently, a traceback is occurring when the user removes the `uom` and 
tries to change the `product_uom_qty` in the stock move. While creating the Manufacturing Order.

To reproduce this issue:

1) Install MRP and enable UOM from the configuration 
2) Create a new mrp order and add a product in components
3) Remove the UOM and change the `To Consume` value

Error:- 
```
AssertionError: precision_rounding must be positive, got 0.0
```

This traceback occurs because when the user changes the `product_uom_qty`, 
an onchange method `_onchange_product_uom_qty` will triggered.

In that method, `float_round` is used with precision_rounding getting from `product_uom.rounding`. 
It leads to the above traceback as `product_uom` has an empty recordset.

sentry-6170644216

