### PR TITLE
[FIX] website: s_tab elements do not get shift tabbed

### DIFF
--- a/addons/website/static/src/snippets/s_tabs/000.js
+++ b/addons/website/static/src/snippets/s_tabs/000.js
@@ -1,0 +1,32 @@
+/** @odoo-module */
+
+import publicWidget from 'web.public.widget';
+import { closestElement } from '@web_editor/js/editor/odoo-editor/src/OdooEditor';
+
+const TabsWidget = publicWidget.Widget.extend({
+    selector: '.s_tabs',
+    disabledInEditableMode: false,
+
+    /**
+     * @override
+     */
+    async start() {
+        const _onKeyDownPreventTab = (ev) => {
+            if (this.editableMode && ev.key === "Tab") {
+                const closestDivEl = closestElement(this.el.ownerDocument.getSelection().anchorNode, "div");
+                if (closestDivEl && closestDivEl.classList.contains("s_tabs_nav")) {
+                    ev.stopPropagation();
+                    ev.preventDefault();
+                }
+            }
+        }
+        if (this.editableMode) {
+            this.el.ownerDocument.addEventListener("keydown", _onKeyDownPreventTab, true);
+        }
+        return this._super(...arguments);
+    },
+});
+
+publicWidget.registry.tabs = TabsWidget;
+
+export default TabsWidget;

--- a/addons/website/views/snippets/s_tabs.xml
+++ b/addons/website/views/snippets/s_tabs.xml
@@ -94,6 +94,12 @@
     </xpath>
 </template>
 
+<record id="website.s_tabs_000_js" model="ir.asset">
+    <field name="name">Tabs 000 JS</field>
+    <field name="bundle">web.assets_frontend</field>
+    <field name="path">website/static/src/snippets/s_tabs/000.js</field>
+</record>
+
 <record id="website.s_tabs_001_scss" model="ir.asset">
     <field name="name">Tabs 001 SCSS</field>
     <field name="bundle">web.assets_frontend</field>


### PR DESCRIPTION
Before the change in the s_tab snippet the tab elements would get indented when the tab key is pressed.

Steps to reproduce:
- Open the website app
- Open any page in edit mode
- Add an s_tab snippet
- Click on any of the buttons generated by the s_tab
- Press tab
- The button gets indented in a list

After the change the buttons in the s_tab snippet do not get indented when the tab key is pressed and instead a tabulation is added to the text of the selected button.

task-4426975
