### PR TITLE
[FIX] l10n_fr: xmlid of account is same as previous group template

### DIFF
--- a/addons/l10n_fr/data/template/account.account-fr.csv
+++ b/addons/l10n_fr/data/template/account.account-fr.csv
@@ -308,7 +308,7 @@
 "pcg_464","Debts payable on purchases of short-term investment securities","464000","liability_current","","True","Dettes sur acquisitions de valeurs mobilières de placement"
 "pcg_465","Debts receivable on realisation of short-term investment securities","465000","asset_current","","True","Créances sur cessions de valeurs mobilières de placement"
 "pcg_467","Other accounts payable and accrued liabilities","467000","liability_current","","False","Divers comptes créditeurs et charges à payer"
-"pcg_468","Other accounts receivable and accrued income","468600","liability_current","","True","Divers comptes débiteurs et produits à recevoir"
+"pcg_468_account","Other accounts receivable and accrued income","468000","liability_current","","True","Divers comptes débiteurs et produits à recevoir"
 "pcg_471","Suspense accounts","471000","asset_current","","True","Compte d'attente"
 "pcg_472","Suspense accounts","472000","asset_current","","True","Compte d'attente"
 "pcg_473","Suspense accounts","473000","asset_current","","True","Compte d'attente"


### PR DESCRIPTION
A new account template got the id pcg_468. The issue is that it is the same as a previous group.
When you reload the CoA, it will try to access the data behind each xmlid of account template.
It will then access a group template thinking it's an account, resulting in a bad field access and a traceback.

Appeared due to a bad fw-port of https://github.com/odoo/odoo/commit/0ebf80b613d229ef5fb07ea97d406496f9df6254

(also fixed the typo in the code)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
