### PR TITLE
[IMP] web: drag and drop if grouped by date field in kanban view

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -17,7 +17,7 @@ import { Component, onPatched, onWillDestroy, onWillPatch, useRef, useState } fr
 import { evaluateExpr } from "@web/core/py_js/py";
 
 const DRAGGABLE_GROUP_TYPES = ["many2one"];
-const MOVABLE_RECORD_TYPES = ["char", "boolean", "integer", "selection", "many2one"];
+const MOVABLE_RECORD_TYPES = ["char", "boolean", "integer", "selection", "many2one", "date", "datetime"];
 
 function validateColumnQuickCreateExamples(data) {
     const { allowedGroupBys = [], examples = [], foldField = "" } = data;

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -4851,6 +4851,7 @@ test("prevent drag and drop of record if grouped by readonly", async () => {
     expect.verifySteps([]);
 });
 
+test.tags("desktop");
 test("prevent drag and drop if grouped by date/datetime field", async () => {
     Partner._records[0].date = "2017-01-08";
     Partner._records[1].date = "2017-01-09";
@@ -4893,10 +4894,10 @@ test("prevent drag and drop if grouped by date/datetime field", async () => {
     );
 
     // should not drag&drop record
-    expect(".o_kanban_group:first-child .o_kanban_record").toHaveCount(2, {
+    expect(".o_kanban_group:first-child .o_kanban_record").toHaveCount(1, {
         message: "Should remain same records in first column (2 records)",
     });
-    expect(".o_kanban_group:nth-child(2) .o_kanban_record").toHaveCount(2, {
+    expect(".o_kanban_group:nth-child(2) .o_kanban_record").toHaveCount(3, {
         message: "Should remain same records in 2nd column (2 record)",
     });
 
@@ -4918,10 +4919,10 @@ test("prevent drag and drop if grouped by date/datetime field", async () => {
     );
 
     // should not drag&drop record
-    expect(".o_kanban_group:first-child .o_kanban_record").toHaveCount(2, {
+    expect(".o_kanban_group:first-child .o_kanban_record").toHaveCount(1, {
         message: "Should remain same records in first column(2 records)",
     });
-    expect(".o_kanban_group:nth-child(2) .o_kanban_record").toHaveCount(2, {
+    expect(".o_kanban_group:nth-child(2) .o_kanban_record").toHaveCount(3, {
         message: "Should remain same records in 2nd column(2 record)",
     });
 });


### PR DESCRIPTION
SPECIFICATION:

Enhance the drag-and-drop functionality in the Kanban view when grouped by date
fields.

Task-4345701
