### PR TITLE
[FIX] im_livechat: attach file button not opening file selector

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -49,7 +49,7 @@
                     t-ref="input-container"
                 >
                     <div t-if="!extended" t-attf-class="{{ actionsContainerClass }}">
-                        <Dropdown position="'top-start'" menuClass="'d-flex flex-column py-0'">
+                        <Dropdown t-if="partitionedActions.other.length > 0" position="'top-start'" menuClass="'d-flex flex-column py-0'">
                             <t t-call="mail.Composer.moreActions"/>
                             <t t-set-slot="content">
                                 <t t-call="mail.Composer.dropdownActions"/>
@@ -57,7 +57,7 @@
                         </Dropdown>
                     </div>
                     <div class="position-relative flex-grow-1">
-                        <t t-set="inputClasses" t-value="'o-mail-Composer-inputStyle form-control border-0 rounded-3'"/>
+                        <t t-set="inputClasses" t-value="{'o-mail-Composer-inputStyle form-control border-0 rounded-3': true, 'ps-2': partitionedActions.other.length === 0}"/>
                         <textarea class="o-mail-Composer-input o-mail-Composer-bg shadow-none overflow-auto"
                             t-att-class="inputClasses"
                             t-ref="textarea"

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -100,11 +100,16 @@ composerActionsRegistry
         sequenceQuick: 20,
     })
     .add("upload-files", {
-        condition: (component) =>
-            !(
+        condition: (component) => {
+            const thread = component.thread ?? component.message?.thread;
+            if (!thread?.allow_public_upload && component.store.self.type === "guest") {
+                return false;
+            }
+            return !(
                 component.thread?.channel_type === "whatsapp" &&
                 component.props.composer.attachments.length > 0
-            ),
+            );
+        },
         icon: "fa fa-paperclip",
         name: _t("Attach Files"),
         onClick: (component, action, ev) => {

--- a/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
@@ -61,6 +61,7 @@ class TestMailPublicPage(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         self._open_group_page_as_user('admin')
 
     def test_discuss_channel_public_page_as_guest(self):
+        self.channel.allow_public_upload = True
         self.start_tour(self.channel.invitation_url, "discuss_channel_as_guest_tour.js")
         guest = self.env['mail.guest'].search([('channel_ids', 'in', self.channel.id)], limit=1, order='id desc')
         self.assertIn("joined the channel", self.channel.message_ids[0].body)
@@ -72,6 +73,7 @@ class TestMailPublicPage(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         self.start_tour(self.channel.invitation_url, "discuss_channel_call_public_tour.js")
 
     def test_mail_group_public_page_as_guest(self):
+        self.channel.allow_public_upload = True
         self.start_tour(self.group.invitation_url, "discuss_channel_as_guest_tour.js")
         guest = self.env['mail.guest'].search([('channel_ids', 'in', self.channel.id)], limit=1, order='id desc')
         self.start_tour(self.group.invitation_url, self.tour, cookies={guest._cookie_name: guest._format_auth_cookie()})


### PR DESCRIPTION
Before this PR, the attachm file button in the composer was displayed even if upload was not allowed. Clicking on this button woudln't do anything since upload is forbidden.

This PR hides the upload file action is upload is not allowed.

task-4433082

https://github.com/odoo/enterprise/pull/76259