### PR TITLE
[IMP] sale_pdf_quote_builder: enhance pdf header/footer creation experience

### DIFF
--- a/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_widget.xml
+++ b/addons/sale_pdf_quote_builder/static/src/js/quotation_document_kanban/quotation_document_kanban_widget.xml
@@ -5,7 +5,7 @@
         t-inherit-mode="primary"
         t-inherit="web.X2ManyField"
     >
-        <xpath expr="//div[hasclass('o_cp_buttons')]" position="inside">
+        <xpath expr="//div[hasclass('o_cp_buttons')]/*" position="before">
             <UploadButton
                 formData="formData"
                 allowedMIMETypes="allowedMIMETypes"

--- a/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
+++ b/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
@@ -30,6 +30,7 @@
                                     icon="fa-pencil"
                                     colspan="2"
                                     groups="base.group_system,base.group_no_one"
+                                    invisible="not (datas and form_field_ids)"
                                 />
                             </div>
                             <field
@@ -97,7 +98,11 @@
                                 <span>Document type:</span>
                                 <field name="document_type" class="ms-2" widget="selection"/>
                             </div>
-                            <div t-if="!!record.quotation_template_ids.raw_value.length" class="mt-2">
+                            <div
+                                t-if="!context.hide_template_ids
+                                      and !!record.quotation_template_ids.raw_value.length"
+                                class="mt-2"
+                            >
                                 <span class="pe-2">Templates:</span>
                                 <field name="quotation_template_ids" class="d-inline-block" widget="many2many_tags"/>
                             </div>
@@ -116,6 +121,7 @@
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="document_type"/>
+                <field name="quotation_template_ids" widget="many2many_tags"/>
                 <field name="company_id" groups="base.group_multi_company" optional="show"/>
             </list>
         </field>

--- a/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
+++ b/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
@@ -17,6 +17,7 @@
                         options="{'create': False}"
                         context="{
                             'kanban_view_ref': 'sale_pdf_quote_builder.quotation_document_kanban',
+                            'hide_template_ids': True,
                         }"
                     />
                     <p class="text-muted">
@@ -25,7 +26,28 @@
                         The pdf of your quotes will be built by putting together header pages, product descriptions,
                         details of the quote and then the footer pages. <br/>
                         If empty, it will use those define in the company settings. <br/>
-                        <widget name="documentation_link" path="/_downloads/5f0840ed187116c425fdac2ab4b592e1/pdfquotebuilderexamples.zip" label=" Download examples" icon="fa-arrow-right"/>
+                        <div class="d-flex flex-column">
+                            <widget
+                                name="documentation_link"
+                                path="/_downloads/5f0840ed187116c425fdac2ab4b592e1/pdfquotebuilderexamples.zip"
+                                label=" Download examples"
+                                icon="fa-arrow-right"
+                            />
+                            <a
+                                href="https://www.youtube.com/watch?v=M_95g8_dhGk"
+                                target="_blank"
+                                invisible="not quotation_document_ids"
+                            >
+                                <i class="fa fa-arrow-right"/> Link to the demo video
+                            </a>
+                            <iframe
+                                title="Quote Builder Demo Video"
+                                src="https://www.youtube.com/embed/M_95g8_dhGk"
+                                class="mt-2"
+                                style="height: 30rem;"
+                                invisible="quotation_document_ids"
+                            />
+                        </div>
                     </p>
                 </page>
             </notebook>


### PR DESCRIPTION
Prior to this commit:
- The 'Configure Dynamic Fields' button was always visible.
- The upload button in the quotation template form view was not positioned after add button.
- The template was displayed in the quote builder section of the quotation template form view.
- No video link was embedded when there was no document in the quote template form view.
- The template column was missing in the list view of quotation documents.

Post this commit:
- The 'Configure Dynamic Fields' button is now shown only if a file exists and contains dynamic fields.
- The upload button position has been adjusted to appear before the add button.
- The template no longer appears in the quote builder section of the quotation template form view.
- A video link is embedded if no document exists in the quote template form view.
- A column for the template has been added to the list view of quotation documents.

task-4348192

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
