### PR TITLE
[IMP] osv: deprecate expression()

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -8,7 +8,7 @@ import json
 
 from odoo import _, api, fields, models, Command, tools
 from odoo.exceptions import UserError, ValidationError
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.tools.mail import is_html_empty, email_normalize, email_split_and_format
 from odoo.tools.misc import clean_context
 from odoo.addons.mail.tools.parser import parse_res_ids
@@ -1395,17 +1395,15 @@ class MailComposeMessage(models.TransientModel):
         :return: an Odoo domain (list of leaves) """
         self.ensure_one()
         if isinstance(self.res_domain, (str, bool)) and not self.res_domain:
-            return expression.FALSE_DOMAIN
+            return Domain.FALSE
         try:
             domain = self.res_domain
             if isinstance(self.res_domain, str):
                 domain = ast.literal_eval(domain)
 
-            expression.expression(
-                domain,
-                self.env[self.model],
-            )
-        except (ValueError, AssertionError) as e:
+            domain = Domain(domain)
+            domain.validate(self.env[self.model])
+        except ValueError as e:
             raise ValidationError(
                 _("Invalid domain “%(domain)s” (type “%(domain_type)s”)",
                     domain=self.res_domain,

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -20,7 +20,6 @@ from odoo.exceptions import ValidationError, AccessError, UserError
 from odoo.http import request
 from odoo.models import check_method_name
 from odoo.modules.module import get_resource_from_path
-from odoo.osv.expression import expression
 from odoo.tools import config, lazy_property, frozendict, SQL
 from odoo.tools.convert import _fix_multiple_roots
 from odoo.tools.misc import file_path, get_diff, ConstantMapping
@@ -590,11 +589,10 @@ actual arch.
         """
         if not self.ids:
             return self.browse()
-        self.browse().check_access('read')
         domain = self._get_inheriting_views_domain()
-        e = expression(domain, self.env['ir.ui.view'])
-        where_clause = e.query.where_clause
-        assert e.query.from_clause == SQL.identifier('ir_ui_view'), f"Unexpected from clause: {e.query.from_clause}"
+        query = self._search(domain)
+        where_clause = query.where_clause
+        assert query.from_clause == SQL.identifier('ir_ui_view'), f"Unexpected from clause: {query.from_clause}"
 
         self.flush_model(['inherit_id', 'priority', 'model', 'mode'])
         query = SQL("""

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -686,7 +686,7 @@ class expression(object):
             :attr result: the result of the parsing, as a pair (query, params)
             :attr query: Query object holding the final result
         """
-        # TODO deprecate
+        warnings.warn("Since 19.0, expression() is deprecated, use Domain or _where_calc instead", DeprecationWarning)
         self._unaccent = model.pool.unaccent
         self._has_trigram = model.pool.has_trigram
         self.root_model = model


### PR DESCRIPTION
Deprecate the function/constructor that translates domains into a query on a given model. To do this, you can use `_where_calc` or `_search` on the models.

task-4280707
odoo/enterprise#76190

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
