### PR TITLE
[FIX] hr_holidays: fix the allocation approval

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -939,14 +939,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/hr_holidays/models/hr_leave_allocation.py:0
 msgid ""
-"Allocation must be \"To Approve\" or \"Second Approval\" in order to "
-"validate it."
-msgstr ""
-
-#. module: hr_holidays
-#. odoo-python
-#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
-msgid "Allocation must be confirmed (\"To Approve\") or validated once (\"Second Approval\") in order to approve it."
+"Allocation must be confirmed \"To Approve\" or validated once \"Second "
+"Approval\" in order to approve it."
 msgstr ""
 
 #. module: hr_holidays
@@ -1375,7 +1369,7 @@ msgstr ""
 
 #. module: hr_holidays
 #. odoo-python
-#: code:addons/hr_holidays/models/hr_employee.py:0
+#: code:addons/hr_holidays/models/hr_employee_base.py:0
 msgid ""
 "Changing this working schedule results in the affected employee(s) not "
 "having enough leaves allocated to accomodate for their leaves already taken "
@@ -2846,6 +2840,14 @@ msgstr ""
 
 #. module: hr_holidays
 #. odoo-python
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid ""
+"Only %s's Time Off Approver, a time off Officer/Responsible or Administrator"
+" can approve or refuse allocation requests."
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
 #: code:addons/hr_holidays/models/hr_leave.py:0
 msgid "Only a Time Off Manager can reset a refused leave."
 msgstr ""
@@ -2878,20 +2880,20 @@ msgstr ""
 #. module: hr_holidays
 #. odoo-python
 #: code:addons/hr_holidays/models/hr_leave_allocation.py:0
-msgid "Only a time off Manager can approve its own requests."
+msgid "Only a time off Administrator can approve their own requests."
 msgstr ""
 
 #. module: hr_holidays
 #. odoo-python
 #: code:addons/hr_holidays/models/hr_leave_allocation.py:0
 msgid ""
-"Only a time off Officer/Responsible or Manager can approve or refuse time "
-"off requests."
+"Only a time off Officer/Responsible or Administrator can approve or refuse "
+"allocation requests."
 msgstr ""
 
 #. module: hr_holidays
 #. odoo-python
-#: code:addons/hr_holidays/models/hr_employee.py:0
+#: code:addons/hr_holidays/models/hr_employee_base.py:0
 msgid "Operation not supported"
 msgstr ""
 
@@ -3338,7 +3340,6 @@ msgstr ""
 #. module: hr_holidays
 #. odoo-python
 #: code:addons/hr_holidays/models/hr_leave_accrual_plan.py:0
-#, python-format
 msgid ""
 "Some of the accrual plans you're trying to delete are linked to an existing "
 "allocation. Delete or cancel them first."
@@ -3485,7 +3486,6 @@ msgstr ""
 #. module: hr_holidays
 #. odoo-python
 #: code:addons/hr_holidays/models/hr_leave_type.py:0
-#, python-format
 msgid ""
 "The allocation requirement of a time off type cannot be changed once leaves "
 "of that type have been taken. You should create a new time off type instead."
@@ -3600,6 +3600,14 @@ msgstr ""
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_type__sequence
 msgid ""
 "The type with the smallest sequence is the default value in time off request"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+msgid ""
+"There is no employee set on the time off. Please make sure you're logged in "
+"the correct company."
 msgstr ""
 
 #. module: hr_holidays
@@ -4375,6 +4383,14 @@ msgstr ""
 #. odoo-python
 #: code:addons/hr_holidays/models/hr_leave.py:0
 msgid "You must be %s's Manager to approve this leave"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid ""
+"You must be either %s's Time Off Approver or Time off Administrator to "
+"validate this allocation request."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -214,7 +214,9 @@ class HolidaysAllocation(models.Model):
     def _compute_can_approve(self):
         for allocation in self:
             try:
-                if allocation.state == 'confirm' and allocation.validation_type != 'no_validation':
+                if allocation.state == 'confirm' and allocation.validation_type == 'both':
+                    allocation._check_approval_update('validate1')
+                else:
                     allocation._check_approval_update('validate')
             except (AccessError, UserError):
                 allocation.can_approve = False
@@ -715,18 +717,24 @@ class HolidaysAllocation(models.Model):
         is_manager = self.env.user.has_group('hr_holidays.group_hr_holidays_manager')
         for allocation in self:
             val_type = allocation.holiday_status_id.sudo().allocation_validation_type
