### PR TITLE
[FIX] iot_box_image: odoo user camera rights

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -220,6 +220,7 @@ chown odoo:odoo "/home/pi/odoo.conf"
 
 groupadd usbusers
 usermod -a -G usbusers odoo
+usermod -a -G video odoo
 usermod -a -G lp odoo
 usermod -a -G input lightdm
 usermod -a -G pi odoo


### PR DESCRIPTION
As Odoo service is now managed by Odoo user, we need to ensure it has access to camera devices.
