### PR TITLE
[FIX] hr_holidays: prevent error when creating time-off type

### DIFF
--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -86,7 +86,6 @@
                             invisible="requires_allocation == 'no'">
                             <field name="allows_negative"/>
                             <field name="max_allowed_negative"
-                                widget="char"
                                 class="o_hr_narrow_field"
                                 invisible="not allows_negative"
                                 required="requires_allocation == 'yes' and allows_negative"/>


### PR DESCRIPTION
Currently below error occurs when creating a time-off type.

Error: `ValueError: invalid literal for int() with base 10: '84,000'`

Steps to reproduce :-
- Open 'Time Off' >> Go to 'Configuration' >> Click 'Time off Types' >> Click 'New' .
- Give 'Time off Type' a name >> Enable 'Allow Negative Cap' >> Set 'Maximum Excess Amount' >> Hit 'Save'.
- The error appears in the log.

This commit solves the above issue by removing the `widget`.

sentry-6184334906

