### PR TITLE
[FIX] sale_timesheet : Access Error when timesheeting a task that has SO

### DIFF
--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -213,7 +213,7 @@ class AccountAnalyticLine(models.Model):
 
     def _timesheet_preprocess_get_accounts(self, vals):
         so_line = self.env['sale.order.line'].browse(vals.get('so_line'))
-        if not (so_line and (distribution := so_line.analytic_distribution)):
+        if not (so_line and (distribution := so_line.sudo().analytic_distribution)):
             return super()._timesheet_preprocess_get_accounts(vals)
 
         company = self.env['res.company'].browse(vals.get('company_id'))


### PR DESCRIPTION
### Steps to reproduce:
	- Create a project and make it billable
	- Create a task in this project and assign it to a user that has Own Documents access in Sales
	- Set a customer for this task and SO
	- Using the user that has been assigned to the task try to timesheet something
	- Notice an access error will be triggered

### Cause:
This is happening because when timesheeting we are checking the so_line analytic distribution https://github.com/odoo/odoo/blob/18.0/addons/sale_timesheet/models/hr_timesheet.py#L216 and since the user doesn't have access for the so_line we are getting this access error.

### Fix:
Use sudo() for this check to give the user access for this field

opw-4338754