### PR TITLE
[IMP] event: trigger Email Queue Manager

### DIFF
--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -319,6 +319,7 @@ class EventRegistration(models.Model):
         async_scheduler = self.env['ir.config_parameter'].sudo().get_param('event.event_mail_async')
         if async_scheduler:
             self.env.ref('event.event_mail_scheduler')._trigger()
+            self.env.ref('mail.ir_cron_mail_scheduler_action')._trigger()
         else:
             # we could simply call _create_missing_mail_registrations and let cron do their job
             # but it currently leads to several delays. We therefore call execute until

--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -525,11 +525,13 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
         """ Async mode for schedulers activated, should not send communication
         in the same transaction. """
         test_event = self.test_event.with_env(self.env)
-        cron = self.env.ref('event.event_mail_scheduler')
+        cron_event = self.env.ref('event.event_mail_scheduler')
+        cron_mail = self.env.ref('mail.ir_cron_mail_scheduler_action')
         reference_now = self.reference_now
 
         self.env['ir.config_parameter'].sudo().set_param('event.event_mail_async', True)
-        with self.capture_triggers(cron.id) as capt, \
+        with self.capture_triggers(cron_event.id) as capt_event, \
+             self.capture_triggers(cron_mail.id) as capt_mail, \
              self.mock_datetime_and_now(reference_now + relativedelta(minutes=10)), \
              self.mock_mail_gateway():
             existing = self.env['event.registration'].create([
@@ -541,13 +543,14 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
             ])
         self.assertEqual(len(self._new_mails), 0)
         self.assertEqual(self.mail_mail_create_mocked.call_count, 0)
-        capt.records.ensure_one()
-        self.assertEqual(capt.records.call_at, reference_now.replace(microsecond=0) + relativedelta(minutes=10))
+        capt_event.records.ensure_one()
+        self.assertEqual(capt_event.records.call_at, reference_now.replace(microsecond=0) + relativedelta(minutes=10))
+        capt_mail.records.ensure_one()
 
         # run cron: emails should be send for registrations
         with self.mock_datetime_and_now(reference_now + relativedelta(minutes=10)), \
              self.mock_mail_gateway():
-            cron.sudo().method_direct_trigger()
+            cron_event.sudo().method_direct_trigger()
         self.assertMailMailWEmails(
             [formataddr((reg.name, reg.email)) for reg in existing],
             "outgoing",


### PR DESCRIPTION
In async mode, trigger both the Mail Scheduler and the Email Queue
Manager.

Rationale
=========

By default, the Email Queue Manager is run once an hour. In case of the
event registration confirmation, it can lead to a lag between the
confirmation and the email received. However, end users tend to expect
a confirmation email incoming within a few minutes.

By triggering the email queue, it leads to a behavior which is closer
to the synchronous configuration.