### PR TITLE
[FIX] stock: prevent an error when compute display name for stock quant

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -589,7 +589,8 @@ class StockQuant(models.Model):
                 name.append(record.package_id.name)
             if record.owner_id:
                 name.append(record.owner_id.name)
-            record.display_name = ' - '.join(name)
+            name = [n for n in name if n]
+            record.display_name = name and ' - '.join(name) or '/'
 
     @api.constrains('product_id')
     def check_product_id(self):


### PR DESCRIPTION
Currently, an error occurs when computing a display name for stock quant.

Step to produce:

- Install the `stock` module(without demo data).
- Go to inventory settings, enable Packages, Quality, Quality Worksheet, Reception Report, Variants, Units of Measure, Product Packagings, Lots & Serial Numbers, Display Lots & Serial Numbers on Delivery Slips, Expiration Dates, and Dropshipping.
- Disable the Barcode Scanner.
- After that, enable 'Display Lots & Serial Numbers on Invoices' in the Valuation section
- Create a product and enable the 'Track Inventory' option.
- In the product form view, click on On Hand in the breadcrumbs to navigate to the stock quantity list view
- Create a new record to update the quantity.
- Click on the 'View' button, remove the location, and try to come back to update quantity list view.

`TypeError: sequence item 0: expected str instance, bool found`

This error occurs because we compute the display name of stock quant and it is derived from location_id, lot_id, package_id, or owner_id. If none of these values are present in stock quant then the system tries to concate the False (bool) value with a string at [1] and an error occurs.

Link [1]: https://github.com/odoo/odoo/blob/be6b327c17435947fc3f10d30fc8c4730c182aed/addons/stock/models/stock_quant.py#L585-L592

To resolve this issue, Assign a default display name of stock quant if none of the values of fields (location_id, lot_id, package_id, owner_id) are available.

Sentry-6165002037


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
