### PR TITLE
[FIX] pos_stripe: consistency on Stripe API calls

### DIFF
--- a/addons/pos_restaurant_stripe/static/src/overrides/models/payment_stripe.js
+++ b/addons/pos_restaurant_stripe/static/src/overrides/models/payment_stripe.js
@@ -19,7 +19,7 @@ patch(PaymentStripe.prototype, {
             this.pos.config.set_tip_after_payment &&
             line.payment_method.use_payment_terminal === "stripe" &&
             line.card_type !== "interac" &&
-            !line.card_type.includes("eftpos")
+            (!line.card_type || !line.card_type.includes("eftpos"))
         );
     },
 });

--- a/addons/pos_stripe/models/pos_payment_method.py
+++ b/addons/pos_stripe/models/pos_payment_method.py
@@ -1,14 +1,10 @@
 # coding: utf-8
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import logging
-import requests
 import werkzeug
 
 from odoo import fields, models, api, _
 from odoo.exceptions import ValidationError, UserError, AccessError
 
-_logger = logging.getLogger(__name__)
-TIMEOUT = 10
 
 class PosPaymentMethod(models.Model):
     _inherit = 'pos.payment.method'
@@ -44,6 +40,7 @@ class PosPaymentMethod(models.Model):
 
     @api.model
     def _get_stripe_secret_key(self):
+        # TODO: unused, remove in master
         stripe_secret_key = self._get_stripe_payment_provider().stripe_secret_key
 
         if not stripe_secret_key:
@@ -55,16 +52,8 @@ class PosPaymentMethod(models.Model):
     def stripe_connection_token(self):
         if not self.env.user.has_group('point_of_sale.group_pos_user'):
             raise AccessError(_("Do not have access to fetch token from Stripe"))
-
-        endpoint = 'https://api.stripe.com/v1/terminal/connection_tokens'
-
-        try:
-            resp = requests.post(endpoint, auth=(self.sudo()._get_stripe_secret_key(), ''), timeout=TIMEOUT)
-        except requests.exceptions.RequestException:
-            _logger.exception("Failed to call stripe_connection_token endpoint")
-            raise UserError(_("There are some issues between us and Stripe, try again later."))
-
-        return resp.json()
+        
+        return self.sudo()._get_stripe_payment_provider()._stripe_make_request('terminal/connection_tokens')
 
     def _stripe_calculate_amount(self, amount):
         currency = self.journal_id.currency_id or self.company_id.currency_id
@@ -76,7 +65,6 @@ class PosPaymentMethod(models.Model):
 
         # For Terminal payments, the 'payment_method_types' parameter must include
         # at least 'card_present' and the 'capture_method' must be set to 'manual'.
-        endpoint = 'https://api.stripe.com/v1/payment_intents'
         currency = self.journal_id.currency_id or self.company_id.currency_id
 
         params = [
@@ -93,14 +81,7 @@ class PosPaymentMethod(models.Model):
         elif currency.name == 'CAD' and self.company_id.country_code == 'CA':
             params.append(("payment_method_types[]", "interac_present"))
 
-        try:
-            data = werkzeug.urls.url_encode(params)
-            resp = requests.post(endpoint, data=data, auth=(self.sudo()._get_stripe_secret_key(), ''), timeout=TIMEOUT)
-        except requests.exceptions.RequestException:
-            _logger.exception("Failed to call stripe_payment_intent endpoint")
-            raise UserError(_("There are some issues between us and Stripe, try again later."))
-
-        return resp.json()
+        return self.sudo()._get_stripe_payment_provider()._stripe_make_request('payment_intents', params)
 
     @api.model
     def stripe_capture_payment(self, paymentIntentId, amount=None):


### PR DESCRIPTION
Before this commit:
pos_stripe doesn't specify a Stripe version when doing its requests. Because of this, Stripe defaults to the API version defined on the Stripe account. This varies from customer to customer, as it is automatically configured to use the latest API version available when the first API request is received. Stripe regularly makes breaking changes to their API:
https://docs.stripe.com/changelog?breaking=true
for example removing the `charges` attribute:
https://docs.stripe.com/changelog/2022-11-15/removes-charges-attribute-paymentintent
which we use in pos_stripe.

After this commit:
We rely on payment_stripe._stripe_make_request which hardcode the API version number. Such change was already started in `pos_stripe.stripe_capture_payment`

opw-4375876
