### PR TITLE
[FIX] account_edi_ubl_cii: prevent an error when generate an invoice

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -555,7 +555,7 @@ class AccountEdiCommon(models.AbstractModel):
         """
         xpath_dict = self._get_invoice_line_xpaths(invoice_line, qty_factor)
         # basis_qty (optional)
-        basis_qty = float(self._find_value(xpath_dict['basis_qty'], tree) or 1)
+        basis_qty = float(self._find_value(xpath_dict['basis_qty'], tree) or 1) or 1.0
 
         # gross_price_unit (optional)
         gross_price_unit = None


### PR DESCRIPTION
Currently, an error occurs when uploading an XML file to generate an invoice.

Step to produce:

- Install the `account_edi_ubl_cii` module.
- Go to Invoicing / Customers / Invoices, And upload this [1] XML file to generate an invoice.

Link[1]: https://drive.google.com/file/d/1t_0XxkX7X3elgqpff4REl6LRjzOv2CFQ/view?usp=drive_link

`ZeroDivisionError: float division by zero`

The issue arises because the '_find_value()' method returns a string value, such as '0'. This value is converted to a float and assigned to the 'basis_qty' variable then the system tries to divide a float number with 'basis_qty'(zero) at [2].

Link [2]: https://github.com/odoo/odoo/blob/4f9e06a701224ef18819391ddd57e56830af52f9/addons/account_edi_ubl_cii/models/account_edi_common.py#L558

To resolve this, assign a default value of 1.0 to the 'basis_qty' variable when '_find_value()' returns a '0' or any other invalid value.

Sentry-6180097960

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
