### PR TITLE
[REF] pos*: use monetary field

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -131,7 +131,7 @@ class PosConfig(models.Model):
     current_session_id = fields.Many2one('pos.session', compute='_compute_current_session', string="Current Session")
     current_session_state = fields.Char(compute='_compute_current_session')
     number_of_rescue_session = fields.Integer(string="Number of Rescue Session", compute='_compute_current_session')
-    last_session_closing_cash = fields.Float(compute='_compute_last_session')
+    last_session_closing_cash = fields.Monetary(compute='_compute_last_session')
     last_session_closing_date = fields.Date(compute='_compute_last_session')
     pos_session_username = fields.Char(compute='_compute_current_session_user')
     pos_session_state = fields.Char(compute='_compute_current_session_user')
@@ -163,7 +163,7 @@ class PosConfig(models.Model):
     is_posbox = fields.Boolean("PosBox")
     is_header_or_footer = fields.Boolean("Custom Header & Footer")
     module_pos_hr = fields.Boolean(help="Show employee login screen")
-    amount_authorized_diff = fields.Float('Amount Authorized Difference',
+    amount_authorized_diff = fields.Monetary('Amount Authorized Difference',
         help="This field depicts the maximum difference allowed between the ending balance and the theoretical cash when "
              "closing a session, for non-POS managers. If this maximum is reached, the user will have an error message at "
              "the closing of his session saying that he needs to contact his manager.")

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -301,8 +301,8 @@ class PosOrder(models.Model):
     partner_id = fields.Many2one('res.partner', string='Customer', change_default=True, index='btree_not_null')
     sequence_number = fields.Integer(string='Sequence Number', help='A session-unique sequence number for the order. Negative if generated from the client', default=1)
     session_id = fields.Many2one('pos.session', string='Session', index=True, domain="[('state', '=', 'opened')]")
-    config_id = fields.Many2one('pos.config', compute='_compute_order_config_id', string="Point of Sale", readonly=False, store=True)
-    currency_id = fields.Many2one('res.currency', related='config_id.currency_id', string="Currency")
+    config_id = fields.Many2one('pos.config', compute='_compute_order_config_id', string="Point of Sale", readonly=False, store=True, precompute=True)
+    currency_id = fields.Many2one('res.currency', related='config_id.currency_id', string="Currency", store=True, precompute=True)
     currency_rate = fields.Float("Currency Rate", compute='_compute_currency_rate', compute_sudo=True, store=True, digits=0, readonly=True,
         help='The rate of the currency to the currency of rate applicable at the date of the order')
 
@@ -1428,13 +1428,13 @@ class PosOrderLine(models.Model):
         comodel_name='product.attribute.custom.value', inverse_name='pos_order_line_id',
         string="Custom Values",
         store=True, readonly=False)
-    price_unit = fields.Float(string='Unit Price', digits=0)
+    price_unit = fields.Monetary(string='Unit Price')
     qty = fields.Float('Quantity', digits='Product Unit', default=1)
     price_subtotal = fields.Monetary(string='Tax Excl.',
         readonly=True, required=True)
     price_subtotal_incl = fields.Monetary(string='Tax Incl.',
         readonly=True, required=True)
-    price_extra = fields.Float(string="Price extra")
+    price_extra = fields.Monetary(string="Price extra")
     price_type = fields.Selection([
         ('original', 'Original'),
         ('manual', 'Manual'),
@@ -1442,7 +1442,7 @@ class PosOrderLine(models.Model):
     ], string='Price Type', default='original')
     margin = fields.Monetary(string="Margin", compute='_compute_margin')
     margin_percent = fields.Float(string="Margin (%)", compute='_compute_margin', digits=(12, 4))
-    total_cost = fields.Float(string='Total cost', digits='Product Price', readonly=True)
+    total_cost = fields.Monetary(string='Total cost', readonly=True)
     is_total_cost_computed = fields.Boolean(help="Allows to know if the total cost has already been computed or not")
     discount = fields.Float(string='Discount (%)', digits=0, default=0.0)
     order_id = fields.Many2one('pos.order', string='Order Ref', ondelete='cascade', required=True, index=True)
