### PR TITLE
[IMP] l10n_in_ewaybill_irn: add irn configuration for user

### DIFF
--- a/addons/l10n_in_ewaybill_irn/__manifest__.py
+++ b/addons/l10n_in_ewaybill_irn/__manifest__.py
@@ -1,14 +1,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 {
-    'name': """Indian - E-waybill thru IRN""",
+    'name': """Indian - E-waybill through IRN""",
     'category': 'Accounting/Localizations',
     'depends': [
         'l10n_in_ewaybill',
         'l10n_in_edi'
     ],
     'description': """
-Indian - E-waybill thru IRN
+Indian - E-waybill through IRN
 ====================================
 This module enables to generate E-waybill through IRN.
     """,

--- a/addons/l10n_in_ewaybill_irn/i18n/l10n_in_ewaybill_irn.pot
+++ b/addons/l10n_in_ewaybill_irn/i18n/l10n_in_ewaybill_irn.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.1alpha1+e\n"
+"Project-Id-Version: Odoo Server 18.2alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-24 12:07+0000\n"
-"PO-Revision-Date: 2024-10-24 12:07+0000\n"
+"POT-Creation-Date: 2024-12-30 10:05+0000\n"
+"PO-Revision-Date: 2024-12-30 10:05+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,8 +16,34 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_in_ewaybill_irn
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_irn.field_l10n_in_ewaybill__display_is_process_through_irn
+msgid "Display Is Process Through Irn"
+msgstr ""
+
+#. module: l10n_in_ewaybill_irn
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_irn.field_l10n_in_ewaybill__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_in_ewaybill_irn
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_irn.field_l10n_in_ewaybill__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_in_ewaybill_irn
 #: model:ir.model.fields,field_description:l10n_in_ewaybill_irn.field_l10n_in_ewaybill__is_process_through_irn
 msgid "Is Process Through Irn"
+msgstr ""
+
+#. module: l10n_in_ewaybill_irn
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py:0
+msgid "Please generate IRN before generating E-waybill."
+msgstr ""
+
+#. module: l10n_in_ewaybill_irn
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_irn.view_l10n_in_ewaybill_irn_inherit
+msgid "Processing Method"
 msgstr ""
 
 #. module: l10n_in_ewaybill_irn
@@ -29,12 +55,11 @@ msgid ""
 msgstr ""
 
 #. module: l10n_in_ewaybill_irn
-#: model:ir.model,name:l10n_in_ewaybill_irn.model_l10n_in_ewaybill
-msgid "e-Waybill"
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_irn.view_l10n_in_ewaybill_irn_inherit
+msgid "Using IRN"
 msgstr ""
 
 #. module: l10n_in_ewaybill_irn
-#. odoo-python
-#: code:addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py:0
-msgid "waiting For IRN generation To create E-waybill"
+#: model:ir.model,name:l10n_in_ewaybill_irn.model_l10n_in_ewaybill
+msgid "e-Waybill"
 msgstr ""

--- a/addons/l10n_in_ewaybill_irn/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_irn/views/l10n_in_ewaybill_views.xml
@@ -5,6 +5,17 @@
         <field name="model">l10n.in.ewaybill</field>
         <field name="inherit_id" ref="l10n_in_ewaybill.l10n_in_ewaybill_form_view"/>
         <field name="arch" type="xml">
+            <xpath expr="//group[@name='document_details']" position="before">
+                <group name="processing_method" string="Processing Method" invisible="not display_is_process_through_irn">
+                    <group>
+                        <field name="is_process_through_irn"
+                               readonly="state != 'pending'"
+                               string="Using IRN"
+                               widget="boolean_toggle"/>
+                    </group>
+                    <group/>
+                </group>
+            </xpath>
             <xpath expr="//group[@name='document_details']" position="attributes">
                 <attribute name="invisible">is_process_through_irn</attribute>
             </xpath>


### PR DESCRIPTION
Before this commit:
While generating E-waybill it was computed automatically,
if E-waybill will be generated using IRN or not (based on
Account EDI document)

In this commit:
We add a boolean field on the E-waybill form
where user can decide if the ewaybill should be
generated with IRN or not and will be only visible
when the related `move_id` is eligible for E-invoice

task-3672493


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
