### PR TITLE
[IMP] sale_async_emails: remove xmlid

### DIFF
--- a/addons/sale_async_emails/__manifest__.py
+++ b/addons/sale_async_emails/__manifest__.py
@@ -2,11 +2,11 @@
 
 {
     'name': "Sales - Async Emails",
+    'version': '1.0',
     'category': 'Sales/Sales',
     'summary': "Send order status emails asynchronously",
     'depends': ['sale'],
     'data': [
-        'data/ir_config_parameter.xml',
         'data/ir_cron.xml',
     ],
     'auto_install': True,

--- a/addons/sale_async_emails/data/ir_config_parameter.xml
+++ b/addons/sale_async_emails/data/ir_config_parameter.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<odoo noupdate="1">
-
-    <record id="async_emails" model="ir.config_parameter">
-        <field name="key">sale.async_emails</field>
-        <field name="value">False</field>
-    </record>
-
-</odoo>

--- a/addons/sale_async_emails/models/sale_order.py
+++ b/addons/sale_async_emails/models/sale_order.py
@@ -17,7 +17,7 @@ class SaleOrder(models.Model):
 
     def _send_order_notification_mail(self, mail_template):
         """ Override of `sale` to reschedule order status emails to be sent asynchronously. """
-        async_send = str2bool(self.env['ir.config_parameter'].sudo().get_param('sale.async_emails'))
+        async_send = str2bool(self.env['ir.config_parameter'].sudo().get_param('sale.async_emails', False))
         cron = async_send and self.env.ref('sale_async_emails.cron', raise_if_not_found=False)
         if async_send and cron and not self.env.context.get('is_async_email', False):
             # Schedule the email to be sent asynchronously.


### PR DESCRIPTION
Having the parameter created by default with an xmlid makes overrides more complex. For example, the module installation will fail if the key already exists. Moreover, its existence in the table doesn't have a real added value since the setting remains hidden and undocumented.

Removing the xmlid allows setting the parameter externally more easily.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
