### PR TITLE
[FIX] point_of_sale: verify category sequence in test cases

### DIFF
--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -373,28 +373,28 @@ registry.category("web_tour.tours").add("PosCategoriesOrder", {
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             {
-                trigger: '.category-button > span:contains("AAA")',
+                trigger: '.category-button:eq(0) > span:contains("AAA")',
             },
             {
-                trigger: '.category-button > span:contains("AAB")',
+                trigger: '.category-button:eq(1) > span:contains("AAB")',
             },
             {
-                trigger: '.category-button > span:contains("AAC")',
+                trigger: '.category-button:eq(2) > span:contains("AAC")',
             },
             {
-                trigger: '.category-button > span:contains("AAB")',
+                trigger: '.category-button:eq(1) > span:contains("AAB")',
                 run: "click",
             },
             ProductScreen.productIsDisplayed("Product in AAB and AAX", 0),
             {
-                trigger: '.category-button > span:contains("AAX")',
+                trigger: '.category-button:eq(2) > span:contains("AAX")',
             },
             {
-                trigger: '.category-button > span:contains("AAX")',
+                trigger: '.category-button:eq(2) > span:contains("AAX")',
                 run: "click",
             },
             {
-                trigger: '.category-button > span:contains("AAY")',
+                trigger: '.category-button:eq(3) > span:contains("AAY")',
             },
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1475,17 +1475,21 @@ class TestUi(TestPointOfSaleHttpCommon):
 
     def test_product_categories_order(self):
         """ Verify that the order of categories doesnt change in the frontend """
+        self.env['pos.category'].search([]).write({'sequence': 100})
         self.env['pos.category'].create({
             'name': 'AAA',
             'parent_id': False,
+            'sequence': 1,
         })
         self.env['pos.category'].create({
             'name': 'AAC',
             'parent_id': False,
+            'sequence': 3,
         })
         parentA = self.env['pos.category'].create({
             'name': 'AAB',
             'parent_id': False,
+            'sequence': 2,
         })
         parentB = self.env['pos.category'].create({
             'name': 'AAX',


### PR DESCRIPTION
In this commit:
===
- Updated the test case to ensure that when clicking on a parent category, its subcategories are displayed immediately after the parent category.
