### PR TITLE
[IMP] pos_viva_wallet: error message for bearer token retrieval

### DIFF
--- a/addons/pos_viva_wallet/models/pos_payment_method.py
+++ b/addons/pos_viva_wallet/models/pos_payment_method.py
@@ -68,7 +68,7 @@ class PosPaymentMethod(models.Model):
             self.viva_wallet_bearer_token = access_token
             return {'Authorization': f"Bearer {access_token}"}
         else:
-            raise UserError(_('Not receive Bearer Token'))
+            raise UserError(_('Unable to retrieve Viva Wallet Bearer Token: Please verify that the Client ID and Client Secret are correct'))
 
     def _get_verification_key(self, endpoint, viva_wallet_merchant_id, viva_wallet_api_key):
         # Get a key to configure the webhook.


### PR DESCRIPTION
In this commit:

- Updated the error message for retrieving the Bearer Token during Viva Wallet payment requests.
- The new message clearly states: `Unable to retrieve Viva Wallet Bearer Token: Please verify that the Client ID and Client Secret are correct`
- This improvement provides more explicit guidance to users, making it easier to identify and resolve configuration issues.

task- 4383616