### PR TITLE
[FIX] mail: recipient list overflow when screen size is increased

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -76,7 +76,7 @@
             <t t-if="state.composerType">
                 <t t-if="state.composerType === 'message'">
                     <div class="d-flex flex-shrink-0 pt-3 text-truncate small mb-2 ms-5">
-                        <span class="fw-bold">To:</span> <span t-if="toRecipientsText" t-out="toRecipientsText" class="ps-1"/>
+                        <span class="fw-bold">To:</span> <span t-if="toRecipientsText" t-out="toRecipientsText" class="ps-1 text-wrap"/>
                         <SuggestedRecipientsList t-elif="state.thread.suggestedRecipients.length > 0" className="'ps-2'" thread="state.thread" onSuggestedRecipientAdded.bind="onSuggestedRecipientAdded"/>
                         <span t-else="" class="ps-1">No recipient</span>
                         <button t-if="state.thread.recipients.length > 0" class="o-mail-Chatter-recipientListButton btn btn-link badge rounded-pill border-0 p-1 ms-1" title="Show all recipients" t-on-click="onClickRecipientList">


### PR DESCRIPTION
Purpose of the commit:
The recipient list overflows when the screen size is increased.
This commit resolves the issue by showing the overflowing text
 on the next line.

task-4417552