@@ -1450,7 +1450,7 @@ class PosOrderLine(models.Model):
     tax_ids_after_fiscal_position = fields.Many2many('account.tax', compute='_get_tax_ids_after_fiscal_position', string='Taxes to Apply')
     pack_lot_ids = fields.One2many('pos.pack.operation.lot', 'pos_order_line_id', string='Lot/serial Number')
     product_uom_id = fields.Many2one('uom.uom', string='Product Unit', related='product_id.uom_id')
-    currency_id = fields.Many2one('res.currency', related='order_id.currency_id')
+    currency_id = fields.Many2one('res.currency', related='order_id.currency_id', store=True, precompute=True)
     full_product_name = fields.Char('Full Product Name')
     customer_note = fields.Char('Customer Note')
     refund_orderline_ids = fields.One2many('pos.order.line', 'refunded_orderline_id', 'Refund Order Lines', help='Orderlines in this field are the lines that refunded this orderline.')

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -22,7 +22,7 @@ class PosPayment(models.Model):
     amount = fields.Monetary(string='Amount', required=True, currency_field='currency_id', help="Total amount of the payment.")
     payment_method_id = fields.Many2one('pos.payment.method', string='Payment Method', required=True)
     payment_date = fields.Datetime(string='Date', required=True, readonly=True, default=lambda self: fields.Datetime.now())
-    currency_id = fields.Many2one('res.currency', string='Currency', related='pos_order_id.currency_id')
+    currency_id = fields.Many2one('res.currency', string='Currency', related='pos_order_id.currency_id', store=True, precompute=True)
     currency_rate = fields.Float(string='Conversion Rate', related='pos_order_id.currency_rate', help='Conversion rate from company currency to order currency.')
     partner_id = fields.Many2one('res.partner', string='Customer', related='pos_order_id.partner_id')
     session_id = fields.Many2one('pos.session', string='Session', related='pos_order_id.session_id', store=True, index=True)

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -41,7 +41,7 @@ class PosSession(models.Model):
         readonly=False,
         default=lambda self: self.env.uid,
         ondelete='restrict')
-    currency_id = fields.Many2one('res.currency', related='config_id.currency_id', string="Currency", readonly=False)
+    currency_id = fields.Many2one('res.currency', related='config_id.currency_id', string="Currency", readonly=False, store=True, precompute=True)
     start_at = fields.Datetime(string='Opening Date', readonly=True)
     stop_at = fields.Datetime(string='Closing Date', readonly=True, copy=False)
 
@@ -87,7 +87,7 @@ class PosSession(models.Model):
         copy=False)
     move_id = fields.Many2one('account.move', string='Journal Entry', index=True)
     payment_method_ids = fields.Many2many('pos.payment.method', related='config_id.payment_method_ids', string='Payment Methods')
-    total_payments_amount = fields.Float(compute='_compute_total_payments_amount', string='Total Payments Amount')
+    total_payments_amount = fields.Monetary(compute='_compute_total_payments_amount', string='Total Payments Amount')
     is_in_company_currency = fields.Boolean('Is Using Company Currency', compute='_compute_is_in_company_currency')
     update_stock_at_closing = fields.Boolean('Stock should be updated at closing')
     bank_payment_ids = fields.One2many('account.payment', 'pos_session_id', 'Bank Payments', help='Account payments representing aggregated and bank split payments.')

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -58,7 +58,7 @@ class ResConfigSettings(models.TransientModel):
     pos_printer_ids = fields.Many2many(related='pos_config_id.printer_ids', readonly=False)
 
     pos_allowed_pricelist_ids = fields.Many2many('product.pricelist', compute='_compute_pos_allowed_pricelist_ids')
