### PR TITLE
[FIX] l10n_in_withholding: fix account tax reload chart template data

### DIFF
--- a/addons/l10n_in_withholding/__init__.py
+++ b/addons/l10n_in_withholding/__init__.py
@@ -10,24 +10,24 @@ _logger = logging.getLogger(__name__)
 
 def _l10n_in_withholding_post_init(env):
     """ Existing companies that have the Indian Chart of Accounts set """
-    data = {
-        model: env['account.chart.template']._parse_csv('in', model, module='l10n_in_withholding')
-        for model in [
-            'account.account',
-            'account.tax',
-        ]
-    }
     for company in env['res.company'].search([('chart_template', '=', 'in'), ('parent_id', '=', False)]):
         _logger.info("Company %s already has the Indian localization installed, updating...", company.name)
         ChartTemplate = env['account.chart.template'].with_company(company)
+        data = {
+            model: ChartTemplate._parse_csv('in', model, module='l10n_in_withholding')
+            for model in [
+                'account.account',
+                'account.tax',
+            ]
+        }
         try:
             ChartTemplate._deref_account_tags('in', data['account.tax'])
             ChartTemplate._pre_reload_data(company, {}, data)
             ChartTemplate._load_data(data)
-            company.l10n_in_withholding_account_id = env.ref('account.%i_p100595' % company.id)
+            company.l10n_in_withholding_account_id = ChartTemplate.ref('p100595')
         except ValidationError as e:
             _logger.warning("Error while updating Chart of Accounts for company %s: %s", company.name, e.args[0])
-        tds_group_id = env.ref(f'account.{company.id}_tds_group', raise_if_not_found=False)
+        tds_group_id = ChartTemplate.ref("tds_group", raise_if_not_found=False)
         if tds_group_id:
             tds_purchase_taxes = env['account.tax'].with_context(active_test=False).search([('tax_group_id', '=', tds_group_id.id), ('type_tax_use', '=', 'purchase')])
             tds_purchase_taxes.write({'l10n_in_tds_tax_type': 'purchase', 'type_tax_use': 'none'})


### PR DESCRIPTION
# Description
When we reload the chart of accounts parsed CSV data is altered after iterating
the first company because we are Only updating the tags of existing taxes 

For existing tax, we are mapping repartition lines here https://github.com/odoo/odoo/blob/a4c14fab299ed98024b7d7148d89bf17e914ccd1/addons/account/models/chart_template.py#L359

So that data_list has been altered after for the next company 
for the next iterator company, it has been eligible for obsolete here https://github.com/odoo/odoo/blob/a4c14fab299ed98024b7d7148d89bf17e914ccd1/addons/account/models/chart_template.py#L400

So, it is better to keep parsing data as it is while reloading the chart accounts for each company

