### PR TITLE
[FIX] project: wrong account company in quick create of project form

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -967,6 +967,12 @@ class Project(models.Model):
     def _get_plan_domain(self, plan):
         return AND([super()._get_plan_domain(plan), ['|', ('company_id', '=', False), ('company_id', '=?', unquote('company_id'))]])
 
+    def _get_account_node_context(self, plan):
+        return {
+            **super()._get_account_node_context(plan),
+            'default_company_id': unquote('company_id'),
+        }
+
     # ---------------------------------------------------
     # Rating business
     # ---------------------------------------------------


### PR DESCRIPTION
Before this commit, when creating a new analytic account in any plan from the project form, the default company of the account was set to the current company of the user. The problem that arises is when the project has no company, and the account is set to a company. Which creates inconsistency between the project and the account.

After this commit, we set the company of the created account to the company of the project by default.

task-4438410
version-18.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
