### PR TITLE
[FIX] web: don't use last record update as unique for related images

### DIFF
--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -9,7 +9,7 @@ import { isBinarySize } from "@web/core/utils/binary";
 import { FileUploader } from "../file_handler";
 import { standardFieldProps } from "../standard_field_props";
 
-import { Component, useState } from "@odoo/owl";
+import { Component, useState, onWillRender } from "@odoo/owl";
 const { DateTime } = luxon;
 
 export const fileTypeMagicWordMap = {
@@ -43,9 +43,26 @@ export class ImageField extends Component {
             isValid: true,
         });
         this.lastURL = undefined;
+
+        if (this.props.record.fields[this.props.name].related) {
+            this.lastUpdate = DateTime.now();
+            let key = this.props.value;
+            onWillRender(() => {
+                const nextKey = this.props.value;
+
+                if (key !== nextKey) {
+                    this.lastUpdate = DateTime.now();
+                }
+
+                key = nextKey;
+            });
+        }
     }
 
     get rawCacheKey() {
+        if (this.props.record.fields[this.props.name].related) {
+            return this.lastUpdate;
+        }
         return this.props.record.data.__last_update;
     }
 

--- a/addons/web/static/tests/views/fields/image_field_tests.js
+++ b/addons/web/static/tests/views/fields/image_field_tests.js
@@ -7,6 +7,7 @@ import {
     triggerEvent,
     clickSave,
     editInput,
+    patchDate,
 } from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 import { pagerNext } from "@web/../tests/search/helpers";
@@ -858,6 +859,102 @@ QUnit.module("Fields", (hooks) => {
             assert.strictEqual(
                 getUnique(target.querySelector(".o_field_image img")),
                 "1659688620000"
+            );
+        }
+    );
+
+    QUnit.test(
+        "url should not use the record last updated date when the field is related",
+        async function (assert) {
+            serverData.models.partner.fields.related = {
+                name: "Binary",
+                type: "binary",
+                related: "user.image",
+            };
+
+            serverData.models.partner.fields.user = {
+                name: "User",
+                type: "many2one",
+                relation: "user",
+                default: 1,
+            };
+
+            serverData.models.user = {
+                fields: {
+                    image: {
+                        name: "Image",
+                        type: "binary",
+                    },
+                },
+                records: [
+                    {
+                        id: 1,
+                        image: "3 kb",
+                    },
+                ],
+            };
+
+            serverData.models.partner.records[0].__last_update = "2017-02-08 10:00:00";
+
+            patchDate(2017, 1, 6, 11, 0, 0);
+
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                resId: 1,
+                serverData,
+                arch: `
+                <form>
+                    <sheet>
+                        <group>
+                            <field name="foo" />
+                            <field name="user"/>
+                            <field name="related" widget="image"/>
+                        </group>
+                    </sheet>
+                </form>`,
+                async mockRPC(route, { args }, performRpc) {
+                    if (route === "/web/dataset/call_kw/partner/read") {
+                        const res = await performRpc(...arguments);
+                        // The mockRPC doesn't implement related fields
+                        res[0].related = "3 kb";
+                        return res;
+                    }
+                },
+            });
+
+            const initialUnique = Number(getUnique(target.querySelector(".o_field_image img")));
+            assert.ok(initialUnique - 1486375200000 < 100);
+
+            await editInput(target, ".o_field_widget[name='foo'] input", "grrr");
+
+            // the unique should be the same
+            assert.strictEqual(
+                initialUnique,
+                Number(getUnique(target.querySelector(".o_field_image img")))
+            );
+
+            patchDate(2017, 1, 9, 11, 0, 0);
+            await editInput(
+                target,
+                "input[type=file]",
+                new File(
+                    [Uint8Array.from([...atob(MY_IMAGE)].map((c) => c.charCodeAt(0)))],
+                    "fake_file.png",
+                    { type: "png" }
+                )
+            );
+            assert.strictEqual(
+                target.querySelector(".o_field_image img").dataset.src,
+                `data:image/png;base64,${MY_IMAGE}`
+            );
+
+            patchDate(2017, 1, 9, 12, 0, 0);
+
+            await clickSave(target);
+
+            assert.ok(
+                Number(getUnique(target.querySelector(".o_field_image img"))) - 1486638000000 < 100
             );
         }
     );


### PR DESCRIPTION
Steps to reproduce
==================

- Install web_studio,mrp
- Go to Manufacturing > Operations > Manufacturing Orders
- Open studio
- Add a related field
- Select Product > Image
- Change the widget to the ImageField
- Exit studio
- Open any record
- Go to the product
- Edit the image
- Go back to the list view => The old image is still displayed

Cause of the issue
==================

We add a unique parameter in the image url with the last record update. In the case of a related field, the record has not been updated even if the image has changed.

Solution
========

We still need to pass a unique value in the URL because browser will not fetch twice the same URL in the same session. In that case, we can simply pass a random value

opw-4378605