### PR TITLE
[IMP] website_sale: eCommerce categories analytics

### DIFF
--- a/addons/website_sale/report/sale_report.py
+++ b/addons/website_sale/report/sale_report.py
@@ -8,6 +8,10 @@ class SaleReport(models.Model):
 
     website_id = fields.Many2one('website', readonly=True)
     is_abandoned_cart = fields.Boolean(string="Abandoned Cart", readonly=True)
+    public_categ_ids = fields.Many2many(
+        string="eCommerce Categories",
+        related='product_tmpl_id.public_categ_ids',
+    )
 
     def _select_additional_fields(self):
         res = super()._select_additional_fields()

--- a/addons/website_sale/report/sale_report_views.xml
+++ b/addons/website_sale/report/sale_report_views.xml
@@ -21,6 +21,11 @@
                     <filter string="Customer" name="groupby_customer" context="{'group_by':'partner_id'}"/>
                     <filter string="Customer Country" name="groupby_country" context="{'group_by':'country_id'}"/>
                     <filter string="Status" name="groupby_status" context="{'group_by':'state'}"/>
+                    <filter
+                        string="eCommerce Category"
+                        name="groupby_product_public_category"
+                        context="{'group_by': 'public_categ_ids'}"
+                    />
                     <separator orientation="vertical"/>
                     <filter string="Order Date" name="groupby_order_date" context="{'group_by':'date'}"/>
                     <!-- Dashboard filter - used by context -->
@@ -62,6 +67,7 @@
         <field name="arch" type="xml">
              <field name="order_reference" position="after">
                 <field name="website_id" optional="hide"/>
+                <field name="public_categ_ids" optional="hide"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Currently, in all e-commerce reports, it's not possible to use e-commerce categories.

This PR adds eCommerce categories in Sales Report, and a related "Group by" option in eCommerce reporting.

task-4365230

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
