### PR TITLE
[FIX] account,l10n_sa_edi: tax values filter overwrite

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2921,6 +2921,9 @@ class AccountMove(models.Model):
     # BUSINESS METHODS
     # -------------------------------------------------------------------------
 
+    def _get_tax_lines_to_aggregate(self):
+        return self.line_ids.filtered(lambda x: x.display_type == 'tax')
+
     def _prepare_invoice_aggregated_taxes(self, filter_invl_to_apply=None, filter_tax_values_to_apply=None, grouping_key_generator=None):
         self.ensure_one()
 
@@ -2944,7 +2947,7 @@ class AccountMove(models.Model):
         # This difference is then distributed evenly across the 'tax_values_list' in 'to_process'
         # such that the manual and computed tax amounts match.
         # The updated tax information is later used by '_aggregate_taxes' to compute the right tax amounts (consistently on all levels).
-        tax_lines = self.line_ids.filtered(lambda x: x.display_type == 'tax')
+        tax_lines = self._get_tax_lines_to_aggregate()
         sign = -1 if self.is_inbound(include_receipts=True) else 1
 
         # Collect the tax_amount_currency/balance from tax lines.

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -210,6 +210,15 @@ class AccountMove(models.Model):
         zatca_doc_ids = self.edi_document_ids.filtered(lambda d: d.edi_format_id.code == 'sa_zatca')
         return len(zatca_doc_ids) > 0 and not any(zatca_doc_ids.filtered(lambda d: d.state == 'to_send'))
 
+    def _get_tax_lines_to_aggregate(self):
+        """
+        If the final invoice has downpayment lines, we skip the tax correction, as we need to recalculate tax amounts
+        without taking into account those lines
+        """
+        if self.country_code == 'SA' and not self._is_downpayment() and self.line_ids._get_downpayment_lines():
+            return self.env['account.move.line']
+        return super()._get_tax_lines_to_aggregate()
+
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -4,6 +4,7 @@ from freezegun import freeze_time
 import logging
 from pytz import timezone
 
+from odoo import Command
 from odoo.tests import tagged
 from odoo.tools import misc
 
@@ -31,6 +32,65 @@ class TestEdiZatca(TestSaEdiCommon):
             current_tree = self.with_applied_xpath(current_tree, self.remove_ubl_extensions_xpath)
 
             self.assertXmlTreeEqual(current_tree, expected_tree)
+
+    def testInvoiceWithDownpayment(self):
+
+        if 'sale' not in self.env["ir.module.module"]._installed():
+            self.skipTest("Sale module is not installed")
+
+        with freeze_time(datetime(year=2022, month=9, day=5, hour=8, minute=20, second=2, tzinfo=timezone('Etc/GMT-3'))):
+            self.partner_us.vat = 'US12345677'
+
+            pricelist = self.env['product.pricelist'].create({'name': 'SAR', 'currency_id': self.env.ref('base.SAR').id})
+            sale_order = self.env['sale.order'].create({
+                'partner_id': self.partner_us.id,
+                'pricelist_id': pricelist.id,
+                'order_line': [
+                    Command.create({
+                        'product_id': self.product_a.id,
+                        'price_unit': 1000,
+                        'product_uom_qty': 1,
+                        'tax_id': [Command.set(self.tax_15.ids)],
+                    })
+                ]
+            })
+            sale_order.action_confirm()
+
+            context = {
+                'active_model': 'sale.order',
+                'active_ids': [sale_order.id],
+                'active_id': sale_order.id,
+                'default_journal_id': self.company_data['default_journal_sale'].id,
+            }
+            downpayment = self.env['sale.advance.payment.inv'].with_context(context).create({
+                'advance_payment_method': 'fixed',
+                'fixed_amount': 100,
+                'deposit_taxes_id': [Command.set(self.tax_15.ids)],
+            })._create_invoices(sale_order)
+
+            final = self.env['sale.advance.payment.inv'].with_context(context).create({})._create_invoices(sale_order)
+
+            for move, test_file in (
+                (downpayment, "downpayment_invoice"),
+                (final, "final_invoice")
+            ):
+                move.write({
+                    'invoice_date': '2022-09-05',
+                    'invoice_date_due': '2022-09-22',
+                    'state': 'posted',
+                    'l10n_sa_confirmation_datetime': datetime.now(),
+                })
+                move._l10n_sa_generate_unsigned_data()
+
+                generated_file = self.env['account.edi.format']._l10n_sa_generate_zatca_template(move)
+                current_tree = self.get_xml_tree_from_string(generated_file)
+                current_tree = self.with_applied_xpath(current_tree, self.remove_ubl_extensions_xpath)
+
+                expected_file = misc.file_open(f'l10n_sa_edi/tests/test_files/{test_file}.xml', 'rb').read()
+                expected_tree = self.get_xml_tree_from_string(expected_file)
+                expected_tree = self.with_applied_xpath(expected_tree, self.invoice_applied_xpath)
+
+                self.assertXmlTreeEqual(current_tree, expected_tree)
 
     def testCreditNoteStandard(self):
 

