### PR TITLE
[FIX] l10n_fr_account: Replace spaces in BIC codes

### DIFF
--- a/addons/l10n_fr_account/migrations/2.2/pre-migrate-add-bank-xmlid.py
+++ b/addons/l10n_fr_account/migrations/2.2/pre-migrate-add-bank-xmlid.py
@@ -21,7 +21,7 @@ def migrate(cr, version):
                     )
              SELECT 'res.bank',
                     'l10n_fr_account',
-                    CONCAT('bank_fr_', banks.bic),
+                    CONCAT('bank_fr_', REPLACE(banks.bic, ' ', '')),
                     banks.id,
                     True
                FROM banks


### PR DESCRIPTION
This commit fixes an issue where BIC codes containing spaces caused errors when creating ```ir_model_data``` names. Spaces in the BIC code are now replaced with underscores to comply with the ```ir_model_data_name_nospaces``` constraint.
```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/18.0/odoo/service/server.py", line 1306, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-13>", line 2, in new
  File "/home/odoo/src/odoo/18.0/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/18.0/odoo/modules/registry.py", line 127, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 476, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 364, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 181, in load_module_graph
    migrations.migrate_module(package, 'pre')
  File "/home/odoo/src/odoo/18.0/odoo/modules/migration.py", line 254, in migrate_module
    mod.migrate(self.cr, installed_version)
  File "/home/odoo/src/odoo/18.0/addons/l10n_fr_account/migrations/2.2/pre-migrate-add-bank-xmlid.py", line 2, in migrate
    cr.execute(
  File "/home/odoo/src/odoo/18.0/odoo/sql_db.py", line 354, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.CheckViolation: new row for relation "ir_model_data" violates check constraint "ir_model_data_name_nospaces"
DETAIL:  Failing row contains (615259, null, 2024-12-27 12:27:08.464508, 2024-12-27 12:27:08.464508, null, t, bank_fr_bous frpp xxx, l10n_fr_account, res.bank, 28, null).
```
- UPG -2401824
- OPW - 4413544
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
