### PR TITLE
[REF] point_of_sale: decouple cash move popup receipt from current order

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
@@ -54,10 +54,16 @@ export class CashMovePopup extends Component {
             `${_t("Cash")} ${translatedType} - ${_t("Amount")}: ${formattedAmount}`,
             "CASH_DRAWER_ACTION"
         );
+        const data = {
+            company: this.pos.company,
+            config: this.pos.config,
+            preset_id: this.pos.config.defualt_preset_id,
+            getCashierName: () => this.pos.getCashier().name,
+        };
         await this.printer.print(CashMoveReceipt, {
             reason,
             translatedType,
-            order: this.pos.getOrder() || this.pos.models["pos.order"].getFirst(),
+            order: data,
             formattedAmount,
             date: new Date().toLocaleString(),
         });

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -6,7 +6,7 @@
         <div class="d-flex flex-column align-items-center">
             <div class="pos-receipt-contact">
                 <!-- contact address -->
-                <div t-if="order.company.partner_id?.[1]" t-esc="order.company.partner_id[1]" />
+                <div t-if="order.company.partner_id?.name" t-esc="order.company.partner_id.name" />
                 <t t-if="order.company.phone">
                     <div>Tel:<t t-esc="order.company.phone" /></div>
                 </t>


### PR DESCRIPTION
Before this commit:
==========
- The cash move popup receipt utilized the `ReceiptHeader` component, which was dependent on the current order.
- The company name was not visible on the order receipt.

After this commit:
==========
- The cash move popup receipt will not depend on the current order.
- This change decouples the cash move popup receipt from the current order, ensuring it operates independently of order-specific context.
- The company name will appear on the order receipt.

task-4395714
