### PR TITLE
[FIX] spreadsheet_dashboard_purchase*: wrong scoreboard data

### DIFF
--- a/addons/spreadsheet_dashboard_purchase/data/files/vendors_dashboard.json
+++ b/addons/spreadsheet_dashboard_purchase/data/files/vendors_dashboard.json
@@ -1973,10 +1973,16 @@
             "colGroupBys": [],
             "context": {},
             "domain": [
+                "&",
                 [
                     "country_id",
                     "!=",
                     false
+                ],
+                [
+                    "state",
+                    "in",
+                    ["purchase", "done"]
                 ]
             ],
             "id": "1",
@@ -2005,7 +2011,7 @@
         "2": {
             "colGroupBys": [],
             "context": {},
-            "domain": [],
+            "domain": [["state", "in", ["purchase", "done"]]],
             "id": "2",
             "measures": [
                 {
@@ -2033,10 +2039,16 @@
             "colGroupBys": [],
             "context": {},
             "domain": [
+                "&",
                 [
                     "user_id",
                     "!=",
                     false
+                ],
+                [
+                   "state",
+                   "in",
+                   ["purchase", "done"]
                 ]
             ],
             "id": "3",
@@ -2065,7 +2077,7 @@
         "4": {
             "colGroupBys": [],
             "context": {},
-            "domain": [],
+            "domain": [["state", "in", ["purchase", "done"]]],
             "id": "4",
             "measures": [
                 {
@@ -2099,7 +2111,7 @@
         "5": {
             "colGroupBys": [],
             "context": {},
-            "domain": [],
+            "domain": [["state", "in", ["purchase", "done"]]],
             "id": "5",
             "measures": [
                 {

--- a/addons/spreadsheet_dashboard_purchase_stock/data/files/purchase_dashboard.json
+++ b/addons/spreadsheet_dashboard_purchase_stock/data/files/purchase_dashboard.json
@@ -2218,10 +2218,16 @@
             "colGroupBys": [],
             "context": {},
             "domain": [
+                "&",
                 [
                     "country_id",
                     "!=",
                     false
+                ],
+                [
+                    "state",
+                    "in",
+                    ["purchase", "done"]
                 ]
             ],
             "id": "1",
@@ -2250,7 +2256,7 @@
         "2": {
             "colGroupBys": [],
             "context": {},
-            "domain": [],
+            "domain": [["state", "in", ["purchase", "done"]]],
             "id": "2",
             "measures": [
                 {
@@ -2278,10 +2284,16 @@
             "colGroupBys": [],
             "context": {},
             "domain": [
+                "&",
                 [
                     "category_id",
                     "!=",
                     false
+                ],
+                [
+                    "state",
+                    "in",
+                    ["purchase", "done"]
                 ]
             ],
             "id": "6",
@@ -2314,10 +2326,16 @@
             "colGroupBys": [],
             "context": {},
             "domain": [
+                "&",
                 [
                     "product_id",
                     "!=",
                     false
+                ],
+                [
+                    "state",
+                    "in",
+                    ["purchase", "done"]
                 ]
             ],
             "id": "7",
@@ -2350,10 +2368,16 @@
             "colGroupBys": [],
             "context": {},
             "domain": [
+                "&",
                 [
                     "user_id",
                     "!=",
                     false
+                ],
+                [
+                    "state",
+                    "in",
+                    ["purchase", "done"]
                 ]
             ],
             "id": "8",
@@ -2385,7 +2409,7 @@
         "10": {
             "colGroupBys": [],
             "context": {},
-            "domain": [],
+            "domain": [["state", "in", ["purchase", "done"]]],
             "id": "10",
             "measures": [
                 {
@@ -2419,7 +2443,7 @@
         "11": {
             "colGroupBys": [],
             "context": {},
-            "domain": [],
+            "domain": [["state", "in", ["purchase", "done"]]],
             "id": "11",
             "measures": [
                 {


### PR DESCRIPTION
* = stock

* PROPBLEM: when viewing purchase or vendor dashboard (under logistic section) , viewing the scoreboard for purchased or order it calculate all record from purchase.report but when clicking on it, redirect to view of 'purchase order' only which is wrong compare to the number display on the scoreboard
* SOLUTION: This commit fix by edit the domain of related pivot which the scoreboard use to display data to the domain having state in either Purchase or Done

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
