### PR TITLE
[FIX] mail,project: constraint trigger when editing task assignees tracked field in batch

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4151,6 +4151,7 @@ class MailThread(models.AbstractModel):
         """
         if not self:
             return True
+        self = self.browse(set(self.ids)) # Filter duplicates to avoid triggering mail_followers_res_partner_res_model_id_uniq constraint
 
         new_partner_subtypes = dict()
 


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Install the Project App
2. Create a new task with two tags 'Tag A' and 'Tag B'
3. Go in the list view and group by tags
4. Select twice the same task (once in group 'Tag A' and the other in group 'Tag B')
5. Add an assignee to the tasks (in batch)
6. A constraint is triggered: "Error, a partner cannot follow twice the same object."

Fix:
-------------------
This constraint is triggered because we try to add twice the same follower to the same task at this line: https://github.com/odoo/odoo/blob/17.0/addons/mail/models/mail_thread.py#L4192 as we have "self" being a recordset containing twice the same task record (e.g. project.task(1,1)).

This seems to be a generic issue as it could also occur for helpdesk tickets for instance, where we also have assignees that we can modify in batch. And probably other models are affected too. So the fix was done in mail for this purpose. 

The fix consists to filter the duplicate records in self, in order to avoid creating multiple 'mail.followers' having the exact same (res_model,res_id,partner_id) combination, which leads to the SQL constraint error "mail_followers_res_partner_res_model_id_uniq".

task-3978491
version-17.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
