### PR TITLE
[IMP] web, base: kanban app list vertical misalignment

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -195,6 +195,7 @@
             display: flex;
             flex-flow: column;
             min-width: 0;
+            height: 100%;
         }
 
         > footer, > main > footer {

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -172,7 +172,7 @@
                         </aside>
                         <main class="me-4" t-att-title="record.shortdesc.value">
                             <field class="fw-bold fs-5" name="shortdesc"/>
-                            <p class="text-muted small my-0 lh-1">
+                            <p class="text-muted small my-0 lh-sm">
                                 <field groups="!base.group_no_one" name="summary"/>
                                 <code groups="base.group_no_one"><field name="name"/></code>
                             </p>

--- a/odoo/addons/base/wizard/base_module_uninstall_views.xml
+++ b/odoo/addons/base/wizard/base_module_uninstall_views.xml
@@ -26,7 +26,7 @@
                                         </aside>
                                         <main t-att-title="record.shortdesc.value">
                                             <field class="fw-bold fs-5 mb-0" name="shortdesc" />
-                                            <p class="text-muted small my-1 lh-1">
+                                            <p class="text-muted small my-1 lh-sm">
                                                 <field groups="!base.group_no_one" name="summary" />
                                                 <code groups="base.group_no_one">
                                                     <field name="name" />


### PR DESCRIPTION
Before this commit, there was a misalignment issue with the buttons in the cards due to varying text lengths in the description. This caused the buttons to appear at different vertical positions, disrupting visual consistency.

Now, the layout ensures that all buttons are aligned at the bottom of the cards regardless of the description length, and also the desc is a bit more readable with improved line spacing.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/e6651d85-bad0-4c45-8eab-537a76615add) | ![image](https://github.com/user-attachments/assets/77503d3a-1bef-4aa2-b797-d09cb9e52d26) |

task-4357026

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
