### PR TITLE
[FIX] l10n_in_withholding: show tds entry button on paid payment

### DIFF
--- a/addons/l10n_in_withholding/views/account_payment_views.xml
+++ b/addons/l10n_in_withholding/views/account_payment_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
                 <button name="%(l10n_in_withholding_entry_form_action)d" string="TDS Entry" type="action" class="btn btn-secondary float-end"
-                        invisible="country_code != 'IN' or state != 'in_process' or is_reconciled"/>
+                        invisible="country_code != 'IN' or state not in ('in_process', 'paid') or is_reconciled"/>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button name="action_l10n_in_withholding_entries"


### PR DESCRIPTION
Before This Commit:
- The TDS Entry button is visible only in `In Process` state.

After This Commit:
- The TDS Entry button is visible in both `In Process` and `Paid` state.

Task: 4432364