### PR TITLE
[FIX] im_livechat: attach file button not opening file selector

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -49,7 +49,7 @@
                     t-ref="input-container"
                 >
                     <div t-if="!extended" t-attf-class="{{ actionsContainerClass }}">
-                        <Dropdown position="'top-start'" menuClass="'d-flex flex-column py-0'">
+                        <Dropdown t-if="partitionedActions.other.length > 0" position="'top-start'" menuClass="'d-flex flex-column py-0'">
                             <t t-call="mail.Composer.moreActions"/>
                             <t t-set-slot="content">
                                 <t t-call="mail.Composer.dropdownActions"/>
@@ -57,7 +57,7 @@
                         </Dropdown>
                     </div>
                     <div class="position-relative flex-grow-1">
-                        <t t-set="inputClasses" t-value="'o-mail-Composer-inputStyle form-control border-0 rounded-3'"/>
+                        <t t-set="inputClasses" t-value="{'o-mail-Composer-inputStyle form-control border-0 rounded-3': true, 'ps-1': partitionedActions.other.length === 0}"/>
                         <textarea class="o-mail-Composer-input o-mail-Composer-bg shadow-none overflow-auto"
                             t-att-class="inputClasses"
                             t-ref="textarea"

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -100,11 +100,15 @@ composerActionsRegistry
         sequenceQuick: 20,
     })
     .add("upload-files", {
-        condition: (component) =>
-            !(
+        condition: (component) => {
+            if (!component.thread.allow_public_upload && component.store.self.type === "guest") {
+                return false;
+            }
+            return !(
                 component.thread?.channel_type === "whatsapp" &&
                 component.props.composer.attachments.length > 0
-            ),
+            );
+        },
         icon: "fa fa-paperclip",
         name: _t("Attach Files"),
         onClick: (component, action, ev) => {


### PR DESCRIPTION
Before this PR, the attachm file button in the composer was displayed even if upload was not allowed. Clicking on this button woudln't do anything since upload is forbidden.

This PR hides the upload file action is upload is not allowed.

task-4433082

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
