### PR TITLE
[FIX] point_of_sale: disable payment method

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
@@ -27,7 +27,7 @@
                             </t>
                         </div>
                         <t t-if="line and line.payment_status">
-                            <div class="paymentline electronic_payment">
+                            <div t-attf-class="{{ this.ui.isSmall ? 'bg-100' : 'bg-200'}} paymentline electronic_payment">
                                 <t t-if="line.payment_status == 'pending'">
                                     <div class="electronic_status">
                                         Payment request pending

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -577,6 +577,7 @@ export class PaymentScreen extends Component {
         );
         if (isCancelSuccessful) {
             line.set_payment_status("retry");
+            this.pos.paymentTerminalInProgress = false;
         } else {
             line.set_payment_status("waitingCard");
         }


### PR DESCRIPTION
Steps to reproduce:
--------------------------
- Install the point_of_sale module.
- Set up any payment terminal.
- Attempt payment using the terminal.
- Cancel the transaction request.

Issue:
--------
- Payment method button remains in progress mode after canceling the transaction.
- In mobile view, the payment status message lacks a visible background.

Cause:
---------
- Transaction progress state is not reset after a successful cancellation.
- Missing responsive classes for mobile view.

Fix:
----
- Reset the payment method progress state after a successful cancellation.
- Add appropriate classes to ensure the payment status background is visible across all views.

Task: 4427387
