### PR TITLE
[IMP] hr: add method to fetch employee contract periods

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -2224,3 +2224,68 @@ class HrEmployee(models.Model):
         self.ensure_one()
         self.action_unarchive()
         self.departure_id.unlink()
+
+    def _get_working_periods_by_field(self, start, stop, field_key):
+        """
+        Compute working periods for employees grouped by a related field.
+
+        This method builds a mapping of working periods for each employee,
+        grouped by the provided ``field_key`` (e.g. resource_id, user_id).
+        It considers employee contracts and falls back to the full period
+        if no contract exists.
+
+        :param start: Start datetime of the period (string or datetime).
+        :param stop: End datetime of the period (string or datetime).
+        :param field_key: Name of the relational field on hr.employee used
+                        to group working periods.
+                          Example values:
+                            - 'resource_id'
+                            - 'user_id'
+                            - any Many2one field usable in views
+                          This allows the result to align with views that
+                          operate on non-employee models.
+        """
+
+        working_periods = {employee[field_key].id: [] for employee in self}
+
+        if self.ids:
+            start, stop = fields.Datetime.from_string(start), fields.Datetime.from_string(stop)
+
+            # Fetch employees that have at least one version with a contract
+            employees_with_contract = self.env["hr.version"].sudo().search_fetch(
+                domain=[
+                    ("employee_id", "in", self.ids),
+                    ('contract_date_start', '!=', False),
+                ],
+                field_names=["employee_id"],
+            ).employee_id
+
+            # Directly search for overlapping contracts to optimize performance
+            contracts = self.env["hr.version"].sudo().search([
+                ('employee_id', 'in', employees_with_contract.ids),
+                ('contract_date_start', '!=', False),
+                ('contract_date_start', '<=', stop.date()),
+                '|',
+                ('contract_date_end', '>=', start.date()),
+                ('contract_date_end', '=', False),
+            ])
+
+            employees_with_contract_in_current_scale = []
+            for contract in contracts:
+                employee = contract.employee_id
+                field_key_id = employee[field_key].id
+                end_datetime = contract.contract_date_end and contract.contract_date_end + relativedelta(hour=23, minute=59, second=59)
+                if end_datetime:
+                    end_datetime = end_datetime.replace(tzinfo=self.env.tz).astimezone(UTC).replace(tzinfo=None)
+                    end_datetime = fields.Datetime.to_string(end_datetime)
+                employees_with_contract_in_current_scale.append(employee.id)
+                working_periods[field_key_id].append({
+                    "start": fields.Datetime.to_string(contract.contract_date_start),
+                    "end": end_datetime,
+                })
+            for employee in self - employees_with_contract:
+                working_periods[employee[field_key].id].append({
+                    "start": start,
+                    "end": stop,
+                })
+        return working_periods

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -2221,3 +2221,62 @@ class HrEmployee(models.Model):
         self.ensure_one()
         self.action_unarchive()
         self.departure_id.unlink()
