### PR TITLE
[IMP] l10n_il: improve import/export fiscal position

### DIFF
--- a/addons/l10n_il/data/template/account.fiscal.position-il.csv
+++ b/addons/l10n_il/data/template/account.fiscal.position-il.csv
@@ -3,7 +3,7 @@
 "account_fiscal_position_palestinian_authority","Palestinian Authority (PA)","base.ps","1","il_vat_sales_18","il_vat_pa_sales_18","הרשות הפלסטינית"
 "","","","","il_vat_inputs_18","il_vat_pa_purchase_16",""
 "account_fiscal_position_import_export","Import / Export","","1","il_vat_sales_18","il_vat_sales_exempt","ייבוא \ ייצוא"
-"","","","","il_vat_inputs_18","",""
+"","","","","il_vat_inputs_18","il_vat_purchase_exempt",""
 "account_fiscal_position_eilat","Eilat","","","il_vat_sales_18","il_vat_sales_exempt","אילת"
 "","","","","il_vat_inputs_18","il_vat_purchase_exempt",""
 "account_fiscal_position_vat_zero","Vat Zero","","","il_vat_sales_18","il_vat_sales_zero","מע""מ אפס"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The current fiscal position for import map purchase tax -> no tax assigned and the exampt tax have to set on the move line in order to recognize the line with this specific vat exampt.

Change in this commit:
Map the default purchase tax to VAT-exempt purchase, similar to the sales mapping.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
