### PR TITLE
[FIX] orm: assert relational field with comodel

### DIFF
--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -69,9 +69,8 @@ class _Relational(Field[M], typing.Generic[M]):
 
     def setup_nonrelated(self, model):
         super().setup_nonrelated(model)
-        if self.comodel_name not in model.pool:
-            _logger.warning("Field %s with unknown comodel_name %r", self, self.comodel_name)
-            self.comodel_name = '_unknown'
+        assert self.comodel_name in model.pool, \
+            f"Field {self} with unknown comodel_name {self.comodel_name or '???'!r}"
 
     def get_domain_list(self, model):
         """ Return a list domain from the domain parameter. """


### PR DESCRIPTION
Assert that the relational fields have a valid comodel in their environment instead of using `_unknown` which shows strange messages afterwards.

task-4213473


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
