### PR TITLE
[IMP] (website_)sale: display unpublished combo's item images

### DIFF
--- a/addons/sale/static/src/js/models/product_product.js
+++ b/addons/sale/static/src/js/models/product_product.js
@@ -13,12 +13,14 @@ export class ProductProduct {
      * @param {number} product_tmpl_id
      * @param {string} display_name
      * @param {ProductTemplateAttributeLine[]|object[]} ptals
+     * @param {string} image_src
      */
-    setup({id, product_tmpl_id, display_name, ptals}) {
+    setup({id, product_tmpl_id, display_name, ptals, image_src}) {
         this.id = id;
         this.product_tmpl_id = product_tmpl_id;
         this.display_name = display_name;
         this.ptals = ptals.map(ptal => new ProductTemplateAttributeLine(ptal));
+        this.image_src = image_src;
     }
 
     /**

--- a/addons/sale/static/src/js/product_card/product_card.xml
+++ b/addons/sale/static/src/js/product_card/product_card.xml
@@ -10,7 +10,7 @@
             <div class="card-header p-0">
                 <img
                     class="w-100"
-                    t-attf-src="/web/image/product.product/{{props.product.id}}/image_128"
+                    t-att-src="props.product.image_src || `/web/image/product.product/${props.product.id}/image_128`"
                     alt="Product Image"
                 />
             </div>

--- a/addons/website_sale/controllers/combo_configurator.py
+++ b/addons/website_sale/controllers/combo_configurator.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.http import request, route
+from odoo.tools.image import image_data_uri
 
 from odoo.addons.sale.controllers.combo_configurator import SaleComboConfiguratorController
 from odoo.addons.website_sale.controllers.main import WebsiteSale
@@ -81,3 +82,20 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
         request.session['website_sale_cart_quantity'] = order_sudo.cart_quantity
 
         return values
+
+    def _get_combo_item_data(
+        self, combo, combo_item, selected_combo_item, date, currency, pricelist, **kwargs
+    ):
+        data = super()._get_combo_item_data(
+            combo, combo_item, selected_combo_item, date, currency, pricelist, **kwargs
+        )
+        # To sell a product type 'combo', one doesn't need to publish all combo choices. This causes
+        # an issue when public users access the image of each choice via the /web/image route. To
+        # bypass this access check, we send the raw image URL if the product is inaccessible to the
+        # current user.
+        if (
+            not combo_item.product_id.sudo(False).has_access('read')
+            and combo_item.product_id.image_128
+        ):
+            data['product']['image_src'] = image_data_uri(combo_item.product_id.image_128)
+        return data

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2032,7 +2032,22 @@
 
     <template id="cart_combo_item_line">
         <div class="d-flex align-items-center">
-            <div t-field="combo_item_line.product_id.image_128"
+            <!--
+                To sell a product type 'combo', one doesn't need to publish all combo choices. This
+                causes an issue when public users access the image of each choice via the /web/image
+                route. To bypass this access check, we send the raw image URL if the product is
+                inaccessible to the current user.
+            -->
+            <img
+                t-if="not combo_item_line.product_id.sudo(False).has_access('read')
+                      and combo_item_line.product_id.image_128"
+                t-att-src="image_data_uri(combo_item_line.product_id.image_128)"
+                class="o_image_64_max img rounded"
+                t-att-alt="combo_item_line.name_short"
+            />
+            <div
+                t-else=""
+                t-field="combo_item_line.product_id.image_128"
                  t-options="{
                     'widget': 'image',
                     'qweb_img_responsive': False,


### PR DESCRIPTION
Similarly to other types of products, combo products must be published to make them available in eCommerce. However, combo item products (i.e. the different choices in a combo) don't need to be published. Unfortunately, if a product is unpublished, public/portal users don't have access to its images, so they won't be shown in the combo configurator.

This is a bad UX, as public/portal users are expected to make a product selection, but we don't show them the corresponding images.

This PR uses the `src` attribute of the `img` tag to show the raw combo item's image instead of using the image url, bypassing access checks.

This is done only for combo items that are not published.

task-4337641

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
