### PR TITLE
[FIX] spreadsheet: include current day in filter on dashboard

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -59,7 +59,7 @@ export function checkFilterFieldMatching(fieldMatchings) {
 
 /**
  * Get a date domain relative to the current date.
- * The domain will span the amount of time specified in rangeType and end the day before the current day.
+ * The domain will span the amount of time specified in rangeType and end on the current day.
  *
  *
  * @param {Object} now current time, as luxon time
@@ -71,7 +71,7 @@ export function checkFilterFieldMatching(fieldMatchings) {
  * @returns {Domain|undefined}
  */
 export function getRelativeDateDomain(now, offset, rangeType, fieldName, fieldType) {
-    let endDate = now.minus({ day: 1 }).endOf("day");
+    let endDate = now.endOf("day");
     let startDate = endDate;
     switch (rangeType) {
         case "last_week": {


### PR DESCRIPTION
This PR updates the logic for the filter in the dashboard to include the current day. Previously, the filter only retrieved data from the past 7 completed days, excluding the current day. This change aligns the filter behavior with user expectations, as many users anticipate seeing data for the current day in real-time dashboards.

Why this change?
- Improved user experience: Including the current day provides more accurate and up-to-date information for dashboards that rely on real-time or near-real-time data.
- Consistency: Aligns with standard practices in other reporting tools where "Last N Days" includes the current day.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
