### PR TITLE
[FIX] spreadsheet: do not apply global filters on non-odoo pivots

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_global_filter_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_global_filter_plugin.js
@@ -273,6 +273,9 @@ export class PivotUIGlobalFilterPlugin extends OdooUIPlugin {
      * @param {string} pivotId pivot id
      */
     _addDomain(pivotId) {
+        if (this.getters.getPivotCoreDefinition(pivotId).type !== "ODOO") {
+            return;
+        }
         const domainList = [];
         for (const [filterId, fieldMatch] of Object.entries(
             this.getters.getPivotFieldMatch(pivotId)

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -5,7 +5,10 @@ import { animationFrame, mockDate, mockTimeZone } from "@odoo/hoot-mock";
 import { DispatchResult, Model, helpers, tokenize } from "@odoo/o-spreadsheet";
 import { Domain } from "@web/core/domain";
 import { defineSpreadsheetModels, getBasicPivotArch } from "@spreadsheet/../tests/helpers/data";
-import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
+import {
+    createModelWithDataSource,
+    createModelFromGrid,
+} from "@spreadsheet/../tests/helpers/model";
 import { createSpreadsheetWithPivotAndList } from "@spreadsheet/../tests/helpers/pivot_list";
 import { CommandResult } from "@spreadsheet/o_spreadsheet/cancelled_reason";
 
@@ -2502,7 +2505,7 @@ test("Updating the pivot domain should keep the global filter domain", async () 
     );
 });
 
-test("Updating the pivot should keep the global filter domain", async function (assert) {
+test("Updating the pivot should keep the global filter domain", async () => {
     mockDate("2022-04-16 00:00:00");
     const { model, pivotId } = await createSpreadsheetWithPivot();
     const filter = {
@@ -2537,6 +2540,36 @@ test("Updating the pivot should keep the global filter domain", async function (
     expect(computedDomain.toString()).toBe(
         `["&", ("date", ">=", "2022-01-01"), ("date", "<=", "2022-12-31")]`
     );
+});
+
+test("Updating a non-odoo pivot should not crash on global filter", async () => {
+    const grid = {
+        A1: "Customer",   B1: "Price", C1: `=PIVOT(1)`,
+        A2: "Alice",      B2: "10",
+        A3: "",           B3: "20",
+        A4: "Olaf",       B4: "30",
+    };
+    const model = createModelFromGrid(grid);
+    const pivot = {
+        name: "Pivot",
+        type: "SPREADSHEET",
+        dataSet: {
+            zone: toZone("A1:B4"),
+            sheetId: model.getters.getActiveSheetId(),
+        },
+        rows: [{ fieldName: "Customer", order: "asc" }],
+        columns: [],
+        measures: [{ id: "price", fieldName: "Price", aggregator: "sum" }],
+    };
+    model.dispatch("ADD_PIVOT", { pivot, pivotId: "1" });
+    model.dispatch("UPDATE_PIVOT", {
+        pivotId: "1",
+        pivot: {
+            ...pivot,
+            rows: [],
+        },
+    });
+    expect(1).toBe(1);
 });
 
 test("Updating the list domain should keep the global filter domain", async () => {


### PR DESCRIPTION
Steps to reproduce:
- Insert a non-odoo pivot table
- Try to update it => Traceback

This was introduced by fe95f7fa64d6c2694980b4d9f6d03dc744ddaf19

opw-4429514

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
