### PR TITLE
[FIX] l10n_in_pos: tb on receipt with customer after payment done

### DIFF
--- a/addons/l10n_in_pos/static/src/overrides/models/order.js
+++ b/addons/l10n_in_pos/static/src/overrides/models/order.js
@@ -11,9 +11,6 @@ patch(Order.prototype, {
                 tax.tax.letter = tax.tax.tax_group_id[1]
             })
         }
-        if (this.get_partner()) {
-            result.partner = this.get_partner();
-        }
         return result;
     },
 });

--- a/addons/l10n_in_pos/static/src/overrides/store/pos_store.js
+++ b/addons/l10n_in_pos/static/src/overrides/store/pos_store.js
@@ -1,0 +1,13 @@
+/** @odoo-module */
+
+import { PosStore } from "@point_of_sale/app/store/pos_store";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosStore.prototype, {
+    getReceiptHeaderData() {
+        return {
+            ...super.getReceiptHeaderData(...arguments),
+            partner: this.selectedOrder.partner
+        }
+    },
+});

--- a/addons/pos_viva_wallet/i18n/pos_viva_wallet.pot
+++ b/addons/pos_viva_wallet/i18n/pos_viva_wallet.pot
@@ -68,13 +68,6 @@ msgstr ""
 #. module: pos_viva_wallet
 #. odoo-python
 #: code:addons/pos_viva_wallet/models/pos_payment_method.py:0
-#, python-format
-msgid "Not receive Bearer Token"
-msgstr ""
-
-#. module: pos_viva_wallet
-#. odoo-python
-#: code:addons/pos_viva_wallet/models/pos_payment_method.py:0
 #: code:addons/pos_viva_wallet/models/pos_payment_method.py:0
 #, python-format
 msgid "Only 'group_pos_user' are allowed to fetch token from Viva Wallet"
@@ -125,6 +118,15 @@ msgstr ""
 #: code:addons/pos_viva_wallet/models/pos_payment_method.py:0
 #, python-format
 msgid "There are some issues between us and Viva Wallet, try again later.%s)"
+msgstr ""
+
+#. module: pos_viva_wallet
+#. odoo-python
+#: code:addons/pos_viva_wallet/models/pos_payment_method.py:0
+#, python-format
+msgid ""
+"Unable to retrieve Viva Wallet Bearer Token: Please verify that the Client "
+"ID and Client Secret are correct"
 msgstr ""
 
 #. module: pos_viva_wallet


### PR DESCRIPTION
Steps:
===
- Open a POS shop.
- Create an order, select a customer, and validate it.

Issue:
===
- The generated receipt did not include customer name and phone details.

Cause:
===
- Customer details were not being passed correctly to the receipt template.

Fix:
===
- Updated the function for setting customer details to correctly include
in the receipt.

Task- 4431623