### PR TITLE
[IMP] website_sale: hide empty eCommerce categories

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -384,6 +384,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         Category = request.env['product.public.category']
         categs_domain = [('parent_id', '=', False)] + website_domain
+        if not self.env.user._is_internal():
+            categs_domain = expression.AND([categs_domain, [('has_published_products', '=', True)]])
         if search:
             search_categories = Category.search(
                 [('product_tmpl_ids', 'in', search_product.ids)] + website_domain

--- a/addons/website_sale/security/ir_rules.xml
+++ b/addons/website_sale/security/ir_rules.xml
@@ -40,4 +40,18 @@
         <field name="domain_force">['|', ('company_id', 'in', [False, website.company_id.id]), ('company_id', 'in', company_ids)]</field>
     </record>
 
+    <record id="empty_public_categories_rule" model="ir.rule">
+        <field name="name">Hide empty eCommerce categories to public/portal users</field>
+        <field name="model_id" ref="website_sale.model_product_public_category"/>
+        <field name="domain_force">[('has_published_products', '=', True)]</field>
+        <field name="groups" eval="[
+            Command.link(ref('base.group_public')),
+            Command.link(ref('base.group_portal')),
+        ]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
 </odoo>

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -8,6 +8,7 @@ from . import test_delivery_ui
 from . import test_ecommerce_access
 from . import test_express_checkout_flows
 from . import test_fuzzy
+from . import test_product_public_category
 from . import test_sale_process
 from . import test_sitemap
 from . import test_website_editor

--- a/addons/website_sale/tests/test_product_public_category.py
+++ b/addons/website_sale/tests/test_product_public_category.py
@@ -1,0 +1,64 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestProductPublicCategory(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        def create_multi(vals_list):
+            return list(map(Command.create, vals_list))
+
+        cls.published_product, cls.unpublished_product = cls.env['product.template'].create([
+            {'name': 'Published Product', 'is_published': True},
+            {'name': 'Unpublished Product', 'is_published': False},
+        ])
+
+        cls.env['product.public.category'].create([
+            {
+                'name': '1',
+                'child_id': create_multi([
+                    {
+                        'name': '1.1',
+                        'child_id': create_multi([{'name': '1.1.1'}]),
+                    },
+                    {'name': '1.2', 'product_tmpl_ids': [Command.link(cls.published_product.id)]},
+                ]),
+            },
+            {
+                'name': '2',
+                'child_id': create_multi([
+                    {
+                        'name': '2.1',
+                        'child_id': create_multi([{
+                            'name': '2.1.1',
+                            'product_tmpl_ids': [
+                                Command.link(cls.published_product.id),
+                                Command.link(cls.unpublished_product.id)
+                            ],
+                        }]),
+                    },
+                    {'name': '2.2'},
+                ]),
+            },
+            {'name': '3', 'product_tmpl_ids': [Command.link(cls.unpublished_product.id)]},
+        ])
+
+    def test_search_has_published_products(self):
+        published_categs = set(self.env['product.public.category'].search(
+            [('has_published_products', 'not in', (False,))]
+        ).mapped('name'))
+
+        self.assertSetEqual(published_categs, {'1', '1.2', '2', '2.1', '2.1.1'})
+
+    def test_search_does_not_have_published_products(self):
+        unpublished_categs = set(self.env['product.public.category'].search(
+            [('has_published_products', '!=', True)]
+        ).mapped('name'))
+
+        self.assertSetEqual(unpublished_categs, {'1.1', '1.1.1', '2.2', '3'})

--- a/addons/website_sale/tests/test_sitemap.py
+++ b/addons/website_sale/tests/test_sitemap.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.fields import Command
 from odoo.tests import HttpCase, tagged
 
 
@@ -18,6 +19,13 @@ class TestSitemap(HttpCase):
         }])
         self.cats[2].parent_id = self.cats[1].id
         self.cats[1].parent_id = self.cats[0].id
+        # 'Level 2' cetegory must have at least one published product to be visible by public users
+        self.env['product.product'].create({
+            'name': 'Dummy product',
+            'list_price': 100.0,
+            'public_categ_ids': [Command.link(self.cats[2].id)],
+            'is_published': True,
+        })
 
     def test_01_shop_route_sitemap(self):
         resp = self.url_open('/sitemap.xml')

--- a/addons/website_sale/tests/test_website_sale_shop_redirects.py
+++ b/addons/website_sale/tests/test_website_sale_shop_redirects.py
@@ -17,6 +17,9 @@ class TestWebsiteSaleShopRedirects(HttpCase, WebsiteSaleCommon):
             'public_categ_ids': [Command.link(category_a.id)],
             'website_published': True,
         })
