### PR TITLE
[FIX] hr_contract: fix UI of notes field in contract details

### DIFF
--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -247,7 +247,7 @@
                                 <group name="contract_details" col="2"/>
                                 <group name="contract_details_2"/>
                                 <group name="notes_group" string="Notes">
-                                    <field name="notes" nolabel="1" placeholder="Type in notes about this contract..."/>
+                                    <field name="notes" colspan="2" nolabel="1" placeholder="Type in notes about this contract..."/>
                                 </group>
                             </page>
                         </notebook>


### PR DESCRIPTION
Steps to Reproduce:
• install the Employees app.
• go to the Contracts, open any contract, navigate to the Details tab. • in the Details tab notes section UI is not user friendly.

Issue:
The notes field in the form was not properly aligned, causing it to occupy less space than intended.

Fix:
Added `colspan="2"` to ensure the notes field spans two columns.

task-4403322