### PR TITLE
[FIX] point_of_sale: remove unused widget from barcode field

### DIFF
--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -183,7 +183,7 @@
                     <field name="image_1920" widget="image" class="oe_avatar" nolabel="1" options="{'convert_to_webp': True,'preview_image': 'image_128'}"/>
                     <group name="name">
                             <field name="name" class="oe_inline" placeholder="e.g. Cheese Burger" string="Product Name"/>
-                            <field name="barcode" class="oe_inline" placeholder="e.g. 1234567890" widget="productScanner"/>
+                            <field name="barcode" class="oe_inline" placeholder="e.g. 1234567890"/>
                             <label for="is_storable" class="oe_inline" invisible="type != 'consu'"/>
                             <div class="o_row w-100" invisible="type != 'consu'">
                                 <field name="is_storable"/>


### PR DESCRIPTION
Before this commit:
===
- The `productScanner` widget was assigned to the barcode field in the point_of_sale module, but this widget is not defined in the module.

After this commit:
===
- The `productScanner` widget has been removed from the barcode field.

Related: https://github.com/odoo/enterprise/pull/76250