--- a/addons/l10n_sa_edi/tests/test_files/downpayment_invoice.xml
+++ b/addons/l10n_sa_edi/tests/test_files/downpayment_invoice.xml
@@ -1,0 +1,200 @@
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+  <cbc:ID>INV/2022/00001</cbc:ID>
+  <cbc:UUID>7a06f916-5f83-4519-9355-89d778d246bd</cbc:UUID>
+  <cbc:IssueDate>2022-09-05</cbc:IssueDate>
+  <cbc:IssueTime>08:20:02</cbc:IssueTime>
+  <cbc:InvoiceTypeCode name="0100100">386</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
+  <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
+  <cbc:BuyerReference>Azure Interior</cbc:BuyerReference>
+  <cac:OrderReference>
+    <cbc:ID>INV/2022/00001</cbc:ID>
+  </cac:OrderReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>PIH</cbc:ID>
+    <cac:Attachment>
+      <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==</cbc:EmbeddedDocumentBinaryObject>
+    </cac:Attachment>
+  </cac:AdditionalDocumentReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>ICV</cbc:ID>
+    <cbc:UUID>0</cbc:UUID>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="CRN">2525252525252</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>SA Company Test</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Al Amir Mohammed Bin Abdul Aziz Street</cbc:StreetName>
+        <cbc:BuildingNumber>1234</cbc:BuildingNumber>
+        <cbc:PlotIdentification>1234</cbc:PlotIdentification>
+        <cbc:CitySubdivisionName>Testomania</cbc:CitySubdivisionName>
+        <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
+        <cbc:PostalZone>42317</cbc:PostalZone>
+        <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+        <cac:Country>
+          <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+          <cbc:Name>Saudi Arabia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:RegistrationName>SA Company Test</cbc:RegistrationName>
+        <cbc:CompanyID>311111111111113</cbc:CompanyID>
+        <cac:RegistrationAddress>
+          <cbc:StreetName>Al Amir Mohammed Bin Abdul Aziz Street</cbc:StreetName>
+          <cbc:BuildingNumber>1234</cbc:BuildingNumber>
+          <cbc:PlotIdentification>1234</cbc:PlotIdentification>
+          <cbc:CitySubdivisionName>Testomania</cbc:CitySubdivisionName>
+          <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
+          <cbc:PostalZone>42317</cbc:PostalZone>
+          <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cac:Country>
+            <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+            <cbc:Name>Saudi Arabia</cbc:Name>
+          </cac:Country>
+        </cac:RegistrationAddress>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>SA Company Test</cbc:RegistrationName>
+        <cbc:CompanyID>311111111111113</cbc:CompanyID>
+        <cac:RegistrationAddress>
+          <cbc:StreetName>Al Amir Mohammed Bin Abdul Aziz Street</cbc:StreetName>
+          <cbc:BuildingNumber>1234</cbc:BuildingNumber>
+          <cbc:PlotIdentification>1234</cbc:PlotIdentification>
+          <cbc:CitySubdivisionName>Testomania</cbc:CitySubdivisionName>
+          <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
+          <cbc:PostalZone>42317</cbc:PostalZone>
+          <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cac:Country>
+            <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+            <cbc:Name>Saudi Arabia</cbc:Name>
+          </cac:Country>
+        </cac:RegistrationAddress>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>407</cbc:ID>
+        <cbc:Name>SA Company Test</cbc:Name>
+        <cbc:Telephone>+966512345678</cbc:Telephone>
+        <cbc:ElectronicMail>info@company.saexample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="CRN">US12345677</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>Chichi Lboukla</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+        <cbc:BuildingNumber>12300</cbc:BuildingNumber>
+        <cbc:PlotIdentification>2323</cbc:PlotIdentification>
+        <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
+        <cbc:CityName>Fremont</cbc:CityName>
+        <cbc:PostalZone>94538</cbc:PostalZone>
+        <cbc:CountrySubentity>California</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+        <cac:Country>
+          <cbc:IdentificationCode>US</cbc:IdentificationCode>
+          <cbc:Name>United States</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Chichi Lboukla</cbc:RegistrationName>
+        <cbc:CompanyID>US12345677</cbc:CompanyID>
+        <cac:RegistrationAddress>
+          <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+          <cbc:BuildingNumber>12300</cbc:BuildingNumber>
+          <cbc:PlotIdentification>2323</cbc:PlotIdentification>
+          <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
+          <cbc:CityName>Fremont</cbc:CityName>
+          <cbc:PostalZone>94538</cbc:PostalZone>
+          <cbc:CountrySubentity>California</cbc:CountrySubentity>
+          <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+          <cac:Country>
+            <cbc:IdentificationCode>US</cbc:IdentificationCode>
+            <cbc:Name>United States</cbc:Name>
+          </cac:Country>
+        </cac:RegistrationAddress>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>411</cbc:ID>
+        <cbc:Name>Chichi Lboukla</cbc:Name>
+        <cbc:Telephone>+18709310505</cbc:Telephone>
+        <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cbc:ActualDeliveryDate>2022-09-05</cbc:ActualDeliveryDate>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode listID="UN/ECE 4461">1</cbc:PaymentMeansCode>
+    <cbc:PaymentDueDate>2022-09-22</cbc:PaymentDueDate>
+    <cbc:InstructionID>INV/2022/00001</cbc:InstructionID>
+    <cbc:PaymentID>INV/2022/00001</cbc:PaymentID>
+  </cac:PaymentMeans>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="SAR">100.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+      <cbc:Percent>15.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>15.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="SAR">100.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="SAR">100.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="SAR">115.00</cbc:TaxInclusiveAmount>
+    <cbc:AllowanceTotalAmount currencyID="SAR">0.00</cbc:AllowanceTotalAmount>
+    <cbc:PrepaidAmount currencyID="SAR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="SAR">115.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="SAR">100.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+      <cbc:RoundingAmount currencyID="SAR">115.00</cbc:RoundingAmount>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>Down Payment</cbc:Description>
+      <cbc:Name>Down payment</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>15.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="SAR">100.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_sa_edi/tests/test_files/final_invoice.xml
+++ b/addons/l10n_sa_edi/tests/test_files/final_invoice.xml
@@ -1,0 +1,244 @@
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+  <cbc:ID>INV/2022/00002</cbc:ID>
+  <cbc:UUID>f60b0627-777e-4374-b8a3-ea071d9220cc</cbc:UUID>
+  <cbc:IssueDate>2022-09-05</cbc:IssueDate>
+  <cbc:IssueTime>08:20:02</cbc:IssueTime>
+  <cbc:InvoiceTypeCode name="0100100">388</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
+  <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
+  <cbc:BuyerReference>Azure Interior</cbc:BuyerReference>
+  <cac:OrderReference>
+    <cbc:ID>INV/2022/00002</cbc:ID>
+  </cac:OrderReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>PIH</cbc:ID>
+    <cac:Attachment>
+      <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==</cbc:EmbeddedDocumentBinaryObject>
+    </cac:Attachment>
+  </cac:AdditionalDocumentReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>ICV</cbc:ID>
+    <cbc:UUID>0</cbc:UUID>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="CRN">2525252525252</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>SA Company Test</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Al Amir Mohammed Bin Abdul Aziz Street</cbc:StreetName>
+        <cbc:BuildingNumber>1234</cbc:BuildingNumber>
+        <cbc:PlotIdentification>1234</cbc:PlotIdentification>
+        <cbc:CitySubdivisionName>Testomania</cbc:CitySubdivisionName>
+        <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
+        <cbc:PostalZone>42317</cbc:PostalZone>
+        <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+        <cac:Country>
+          <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+          <cbc:Name>Saudi Arabia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:RegistrationName>SA Company Test</cbc:RegistrationName>
+        <cbc:CompanyID>311111111111113</cbc:CompanyID>
+        <cac:RegistrationAddress>
+          <cbc:StreetName>Al Amir Mohammed Bin Abdul Aziz Street</cbc:StreetName>
+          <cbc:BuildingNumber>1234</cbc:BuildingNumber>
+          <cbc:PlotIdentification>1234</cbc:PlotIdentification>
+          <cbc:CitySubdivisionName>Testomania</cbc:CitySubdivisionName>
+          <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
+          <cbc:PostalZone>42317</cbc:PostalZone>
+          <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cac:Country>
+            <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+            <cbc:Name>Saudi Arabia</cbc:Name>
+          </cac:Country>
+        </cac:RegistrationAddress>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>SA Company Test</cbc:RegistrationName>
+        <cbc:CompanyID>311111111111113</cbc:CompanyID>
+        <cac:RegistrationAddress>
+          <cbc:StreetName>Al Amir Mohammed Bin Abdul Aziz Street</cbc:StreetName>
+          <cbc:BuildingNumber>1234</cbc:BuildingNumber>
+          <cbc:PlotIdentification>1234</cbc:PlotIdentification>
+          <cbc:CitySubdivisionName>Testomania</cbc:CitySubdivisionName>
+          <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
+          <cbc:PostalZone>42317</cbc:PostalZone>
+          <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cac:Country>
+            <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+            <cbc:Name>Saudi Arabia</cbc:Name>
+          </cac:Country>
+        </cac:RegistrationAddress>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>316</cbc:ID>
+        <cbc:Name>SA Company Test</cbc:Name>
+        <cbc:Telephone>+966512345678</cbc:Telephone>
+        <cbc:ElectronicMail>info@company.saexample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="CRN">US12345677</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>Chichi Lboukla</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+        <cbc:BuildingNumber>12300</cbc:BuildingNumber>
+        <cbc:PlotIdentification>2323</cbc:PlotIdentification>
+        <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
+        <cbc:CityName>Fremont</cbc:CityName>
+        <cbc:PostalZone>94538</cbc:PostalZone>
+        <cbc:CountrySubentity>California</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+        <cac:Country>
+          <cbc:IdentificationCode>US</cbc:IdentificationCode>
+          <cbc:Name>United States</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Chichi Lboukla</cbc:RegistrationName>
+        <cbc:CompanyID>US12345677</cbc:CompanyID>
+        <cac:RegistrationAddress>
+          <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+          <cbc:BuildingNumber>12300</cbc:BuildingNumber>
+          <cbc:PlotIdentification>2323</cbc:PlotIdentification>
+          <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
+          <cbc:CityName>Fremont</cbc:CityName>
+          <cbc:PostalZone>94538</cbc:PostalZone>
+          <cbc:CountrySubentity>California</cbc:CountrySubentity>
+          <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+          <cac:Country>
+            <cbc:IdentificationCode>US</cbc:IdentificationCode>
+            <cbc:Name>United States</cbc:Name>
+          </cac:Country>
+        </cac:RegistrationAddress>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>320</cbc:ID>
+        <cbc:Name>Chichi Lboukla</cbc:Name>
+        <cbc:Telephone>+18709310505</cbc:Telephone>
+        <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cbc:ActualDeliveryDate>2022-09-05</cbc:ActualDeliveryDate>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode listID="UN/ECE 4461">1</cbc:PaymentMeansCode>
+    <cbc:PaymentDueDate>2022-09-22</cbc:PaymentDueDate>
+    <cbc:InstructionID>INV/2022/00002</cbc:InstructionID>
+    <cbc:PaymentID>INV/2022/00002</cbc:PaymentID>
+  </cac:PaymentMeans>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="SAR">150.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="SAR">1000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="SAR">150.00</cbc:TaxAmount>
+      <cbc:Percent>15.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>15.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="SAR">150.00</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="SAR">1000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="SAR">1000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="SAR">1150.00</cbc:TaxInclusiveAmount>
+    <cbc:AllowanceTotalAmount currencyID="SAR">0.00</cbc:AllowanceTotalAmount>
+    <cbc:PrepaidAmount currencyID="SAR">115.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="SAR">1035.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="SAR">1000.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="SAR">150.00</cbc:TaxAmount>
+      <cbc:RoundingAmount currencyID="SAR">1150.00</cbc:RoundingAmount>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>[P0001] Product A</cbc:Description>
+      <cbc:Name>Product A</cbc:Name>
+      <cac:SellersItemIdentification>
+        <cbc:ID>P0001</cbc:ID>
+      </cac:SellersItemIdentification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>15.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="SAR">1000.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>2</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="SAR">0.00</cbc:LineExtensionAmount>
+    <cac:DocumentReference>
+      <cbc:ID>INV/2022/00001</cbc:ID>
+      <cbc:IssueDate>2022-09-05</cbc:IssueDate>
+      <cbc:IssueTime>08:20:02</cbc:IssueTime>
+      <cbc:DocumentTypeCode>386</cbc:DocumentTypeCode>
+    </cac:DocumentReference>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+      <cbc:RoundingAmount currencyID="SAR">0.00</cbc:RoundingAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="SAR">100.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+        <cbc:Percent>15.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cbc:ID>S</cbc:ID>
+          <cbc:Percent>15.0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>Down Payment: 09 2022 (Draft)</cbc:Description>
+      <cbc:Name>Down payment</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>15.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="SAR">0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>


