### PR TITLE
[FIX] correct POS phone search character length

### DIFF
--- a/addons/phone_validation/models/mail_thread_phone.py
+++ b/addons/phone_validation/models/mail_thread_phone.py
@@ -92,7 +92,7 @@ class PhoneMixin(models.AbstractModel):
             return op([[(phone_field, operator, False)] for phone_field in phone_fields])
 
         if self._phone_search_min_length and len(value) < self._phone_search_min_length:
-            raise UserError(_('Please enter at least 3 characters when searching a Phone/Mobile number.'))
+            raise UserError(_('Please enter at least %s characters when searching a Phone/Mobile number.', self._phone_search_min_length))
 
         sql_operator = {'=like': 'LIKE', '=ilike': 'ILIKE'}.get(operator, operator)
 

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -134,7 +134,7 @@ export class PartnerList extends Component {
             ];
             domain = [
                 ...Array(search_fields.length - 1).fill("|"),
-                ...search_fields.map((field) => [field, "ilike", this.state.query + "%"]),
+                ...search_fields.map((field) => [field, "ilike", field === "phone_mobile_search" ? this.state.query : this.state.query + "%"]),
             ];
         }
 

--- a/doc/cla/individual/S-Ouaydah.md
+++ b/doc/cla/individual/S-Ouaydah.md
@@ -1,0 +1,11 @@
+Lebanon, 24/12/2024
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+S. Ouaydah s.ouaydah@gmail.com https://github.com/S-Ouaydah


### PR DESCRIPTION
Current behavior before PR:
In POS customer search adds a % to the user query, which is then interpreted as an additional digit in mail_thread_phone.py

Desired behavior after PR is merged:
Remove the % from phone/mobile field since _search_phone_mobile_search handles the search



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
