### PR TITLE
[FIX] hr_homeworking: fixes to work location display on calendar

### DIFF
--- a/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.js
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.js
@@ -105,14 +105,24 @@ patch(AttendeeCalendarCommonRenderer.prototype, {
         const parsedDate = DateTime.fromJSDate(date).toISODate();
         const multiCalendar = this.props.model.multiCalendar;
         const showLine = ["week", "month"].includes(this.props.model.scale);
-        const worklocation = this.props.model.worklocations[parsedDate];
+        let worklocation = this.props.model.worklocations[parsedDate];
         const workLocationSetForCurrentUser =
             multiCalendar ?
             Object.keys(worklocation).some(key => worklocation[key].some(wlItem => wlItem.userId === user.userId)
             ) : worklocation?.userId === user.userId;
+
+        let displayedWorkLocation = worklocation ? (JSON.parse(JSON.stringify(worklocation))) : {};
+        // do not display the work locations of the current user if the user filter is not active
+        if (multiCalendar && !this.props.model.data.userFilterActive) {
+            for (let wl in worklocation){
+                displayedWorkLocation[wl] = worklocation[wl].filter(wlItem => wlItem.userId !== user.userId);
+            }
+            displayedWorkLocation = Object.fromEntries(Object.entries(displayedWorkLocation).filter(([_, wlItems]) => wlItems.length !== 0));
+        }
+
         return {
             ...super.headerTemplateProps(date),
-            worklocation,
+            worklocation : displayedWorkLocation,
             workLocationSetForCurrentUser,
             multiCalendar,
             showLine,

--- a/addons/hr_homeworking_calendar/static/tests/calendar_homeworking_tests.js
+++ b/addons/hr_homeworking_calendar/static/tests/calendar_homeworking_tests.js
@@ -19,6 +19,7 @@ const mockRegistry = registry.category("mock_server");
 let target;
 let serverData;
 const uid = 1;
+const partnerId = 1;
 
 const office = {
     location_type: 'office',
@@ -122,6 +123,7 @@ QUnit.module("Homeworking Calendar", ({ beforeEach }) => {
         patchWithCleanup(AttendeeCalendarCommonPopover, patchAttendeeCalendarCommonPopoverClass);
         patchWithCleanup(user, {
             userId: uid,
+            partnerId: partnerId,
         });
 
         serverData = {
@@ -322,7 +324,7 @@ QUnit.module("Homeworking Calendar", ({ beforeEach }) => {
 
 
     QUnit.test("homeworking: multicalendar", async function (assert) {
-        assert.expect(14);
+        assert.expect(16);
         const previousMock = mockRegistry.get("get_worklocation");
         await createHomeWorkingView(serverData, multiCalendarData);
 
@@ -337,6 +339,9 @@ QUnit.module("Homeworking Calendar", ({ beforeEach }) => {
                 assert.equal(multiCalendarData[employee][`${s.weekdayLong.toLowerCase()}_location_id`].location_type, location);
             });
         });
+
+        assert.containsNone(target,'.fc-col-header-cell[data-date="2020-12-10"] .o_worklocation_text i .add_wl', "should show add work location button");
+        assert.containsNone(target,'.fc-col-header-cell[data-date="2020-12-12"] .o_worklocation_text i .add_wl', "should not show add work location button");
 
         await click(target, '.fc-col-header-cell[data-date="2020-12-10"] .o_homework_content');
         assert.equal(target.querySelector(".o_cw_popover div[name='employee_name']").textContent, "Brian");


### PR DESCRIPTION
- In calendar, when only one employee (different from the user) was selected as an attendeed in the calendar sidebar, the working location of this employee was not displayed. To work around this, switch to `multiCalendar` in that case.

- When the current user was not selected as an attendee, it was possible to add a working location for the user on a day even if there was already an exisiting one. To avoid this, always fetch the user's working location to check if one already exists for a given day, but only display them if the user's filter is active.

- Work locations were not displayed when "Everybody's calendar" was selected because the elements of `attendeeIds` had the wrong type.

opw-4373391

