### PR TITLE
[FIX] website: exclude technical content from search results

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -169,6 +169,18 @@ def text_from_html(html_fragment, collapse_whitespace=False):
     """
     # lxml requires one single root element
     tree = etree.fromstring('<p>%s</p>' % html_fragment, etree.XMLParser(recover=True))
+
+    # Remove scripts or other technical elements that should not be converted
+    # into text.
+    xpath_filters = [
+        '//script',
+        '//style',
+        '//svg',
+        '//*[@class="css_non_editable_mode_hidden"]',
+    ]
+    for xpath_filter in xpath_filters:
+        for element in tree.xpath(xpath_filter): element.getparent().remove(element)
+
     content = ' '.join(tree.itertext())
     if collapse_whitespace:
         content = re.sub('\\s+', ' ', content).strip()


### PR DESCRIPTION
Steps to reproduce:

- Enter website edit mode.
- Drag and drop a "Products" dynamic snippet onto the page.
- Drag and drop a "Search" snippet onto the page.
- Save the page.
- Perform a search for "dynamic" using the search input.
- Bug: The dynamic snippet alert message appears in the results.

The same issue occurs with the "Embed code" snippet, where text inside "<script>" elements appears in search results.

With this commit, elements like "css_non_editable_mode_hidden" and "<script>" are excluded from search results.

opw-4420622
