### PR TITLE
[FIX] data_recycle: Fix notify_frequency_period field style

### DIFF
--- a/addons/data_recycle/views/data_recycle_model_views.xml
+++ b/addons/data_recycle/views/data_recycle_model_views.xml
@@ -50,7 +50,7 @@
                                 <label for="notify_user_ids" attrs="{'invisible': [('recycle_mode', '=', 'automatic')]}" />
                                 <div attrs="{'invisible': [('recycle_mode', '=', 'automatic')]}">
                                     <field name="notify_user_ids" widget="many2many_tags"  options="{'no_create': True, 'no_edit': True}" domain="[('share', '=', False)]" nolabel="1"/>
-                                    <div class="d-flex w-25" attrs="{'invisible': [('notify_user_ids', '=', [])]}">
+                                    <div class="d-flex w-50" attrs="{'invisible': [('notify_user_ids', '=', [])]}">
                                         <span class="me-1">Every</span>
                                         <field name="notify_frequency" attrs="{'required': [('notify_user_ids', '!=', [])]}" />
                                         <field name="notify_frequency_period" attrs="{'required': [('notify_user_ids', '!=', [])]}" />


### PR DESCRIPTION
**Steps to Reproduce:**
- Install data_recycle module.
- Navigate to Configuration → Rules and create any rule for the data_recycle.

**Issue:**
- The selected option for the notify_frequency_period field is not displayed correctly due to a fixed width class (w-25) assigned to its parent div element.

![image](https://github.com/user-attachments/assets/1656d3f1-d248-45d7-92e3-3722b7679fa5)

**Solution:**
- Updated the width class from w-25 to w-50 to ensure proper display of the selected option.

![image](https://github.com/user-attachments/assets/49d43886-1a32-4256-80a1-f3d3aa69de42)

opw-4414071

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