+        # Add a different published product to category B so that it is accessible to public users
+        self._create_product(website_published=True, public_categ_ids=[Command.link(category_b.id)])
+
         slug = self.env['ir.http']._slug
 
         response = self.url_open(

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -10,6 +10,13 @@
                 <separator/>
                 <filter string="Published" name="published" domain="[('is_published', '=', True)]"/>
             </filter>
+            <filter name="group_by_categ_id" position="after">
+                <filter
+                    string="eCommerce Category"
+                    name="groupby_public_category"
+                    context="{'group_by':'public_categ_ids'}"
+                />
+            </filter>
         </field>
     </record>
 

--- a/addons/website_sale/views/snippets/s_mega_menu/big_icons_subtitles.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/big_icons_subtitles.xml
@@ -14,12 +14,11 @@
             <div class="container">
                 <div class="row">
                     <t
-                        t-set="categories"
-                        t-value="request.env['product.public.category'].search([
-                            ('parent_id', '=', False)
-                        ])[:9]"
-                    />
-                    <t t-foreach="categories" t-as="category">
+                        t-foreach="request.env['product.public.category'].search([
+                            ('parent_id', '=', False), ('has_published_products', '=', True),
+                        ], limit=9)"
+                        t-as="category"
+                    >
                         <div class="col-12 col-lg-4">
                             <nav class="nav flex-column w-100">
                                 <a

--- a/addons/website_sale/views/snippets/s_mega_menu/cards.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/cards.xml
@@ -10,12 +10,11 @@
             <div class="container">
                 <nav class="row">
                     <t
-                        t-set="categories"
-                        t-value="request.env['product.public.category'].search([
-                            ('parent_id', '=', False)
-                        ])[:8]"
-                    />
-                    <t t-foreach="categories" t-as="category">
+                        t-foreach="request.env['product.public.category'].search([
+                            ('parent_id', '=', False), ('has_published_products', '=', True),
+                        ], limit=8)"
+                        t-as="category"
+                    >
                         <div class="col-12 col-lg-3">
                             <a
                                 t-att-href="'/shop/category/%s' % category.id"

--- a/addons/website_sale/views/snippets/s_mega_menu/image_menu.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/image_menu.xml
@@ -10,12 +10,12 @@
             <div class="container">
                 <div class="row align-items-center">
                     <t
-                        t-set="categories"
-                        t-value="request.env['product.public.category'].search([
-                            ('parent_id', '=', False)
-                        ])[:1]"
-                    />
-                    <t t-foreach="categories" t-as="category">
+                        t-foreach="request.env['product.public.category'].search(
+                            [('parent_id', '=', False), ('has_published_products', '=', True)],
+                            limit=2,
+                        )"
+                        t-as="category"
+                    >
                         <div class="col-12 col-lg-4 py-2 text-center">
                             <h4>
                                 <a
@@ -25,7 +25,8 @@
                                 />
                             </h4>
                             <nav class="nav flex-column">
-                                <t t-foreach="category.child_id" t-as="sub_category">
+                                <t t-foreach="category.child_id.filtered('has_published_products')"
+                                   t-as="sub_category">
                                     <a
                                         t-att-href="'/shop/category/%s' % sub_category.id"
                                         class="nav-link"
@@ -34,38 +35,12 @@
                                 </t>
                             </nav>
                         </div>
-                    </t>
-                    <div class="col-12 col-lg-4 py-2 text-center">
-                        <img
-                            class="img-fluid"
-                            src="/web/image/website.s_mega_menu_menu_image_menu_default_image"
-                            alt="Mega menu default image"
-                        />
-                    </div>
-                    <t
-                        t-set="categories"
-                        t-value="request.env['product.public.category'].search([
-                            ('parent_id', '=', False)
-                        ])[1:2]"
-                    />
-                    <t t-foreach="categories" t-as="category">
-                        <div class="col-12 col-lg-4 py-2 text-center">
-                            <h4>
-                                <a
-                                    t-att-href="'/shop/category/%s' % category.id"
-                                    class="nav-link p-0 text-black"
-                                    t-esc="category.name"
-                                />
-                            </h4>
-                            <nav class="nav flex-column">
-                                <t t-foreach="category.child_id" t-as="sub_category">
-                                    <a
-                                        t-att-href="'/shop/category/%s' % sub_category.id"
-                                        class="nav-link"
-                                        t-esc="sub_category.name"
-                                    />
-                                </t>
-                            </nav>
+                        <div t-if="not category_last" class="col-12 col-lg-4 py-2 text-center">
+                            <img
+                                class="img-fluid"
+                                src="/web/image/website.s_mega_menu_menu_image_menu_default_image"
+                                alt="Mega menu default image"
+                            />
                         </div>
                     </t>
                 </div>

