### PR TITLE
[FIX] pos_loyalty: prevent traceback when applying discount code coupons

### DIFF
--- a/addons/pos_loyalty/i18n/pos_loyalty.pot
+++ b/addons/pos_loyalty/i18n/pos_loyalty.pot
@@ -652,6 +652,12 @@ msgstr ""
 #. module: pos_loyalty
 #. odoo-python
 #: code:addons/pos_loyalty/models/pos_config.py:0
+msgid "This programs requires a code to be applied."
+msgstr ""
+
+#. module: pos_loyalty
+#. odoo-python
+#: code:addons/pos_loyalty/models/pos_config.py:0
 msgid ""
 "To continue, make the following reward products available in Point of Sale."
 msgstr ""

--- a/addons/pos_loyalty/models/pos_config.py
+++ b/addons/pos_loyalty/models/pos_config.py
@@ -95,6 +95,8 @@ class PosConfig(models.Model):
             error_message = _("No reward can be claimed with this coupon.")
         elif program.pricelist_ids and pricelist_id not in program.pricelist_ids.ids:
             error_message = _("This coupon is not available with the current pricelist.")
+        elif coupon and program.program_type == 'promo_code':
+            error_message = _("This programs requires a code to be applied.")
 
         if error_message:
             return {


### PR DESCRIPTION
Steps:
- Create a discount program with `Discount Code` as the program type.
- Add a coupon for the program using the stat button.
- Open the POS UI and add products to the cart.
- Apply the coupon to the cart.

Issue:
- A traceback error occurs when applying that coupon.

Fix:
- added a validation warning when a user attempts to apply a coupon code from a discount code program type (similar to sales)

Task - 4422507

