### PR TITLE
18.0 fix dynamic snippet link not editable bvr

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.js
@@ -197,11 +197,13 @@ const DynamicSnippet = publicWidget.Widget.extend({
         this.trigger_up('widgets_stop_request', {
             $target: $templateArea,
         });
-        const mainPageUrl = this._getMainPageUrl();
         const allContentLink = this.el.querySelector(".s_dynamic_snippet_main_page_url");
-        if (allContentLink && mainPageUrl) {
-            allContentLink.href = mainPageUrl;
-            allContentLink.classList.remove("d-none");
+        if (allContentLink?.classList.contains("d-none")) {
+            const mainPageUrl = this._getMainPageUrl();
+            if (mainPageUrl) {
+                allContentLink.href = mainPageUrl;
+                allContentLink.classList.remove("d-none");
+            }
         }
         $templateArea.html(this.renderedContent);
         // TODO this is probably not the only public widget which creates DOM


### PR DESCRIPTION
Steps to reproduce:

- Install the e-commerce module.
- Go to the homepage.
- Enter edit mode.
- Drag and drop a "Products" block onto the page.
- Click on the "See all" link.
- Edit the link (e.g., change "/shop" to "/contactus").
- Save the page.
- Click on the "See all" link.
- Bug: You are redirected to the "/shop" page instead of the
"/contactus" page as expected.

The bug occurs since commit [1], where the "See all" link was added to
"Dynamic" snippets. Each time a "Dynamic" snippet is rendered during a
page load, the href of the "See all" link is reset to the main module
page. While this behavior is useful when the snippet is first rendered
after being dropped onto the page, it is problematic afterward. Once the
user has edited the link with a different href, it should not be reset
on every page load.

[1]: https://github.com/odoo/odoo/commit/bbcff746075485be61807d08ad8232dbad347713

[opw-4418048](https://www.odoo.com/web#id=4418048&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)