### PR TITLE
[FIX] account: prevent an error when print and send an invoice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5108,6 +5108,7 @@ class AccountMove(models.Model):
         return action
 
     def action_send_and_print(self):
+        self.env['account.move.send']._check_move_constrains(self)
         return {
             'name': _("Print & Send"),
             'type': 'ir.actions.act_window',


### PR DESCRIPTION
Currently, an error occurs when attempting to print and send an invoice that is in a draft state.

Step to produce:

- Install the `account` module.
- Go to Invoicing / Customers / Invoices, Create one invoice without a customer and invoice line, and come to the list view of Invoices.
- Select this invoice and click on 'Print & Send'.

`AttributeError: 'bool' object has no attribute 'replace'`

The issue occurs because the system attempts to replace the name at [1] to generate a PDF file name. But the invoice's name is not available.

Link [1]: https://github.com/odoo/odoo/blob/41de88b930e569daea7624ee3655cef218f9136f/addons/account/models/account_move.py#L5739

To resolve this issue, Raise a user error if the user attempts to select the 'Print & Send' action on an invoice that is not in the confirmed state.


Sentry-6185757435

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
