### PR TITLE
[IMP] im_livechat: add continue button when chat bot is done

### DIFF
--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -68,7 +68,6 @@ class LivechatChatbotScriptController(http.Controller):
             "ChatbotStep",
             {
                 "id": (next_step.id, discuss_channel.id),
-                "isLast": next_step._is_last_step(discuss_channel),
                 "message": posted_message.id,
                 "operatorFound": next_step.is_forward_operator
                 and discuss_channel.livechat_operator_id != chatbot.operator_partner_id,

--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.js
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.js
@@ -18,9 +18,14 @@ patch(ChatWindow.prototype, {
         this.livechatState = useState({ showCloseConfirmation: false });
     },
 
-    async close() {
+    async close({ withConfirmation = true } = {}) {
         const chatWindow = toRaw(this.props.chatWindow);
-        if (chatWindow.thread.id > 0 && !this.livechatState.showCloseConfirmation) {
+        if (
+            withConfirmation &&
+            !chatWindow.hasFeedbackPanel &&
+            chatWindow.thread.id > 0 &&
+            !this.livechatState.showCloseConfirmation
+        ) {
             this.state.actionsDisabled = true;
             this.livechatState.showCloseConfirmation = true;
         } else {
@@ -32,5 +37,9 @@ patch(ChatWindow.prototype, {
     onCloseConfirmationDialog() {
         this.state.actionsDisabled = false;
         this.livechatState.showCloseConfirmation = false;
+    },
+
+    onClickContinue() {
+        this.close({ withConfirmation: false });
     },
 });

--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
@@ -18,9 +18,11 @@
         </xpath>
         <xpath expr="//Composer" position="replace">
             <t t-if="chatbotService.inputEnabled">$0</t>
-            <t t-else="">
-                <span class="bg-200 py-1 text-center fst-italic" t-esc="chatbotService.inputDisabledText"/>
-            </t>
+            <div t-else="" class="bg-200 d-flex justify-content-center">
+                <span t-if="chatbotService.chatbot.completed" class="flex-grow-1"/>
+                <span class="text-center py-1 fst-italic flex-grow-1" t-esc="chatbotService.inputDisabledText"/>
+                <button t-if="chatbotService.chatbot.completed" class="btn btn-link btn-sm me-1" t-on-click="onClickContinue">Continue</button>
+            </div>
         </xpath>
     </t>
 </templates>

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_script_step_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_script_step_model.js
@@ -10,7 +10,7 @@ export class ChatbotScriptStep extends Record {
     message;
     /** @type {"free_input_multi"|"free_input_single"|"question_email"|"question_phone"|"question_selection"|"text"|"forward_operator"} */
     type;
-    isLast = false;
+    is_last = false;
     answers = Record.many("chatbot.script.answer");
 }
 ChatbotScriptStep.register();

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
@@ -110,7 +110,7 @@ export class ChatBotService {
         if (!this.chatbot?.currentStep) {
             return;
         }
-        if (this.chatbot.currentStep.expectAnswer || this.chatbot.currentStep.isLast) {
+        if (this.chatbot.currentStep.expectAnswer || this.chatbot.currentStep.scriptStep.is_last) {
             return;
         }
         this.nextStepTimeout = browser.setTimeout(async () => this._triggerNextStep(), STEP_DELAY);

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_step_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_step_model.js
@@ -17,7 +17,6 @@ export class ChatbotStep extends Record {
             return this.scriptStep?.type;
         },
     });
-    isLast = false;
 
     get expectAnswer() {
         return [

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_continue.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_continue.js
@@ -1,0 +1,25 @@
+import { registry } from "@web/core/registry";
+
+const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:contains("${text}")`;
+
+registry.category("web_tour.tours").add("website_livechat.chatbot_continue_tour", {
+    steps: () => [
+        {
+            trigger: messagesContain("Hello, what can I do for you?"),
+        },
+        {
+            trigger: ".o-livechat-root:shadow li:contains(No, thank you for your time.)",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow span:contains(Conversation ended...)",
+        },
+        {
+            trigger: ".o-livechat-root:shadow button:contains(Continue)",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow *:contains(Did we correctly answer your question?)",
+        },
+    ],
+});


### PR DESCRIPTION
When the chat bot is completed, the visitor is in a dead-end. He can either restart the script, or close the chat window. This PR adds a continue button to reach the feedback panel.

task-4433028

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