+
+    def _get_working_periods_by_field(self, start, stop, field_key):
+        """
+        Compute working periods for employees grouped by a related field.
+
+        This method builds a mapping of working periods for each employee,
+        grouped by the provided ``field_key`` (e.g. resource_id, user_id).
+        It considers employee contracts and falls back to the full period
+        if no contract exists.
+
+        :param start: Start datetime of the period (string or datetime).
+        :param stop: End datetime of the period (string or datetime).
+        :param field_key: Name of the relational field on hr.employee used
+                        to group working periods.
+                          Example values:
+                            - 'resource_id'
+                            - 'user_id'
+                            - any Many2one field usable in views
+                          This allows the result to align with views that
+                          operate on non-employee models.
+        """
+
+        working_periods = {employee[field_key].id: [] for employee in self}
+
+        if self.ids:
+            start, stop = fields.Datetime.from_string(start), fields.Datetime.from_string(stop)
+
+            employees_with_contract = dict(
+                self.env["hr.version"].sudo()._read_group(
+                    domain=[
+                        ("employee_id", "in", self.ids),
+                        ('contract_date_start', '!=', False),
+                    ],
+                    groupby=["employee_id"],
+                    aggregates=["__count"],
+                )
+            )
+            contracts = self.sudo()._get_versions_with_contract_overlap_with_period(start.date(), stop.date())
+            employees_with_contract_in_current_scale = []
+            for contract in contracts:
+                employee = contract.employee_id
+                field_key_id = employee[field_key].id
+                end_datetime = contract.contract_date_end and contract.contract_date_end + relativedelta(hour=23, minute=59, second=59)
+                if end_datetime:
+                    end_datetime = end_datetime.replace(tzinfo=self.env.tz).astimezone(UTC).replace(tzinfo=None)
+                    end_datetime = fields.Datetime.to_string(end_datetime)
+                employees_with_contract_in_current_scale.append(employee.id)
+                working_periods[field_key_id].append({
+                    "start": fields.Datetime.to_string(contract.contract_date_start),
+                    "end": end_datetime,
+                })
+            for employee in self - self.env["hr.employee"].browse(employees_with_contract_in_current_scale):
+                if employees_with_contract.get(employee):
+                    continue
+                working_periods[employee[field_key].id].append({
+                    "start": start,
+                    "end": stop,
+                })
+        return working_periods

--- a/addons/hr/static/tests/mock_server/mock_models/hr_employee.js
+++ b/addons/hr/static/tests/mock_server/mock_models/hr_employee.js
@@ -1,5 +1,6 @@
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 
+import { Domain } from "@web/core/domain";
 import { fields, models } from "@web/../tests/web_test_helpers";
 
 export class HrEmployee extends models.ServerModel {
@@ -39,6 +40,45 @@ export class HrEmployee extends models.ServerModel {
             );
         }
         return res;
