### PR TITLE
[FIX] point_of_sale: payment providers terminal selector

### DIFF
--- a/addons/point_of_sale/static/src/backend/pos_payment_provider_cards/pos_payment_provider_cards.xml
+++ b/addons/point_of_sale/static/src/backend/pos_payment_provider_cards/pos_payment_provider_cards.xml
@@ -1,21 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates>
     <t t-name="point_of_sale.PosPaymentProviderCards">
-        <div class="container gap-0" t-ref="cards_container">
-            <div class="row">
-                <div t-foreach="state.providers" t-as="provider" t-key="provider.selection" t-att-class="this.env.inDialog ? 'col-12' : 'col-xl-6 col-xxl-4'" class="p-1">
-                    <div class="d-flex border rounded justify-content-between w-100 h-100 p-1 gap-1">
-                        <div class="d-inline-block position-relative opacity-trigger-hover">
-                            <img class="img" style="max-width: 65px;" t-att-alt="provider.provider" t-att-src="`/point_of_sale/static/img/providers/${provider.selection}.png`" />
-                        </div>
-                        <div class="text-start flex-grow-1">
-                            <span class="mb-0 fs-6" t-esc="provider.provider" />
-                        </div>
-                        <div class="d-flex justify-content-end align-items-end">
-                            <button t-if="provider.state === 'uninstalled'" t-on-click="() => this.installModule(provider.id)" class="btn btn-sm btn-primary ms-auto">Install</button>
-                            <button t-else="" t-on-click="() => this.setupProvider(provider.id)" class="btn btn-sm btn-secondary ms-auto">Setup</button>
-                        </div>
-                    </div>
+        <div class="d-flex flex-wrap gap-1" t-ref="cards_container">
+            <div t-foreach="state.providers"
+                 t-as="provider"
+                 t-key="provider.selection"
+                 class="d-flex border rounded justify-content-between h-100 p-1 gap-1"
+                 t-att-class="this.env.inDialog ? 'col-12' : 'col-5 col-xl-5 col-xxl-4'">
+                <div class="d-inline-block position-relative opacity-trigger-hover">
+                    <img class="img" style="max-width: 65px;" t-att-alt="provider.provider" t-att-src="`/point_of_sale/static/img/providers/${provider.selection}.png`" />
+                </div>
+                <div class="d-flex flex-column justify-content-between w-100">
+                    <span class="mb-0 fs-6 fw-bold" t-esc="provider.provider" />
+                    <button t-if="provider.state === 'uninstalled'" t-on-click="() => this.installModule(provider.id)" class="btn btn-sm btn-primary ms-auto align-self-end">Install</button>
+                    <button t-else="" t-on-click="() => this.setupProvider(provider.id)" class="btn btn-sm btn-secondary ms-auto align-self-end">Setup</button>
                 </div>
             </div>
         </div>

--- a/addons/point_of_sale/views/pos_payment_method_views.xml
+++ b/addons/point_of_sale/views/pos_payment_method_views.xml
@@ -26,14 +26,16 @@
                             <field name="company_id" readonly="1" groups="base.group_multi_company" />
                             <field name="config_ids" widget="many2many_tags" placeholder="No Point of Sale" />
                         </group>
-                        <group>
-                            <field name="hide_use_payment_terminal" invisible="1"/>
-                            <field name="hide_qr_code_method" invisible="1"/>
-                            <field name="payment_method_type" />
-                            <field name="use_payment_terminal" string="Integrate with" />
-                            <field name="qr_code_method" invisible="hide_qr_code_method" required="payment_method_type == 'qr_code'"/>
+                        <div>
+                            <group>
+                                <field name="hide_use_payment_terminal" invisible="1"/>
+                                <field name="hide_qr_code_method" invisible="1"/>
+                                <field name="payment_method_type" />
+                                <field name="use_payment_terminal" string="Integrate with" />
+                                <field name="qr_code_method" invisible="hide_qr_code_method" required="payment_method_type == 'qr_code'"/>
+                            </group>
                             <widget name="pos_payment_provider_cards" invisible="use_payment_terminal or payment_method_type != 'terminal'" />
-                        </group>
+                        </div>
                     </group>
                 </sheet>
             </form>

--- a/addons/pos_online_payment/views/pos_payment_method_views.xml
+++ b/addons/pos_online_payment/views/pos_payment_method_views.xml
@@ -17,10 +17,10 @@
             <xpath expr="//form/sheet/group/group/field[@name='split_transactions']" position="attributes">
                 <attribute name="invisible">is_online_payment</attribute>
             </xpath>
-            <xpath expr="//form/sheet/group/group/field[@name='payment_method_type']" position="attributes">
+            <xpath expr="//form/sheet/group/div/group/field[@name='payment_method_type']" position="attributes">
                 <attribute name="invisible">is_online_payment</attribute>
             </xpath>
-            <xpath expr="//form/sheet/group/group/field[@name='qr_code_method']" position="attributes">
+            <xpath expr="//form/sheet/group/div/group/field[@name='qr_code_method']" position="attributes">
                 <attribute name="invisible">is_online_payment or hide_qr_code_method</attribute>
             </xpath>
             <xpath expr="//form/sheet/group/group/field[@name='journal_id']" position="attributes">


### PR DESCRIPTION
Payment terminal providers for a payment method, were displayed in a grid, whose width was blocked to the width of the label in the form wiew, making them illegible.

Before:
![image](https://github.com/user-attachments/assets/49de5a23-b1e2-412f-a772-c99b0b504358)


After:
![image](https://github.com/user-attachments/assets/3a8646d1-bc2e-4207-a885-2f0cffefb762)
