### PR TITLE
[WIP] mail: improve discuss call UX

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -1,5 +1,4 @@
-// $o-discuss-talkingColor: mix($white, darken($o-enterprise-action-color, 5%), 35%);
-$o-discuss-talkingColor: lighten($success, 5%);
+$o-discuss-talkingColor: rgba(lighten($success, 10%), 1);
 
 .o-mail-discussSidebarBgColor {
     background-color: $white;
@@ -70,8 +69,17 @@ $o-discuss-talkingColor: lighten($success, 5%);
     font-size: 0.65rem;
 }
 
+.o-xxsmaller {
+    font-size: 0.5rem;
+}
+
 .o-yellow {
     color: $yellow;
+}
+
+@mixin o-mail-call-bordered() {
+    outline: 2px solid rgba($o-action, 0.5) !important;
+    background-color: mix($white, $o-action, 95%) !important;
 }
 
 // see `@mixin button-variant`, this is the implementation without requiring `.btn` classname

--- a/addons/mail/static/src/core/common/search_messages_panel.xml
+++ b/addons/mail/static/src/core/common/search_messages_panel.xml
@@ -5,7 +5,7 @@
             title="title"
             minWidth="200"
             initialWidth="400"
-            icon="'oi oi-serch'"
+            icon="'oi oi-search'"
         >
             <SearchMessageInput closeSearch="props.closeSearch" messageSearch="messageSearch" thread="props.thread"/>
             <SearchMessageResult thread="props.thread" messageSearch="messageSearch"/>

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -84,6 +84,49 @@ threadActionsRegistry
             });
         },
         toggle: true,
