### PR TITLE
[FIX] portal, point_of_sale: return new instance of fields list

### DIFF
--- a/addons/l10n_mx/__init__.py
+++ b/addons/l10n_mx/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+from . import controllers

--- a/addons/l10n_mx/controllers/__init__.py
+++ b/addons/l10n_mx/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import portal

--- a/addons/l10n_mx/controllers/portal.py
+++ b/addons/l10n_mx/controllers/portal.py
@@ -1,0 +1,28 @@
+from odoo.addons.portal.controllers import portal
+from odoo.http import request
+
+class CustomerPortal(portal.CustomerPortal):
+
+    def _get_mandatory_fields(self):
+        # EXTENDS 'portal'
+        try:
+            country_id = int(request.env.context.get('portal_form_country_id', ''))
+        except ValueError:
+            country_id = None
+
+        mandatory_fields = super()._get_mandatory_fields()
+        if country_id and request.env['res.country'].sudo().browse(country_id).code == 'MX':
+            mandatory_fields += ['zipcode', 'vat']
+        return mandatory_fields
+
+    def _get_optional_fields(self):
+        # EXTENDS 'portal'
+        try:
+            country_id = int(request.env.context.get('portal_form_country_id', ''))
+        except ValueError:
+            country_id = None
+
+        optional_fields = super()._get_optional_fields()
+        if country_id and request.env['res.country'].sudo().browse(country_id).code == 'MX':
+            optional_fields = [field for field in optional_fields if field not in ['zipcode', 'vat']]
+        return optional_fields

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -381,10 +381,13 @@ class CustomerPortal(Controller):
         error = dict()
         error_message = []
 
+        request.update_context(portal_form_country_id=data['country_id'])
         # Validation
         for field_name in self._get_mandatory_fields():
             if not data.get(field_name):
                 error[field_name] = 'missing'
+                if field_name == 'zipcode':
+                    error['zip'] = 'missing'
 
         # email validation
         if data.get('email') and not tools.single_email_re.match(data.get('email')):


### PR DESCRIPTION
Manual forward port of https://github.com/odoo/odoo/pull/187674

In the l10n_mx localization, the field RFC(VAT) and zipcode should be required to prevent the field from being defaulted to "public en general".

How to reproduce:

-Install l10n_mx and pos
-Activate the option "Generate a code on ticket"
-Go to POS and sell an article to generate the ticket -Go to the POS portal to request an invoice (/pos/ticket/) -Fill all the fields except for RFC
-Odoo does not request this field and allows the client to submit the information -The invoice will be generated to "public en general" and not to the client requesting the invoice (Expected when there is no RFC)

In addons/portal/views/portal_templates.xml, zip was used which was not part of OPTIONAL_BILLING_FIELDS in addons/portal/controllers/portal.py. This forces us to manually inject data['zipcode'] to data['zip'] in `details_form_validate`

opw-4332357

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
