### PR TITLE
[FIX] account: allow salesman to Send & Print

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -441,9 +441,10 @@ class AccountMoveSend(models.TransientModel):
         """
         # create an attachment that will become 'invoice_pdf_report_file'
         # note: Binary is used for security reason
-        invoice.message_main_attachment_id = self.env['ir.attachment'].create(invoice_data['pdf_attachment_values'])
-        invoice.invalidate_recordset(fnames=['invoice_pdf_report_id', 'invoice_pdf_report_file'])
-        invoice.is_move_sent = True
+        invoice_sudo = invoice.sudo()
+        invoice_sudo.message_main_attachment_id = self.sudo().env['ir.attachment'].create(invoice_data['pdf_attachment_values'])
+        invoice_sudo.invalidate_recordset(fnames=['invoice_pdf_report_id', 'invoice_pdf_report_file'])
+        invoice_sudo.is_move_sent = True
 
     @api.model
     def _hook_if_errors(self, moves_data, from_cron=False, allow_fallback_pdf=False):
@@ -792,7 +793,7 @@ class AccountMoveSend(models.TransientModel):
             }
 
         return self._process_send_and_print(
-            self.move_ids,
+            self.move_ids.sudo(),
             wizard=self,
             allow_fallback_pdf=allow_fallback_pdf,
             **kwargs,

--- a/addons/account_edi_ubl_cii/wizard/account_move_send.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send.py
@@ -173,7 +173,7 @@ class AccountMoveSend(models.TransientModel):
 
         # during tests, no wkhtmltopdf, create the attachment for test purposes
         if tools.config['test_enable']:
-            self.env['ir.attachment'].create({
+            self.env['ir.attachment'].sudo().create({
                 'name': 'factur-x.xml',
                 'raw': xml_facturx,
                 'res_id': invoice.id,

--- a/addons/account_peppol/wizard/account_move_send.py
+++ b/addons/account_peppol/wizard/account_move_send.py
@@ -103,7 +103,7 @@ class AccountMoveSend(models.TransientModel):
             'demo': _('Demo'),
         }
         for wizard in self:
-            edi_user = wizard.company_id.account_edi_proxy_client_ids.filtered(
+            edi_user = wizard.company_id.sudo().account_edi_proxy_client_ids.filtered(
                 lambda usr: usr.proxy_type == 'peppol'
             )
             mode = mode_strings.get(edi_user.edi_mode)
@@ -137,7 +137,7 @@ class AccountMoveSend(models.TransientModel):
         if self.checkbox_send_peppol and self.enable_peppol:
             for move in self.move_ids:
                 if not move.peppol_move_state or move.peppol_move_state == 'ready':
-                    move.peppol_move_state = 'to_send'
+                    move.sudo().peppol_move_state = 'to_send'
 
         return super().action_send_and_print(force_synchronous=force_synchronous, allow_fallback_pdf=allow_fallback_pdf, **kwargs)
 


### PR DESCRIPTION
When a quotation has been confirmed, the invoice generated and confirmed by an accountant, the salesman of that first quotation has access to the invoice and its button "Send & Print". However, when trying to
generate the document and send it, he receives an access right error. The salesman should be able to Send & Print when the invoice has been confirmed by an accountant.

task-4378899