### PR TITLE
[FIX] requirements: bump rjsmin to 1.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ reportlab==4.1.0 ; python_version >= '3.12' # (Noble) Mostly to have a wheel pac
 requests==2.25.1 ;  python_version < '3.11' # versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
 requests==2.31.0 ; python_version >= '3.11' # (Noble)
 rjsmin==1.1.0 ; python_version < '3.11'  # (jammy)
-rjsmin==1.2.0 ; python_version >= '3.11'
+rjsmin==1.2.2 ; python_version >= '3.11'
 rl-renderPM==4.0.3 ; sys_platform == 'win32' and python_version >= '3.12'  # Needed by reportlab 4.1.0 but included in deb package
 urllib3==1.26.5 ; python_version < '3.12' # indirect / min version = 1.25.8 (Focal with security backports)
 urllib3==2.0.7  ; python_version >= '3.12'  # (Noble) Compatibility with cryptography


### PR DESCRIPTION
1.2.0 requires GCC profiling records which aren't available on the system

Description of the issue/feature this PR addresses: https://github.com/odoo/odoo/issues/191873

Current behavior before PR: Every odoo start/import throws an warning about missing gcda files

Desired behavior after PR is merged: No warning about missing files on odoo start/import




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