+    }
+
+    _get_working_periods_by_field(employeeIds, start_time, end_time, field_key) {
+        const employeeToFieldId = Object.fromEntries(
+            this.env["hr.employee"]
+                .browse(employeeIds)
+                .map((employee) => [employee.id, employee[field_key]])
+        );
+        const periodsByFieldId = Object.fromEntries(
+            Object.values(employeeToFieldId).map((fieldId) => [fieldId, []])
+        );
+        const fieldPath = `employee_id.${field_key}`;
+        if (employeeIds.size) {
+            const contractGroups = this.env["hr.version"].formatted_read_group(
+                new Domain([["employee_id", "in", [...employeeIds]]]).toList(),
+                ["employee_id", fieldPath, "contract_date_start:day", "contract_date_end:day"],
+                [],
+                "",
+                "",
+                ""
+            );
+            contractGroups.forEach((group) => {
+                const fieldId = group[fieldPath][0];
+                periodsByFieldId[fieldId].push({
+                    start: group["contract_date_start:day"][1],
+                    end: group["contract_date_end:day"][1],
+                });
+            });
+
+            const employeesWithContracts = new Set(contractGroups.map((g) => g.employee_id[0]));
+
+            employeeIds.difference(employeesWithContracts).forEach((employeeId) => {
+                periodsByFieldId[employeeToFieldId[employeeId]].push({
+                    start: start_time,
+                    end: end_time,
+                });
+            });
+        }
+        return periodsByFieldId;
     }
 
     _views = {

--- a/addons/hr/static/tests/mock_server/mock_models/hr_employee.js
+++ b/addons/hr/static/tests/mock_server/mock_models/hr_employee.js
@@ -1,5 +1,6 @@
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 
+import { Domain } from "@web/core/domain";
 import { fields, models } from "@web/../tests/web_test_helpers";
 
 export class HrEmployee extends models.ServerModel {
@@ -38,6 +39,45 @@ export class HrEmployee extends models.ServerModel {
             );
         }
         return res;
+    }
+
+    _get_working_periods_by_field(employeeIds, start_time, end_time, field_key) {
+        const employeeToFieldId = Object.fromEntries(
+            this.env["hr.employee"]
+                .browse(employeeIds)
+                .map((employee) => [employee.id, employee[field_key]])
+        );
+        const periodsByFieldId = Object.fromEntries(
+            Object.values(employeeToFieldId).map((fieldId) => [fieldId, []])
+        );
+        const fieldPath = `employee_id.${field_key}`;
+        if (employeeIds.size) {
+            const contractGroups = this.env["hr.version"].formatted_read_group(
+                new Domain([["employee_id", "in", [...employeeIds]]]).toList(),
+                ["employee_id", fieldPath, "contract_date_start:day", "contract_date_end:day"],
+                [],
+                "",
+                "",
+                ""
+            );
+            contractGroups.forEach((group) => {
+                const fieldId = group[fieldPath][0];
+                periodsByFieldId[fieldId].push({
+                    start: group["contract_date_start:day"][1],
+                    end: group["contract_date_end:day"][1],
+                });
+            });
+
+            const employeesWithContracts = new Set(contractGroups.map((g) => g.employee_id[0]));
+
+            employeeIds.difference(employeesWithContracts).forEach((employeeId) => {
+                periodsByFieldId[employeeToFieldId[employeeId]].push({
+                    start: start_time,
+                    end: end_time,
+                });
+            });
+        }
+        return periodsByFieldId;
     }
 
     _views = {

--- a/addons/hr/tests/__init__.py
+++ b/addons/hr/tests/__init__.py
@@ -18,6 +18,7 @@ from . import test_hr_department
 from . import test_hr_version
 from . import test_hr_contract_versions
 from . import test_flexible_resource_calendar
+from . import test_get_employee_working_periods
 from . import test_multiple_bank_accounts
 from . import test_hr_org_chart
 from . import test_utils

--- a/addons/hr/tests/test_get_employee_working_periods.py
+++ b/addons/hr/tests/test_get_employee_working_periods.py
@@ -1,0 +1,138 @@
+from odoo import fields
+
+from odoo.tests import tagged
+
+from .common import TestHrCommon
+
+
+@tagged('at_install', '-post_install')  # LEGACY at_install
+class TestPlanningGanttResourceEmployeeWorkingPeriods(TestHrCommon):
+    """
+        Currently _get_working_periods_by_field method supplies contract data.
+        The goal is check if the method correctly filters contracts.
+        Test Goals -
+        1). Contract in State "draft" is only chosen if its kanban_state is in "done"
+        2). Contracts in States "open" and "close" are chosen regardless of the kanban_state
+        3). Any other type of combination is not accepted and takes its working period as default scale time
+        Here the context dates refer to dates we from gantt view through the RPC request sent. These refer to
+        start date and end dates of the scale. If the scale is week, the starting date of week is default_start_datetime
+        and end date if weeek is default_end_datetime.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.tz = 'UTC'
+
+        cls.contract_start_date = "2024-08-15 00:00:00"
+        cls.contract_end_date = "2024-08-16 23:59:59"
+        field_key_dict = {"field_key": "resource_id"}
+
+        cls.context_dates_inside_contracts = {
+            "start": fields.Datetime.to_datetime("2024-08-11 10:00:00"),
+            "stop": fields.Datetime.to_datetime("2024-08-17 19:00:00"),
+            **field_key_dict,
+        }
+        cls.context_dates_outside_contract = {
+            "start": fields.Datetime.to_datetime("2024-08-18 10:00:00"),
+            "stop": fields.Datetime.to_datetime("2024-08-24 19:00:00"),
+            **field_key_dict,
+        }
+
+        cls.employee.version_id.write({
+            "date_version": fields.Date.to_date(cls.contract_start_date),
+            "contract_date_start": fields.Date.to_date(cls.contract_start_date),
+            "contract_date_end": fields.Date.to_date(cls.contract_end_date),
+            "name": "contract for Joseph",
+            "wage": 5000.0,
+        })
+
+    def test_with_future_contract(self):
+        """ Check the working period is only inside the contract created for the resource
+
+            Create a contract in draft but ready in a certain period.
+        """
+        employee_rows = self.employee._get_working_periods_by_field(**self.context_dates_inside_contracts)
+        working_periods = employee_rows[self.employee.resource_id.id]
+        self.assertEqual(len(working_periods), 1)
+        self.assertDictEqual(
+            working_periods[0],
+            {'start': self.contract_start_date, 'end': self.contract_end_date},
+            "The working period for that resource should be the contract period only."
+        )
+
+        employee_rows = self.employee._get_working_periods_by_field(**self.context_dates_outside_contract)
+        working_periods = employee_rows[self.employee.resource_id.id]
+        self.assertFalse(working_periods, "No working period should be found since the contract period is before the period displayed in the gantt view.")
+
+        self.employee.version_id.contract_date_end = False
+        employee_rows = self.employee._get_working_periods_by_field(**self.context_dates_outside_contract)
+        working_periods = employee_rows[self.employee.resource_id.id]
+        self.assertDictEqual(
+            working_periods[0],
+            {'start': self.contract_start_date, 'end': False},
+            "The working period for that resource should be the whole gantt periods displayed since it is inside the contract period."
+        )
+
+    def test_with_running_contract(self):
+        """ Check the working period is only inside the contract running of the resource
+
+            Create a running contract
+        """
+        employee_rows = self.employee._get_working_periods_by_field(**self.context_dates_inside_contracts)
+        working_periods = employee_rows[self.employee.resource_id.id]
+        self.assertEqual(len(working_periods), 1)
+        self.assertDictEqual(
+            working_periods[0],
+            {'start': self.contract_start_date, 'end': self.contract_end_date},
+            "The working period for that resource should be the contract period only."
+        )
+
+        employee_rows = self.employee._get_working_periods_by_field(**self.context_dates_outside_contract)
+        working_periods = employee_rows[self.employee.resource_id.id]
+        self.assertFalse(working_periods, "No working period should be found since the period displayed in the gantt view is after the contract period.")
+
+        self.assertEqual(
+            employee_rows[self.employee.resource_id.id],
+            [],
+            "The resource working_periods should be empty with a contract in open state outside contract period in context date",
+        )
+
+        self.employee.version_id.contract_date_end = False
+        employee_rows = self.employee._get_working_periods_by_field(**self.context_dates_outside_contract)
+        working_periods = employee_rows[self.employee.resource_id.id]
+        self.assertDictEqual(
+            working_periods[0],
+            {'start': self.contract_start_date, 'end': False},
+            "The working period for that resource should be the whole gantt periods displayed since it is inside the contract period."
+        )
+
+    def test_new_employee_with_no_contract(self):
+        """ Test the working period of a new employee with no contract """
+
+        # Create a new employee with no contract
+        employee_hope = self.env['hr.employee'].create({'name': 'Hope'})
+        self.assertTrue(employee_hope.version_id, "A default version should be created for a new employee.")
+        self.assertFalse(employee_hope.version_id.contract_date_start, "The default version should not yet have a contract start date.")
+
+        # The employee should be considered available for the entire Gantt period.
+        employee_rows = employee_hope._get_working_periods_by_field(**self.context_dates_inside_contracts)
+        working_periods = employee_rows[employee_hope.resource_id.id]
+        self.assertDictEqual(
+            working_periods[0],
+            {
+                'start': self.context_dates_inside_contracts['start'],
+                'end': self.context_dates_inside_contracts['stop']
+            },
+            "A new employee should be considered available for the full default period."
+        )
+
+        # After setting a contract start date, the working period should adjust accordingly.
+        employee_hope.version_id.write({'contract_date_start': fields.Date.to_date(self.contract_start_date)})
+        employee_rows = employee_hope._get_working_periods_by_field(**self.context_dates_inside_contracts)
+        working_periods = employee_rows[employee_hope.resource_id.id]
+
+        self.assertEqual(
+            working_periods[0]['start'],
+            self.contract_start_date,
+            "The working period's start should now match the contract_date_start."
+        )


### PR DESCRIPTION
In this commit a method is added to find contract working periods in a specific
intervals.

Moved in a test case covering the new method.

task-3885152