TBG: [Traceback Group-1421](https://upgrade.odoo.com/web#id=1421&cids=1&menu_id=107&model=upgrade.request.traceback.group&view_type=form) 
OPWS:
- [4391978](https://www.odoo.com/odoo/project/70/tasks/4391978)
- [4402365](https://www.odoo.com/odoo/70/tasks/4402365)

```py
2024-12-26 10:21:46,303 16 INFO higo_2397155_18.0 odoo.addons.base.models.ir_module: module l10n_in_withholding: no translation for language en_IN 
2024-12-26 10:21:47,426 16 INFO higo_2397155_18.0 odoo.addons.l10n_in_withholding: Company Repose Foods Private Limited already has the Indian localization installed, updating... 
> /home/odoo/src/odoo/18.0/addons/account/models/chart_template.py(322)_pre_reload_data()
-> for model_name, records in data.items():
(Pdb) len([i for i in data['account.tax'].values() if i.get('name')])
163
(Pdb) c
> /home/odoo/src/odoo/18.0/addons/account/models/chart_template.py(397)_pre_reload_data()
-> if obsolete_xmlid:
(Pdb) len([i for i in data['account.tax'].values() if i.get('name')])
75
(Pdb) c
2024-12-26 10:22:14,417 16 INFO higo_2397155_18.0 odoo.addons.l10n_in_withholding: Company M/S Repose already has the Indian localization installed, updating... 
> /home/odoo/src/odoo/18.0/addons/account/models/chart_template.py(322)_pre_reload_data()
-> for model_name, records in data.items():
(Pdb) len([i for i in data['account.tax'].values() if i.get('name')])
75
(Pdb) c
> /home/odoo/src/odoo/18.0/addons/account/models/chart_template.py(397)_pre_reload_data()
-> if obsolete_xmlid:
(Pdb) l
392  	                        skip_update.add((model_name, xmlid))
393  	
394  	        for skip_model, skip_xmlid in skip_update:
395  	            data[skip_model].pop(skip_xmlid, None)
396  	        import pdb; pdb.set_trace()
397  ->	        if obsolete_xmlid:
398  	            self.env['ir.model.data'].search([
399  	                ('name', 'in', [f"{company.id}_{xmlid}" for xmlid in obsolete_xmlid]),
400  	                ('module', '=', 'account'),
401  	            ]).unlink()
402  	
(Pdb) len(obsolete_xmlid)
88
(Pdb) c
2024-12-26 10:22:56,209 16 INFO higo_2397155_18.0 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [48827, 48804, 48815, 48813, 48823, 48828, 48811, 48809, 48807, 48821, 48817, 48819, 48805, 48812, 48816, 48814, 48806, 48810, 48808, 48822, 48818, 48820, 48824, 48826, 48825, 48887, 48888, 48829, 48831, 48833, 48835, 48843, 48848, 48856, 48862, 48865, 48867, 48869, 48871, 48873, 48877, 48889, 48839, 48858, 48885, 48890, 48830, 48832, 48834, 48836, 48841, 48844, 48846, 48847, 48849, 48850, 48852, 48854, 48857, 48859, 48861, 48863, 48866, 48868, 48870, 48876, 48872, 48874, 48881, 48884, 48886, 48878, 48840, 48855, 48864, 48882, 48837, 48838, 48879, 48891, 48842, 48845, 48851, 48853, 48860, 48875, 48880, 48883] 
2024-12-26 10:22:56,738 16 ERROR higo_2397155_18.0 odoo.sql_db: bad query: b'INSERT INTO "account_tax" ("active", "amount", "amount_type", "company_id", "country_id", "create_date", "create_uid", "description", "formula", "include_base_amount", "invoice_label", "is_base_affected", "l10n_in_section_id", "l10n_in_tds_tax_type", "name", "sequence", "tax_exigibility", "tax_group_id", "tax_scope", "type_tax_use", "write_date", "write_uid") ...
```


**Traceback**
```py
2024-12-26 06:49:10,588 26 INFO higo_2403300_18.0 odoo.addons.l10n_in_withholding: Company Sah Estates already has the Indian localization installed, updating...
2024-12-26 07:14:31,217 26 INFO higo_2403300_18.0 odoo.addons.l10n_in_withholding: Company sahaccounts already has the Indian localization installed, updating...
2024-12-26 07:16:43,050 26 INFO higo_2403300_18.0 odoo.models.unlink: User #1 deleted ir.model.data records with IDs: [26281, 26258, 26269, 26267, 26277, 26282, 26265, 26263, 26261, 26275, 26271, 26273, 26259, 26266, 26270, 26268, 26260, 26264, 26262, 26276, 26272, 26274, 26278, 26280, 26279, 26341, 26342, 26283, 26285, 26287, 26289, 26297, 26302, 26310, 26316, 26319, 26321, 26323, 26325, 26327, 26331, 26343, 26293, 26312, 26339, 26344, 26284, 26286, 26288, 26290, 26295, 26298, 26300, 26301, 26303, 26304, 26306, 26308, 26311, 26313, 26315, 26317, 26320, 26322, 26324, 26330, 26326, 26328, 26335, 26338, 26340, 26332, 26294, 26309, 26318, 26336, 26291, 26292, 26333, 26345, 26296, 26299, 26305, 26307, 26314, 26329, 26334, 26337] 

2024-12-26 07:35:03,359 28 ERROR higo_2397155_18.0 odoo.modules.registry: Failed to load registry
2024-12-26 07:35:03,359 28 CRITICAL higo_2397155_18.0 odoo.service.server: Failed to initialize database `higo_2397155_18.0`.
Traceback (most recent call last):
  File "/home/odoo/src/odoo/18.0/odoo/service/server.py", line 1306, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-13>", line 2, in new
  File "/home/odoo/src/odoo/18.0/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/18.0/odoo/modules/registry.py", line 127, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 480, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 364, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 245, in load_module_graph
    getattr(py_module, post_init)(env)
  File "/home/odoo/src/odoo/18.0/addons/l10n_in_withholding/__init__.py", line 26, in _l10n_in_withholding_post_init
    ChartTemplate._load_data(data)
  File "/tmp/tmpqk9sqppy/migrations/account/0.0.0/pre-ensure-deferred-accounts.py", line 36, in _load_data
    return super()._load_data(data, *args, **kwargs)
  File "/home/odoo/src/odoo/18.0/addons/account/models/chart_template.py", line 635, in _load_data
    created_records[model] = self.with_context(lang='en_US').env[model]._load_records(all_records_vals, ignore_duplicates=ignore_duplicates)
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 5467, in _load_records
    records = self._load_records_create([data['values'] for data in to_create])
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 5371, in _load_records_create
    records = self.create(vals_list)
  File "<decorator-gen-228>", line 2, in create
  File "/home/odoo/src/odoo/18.0/odoo/api.py", line 480, in _model_create_multi
    return create(self, arg)
  File "/home/odoo/src/odoo/18.0/addons/account/models/account_tax.py", line 599, in create
    taxes = super(AccountTax, self.with_context(context)).create([self._sanitize_vals(vals) for vals in vals_list])
  File "<decorator-gen-140>", line 2, in create
  File "/home/odoo/src/odoo/18.0/odoo/api.py", line 480, in _model_create_multi
    return create(self, arg)
  File "/home/odoo/src/odoo/18.0/addons/mail/models/mail_thread.py", line 268, in create
    threads = super(MailThread, self).create(vals_list)
  File "<decorator-gen-120>", line 2, in create
  File "/home/odoo/src/odoo/18.0/odoo/api.py", line 480, in _model_create_multi
    return create(self, arg)
  File "/tmp/tmpqk9sqppy/migrations/util/orm.py", line 244, in wrapper
    return f(*args, **kwargs)
  File "/tmp/tmpqk9sqppy/migrations/base/0.0.0/pre-models-match_uniq.py", line 96, in create
    records = super().create([vals_list[idx] for idx in create_idx_list])
  File "<decorator-gen-31>", line 2, in create
  File "/home/odoo/src/odoo/18.0/odoo/api.py", line 480, in _model_create_multi
    return create(self, arg)
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 4975, in create
    records = self._create(data_list)
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 5159, in _create
    cr.execute(SQL(
  File "/home/odoo/src/odoo/18.0/odoo/sql_db.py", line 354, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.NotNullViolation: null value in column "name" of relation "account_tax" violates not-null constraint
DETAIL:  Failing row contains (1941, 18, 1, 12, null, 104, 1, 1, sale, null, percent, on_invoice, null, null, null, 0.0000, t, f, t, null, 2024-12-26 07:34:58.528488, 2024-12-26 07:34:58.528488, price_unit * 0.10, null, null, null, null, null).
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
