### PR TITLE
[IMP] web: decrease text-muted opacity

### DIFF
--- a/addons/web/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden.scss
@@ -82,7 +82,7 @@ $link-shade-percentage: 30% !default;
 //
 // Style .text-muted elements
 
-$text-muted: $o-main-color-muted !default;
+$text-muted: rgba($o-main-text-color, 0.5) !default;
 
 // Grid columns
 //


### PR DESCRIPTION
The current opacity of text-muted is set to 0.76, which provides limited the contrast between elements.

Reducing the opacity of text-muted to 0.5 to improve visibility and contrast.

Task-4286482

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
