### PR TITLE
[FIX] project_timesheet_holidays: prevent access error for non-timesheet users

### DIFF
--- a/addons/project_timesheet_holidays/models/project_task.py
+++ b/addons/project_timesheet_holidays/models/project_task.py
@@ -8,7 +8,7 @@ class ProjectTask(models.Model):
     _inherit = 'project.task'
 
     leave_types_count = fields.Integer(compute='_compute_leave_types_count', string="Time Off Types Count")
-    is_timeoff_task = fields.Boolean("Is Time off Task", compute="_compute_is_timeoff_task", search="_search_is_timeoff_task", export_string_translation=False)
+    is_timeoff_task = fields.Boolean("Is Time off Task", compute="_compute_is_timeoff_task", search="_search_is_timeoff_task", export_string_translation=False, groups="hr_timesheet.group_hr_timesheet_user")
 
     def _compute_leave_types_count(self):
         timesheet_read_group = self.env['account.analytic.line']._read_group(


### PR DESCRIPTION
Steps to reproduce
- Install the `project_timesheet_holidays` module along with all its related dependencies.
- Assign Demo user rights only in the Project user group(no additional rights in other apps).
- Log in as the Demo user.
- Navigate to: Project > Task.
- Click on a task that has an associated timesheet
- Observe that an access error is encountered.

Cause:
- The `is_timeoff_task` field is loaded for users without Timesheet access, causing an `AccessError` due to its dependency on `account.analytic.line`.
- In this commit, we are counting time-off tasks from the timesheet instead of the time-off type. The time-off type model was accessible to all users, so this issue didn’t happen before. See [this commit](https://github.com/odoo/odoo/commit/4f887a878b1ef23b0fd8eb7b440fd2aa04c9d36c#diff-4f3297774d04158af2337bf66b96044ae115007ac202fd96fa46760dfbc470e2L14) for details.

Solution:
- Restrict the field's loading and add the hr_timesheet.group_hr_timesheet_user group in the field definition to ensure it is only computed for authorized users.

task-4417760

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
