### PR TITLE
[FIX] point_of_sale: fix payment provider cards

### DIFF
--- a/addons/point_of_sale/static/src/scss/pos_dashboard.scss
+++ b/addons/point_of_sale/static/src/scss/pos_dashboard.scss
@@ -24,3 +24,7 @@
         width: auto;
     }
 }
+
+.o_pos_provider_cards_group .o_cell_custom {
+    grid-column: span 2;
+}

--- a/addons/point_of_sale/views/pos_payment_method_views.xml
+++ b/addons/point_of_sale/views/pos_payment_method_views.xml
@@ -26,7 +26,7 @@
                             <field name="company_id" readonly="1" groups="base.group_multi_company" />
                             <field name="config_ids" widget="many2many_tags" placeholder="No Point of Sale" />
                         </group>
-                        <group>
+                        <group class="o_pos_provider_cards_group">
                             <field name="hide_use_payment_terminal" invisible="1"/>
                             <field name="hide_qr_code_method" invisible="1"/>
                             <field name="payment_method_type" />


### PR DESCRIPTION
Payment provider card didn't take the full with of the parent container, that was due to a recent change of o_cell_custom.

Adding a CSS rules in point_of_sale to override this change.


