### PR TITLE
[FIX] point_of_sale: prevent concurrent invoice creation from QR

### DIFF
--- a/addons/point_of_sale/views/pos_ticket_view.xml
+++ b/addons/point_of_sale/views/pos_ticket_view.xml
@@ -6,7 +6,7 @@
         <t t-call="portal.portal_layout">
             <t t-set="no_breadcrumbs" t-value="True"/>
             <div class="row justify-content-md-center">
-                <form method="post" target="_self" t-att-action="'/pos/ticket/validate'">
+                <form method="post" target="_self" t-att-action="'/pos/ticket/validate'" onsubmit="$('button:submit').attr('disabled', 'disabled')">
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                     <input type="hidden" name="access_token" t-att-value="access_token"/>
                     <div class="col-12 col-md-6 mt-4 offset-md-3">


### PR DESCRIPTION
**Steps to reproduce:**
- Install point_of_sale and l10n_mx_edi
- Switch to a Mexican company (e.g. ESCUELA KEMPER URGATE)
- Create a product with an UNSPSC Category
- In POS settings, enable "Use QR code on ticket" option
- Open a POS session
- Make an orders with the created product (without invoice)
- Print the receipt
- Close the POS session
- Scan the QR code on the receipt with a mobile (Or just open the link retrieved from the QR code in a browser from the computer without being logged)
- Enter all the required data
- Click several times on "Get my invoice" button quickly to generate the invoice

**Issue:**
Several concurrent processes are executed to create the invoice. In the Mexican localization, an electronic invoice is also generated and signed.
However, an error is raised when trying to commit the electronic invoice document from the concurrent processes.
These errors prevents the normal flow to continue after the creation of the invoice and the reversal of the POS closing entry is not generated as expected.

**Solution:**
Disable the "Get my invoice" button when the form is submitted to prevent concurrent calls to the action.

opw-4399540




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
