### PR TITLE
[FIX] website_slides: adjust quiz question spacing layout

### DIFF
--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -164,7 +164,7 @@
                                         </group>
                                     </group>
                                     <group name="questions" string="Questions">
-                                        <field name="question_ids" nolabel="1">
+                                        <field name="question_ids" nolabel="1" colspan="2">
                                             <list>
                                                 <field name="sequence" widget="handle"/>
                                                 <field name="question" string="Question"/>


### PR DESCRIPTION
This commit resolves an issue with the quiz question section:
- Excessive white space when creating a new record.
- Overly wide layout in existing records, requiring horizontal scrolling.

**Technical**:
In grid groups, the layout enforces two columns:
- A smaller left column (max 150px).
- A right column that occupies the remaining space. 

When adding an element with nolabel="1", it occupies only one part of the grid.
To span the full width, colspan="2" must be explicitly set.

Ref - https://github.com/odoo/odoo/commit/8df2049f170a739c535f6a18aa1fa5775289d972

Task-4435075
