### PR TITLE
[IMP] hr: change default employee pivot row and column

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -256,7 +256,8 @@
             <field name="model">hr.employee</field>
             <field name="arch" type="xml">
                 <pivot string="New Employees Over Time" sample="1" js_class="hr_pivot_view">
-                    <field name="create_date" interval="month" type="row"/>
+                    <field name="job_id" type="row"/>
+                    <field name="create_date" interval="year" type="col"/>
                     <field name="id"/>
                     <field name="color" type="measure" invisible="1"/>
                     <field name="distance_home_work" type="measure" invisible="1"/>

--- a/addons/hr_contract/views/hr_employee_views.xml
+++ b/addons/hr_contract/views/hr_employee_views.xml
@@ -55,7 +55,7 @@
         <field name="priority">0</field>
         <field name="arch" type="xml">
             <field name="create_date" position="replace">
-                <field name="first_contract_date" interval="month" type="row"/>
+                <field name="first_contract_date" interval="year" type="col"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
The current pivot view for employees shows how many employees entered each month. It seems more useful to show on the rows each job position and on the columns, the year at which the employees entered the company.

Task: 4433247
