### PR TITLE
[REF] pos*: normalize pos payment method fields

### DIFF
--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -61,6 +61,10 @@ class PosPaymentMethod(models.Model):
         help='Type of QR-code to be generated for this payment method.',
     )
     hide_qr_code_method = fields.Boolean(compute='_compute_hide_qr_code_method')
+    terminal_identifier = fields.Char(string="Terminal Identifier", help = "[Terminal ID, e.g., 16002169] or [Terminal model]-[Serial number], e.g., P400-Plus-123456789", copy=False)
+    terminal_merchant_key = fields.Char(string="Merchant ID/Account", help="Used when connecting to Payment Terminal", copy=False)
+    terminal_api_key = fields.Char(string="API Key", help="Api Key for authorize Payment Terminal", copy=False)
+    test_mode = fields.Boolean(string="Test Mode", help="Run transactions in the test environment.", groups="base.group_erp_manager")
 
     @api.model
     def get_provider_status(self, modules_list):
@@ -74,7 +78,7 @@ class PosPaymentMethod(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['id', 'name', 'is_cash_count', 'use_payment_terminal', 'split_transactions', 'type', 'image', 'sequence', 'payment_method_type', 'default_qr']
+        return ['id', 'name', 'is_cash_count', 'use_payment_terminal', 'split_transactions', 'type', 'image', 'sequence', 'payment_method_type', 'default_qr', 'terminal_identifier']
 
     @api.depends('type', 'payment_method_type')
     def _compute_hide_use_payment_terminal(self):

--- a/addons/point_of_sale/views/pos_payment_method_views.xml
+++ b/addons/point_of_sale/views/pos_payment_method_views.xml
@@ -32,6 +32,10 @@
                                 <field name="hide_qr_code_method" invisible="1"/>
                                 <field name="payment_method_type" />
                                 <field name="use_payment_terminal" string="Integrate with" invisible="hide_use_payment_terminal"/>
+                                <field name="terminal_merchant_key" invisible="hide_use_payment_terminal or use_payment_terminal not in ['paytm', 'viva_com']" required="use_payment_terminal in ['paytm', 'viva_com']"/>
+                                <field name="terminal_identifier" invisible="hide_use_payment_terminal or use_payment_terminal not in ['adyen', 'paytm', 'razorpay', 'viva_com']" required="use_payment_terminal in ['adyen', 'paytm', 'razorpay', 'viva_com']"/>
+                                <field name="terminal_api_key" invisible="hide_use_payment_terminal or use_payment_terminal not in ['adyen', 'paytm', 'razorpay', 'viva_com']" required="use_payment_terminal in ['adyen', 'paytm', 'razorpay', 'viva_com']"/>
+                                <field name="test_mode" invisible="hide_use_payment_terminal or use_payment_terminal not in ['adyen', 'paytm', 'razorpay', 'viva_com']" />
                                 <field name="qr_code_method" invisible="hide_qr_code_method" required="payment_method_type == 'qr_code'"/>
                             </group>
                             <widget name="pos_payment_provider_cards" invisible="use_payment_terminal or payment_method_type != 'terminal'" />

--- a/addons/pos_adyen/controllers/main.py
+++ b/addons/pos_adyen/controllers/main.py
@@ -33,7 +33,7 @@ class PosAdyenController(http.Controller):
             return
 
         terminal_identifier = msg_header['POIID']
-        adyen_pm_sudo = request.env['pos.payment.method'].sudo().search([('adyen_terminal_identifier', '=', terminal_identifier)], limit=1)
+        adyen_pm_sudo = request.env['pos.payment.method'].sudo().search([('terminal_identifier', '=', terminal_identifier)], limit=1)
         if not adyen_pm_sudo:
             _logger.warning('Received an Adyen event notification for a terminal not registered in Odoo: %s', terminal_identifier)
             return

--- a/addons/pos_adyen/data/neutralize.sql
+++ b/addons/pos_adyen/data/neutralize.sql
@@ -1,3 +1,3 @@
 -- disable Adyen Payement POS integration
 UPDATE pos_payment_method
-   SET adyen_test_mode = true;
+   SET test_mode = true;

--- a/addons/pos_adyen/models/pos_payment_method.py
+++ b/addons/pos_adyen/models/pos_payment_method.py
@@ -21,11 +21,6 @@ class PosPaymentMethod(models.Model):
     def _get_payment_terminal_selection(self):
         return super(PosPaymentMethod, self)._get_payment_terminal_selection() + [('adyen', 'Adyen')]
 
-    # Adyen
-    adyen_api_key = fields.Char(string="Adyen API key", help='Used when connecting to Adyen: https://docs.adyen.com/user-management/how-to-get-the-api-key/#description', copy=False, groups='base.group_erp_manager')
-    adyen_terminal_identifier = fields.Char(help='[Terminal model]-[Serial number], for example: P400Plus-123456789', copy=False)
-    adyen_test_mode = fields.Boolean(help='Run transactions in the test environment.', groups='base.group_erp_manager')
-
     adyen_latest_response = fields.Char(copy=False, groups='base.group_erp_manager') # used to buffer the latest asynchronous notification from Adyen.
     adyen_event_url = fields.Char(
         string="Event URL",
@@ -35,28 +30,22 @@ class PosPaymentMethod(models.Model):
         default=lambda self: f"{self.get_base_url()}/pos_adyen/notification",
     )
 
-    @api.model
-    def _load_pos_data_fields(self, config_id):
-        params = super()._load_pos_data_fields(config_id)
-        params += ['adyen_terminal_identifier']
-        return params
-
-    @api.constrains('adyen_terminal_identifier')
+    @api.constrains('terminal_identifier')
     def _check_adyen_terminal_identifier(self):
         for payment_method in self:
-            if not payment_method.adyen_terminal_identifier:
+            if payment_method.use_payment_terminal != 'adyen' or not payment_method.terminal_identifier:
                 continue
             # sudo() to search all companies
             existing_payment_method = self.sudo().search([('id', '!=', payment_method.id),
-                                                   ('adyen_terminal_identifier', '=', payment_method.adyen_terminal_identifier)],
+                                                   ('terminal_identifier', '=', payment_method.terminal_identifier)],
                                                   limit=1)
             if existing_payment_method:
                 if existing_payment_method.company_id == payment_method.company_id:
                     raise ValidationError(_('Terminal %(terminal)s is already used on payment method %(payment_method)s.',
-                                      terminal=payment_method.adyen_terminal_identifier, payment_method=existing_payment_method.display_name))
+                                      terminal=payment_method.terminal_identifier, payment_method=existing_payment_method.display_name))
                 else:
                     raise ValidationError(_('Terminal %(terminal)s is already used in company %(company)s on payment method %(payment_method)s.',
-                                             terminal=payment_method.adyen_terminal_identifier,
+                                             terminal=payment_method.terminal_identifier,
                                              company=existing_payment_method.company_id.name,
                                              payment_method=existing_payment_method.display_name))
 
