### PR TITLE
[FIX] website: do not observe mutations making s_popup visible

### DIFF
--- a/addons/website/static/src/snippets/s_popup/options.js
+++ b/addons/website/static/src/snippets/s_popup/options.js
@@ -67,8 +67,10 @@ options.registry.SnippetPopup = options.Class.extend({
      * @override
      */
     onTargetShow: async function () {
+        this.options.wysiwyg.odooEditor.observerUnactive();
         this.$bsTarget.modal('show');
         $(this.$target[0].ownerDocument.body).children('.modal-backdrop:last').addClass('d-none');
+        this.options.wysiwyg.odooEditor.observerActive();
     },
     /**
      * @override

--- a/addons/website/static/tests/tours/snippet_popup_add_remove.js
+++ b/addons/website/static/tests/tours/snippet_popup_add_remove.js
@@ -19,6 +19,30 @@ wTourUtils.registerWebsitePreviewTour('snippet_popup_add_remove', {
     in_modal: false,
     trigger: '.o_we_customize_panel',
     run: () => null,
+},
+...wTourUtils.clickOnSave(),
+...wTourUtils.clickOnEditAndWaitEditMode(),
+{
+    content: 'Toggle the visibility of the Popup',
+    in_modal: false,
+    trigger: '.o_we_invisible_el_panel .o_we_invisible_entry:contains("Popup")',
+}, {
+    content: 'Edit s_popup snippet(2)',
+    in_modal: false,
+    trigger: 'iframe #wrap.o_editable [data-snippet="s_popup"] h2',
+    run: function() {
+        // Simulating pressing enter.
+        const anchor = this.$anchor[0];
+        // Trick the editor into keyboardType === 'PHYSICAL' and press enter
+        anchor.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+        // Trigger editor's '_onInput' handler, which leads to historyRollback.
+        anchor.dispatchEvent(new InputEvent('input', { inputType: 'insertLineBreak', bubbles: true }));
+    }
+}, {
+    content: 'Check the s_popup was visible',
+    in_modal: false,
+    trigger: 'iframe #wrap.o_editable [data-snippet="s_popup"]:not(.d-none)',
+    run: () => null,
 }, {
     content: `Remove the s_popup snippet`,
     in_modal: false,


### PR DESCRIPTION
Description of the issue this PR addresses:

Pressing enter in the `s_popup` snippet after making it visible via the right panel would hide the popup. This occurred because the mutation observer detected changes which shows the modal and rolled them back during the `insertLineBreak` operation. This commit ensures that those mutations are not observed.

task-4255083

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