+    })
+    .add("thread-call-layout", {
+        component: SearchMessagesPanel,
+        condition(component) {
+            return component.env.inDiscussApp && component.thread?.allowCalls;
+        },
+        icon: "oi oi-fw oi-view-kanban",
+        iconLarge: "oi oi-fw fa-lg oi-view-kanban",
+        name: _t("Conversation & Call Layout"),
+        sequence: 30,
+        sequenceGroup: 40,
+        open(component) {
+            component.store.discuss.callThreadLayout =
+                component.store.discuss.callThreadLayout === "h" ? "v" : "h";
+        },
+    })
+    .add("show-conversation-while-in-call", {
+        component: SearchMessagesPanel,
+        condition(component) {
+            return component.env.inDiscussApp && component.state.hideWhileInCall === "t";
+        },
+        icon: "fa fa-fw fa-comment",
+        iconLarge: "fa fa-fw fa-lg fa-comment",
+        name: _t("Show conversation"),
+        sequence: 20,
+        sequenceGroup: 40,
+        open(component) {
+            component.state.hideWhileInCall = false;
+        },
+    })
+    .add("show-call-while-in-call", {
+        component: SearchMessagesPanel,
+        condition(component) {
+            return component.env.inDiscussApp && component.state.hideWhileInCall === "c";
+        },
+        icon: "fa fa-fw fa-photo",
+        iconLarge: "fa fa-fw fa-lg fa-photo",
+        name: _t("Show call view"),
+        sequence: 10,
+        sequenceGroup: 40,
+        open(component) {
+            component.state.hideWhileInCall = false;
+        },
     });
 
 function transformAction(component, id, action) {

--- a/addons/mail/static/src/core/public_web/discuss.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss.dark.scss
@@ -10,10 +10,10 @@
     background-color: mix($gray-100, $gray-200);
 
     &:not(.o-isActive):hover {
-        background-color: $gray-300;
+        background-color: mix($gray-200, $gray-300);
     }
     &.o-isActive {
-        background-color: $gray-400;
+        background-color: $gray-300;
     }
     &.o-isActive:hover {
         background-color: mix($gray-300, $gray-400);
@@ -21,6 +21,5 @@
 }
 
 .o-mail-Discuss-headerActionsGroup {
-    --border-opacity: .1;
-    background-color: mix($gray-200, $gray-300);
+    --border-opacity: .2;
 }

--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -55,12 +55,15 @@ export class Discuss extends Component {
         this.messageToReplyTo = useMessageToReplyTo();
         this.contentRef = useRef("content");
         this.root = useRef("root");
-        this.state = useState({ jumpThreadPresent: 0 });
+        this.state = useState({
+            jumpThreadPresent: 0,
+            hideWhileInCall: false, // 't' for conversation/thread, 'c' for call view
+        });
         this.orm = useService("orm");
         this.effect = useService("effect");
         this.ui = useState(useService("ui"));
         useSubEnv({
-            inDiscussApp: true,
+            inDiscussApp: this.state,
             messageHighlight: this.messageHighlight,
         });
         this.notification = useService("notification");

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -8,6 +8,14 @@
     background-color: var(--mail-Discuss-coreBgColor, $body-bg);
 }
 
+.o-mail-Discuss-threadContainer.o-inDiscussAppHorizontalLayout {
+    flex-basis: 33%;
+}
+
+.o-mail-Discuss-threadContainerHeader {
+    background-color: var(--mail-Discuss-coreBgColor, $body-bg);
+}
+
 .o-mail-Discuss-selfAvatar {
     height: $o-mail-Avatar-sizeSmall;
     width: $o-mail-Avatar-sizeSmall;
@@ -24,7 +32,11 @@
 
 .o-mail-Discuss-headerActions button {
     --btn-disabled-opacity: 0.25;
+    opacity: 75%;
 
+    &:hover, &.o-isActive {
+        opacity: 100%;
+    }
     &:not(.o-isActive):hover {
         background-color: $gray-200;
     }
@@ -32,6 +44,7 @@
         background-color: $gray-300;
         outline: $border-width solid $gray-500;
         outline-offset: -$border-width;
+        opacity: 100%;
     }
     &.o-isActive:hover {
         background-color: $gray-300;
@@ -45,6 +58,10 @@
 
 .o-mail-Discuss-headerCountry {
     width: 24px;
+}
+
+.o-mail-Discuss-panelContainer {
+    --border-opacity: .5;
 }
 
 .o-mail-Discuss-threadAvatar {

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -89,19 +89,28 @@
             </div>
             <div class="o-mail-Discuss-main d-flex overflow-hidden flex-grow-1" t-ref="main">
                 <t t-if="ui.isSmall" t-call="mail.Discuss.loading"/>
-                <div class="o-mail-Discuss-core overflow-auto d-flex flex-grow-1" t-ref="core">
-                    <t t-if="thread">
-                        <div class="d-flex flex-column flex-grow-1">
-                            <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo"/></t>
-                            <Composer t-if="thread.model !== 'mail.box' or thread.eq(messageToReplyTo.thread)" t-key="thread.localId" composer="thread.composer" autofocus="true" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onDiscardCallback="() => messageToReplyTo.cancel()" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="messageToReplyTo?.message ? (messageToReplyTo.message.is_note ? 'note' : 'message') : undefined"/>
-                        </div>
-                        <div t-if="threadActions.activeAction?.componentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="h-100 border-start flex-shrink-0">
-                            <t t-component="threadActions.activeAction.component" thread="thread" t-props="threadActions.activeAction.componentProps"/>
+                <div class="o-mail-Discuss-core overflow-auto d-flex flex-grow-1 w-100" t-ref="core">
+                    <t name="core-content">
+                        <t t-if="thread">
+                            <div t-if="!(rtc?.state.channel?.eq(thread) and thread.rtcSessions?.length > 0 and state.hideWhileInCall === 't')" class="o-mail-Discuss-threadContainer d-flex flex-column flex-grow-1" t-att-class="{ 'o-inDiscussAppHorizontalLayout': thread.rtcSessions.length > 0 and store.discuss.callThreadLayout === 'h' }">
+                                <t t-if="thread.rtcSessions.length > 0 and store.discuss.callThreadLayout === 'h'">
+                                    <div class="o-mail-Discuss-threadContainerHeader o-mail-ActionPanel-header position-sticky top-0 pt-2 pb-2 d-flex flex-column bg-inherit small px-2">
+                                        <div class="d-flex align-items-baseline gap-1">
+                                            <i class="text-muted opacity-50 fa fa-comment"/><p class="fw-bold text-uppercase m-0 text-muted opacity-50 flex-grow-1">Conversation</p><i class="oi oi-close opacity-25 opacity-100-hover cursor-pointer" title="Hide conversation" t-on-click="() => this.state.hideWhileInCall = 't'"/>
+                                        </div>
+                                    </div>
+                                </t>
+                                <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo"/></t>
+                                <Composer t-if="thread.model !== 'mail.box' or thread.eq(messageToReplyTo.thread)" t-key="thread.localId" composer="thread.composer" autofocus="true" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onDiscardCallback="() => messageToReplyTo.cancel()" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="messageToReplyTo?.message ? (messageToReplyTo.message.is_note ? 'note' : 'message') : undefined"/>
+                            </div>
+                            <div t-if="threadActions.activeAction?.componentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-Discuss-panelContainer h-100 border-start border-secondary flex-shrink-0">
+                                <t t-component="threadActions.activeAction.component" thread="thread" t-props="threadActions.activeAction.componentProps"/>
+                            </div>
+                        </t>
+                        <div t-elif="(!ui.isSmall or store.discuss.activeTab === 'main') and store.discuss.hasRestoredThread" class="d-flex flex-grow-1 align-items-center justify-content-center w-100 bg-view">
+                            <h4 class="text-muted"><b><i>No conversation selected.</i></b></h4>
                         </div>
                     </t>
-                    <div t-elif="(!ui.isSmall or store.discuss.activeTab === 'main') and store.discuss.hasRestoredThread" class="d-flex flex-grow-1 align-items-center justify-content-center w-100 bg-view">
-                        <h4 class="text-muted"><b><i>No conversation selected.</i></b></h4>
-                    </div>
                 </div>
             </div>
         </div>

--- a/addons/mail/static/src/core/public_web/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app_model.js
@@ -46,6 +46,32 @@ export class DiscussApp extends Record {
     INSPECTOR_WIDTH = 300;
     /** @type {'main'|'channel'|'chat'|'livechat'} */
     activeTab = "main";
+    /**
+     * Layout of call and thread in discuss app.
+     * - 'v' (default): call view is above thread, aka 'vertical'.
+     * - 'h': call view is next to thread, aka 'horizontal'.
+     */
+    callThreadLayout = Record.attr("h", {
+        // 'h' for horizontal, 'v' for vertical
+        compute() {
+            return browser.localStorage.getItem(
+                "mail.user_setting.discuss_call_thread_layout_h"
+            ) !== "true"
+                ? "h"
+                : "v";
+        },
+        /** @this {import("models").DiscussApp} */
+        onUpdate() {
+            if (this.callThreadLayout === "v") {
+                browser.localStorage.removeItem("mail.user_setting.discuss_call_thread_layout_h");
+            } else {
+                browser.localStorage.setItem(
+                    "mail.user_setting.discuss_call_thread_layout_h",
+                    "true"
+                );
+            }
+        },
+    });
     searchTerm = "";
     isActive = false;
     isMemberPanelOpenByDefault = Record.attr(true, {

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -23,12 +23,12 @@
 
     <t t-name="mail.Mailbox.main">
         <button
-            class="o-mail-DiscussSidebar-item o-mail-Mailbox btn d-flex align-items-center px-0 border-0 rounded-2 fw-normal text-reset"
+            class="o-mail-DiscussSidebar-item o-mail-Mailbox btn d-flex align-items-center px-0 mx-2 border-0 rounded-2 fw-normal text-reset"
             t-att-class="{
                 'bg-inherit': mailbox.notEq(store.discuss.thread),
                 'o-active': mailbox.eq(store.discuss.thread),
-                'mx-2 justify-content-center position-relative o-compact': store.discuss.isSidebarCompact,
-                'mx-3 o-py-0_5': !store.discuss.isSidebarCompact,
+                'justify-content-center position-relative o-compact': store.discuss.isSidebarCompact,
+                'o-py-0_5': !store.discuss.isSidebarCompact,
                 'o-unread': mailbox.counter,
             }"
             t-on-click="(ev) => this.openThread(ev)"

--- a/addons/mail/static/src/discuss/call/common/call.scss
+++ b/addons/mail/static/src/discuss/call/common/call.scss
@@ -15,6 +15,11 @@
             min-height: #{"max(10%, 100px)"};
         }
     }
+
+    &.o-inDiscussAppHorizontalLayout {
+        height: 100% !important;
+        flex-basis: 66%;
+    }
 }
 
 .o-discuss-Call-main {

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -3,8 +3,17 @@
 
     <t t-name="discuss.Call">
         <PttAdBanner/>
-        <div class="o-discuss-Call user-select-none d-flex" t-att-class="{'o-fullscreen fixed-top vw-100 vh-100': state.isFullscreen, 'o-compact': props.compact,'o-minimized': minimized, 'position-relative': !state.isFullscreen }">
-            <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto" t-on-mouseleave="onMouseleaveMain">
+        <div class="o-discuss-Call user-select-none d-flex position-relative" t-att-class="{
+            'o-fullscreen fixed-top vw-100 vh-100': state.isFullscreen,
+            'o-compact': props.compact,
+            'o-minimized': minimized,
+            'position-relative': !state.isFullscreen,
+            'flex-grow-1 o-inDiscussAppHorizontalLayout min-w-0': env.inDiscussApp and store.discuss.callThreadLayout === 'h',
+        }">
+            <t t-if="env.inDiscussApp">
+                <i class="oi oi-close opacity-25 opacity-100-hover cursor-pointer position-absolute top-0 end-0 z-1 mt-1 pt-2 p-1" title="Hide call view" t-on-click="() => this.env.inDiscussApp.hideWhileInCall = 'c'"/>
+            </t>
+            <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto" t-att-class="{ 'px-2 py-3': env.inDiscussApp and store.discuss.callThreadLayout === 'h' }" t-on-mouseleave="onMouseleaveMain">
                 <div
                     class="o-discuss-Call-mainCards d-flex align-items-center overflow-hidden h-100 w-100 flex-wrap justify-content-center"
                     t-attf-style="--height:{{state.tileHeight}}px; --width:{{state.tileWidth}}px;"

--- a/addons/mail/static/src/discuss/call/common/call_menu.scss
+++ b/addons/mail/static/src/discuss/call/common/call_menu.scss
@@ -1,7 +1,10 @@
 .o-discuss-CallMenu-buttonContent {
     max-width: 150px;
+    @include o-mail-call-bordered;
 }
 
-.o-discuss-CallMenu-dot {
-    animation: flash 3s ease infinite;
+.o-discuss-CallMenu-animation {
+    animation: flash 2s;
+    animation-direction: alternate;
+    animation-iteration-count: 2;
 }

--- a/addons/mail/static/src/discuss/call/common/call_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_menu.xml
@@ -3,15 +3,15 @@
 
     <t t-name="discuss.CallMenu">
         <div class="dropdown" t-attf-class="{{ className }}" t-ref="root">
-            <button t-if="rtc.state.channel" class="px-3 user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="rtc.state.channel.open">
-                <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center">
-                    <span class="position-relative me-2">
+            <button t-if="rtc.state.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="rtc.state.channel.open">
+                <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center o-gap-0_5 rounded-3 opacity-75 opacity-100-hover px-1">
+                    <span class="position-relative small">
                         <i class="me-2 fa fa-fw" t-att-class="icon" />
-                        <small class="position-absolute top-0 end-0 bottom-0 mt-n3 pt-1">
-                            <i class="o-discuss-CallMenu-dot fa fa-circle text-warning small"/>
+                        <small class="d-flex position-absolute top-0 end-0 smaller">
+                            <i class="o-discuss-CallMenu-animation fa fa-volume-up text-danger"/>
                         </small>
                     </span>
-                    <em class="text-truncate" t-esc="rtc.state.channel.displayName"/>
+                    <span class="text-truncate fw-bold pe-1" t-esc="rtc.state.channel.displayName"/>
                 </div>
             </button>
         </div>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.dark.scss
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.dark.scss
@@ -1,3 +1,4 @@
 .o-discuss-CallParticipantCard {
-    --discuss-talkingColor: #{darken($o-enterprise-action-color, 5%)};
+    --o-discuss-CallParticipantCard-avatarBgColor: #{mix($gray-200, $gray-300)};
+    --discuss-talkingColor: #{rgba(darken($o-enterprise-action-color, 5%), .75)};
 }

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.scss
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.scss
@@ -66,6 +66,7 @@
 
 .o-discuss-CallParticipantCard-iconBlackBg {
     background-color: rgba(0, 0, 0, 0.75);
+    opacity: 75%;
 }
 
 .o-discuss-CallParticipantCard-overlay {

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -28,8 +28,8 @@
             </div>
             <t t-if="rtcSession">
                 <!-- overlay -->
-                <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden">
-                    <span t-if="!props.minimized and !props.inset" class="p-1 rounded-1 text-truncate" t-esc="name"/>
+                <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden rounded-1">
+                    <span t-if="!props.minimized and !props.inset" class="px-1 text-truncate smaller opacity-75" t-esc="name"/>
                     <small t-if="rtcSession.isScreenSharingOn and props.minimized and !isOfActiveCall" class="user-select-none o-minimized rounded-pill text-bg-danger d-flex align-items-center fw-bolder" title="live" aria-label="live">
                         LIVE
                     </small>

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.dark.scss
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.dark.scss
@@ -1,0 +1,3 @@
+.o-mail-DiscussSidebarCallIndicator {
+    --o-mail-DiscussSidebarCallIndicator-bgColor: #{$gray-100};
+}

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.js
@@ -1,5 +1,6 @@
 import { Thread } from "@mail/core/common/thread_model";
 import { discussSidebarChannelIndicatorsRegistry } from "@mail/discuss/core/public_web/discuss_sidebar_categories";
+import { useHover } from "@mail/utils/common/hooks";
 
 import { Component, useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
@@ -18,6 +19,18 @@ export class DiscussSidebarCallIndicator extends Component {
         super.setup();
         this.store = useState(useService("mail.store"));
         this.rtc = useState(useService("discuss.rtc"));
+        this.hover = useHover("root");
+    }
+
+    onClick() {
+        if (this.store.discuss.isSidebarCompact) {
+            return;
+        }
+        if (this.props.thread.eq(this.rtc.state.channel)) {
+            this.rtc.leaveCall(this.props.thread);
+        } else {
+            this.rtc.joinCall(this.props.thread);
+        }
     }
 }
 

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.scss
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.scss
@@ -1,0 +1,9 @@
+.o-mail-DiscussSidebarCallIndicator {
+    opacity: 75%;
+
+    &.o-hover {
+        opacity: 100%;
+        background-color: var(--o-mail-DiscussSidebarCallIndicator-bgColor, $gray-100);
+        --border-opacity: .15;
+    }
+}

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCallIndicator">
-        <div t-if="props.thread.rtcSessions.length > 0" class="fa fa-volume-up" title="Ongoing call" t-att-class="{ 'text-danger': props.thread.eq(rtc.state.channel), 'mx-1': !store.discuss.isSidebarCompact }"/>
+        <div t-if="props.thread.rtcSessions.length > 0" title="Ongoing call" t-ref="root" class="o-mail-DiscussSidebarCallIndicator o-py-0_5 fa-fw rounded border" t-att-class="{
+            'fa fa-volume-up border-transparent': !hover.isHover or store.discuss.isSidebarCompact,
+            'o-hover': hover.isHover and !store.discuss.isSidebarCompact,
+            'fa fa-sign-in text-success border-success': hover.isHover and !props.thread.eq(rtc.state.channel) and !store.discuss.isSidebarCompact,
+            'fa fa-sign-out': hover.isHover and props.thread.eq(rtc.state.channel) and !store.discuss.isSidebarCompact,
+            'text-danger border-danger': props.thread.eq(rtc.state.channel),
+            'me-2': !store.discuss.isSidebarCompact,
+        }" t-on-click="onClick"/>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.dark.scss
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.dark.scss
@@ -1,3 +1,3 @@
 .o-mail-DiscussSidebarCallParticipants {
-    --discuss-talkingColor: #{darken($o-enterprise-action-color, 5%)};
+    --discuss-talkingColor: #{rgba(darken($o-enterprise-action-color, 5%), .75)};
 }

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.scss
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.scss
@@ -1,21 +1,19 @@
 .o-mail-DiscussSidebarCallParticipants-avatar.o-isTalking {
     outline: 3px solid var(--discuss-talkingColor, $o-discuss-talkingColor);
-    outline-offset: -3px;
+    outline-offset: -2px;
 }
 
 .o-mail-DiscussSidebarCallParticipants-name {
     color: $black;
+    opacity: 60%;
 
-    &:not(.o-isTalking) {
-        color: $text-muted;
-        opacity: 75%;
+    &.o-isTalking {
+        opacity: 100%;
     }
 }
 
 .o-mail-DiscussSidebarCallParticipants-status {
     &.o-compact {
-        top: -3px;
-
         span {
             padding: map-get($spacers, 1) / 2;
         }

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCallParticipants">
         <t t-if="sessions.length gt 0">
-            <Dropdown t-if="compact" state="floating" position="'right-middle'" manual="true" menuClass="'py-0'">
+            <Dropdown t-if="compact" state="floating" position="'right-middle'" manual="true" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view py-0'">
                 <t t-call="mail.DiscussSidebarCallParticipants.main"/>
                 <t t-set-slot="content">
                     <div t-ref="floating">
@@ -15,7 +15,13 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCallParticipants.main">
-        <div class="o-mail-DiscussSidebarCallParticipants d-flex flex-column gap-1 py-1" t-att-class="{ 'position-relative': compact, 'ps-4 pe-2 mx-2': props.compact === undefined and !compact, 'px-2': props.compact === false, 'rounded-3': props.compact === undefined }" t-ref="root">
+        <div class="o-mail-DiscussSidebarCallParticipants d-flex flex-column gap-1 py-1" t-ref="root" t-att-class="{
+            'position-relative': compact,
+            'ps-4 pe-2': props.compact === undefined and !compact,
+            'px-2': props.compact === false,
+            'rounded-3': props.compact === undefined,
+            'opacity-75': props.thread.notEq(rtc.state.channel) and compact,
+        }">
             <t t-if="store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarCallParticipants.participant">
                 <t t-set="session" t-value="lastActiveSession"/>
             </t>
@@ -28,25 +34,25 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCallParticipants.participant">
-        <div class="o-mail-DiscussSidebarCallParticipants-participant d-flex text-reset overflow-hidden align-items-center" t-att-class="{ 'justify-content-center bg-inherit': compact, 'me-2': !compact and props.compact === undefined }">
-            <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:24px;height:24px">
-                <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle o_object_fit_cover" t-att-src="session.channelMember.persona.avatarUrl" t-att-class="{'o-isTalking': !session.isMute and session.isTalking}" alt="Participant avatar"/>
+        <div class="o-mail-DiscussSidebarCallParticipants-participant d-flex text-reset overflow-hidden align-items-center" t-att-class="{ 'justify-content-center bg-inherit': compact }">
+            <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:24px;height:24px;padding:1px">
+                <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle o_object_fit_cover" t-att-src="session.channelMember.persona.avatarUrl" t-att-class="{'o-isTalking shadow': !session.isMute and session.isTalking}" alt="Participant avatar"/>
             </div>
             <span t-if="!compact" class="o-mail-DiscussSidebarCallParticipants-name mx-1 text-truncate fw-bolder smaller user-select-none" t-att-title="session.channelMember.persona.name" t-att-class="{ 'o-isTalking': !session.isMute and session.isTalking }">
                 <t t-esc="session.channelMember.persona.name"/>
             </span>
             <div t-if="!compact" class="flex-grow-1"/>
-            <div class="o-mail-DiscussSidebarCallParticipants-status" t-att-class="{ 'position-absolute bg-inherit p-0 rounded-circle o-compact d-flex smaller start-0 text-start': compact, 'ms-1 d-flex align-items-center justify-content-center': !compact }">
+            <div class="o-mail-DiscussSidebarCallParticipants-status small" t-att-class="{ 'position-absolute bottom-0 end-0 bg-inherit p-0 rounded-circle o-compact d-flex o-xsmaller text-start': compact, 'ms-1 d-flex align-items-center justify-content-center': !compact }">
                 <t t-if="compact">
                     <span t-if="session.shortStatus" t-att-class="{
-                        [`fa ${callActionsRegistry.get('mute').icon}`]: session.shortStatus === 'mute',
-                        [`fa ${callActionsRegistry.get('deafen').icon}`]: session.shortStatus === 'deafen',
+                        [`fa ${callActionsRegistry.get('mute').icon} opacity-75`]: session.shortStatus === 'mute',
+                        [`fa ${callActionsRegistry.get('deafen').icon} opacity-75`]: session.shortStatus === 'deafen',
                         'o-live bg-danger o-text-white rounded': session.shortStatus === 'live',
                     }"><t t-if="session.shortStatus === 'live'">LIVE</t></span>
                 </t>
                 <t t-else="">
-                    <span t-if="session.isMute" class="p-1 fa" t-att-class="callActionsRegistry.get('mute').icon"/>
-                    <span t-if="session.isDeaf" class="p-1 fa" t-att-class="callActionsRegistry.get('deafen').icon"/>
+                    <span t-if="session.isMute" class="p-1 fa opacity-75" t-att-class="callActionsRegistry.get('mute').icon"/>
+                    <span t-if="session.isDeaf" class="p-1 fa opacity-75" t-att-class="callActionsRegistry.get('deafen').icon"/>
                     <span t-if="session.isScreenSharingOn" class="o-live bg-danger o-text-white rounded">LIVE</span>
                 </t>
             </div>

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_categories_patch.dark.scss
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_categories_patch.dark.scss
@@ -1,3 +1,0 @@
-.o-mail-DiscussSidebarChannel-container {
-    --mail-DiscussSidebarChannel-borderSelfInCallOpacity: .35;
-}

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_categories_patch.scss
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_categories_patch.scss
@@ -1,5 +1,9 @@
 .o-mail-DiscussSidebarChannel-container.o-bordered.o-selfInCall {
-    --border-opacity: var(--mail-DiscussSidebarChannel-borderSelfInCallOpacity, 0.25);
-    border-color: rgba($o-action, var(--border-opacity, 1)) !important;
-    background-color: mix($white, $o-action, 95%) !important;
+    @include o-mail-call-bordered;
+
+    .o-mail-DiscussSidebar-item {
+        &.o-active, &:hover {
+            background-color: mix(mix($white, $o-action, 95%), $gray-200, 15%) !important;
+        }
+    }
 }

--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -11,7 +11,7 @@
     </t>
 
     <t t-name="mail.ActionPanel.content">
-        <div class="o-mail-ActionPanel-header position-sticky top-0 pt-2 pb-1 d-flex flex-column bg-inherit small" t-att-class="{ 'px-1': env.inChatWindow, 'px-2': !env.inChatWindow }">
+        <div class="o-mail-ActionPanel-header position-sticky top-0 pt-2 pb-1 d-flex flex-column bg-inherit small" t-att-class="{ 'px-1': env.inChatWindow, 'pe-2': !env.inChatWindow }">
             <div class="d-flex align-items-baseline gap-1">
                 <button t-if="env.closeActionPanel" class="btn p-1 opacity-75 opacity-100-hover" title="Close panel" t-on-click.stop="env.closeActionPanel">
                     <i class="oi oi-arrow-left fa-fw"/>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.scss
@@ -2,11 +2,14 @@
 
     &.o-offline {
         opacity: 33%;
+
+        &.cursor-pointer:hover {
+            opacity: 75%;
+        }
     }
 
     &.cursor-pointer:hover {
         background-color: var(--discuss-ChannelMember-hoverBg, mix($gray-100, $gray-200));
-        opacity: 100%;
     }
 }
 

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.ChannelMemberList">
-        <ActionPanel title.translate="Members" minWidth="200" icon="'fa fa-users'">
+        <ActionPanel title.translate="Members" minWidth="200" initialWidth="250" icon="'fa fa-users'">
             <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-sm btn-secondary m-2 mt-0 d-flex align-items-center justify-content-center gap-1"><i class="fa fa-user-plus"/><span>Invite a User</span></button>
             <t t-if="props.thread.onlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
@@ -31,7 +31,7 @@
     </t>
 
     <t t-name="discuss.ChannelMemberList.section">
-        <h6 class="text-muted pt-2 text-uppercase smaller" t-esc="sectionName"/>
+        <h6 class="text-muted pt-4 text-uppercase o-xsmaller opacity-75" t-esc="sectionName"/>
     </t>
 
     <t t-name="discuss.channel_member">
@@ -40,7 +40,7 @@
                 <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="member.persona.avatarUrl"/>
                 <ImStatus member="member" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
             </div>
-            <span t-ref="displayName" class="ms-2 text-truncate" t-esc="member.name"/>
+            <span t-ref="displayName" class="ms-2 text-truncate text-muted fw-bold" t-esc="member.name"/>
             <span class="ms-auto">
                 <span t-if="member.in(props.thread.invitedMembers)" class="p-1 fa fa-user-plus"/>
                 <span t-if="member.rtcSession?.isSelfMuted and !member.rtcSession?.isDeaf" class="p-1 fa fa-microphone-slash"/>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -46,6 +46,10 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
     }
 }
 
+.o-mail-DiscussSidebarCategory-chevronCompact {
+    left: map-get($spacers, 1);
+}
+
 .o-mail-DiscussSidebarCategory-toggler {
     &.o-compact {
         font-size: .65rem;
@@ -75,19 +79,15 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
 }
 
 .o-mail-DiscussSidebarChannel-subChannel.o-nonCompact {
-    margin-left: map-get($spacers, 4) + map-get($spacers, 2) + map-get($spacers, 1);
+    margin-left: map-get($spacers, 4) + map-get($spacers, 1);
 }
 
 .o-mail-DiscussSidebar-unreadIndicator {
     font-size: 0.35rem;
-    left: 6px;
-
-    &.o-compact {
-        left: 1px;
-    }
+    left: 1px;
 
     .o-mail-DiscussSidebarSubchannel &:not(.o-compact) {
-        left: 12px;
+        left: map-get($spacers, 2);
     }
 }
 
@@ -112,6 +112,6 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .1;
 
 .o-mail-DiscussSidebarSubchannel svg {
     color: var(--mail-DiscussSidebarSubchannel-svgColor, $gray-300);
-    left: 26px;
+    left: 18px;
     transform: scaleX(1) #{"/* rtl:scaleX(-1) */"};
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -51,17 +51,17 @@
 
     <t t-name="mail.DiscussSidebarCategory.main">
         <div class="o-mail-DiscussSidebarCategory d-flex align-items-center" t-att-class="{ 'mx-1 my-2 position-relative': store.discuss.isSidebarCompact, 'mt-1 me-2': !store.discuss.isSidebarCompact }" t-attf-class="#{category.extraClass}" name="header" t-ref="root">
-            <button class="o-mail-DiscussSidebarCategory-toggler btn btn-link text-reset flex-grow-1 d-flex p-0 text-start opacity-100-hover opacity-75" t-att-class="{ 'mx-1 align-items-baseline': !store.discuss.isSidebarCompact, 'align-items-center justify-content-center border-0 o-compact': store.discuss.isSidebarCompact }" t-on-click="() => this.toggle()" name="toggler">
+            <button class="o-mail-DiscussSidebarCategory-toggler btn btn-link text-reset flex-grow-1 d-flex p-0 text-start opacity-100-hover o-gap-0_5" t-att-class="{ 'ms-1 align-items-baseline opacity-75': !store.discuss.isSidebarCompact, 'align-items-center justify-content-center border-0 o-compact opacity-50': store.discuss.isSidebarCompact }" t-on-click="() => this.toggle()" name="toggler">
                 <t t-if="store.discuss.isSidebarCompact">
-                    <i class="start-0 position-absolute" t-att-class="{
+                    <i class="o-mail-DiscussSidebarCategory-chevronCompact position-absolute fa-fw o-xxsmaller" t-att-class="{
                         'oi oi-chevron-down': category.open,
                         'oi oi-chevron-right opacity-50': !category.open,
                     }"/>
                     <span class="rounded p-1" t-att-class="{ 'opacity-50': !category.open }"><i t-if="store.channels.status === 'fetching'" class="fa fa-fw fa-circle-o-notch fa-spin"/><i t-else="" class="fa-fw fa-lg" t-att-class="category.icon ?? 'fa fa-user'"/></span>
                 </t>
                 <t t-else="">
-                    <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-xsmaller mx-1 fa fa-fw fa-circle-o-notch fa-spin opacity-50"/></span>
-                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-xsmaller mx-1" t-att-class="category.open ? 'oi oi-chevron-down opacity-100' : 'oi oi-chevron-right opacity-50'"/>
+                    <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-xxsmallerfa fa-fw fa-circle-o-notch fa-spin opacity-50"/></span>
+                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-xxsmaller fa-fw" t-att-class="category.open ? 'oi oi-chevron-down opacity-100' : 'oi oi-chevron-right opacity-50'"/>
                     <span class="btn-sm p-0 text-uppercase text-break fw-bolder o-xsmaller text-muted" t-att-class="{ 'opacity-50': !category.open }"><t t-esc="category.name"/></span>
                 </t>
             </button>
@@ -88,7 +88,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebarChannel">
-        <div class="o-mail-DiscussSidebarChannel-container d-flex flex-column mx-2 bg-inherit o-py-0_5" t-att-class="attClassContainer">
+        <div class="o-mail-DiscussSidebarChannel-container d-flex flex-column mx-2 bg-inherit" t-att-class="attClassContainer">
             <t name="root">
                 <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
                     <t t-call="mail.DiscussSidebarChannel.main"/>
@@ -102,7 +102,7 @@
                 <t t-else="" t-call="mail.DiscussSidebarChannel.main"/>
                 <t t-set="subChannels" t-value="env.filteredThreads?.(thread.sub_channel_ids) ?? []"/>
                 <t t-set="isCategoryOpen" t-value="thread.discussAppCategory.open" />
-                <ul t-if="subChannels.length > 0" class="list-unstyled position-relative flex-grow-1" t-att-class="{ 'my-1 d-flex flex-column gap-1': store.discuss.isSidebarCompact, 'mt-1 mb-0': !store.discuss.isSidebarCompact }">
+                <ul t-if="subChannels.length > 0" class="list-unstyled position-relative flex-grow-1" t-att-class="{ 'my-1 d-flex flex-column gap-1': store.discuss.isSidebarCompact, 'mt-0 mb-0 d-flex flex-column gap-1': !store.discuss.isSidebarCompact }">
                     <t t-foreach="subChannels" t-as="sub" t-key="sub.localId">
                         <DiscussSidebarSubchannel t-if="isCategoryOpen or sub.eq(store.discuss.thread)" thread="sub" isFirst="sub_first or !isCategoryOpen"/>
                     </t>
@@ -124,11 +124,11 @@
     <t t-name="mail.DiscussSidebarSubchannel.main">
         <li class="o-mail-DiscussSidebarSubchannel d-flex align-items-center flex-grow-1 position-relative" t-att-class="{ 'p-0': !store.discuss.isSidebarCompact }" t-ref="root">
             <t t-if="!store.discuss.isSidebarCompact">
-                <svg t-if="props.isFirst" class="position-absolute me-1" style="top: -6px;" xmlns="http://www.w3.org/2000/svg" width="10" height="20" viewBox="0 0 10 20">
+                <svg t-if="props.isFirst" class="position-absolute" style="top: -9px;" xmlns="http://www.w3.org/2000/svg" width="10" height="24" viewBox="0 0 10 24">
                     <line x1="0" y1="3" x2="0" y2="100%" stroke="currentColor" stroke-width="3"/>
                     <line x1="0" y1="100%" x2="100%" y2="100%" stroke="currentColor" stroke-width="3"/>
                 </svg>
-                <svg t-else="" class="position-absolute me-1" style="top: -20px;" xmlns="http://www.w3.org/2000/svg" width="10" height="34" viewBox="0 0 10 34">
+                <svg t-else="" class="position-absolute" style="top: -20px;" xmlns="http://www.w3.org/2000/svg" width="10" height="34" viewBox="0 0 10 34">
                     <line x1="0" y1="3" x2="0" y2="100%" stroke="currentColor" stroke-width="3"/>
                     <line x1="0" y1="100%" x2="100%" y2="100%" stroke="currentColor" stroke-width="3"/>
                 </svg>
@@ -136,7 +136,7 @@
             <button class="o-mail-DiscussSidebarChannel-subChannel o-mail-DiscussSidebar-item btn btn-secondary border-0 bg-inherit d-flex flex-grow-1 smaller rounded text-start text-truncate align-items-center" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName" t-on-click="(ev) => this.openThread(ev, thread)" t-att-class="{
                 'o-active': thread.eq(this.store.discuss.thread),
                 'px-1 py-2 mx-1 text-wrap word-break lh-1': store.discuss.isSidebarCompact,
-                'o-nonCompact me-0 mb-1 p-0 ps-2': !store.discuss.isSidebarCompact,
+                'o-nonCompact me-1 p-0 ps-1': !store.discuss.isSidebarCompact,
                 'o-item-unread': thread.selfMember?.message_unread_counter > 0 and !thread.isMuted,
             }">
                 <span class="text-truncate" t-esc="thread.displayName" t-att-class="{
@@ -156,13 +156,13 @@
     </t>
 
     <t t-name="mail.DiscussSidebarChannel.main">
-        <button class="o-mail-DiscussSidebarChannel btn o-mail-DiscussSidebar-item d-flex align-items-center cursor-pointer mb-0 position-relative rounded-2 gap-1 border-0"
+        <button class="o-mail-DiscussSidebarChannel btn o-mail-DiscussSidebar-item d-flex align-items-center cursor-pointer o-py-0_5 mb-0 position-relative rounded-2 gap-1 border-0"
             t-att-class="attClass"
             t-on-click="(ev) => this.openThread(ev, thread)"
             t-ref="root"
         >
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0" t-att-class="{ 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
-                <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:26px;height:26px" t-att-class="{ 'ms-3': !store.discuss.isSidebarCompact }">
+                <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:20px;height:20px" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
                     <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border'"/>

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -4,7 +4,7 @@
         <ActionPanel title.translate="Threads" resizable="false" icon="'fa fa-comments-o'">
             <t t-set-slot="header">
                 <div class="d-flex align-items-center my-0">
-                    <div class="input-group my-2">
+                    <div class="input-group ms-2 my-2">
                         <div class="form-control d-flex align-items-center p-0 bg-view" role="search" aria-autocomplete="list">
                             <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 h-100">
                                 <input t-ref="search" t-model="state.searchTerm" type="text" class="o_searchview_input rounded flex-grow-1 w-auto border-0 px-2" t-on-keydown="onKeydownSearch" placeholder="Search by name"/>

--- a/addons/mail/static/src/discuss/public_web/discuss_patch.xml
+++ b/addons/mail/static/src/discuss/public_web/discuss_patch.xml
@@ -2,7 +2,16 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Discuss" t-inherit-mode="extension">
         <xpath expr="//Thread" position="before">
-            <Call t-if="thread.rtcSessions.length > 0" thread="thread"/>
+            <Call t-if="state.hideWhileInCall !== 'c' and thread.rtcSessions.length > 0 and !(store.discuss.callThreadLayout === 'h' or state.hideWhileInCall === 't')" thread="thread"/>
+        </xpath>
+        <xpath expr="//*[@name='core-content']" position="replace">
+            <t t-if="state.hideWhileInCall !== 'c' and thread?.rtcSessions.length > 0 and (store.discuss.callThreadLayout === 'h' or state.hideWhileInCall === 't')">
+                <div class="d-flex w-100">
+                    <Call thread="thread"/>
+                    <t>$0</t>
+                </div>
+            </t>
+            <t t-else="">$0</t>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
Minor style improvements:
- less start spacing on non-compact discuss sidebar items
- discuss sidebar item outline style when self in call is improved (better lines, more visible)
- discuss sidebar item when there's a call is improved: outline color matches border, background colors are more pleasing, spacing of participants and icons feels more right
- discuss app header buttons are less distracting (reduced opacity when not hovered, active color is more suble in dark theme)
- member panel is narrower in width by default
- member panel categories (online / offline) are smaller and reduced opacity, so that they are less distracting
- hover effect on offline members is less intense (opacity on hover is reduced)
- member names have slightly reduced opacity (was more catchy than messages with white color)
- call status in systray is `.fa-volume-up.text-danger` rather than `text-warning` blinking dot. Also blinking animation duration is 6 seconds rather than infinite.

New minor features:
- can quickly join and leave conversation from discuss sidebar when there's an ongoing call: simply hover and click on the ongoing call icon (`.fa-volume-up`). Note that the feature is not available in compact mode, as this is too easy to misclick conversation and the call indicator.
- can change layout of call/thread in discuss app: either vertically (default, same as before), or horizontal i.e. call view on left and textual conversation on right.
- Call view and textual thread can be hidden while in call: there's a "X" in top-right corner of each view to close it. A dynamic thread action allow to add them back. Only call or thread can be closed simultaneously.

TODO:
- layout button should show a popover rather than plain click for clarity.
- small layout issue when closing thread and showing vertical layout.
