### PR TITLE
[FIX] google_address_autocomplete: neutralise

### DIFF
--- a/addons/google_address_autocomplete/data/neutralize.sql
+++ b/addons/google_address_autocomplete/data/neutralize.sql
@@ -1,0 +1,4 @@
+UPDATE ir_config_parameter
+   SET value = 'dummy'
+ WHERE key = 'google_address_autocomplete.google_places_api_key';
+


### PR DESCRIPTION
This commit adds the missing neutralization necessary for the
google_address_autocomplete module introduced in saas-18.1 in [1]

The purpose of the standard neutralization framework is to allow us to
create database copies that will not interact with external systems in
ways that could impact the production database (or if it is not possible
to prevent the interactions, make sure that they are benign or won't
result in actual changes), or impact the customers of the operator of
the production database.

This is mainly useful to allow safe support investigation on database
duplicates.

[1] https://github.com/odoo/odoo/pull/176262
