### PR TITLE
[IMP] point_of_sale: display contact address without company

### DIFF
--- a/addons/l10n_mt_pos/wizards/compliance_letter.py
+++ b/addons/l10n_mt_pos/wizards/compliance_letter.py
@@ -17,7 +17,7 @@ class ComplianceLetter(models.TransientModel):
             "date": self._get_formatted_date(),
             "name": self.company_id.name,
             "vat": self.company_id.vat,
-            "address": self.company_id.partner_id.contact_address,
+            "address": self.company_id.partner_id.pos_contact_address,
         }
         return self.env.ref('l10n_mt_pos.report_compliance_letter').report_action([], data=data)
 

--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -12,6 +12,12 @@ class ResPartner(models.Model):
         groups="point_of_sale.group_pos_user",
     )
     pos_order_ids = fields.One2many('pos.order', 'partner_id', readonly=True)
+    pos_contact_address = fields.Char('PoS Address', compute='_compute_contact_address')
+
+    def _compute_contact_address(self):
+        super()._compute_contact_address()
+        for partner in self:
+            partner.pos_contact_address = partner._display_address(without_company=True)
 
     @api.model
     def get_new_partner(self, config_id, domain, offset):
@@ -40,7 +46,7 @@ class ResPartner(models.Model):
     def _load_pos_data_fields(self, config_id):
         return [
             'id', 'name', 'street', 'city', 'state_id', 'country_id', 'vat', 'lang', 'phone', 'zip', 'mobile', 'email',
-            'barcode', 'write_date', 'property_account_position_id', 'property_product_pricelist', 'parent_name', 'contact_address'
+            'barcode', 'write_date', 'property_account_position_id', 'property_product_pricelist', 'parent_name', 'pos_contact_address'
         ]
 
     def _compute_pos_order(self):

--- a/addons/point_of_sale/static/src/app/models/res_partner.js
+++ b/addons/point_of_sale/static/src/app/models/res_partner.js
@@ -13,7 +13,7 @@ export class ResPartner extends Base {
             "email",
             "vat",
             "parent_name",
-            "contact_address",
+            "pos_contact_address",
         ];
         return fields
             .map((field) => {

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.xml
@@ -22,7 +22,7 @@
                         </t>
                     </Dropdown>
                 </div>
-                <div class="partner-line-adress p-1" t-if="props.partner.contact_address" t-esc="props.partner.contact_address" />
+                <div class="partner-line-adress p-1" t-if="props.partner.pos_contact_address" t-esc="props.partner.pos_contact_address" />
                 <div class="partner-line-email p-1">
                     <div class="mb-1" t-if="props.partner.phone">
                         <i class="fa fa-fw fa-phone me-2" /><t t-esc="props.partner.phone" />
@@ -50,7 +50,7 @@
                     <div class="company-field text-bg-muted" t-esc="props.partner.parent_name or ''" />
                 </td>
                 <td>
-                    <div class="partner-line-adress" t-if="props.partner.contact_address" t-esc="props.partner.contact_address" />
+                    <div class="partner-line-adress" t-if="props.partner.pos_contact_address" t-esc="props.partner.pos_contact_address" />
                 </td>
                 <td class="partner-line-email ">
                     <div t-if="props.partner.phone">

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
@@ -11,6 +11,6 @@ export class ReceiptHeader extends Component {
     }
 
     get partnerAddress() {
-        return this.order.partner_id.contact_address.split("\n");
+        return this.order.partner_id.pos_contact_address.split("\n");
     }
 }


### PR DESCRIPTION
- Creation of a new field `pos_contact_address` in `res_partner.py` to display the address of the partner without the company name.

task-id: 4414057

enterprise PR: https://github.com/odoo/enterprise/pull/76289

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
