### PR TITLE
[FIX] l10n_in_gstin_status: neutralisation

### DIFF
--- a/addons/l10n_in/data/neutralize.sql
+++ b/addons/l10n_in/data/neutralize.sql
@@ -1,0 +1,3 @@
+UPDATE res_company
+   SET l10n_in_edi_production_env = false;
+

--- a/addons/l10n_in_edi/data/neutralize.sql
+++ b/addons/l10n_in_edi/data/neutralize.sql
@@ -1,7 +1,6 @@
 -- disable l10n_in_edi integration
 UPDATE res_company
-   SET l10n_in_edi_production_env = false,
-       l10n_in_edi_username = NULL,
+   SET l10n_in_edi_username = NULL,
        l10n_in_edi_password = NULL,
        l10n_in_edi_token = NULL,
        l10n_in_edi_token_validity = NULL;


### PR DESCRIPTION
Since [1], the filed `l10n_in_edi_production_env` has been moved from
module `l10n_in_edi` to `l10n_in`. `l10n_in_gstin_status` needs to
be neutralized to not hit the production servers, but it does not depend
on the `l1on_in_edi` module which holds the neutralization script.

Even if the `l10n_in_gstin_status` does not end up performing operation
that require a strict neutralization, future modules that also depend
solely on `l10n_in` might not be so lucky, rendering this change
absolutely necessary.

The purpose of the standard neutralization framework is to allow us to
create database copies that will not interact with external systems in
ways that could impact the production database (or if it is not possible
to prevent the interactions, make sure that they are benign or won't
result in actual changes), or impact the customers of the operator of
the production database.

This is mainly useful to allow safe support investigation on database
duplicates.

[1] https://github.com/odoo/odoo/pull/175290