-    pos_amount_authorized_diff = fields.Float(related='pos_config_id.amount_authorized_diff', readonly=False)
+    pos_amount_authorized_diff = fields.Monetary(related='pos_config_id.amount_authorized_diff', readonly=False)
     pos_available_pricelist_ids = fields.Many2many('product.pricelist', string='Available Pricelists', compute='_compute_pos_pricelist_id', readonly=False, store=True)
     pos_cash_control = fields.Boolean(related='pos_config_id.cash_control')
     pos_cash_rounding = fields.Boolean(related='pos_config_id.cash_rounding', readonly=False, string="Cash Rounding (PoS)")

--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -20,11 +20,12 @@ class ReportPosOrder(models.Model):
         [('draft', 'New'), ('paid', 'Paid'), ('done', 'Posted'), ('cancel', 'Cancelled')],
         string='Status', readonly=True)
     user_id = fields.Many2one('res.users', string='User', readonly=True)
-    price_total = fields.Float(string='Total Price', readonly=True)
-    price_sub_total = fields.Float(string='Subtotal w/o discount', readonly=True)
-    price_subtotal_excl = fields.Float(string='Subtotal w/o Tax', readonly=True)
-    total_discount = fields.Float(string='Total Discount', readonly=True)
-    average_price = fields.Float(string='Average Price', readonly=True, aggregator="avg")
+    currency_id = fields.Many2one('res.currency', related='order_id.currency_id', string="Currency")
+    price_total = fields.Monetary(string='Total Price', readonly=True)
+    price_sub_total = fields.Monetary(string='Subtotal w/o discount', readonly=True)
+    price_subtotal_excl = fields.Monetary(string='Subtotal w/o Tax', readonly=True)
+    total_discount = fields.Monetary(string='Total Discount', readonly=True)
+    average_price = fields.Monetary(string='Average Price', readonly=True, aggregator="avg")
     company_id = fields.Many2one('res.company', string='Company', readonly=True)
     nbr_lines = fields.Integer(string='Sale Line Count', readonly=True)
     product_qty = fields.Integer(string='Product Quantity', readonly=True)
@@ -36,7 +37,7 @@ class ReportPosOrder(models.Model):
     config_id = fields.Many2one('pos.config', string='Point of Sale', readonly=True)
     pricelist_id = fields.Many2one('product.pricelist', string='Pricelist', readonly=True)
     session_id = fields.Many2one('pos.session', string='Session', readonly=True)
-    margin = fields.Float(string='Margin', readonly=True)
+    margin = fields.Monetary(string='Margin', readonly=True)
     payment_method_id = fields.Many2one('pos.payment.method', string='Payment Method', readonly=True)
 
     def _select(self):

--- a/addons/point_of_sale/views/point_of_sale_dashboard.xml
+++ b/addons/point_of_sale/views/point_of_sale_dashboard.xml
@@ -155,7 +155,7 @@
                                         <div class="col-6">
                                             <span>Balance</span>
                                         </div>
-                                        <field name="last_session_closing_cash" widget="monetary" class="col-6"/>
+                                        <field name="last_session_closing_cash" class="col-6"/>
                                     </div>
                                 </t>
                                 

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -162,7 +162,7 @@
                 <field name="company_id"  options="{'no_create': True}" groups="base.group_multi_company"/>
                 <field name="last_session_closing_date" string="Closing"/>
                 <field name="currency_id" column_invisible="True"/>
-                <field name="last_session_closing_cash" widget="monetary" string="Balance"/>
+                <field name="last_session_closing_cash" string="Balance"/>
             </list>
         </field>
     </record>

--- a/addons/point_of_sale/views/pos_order_report_view.xml
+++ b/addons/point_of_sale/views/pos_order_report_view.xml
@@ -31,13 +31,14 @@
             <field name="arch" type="xml">
                 <list string="Point of Sale Analysis">
                     <field name="date"/>
