### PR TITLE
[IMP] l10n_in_pos: move HSN field after the product field

### DIFF
--- a/addons/l10n_in_pos/views/pos_order_line_views.xml
+++ b/addons/l10n_in_pos/views/pos_order_line_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='lines']/list/field[@name='full_product_name']" position="after">
-                <field name="l10n_in_hsn_code"/>
+                <field name="l10n_in_hsn_code" optional="hide"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
In this commit:
===
- Move `l10n_in_hsn_code` field in the order lines view to appear after the `product_id` field.

task-4432432

