### PR TITLE
[FIX] mail: load documents with the correct domain on archiving

### DIFF
--- a/addons/mail/static/src/views/web/activity/activity_model.js
+++ b/addons/mail/static/src/views/web/activity/activity_model.js
@@ -6,10 +6,13 @@ export class ActivityModel extends RelationalModel {
     static DEFAULT_LIMIT = 100;
 
     async load(params = {}) {
-        this.originalDomain = params.domain ? [...params.domain] : [];
+        this.originalDomain = params.domain ? [...params.domain] : this.originalDomain;
         // Ensure that only (active) records with at least one activity, "done" (archived) or not, are fetched.
         // We don't use active_test=false in the context because otherwise we would also get archived records.
-        params.domain = [...(params.domain || []), ["activity_ids.active", "in", [true, false]]];
+        params.domain = [
+            ...(params.domain || this.originalDomain),
+            ["activity_ids.active", "in", [true, false]],
+        ];
         if (params && "groupBy" in params) {
             params.groupBy = [];
         }


### PR DESCRIPTION
To reproduce
============

- Go to Documents app
- schedule some activities on different documents for Mitchel Admin and Marc Demo
- Go to the activity view, and set filter to Activities assigned to Mitchel Admin
- only documents with activities assigned to Mitchel Admin should be shown
- select one of them and move it to the trash -> the filter won't be applied anymore, and all documents with activities will be shown

Problem
=======
after archiving a document, the `load` method is called without `searchParams` where `domain` should be defined, so an empty domain is used.

Solution
========
in case domain is not defined, we should use the domain from `originalDomain` instead of an empty domain.

opw-4354175
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
