### PR TITLE
[FIX] stock: sync SM's dest loc with picking's dest loc

### DIFF
--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6897,3 +6897,25 @@ class StockMove(TransactionCase):
             {'location_id': subloc.id, 'lot_id': lots[1].id, 'package_id': pack.id},
             {'location_id': self.stock_location.id, 'lot_id': lots[2].id, 'package_id': False},
         ])
+
+    def test_change_dest_loc_after_sm_creation(self):
+        form = Form(self.env['stock.picking'].with_context(restricted_picking_type_code="incoming"))
+        with form.move_ids_without_package.new() as move:
+            move.product_id = self.product
+            move.product_uom_qty = 1
+        form.location_dest_id = self.customer_location
+        self.assertEqual(form.move_ids_without_package.edit(0).location_dest_id, self.customer_location)
+
+        picking = form.save()
+        self.assertEqual(picking.move_ids_without_package.location_dest_id, self.customer_location)
+
+        form = Form(picking)
+        with form.move_ids_without_package.new() as move:
+            move.product_id = self.product_consu
+            move.product_uom_qty = 1
+        form.location_dest_id = self.stock_location
+        self.assertEqual(form.move_ids_without_package.edit(0).location_dest_id, self.stock_location)
+        self.assertEqual(form.move_ids_without_package.edit(1).location_dest_id, self.stock_location)
+
+        picking = form.save()
+        self.assertEqual(picking.move_ids_without_package.location_dest_id, self.stock_location)


### PR DESCRIPTION
When changing the destination location of a picking, the destination
location of the stock moves are not updated and the user may not
even notice it.

To reproduce the issue:
1. In Settings, enable "Storage Locations"
2. Inventory > Operations > Receipt, New
   - Add an operation
   - Change the destination location of the picking
3. Save
4. Mark as Todo
5. Open the created move

Error: the destination location of the stock move is still the
initial one

On the picking model, there are two fields that contain the stock moves:
https://github.com/odoo/odoo/blob/17a63a6cda41a44e3d4ff8b5a9042e93ba956bc8/addons/stock/models/stock_picking.py#L612-L614
Where `move_ids_without_packages` is a subset of `move_ids`

When editing the operations of a picking, we are actually dealing
with the field `move_ids_without_packages`. So, when changing the
destination location of the picking, the webclient sends the SMs via
the field `move_ids_without_packages`, i.e.: the web client does not
provide any value for `move_ids`.

Server side, when creating a `new` record based on the provided
values, we will handle the inverse of `move_ids_without_packages`,
i.e.: we will make sure that the stock moves have the field
`picking_id` correctly defined:
https://github.com/odoo/odoo/blob/a4c2f66700dd98487ac6bb8f0f25fdc4abffd0bf/odoo/models.py#L6366-L6374
**But** we don't define any value for the siblings of the field. It
means that we don't set any value for the field `move_ids`.

This will lead to the bug: later on in the onchange, we flag all
fields that will have to be recomputed:
https://github.com/odoo/odoo/blob/b794f0f332f473deb2c04eba60baf4761db3b508/addons/web/models/models.py#L983
And here we would hope that the field `location_dest_id` of the
stock moves will be flagged, as mentioned in the dependencies:
https://github.com/odoo/odoo/blob/68ae97bd27fbdc874922e03f52f8b0c7953df801/addons/stock/models/stock_move.py#L206-L207
But... In `_modified_triggers`, at some point, we are here
https://github.com/odoo/odoo/blob/a4c2f66700dd98487ac6bb8f0f25fdc4abffd0bf/odoo/models.py#L7200-L7203
Where `field` is `stock.move.picking_id`. So, we iterate on the
inverse field of `field`, i.e.: `move_ids` and
`move_ids_without_packages`. However, as explicitly mentioned in the
comment, we "use an inverse of field without domain", i.e.:
`move_ids`. We therefore read the value of this field on the picking
which is, because of the bug explained in the previous paragraph, an
empty record. As a result, the ORM considers that it does not have
to recompute any `location_dest_id`.

The ORM team is aware of the issue. They have tried to write a generic
solution (cf PR [191318](https://github.com/odoo/odoo/pull/191318)) but it led to a lot of other errors. So, the
issue has been considered as a limitation and added to a todo list
on their side.

In the meantime, it is possible to patch the issue with a
stock-specific fix.

Note: the issue will also happen when editing an existing picking.
Suppose a picking with one move SM01. The user adds a second move
SM02, does not save and edits the destination location of the
picking: for the same reasons, the ORM will only see SM01 and,
therefore, will call the compute method for SM01 only.

OPW-4379509