--- a/addons/website_sale/views/snippets/s_mega_menu/images_subtitles.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/images_subtitles.xml
@@ -12,12 +12,11 @@
                     <div class="col-12 col-lg-8">
                         <nav class="nav d-flex">
                             <t
-                                t-set="categories"
-                                t-value="request.env['product.public.category'].search([
-                                    ('parent_id', '=', False)
-                                ])[:8]"
-                            />
-                            <t t-foreach="categories" t-as="category">
+                                t-foreach="request.env['product.public.category'].search([
+                                    ('parent_id', '=', False), ('has_published_products', '=', True)
+                                ], limit=8)"
+                                t-as="category"
+                            >
                                 <a
                                     t-att-href="'/shop/category/%s' % category.id"
                                     class="col-lg-6 nav-link px-2 rounded text-wrap"

--- a/addons/website_sale/views/snippets/s_mega_menu/little_icons.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/little_icons.xml
@@ -12,12 +12,11 @@
                     <div class="col-lg-9 py-2 align-content-center">
                         <nav class="nav col-12 d-flex">
                             <t
-                                t-set="categories"
-                                t-value="request.env['product.public.category'].search([
-                                    ('parent_id', '=', False)
-                                ])[:9]"
-                            />
-                            <t t-foreach="categories" t-as="category">
+                                t-foreach="request.env['product.public.category'].search([
+                                    ('parent_id', '=', False), ('has_published_products', '=', True)
+                                ], limit=9)"
+                                t-as="category"
+                            >
                                 <a
                                     t-att-href="'/shop/category/%s' % category.id"
                                     class="col-lg-4 nav-link px-2 rounded text-wrap"

--- a/addons/website_sale/views/snippets/s_mega_menu/logos.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/logos.xml
@@ -12,12 +12,11 @@
                     <div class="col-12 col-lg-8">
                         <div class="row py-3 h-100">
                             <t
-                                t-set="categories"
-                                t-value="request.env['product.public.category'].search([
-                                    ('parent_id', '=', False)
-                                ])[:6]"
-                            />
-                            <t t-foreach="categories" t-as="category">
+                                t-foreach="request.env['product.public.category'].search([
+                                    ('parent_id', '=', False), ('has_published_products', '=', True)
+                                ], limit=6)"
+                                t-as="category"
+                            >
                                 <div class="col-12 col-lg-4 py-2">
                                     <h4>
                                         <a
@@ -27,9 +26,9 @@
                                         />
                                     </h4>
                                     <nav class="nav flex-column">
-                                        <t t-foreach="category.child_id" t-as="sub_category">
+                                        <t t-foreach="category.child_id.filtered('has_published_products')"
+                                           t-as="sub_category">
                                             <a
-                                                t-if="sub_category_index &lt; 3"
                                                 t-att-href="'/shop/category/%s' % sub_category.id"
                                                 class="nav-link px-0"
                                                 t-esc="sub_category.name"

--- a/addons/website_sale/views/snippets/s_mega_menu/multi_menus.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/multi_menus.xml
@@ -10,12 +10,11 @@
             <div class="container">
                 <div class="row">
                     <t
-                        t-set="categories"
-                        t-value="request.env['product.public.category'].search([
-                            ('parent_id', '=', False)
-                        ])[:4]"
-                    />
-                    <t t-foreach="categories" t-as="category">
+                        t-foreach="request.env['product.public.category'].search([
+                            ('parent_id', '=', False), ('has_published_products', '=', True),
+                        ], limit=4)"
+                        t-as="category"
+                    >
                         <div class="col-12 col-sm py-2 text-center">
                             <h4>
                                 <a
@@ -25,7 +24,8 @@
                                 />
                             </h4>
                             <nav class="nav flex-column">
-                                <t t-foreach="category.child_id" t-as="sub_category">
+                                <t t-foreach="category.child_id.filtered('has_published_products')"
+                                   t-as="sub_category">
                                     <a
                                         t-att-href="'/shop/category/%s' % sub_category.id"
                                         class="nav-link"

--- a/addons/website_sale/views/snippets/s_mega_menu/odoo_menu.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/odoo_menu.xml
@@ -10,12 +10,11 @@
             <div class="container">
                 <div class="row">
                     <t
-                        t-set="categories"
-                        t-value="request.env['product.public.category'].search([
-                            ('parent_id', '=', False)
-                        ])[:4]"
-                    />
-                    <t t-foreach="categories" t-as="category">
+                        t-foreach="request.env['product.public.category'].search([
+                            ('parent_id', '=', False), ('has_published_products', '=', True),
+                        ], limit=4)"
+                        t-as="category"
+                    >
                         <div class="col-12 col-lg-3 pt16 pb24">
                             <h4 class="text-uppercase h5 fw-bold mt-0">
                                 <a
