### PR TITLE
[IMP] event: send email asynchronously by default

### DIFF
--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -318,9 +318,10 @@ class EventRegistration(models.Model):
             return
 
         # either trigger the cron, either run schedulers immediately (scaling choice)
-        async_scheduler = self.env['ir.config_parameter'].sudo().get_param('event.event_mail_async')
+        async_scheduler = self.env['ir.config_parameter'].sudo().get_param('event.event_mail_async', True)
         if async_scheduler:
             self.env.ref('event.event_mail_scheduler')._trigger()
+            self.env.ref('mail.ir_cron_mail_scheduler_action')._trigger()
         else:
             # we could simply call _create_missing_mail_registrations and let cron do their job
             # but it currently leads to several delays. We therefore call execute until


### PR DESCRIPTION
Sending emails synchronously has the drawback of causing major unavailability issues in case of popular events. As a workaround, an asynchronous parameter was introduced in #155777.

Having the emails sent synchronously by default remains a problem: the unavailability starts as soon as the users register massively, and it is impossible to access to the backend in order to change the configuration.

We change the default behavior to be asynchronous, and we also make sure to trigger the Email Queue Manager. This way, the delay is reduced to the minimum.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