-            if state == 'confirm':
+            if state == 'confirm' or is_manager or val_type == 'no_validation':
                 continue
 
-            if not is_officer and self.env.user != allocation.employee_id.leave_manager_id and not val_type == 'no_validation':
-                raise UserError(_('Only a time off Officer/Responsible or Manager can approve or refuse time off requests.'))
+            if not is_officer and self.env.user != allocation.employee_id.leave_manager_id:
+                raise UserError(_('Only %s\'s Time Off Approver, a time off Officer/Responsible or Administrator can approve or refuse allocation requests.') % (allocation.employee_id.name))
+
+            # both -> 1st approver and 2nd officer
+            if (val_type == 'manager' or state == 'validate1') and self.env.user != allocation.employee_id.leave_manager_id:
+                raise UserError(_('You must be either %s\'s Time Off Approver or Time off Administrator to validate this allocation request.') % (allocation.employee_id.name))
+            if (val_type == 'both' and state == 'validate' or val_type == 'hr') and not is_officer:
+                raise UserError(_('Only a time off Officer/Responsible or Administrator can approve or refuse allocation requests.'))
 
             if is_officer or self.env.user == allocation.employee_id.leave_manager_id:
                 # use ir.rule based first access check: department, members, ... (see security.xml)
                 allocation.check_access_rule('write')
 
-            if allocation.employee_id == current_employee and not is_manager and not val_type == 'no_validation':
-                raise UserError(_('Only a time off Manager can approve its own requests.'))
+            if allocation.employee_id == current_employee:
+                raise UserError(_('Only a time off Administrator can approve their own requests.'))
 
     @api.onchange('allocation_type')
     def _onchange_allocation_type(self):

--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -164,12 +164,12 @@
         <field name="name">Allocations: base.group_user create/write</field>
         <field name="model_id" ref="model_hr_leave_allocation"/>
         <field name="domain_force">[
-            ('holiday_status_id.requires_allocation', '=', 'yes'),
-            ('holiday_status_id.employee_requests', '=', 'yes'),
             '|',
-                ('employee_id.user_id', '=', user.id),
                 '&amp;',
-                    ('validation_type', '=', 'hr'),
+                    ('employee_id.user_id', '=', user.id),
+                    ('state', '=', 'confirm'),
+                '&amp;',
+                    ('validation_type', 'in', ['manager', 'both', 'no_validation']),
                     ('employee_id.leave_manager_id', '=', user.id),
         ]</field>
         <field name="perm_read" eval="False"/>

--- a/addons/hr_holidays/tests/test_allocation_access_rights.py
+++ b/addons/hr_holidays/tests/test_allocation_access_rights.py
@@ -16,16 +16,16 @@ class TestAllocationRights(TestHrHolidaysCommon):
         cls.employee_emp.parent_id = False
         cls.employee_emp.leave_manager_id = False
 
-        cls.lt_no_allocation = cls.env['hr.leave.type'].create({
+        cls.lt_validation_hr = cls.env['hr.leave.type'].create({
             'name': 'Validation = HR',
             'allocation_validation_type': 'hr',
-            'requires_allocation': 'no',
+            'requires_allocation': 'yes',
             'employee_requests': 'yes',
         })
 
         cls.lt_validation_manager = cls.env['hr.leave.type'].create({
             'name': 'Validation = manager',
-            'allocation_validation_type': 'hr',
+            'allocation_validation_type': 'manager',
             'requires_allocation': 'yes',
             'employee_requests': 'yes',
         })
@@ -142,7 +142,7 @@ class TestAccessRightsHolidayUser(TestAllocationRights):
         """ A holiday user can request and approve an allocation for any employee """
         values = {
             'employee_id': self.employee_emp.id,
-            'holiday_status_id': self.lt_validation_manager.id,
+            'holiday_status_id': self.lt_validation_hr.id,
         }
         allocation = self.request_allocation(self.user_hruser.id, values)
         allocation.action_validate()


### PR DESCRIPTION
- fix the `hr_leave_allocation_rule_employee_update` rule to include `('manager','both') in validation_type` instead of `hr` as those are the types where the emoployee's manager should be able to update
- fix `_check_approval_update` function to match the designed access rules where TOO only approve `hr` and validate `both` and manager approvre `manager, both`

Task: 4432503



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