+                    <field name="currency_id" column_invisible="True"/>
                     <field name="order_id" optional="hide"/>
                     <field name="partner_id" optional="hide"/>
                     <field name="product_id" optional="show"/>
                     <field name="product_categ_id" optional="show"/>
                     <field name="config_id" optional="hide"/>
                     <field name="company_id" optional="show" groups="base.group_multi_company"/>
-                    <field name="price_total" optional="show"/>
+                    <field name="price_total" optional="show" sum="sum"/>
                     <field name="state" optional="show"/>
                 </list>
             </field>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -18,6 +18,7 @@
                 <sheet>
                 <field name="failed_pickings" invisible="1"/>
                 <div class="oe_button_box" name="button_box">
+                    <field name="currency_id" invisible="1" />
                     <button name="action_stock_picking"
                         type="object"
                         class="oe_stat_button"
@@ -70,13 +71,13 @@
                                     <main class="col">
                                         <div class="d-flex">
                                             <field name="full_product_name" class="fw-bolder"/>
-                                            <field name="price_subtotal_incl" widget="monetary" class="ms-auto me-3"/>
+                                            <field name="price_subtotal_incl" class="ms-auto me-3"/>
                                         </div>
                                         <div class="text-muted">
                                             Quantity: <field name="qty"/> <field name="product_uom_id" groups="uom.group_uom"/>
                                         </div>
                                         <div class="text-muted">
-                                            Unit price: <field name="price_unit" widget="monetary"/>
+                                            Unit price: <field name="price_unit"/>
                                         </div>
                                     </main>
                                 </t>
@@ -90,16 +91,16 @@
                                 <field name="qty"/>
                                 <field name="customer_note" optional="hide"/>
                                 <field name="product_uom_id" groups="uom.group_uom"/>
-                                <field name="price_unit" widget="monetary"/>
+                                <field name="price_unit"/>
                                 <field name="is_total_cost_computed" column_invisible="True"/>
-                                <field name="total_cost" invisible="not is_total_cost_computed" optional="hide" widget="monetary"/>
-                                <field name="margin" invisible="not is_total_cost_computed" optional="hide" widget="monetary"/>
+                                <field name="total_cost" invisible="not is_total_cost_computed" optional="hide"/>
+                                <field name="margin" invisible="not is_total_cost_computed" optional="hide"/>
                                 <field name="margin_percent" invisible="not is_total_cost_computed" optional="hide" widget="percentage"/>
                                 <field name="discount" width="50px" string="Disc.%"/>
                                 <field name="tax_ids_after_fiscal_position" widget="many2many_tax_tags" string="Taxes"/>
                                 <field name="tax_ids" widget="many2many_tax_tags" column_invisible="True"/>
-                                <field name="price_subtotal" widget="monetary" force_save="1"/>
-                                <field name="price_subtotal_incl" widget="monetary" force_save="1"/>
+                                <field name="price_subtotal" force_save="1"/>
+                                <field name="price_subtotal_incl" force_save="1"/>
                                 <field name="currency_id" column_invisible="True"/>
                                 <field name="refunded_qty" optional="hide" />
                             </list>
@@ -108,9 +109,9 @@
                                     <field name="product_id" />
                                     <field name="qty"/>
                                     <field name="discount"/>
-                                    <field name="price_unit" widget="monetary"/>
-                                    <field name="price_subtotal" invisible="1" widget="monetary" force_save="1"/>
-                                    <field name="price_subtotal_incl" invisible="1" widget="monetary" force_save="1"/>
+                                    <field name="price_unit"/>
+                                    <field name="price_subtotal" invisible="1" force_save="1"/>
+                                    <field name="price_subtotal_incl" invisible="1" force_save="1"/>
                                     <field name="tax_ids_after_fiscal_position" widget="many2many_tax_tags" string="Taxes"/>
                                     <field name="tax_ids" widget="many2many_tax_tags" invisible="1"/>
                                     <field name="pack_lot_ids" widget="many2many_tags" groups="stock.group_production_lot"/>
