### PR TITLE
[FIX] base: Fix display_name visibility

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -57,7 +57,7 @@
             <field eval="8" name="priority"/>
             <field name="arch" type="xml">
                 <tree string="Contacts" sample="1" multi_edit="1">
-                    <field name="display_name" string="Name" invisible="1"/>
+                    <field name="display_name" string="Name" column_invisible="1"/>
                     <field name="complete_name" string="Name"/>
                     <field name="function" column_invisible="True"/>
                     <field name="phone" class="o_force_ltr" optional="show"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- A recent change in the contact's list view introduces a small bug, due to which, now a blank column for display name appears. commit ensure correct attribute value for list view.
- [commit](https://github.com/odoo/odoo/commit/76aa55dbfcce535d645270448b096ed8cfede104) that introduces issue.


Current behavior before PR:
- a blank column is visible 
![contact](https://github.com/user-attachments/assets/4a9c9d83-9a1d-4fe8-a6a0-2e41daf34daa)


Desired behavior after PR is merged:
- `display_name` field is hidden properly. 
![image](https://github.com/user-attachments/assets/821393de-1741-4e1c-a06c-7bcf50c65448)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
