### PR TITLE
[FIX] project: align the field and the field selection for analytic setting

### DIFF
--- a/addons/project/static/src/scss/project_form.scss
+++ b/addons/project/static/src/scss/project_form.scss
@@ -49,3 +49,9 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+.o_flexible_margin_top {
+    @media only screen and (max-width: 650px) {
+        margin-top: 10px;
+    }
+}

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -107,9 +107,9 @@
                                         <i class="fa fa-warning pe-2" title="Warning"/><field class="d-inline" name="privacy_visibility_warning" nolabel="1"/>
                                     </span>
                                 </group>
-                                <group name="analytic">
-                                    <div class="o_horizontal_separator text-uppercase fw-bolder small mb-3" groups="analytic.group_analytic_accounting">analytic</div>
-                                    <field name="account_id" groups="analytic.group_analytic_accounting"/>
+                                <group name="analytic" groups="analytic.group_analytic_accounting">
+                                    <div class="o_flexible_margin_top o_horizontal_separator text-uppercase fw-bolder small mb-3" colspan="2">analytic</div>
+                                    <field name="account_id"/>
                                 </group>
                                 <group name="extra_settings">
                                 </group>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -118,7 +118,7 @@
                     </div>
                 </group>
             </xpath>
-            <xpath expr="//group[@name='analytic']//div" position="before">
+            <xpath expr="//page[@name='settings']//field[@name='privacy_visibility']" position="after">
                 <field name="reinvoiced_sale_order_id" invisible="not allow_billable or not partner_id"/>
                 <label for="sale_line_id" invisible="not allow_billable or not partner_id"/>
                 <div 


### PR DESCRIPTION
This commit's purpose is to fix the alignment of the plans and the selection fields associated to those plan in the setting of the form view of projects. The issue was caused by the extra 'div' inside the group, which was disrupting the usual display order of 'field name' - 'field selection'

Solution: remove that extra div and adds a css class to handle margin issue with the group section. Adding a 'colspan' was a cleaner solution, but it also update the display of fields in mobile view, and we don't want that.

task - 4397694

