### PR TITLE
[FIX] im_livechat: fix chat bot not restarting on embedded pages

### DIFF
--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -28,14 +28,25 @@ patch(Thread.prototype, {
             },
         });
         this.chatbot = Record.one("Chatbot");
+        this._startChatbot = Record.attr(false, {
+            compute() {
+                return (
+                    this.chatbot?.thread?.eq(
+                        this.store.env.services["im_livechat.livechat"].thread
+                    ) && this.isLoaded
+                );
+            },
+            onUpdate() {
+                if (this._startChatbot) {
+                    this.store.env.services["im_livechat.chatbot"].start();
+                }
+            },
+        });
         this.requested_by_operator = false;
     },
 
     get isLastMessageFromCustomer() {
-        if (this.channel_type !== "livechat") {
-            return super.isLastMessageFromCustomer;
-        }
-        return this.newestMessage?.isSelfAuthored;
+        return this.newestPersistentOfAllMessage?.isSelfAuthored;
     },
 
     get membersThatCanSeen() {

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -657,12 +657,12 @@ export class Thread extends Record {
         try {
             const { data, messages } = await this.fetchMessagesData({ after, around, before });
             this.store.insert(data, { html: true });
-            this.isLoaded = true;
             return this.store.Message.insert(messages.reverse());
         } catch (e) {
             this.hasLoadingFailed = true;
             throw e;
         } finally {
+            this.isLoaded = true;
             this.status = "ready";
         }
     }


### PR DESCRIPTION
Previously, the chat bot would fail to restart on external websites after a redirection.

The issue occurs because the chat bot service waits for the mail store to be ready before verifying if the current live chat thread is linked to a chat bot. However, since [1], the thread is only assigned after the ready event. While the website app assigns the visitor thread earlier, embedded websites do not, causing the chat bot service to incorrectly assume that no bot is linked to the live chat thread and fail to start.

This PR resolves the issue by leveraging modelization. The chat bot now starts when the current live chat thread is inserted.

[1]: https://github.com/odoo/odoo/pull/173197

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