@@ -93,22 +82,22 @@ class PosPaymentMethod(models.Model):
 
         # These checks are not optimal. This RPC method should be changed.
 
-        is_capture_data = operation == 'capture' and hasattr(self, 'adyen_merchant_account') and self._is_valid_adyen_request_data(data, {
+        is_capture_data = operation == 'capture' and hasattr(self, 'terminal_merchant_key') and self._is_valid_adyen_request_data(data, {
             'originalReference': UNPREDICTABLE_ADYEN_DATA,
             'modificationAmount': {
                 'value': UNPREDICTABLE_ADYEN_DATA,
                 'currency': UNPREDICTABLE_ADYEN_DATA,
             },
-            'merchantAccount': self.adyen_merchant_account,
+            'merchantAccount': self.terminal_merchant_key,
         })
 
-        is_adjust_data = operation == 'adjust' and hasattr(self, 'adyen_merchant_account') and self._is_valid_adyen_request_data(data, {
+        is_adjust_data = operation == 'adjust' and hasattr(self, 'terminal_merchant_key') and self._is_valid_adyen_request_data(data, {
             'originalReference': UNPREDICTABLE_ADYEN_DATA,
             'modificationAmount': {
                 'value': UNPREDICTABLE_ADYEN_DATA,
                 'currency': UNPREDICTABLE_ADYEN_DATA,
             },
-            'merchantAccount': self.adyen_merchant_account,
+            'merchantAccount': self.terminal_merchant_key,
             'additionalData': {
                 'industryUsage': 'DelayedCharge',
             },
@@ -186,7 +175,7 @@ class PosPaymentMethod(models.Model):
             'MessageCategory': expected_message_category,
             'SaleID': UNPREDICTABLE_ADYEN_DATA,
             'ServiceID': UNPREDICTABLE_ADYEN_DATA,
-            'POIID': self.adyen_terminal_identifier,
+            'POIID': self.terminal_identifier,
         }
 
     def _get_expected_payment_request(self, with_acquirer_data):
@@ -235,10 +224,10 @@ class PosPaymentMethod(models.Model):
 
         _logger.info('Request to Adyen by user #%d:\n%s', self.env.uid, pprint.pformat(data))
 
-        environment = 'test' if self.sudo().adyen_test_mode else 'live'
+        environment = 'test' if self.sudo().test_mode else 'live'
         endpoint = self._get_adyen_endpoints()[operation] % environment
         headers = {
-            'x-api-key': self.sudo().adyen_api_key,
+            'x-api-key': self.sudo().terminal_api_key,
         }
         req = requests.post(endpoint, json=data, headers=headers, timeout=TIMEOUT)
 

--- a/addons/pos_adyen/static/src/app/utils/payment/payment_adyen.js
+++ b/addons/pos_adyen/static/src/app/utils/payment/payment_adyen.js
@@ -69,7 +69,7 @@ export class PaymentAdyen extends PaymentInterface {
             MessageType: "Request",
             SaleID: this._adyenGetSaleId(config),
             ServiceID: this.most_recent_service_id,
-            POIID: this.payment_method_id.adyen_terminal_identifier,
+            POIID: this.payment_method_id.terminal_identifier,
         };
     }
 

--- a/addons/pos_adyen/tests/test_basic.py
+++ b/addons/pos_adyen/tests/test_basic.py
@@ -11,9 +11,9 @@ class TestAdyenPoS(TestPointOfSaleHttpCommon):
                 (0, 0, {
                     "name": "Adyen",
                     "use_payment_terminal": True,
-                    "adyen_api_key": "my_adyen_api_key",
-                    "adyen_terminal_identifier": "my_adyen_terminal",
-                    "adyen_test_mode": False,
+                    "terminal_api_key": "my_adyen_api_key",
+                    "terminal_identifier": "my_adyen_terminal",
+                    "test_mode": False,
                     "use_payment_terminal": "adyen",
                     "payment_method_type": "terminal",
                     'journal_id': self.bank_journal.id,

--- a/addons/pos_adyen/views/pos_payment_method_views.xml
+++ b/addons/pos_adyen/views/pos_payment_method_views.xml
@@ -5,12 +5,9 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
+            <xpath expr="//field[@name='terminal_api_key']" position="after">
                 <!-- Adyen -->
-                <field name="adyen_api_key" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'" password="True"/>
-                <field name="adyen_terminal_identifier" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
                 <field name="adyen_event_url" invisible="use_payment_terminal != 'adyen'" widget="CopyClipboardChar"/>
-                <field name="adyen_test_mode" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
             </xpath>
         </field>
     </record>

--- a/addons/pos_paytm/data/neutralize.sql
+++ b/addons/pos_paytm/data/neutralize.sql
@@ -1,3 +1,3 @@
 UPDATE pos_payment_method
-SET paytm_test_mode = true,
-    paytm_merchant_key = 'dummykey00012345';
+SET test_mode = true,
+    terminal_api_key = 'dummykey00012345';

--- a/addons/pos_paytm/models/pos_payment_method.py
+++ b/addons/pos_paytm/models/pos_payment_method.py
@@ -21,13 +21,9 @@ iv = b'@@@@&&&&####$$$$'
 class PosPaymentMethod(models.Model):
     _inherit = 'pos.payment.method'
 
-    paytm_tid = fields.Char(string='PayTM Terminal ID', help="Terminal model or Activation code \n ex: 70000123")
     channel_id = fields.Char(string='PayTM Channel ID', default='EDC')
     accept_payment = fields.Selection(selection=[('auto', 'Automatically'), ('manual', 'Manually')], default='auto', help="Choose accept payment mode: \n Manually or Automatically")
     allowed_payment_modes = fields.Selection(selection=[('all', 'All'), ('card', 'Card'), ('qr', 'QR')], default='all', help="Choose allow payment mode: \n All/Card or QR")
-    paytm_mid = fields.Char(string="PayTM Merchant ID", help="Go to https://business.paytm.com/ and create the merchant account")
-    paytm_merchant_key = fields.Char(string="PayTM Merchant API Key", help="Merchant/AES key \n ex: B1o6Ivjy8L1@abc9")
-    paytm_test_mode = fields.Boolean(string="PayTM Test Mode", default=False, help="Turn it on when in Test Mode")
 
     def _get_payment_terminal_selection(self):
         return super()._get_payment_terminal_selection() + [('paytm', 'PayTM')]
@@ -41,7 +37,7 @@ class PosPaymentMethod(models.Model):
         :rtype: dict
         """
         try:
-            if self.paytm_test_mode:
+            if self.test_mode:
                 api_url = 'https://securegw-stage.paytm.in/ecr/'
             else:
                 api_url = 'https://securegw-edc.paytm.in/ecr/'
@@ -142,15 +138,15 @@ class PosPaymentMethod(models.Model):
 
         time = datetime.fromtimestamp(timestamp).astimezone(tz=tz.gettz('Asia/Kolkata')).strftime("%Y-%m-%d %H:%M:%S")
         return {
-            'paytmMid': self.paytm_mid,
-            'paytmTid': self.paytm_tid,
+            'paytmMid': self.terminal_merchant_key,
+            'paytmTid': self.terminal_identifier,
             'transactionDateTime': time,
             'merchantTransactionId': transaction_id,
             'merchantReferenceNo': reference_id,
         }
 
     def _paytm_get_request_head(self, body):
-        paytm_signature = self._paytm_generate_signature(body, self.paytm_merchant_key)
+        paytm_signature = self._paytm_generate_signature(body, self.terminal_api_key)
         error = isinstance(paytm_signature, dict) and paytm_signature.get('error')
         if error:
             return {'error': '%s' % error}

--- a/addons/pos_paytm/views/pos_payment_method_views.xml
+++ b/addons/pos_paytm/views/pos_payment_method_views.xml
@@ -6,13 +6,9 @@
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='use_payment_terminal']" position="after">
-                <field name="paytm_mid" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
-                <field name="paytm_tid" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
-                <field name="paytm_merchant_key" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
                 <field name="channel_id" groups="base.group_no_one" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
                 <field name="accept_payment" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
                 <field name="allowed_payment_modes" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
-                <field name="paytm_test_mode" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
             </xpath>
         </field>
     </record>

--- a/addons/pos_razorpay/data/neutralize.sql
+++ b/addons/pos_razorpay/data/neutralize.sql
@@ -1,3 +1,3 @@
 UPDATE pos_payment_method
-SET razorpay_test_mode = true,
-    razorpay_api_key = 'dummykey00012345';
+SET test_mode = true,
+    terminal_api_key = 'dummykey00012345';

--- a/addons/pos_razorpay/models/pos_payment_method.py
+++ b/addons/pos_razorpay/models/pos_payment_method.py
@@ -7,11 +7,8 @@ from .razorpay_pos_request import RazorpayPosRequest
 class PosPaymentMethod(models.Model):
     _inherit = 'pos.payment.method'
 
-    razorpay_tid = fields.Char(string='Razorpay Device Serial No', help='Device Serial No \n ex: 7000012300')
     razorpay_allowed_payment_modes = fields.Selection(selection=[('all', 'All'), ('card', 'Card'), ('upi', 'UPI'), ('bharatqr', 'BHARATQR')], default='all', help='Choose allow payment mode: \n All/Card/UPI or QR')
     razorpay_username = fields.Char(string='Razorpay Username', help='Username(Device Login) \n ex: 1234500121')
-    razorpay_api_key = fields.Char(string='Razorpay API Key', help='Used when connecting to Razorpay: https://razorpay.com/docs/payments/dashboard/account-settings/api-keys/')
-    razorpay_test_mode = fields.Boolean(string='Razorpay Test Mode', default=False, help='Turn it on when in Test Mode')
 
     def _get_payment_terminal_selection(self):
         return super()._get_payment_terminal_selection() + [('razorpay', 'Razorpay')]

--- a/addons/pos_razorpay/models/razorpay_pos_request.py
+++ b/addons/pos_razorpay/models/razorpay_pos_request.py
@@ -8,10 +8,10 @@ _logger = logging.getLogger(__name__)
 
 class RazorpayPosRequest:
     def __init__(self, payment_method):
-        self.razorpay_test_mode = payment_method.razorpay_test_mode
-        self.razorpay_api_key = payment_method.razorpay_api_key
+        self.razorpay_test_mode = payment_method.test_mode
+        self.razorpay_api_key = payment_method.terminal_api_key
         self.razorpay_username = payment_method.razorpay_username
-        self.razorpay_tid = payment_method.razorpay_tid
+        self.razorpay_tid = payment_method.terminal_identifier
         self.razorpay_allowed_payment_modes = payment_method.razorpay_allowed_payment_modes
         self.payment_method = payment_method
         self.session = requests.Session()

--- a/addons/pos_razorpay/views/pos_payment_method_views.xml
+++ b/addons/pos_razorpay/views/pos_payment_method_views.xml
@@ -7,9 +7,8 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='use_payment_terminal']" position="after">
                 <field name="razorpay_username" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
-                <field name="razorpay_tid" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
-                <field name="razorpay_api_key" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
-                <field name="razorpay_test_mode" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
+            </xpath>
+            <xpath expr="//field[@name='terminal_api_key']" position="after">
                 <field name="razorpay_allowed_payment_modes" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
             </xpath>
         </field>

--- a/addons/pos_restaurant_adyen/models/pos_payment.py
+++ b/addons/pos_restaurant_adyen/models/pos_payment.py
@@ -26,7 +26,7 @@ class PosPayment(models.Model):
                 'value': int(self.amount * 10**self.currency_id.decimal_places),
                 'currency': self.currency_id.name,
             },
-            'merchantAccount': self.payment_method_id.adyen_merchant_account,
+            'merchantAccount': self.payment_method_id.terminal_merchant_key,
         }
 
         return self.payment_method_id.proxy_adyen_request(data, 'capture')

--- a/addons/pos_restaurant_adyen/models/pos_payment_method.py
+++ b/addons/pos_restaurant_adyen/models/pos_payment_method.py
@@ -7,8 +7,6 @@ from odoo import fields, models, api
 class PosPaymentMethod(models.Model):
     _inherit = 'pos.payment.method'
 
-    adyen_merchant_account = fields.Char(help='The POS merchant account code used in Adyen')
-
     def _get_adyen_endpoints(self):
         return {
             **super(PosPaymentMethod, self)._get_adyen_endpoints(),
@@ -19,5 +17,5 @@ class PosPaymentMethod(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         params = super()._load_pos_data_fields(config_id)
-        params += ['adyen_merchant_account']
+        params += ['terminal_merchant_key']
         return params

--- a/addons/pos_restaurant_adyen/static/src/overrides/models/payment_adyen.js
+++ b/addons/pos_restaurant_adyen/static/src/overrides/models/payment_adyen.js
@@ -25,7 +25,7 @@ patch(PaymentAdyen.prototype, {
                 value: parseInt(line.amount * Math.pow(10, this.pos.currency.decimal_places)),
                 currency: this.pos.currency.name,
             },
-            merchantAccount: this.payment_method_id.adyen_merchant_account,
+            merchantAccount: this.payment_method_id.terminal_merchant_key,
             additionalData: {
                 industryUsage: "DelayedCharge",
             },

--- a/addons/pos_restaurant_adyen/views/pos_payment_method_views.xml
+++ b/addons/pos_restaurant_adyen/views/pos_payment_method_views.xml
@@ -5,8 +5,9 @@
       <field name="model">pos.payment.method</field>
       <field name="inherit_id" ref="pos_adyen.pos_payment_method_view_form_inherit_pos_adyen"/>
       <field name="arch" type="xml">
-          <xpath expr="//field[@name='adyen_terminal_identifier']" position="after">
-                <field name="adyen_merchant_account" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
+          <xpath expr="//field[@name='terminal_merchant_key']" position="attributes">
+                <attribute name="invisible">hide_use_payment_terminal or use_payment_terminal not in ['adyen', 'paytm', 'viva_com']</attribute>
+                <attribute name="required">hide_use_payment_terminal or use_payment_terminal not in ['adyen', 'paytm', 'viva_com']</attribute>
           </xpath>
       </field>
     </record>

--- a/addons/pos_self_order_adyen/models/pos_payment_method.py
+++ b/addons/pos_self_order_adyen/models/pos_payment_method.py
@@ -30,7 +30,7 @@ class PosPaymentMethod(models.Model):
                         'MessageCategory': "Payment",
                         'SaleID': f'{pos_config.display_name} (ID:{pos_config.id})', #	Your unique ID for the POS system component to send this request from.
                         'ServiceID': str(random_number), # Your unique ID for this request, consisting of 1-10 alphanumeric characters.
-                        'POIID': self.adyen_terminal_identifier, #	The unique ID of the terminal to send this request to.
+                        'POIID': self.terminal_identifier, #	The unique ID of the terminal to send this request to.
                     },
                     'PaymentRequest': {
                         'SaleData': {

--- a/addons/pos_viva_com/controllers/main.py
+++ b/addons/pos_viva_com/controllers/main.py
@@ -29,7 +29,7 @@ class PosVivaComController(http.Controller):
                 data_webhook = data.get('EventData', {})
                 if terminal_id:
                     payment_method_sudo = request.env['pos.payment.method'].sudo().search(
-                        [('viva_com_terminal_id', '=', terminal_id)], limit=1
+                        [('terminal_identifier', '=', terminal_id)], limit=1
                     )
                     payment_method_sudo._retrieve_session_id(data_webhook)
                 else:

--- a/addons/pos_viva_com/data/neutralize.sql
+++ b/addons/pos_viva_com/data/neutralize.sql
@@ -1,2 +1,2 @@
 UPDATE pos_payment_method
-   SET viva_com_test_mode = true;
+   SET test_mode = true;

--- a/addons/pos_viva_com/static/src/app/payment_viva_com.js
+++ b/addons/pos_viva_com/static/src/app/payment_viva_com.js
@@ -80,7 +80,7 @@ export class PaymentVivaCom extends PaymentInterface {
         var data = {
             sessionId: line.viva_com_session_id,
             parentSessionId: line.vivaComParentSessionId,
-            terminalId: line.payment_method_id.viva_com_terminal_id,
+            terminalId: line.payment_method_id.terminal_identifier,
             cashRegisterId: this.pos.getCashier().name,
             amount: roundPrecision(Math.abs(line.amount * 100)),
             currencyCode: this.pos.currency.iso_numeric.toString(),

--- a/addons/pos_viva_com/tests/test_frontend.py
+++ b/addons/pos_viva_com/tests/test_frontend.py
@@ -19,11 +19,11 @@ class TestVivaComHttpCommon(TestPointOfSaleHttpCommon):
             'name': 'Viva',
             'journal_id': cls.bank_journal.id,
             'use_payment_terminal': 'viva_com',
-            'viva_com_merchant_id': 'test-merchant-id',
-            'viva_com_api_key': 'test-api-key',
+            'terminal_merchant_key': 'test-merchant-id',
+            'terminal_api_key': 'test-api-key',
             'viva_com_client_id': 'test-client-id',
             'viva_com_client_secret': 'test-client-secret',
-            'viva_com_terminal_id': '01234543210',
+            'terminal_identifier': '01234543210',
         })
         payment_methods = cls.main_pos_config.payment_method_ids | viva_payment_method
         cls.main_pos_config.write({'payment_method_ids': [Command.set(payment_methods.ids)]})

--- a/addons/pos_viva_com/views/pos_payment_method_views.xml
+++ b/addons/pos_viva_com/views/pos_payment_method_views.xml
@@ -7,12 +7,8 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='use_payment_terminal']" position="after">
                 <!-- Viva.com -->
-                <field name="viva_com_merchant_id" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
-                <field name="viva_com_api_key" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
                 <field name="viva_com_client_id" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
                 <field name="viva_com_client_secret" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
-                <field name="viva_com_test_mode" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
-                <field name="viva_com_terminal_id" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
                 <field name="viva_com_webhook_endpoint" invisible="use_payment_terminal != 'viva_com' or not id" required="use_payment_terminal == 'viva_com'" widget="CopyClipboardChar"/>
             </xpath>
         </field>


### PR DESCRIPTION
pos*: point_of_sale, pos_razorpay, pos_paytm, pos_adyen, pos_restaurant_adyen, pos_viva_wallet

Before this commit:
===================
There were separate fields for pos_payment_method for each module, such as pos_paytm, pos_razorpay, pos_adyen, pos_restaurant_adyen, pos_viva_wallet. Each field stored the same data for each module individually.

After this commit:
================
A common fields for pos_payment_method are created to store data based on the module, simplifying the data management.

task-4383639

related upgrade PR: https://github.com/odoo/upgrade/pull/6992

