### PR TITLE
[IMP] im_livechat: add continue button when chat bot is done

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.js
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.js
@@ -18,9 +18,14 @@ patch(ChatWindow.prototype, {
         this.livechatState = useState({ showCloseConfirmation: false });
     },
 
-    async close() {
+    async close({ withConfirmation = true } = {}) {
         const chatWindow = toRaw(this.props.chatWindow);
-        if (chatWindow.thread.id > 0 && !this.livechatState.showCloseConfirmation) {
+        if (
+            withConfirmation &&
+            !chatWindow.hasFeedbackPanel &&
+            chatWindow.thread.id > 0 &&
+            !this.livechatState.showCloseConfirmation
+        ) {
             this.state.actionsDisabled = true;
             this.livechatState.showCloseConfirmation = true;
         } else {
@@ -32,5 +37,9 @@ patch(ChatWindow.prototype, {
     onCloseConfirmationDialog() {
         this.state.actionsDisabled = false;
         this.livechatState.showCloseConfirmation = false;
+    },
+
+    onClickContinue() {
+        this.close({ withConfirmation: false });
     },
 });

--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
@@ -18,9 +18,11 @@
         </xpath>
         <xpath expr="//Composer" position="replace">
             <t t-if="chatbotService.inputEnabled">$0</t>
-            <t t-else="">
-                <span class="bg-200 py-1 text-center fst-italic" t-esc="chatbotService.inputDisabledText"/>
-            </t>
+            <div t-else="" class="bg-200 d-flex justify-content-center">
+                <span t-if="chatbotService.chatbot.completed" class="flex-grow-1"/>
+                <span class="text-center py-1 fst-italic flex-grow-1" t-esc="chatbotService.inputDisabledText"/>
+                <button t-if="chatbotService.chatbot.completed" class="btn btn-link btn-sm me-1" t-on-click="onClickContinue">Continue</button>
+            </div>
         </xpath>
     </t>
 </templates>

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_step_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_step_model.js
@@ -11,6 +11,7 @@ export class ChatbotStep extends Record {
             return this.scriptStep?.answers;
         },
     });
+    completed = false;
     selectedAnswer = Record.one("chatbot.script.answer");
     type = Record.attr("", {
         compute() {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_continue.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_continue.js
@@ -1,0 +1,25 @@
+import { registry } from "@web/core/registry";
+
+const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:contains("${text}")`;
+
+registry.category("web_tour.tours").add("website_livechat.chatbot_continue_tour", {
+    steps: () => [
+        {
+            trigger: messagesContain("Hello, what can I do for you?"),
+        },
+        {
+            trigger: ".o-livechat-root:shadow li:contains(No, thank you for your time.)",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow span:contains(Conversation ended...)",
+        },
+        {
+            trigger: ".o-livechat-root:shadow button:contains(Continue)",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow *:contains(Did we correctly answer your question?)",
+        },
+    ],
+});


### PR DESCRIPTION
When the chat bot is completed, the visitor is in a dead-end. He can either restart the script, or close the chat window. This PR adds a continue button to reach the feedback panel.

task-4433028

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
