### PR TITLE
[REM] orm: Model._apply_ir_rules

### DIFF
--- a/addons/account/models/account_move_line_tax_details.py
+++ b/addons/account/models/account_move_line_tax_details.py
@@ -15,12 +15,7 @@ class AccountMoveLine(models.Model):
         :param fallback:    Fallback on an approximated mapping if the mapping failed.
         :return:            query as SQL object
         """
-        self.env['account.move.line'].check_access('read')
-
-        query = self.env['account.move.line']._where_calc(domain)
-
-        # Wrap the query with 'company_id IN (...)' to avoid bypassing company access rights.
-        self.env['account.move.line']._apply_ir_rules(query)
+        query = self.env['account.move.line'].sudo(False)._search(domain)
 
         return self._get_query_tax_details(query.from_clause, query.where_clause, fallback=fallback)
 

--- a/addons/gamification/models/gamification_badge.py
+++ b/addons/gamification/models/gamification_badge.py
@@ -100,8 +100,7 @@ class GamificationBadge(models.Model):
             return
 
         Users = self.env["res.users"]
-        query = Users._where_calc([])
-        Users._apply_ir_rules(query)
+        query = Users._search([])
         badge_alias = query.join("res_users", "id", "gamification_badge_user", "user_id", "badges")
 
         rows = self.env.execute_query(SQL(

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -391,8 +391,7 @@ class ProjectProject(models.Model):
                 project_domain,
                 billable_project_domain,
             ])
-        project_query = self.env['project.project']._where_calc(project_domain)
-        self._apply_ir_rules(project_query, 'read')
+        project_query = self.env['project.project']._search(project_domain)
         project_sql = project_query.select(f'{self._table}.id ', f'{self._table}.sale_line_id')
 
         Task = self.env['project.task']
@@ -402,8 +401,7 @@ class ProjectProject(models.Model):
                 domain_per_model[Task._name],
                 task_domain,
             ])
-        task_query = Task._where_calc(task_domain)
-        Task._apply_ir_rules(task_query, 'read')
+        task_query = Task._search(task_domain)
         task_sql = task_query.select(f'{Task._table}.project_id AS id', f'{Task._table}.sale_line_id')
 
         ProjectMilestone = self.env['project.milestone']
@@ -414,8 +412,7 @@ class ProjectProject(models.Model):
                 milestone_domain,
                 billable_project_domain,
             ])
-        milestone_query = ProjectMilestone._where_calc(milestone_domain)
-        ProjectMilestone._apply_ir_rules(milestone_query)
+        milestone_query = ProjectMilestone._search(milestone_domain)
         milestone_sql = milestone_query.select(
             f'{ProjectMilestone._table}.project_id AS id',
             f'{ProjectMilestone._table}.sale_line_id',

--- a/addons/sale_timesheet/models/project_project.py
+++ b/addons/sale_timesheet/models/project_project.py
@@ -307,8 +307,7 @@ class ProjectProject(models.Model):
                 domain_per_model.get(Timesheet._name, []),
                 timesheet_domain,
             ])
-        timesheet_query = Timesheet._where_calc(timesheet_domain)
-        Timesheet._apply_ir_rules(timesheet_query, 'read')
+        timesheet_query = Timesheet._search(timesheet_domain)
         timesheet_sql = timesheet_query.select(
             f'{Timesheet._table}.project_id AS id',
             f'{Timesheet._table}.so_line AS sale_line_id',
@@ -321,8 +320,7 @@ class ProjectProject(models.Model):
                 domain_per_model[EmployeeMapping._name],
                 employee_mapping_domain,
             ])
-        employee_mapping_query = EmployeeMapping._where_calc(employee_mapping_domain)
-        EmployeeMapping._apply_ir_rules(employee_mapping_query, 'read')
+        employee_mapping_query = EmployeeMapping._search(employee_mapping_domain)
         employee_mapping_sql = employee_mapping_query.select(
             f'{EmployeeMapping._table}.project_id AS id',
             f'{EmployeeMapping._table}.sale_line_id',

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -296,8 +296,7 @@ class CrmTeam(models.Model):
         extra_conditions = self._extra_sql_conditions() or SQL("TRUE")
         dashboard_graph_model = self._graph_get_model()
         GraphModel = self.env[dashboard_graph_model]
-        where_query = GraphModel._where_calc([])
-        GraphModel._apply_ir_rules(where_query, 'read')
+        where_query = GraphModel._search([])
         if where_clause := where_query.where_clause:
             extra_conditions = SQL("%s AND (%s)", extra_conditions, where_clause)
 

--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
@@ -63,7 +63,7 @@ class SpreadsheetDashboard(models.Model):
             return
 
     def _dashboard_is_empty(self):
-        return any(self.env[model].search_count([], limit=1) == 0 for model in self.main_data_model_ids.sudo().mapped("model"))
+        return any(self.env[model].search_count([], limit=1) == 0 for model in self.sudo().main_data_model_ids.mapped("model"))
 
     def copy_data(self, default=None):
         default = dict(default or {})

--- a/addons/spreadsheet_dashboard/tests/test_dashboard_controllers.py
+++ b/addons/spreadsheet_dashboard/tests/test_dashboard_controllers.py
@@ -41,7 +41,7 @@ class TestDashboardController(DashboardTestCommon, HttpCase):
         dashboard = self.create_dashboard()
         dashboard.sample_dashboard_file_path = sample_dashboard_path
         dashboard.main_data_model_ids = [(4, self.env.ref('base.model_res_bank').id)]
-        self.env['res.bank'].search([]).action_archive()
+        self.env['res.bank'].sudo().search([]).action_archive()
         response = self.url_open(f'/spreadsheet/dashboard/data/{dashboard.id}')
         self.assertEqual(response.json(), {
             'is_sample': True,

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -378,8 +378,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             domain = self._get_shop_domain(search, category, attribute_value_dict)
 
             # This is ~4 times more efficient than a search for the cheapest and most expensive products
-            query = Product._where_calc(domain)
-            Product._apply_ir_rules(query, 'read')
+            query = Product._search(domain)
             sql = query.select(
                 SQL(
                     "COALESCE(MIN(list_price), 0) * %(conversion_rate)s, COALESCE(MAX(list_price), 0) * %(conversion_rate)s",

--- a/odoo/addons/test_access_rights/tests/test_ir_rules.py
+++ b/odoo/addons/test_access_rights/tests/test_ir_rules.py
@@ -126,7 +126,7 @@ class TestRules(TransactionCase):
     def test_check_access_rule_with_inherits(self):
         """
         For models in `_inherits`, verify that both methods `check_access`
