### PR TITLE
[FIX] account_payment: fix traceback while generating account payment link

### DIFF
--- a/addons/account_payment/models/account_move.py
+++ b/addons/account_payment/models/account_move.py
@@ -129,7 +129,6 @@ class AccountMove(models.Model):
             'currency_id': self.currency_id.id,
             'partner_id': self.partner_id.id,
             'open_installments': open_installments,
-            'installment_state': installment_state,
             'amount': next_amount_to_pay,
             'amount_max': amount_max,
             **additional_info

--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -246,7 +246,6 @@ class TestAccountPayment(AccountPaymentCommon):
             'currency_id': invoice.currency_id.id,
             'partner_id': invoice.partner_id.id,
             'open_installments': [],
-            'installment_state': None,
             'amount': None,
             'amount_max': None,
         })


### PR DESCRIPTION
Currently, a traceback occurs when the user tries to generate a payment link and tries to refresh it.

To reproduce this issue:

1) Install `Accounting`
2) Create a confirmed Customer Invoice
3) Generate a Payment link from `Actions`
4) Change the `Amount` and refresh the tab
5) You can see the error in the terminal

Error:- 
```
KeyError: 'installment_state'
```

This traceback occurs because when the user refreshes the tab, 
it executes the `default_get` method, with self as `payment.link.wizard`.

https://github.com/odoo/odoo/blob/be6b327c17435947fc3f10d30fc8c4730c182aed/odoo/models.py#L1897-L1899

In that `payment.link.wizard`, we have overridden the `default_get` and updated the values from the `_get_default_payment_link_values` method with the model as `account.move`.

https://github.com/odoo/odoo/blob/4787c91c434c7e22ca030bc7a62588482c24b2ab/addons/payment/wizards/payment_link_wizard.py#L21-L23

The method mentioned above will return a dict containing the `installment_state` key-value pair.

https://github.com/odoo/odoo/blob/be6b327c17435947fc3f10d30fc8c4730c182aed/addons/account_payment/models/account_move.py#L128-L132

But `installment_state` is not a field. It is just a variable 
that gets its value from the `_get_invoice_next_payment_values`. 

https://github.com/odoo/odoo/blob/be6b327c17435947fc3f10d30fc8c4730c182aed/addons/account_payment/models/account_move.py#L104

So eventually it leads to the above traceback from the below line. 

https://github.com/odoo/odoo/blob/be6b327c17435947fc3f10d30fc8c4730c182aed/odoo/models.py#L1897-L1899 

sentry-6058398917
