### PR TITLE
[FIX] mrp: unbuild uses incorrect move quantities

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -136,7 +136,7 @@ class MrpUnbuild(models.Model):
         return {
             'move_id': finished_move.id,
             'lot_id': self.lot_id.id,
-            'qty_done': self.product_qty,
+            'qty_done': finished_move.product_uom_qty,
             'product_id': finished_move.product_id.id,
             'product_uom_id': finished_move.product_uom.id,
             'location_id': finished_move.location_id.id,


### PR DESCRIPTION
Steps to reproduce:
Not reproducible in V16. However, in older versions, it was possible to have multiple finished_moves with different quantities (see https://github.com/odoo/odoo/pull/46718).

This fix ensures such issues are avoided in the future and also addresses potential problems for clients migrating from older versions.

Example:
Two finished_moves with different quantities.
Before the fix, both moves would be updated based
on the unbuild quantity, resulting in incorrect quantities. After the fix, the moves for unbuild will use only the move's quantity.

opw-4379204
