### PR TITLE
[IMP] website_sale: new options for the dynamic product carousel template

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -445,6 +445,9 @@ class Website(Home):
             t['extraClasses'] = attribs.get('data-extra-classes')
             t['columnClasses'] = attribs.get('data-column-classes')
             t['thumb'] = attribs.get('data-thumb')
+            t['title'] = attribs.get('title')
+            t['showPriceOpt'] = attribs.get('data-show-price-opt')
+            t['showDescriptionOpt'] = attribs.get('data-show-description-opt')
         return templates
 
     @http.route('/website/get_current_currency', type='jsonrpc', auth="public", website=True, readonly=True)

--- a/addons/website/static/src/snippets/s_dynamic_snippet/options.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/options.js
@@ -15,6 +15,8 @@ const dynamicSnippetOptions = options.Class.extend({
      * @property {string} rowPerSlide - number of rows per slide
      * @property {string} arrowPosition - position of the arrows
      * @property {string} extraClasses - classes to be added to the <section>
+     * @property {string} showPriceOpt - should the option for price showing be displayed
+     * @property {string} showDescriptionOpt - should the option for price showing be displayed
      */
 
     /**
@@ -240,6 +242,9 @@ const dynamicSnippetOptions = options.Class.extend({
                 button.dataset.img = data[id].thumb;
             } else {
                 button.innerText = data[id].name;
+            }
+            if (data[id].title) {
+                button.title = data[id].title;
             }
             selectUserValueWidgetElement.appendChild(button);
         }

--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -3,7 +3,10 @@
 
         <!-- Templates for Dynamic Snippet -->
         <template id="dynamic_filter_template_product_product_add_to_cart" name="Classic Card">
-            <t t-foreach="records" t-as="data" data-thumb="/website_sale/static/src/img/snippets_options/product_add_to_cart.svg">
+            <t t-foreach="records" t-as="data"
+               title="Classic Card"
+               data-show-price-opt="true"
+               data-thumb="/website_sale/static/src/img/snippets_options/product_add_to_cart.svg">
                 <t t-set="record" t-value="data['_record']"/>
                 <t t-set="product_template_id" t-value="record.id if not record.is_product_variant else record.product_tmpl_id.id"/>
                 <t t-set="product_id" t-value="record.id if record.is_product_variant else record.product_variant_id.id"/>
@@ -57,7 +60,12 @@
         </template>
 
         <template id="dynamic_filter_template_product_product_view_detail" name="Classic Card - Detailed">
-            <t t-foreach="records" t-as="data" data-number-of-elements="3" data-thumb="/website_sale/static/src/img/snippets_options/product_view_detail.svg">
+            <t t-foreach="records" t-as="data"
+               title="Classic Card - Detailed"
+               data-show-price-opt="true"
+               data-show-description-opt="true"
+               data-number-of-elements="3"
+               data-thumb="/website_sale/static/src/img/snippets_options/product_view_detail.svg">
                 <t t-set="record" t-value="data['_record']" data-arrow-position="bottom"/>
                 <div class="o_carousel_product_card card h-100 w-100" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
@@ -93,7 +101,11 @@
         </template>
 
         <template id="dynamic_filter_template_product_product_mini_image" name="Image only">
-            <t t-foreach="records" t-as="data" data-number-of-elements="4" data-number-of-elements-sm="1" data-thumb="/website_sale/static/src/img/snippets_options/product_image_only.svg">
+            <t t-foreach="records" t-as="data"
+               title="Image only"
+               data-number-of-elements="4"
+               data-number-of-elements-sm="1"
+               data-thumb="/website_sale/static/src/img/snippets_options/product_image_only.svg">
                 <t t-set="record" t-value="data['_record']"/>
                 <div class="card h-100 border-0 w-100 rounded-0 bg-transparent" t-att-data-url="record.website_url">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
@@ -105,7 +117,10 @@
         </template>
 
         <template id="dynamic_filter_template_product_product_mini_price" name="Image with price">
-            <t t-foreach="records" t-as="data" data-thumb="/website_sale/static/src/img/snippets_options/product_image_with_price.svg">
+            <t t-foreach="records" t-as="data"
+               title="Image with price"
+               data-show-price-opt="true"
+               data-thumb="/website_sale/static/src/img/snippets_options/product_image_with_price.svg">
                 <t t-set="record" t-value="data['_record']"/>
                 <div class="card h-100 border-0 w-100 rounded-0 bg-transparent o_dynamic_product_hovered" t-att-data-url="record.website_url">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
@@ -131,7 +146,9 @@
         </template>
 
         <template id="dynamic_filter_template_product_product_mini_name" name="Image with name">
-            <t t-foreach="records" t-as="data" data-thumb="/website_sale/static/src/img/snippets_options/product_image_with_name.svg">
+            <t t-foreach="records" t-as="data"
+               title="Image with name"
+               data-thumb="/website_sale/static/src/img/snippets_options/product_image_with_name.svg">
                 <t t-set="record" t-value="data['_record']"/>
                 <div class="card h-100 border-0 w-100 rounded-0 bg-transparent o_dynamic_product_hovered" t-att-data-url="record.website_url">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
@@ -152,7 +169,11 @@
         </template>
 
         <template id="dynamic_filter_template_product_product_centered" name="Centered Product">
-            <t t-foreach="records" t-as="data" data-arrow-position="bottom" data-thumb="/website_sale/static/src/img/snippets_options/product_centered.svg">
+            <t t-foreach="records" t-as="data"
+               title="Centered Product"
+               data-show-price-opt="true"
+               data-arrow-position="bottom"
+               data-thumb="/website_sale/static/src/img/snippets_options/product_centered.svg">
                 <t t-set="record" t-value="data['_record']"/>
                 <div class="o_carousel_product_card card w-100" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
@@ -190,7 +211,10 @@
         </template>
 
         <template id="dynamic_filter_template_product_product_borderless_1" name="Borderless Product n°1">
-            <t t-foreach="records" t-as="data" data-thumb="/website_sale/static/src/img/snippets_options/product_borderless_1.svg">
+            <t t-foreach="records" t-as="data"
+               title="Borderless Product n°1"
+               data-show-price-opt="true"
+               data-thumb="/website_sale/static/src/img/snippets_options/product_borderless_1.svg">
                 <t t-set="record" t-value="data['_record']"/>
                 <div class="o_carousel_product_card bg-transparent w-100 card border-0">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
@@ -222,7 +246,10 @@
         </template>
 
         <template id="dynamic_filter_template_product_product_borderless_2" name="Borderless Product n°2">
-            <t t-foreach="records" t-as="data" data-thumb="/website_sale/static/src/img/snippets_options/product_borderless_2.svg">
+            <t t-foreach="records" t-as="data"
+               title="Borderless Product n°2"
+               data-show-price-opt="true"
+               data-thumb="/website_sale/static/src/img/snippets_options/product_borderless_2.svg">
                 <t t-set="record" t-value="data['_record']"/>
                 <div class="o_carousel_product_card card w-100 border-0 bg-transparent" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
@@ -274,7 +301,13 @@
         </template>
 
         <template id="dynamic_filter_template_product_product_banner" name="Large Banner">
-            <t t-foreach="records" t-as="data" data-number-of-elements="1" data-number-of-elements-sm="1" data-thumb="/website_sale/static/src/img/snippets_options/product_banner.svg">
+            <t t-foreach="records" t-as="data"
+               title="Large Banner"
+               data-show-price-opt="true"
+               data-show-description-opt="true"
+               data-number-of-elements="1"
+               data-number-of-elements-sm="1"
+               data-thumb="/website_sale/static/src/img/snippets_options/product_banner.svg">
                 <t t-set="record" t-value="data['_record']"/>
                 <div class="o_carousel_product_card card w-100" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
@@ -330,12 +363,14 @@
 
         <template id="dynamic_filter_template_product_product_horizontal_card" name="Horizontal Card">
             <t t-foreach="records" t-as="data"
-                data-number-of-elements="3"
-                data-number-of-elements-sm="1"
-                data-row-per-slide="2"
-                data-arrow-position="bottom"
-                data-extra-classes="o_carousel_multiple_rows"
-                data-thumb="/website_sale/static/src/img/snippets_options/product_horizontal_card.svg">
+               title="Horizontal Card"
+               data-show-price-opt="true"
+               data-number-of-elements="3"
+               data-number-of-elements-sm="1"
+               data-row-per-slide="2"
+               data-arrow-position="bottom"
+               data-extra-classes="o_carousel_multiple_rows"
+               data-thumb="/website_sale/static/src/img/snippets_options/product_horizontal_card.svg">
                 <t t-set="record" t-value="data['_record']"/>
                 <div class="o_carousel_product_card card w-100 border-0 bg-light p-3" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
@@ -389,12 +424,15 @@
         </template>
         <template id="dynamic_filter_template_product_product_horizontal_card_2" name="Horizontal Card width covered image">
             <t t-foreach="records" t-as="data"
-                data-row-per-slide="2"
-                data-arrow-position="bottom"
-                data-number-of-elements="2"
-                data-number-of-elements-sm="1"
-                data-extra-classes="o_carousel_multiple_rows"
-                data-thumb="/website_sale/static/src/img/snippets_options/product_horizontal_card_2.svg">
+               title="Horizontal Card width covered image"
+               data-show-price-opt="true"
+               data-show-description-opt="true"
+               data-row-per-slide="2"
+               data-arrow-position="bottom"
+               data-number-of-elements="2"
+               data-number-of-elements-sm="1"
+               data-extra-classes="o_carousel_multiple_rows"
+               data-thumb="/website_sale/static/src/img/snippets_options/product_horizontal_card_2.svg">
                 <t t-set="record" t-value="data['_record']"/>
                 <div class="o_carousel_product_card card w-100 border-0 o_dynamic_product_hovered o_cc o_cc5">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
@@ -444,6 +482,9 @@
 
         <template id="dynamic_filter_template_product_product_card_group" name="Card group">
             <t t-foreach="records" t-as="data"
+                title="Card group"
+                data-show-price-opt="true"
+                data-show-description-opt="true"
                 data-row-per-slide="2"
                 data-number-of-elements="2"
                 data-number-of-elements-sm="1"

--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -75,7 +75,7 @@
                     <div class="o_carousel_product_card_body card-body d-flex flex-column justify-content-between">
                         <div class="card-title h5" t-field="record.display_name"/>
                         <t t-if="showDescription">
-                            <div class="card-text flex-grow-1 text-muted h6" t-field="record.description_sale"/>
+                            <div class="card-text flex-grow-1 text-muted h6" t-field="record.description_ecommerce"/>
                         </t>
                         <div class="mt-2">
                             <t t-if="showReviews">
@@ -332,7 +332,7 @@
                                     </t>
                                 </div>
                                 <t t-if="showDescription">
-                                    <div class="card-text text-muted" t-field="record.description_sale"/>
+                                    <div class="card-text text-muted" t-field="record.description_ecommerce"/>
                                 </t>
                                 <div class="mt-4">
                                     <t t-set="product_template_id" t-value="record.id if not record.is_product_variant else record.product_tmpl_id.id"/>
@@ -450,7 +450,7 @@
                             </t>
                         </div>
                         <t t-if="showDescription">
-                            <div class="card-text h6 flex-grow-1" t-field="record.description_sale"/>
+                            <div class="card-text h6 flex-grow-1" t-field="record.description_ecommerce"/>
                         </t>
                         <div class="d-flex justify-content-between align-items-center flex-wrap mt-3">
                             <t t-if="showPrice">
@@ -500,7 +500,7 @@
                             <div class="col-8 d-flex flex-column">
                                 <div class="card-title h5" t-field="record.display_name"/>
                                 <t t-if="showDescription">
-                                    <div class="card-text h6 text-muted" t-field="record.description_sale"/>
+                                    <div class="card-text h6 text-muted" t-field="record.description_ecommerce"/>
                                 </t>
                                 <div class="d-flex justify-content-between align-items-center flex-wrap w-100 mt-auto">
                                     <t t-if="showPrice">

--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -23,15 +23,19 @@
                             <div class="h6 card-title mb-0" t-field="record.display_name"/>
                         </a>
                         <div class="mt-2">
-                            <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                <t t-set="rating_avg" t-value="record.rating_avg"/>
-                                <t t-set="rating_count" t-value="record.rating_count"/>
+                            <t t-if="showReviews">
+                                <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
+                                    <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                    <t t-set="rating_count" t-value="record.rating_count"/>
+                                </t>
                             </t>
                         </div>
                         <div class="w-100 d-flex flex-wrap flex-md-column flex-lg-row align-items-center align-self-end justify-content-between mt-3">
-                            <div class="py-2">
-                                <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
-                            </div>
+                            <t t-if="showPrice">
+                                <div class="py-2">
+                                    <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
+                                </div>
+                            </t>
                             <div class="o_dynamic_snippet_btn_wrapper" t-if="record._website_show_quick_add()">
                                 <button
                                     type="button"
@@ -62,17 +66,23 @@
                     </a>
                     <div class="o_carousel_product_card_body card-body d-flex flex-column justify-content-between">
                         <div class="card-title h5" t-field="record.display_name"/>
-                        <div class="card-text flex-grow-1 text-muted h6" t-field="record.description_sale"/>
+                        <t t-if="showDescription">
+                            <div class="card-text flex-grow-1 text-muted h6" t-field="record.description_sale"/>
+                        </t>
                         <div class="mt-2">
-                            <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                <t t-set="rating_avg" t-value="record.rating_avg"/>
-                                <t t-set="rating_count" t-value="record.rating_count"/>
+                            <t t-if="showReviews">
+                                <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
+                                    <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                    <t t-set="rating_count" t-value="record.rating_count"/>
+                                </t>
                             </t>
                         </div>
                         <div class="d-flex justify-content-between flex-wrap flex-md-column flex-lg-row align-items-center align-self-end w-100 mt-2 pt-3 border-top">
-                            <div class="pb-2">
-                                <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
-                            </div>
+                            <t t-if="showPrice">
+                                <div class="pb-2">
+                                    <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
+                                </div>
+                            </t>
                             <a class="btn btn-primary" t-att-href="record.website_url">
                                 View product
                             </a>
@@ -103,14 +113,18 @@
                         <img class="card-img-top h-auto o_img_product_square o_img_product_cover rounded" loading="lazy" t-att-src="data['image_512']" t-att-alt="record.display_name"/>
                     </a>
                     <div class="o_carousel_product_card_body mt-2 d-flex justify-content-between">
-                        <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                            <t t-set="rating_style_compressed" t-value="true"/>
-                            <t t-set="rating_avg" t-value="record.rating_avg"/>
-                            <t t-set="rating_count" t-value="record.rating_count"/>
+                        <t t-if="showReviews">
+                            <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
+                                <t t-set="rating_style_compressed" t-value="true"/>
+                                <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                <t t-set="rating_count" t-value="record.rating_count"/>
+                            </t>
                         </t>
-                        <div class="ms-auto">
-                            <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
-                        </div>
+                        <t t-if="showPrice">
+                            <div class="ms-auto">
+                                <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
+                            </div>
+                        </t>
                     </div>
                 </div>
             </t>
@@ -126,9 +140,11 @@
                     </a>
                     <div class="h6 text-center mt-2 p-2" t-field="record.display_name"/>
                     <div class="text-center">
-                        <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                            <t t-set="rating_avg" t-value="record.rating_avg"/>
-                            <t t-set="rating_count" t-value="record.rating_count"/>
+                        <t t-if="showReviews">
+                            <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
+                                <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                <t t-set="rating_count" t-value="record.rating_count"/>
+                            </t>
                         </t>
                     </div>
                 </div>
@@ -147,14 +163,18 @@
                     <div class="o_carousel_product_card_body card-body d-flex flex-column justify-content-between">
                         <div class="card-title h5 text-center" t-field="record.display_name"/>
                         <div class="text-center">
-                            <div class="h5">
-                                <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
-                            </div>
+                            <t t-if="showPrice">
+                                <div class="h5">
+                                    <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
+                                </div>
+                            </t>
                             <div class="h6 mb-0">
-                                <t t-if="is_view_active('website_sale.product_comment')">
-                                    <t t-call="portal_rating.rating_widget_stars_static">
-                                        <t t-set="rating_avg" t-value="record.rating_avg"/>
-                                        <t t-set="rating_count" t-value="record.rating_count"/>
+                                <t t-if="showReviews">
+                                    <t t-if="is_view_active('website_sale.product_comment')">
+                                        <t t-call="portal_rating.rating_widget_stars_static">
+                                            <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                            <t t-set="rating_count" t-value="record.rating_count"/>
+                                        </t>
                                     </t>
                                 </t>
                             </div>
@@ -184,13 +204,17 @@
                     <div class="o_carousel_product_card_body d-flex flex-wrap flex-column justify-content-between h-100 p-3">
                         <div class="h6 card-title" t-field="record.display_name"/>
                         <div>
-                            <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                <t t-set="rating_avg" t-value="record.rating_avg"/>
-                                <t t-set="rating_count" t-value="record.rating_count"/>
+                            <t t-if="showReviews">
+                                <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
+                                    <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                    <t t-set="rating_count" t-value="record.rating_count"/>
+                                </t>
                             </t>
-                            <div class="mt-2">
-                                <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
-                            </div>
+                            <t t-if="showPrice">
+                                <div class="mt-2">
+                                    <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
+                                </div>
+                            </t>
                         </div>
                     </div>
                 </div>
@@ -210,15 +234,19 @@
                     </a>
                     <div class="o_carousel_product_card_body h-100 p-3 d-flex flex-column justify-content-between">
                         <div class="d-flex justify-content-between align-items-center flex-wrap mb-2">
-                            <div class="h5 mb-0 me-4">
-                                <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
-                            </div>
+                            <t t-if="showPrice">
+                                <div class="h5 mb-0 me-4">
+                                    <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
+                                </div>
+                            </t>
                             <div class="h6 mb-0">
-                                <t t-if="is_view_active('website_sale.product_comment')">
-                                    <t t-call="portal_rating.rating_widget_stars_static">
-                                        <t t-set="rating_style_compressed" t-value="true"/>
-                                        <t t-set="rating_avg" t-value="record.rating_avg"/>
-                                        <t t-set="rating_count" t-value="record.rating_count"/>
+                                <t t-if="showReviews">
+                                    <t t-if="is_view_active('website_sale.product_comment')">
+                                        <t t-call="portal_rating.rating_widget_stars_static">
+                                            <t t-set="rating_style_compressed" t-value="true"/>
+                                            <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                            <t t-set="rating_count" t-value="record.rating_count"/>
+                                        </t>
                                     </t>
                                 </t>
                             </div>
@@ -258,15 +286,21 @@
                             <div class="o_carousel_product_card_body card-body p-5">
                                 <div class="card-title h1" t-field="record.display_name"/>
                                 <div class="d-flex align-items-center my-4">
-                                    <div class="h4 mb-0 me-3">
-                                        <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
-                                    </div>
-                                    <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                        <t t-set="rating_avg" t-value="record.rating_avg"/>
-                                        <t t-set="rating_count" t-value="record.rating_count"/>
+                                    <t t-if="showPrice">
+                                        <div class="h4 mb-0 me-3">
+                                            <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
+                                        </div>
+                                    </t>
+                                    <t t-if="showReviews">
+                                        <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
+                                            <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                            <t t-set="rating_count" t-value="record.rating_count"/>
+                                        </t>
                                     </t>
                                 </div>
-                                <div class="card-text text-muted" t-field="record.description_sale"/>
+                                <t t-if="showDescription">
+                                    <div class="card-text text-muted" t-field="record.description_sale"/>
+                                </t>
                                 <div class="mt-4">
                                     <t t-set="product_template_id" t-value="record.id if not record.is_product_variant else record.product_tmpl_id.id"/>
                                     <t t-set="product_id" t-value="record.id if record.is_product_variant else record.product_variant_id.id"/>
@@ -317,15 +351,19 @@
                             </div>
                             <div>
                                 <div class="mb-1">
-                                    <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                        <t t-set="rating_avg" t-value="record.rating_avg"/>
-                                        <t t-set="rating_count" t-value="record.rating_count"/>
+                                    <t t-if="showReviews">
+                                        <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
+                                            <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                            <t t-set="rating_count" t-value="record.rating_count"/>
+                                        </t>
                                     </t>
                                 </div>
                                 <div class="d-flex align-items-center flex-wrap">
-                                    <div class="my-2">
-                                        <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
-                                    </div>
+                                    <t t-if="showPrice">
+                                        <div class="my-2">
+                                            <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
+                                        </div>
+                                    </t>
                                     <div t-if="record._website_show_quick_add()" class="o_dynamic_snippet_btn_wrapper ms-auto">
                                         <t t-set="product_template_id" t-value="record.id if not record.is_product_variant else record.product_tmpl_id.id"/>
                                         <t t-set="product_id" t-value="record.id if record.is_product_variant else record.product_variant_id.id"/>
@@ -366,16 +404,22 @@
                     <div class="o_carousel_product_card_body d-flex flex-column justify-content-between h-100 bg-black-50 p-3 position-relative">
                         <div class="mb-3">
                             <div class="card-title h5" t-field="record.display_name"/>
-                            <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                    <t t-set="rating_avg" t-value="record.rating_avg"/>
-                                    <t t-set="rating_count" t-value="record.rating_count"/>
+                            <t t-if="showReviews">
+                                <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
+                                        <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                        <t t-set="rating_count" t-value="record.rating_count"/>
                                 </t>
+                            </t>
                         </div>
-                        <div class="card-text h6 flex-grow-1" t-field="record.description_sale"/>
+                        <t t-if="showDescription">
+                            <div class="card-text h6 flex-grow-1" t-field="record.description_sale"/>
+                        </t>
                         <div class="d-flex justify-content-between align-items-center flex-wrap mt-3">
-                            <div class="h5 mb-0 me-2">
-                                <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
-                            </div>
+                            <t t-if="showPrice">
+                                <div class="h5 mb-0 me-2">
+                                    <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
+                                </div>
+                            </t>
                             <div t-if="record._website_show_quick_add()" class="o_dynamic_snippet_btn_wrapper">
                                 <t t-set="product_template_id" t-value="record.id if not record.is_product_variant else record.product_tmpl_id.id"/>
                                 <t t-set="product_id" t-value="record.id if record.is_product_variant else record.product_variant_id.id"/>
@@ -414,14 +458,20 @@
                         <div class="row h-100">
                             <div class="col-8 d-flex flex-column">
                                 <div class="card-title h5" t-field="record.display_name"/>
-                                <div class="card-text h6 text-muted" t-field="record.description_sale"/>
+                                <t t-if="showDescription">
+                                    <div class="card-text h6 text-muted" t-field="record.description_sale"/>
+                                </t>
                                 <div class="d-flex justify-content-between align-items-center flex-wrap w-100 mt-auto">
-                                    <div class="h5 text-primary mb-0 me-2">
-                                        <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
-                                    </div>
-                                    <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
-                                        <t t-set="rating_avg" t-value="record.rating_avg"/>
-                                        <t t-set="rating_count" t-value="record.rating_count"/>
+                                    <t t-if="showPrice">
+                                        <div class="h5 text-primary mb-0 me-2">
+                                            <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
+                                        </div>
+                                    </t>
+                                    <t t-if="showReviews">
+                                        <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
+                                            <t t-set="rating_avg" t-value="record.rating_avg"/>
+                                            <t t-set="rating_count" t-value="record.rating_count"/>
+                                        </t>
                                     </t>
                                 </div>
                             </div>

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
@@ -6,11 +6,42 @@ import { WebsiteSale } from "../../js/website_sale";
 
 const DynamicSnippetProducts = DynamicSnippetCarousel.extend({
     selector: '.s_dynamic_snippet_products',
+    events: {
+        'slid.bs.carousel': '_preloadCarouselItems',
+    },
+
+    /**
+     * @override
+     */
+    start: async function () {
+        await this._super.apply(this, arguments);
+        this._preloadCarouselItems();
+    },
 
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
 
+    /**
+     * Preload next and prev carousel items to avoid animation lag
+     *
+     * @private
+     */
+    _preloadCarouselItems: function () {
+        const activeCarouselItemEl = this.el.querySelector('.carousel-item.active');
+        if (activeCarouselItemEl) {
+            const carouselItemArray = [
+                activeCarouselItemEl.previousElementSibling || this.el.querySelector('.carousel-item:last-child'),
+                activeCarouselItemEl.nextElementSibling || this.el.querySelector('.carousel-item:first-child')
+            ];
+
+            carouselItemArray.forEach(carouselItemEl => {
+                carouselItemEl.querySelectorAll('img[loading="lazy"]').forEach(img => {
+                    img.setAttribute('loading', 'eager');
+                });
+            });
+        }
+    },
     /**
      * Gets the category search domain
      *

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
@@ -105,6 +105,9 @@ const DynamicSnippetProducts = DynamicSnippetCarousel.extend({
         const productTemplateId = $("#product_details").find(".product_template_id");
         return Object.assign(this._super.apply(this, arguments), {
             productTemplateId: productTemplateId && productTemplateId.length ? productTemplateId[0].value : undefined,
+            showDescription: this.el.dataset.showDescription,
+            showPrice: this.el.dataset.showPrice,
+            showReviews: this.el.dataset.showReviews,
         });
     },
     /**

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/options.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/options.js
@@ -79,6 +79,9 @@ const dynamicSnippetProductsOptions = s_dynamic_snippet_carousel_options.extend(
     _setOptionsDefaultValues: function () {
         this._setOptionValue('productCategoryId', 'all');
         this._setOptionValue('showVariants', true);
+        this._setOptionValue('showDescription', true);
+        this._setOptionValue('showPrice', true);
+        this._setOptionValue('showReviews', true);
         this._super.apply(this, arguments);
     },
 });

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/options.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/options.js
@@ -36,9 +36,26 @@ const dynamicSnippetProductsOptions = s_dynamic_snippet_carousel_options.extend(
      * @private
      * @override
      */
-     _computeWidgetVisibility(widgetName, params) {
+     async _computeWidgetVisibility(widgetName, params) {
         if (this.isAlternativeProductSnippet && alternativeSnippetRemovedOptions.includes(widgetName)) {
             return false;
+        }
+        if (widgetName === 'show_price_opt') {
+            const template = this._getCurrentTemplate();
+            return template && template.showPriceOpt;
+        }
+        if (widgetName === 'show_description_opt') {
+            const template = this._getCurrentTemplate();
+            return template && template.showDescriptionOpt;
+        }
+        if (widgetName === 'show_reviews_opt') {
+            const template = this._getCurrentTemplate();
+            // If later new templates are added and don't display the reviews,
+            // maybe refactor this the same way as showPriceOpt and showDescriptionOpt
+            if( template && template.key === "website_sale.dynamic_filter_template_product_product_mini_image" ){
+                return false;
+            }
+            return this._getEnabledCustomizeValues(['website_sale.product_comment',''], true);
         }
         return this._super(...arguments);
     },

--- a/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
+++ b/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
@@ -38,6 +38,22 @@
                     placeholder="e.g. lamp,bin" title="Comma-separated list of parts of product names, barcodes or internal reference"/>
             </t>
         </xpath>
+        <xpath expr="//we-select[@data-name='template_opt']" position="after">
+            <t t-if="snippet_name == 'dynamic_snippet_products'">
+                    <we-checkbox data-name="show_description_opt" string="Show Description" class="o_we_sublevel_1"
+                                 data-select-data-attribute="true"
+                                 data-attribute-name="showDescription"
+                                 data-no-preview="true"/>
+                    <we-checkbox data-name="show_price_opt" string="Show Price" class="o_we_sublevel_1"
+                                 data-select-data-attribute="true"
+                                 data-attribute-name="showPrice"
+                                 data-no-preview="true"/>
+                    <we-checkbox data-name="show_reviews_opt" string="Show Reviews" class="o_we_sublevel_1"
+                                 data-select-data-attribute="true"
+                                 data-attribute-name="showReviews"
+                                 data-no-preview="true"/>
+            </t>
+        </xpath>
     </template>
 
     <record id="website_sale.s_dynamic_snippet_products_000_js" model="ir.asset">


### PR DESCRIPTION
This PR modify the product carousel by adding multiple options and improvements to the carousel template

First it adds options about what to show in the carousel items for the `s_dynamic_product`
- [x] - show/hide description in the carousel items (visible if description present in template)
- [x] - show/hide price in the carousel items (visible if description present in template)
- [x] - show/hide reviews in the carousel items (visible if reviews are enable in the product page)

Then it now displays the eCommerce description in the carousel instead of the quotation description. 

Moreover it fixes a sliding animation lag when first seeing the carousel-items. Now the cards that are susceptible to appear are pre-loaded. 

TBD: Add  a _Add to wishlist_ button

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr