### PR TITLE
[CLN] various: rename 'taxes_id' field to 'tax_ids' on purchase order line

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -177,9 +177,9 @@ class AccountAccruedOrdersWizard(models.TransientModel):
                 for order_line in lines:
                     if is_purchase:
                         account = self._get_computed_account(order, order_line.product_id, is_purchase)
-                        if any(tax.price_include for tax in order_line.taxes_id):
+                        if any(tax.price_include for tax in order_line.tax_ids):
                             # As included taxes are not taken into account in the price_unit, we need to compute the price_subtotal
-                            price_subtotal = order_line.taxes_id.compute_all(
+                            price_subtotal = order_line.tax_ids.compute_all(
                                 order_line.price_unit,
                                 currency=order_line.order_id.currency_id,
                                 quantity=order_line.qty_to_invoice,

--- a/addons/l10n_in_purchase_stock/models/stock_move.py
+++ b/addons/l10n_in_purchase_stock/models/stock_move.py
@@ -26,6 +26,6 @@ class StockMove(models.Model):
         if line_id := self.purchase_line_id:
             return {
                 'is_from_order': True,
-                'taxes': line_id.taxes_id
+                'taxes': line_id.tax_ids
             }
         return super()._l10n_in_get_product_tax()

--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -72,7 +72,7 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
                 'name': self.product_a.name,
                 'product_qty': 2.0,
                 'price_unit': 100,
-                'taxes_id': False,
+                'tax_ids': False,
             })],
         })
         po.button_confirm()

--- a/addons/project_purchase/tests/test_project_profitability.py
+++ b/addons/project_purchase/tests/test_project_profitability.py
@@ -582,7 +582,7 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
                 'analytic_distribution': {self.analytic_account.id: 100},
                 'product_id': self.product_order.id,
                 'product_qty': 2,  # plural value to check if the price is multiplied more than once
-                'taxes_id': [included_tax.id],  # set the included tax
+                'tax_ids': [included_tax.id],  # set the included tax
                 'price_unit': self.product_order.standard_price,
                 'currency_id': self.env.company.currency_id.id,
             })],

--- a/addons/purchase/models/account_tax.py
+++ b/addons/purchase/models/account_tax.py
@@ -13,7 +13,7 @@ class AccountTax(models.Model):
         taxes_to_compute -= used_taxes
 
         if taxes_to_compute:
-            self.env['purchase.order.line'].flush_model(['taxes_id'])
+            self.env['purchase.order.line'].flush_model(['tax_ids'])
             self.env.cr.execute("""
                 SELECT id
                 FROM account_tax

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -89,7 +89,7 @@
                                     <span class="text-align-bottom"><span t-field="line.discount"/>%</span>
                                 </td>
                                 <td class="text-end">
-                                    <span t-out="', '.join([(tax.invoice_label or tax.name) for tax in line.taxes_id])"/>
+                                    <span t-out="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_ids])"/>
                                 </td>
                                 <td class="text-end">
                                     <span t-field="line.price_subtotal"

--- a/addons/purchase/tests/test_accrued_purchase_orders.py
+++ b/addons/purchase/tests/test_accrued_purchase_orders.py
@@ -38,7 +38,7 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
                     'product_qty': 10.0,
                     'product_uom_id': cls.product_a.uom_id.id,
                     'price_unit': cls.product_a.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                     'analytic_distribution': {
                         cls.analytic_account_a.id : 80.0,
                         cls.analytic_account_b.id : 20.0,
@@ -50,7 +50,7 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
                     'product_qty': 10.0,
                     'product_uom_id': cls.product_b.uom_id.id,
                     'price_unit': cls.product_b.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                     'analytic_distribution': {
                         cls.analytic_account_b.id : 100.0,
                     },
@@ -130,7 +130,7 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
             'type_tax_use': 'purchase',
             'price_include_override': 'tax_included',
         })
-        self.purchase_order.order_line.taxes_id = tax_10_included
+        self.purchase_order.order_line.tax_ids = tax_10_included
         self.purchase_order.order_line.qty_received = 5
         self.assertRecordValues(self.env['account.move'].search(self.wizard.create_entries()['domain']).line_ids, [
             # reverse move lines

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -704,10 +704,10 @@ class TestPurchase(AccountTestInvoicingCommon):
             line.product_id = product_no_tax
         po = po_form.save()
         self.assertRecordValues(po.order_line, [
-            {'product_id': product_all_taxes.id, 'taxes_id': tax_xx.ids},
-            {'product_id': product_no_xx_tax.id, 'taxes_id': tax_x.ids},
-            {'product_id': product_no_branch_tax.id, 'taxes_id': (tax_a + tax_b).ids},
-            {'product_id': product_no_tax.id, 'taxes_id': []},
+            {'product_id': product_all_taxes.id, 'tax_ids': tax_xx.ids},
+            {'product_id': product_no_xx_tax.id, 'tax_ids': tax_x.ids},
+            {'product_id': product_no_branch_tax.id, 'tax_ids': (tax_a + tax_b).ids},
+            {'product_id': product_no_tax.id, 'tax_ids': []},
         ])
 
     @freeze_time('2024-07-08')

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -123,7 +123,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom_id': self.product_deliver.uom_id.id,
             'price_unit': self.product_deliver.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         pol_serv_deliver = PurchaseOrderLine.create({
             'name': self.service_deliver.name,
@@ -132,7 +132,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom_id': self.service_deliver.uom_id.id,
             'price_unit': self.service_deliver.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         purchase_order.button_confirm()
 
@@ -167,7 +167,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom_id': self.product_order.uom_id.id,
             'price_unit': self.product_order.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         pol_serv_order = PurchaseOrderLine.create({
             'name': self.service_order.name,
@@ -176,7 +176,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom_id': self.service_order.uom_id.id,
             'price_unit': self.service_order.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         purchase_order.button_confirm()
 
@@ -211,7 +211,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom_id': self.product_deliver.uom_id.id,
             'price_unit': self.product_deliver.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         pol_serv_deliver = PurchaseOrderLine.create({
             'name': self.service_deliver.name,
@@ -220,7 +220,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom_id': self.service_deliver.uom_id.id,
             'price_unit': self.service_deliver.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         purchase_order.button_confirm()
 
@@ -256,7 +256,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom_id': self.product_order.uom_id.id,
             'price_unit': self.product_order.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         pol_serv_order = PurchaseOrderLine.create({
             'name': self.service_order.name,
@@ -265,7 +265,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom_id': self.service_order.uom_id.id,
             'price_unit': self.service_order.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         purchase_order.button_confirm()
 
@@ -309,7 +309,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
                 'product_uom_id': self.product_order.uom_id.id,
                 'price_unit': 1000,
                 'order_id': po.id,
-                'taxes_id': False,
+                'tax_ids': False,
             })
             po.button_confirm()
             pol_prod_order.write({'qty_received': 1})
@@ -351,7 +351,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
                 'product_qty': 12,
                 'product_uom_id': self.product_a.uom_id.id,
                 'price_unit': 0.001,
-                'taxes_id': False,
+                'tax_ids': False,
             })]
         })
         po.button_confirm()
@@ -488,7 +488,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
                     'product_qty': 10.0,
                     'product_uom_id': self.product_order.uom_id.id,
                     'price_unit': self.product_order.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                     'sequence': sequence_number,
                 }) for sequence_number in range(10, 13)]
             purchase_order = self.env['purchase.order'].with_context(tracking_disable=True).create({
@@ -522,7 +522,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
                     'product_qty': 10.0,
                     'product_uom_id': self.product_order.uom_id.id,
                     'price_unit': self.product_order.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                     'sequence': sequence_number,
                 }) for sequence_number in range(10, 13)]
             purchase_order = self.env['purchase.order'].with_context(tracking_disable=True).create({
@@ -564,7 +564,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
                     'product_qty': 20.0,
                     'product_uom_id': self.product_deliver.uom_id.id,
                     'price_unit': self.product_deliver.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ],
         })
@@ -714,7 +714,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom_id': self.product_deliver.uom_id.id,
             'price_unit': self.product_deliver.list_price,
             'order_id': po.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         pol_prod_same = PurchaseOrderLine.create({
             'name': self.product_deliver.display_name,
@@ -723,7 +723,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom_id': self.product_deliver.uom_id.id,
             'price_unit': self.product_deliver.list_price,
             'order_id': po.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         pol_prod_product_in_name = PurchaseOrderLine.create({
             'name': f"{self.product_deliver.display_name} with more description",
@@ -732,7 +732,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom_id': self.product_deliver.uom_id.id,
             'price_unit': self.product_deliver.list_price,
             'order_id': po.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         pol_prod_name_in_product = PurchaseOrderLine.create({
             'name': "Switch",
@@ -741,7 +741,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom_id': self.product_deliver.uom_id.id,
             'price_unit': self.product_deliver.list_price,
             'order_id': po.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
 
         # Invoice the purchase order
@@ -981,8 +981,8 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         action = wizard.action_add_to_po()
         po = self.env['purchase.order'].browse(action['res_id'])
         self.assertEqual(po.partner_id, self.partner_a)
-        self.assertTrue(po.order_line.taxes_id)
-        self.assertEqual(po.order_line.taxes_id, bill.invoice_line_ids.tax_ids)
+        self.assertTrue(po.order_line.tax_ids)
+        self.assertEqual(po.order_line.tax_ids, bill.invoice_line_ids.tax_ids)
         self.assertEqual(po.order_line.product_id, bill.invoice_line_ids.product_id)
         self.assertEqual(po.order_line.product_id, self.product_order_var_name + self.service_deliver)
 
@@ -1123,7 +1123,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
                         'product_id': self.product_order.id,
                         'product_qty': 1.0,
                         'price_unit': self.product_order.list_price,
-                        'taxes_id': False,
+                        'tax_ids': False,
                     }),
                 ]
             } for partner_ref in ('PO-001', False)
@@ -1174,7 +1174,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
                     'product_id': self.product_order.id,
                     'product_qty': 1.0,
                     'price_unit': self.product_order.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })

--- a/addons/purchase/tests/test_purchase_order_report.py
+++ b/addons/purchase/tests/test_purchase_order_report.py
@@ -28,7 +28,7 @@ class TestPurchaseOrderReport(AccountTestInvoicingCommon):
                     'product_uom_id': uom_dozen.id,
                     'price_unit': 100.0,
                     'date_planned': datetime.today(),
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
                 (0, 0, {
                     'name': self.product_b.name,
@@ -37,7 +37,7 @@ class TestPurchaseOrderReport(AccountTestInvoicingCommon):
                     'product_uom_id': uom_dozen.id,
                     'price_unit': 200.0,
                     'date_planned': datetime.today(),
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ],
         })
@@ -138,7 +138,7 @@ class TestPurchaseOrderReport(AccountTestInvoicingCommon):
                     'product_qty': 0.0,
                     'product_uom_id': False,
                     'price_unit': 0.0,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
                 (0, 0, {
                     'name': 'This is a section',
@@ -147,7 +147,7 @@ class TestPurchaseOrderReport(AccountTestInvoicingCommon):
                     'product_qty': 0.0,
                     'product_uom_id': False,
                     'price_unit': 0.0,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ],
         })

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -369,7 +369,7 @@
                                         />
                                     </td>
                                     <td t-if="display_price_and_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                        <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.taxes_id))"/>
+                                        <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_ids))"/>
                                     </td>
                                     <td t-if="display_price_and_taxes" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
                                         <div t-field="line.discount" class="text-end"/>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -255,7 +255,7 @@
                                         force_save="1" optional="show"/>
                                     <field name="price_unit" readonly="qty_invoiced != 0"/>
                                     <button name="action_purchase_history" type="object" icon="fa-history" title="Purchase History" invisible="not id"/>
-                                    <field name="taxes_id" widget="many2many_tax_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id), ('active', '=', True)]" context="{'default_type_tax_use': 'purchase', 'search_view_ref': 'account.account_tax_view_search'}" options="{'no_create': True}" optional="show" readonly="is_downpayment"/>
+                                    <field name="tax_ids" widget="many2many_tax_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id), ('active', '=', True)]" context="{'default_type_tax_use': 'purchase', 'search_view_ref': 'account.account_tax_view_search'}" options="{'no_create': True}" optional="show" readonly="is_downpayment"/>
                                     <field name="discount" string="Disc.%" width="50px" readonly="qty_invoiced != 0" optional="hide"/>
                                     <field name="price_subtotal" string="Amount"/>
                                 </list>
@@ -282,7 +282,7 @@
                                                 <field name="qty_invoiced" string="Billed Quantity" invisible="parent.state not in ('purchase', 'done')"/>
                                                 <field name="price_unit"/>
                                                 <field name="discount"/>
-                                                <field name="taxes_id" widget="many2many_tax_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]" options="{'no_create': True}"/>
+                                                <field name="tax_ids" widget="many2many_tax_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]" options="{'no_create': True}"/>
                                             </group>
                                             <group>
                                                 <field name="date_planned" required="not display_type and not is_downpayment"/>
@@ -724,7 +724,7 @@
                                 <field name="price_unit"/>
                             </group>
                             <group>
-                                <field name="taxes_id" widget="many2many_tax_tags"
+                                <field name="tax_ids" widget="many2many_tax_tags"
                                     domain="[('type_tax_use', '=', 'purchase')]"/>
                                 <field name="date_planned" readonly="1"/>
                                 <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>

--- a/addons/purchase/wizard/bill_to_po_wizard.py
+++ b/addons/purchase/wizard/bill_to_po_wizard.py
@@ -55,7 +55,7 @@ class BillToPoWizard(models.TransientModel):
                 'product_uom_id': aml.product_uom_id.id,
                 'is_downpayment': True,
                 'price_unit': aml.price_unit,
-                'taxes_id': aml.tax_ids,
+                'tax_ids': aml.tax_ids,
                 'order_id': self.purchase_order_id.id,
             }
             for aml in lines_to_convert

--- a/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
+++ b/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
@@ -77,9 +77,9 @@ class PurchaseEdiXmlUbl_Bis3(models.AbstractModel):
         }
 
     def _get_tax_category_vals(self, order, order_line):
-        if not order_line.taxes_id:
+        if not order_line.tax_ids:
             return None
-        tax = order_line.taxes_id[0]
+        tax = order_line.tax_ids[0]
         customer = order.company_id.partner_id.commercial_partner_id
         supplier = order.partner_id
         tax_unece_codes = self._get_tax_unece_codes(customer, supplier, tax)

--- a/addons/purchase_mrp/report/mrp_report_mo_overview.py
+++ b/addons/purchase_mrp/report/mrp_report_mo_overview.py
@@ -35,7 +35,7 @@ class ReportMrpReport_Mo_Overview(models.AbstractModel):
 
     def _format_extra_replenishment(self, po_line, quantity, production_id=False):
         po = po_line.order_id
-        price = po_line.taxes_id.compute_all(
+        price = po_line.tax_ids.compute_all(
             po_line.price_unit,
             currency=po.currency_id,
             quantity=quantity,
@@ -88,7 +88,7 @@ class ReportMrpReport_Mo_Overview(models.AbstractModel):
         if move_in and move_in.purchase_line_id:
             po_line = move_in.purchase_line_id
             po = po_line.order_id
-            price = po_line.taxes_id.compute_all(
+            price = po_line.tax_ids.compute_all(
                 po_line.price_unit,
                 currency=po.currency_id,
                 quantity=uom_id._compute_quantity(quantity, move_in.purchase_line_id.product_uom_id),

--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -132,7 +132,7 @@ class TestAngloSaxonValuationPurchaseMRP(AccountTestInvoicingCommon):
         with po_form.order_line.new() as pol_form:
             pol_form.product_id = kit
             pol_form.price_unit = 100
-            pol_form.taxes_id.clear()
+            pol_form.tax_ids.clear()
         po = po_form.save()
         po.button_confirm()
 

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -1077,7 +1077,7 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
             pol_form.product_qty = 30
             pol_form.product_uom_id = self.uom_kg
             pol_form.price_unit = 90000
-            pol_form.taxes_id.clear()
+            pol_form.tax_ids.clear()
         po = po_form.save()
         po.button_confirm()
 
@@ -1201,7 +1201,7 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
             pol_form.product_id = prod
             pol_form.product_qty = 1
             pol_form.price_unit = 100
-            pol_form.taxes_id.clear()
+            pol_form.tax_ids.clear()
         po = po_form.save()
         po.button_confirm()
         receipt = po.picking_ids

--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -271,7 +271,7 @@ class PurchaseRequisitionLine(models.Model):
             'product_uom_id': self.product_id.uom_id.id,
             'product_qty': product_qty,
             'price_unit': price_unit,
-            'taxes_id': [(6, 0, taxes_ids)],
+            'tax_ids': [(6, 0, taxes_ids)],
             'date_planned': date_planned,
             'analytic_distribution': self.analytic_distribution,
         }

--- a/addons/purchase_requisition/tests/test_purchase_requisition.py
+++ b/addons/purchase_requisition/tests/test_purchase_requisition.py
@@ -556,7 +556,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         alt_po_wizard = alt_po_wizard_form.save()
         alt_po_id = alt_po_wizard.action_create_alternative()['res_id']
         alt_po = self.env['purchase.order'].browse(alt_po_id)
-        self.assertEqual(orig_po.order_line.taxes_id, alt_po.order_line.taxes_id)
+        self.assertEqual(orig_po.order_line.tax_ids, alt_po.order_line.tax_ids)
 
     def test_alternative_purchase_order_merge(self):
         group_purchase_alternatives = self.env.ref('purchase_requisition.group_purchase_alternatives')

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -197,9 +197,9 @@ class PurchaseOrderLine(models.Model):
         order = self.order_id
         price_unit = self.price_unit
         price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
-        if self.taxes_id:
+        if self.tax_ids:
             qty = self.product_qty or 1
-            price_unit = self.taxes_id.compute_all(
+            price_unit = self.tax_ids.compute_all(
                 price_unit,
                 currency=self.order_id.currency_id,
                 quantity=qty,

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -250,7 +250,7 @@ class StockRule(models.Model):
             date=line.order_id.date_order and line.order_id.date_order.date(),
             uom_id=uom)
 
-        price_unit = self.env['account.tax']._fix_tax_included_price_company(seller.price, line.product_id.supplier_taxes_id, line.sudo().taxes_id, company_id) if seller else 0.0
+        price_unit = self.env['account.tax']._fix_tax_included_price_company(seller.price, line.product_id.supplier_taxes_id, line.sudo().tax_ids, company_id) if seller else 0.0
         if price_unit and seller and line.order_id.currency_id and seller.currency_id != line.order_id.currency_id:
             price_unit = seller.currency_id._convert(
                 price_unit, line.order_id.currency_id, line.order_id.company_id, fields.Date.today())

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -45,7 +45,7 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
                         'product_uom_id': product.uom_id.id,
                         'price_unit': price_unit,
                         'date_planned': date,
-                        'taxes_id': [(6, 0, product.supplier_taxes_id.ids)] if set_tax else False,
+                        'tax_ids': [(6, 0, product.supplier_taxes_id.ids)] if set_tax else False,
                     })],
                 'date_order': date,
             })

--- a/addons/purchase_stock/tests/test_average_price.py
+++ b/addons/purchase_stock/tests/test_average_price.py
@@ -277,7 +277,7 @@ class TestAveragePrice(ValuationReconciliationTestCommon):
             'order_line': [(0, 0, {
                 'product_id': avco_product.id,
                 'product_qty': 999,
-                'taxes_id': [(6, 0, [incl_tax.id])],
+                'tax_ids': [(6, 0, [incl_tax.id])],
             })],
         })
         po.button_confirm()

--- a/addons/purchase_stock/tests/test_fifo_price.py
+++ b/addons/purchase_stock/tests/test_fifo_price.py
@@ -341,7 +341,7 @@ class TestFifoPrice(ValuationReconciliationTestCommon):
                 'product_uom_id': super_product.uom_id.id,
                 'price_unit': super_product.standard_price,
                 'date_planned': time.strftime('%Y-%m-%d'),
-                'taxes_id': [(4, tax.id)],
+                'tax_ids': [(4, tax.id)],
             })],
         })
 

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -420,7 +420,7 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
                 'product_qty': 7,
                 'product_uom_id': super_product.uom_id.id,
                 'price_unit': super_product.standard_price,
-                'taxes_id': [(4, tax.id)],
+                'tax_ids': [(4, tax.id)],
             })],
         })
 

--- a/addons/purchase_stock/tests/test_purchase_stock_accrued_entries.py
+++ b/addons/purchase_stock/tests/test_purchase_stock_accrued_entries.py
@@ -29,7 +29,7 @@ class TestAccruedPurchaseStock(AccountTestInvoicingCommon):
                     'product_qty': 10.0,
                     'product_uom_id': product.uom_id.id,
                     'price_unit': product.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -1221,7 +1221,7 @@ class TestReorderingRule(TransactionCase):
         po_line = self.env['purchase.order.line'].search([('product_id', '=', product.id)])
         self.assertEqual(len(po_line), 1, 'There should be only one PO line')
         self.assertEqual(po_line.product_qty, 10, 'The PO line quantity should be 10')
-        self.assertTrue(po_line.taxes_id)
+        self.assertTrue(po_line.tax_ids)
 
     def test_forbid_snoozing_auto_trigger_orderpoint(self):
         """

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -661,7 +661,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                 (0, 0, {
                     'name': self.product1.name,
                     'product_id': self.product1.id,
-                    'taxes_id': [(4, tax_with_no_account.id)],
+                    'tax_ids': [(4, tax_with_no_account.id)],
                     'product_qty': 10.0,
                     'product_uom_id': self.product1.uom_id.id,
                     'price_unit': 10.0,
@@ -958,7 +958,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                     'product_qty': 1.0,
                     'product_uom_id': self.product1.uom_id.id,
                     'price_unit': 105.0,  # 50$
-                    'taxes_id': [(4, tax.id)],
+                    'tax_ids': [(4, tax.id)],
                     'date_planned': date_po,
                 }),
             ],
@@ -1044,7 +1044,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                     'product_qty': 1.0,
                     'product_uom_id': self.product1.uom_id.id,
                     'price_unit': 100.0,  # 50$
-                    'taxes_id': [(4, tax_without_account.id)],
+                    'tax_ids': [(4, tax_without_account.id)],
                 }),
             ],
         })
@@ -2744,7 +2744,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                     'product_qty': 1.0,
                     'product_uom_id': self.product1.uom_id.id,
                     'price_unit': 100.0,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ],
         })
@@ -2804,7 +2804,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                     'product_qty': 3.0,
                     'product_uom_id': product.uom_id.id,
                     'price_unit': 100.0,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ],
         })
@@ -3008,7 +3008,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                     'product_qty': 1.0,
                     'product_uom_id': self.product1.uom_id.id,
                     'price_unit': 100.0,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ],
         })
@@ -3074,7 +3074,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                         'product_id': self.product1.id,
                         'product_qty': 1.0,
                         'price_unit': purchase_price,
-                        'taxes_id': False,
+                        'tax_ids': False,
                     }),
                 ]
             })
@@ -3183,7 +3183,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                         'product_id': self.product1.id,
                         'product_qty': 1.0,
                         'price_unit': purchase_price,
-                        'taxes_id': False,
+                        'tax_ids': False,
                     }),
                 ]
             })
@@ -3358,7 +3358,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                         'product_qty': 1.0,
                         'product_uom_id': self.product1.uom_id.id,
                         'price_unit': 1000.0,
-                        'taxes_id': False,
+                        'tax_ids': False,
                     }),
                 ],
             })

--- a/addons/sale_purchase/models/sale_order_line.py
+++ b/addons/sale_purchase/models/sale_order_line.py
@@ -210,7 +210,7 @@ class SaleOrderLine(models.Model):
             'product_uom_id': supplierinfo.product_uom_id.id or self.product_id.uom_id.id,
             'price_unit': price_unit,
             'date_planned': purchase_order.date_order + relativedelta(days=int(supplierinfo.delay)),
-            'taxes_id': [(6, 0, taxes.ids)],
+            'tax_ids': [(6, 0, taxes.ids)],
             'order_id': purchase_order.id,
             'sale_line_id': self.id,
             'discount': supplierinfo.discount,

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs.py
@@ -185,7 +185,7 @@ class TestStockLandedCosts(TestStockLandedCostsCommon):
                         'product_qty': 1.0,
                         'product_uom_id': self.product_a.uom_id.id,
                         'price_unit': 100.0,
-                        'taxes_id': False,
+                        'tax_ids': False,
                     }),
                     (0, 0, {
                         'name': self.landed_cost.name,

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_branches.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_branches.py
@@ -74,7 +74,7 @@ class TestStockLandedCostsBranches(TestStockValuationLCCommon):
             po_line.product_id = self.product1
             po_line.product_qty = 1
             po_line.price_unit = 10
-            po_line.taxes_id.clear()
+            po_line.tax_ids.clear()
         po = po_form.save()
         po.button_confirm()
 

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -513,7 +513,7 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
                     'product_qty': 1.0,
                     'product_uom_id': self.product_a.uom_id.id,
                     'price_unit': 100.0,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
                 (0, 0, {
                     'name': self.landed_cost.name,

--- a/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
+++ b/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
@@ -329,7 +329,7 @@ class TestStockValuationLCAVCO(TestStockValuationLCCommon):
             po_line.product_id = self.product1
             po_line.product_qty = 1
             po_line.price_unit = 10
-            po_line.taxes_id.clear()
+            po_line.tax_ids.clear()
         po = po_form.save()
         po.button_confirm()
 
@@ -382,7 +382,7 @@ class TestStockValuationLCFIFOVB(TestStockValuationLCCommon):
             po_line.product_id = self.product1
             po_line.product_qty = 10
             po_line.price_unit = 10
-            po_line.taxes_id.clear()
+            po_line.tax_ids.clear()
 
         rfq = rfq.save()
         rfq.button_confirm()
@@ -469,7 +469,7 @@ class TestStockValuationLCFIFOVB(TestStockValuationLCCommon):
             po_line.product_id = self.product1
             po_line.product_qty = 10
             po_line.price_unit = 10
-            po_line.taxes_id.clear()
+            po_line.tax_ids.clear()
 
         rfq = rfq.save()
         rfq.button_confirm()
@@ -521,7 +521,7 @@ class TestStockValuationLCFIFOVB(TestStockValuationLCCommon):
             po_line.product_id = self.product1
             po_line.product_qty = 10
             po_line.price_unit = 10
-            po_line.taxes_id.clear()
+            po_line.tax_ids.clear()
 
         rfq = rfq.save()
         rfq.button_confirm()

--- a/addons/test_sale_purchase_edi_ubl/tests/test_order_ubl_bis3.py
+++ b/addons/test_sale_purchase_edi_ubl/tests/test_order_ubl_bis3.py
@@ -57,13 +57,13 @@ class TestOrderEdiUbl(TestAccountEdiUblCii):
                 'price_unit': 30.0,
                 'product_uom_id': self.uom_units.id,
                 'product_qty': 10.0,
-                'taxes_id': self.purchase_tax.ids,
+                'tax_ids': self.purchase_tax.ids,
             }, {
                 'product_id': self.displace_prdct.id,
                 'price_unit': 30.0,
                 'product_uom_id': self.uom_units.id,
                 'product_qty': 50.0,
-                'taxes_id': self.purchase_tax.ids,
+                'tax_ids': self.purchase_tax.ids,
             },
         ]
         xml_attachment = self.get_xml_attachment_of_po(line_vals)
@@ -87,7 +87,7 @@ class TestOrderEdiUbl(TestAccountEdiUblCii):
             line['tax_ids'] = related_sales_tax.ids
             line['price_unit'] = line_product.list_price
             del line['product_qty']
-            del line['taxes_id']
+            del line['tax_ids']
 
         self.assertRecordValues(so.order_line, line_vals)
 


### PR DESCRIPTION
This commit renames the `taxes_id` field on the purchase order line
to `tax_ids`. The `taxes_id` is a many2many field, and this change 
standardizes the naming for improved clarity and maintainability. 
It also aligns with the `tax_ids` field in `sales orders`, facilitating
easier EDI order processing.
Most importantly, this update ensures consistency with Odoo's
naming conventions.