### PR TITLE
[IMP] l10n_il:load tax account tags translations

### DIFF
--- a/addons/l10n_il/models/template_il.py
+++ b/addons/l10n_il/models/template_il.py
@@ -34,3 +34,34 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_purchase_tax_id': 'il_vat_inputs_18',
             },
         }
+    
+    def try_loading(self, template_code, company, install_demo=False):
+        # During company creation load account tags translations
+        res = super().try_loading(template_code, company, install_demo)
+        if not company:
+            return res
+        if isinstance(company, int):
+            company = self.env['res.company'].browse([company])
+        if company.country_code == 'IL' and company.chart_template == 'il':
+            TAG_PAIRS = [
+                ('VAT SALES (BASE)', 'הכנסות חייבות במע"מ'),
+                ('VAT Exempt Sales (BASE)', 'הכנסות פטורות ממע"מ'),
+                ('VAT Sales', 'מע"מ עסקאות'),
+                ('VAT PA Sales', 'מע"מ עסקאות רש"פ'),
+                ('VAT Inputs 18%','מע"מ תשומות 18%'),
+                ('VAT Inputs 17%', 'מע"מ תשומות 17%'),
+                ('VAT Inputs PA 16%', 'מע"מ תשומות רש"פ 16%'),
+                ('VAT Inputs 2/3', 'מע"מ תשומות 2/3'),
+                ('VAT Inputs 1/4', 'מע"מ תשומות 1/4'),
+                ('VAT INPUTS (fixed assets)', 'מע"מ תשומות (רכוש קבוע)')
+            ]
+            for EN_TAG, HE_TAG in TAG_PAIRS:
+                for sign in ['+','-']:
+                    FULL_EN_TAG = f"{sign}{EN_TAG}"
+                    FULL_HE_TAG = f"{sign}{HE_TAG}"
+                    tag_ids = self.env['account.account.tag'].with_context(lang='en_US').search([
+                        ('name', '=', FULL_EN_TAG),
+                        ('applicability', '=', 'taxes')
+                    ])
+                    tag_ids.with_context(lang='he_IL').write({'name': FULL_HE_TAG})
+        return res


### PR DESCRIPTION
Labels such as 'Vat Sale' or 'Vat Input' have to be translated for the israely conventions. Change:
- Load the hebrew translation for the account tags name field in the try_loading function




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
