### PR TITLE
[FIX] im_livechat: correct author name display for visitor messages in demo data

### DIFF
--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
@@ -36,6 +36,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_1"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_1_guest"/>
+            <field name="author_id"/>
             <field name="email_from">Visitor</field>
             <field name="body">I'm looking for an application to record my timesheet, any tips?</field>
             <field name="message_type">comment</field>
@@ -55,6 +56,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_1"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_1_guest"/>
+            <field name="author_id"/>
             <field name="email_from">Visitor</field>
             <field name="body">Great! Thanks for the info</field>
             <field name="message_type">comment</field>
@@ -74,6 +76,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_1"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_1_guest"/>
+            <field name="author_id"/>
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=5, seconds=25)" name="date"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
@@ -26,6 +26,7 @@
 
         <record id="livechat_channel_session_10_message_1" model="mail.message">
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_10_guest"/>
+            <field name="author_id"/>
             <field name="email_from">Visitor</field>
             <field name="record_name">Visitor</field>
             <field name="date" eval="datetime.now() - timedelta(days=1)"/>
@@ -50,6 +51,7 @@
         </record>
         <record id="livechat_channel_session_10_message_3" model="mail.message">
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_10_guest"/>
+            <field name="author_id"/>
             <field name="email_from">Visitor</field>
             <field name="record_name">Visitor</field>
             <field name="date" eval="datetime.now() - timedelta(days=1, seconds=-25)"/>
@@ -65,6 +67,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_10"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_10_guest"/>
+            <field name="author_id"/>
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="datetime.now() - timedelta(days=1, seconds=-60)" name="date"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
@@ -24,6 +24,7 @@
 
         <record id="livechat_channel_session_11_message_1" model="mail.message">
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_11_guest"/>
+            <field name="author_id"/>
             <field name="record_name">Visitor</field>
             <field name="date" eval="datetime.now()"/>
             <field name="create_date" eval="datetime.now()"/>
@@ -48,6 +49,7 @@
         </record>
         <record id="livechat_channel_session_11_message_3" model="mail.message">
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_11_guest"/>
+            <field name="author_id"/>
             <field name="record_name">Visitor</field>
             <field name="date" eval="datetime.now() - timedelta(seconds=-25)"/>
             <field name="create_date" eval="datetime.now() - timedelta(seconds=-25)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
@@ -35,6 +35,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_2"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_2_guest"/>
+            <field name="author_id"/>
             <field name="email_from">Visitor</field>
             <field name="body">I was wondering if Odoo has an application to easily manage social media for my business..</field>
             <field name="message_type">comment</field>
@@ -54,6 +55,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_2"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_2_guest"/>
+            <field name="author_id"/>
             <field name="email_from">Visitor</field>
             <field name="body">Awesome, thanks!</field>
             <field name="message_type">comment</field>
@@ -73,6 +75,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_2"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_2_guest"/>
+            <field name="author_id"/>
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=11)" name="date"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
@@ -35,6 +35,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_5"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_5_guest"/>
+            <field name="author_id"/>
             <field name="email_from">Visitor</field>
             <field name="body">Hello, it seems that I can't log in to my database. Can you help?</field>
             <field name="message_type">comment</field>
@@ -54,6 +55,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_5"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_5_guest"/>
+            <field name="author_id"/>
             <field name="email_from">Visitor</field>
             <field name="body">Ok.. Will do, thanks</field>
             <field name="message_type">comment</field>
@@ -64,6 +66,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_5"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_5_guest"/>
+            <field name="author_id"/>
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-2, days=-4, minutes=33)" name="date"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
@@ -35,6 +35,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_6"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_6_guest"/>
+            <field name="author_id"/>
             <field name="email_from">Visitor</field>
             <field name="body">Hello, I'm a bit lost in the Invetory module, is there some documentation I could find?</field>
             <field name="message_type">comment</field>
@@ -54,6 +55,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_6"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_6_guest"/>
+            <field name="author_id"/>
             <field name="email_from">Visitor</field>
             <field name="body">Thanks!</field>
             <field name="message_type">comment</field>
@@ -64,6 +66,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_6"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_6_guest"/>
+            <field name="author_id"/>
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-5, minutes=35)" name="date"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
@@ -35,6 +35,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_8"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_8_guest"/>
+            <field name="author_id"/>
             <field name="body">Heeeey Marc, how are you?</field>
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
@@ -53,6 +54,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_8"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_8_guest"/>
+            <field name="author_id"/>
             <field name="body">I'm great, thanks for asking!</field>
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
@@ -62,6 +64,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_8"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_8_guest"/>
+            <field name="author_id"/>
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-7, minutes=52)" name="date"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
@@ -25,6 +25,7 @@
 
         <record id="livechat_channel_session_9_message_1" model="mail.message">
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_9_guest"/>
+            <field name="author_id"/>
             <field name="record_name">Visitor</field>
             <field name="date" eval="datetime.now() - timedelta(days=1)"/>
             <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
@@ -48,6 +49,7 @@
         </record>
         <record id="livechat_channel_session_9_message_3" model="mail.message">
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_9_guest"/>
+            <field name="author_id"/>
             <field name="record_name">Visitor</field>
             <field name="date" eval="datetime.now() - timedelta(days=1, seconds=-25)"/>
             <field name="create_date" eval="datetime.now() - timedelta(days=1, seconds=-25)"/>
@@ -71,6 +73,7 @@
         </record>
         <record id="livechat_channel_session_9_message_5" model="mail.message">
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_9_guest"/>
+            <field name="author_id"/>
             <field name="record_name">Visitor</field>
             <field name="date" eval="datetime.now() - timedelta(days=1, seconds=-42)"/>
             <field name="create_date" eval="datetime.now() - timedelta(days=1, seconds=-42)"/>
@@ -83,6 +86,7 @@
         </record>
         <record id="livechat_channel_session_9_message_6" model="mail.message">
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_9_guest"/>
+            <field name="author_id"/>
             <field name="record_name">Visitor</field>
             <field name="date" eval="datetime.now() - timedelta(days=1, seconds=-53)"/>
             <field name="create_date" eval="datetime.now() - timedelta(days=1, seconds=-53)"/>
@@ -97,6 +101,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_9"/>
             <field name="author_guest_id" ref="im_livechat.livechat_channel_session_9_guest"/>
+            <field name="author_id"/>
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="datetime.now() - timedelta(days=1, seconds=-60)" name="date"/>


### PR DESCRIPTION
**Current behavior before PR:**

Messages posted by visitors in demo data incorrectly displayed the author name
as `Odoobot` instead of `Visitor`. This happened because the messages created
for visitors in the demo data do not have the `author_id` field explicitly set to
`False`, leading the `_message_compute_author()` method to compute the author incorrectly.

**Desired behavior after PR is merged:**

Messages posted by visitors in demo data correctly display the author name as Visitor.


Task-[4420677](https://www.odoo.com/odoo/project/1519/tasks/4420677)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