@@ -30,8 +29,10 @@
                                 />
                             </div>
                             <nav class="nav flex-column">
-                                <t t-foreach="category.child_id" t-as="sub_category">
-                                    <a t-att-href="'/shop/category/%s' % sub_category.id"
+                                <t t-foreach="category.child_id.filtered('has_published_products')"
+                                   t-as="sub_category">
+                                    <a
+                                        t-att-href="'/shop/category/%s' % sub_category.id"
                                         class="nav-link px-0"
                                         t-esc="sub_category.name"/>
                                 </t>

--- a/addons/website_sale/views/snippets/s_mega_menu/thumbnails.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/thumbnails.xml
@@ -9,14 +9,13 @@
         <section class="s_mega_menu_thumbnails pt24 o_colored_level o_cc o_cc1">
             <div class="container">
                 <div class="row ustify-content-center">
-                    <t
-                        t-set="categories"
-                        t-value="request.env['product.public.category'].search([
-                            ('parent_id', '=', False)
-                        ])[:10]"
-                    />
                     <t t-set="counter" t-value="0"/>
-                    <t t-foreach="categories" t-as="category">
+                    <t
+                        t-foreach="request.env['product.public.category'].search([
+                            ('parent_id', '=', False), ('has_published_products', '=', True),
+                        ], limit=10)"
+                        t-as="category"
+                    >
                         <t t-set="counter" t-value="counter + 1"/>
                         <t t-if="(counter - 1) % 5 == 0 and counter != 1">
                             <div class="w-100 d-none d-lg-block"></div>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1243,6 +1243,7 @@
         <t t-else="">
             <t t-set="entries" t-value="categories"/>
         </t>
+        <t t-set="entries" t-value="request.env.user._is_internal() and entries or entries.filtered('has_published_products')"/>
 
         <div t-if="entries" class="o_wsale_filmstip_container d-flex align-items-stretch overflow-hidden">
             <div class="o_wsale_filmstip_wrapper pb-1 overflow-auto">
@@ -1251,6 +1252,7 @@
                         t-foreach="entries"
                         t-as="c"
                         t-attf-class="d-flex {{'pe-3' if not c_last else ''}}"
+                        t-att-data-publish="c.has_published_products and 'on' or 'off'"
                     >
                         <a
                             t-att-href="keep('%s/category/%s' % (shop_path, slug(c)))"
@@ -1368,7 +1370,7 @@
 
     <!-- Add to cart button-->
     <template id="categories_recursive" name="Category list">
-        <li class="nav-item mb-1">
+        <li class="nav-item mb-1" t-att-data-publish="c.has_published_products and 'on' or 'off'">
             <t t-call="website_sale.categorie_link"/>
             <ul t-if="c.child_id" class="nav flex-column nav-hierarchy mt-1 ps-3">
                 <t t-foreach="c.child_id" t-as="c">
@@ -1458,11 +1460,12 @@
 
     <template id="option_collapse_categories_recursive" name="Collapse Category Recursive">
         <t t-set="children" t-value="not search and c.child_id or c.child_id.filtered(lambda c: c.id in search_categories_ids)"/>
+        <t t-set="children" t-value="request.env.user._is_internal() and children or children.filtered('has_published_products')"/>
 
         <t t-if="children">
             <t t-set="isOpen" t-value="c.id in category.parents_and_self.ids"/>
 
-            <li class="nav-item">
+            <li class="nav-item" t-att-data-publish="c.has_published_products and 'on' or 'off'">
                 <div class="accordion-header d-flex mb-1">
                     <t t-call="website_sale.categorie_link"/>
                     <button t-attf-id="o_wsale_cat_accordion_title_{{c.id}}"
@@ -1486,7 +1489,8 @@
             </li>
         </t>
 
-        <li t-else="" class="nav-item mb-1">
+        <li t-else="" class="nav-item mb-1"
+            t-att-data-publish="c.has_published_products and 'on' or 'off'">
             <t t-if="isOffcanvas" t-set="parentCategoryId" t-valuef="offcanvas"/>
             <div class="d-flex flex-wrap justify-content-between align-items-center">
                 <t t-call="website_sale.categorie_link"/>


### PR DESCRIPTION
To avoid displaying empty or not yet published categories, we need to
adapt the visibility of it.

This commit limits access of eCommerce categories.
Only internal users can see categories with unpublished products.

Ecommerce categories mega-menus where also updated to reflect that
change.

This commit also adds a new "group by eCommerce categories" filter on
the `website_sale.product_view`.

task-4325764

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