-        and `_apply_ir_rules` check the rules from parent models.
+        and `_search` check the rules from parent models.
         """
         ChildModel = self.env['test_access_right.inherits']
         allowed_child, __ = children = ChildModel.create([

--- a/odoo/addons/test_lint/tests/test_checkers.py
+++ b/odoo/addons/test_lint/tests/test_checkers.py
@@ -377,11 +377,10 @@ class TestSqlLint(TestPylintChecks):
 
             # apply rules
             dashboard_graph_model = self._graph_get_model()
-            GraphModel = self.env[dashboard_graph_model] 
+            GraphModel = self.env[dashboard_graph_model]
             graph_table = self._graph_get_table(GraphModel)
-            extra_conditions = self._extra_sql_conditions() 
-            where_query = GraphModel._where_calc([])  
-            GraphModel._apply_ir_rules(where_query, 'read')
+            extra_conditions = self._extra_sql_conditions()
+            where_query = GraphModel._search([])
             from_clause, where_clause, where_clause_params = where_query.get_sql()
             if where_clause:
                 extra_conditions += " AND " + where_clause
@@ -394,7 +393,7 @@ class TestSqlLint(TestPylintChecks):
                 'date_column': self._graph_date_column(),
                 'start_date': "%s",
                 'end_date': "%s",
-                'extra_conditions': extra_conditions 
+                'extra_conditions': extra_conditions
             }
 
             self._cr.execute(query, [self.id, start_date, end_date] + where_clause_params) #@

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -1948,6 +1948,12 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         Discussion = self.env['test_orm.discussion']
 
         # add an ir.rule that forces reading field 'name'
+        self.env['ir.model.access'].create({
+            'name': 'demo',
+            'model_id': self.env['ir.model']._get(Discussion.categories._name).id,
+            'group_id': self.env.ref('base.group_user').id,
+            'perm_read': True,
+        })
         self.env['ir.rule'].create({
             'model_id': self.env['ir.model']._get(Discussion._name).id,
             'groups': [self.env.ref('base.group_user').id],

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -1289,8 +1289,7 @@ class Many2many(_RelationalMulti):
 
         # make the query for the lines
         domain = self.get_comodel_domain(records)
-        query = comodel._where_calc(domain)
-        comodel._apply_ir_rules(query, 'read')
+        query = comodel._search(domain)
         query.order = comodel._order_to_sql(comodel._order, query)
 
         # join with many2many relation table


### PR DESCRIPTION
The rules are applied when using `_search`. Overwriting `_apply_ir_rules` has no effect.
Moreover, since `_search` is used directly in the ORM, the functions give more correct behaviour since `_search` can be overwritten and checks also the permissions on the model.

task-4067945
odoo/enterprise#76183

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