@@ -121,19 +122,13 @@
                             </form>
                         </field>
                         <group class="oe_subtotal_footer" colspan="2" name="order_total">
-                            <field name="amount_tax"
-                                   force_save="1"
-                                   widget="monetary"/>
-                            <field name="amount_total"
-                                   force_save="1"
-                                   class="h3"
-                                   widget="monetary"/>
+                            <field name="amount_tax" force_save="1"/>
+                            <field name="amount_total" force_save="1" class="h3"/>
                             <div class="oe_inline o_td_label">
                                 <label class="o_form_label_readonly" for="amount_paid" string="Total Paid (with rounding)"/>
                             </div>
                             <field name="amount_paid"
                                 nolabel="1"
-                                widget="monetary"
                                 class="h3"
                                 invisible="amount_paid == 'amount_total'"
                                 readonly="state != 'draft'"/>
@@ -164,9 +159,9 @@
                             </list>
                         </field>
                         <group class="oe_subtotal_footer" colspan="2" name="order_total">
-                            <field name="amount_total" class="h3" widget="monetary"/>
-                            <field name="amount_paid" widget="monetary" class="h3" readonly="1" />
-                            <field name="amount_difference" widget="monetary" force_save="1" />
+                            <field name="amount_total" class="h3"/>
+                            <field name="amount_paid" class="h3" readonly="1" />
+                            <field name="amount_difference" force_save="1" />
                         </group>
                     </page>
                     <page name="extra" string="Extra Info">
@@ -227,7 +222,7 @@
                             <span t-else="">
                                 <field name="name" class="fw-bolder me-2"/>
                             </span>
-                            <field name="amount_total" widget="monetary" class="fw-bolder ms-auto flex-shrink-0"/>
+                            <field name="amount_total" class="fw-bolder ms-auto flex-shrink-0"/>
                         </div>
                         <field name="pos_reference" />
                         <footer class="flex-wrap">
@@ -300,7 +295,7 @@
                 <field name="tracking_number" optional="hide"/>
                 <field name="partner_id"/>
                 <field name="user_id" widget="many2one_avatar_user" readonly="account_move or state == 'done'"/>
-                <field name="amount_total" sum="Amount total" widget="monetary" decoration-bf="1"/>
+                <field name="amount_total" sum="Amount total" decoration-bf="1"/>
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-success="state not in ('draft','cancel')"/>
                 <field name="invoice_status" widget="badge" decoration-success="invoice_status == 'invoiced'" decoration-info="invoice_status == 'to_invoice'"/>
                 <field name="is_edited" readonly="1" optional="hide"/>
@@ -339,9 +334,9 @@
                 <field name="product_id" readonly="1"/>
                 <field name="qty" readonly="1" sum="Total qty"/>
                 <field name="discount" readonly="1"/>
-                <field name="price_unit" readonly="1" widget="monetary"/>
-                <field name="price_subtotal" readonly="1" sum="Sum of subtotals" widget="monetary"/>
-                <field name="price_subtotal_incl" readonly="1" sum="Sum of subtotals" widget="monetary"/>
+                <field name="price_unit" readonly="1"/>
+                <field name="price_subtotal" readonly="1" sum="Sum of subtotals"/>
+                <field name="price_subtotal_incl" readonly="1" sum="Sum of subtotals"/>
                 <field name="create_date" readonly="1"/>
                 <field name="currency_id" column_invisible="True"/>
             </list>
@@ -357,7 +352,7 @@
                     <field name="product_id" />
                     <field name="qty" />
                     <field name="discount"/>
-                    <field name="price_unit" widget="monetary"/>
+                    <field name="price_unit"/>
                     <field name="create_date" />
                     <field name="currency_id"/>
                 </group>
@@ -396,7 +391,7 @@
                 <field name="create_date" />
                 <field name="product_id" />
                 <field name="qty" />
