### PR TITLE
[FIX] mrp: search for candidate MO with similar “location_dest_id”

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -61,6 +61,7 @@ class StockRule(models.Model):
                     ('picking_type_id', '=', rule.picking_type_id.id),
                     ('company_id', '=', procurement.company_id.id),
                     ('user_id', '=', False),
+                    ('location_dest_id', 'child_of', procurement.location_id.id)
                 )
                 if procurement.values.get('orderpoint_id'):
                     procurement_date = datetime.combine(


### PR DESCRIPTION
Steps to Reproduce the Bug:
- Enable multi-storage location
- Create a storable product “P1” with the following BoM:
    - Component: C1
- Create two orderpoints:
    - First orderpoint: - Route: Manufacture - Product: P1 - Min: 1, Max: 1 - Location: Shelf 1
    - Second orderpoint:
        - Route: Manufacture
        - Product: P1 - Min: 1, Max: 1 - Location: Shelf 2
- Click on “Order Once” of the first orderpoint.
    - A manufacturing order (MO) is created with the destination location: Shelf 1.
    - The “To Order” field will be computed as 0.
- Click on “Order Once” of the second orderpoint.

Problem:
The same manufacturing order is updated, even though its destination location is Shelf 1 which is wrong and The “To Order” quantity for the second orderpoint remains at 1. So each time the scheduler is triggered, the MO is updated by one unit if the trigger is set to “auto”.

opw-4418632
