### PR TITLE
[FIX] mail: add empty paragraph for composer default body

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -538,7 +538,7 @@ export class Composer extends Component {
             ((this.props.composer.emailAddSignature && signature) ? ("<br>" + signature) : "");
         const context = {
             default_attachment_ids: attachmentIds,
-            default_body: "<div>" + default_body + "</div>", // as to not wrap in <p> by html_sanitize,
+            default_body,
             default_email_add_signature: false,
             default_model: this.thread.model,
             default_partner_ids:

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -262,42 +262,5 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
             content: "Check message is shown",
             trigger: '.o-mail-Message-body:contains("hello world")',
         },
-        // Test text input lines are each wrapped in <p> in editor
-        // this makes each line editable without impacting the other lines
-        {
-            content: "Click on Send Message",
-            trigger: "button:contains(Send message)",
-            run: "click",
-        },
-        {
-            content: "Write first line",
-            trigger: ".o-mail-Composer-input",
-            run: "edit abc",
-        },
-        {
-            content: "Press enter to go to next line",
-            trigger: ".o-mail-Composer-input",
-            run: "press enter",
-        },
-        {
-            content: "write second line",
-            trigger: ".o-mail-Composer-input",
-            run: "fill efg",
-        },
-        {
-            content: "Open full composer",
-            trigger: "button[aria-label='Full composer']",
-            run: "click",
-        },
-        {
-            content: "Check the content of the editor",
-            trigger:
-                ".o_mail_composer_form_view .odoo-editor-editable > p:contains(abc):not(:contains(efg))",
-        },
-        {
-            content: "Check the content of the editor",
-            trigger:
-                ".o_mail_composer_form_view .odoo-editor-editable > p:contains(efg):not(:contains(abc))",
-        },
     ],
 });


### PR DESCRIPTION
**Problem**:
When a `default_body` is added, it contains only a `div` in the editable area. This causes issues with some editor features, such as bullet lists, which do not behave as expected.

**Solution**:
Ensure the content includes a `<p><br/></p>` by default, selected for proper functionality, aligning with the default behavior of the editor.

**Steps to reproduce**:
1. Go to Sales > Send Message > Full Composer.
2. Write content spanning 2+ lines.
3. On a new line, apply a bullet list.
4. Observe that the bullet list is applied to the entire content instead of just the current line.

opw-4419775

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
