### PR TITLE
[FIX] pos_restaurant: prevent issue with online payment

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -138,7 +138,7 @@ patch(PosStore.prototype, {
 
         if (
             this.get_order()?.finalized &&
-            ![ReceiptScreen, TipScreen].includes([this.mainScreen.component])
+            ![ReceiptScreen, TipScreen].includes(this.mainScreen.component)
         ) {
             this.add_new_order();
         }


### PR DESCRIPTION
Before this commit, proceeding with online payment would cause some issues. This was because a new order was being added when the ReceiptScreen was shown.

opw-4432110

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
