### PR TITLE
[FIX] l10n_fr: remove is_france_country

### DIFF
--- a/addons/l10n_fr/views/res_company_views.xml
+++ b/addons/l10n_fr/views/res_company_views.xml
@@ -8,7 +8,6 @@
         <field name="arch" type="xml">
         <data>
              <xpath expr="//field[@name='company_registry']" position="after">
-                 <field name="is_france_country" invisible="1"/>
                  <field name="siret" invisible="not is_france_country"/>
                  <field name="ape" invisible="not is_france_country"/>
              </xpath>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The field **is_france_country** was added to the **l10n_fr.res_company_form_l10n_fr** view with the invisible attribute set to 1. This caused an error on Odoo SH due to commit #162009. Since fields used in Python expressions are automatically added to the view, we do not need to keep it.

Current behavior before PR:
When you enable tests for the module l10n_fr, you have the following error : 

Please indicate why the always invisible fields are present in the view, or remove the field tag.
Addons: 'l10n_fr'   Views: ['res_company_form_l10n_fr']

Desired behavior after PR is merged:

Pass the test test_uncommented_invisible_field


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