-                <field name="price_unit" widget="monetary"/>
+                <field name="price_unit"/>
                 <field name="currency_id" column_invisible="True"/>
             </list>
         </field>

--- a/addons/point_of_sale/views/pos_payment_views.xml
+++ b/addons/point_of_sale/views/pos_payment_views.xml
@@ -7,6 +7,7 @@
             <form string="Payments" create="0" edit="0" delete="0">
                 <sheet>
                     <group>
+                        <field name="currency_id" invisible="1" />
                         <field name="session_id" readonly="0"/>
                         <field name="pos_order_id"/>
                         <field name="amount" readonly="0"/>

--- a/addons/point_of_sale/views/pos_session_view.xml
+++ b/addons/point_of_sale/views/pos_session_view.xml
@@ -83,6 +83,7 @@
         <field name="model">pos.session</field>
         <field name="arch" type="xml">
             <list string="Point of Sale Session" create="0" sample="1">
+                <field name="currency_id" column_invisible="True" />
                 <field name="name" decoration-bf="1"/>
                 <field name="config_id" />
                 <field name="user_id" widget="many2one_avatar_user" readonly="state != 'opening_control'"/>

--- a/addons/point_of_sale/wizard/pos_close_session_wizard.py
+++ b/addons/point_of_sale/wizard/pos_close_session_wizard.py
@@ -8,8 +8,9 @@ class PosCloseSessionWizard(models.TransientModel):
     _name = 'pos.close.session.wizard'
     _description = "Close Session Wizard"
 
-    amount_to_balance = fields.Float("Amount to balance")
+    amount_to_balance = fields.Monetary("Amount to balance")
     account_id = fields.Many2one("account.account", "Destination account")
+    currency_id = fields.Many2one('res.currency', related='account_id.currency_id', string="Currency", store=True, precompute=True)
     account_readonly = fields.Boolean("Destination account is readonly")
     message = fields.Text("Information message")
 

--- a/addons/point_of_sale/wizard/pos_payment.py
+++ b/addons/point_of_sale/wizard/pos_payment.py
@@ -35,7 +35,8 @@ class PosMakePayment(models.TransientModel):
         return False
 
     config_id = fields.Many2one('pos.config', string='Point of Sale Configuration', required=True, default=_default_config)
-    amount = fields.Float(digits=0, required=True, default=_default_amount)
+    amount = fields.Monetary(required=True, default=_default_amount)
+    currency_id = fields.Many2one('res.currency', related='config_id.currency_id', string="Currency", store=True, precompute=True)
     payment_method_id = fields.Many2one('pos.payment.method', string='Payment Method', required=True, default=_default_payment_method)
     payment_name = fields.Char(string='Payment Reference')
     payment_date = fields.Datetime(string='Payment Date', required=True, default=lambda self: fields.Datetime.now())

--- a/addons/pos_online_payment/models/pos_order.py
+++ b/addons/pos_online_payment/models/pos_order.py
@@ -8,7 +8,7 @@ class PosOrder(models.Model):
     _inherit = 'pos.order'
 
     online_payment_method_id = fields.Many2one('pos.payment.method', compute="_compute_online_payment_method_id")
-    next_online_payment_amount = fields.Float(string='Next online payment amount to pay', digits=0, required=False) # unlimited precision
+    next_online_payment_amount = fields.Monetary(string='Next online payment amount to pay')
 
     @api.depends('config_id.payment_method_ids')
     def _compute_online_payment_method_id(self):


### PR DESCRIPTION
`point_of_sale`, `pos_online_payment`, `l10n_se_pos`, `pos_pricer`

before this commit:
==============
- using Float fields to display currency values.
- Some views did not display monetary data correctly,.

after this commit:
==============
- All currency-related fields have been replaced with Monetary fields instead of Float fields.
- Views have been updated to follow the new approach for displaying monetary data consistently.

Related enterprise PR: odoo/enterprise#76173   
Related upgrade PR: odoo/upgrade#7298


Task- 4424052