### PR TITLE
[FIX] product: fix traceback when deleting the archived product variants

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -392,7 +392,7 @@ class ProductProduct(models.Model):
             if product.image_variant_1920 and not product.product_tmpl_id.image_1920:
                 product.product_tmpl_id.image_1920 = product.image_variant_1920
             # Check if the product is last product of this template...
-            has_other_products = product_ids_by_template_id[product.product_tmpl_id.id] - {product.id}
+            has_other_products = product_ids_by_template_id.get(product.product_tmpl_id.id, set()) - {product.id}
             # ... and do not delete product template if it's configured to be created "on demand"
             if not has_other_products and not product.product_tmpl_id.has_dynamic_attributes():
                 unlink_templates_ids.add(product.product_tmpl_id.id)

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -1349,6 +1349,40 @@ class TestVariantsArchive(ProductVariantsCommon):
         self.assertEqual(len(variants), 1)
         self.assertFalse(variants[0].product_template_attribute_value_ids)
 
+    @mute_logger('odoo.models.unlink')
+    def test_unlink_and_archive_multiple_variants(self):
+        """
+        Test unlinking multiple variants in various scenarios
+        - Unlink one archived variant
+        - Unlink one archived and one active variant
+        - Unlink multiple archived variants and multiple active variants at once
+        """
+        products = self.env['product.product'].create([
+            {'name': 'variant 1', 'description': 'var 1'},
+            {'name': 'variant 2', 'description': 'var 2'},
+            {'name': 'variant 3', 'description': 'var 3'},
+            {'name': 'variant 4', 'description': 'var 4'},
+            {'name': 'variant 5', 'description': 'var 5'},
+            {'name': 'variant 6', 'description': 'var 6'},
+            {'name': 'variant 7', 'description': 'var 7'},
+        ])
+        # Unlink one archived variant
+        products[0].action_archive()
+        products[0].unlink()
+        self.assertFalse(products[0].exists())
+
+        # Unlink one archived and one active variant
+        products[1].action_archive()
+        active_and_archived = products[1] + products[2]
+        active_and_archived.unlink()
+        self.assertFalse(active_and_archived.exists())
+
+        # Unlink multiple archived variants and multiple active variants at once
+        multiple_archived = products[3] + products[4]
+        multiple_active = products[5] + products[6]
+        multiple_archived.action_archive()
+        (multiple_archived + multiple_active).unlink()
+        self.assertFalse(products.exists())
 
 @tagged('post_install', '-at_install')
 class TestVariantWrite(TransactionCase):


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to delete archived product variants.

To reproduce this issue:

1) Install sale and enable product variants from configuration 
2) Create a product from the variant and archive it
3) Now try to delete the above archived product.

Error:- 
```
KeyError: 2
```

When the user archives a product and tries to delete the archived product, 
we get the `product_ids_by_template_id` as an empty dict.

https://github.com/odoo/odoo/blob/f118a44c5b15163556e3388c5a7daa72119f58f8/addons/product/models/product_product.py#L384-L388

This leads to the above traceback when accessing the product template id from an empty dict
from the below line.

https://github.com/odoo/odoo/blob/f118a44c5b15163556e3388c5a7daa72119f58f8/addons/product/models/product_product.py#L395

sentry-6173505059

