### PR TITLE
[FIX] stock*: fix timezone handling in stock scheduled dates

### DIFF
--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -86,7 +86,7 @@ class StockPickingType(models.Model):
         domains = {
             'count_mo_waiting': [('reservation_state', '=', 'waiting')],
             'count_mo_todo': [('state', '=', 'confirmed')],
-            'count_mo_late': [('date_start', '<', fields.Date.today()), ('state', '=', 'confirmed')],
+            'count_mo_late': [('date_start', '<', fields.Datetime.now()), ('state', '=', 'confirmed')],
             'count_mo_in_progress': [('state', '=', 'progress')],
             'count_mo_to_close': [('state', '=', 'to_close')],
         }

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -656,7 +656,7 @@
                     <filter invisible="1" name="day_1" string="Tomorrow" domain="[('search_date_category', '=', 'day_1')]"/>
                     <filter invisible="1" name="day_2" string="The day after tomorrow" domain="[('search_date_category', '=', 'day_2')]"/>
                     <filter invisible="1" name="after" string="After" domain="[('search_date_category', '=', 'after')]"/>
-                    <filter string="Late" name="filter_late_mo" help="Late" domain="[('date_start', '&lt;', context_today()), ('state', '=', 'confirmed')]"/>
+                    <filter string="Late" name="filter_late_mo" help="Late" domain="[('date_start', '&lt;', datetime.datetime.now().to_utc().strftime('%Y-%m-%d %H:%M:%S')), ('state', '=', 'confirmed')]"/>
                     <filter string="Delayed Productions" name="planning_issues" help="Late MO or Late delivery of components"
                         domain="['|', ('delay_alert_date', '!=', False), ('is_delayed', '=', True)]"/>
                     <filter string="Components Available" name="available" domain="[('components_availability_state', '=', 'available')]"/>

--- a/addons/repair/models/stock_picking.py
+++ b/addons/repair/models/stock_picking.py
@@ -75,7 +75,7 @@ class StockPickingType(models.Model):
                 ('picking_type_id', 'in', repair_picking_types.ids),
                 ('state', '=', 'confirmed'),
                 '|',
-                ('schedule_date', '<', fields.Date.today()),
+                ('schedule_date', '<', fields.Datetime.now()),
                 ('is_parts_late', '=', True),
             ],
             groupby=['picking_type_id'],

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -245,7 +245,7 @@
                 <filter invisible="1" name="day_2" string="The day after tomorrow" domain="[('search_date_category', '=', 'day_2')]"/>
                 <filter invisible="1" name="after" string="After" domain="[('search_date_category', '=', 'after')]"/>
                 <filter string="Ready" name="ready" domain="[('state', '=', 'confirmed'), ('is_parts_available', '=', True)]" invisible="True"/>
-                <filter string="Late" name="filter_late" domain="[('state', '=', 'confirmed'), ('schedule_date', '&lt;', context_today().strftime('%Y-%m-%d'))]"/>
+                <filter string="Late" name="filter_late" domain="[('state', '=', 'confirmed'), ('schedule_date', '&lt;', datetime.datetime.now().to_utc().strftime('%Y-%m-%d %H:%M:%S'))]"/>
                 <filter name="filter_create_date" date="create_date"/>
                 <separator/>
                 <filter invisible="1" string="My Activities" name="filter_activities_my"

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -257,7 +257,7 @@ class StockPickingType(models.Model):
             'count_picking_waiting': [('state', 'in', ('confirmed', 'waiting'))],
             'count_picking_ready': [('state', '=', 'assigned')],
             'count_picking': [('state', 'in', ('assigned', 'waiting', 'confirmed'))],
-            'count_picking_late': [('state', 'in', ('assigned', 'waiting', 'confirmed')), '|', ('scheduled_date', '<', fields.Date.today()), ('has_deadline_issue', '=', True)],
+            'count_picking_late': [('state', 'in', ('assigned', 'waiting', 'confirmed')), '|', ('scheduled_date', '<', fields.Datetime.now()), ('has_deadline_issue', '=', True)],
             'count_picking_backorders': [('backorder_id', '!=', False), ('state', 'in', ('confirmed', 'assigned', 'waiting'))],
         }
         for field_name, domain in domains.items():

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -227,7 +227,7 @@
                             <div class="o_row">
                                 <field name="scheduled_date" readonly="state in ['cancel', 'done']" required="id"
                                     decoration-warning="state not in ('done', 'cancel') and scheduled_date &lt; now"
-                                    decoration-danger="state not in ('done', 'cancel') and scheduled_date &lt; current_date"
+                                    decoration-danger="state not in ('done', 'cancel') and scheduled_date &lt; datetime.datetime.now().to_utc().strftime('%Y-%m-%d')"
                                     decoration-bf="state not in ('done', 'cancel') and (scheduled_date &lt; current_date or scheduled_date &lt; now)"/>
                                 <field name="json_popover" nolabel="1" widget="stock_rescheduling_popover" invisible="not json_popover"/>
                             </div>
@@ -362,7 +362,7 @@
                     <filter name="internal" invisible="1" string="Internal" domain="[('picking_type_code', '=', 'internal')]"/>
                     <filter invisible="1" name="before" string="Before" domain="[('search_date_category', '=', 'before')]"/>
                     <filter name="late" string="Late" help="Deadline exceed or/and by the scheduled"
-                        domain="[('state', 'in', ('assigned', 'waiting', 'confirmed')), '|', '|', ('has_deadline_issue', '=', True), ('date_deadline', '&lt;', current_date), ('scheduled_date', '&lt;', current_date)]"/>
+                        domain="[('state', 'in', ('assigned', 'waiting', 'confirmed')), '|', '|', ('has_deadline_issue', '=', True), ('date_deadline', '&lt;', current_date), ('scheduled_date', '&lt;', datetime.datetime.now().to_utc().strftime('%Y-%m-%d %H:%M:%S'))]"/>
                     <filter name="yesterday" string="Yesterday" domain="[('search_date_category', '=', 'yesterday')]"/>
                     <filter name="today" string="Today" domain="[('search_date_category', '=', 'today')]"/>
                     <filter name="day_1" string="Tomorrow" domain="[('search_date_category', '=', 'day_1')]"/>


### PR DESCRIPTION
*: mrp, repair

Issue Before This Commit:
============================
- Currently, scheduled dates in the inventory overview were incorrectly marked as 'late' / 'Today' / 'in the future' due to filtering based on server time while scheduled dates are stored in UTC.

Steps to Produce:
=====================
1. Install stock, mrp, repair.
2. Create a picking and assign a scheduled date with a difference between UTC and server time so that both have a different date.
3. Notice incorrect counts and filters for 'Late' pickings.

With This Commit:
=====================
- Now, late picking counts are calculated based on UTC, ensuring consistent and accurate data classification for pickings.

Task - [4242221](https://www.odoo.com/odoo/my-tasks/4242221)

