### PR TITLE
[IMP] point_of_sale: product name out of card

### DIFF
--- a/addons/point_of_sale/static/src/app/components/category_selector/category_selector.xml
+++ b/addons/point_of_sale/static/src/app/components/category_selector/category_selector.xml
@@ -13,7 +13,7 @@
                         class="category-img-thumb h-100 rounded-3 object-fit-cover me-1"
                         alt="Category"
                     />
-                    <span t-if="category.name" class="text-wrap-categ text-center fs-5" t-esc="category.name" />
+                    <span t-if="category.name" class="text-wrap-categ justify-content-center w-100 fs-5" t-esc="category.name" />
                 </button>
             </t>
         </div>

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
@@ -19,9 +19,7 @@
                     t-att-class="{'no-image d-flex justify-content-center align-items-center text-center fs-4': !props.imageUrl}"
                     t-attf-id="article_product_{{props.productId}}"
                     t-esc="props.name" />
-                <h1 t-if="props.productCartQty"
-                    t-out="props.productCartQty"
-                    class="product-cart-qty text-muted display-6 fw-bolder m-0 mt-auto" />
+                <t t-tag="props.imageUrl ? 'h1' : 'h2'" t-if="props.productCartQty" t-out="props.productCartQty" class="product-cart-qty text-muted fw-bolder m-0 mt-auto" />
             </div>
         </article>
     </t>


### PR DESCRIPTION
Following this commit :
====
- When a product does not have an image then the product quantity is not aligned properly in the product card due to the bigger heading tag which is been handled now.
- Category name is also aligned to center when category does not have
image associated with it.

task-4432493
