### PR TITLE
[IMP] base_sparse_field: deprecate the Serialized field in favor of Json

### DIFF
--- a/addons/base_sparse_field/__manifest__.py
+++ b/addons/base_sparse_field/__manifest__.py
@@ -12,7 +12,6 @@ fields are stored in a JSON field.
     'version': '1.0',
     'depends': ['base'],
     'data': [
-        'security/ir.model.access.csv',
         'views/views.xml',
     ],
     'license': 'LGPL-3',

--- a/addons/base_sparse_field/__manifest__.py
+++ b/addons/base_sparse_field/__manifest__.py
@@ -6,7 +6,7 @@
 The purpose of this module is to implement "sparse" fields, i.e., fields
 that are mostly null. This implementation circumvents the PostgreSQL
 limitation on the number of columns in a table. The values of all sparse
-fields are stored in a "serialized" field in the form of a JSON mapping.
+fields are stored in a JSON field.
     """,
     'category': 'Hidden',
     'version': '1.0',

--- a/addons/base_sparse_field/models/models.py
+++ b/addons/base_sparse_field/models/models.py
@@ -86,16 +86,3 @@ class IrModelFields(models.Model):
             serialization_record = self.browse(field_data['serialization_field_id'])
             attrs['sparse'] = serialization_record.name
         return attrs
-
-
-class Sparse_FieldsTest(models.TransientModel):
-    _name = 'sparse_fields.test'
-    _description = 'Sparse fields Test'
-
-    data = fields.Json()
-    boolean = fields.Boolean(sparse='data')
-    integer = fields.Integer(sparse='data')
-    float = fields.Float(sparse='data')
-    char = fields.Char(sparse='data')
-    selection = fields.Selection([('one', 'One'), ('two', 'Two')], sparse='data')
-    partner = fields.Many2one('res.partner', sparse='data')

--- a/addons/base_sparse_field/models/models.py
+++ b/addons/base_sparse_field/models/models.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 
-from odoo import models, fields, api, _
+from odoo import models, fields, _
 from odoo.exceptions import UserError
 
 
@@ -20,7 +20,7 @@ class IrModelFields(models.Model):
         ('serialized', 'serialized'),
     ], ondelete={'serialized': 'cascade'})
     serialization_field_id = fields.Many2one('ir.model.fields', string='Serialization Field',
-        ondelete='cascade', domain="[('ttype','=','serialized'), ('model_id', '=', model_id)]",
+        ondelete='cascade', domain="[('ttype','in',('json', 'serialized')), ('model_id', '=', model_id)]",
         help="If set, this field will be stored in the sparse structure of the "
              "serialization field, instead of having its own database column. "
              "This cannot be changed after creation.",
@@ -35,8 +35,7 @@ class IrModelFields(models.Model):
                     raise UserError(_('Changing the storing system for field "%s" is not allowed.', field.name))
                 if field.serialization_field_id and (field.name != vals['name']):
                     raise UserError(_('Renaming sparse field "%s" is not allowed', field.name))
-
-        return super(IrModelFields, self).write(vals)
+        return super().write(vals)
 
     def _reflect_fields(self, model_names):
         super()._reflect_fields(model_names)
@@ -82,7 +81,7 @@ class IrModelFields(models.Model):
         self.pool.post_init(records.modified, ['serialization_field_id'])
 
     def _instanciate_attrs(self, field_data):
-        attrs = super(IrModelFields, self)._instanciate_attrs(field_data)
+        attrs = super()._instanciate_attrs(field_data)
         if attrs and field_data.get('serialization_field_id'):
             serialization_record = self.browse(field_data['serialization_field_id'])
             attrs['sparse'] = serialization_record.name
@@ -93,7 +92,7 @@ class Sparse_FieldsTest(models.TransientModel):
     _name = 'sparse_fields.test'
     _description = 'Sparse fields Test'
 
-    data = fields.Serialized()
+    data = fields.Json()
     boolean = fields.Boolean(sparse='data')
     integer = fields.Integer(sparse='data')
     float = fields.Float(sparse='data')

--- a/addons/base_sparse_field/security/ir.model.access.csv
+++ b/addons/base_sparse_field/security/ir.model.access.csv
@@ -1,2 +1,0 @@
-"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
-"access_sparse_fields_test","access.sparse_fields.test","model_sparse_fields_test","base.group_system",1,1,1,0

--- a/addons/base_sparse_field/tests/test_sparse_fields.py
+++ b/addons/base_sparse_field/tests/test_sparse_fields.py
@@ -1,9 +1,35 @@
-# -*- coding: utf-8 -*-
-
+from odoo import models, fields
 from odoo.tests import common
+from odoo.tools import mute_logger
 
 
 class TestSparseFields(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        class SparseFieldsTest(models.TransientModel):
+            _name = 'sparse_fields.test'
+            _description = 'Sparse fields Test'
+
+            data = fields.Json()
+            boolean = fields.Boolean(sparse='data')
+            integer = fields.Integer(sparse='data')
+            float = fields.Float(sparse='data')
+            char = fields.Char(sparse='data')
+            selection = fields.Selection([('one', 'One'), ('two', 'Two')], sparse='data')
+            partner = fields.Many2one('res.partner', sparse='data')
+
+
+        SparseFieldsTest._build_model(cls.registry, cls.env.cr)
+        cls.registry.setup_models(cls.env.cr)
+        cls.registry.init_models(cls.env.cr, [SparseFieldsTest._name], cls.env.context)
+
+    @classmethod
+    def tearDownClass(cls):
+        with mute_logger('odoo.models.unlink'):
+            del cls.env.registry['sparse_fields.test']
+            cls.env.registry.reset_changes()
 
     def test_sparse(self):
         """ test sparse fields. """

--- a/addons/base_sparse_field/tests/test_sparse_fields.py
+++ b/addons/base_sparse_field/tests/test_sparse_fields.py
@@ -29,7 +29,7 @@ class TestSparseFields(common.TransactionCase):
 
         for n, (key, _val) in enumerate(values):
             record.write({key: False})
-            self.assertEqual(record.data, dict(values[n+1:]))
+            self.assertEqual(record.data or {}, dict(values[n+1:]))
 
         # check reflection of sparse fields in 'ir.model.fields'
         names = [name for name, _ in values]


### PR DESCRIPTION
Since the introduction of the Json field, there's no reason to keep the old Serialized field.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
