### PR TITLE
[FIX] pos_loyalty: prevent loading unavailable programs

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
@@ -12,9 +12,11 @@ patch(PartnerList.prototype, {
 
     async searchPartner() {
         const res = await super.searchPartner();
+        const programIds = this.pos.models["loyalty.program"].getAll().map((p) => p.id);
         const coupons = await this.pos.fetchCoupons([
             ["partner_id", "in", res.map((partner) => partner.id)],
             ["program_id.active", "=", true],
+            ["program_id", "in", programIds],
         ]);
         this.pos.computePartnerCouponIds(coupons);
         return res;

--- a/addons/pos_loyalty/static/src/overrides/models/data_service_options.js
+++ b/addons/pos_loyalty/static/src/overrides/models/data_service_options.js
@@ -15,4 +15,12 @@ patch(DataServiceOptions.prototype, {
         });
         return data;
     },
+    get pohibitedAutoLoadedModels() {
+        return [
+            ...super.pohibitedAutoLoadedModels,
+            "loyalty.program",
+            "loyalty.rule",
+            "loyalty.reward",
+        ];
+    },
 });


### PR DESCRIPTION
Before this commit, when loading a partner, it was possible to load programs that were not available.

opw-4339514

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
