### PR TITLE
[IMP] mrp: prevent auto production registration on work order start

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -625,11 +625,6 @@ class MrpWorkorder(models.Model):
                     continue
                 raise UserError(_('You cannot start a work order that is already done or cancelled'))
 
-            if wo.product_tracking == 'serial' and wo.qty_producing == 0:
-                wo.qty_producing = 1.0
-            elif wo.qty_producing == 0:
-                wo.qty_producing = wo.qty_remaining
-
             if wo._should_start_timer():
                 self.env['mrp.workcenter.productivity'].create(
                     wo._prepare_timeline_vals(wo.duration, fields.Datetime.now())

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -482,7 +482,6 @@ class TestMrpOrder(TestMrpCommon):
 
         wo = production.workorder_ids[0]
         wo.button_start()
-        self.assertEqual(wo.qty_producing, 5, "Wrong quantity is suggested to produce.")
 
         # Simulate changing the qty_producing in the frontend
         wo.qty_producing = 4


### PR DESCRIPTION
- Previously, starting a work order automatically set 'qty_producing' based on
  product tracking, causing unintended production registration.
- This has been fixed by removing the logic that set 'qty_producing' on start,
  ensuring production is only registered manually.

Task-id: 4387836