### PR DESCRIPTION
When exporting a SA E-invoice file, the system needs to collect
invoice line without downpayment lines. However, when collecting tax
values, because of an error correction mechanism, the tax amount will
still include the amount of the downpayment tax line

Steps to reproduce (with SA localization installed and SA company):
- Create a SO of 1000$ with 15% tax
- Make a downpayment of 100$ with 15% tax and confirm
- Make the final invoice with downpayment deducted
- Confirm and send e-invoice for validation

Issue: The invoice is validated, but a warning is logged
```
Invoice was Accepted by ZATCA (with Warnings)
The invoice was accepted by ZATCA, but returned warnings. Please, check the response below:

BR-CO-17: VAT category tax amount (BT-117) = VAT category taxable amount (BT-116) x (VAT category rate (BT-119) / 100), rounded to two decimals.
BR-S-09: The VAT category tax amount (BT-117) in a VAT breakdown (BG-23) where VAT category code (BT-118) is Standard rated shall equal the VAT category taxable amount (BT-116) multiplied by the VAT category rate (BT-119).
```

As the warning states the is an issue with the tax computation.
When collecting amounts from the final invoice, we should
filter out downpayment amounts, but due to the error correction
mechanism introduced to account for manual modification of the journal
items, the filter is ignored, so we will have the filtered base amount
(1000) and the unfiltered tax amount (135 instead of 150)

A possible solution is to avoid the error correction when we know we
need to filter invoice lines

opw-4380798