### PR TITLE
[FIX] web: prevent daterange from closing in list view

### DIFF
--- a/addons/web/static/src/views/fields/daterange/daterange_field.js
+++ b/addons/web/static/src/views/fields/daterange/daterange_field.js
@@ -41,6 +41,14 @@ export class DateRangeField extends Component {
                     window.$(el).on("show.daterangepicker", this.onPickerShow.bind(this));
                     window.$(el).on("hide.daterangepicker", this.onPickerHide.bind(this));
 
+                    this.pickerContainer.addEventListener(
+                        "click",
+                        (ev) => {
+                            ev.isFromDateRangePicker = true;
+                        },
+                        { capture: true }
+                    );
+
                     this.pickerContainer.dataset.name = this.props.name;
                 }
 

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1617,7 +1617,7 @@ export class ListRenderer extends Component {
             return;
         }
         // Legacy DatePicker
-        if (target.closest(".daterangepicker")) {
+        if (target.closest(".daterangepicker") || ev.isFromDateRangePicker) {
             return;
         }
         // Legacy autocomplete


### PR DESCRIPTION
Steps to reproduce
==================

- Add a daterange widget to an x2many view (with studio)
- Open the picker
- Click on the next month

=> The picker closes

Cause of the issue
==================

The previous/next handler [0] rerenders the datetime picker.
By the time the list renderer intercepts the click, the ev target is no longer connected to the DOM.
This means that `.closest(".daterangepicker")` returns nothing.

Solution
========

We can add a property `isFromDateRangePicker` to the event in the capture phase and check that after the rerender.

---

[0]: https://github.com/odoo/odoo/blob/2a1857db4bee43ff266b4be279791c9b5c957085/addons/web/static/lib/daterangepicker/daterangepicker.js#L1231-L1253

opw-4375790