### PR TITLE
[IMP] sale_loyalty: let user claim reward again

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -790,9 +790,6 @@ class SaleOrder(models.Model):
             'used': order_coupon_history.used + points,
         })
 
-    def _remove_program_from_points(self, programs):
-        self.coupon_point_ids.filtered(lambda p: p.coupon_id.program_id in programs).sudo().unlink()
-
     def _get_reward_line_values(self, reward, coupon, **kwargs):
         self.ensure_one()
         self = self.with_context(lang=self._get_lang())

--- a/addons/sale_loyalty/models/sale_order_line.py
+++ b/addons/sale_loyalty/models/sale_order_line.py
@@ -99,27 +99,14 @@ class SaleOrderLine(models.Model):
         reward_coupon_set = {(l.reward_id, l.coupon_id, l.reward_identifier_code) for l in self if l.reward_id}
         related_lines = self.env['sale.order.line']
         related_lines |= self.order_id.order_line.filtered(lambda l: (l.reward_id, l.coupon_id, l.reward_identifier_code) in reward_coupon_set)
-        # Remove the line's coupon from order if it is the last line using that coupon
-        coupons_to_unlink = self.env['loyalty.card']
         for line in self:
             if line.coupon_id:
-                # 2 cases:
-                #  case 1: coupon has been applied directly
-                #  case 2: coupon was created from a program
-                if line.coupon_id in line.order_id.applied_coupon_ids:
-                    line.order_id.applied_coupon_ids -= line.coupon_id
-                elif line.coupon_id.order_id == line.order_id and line.coupon_id.program_id.applies_on == 'current' and\
-                    not any(oLine.coupon_id == line.coupon_id and oLine not in related_lines for oLine in line.order_id.order_line):
-                    # ondelete='restrict' would prevent deletion of the coupon unlink after unlinking lines
-                    coupons_to_unlink |= line.coupon_id
-                    line.order_id.code_enabled_rule_ids = line.order_id.code_enabled_rule_ids.filtered(lambda r: r.program_id != line.coupon_id.program_id)
+                line.order_id.applied_coupon_ids -= line.coupon_id
         # Give back the points if the order is confirmed, points are given back if the order is cancelled but in this case we need to do it directly
         for line in related_lines:
             if line.state == 'sale':
                 line.coupon_id.points += line.points_cost
-        res = super(SaleOrderLine, self | related_lines).unlink()
-        coupons_to_unlink.sudo().unlink()
-        return res
+        return super(SaleOrderLine, self | related_lines).unlink()
 
     def _sellable_lines_domain(self):
         return super()._sellable_lines_domain() + [('reward_id', '=', False)]

--- a/addons/sale_loyalty/tests/common.py
+++ b/addons/sale_loyalty/tests/common.py
@@ -232,6 +232,16 @@ class TestSaleCouponCommon(SaleCommon):
                 continue
             self._claim_reward(order, program, coupons_per_program[program])
 
+    def _clear_rewards(self, order, programs=None):
+        def filter_program(p): return programs is None or p in programs
+        order.order_line.filtered(
+            lambda l: l.reward_id.program_id and filter_program(l.reward_id.program_id)
+        ).unlink()
+        order.coupon_point_ids.filtered(lambda p: filter_program(p.coupon_id.program_id)).unlink()
+        order.code_enabled_rule_ids = order.code_enabled_rule_ids.filtered(
+            lambda r: not filter_program(r.program_id)
+        )
+
 class TestSaleCouponNumbersCommon(TestSaleCouponCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/sale_loyalty/tests/test_program_numbers.py
+++ b/addons/sale_loyalty/tests/test_program_numbers.py
@@ -29,8 +29,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._apply_promo_code(order, 'test_10pc')
         self.assertEqual(len(order.order_line.ids), 3, "We should have 3 lines as we should have a new line for promo code reduction")
         self.assertEqual(order.amount_total, 864, "Only paid product should have their price discounted")
-        order.order_line.filtered(lambda x: 'Discount' in x.name).unlink()  # Remove Discount
-        order._remove_program_from_points(self.p1)
+        self._clear_rewards(order)  # Remove Discount
 
         # Check free product is removed since we are below minimum required quantity
         sol1.product_uom_qty = 2
@@ -143,8 +142,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         # test coupon with code works the same as auto applied_programs
         p_specific_product.write({'trigger': 'with_code'})
         p_specific_product.rule_ids.write({'mode': 'with_code', 'code': '20pc'})
-        order.order_line.filtered(lambda l: l.is_reward_line).unlink()
-        order._remove_program_from_points(p_specific_product)
+        self._clear_rewards(order)
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(len(order.order_line.ids), 1, "Reduction should be removed since we deleted it and it is now a promo code usage, it shouldn't be automatically reapplied")
 
@@ -418,8 +416,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self.assertEqual(len(order.order_line.ids), 13, "Order should have a new discount line for 20% on Large Cabinet")
 
         # Check that if you delete one of the discount tax line, the others tax lines from the same promotion got deleted as well.
-        order.order_line.filtered(lambda l: '10%' in l.name)[0].unlink()
-        order._remove_program_from_points(self.p1)
+        self._clear_rewards(order, self.p1)
         self.assertEqual(len(order.order_line.ids), 9, "All of the 10% discount line per tax should be removed")
         # At this point, removing the Conference Chair's discount line (split per tax) removed also the others discount lines
         # linked to the same program (eg: other taxes lines). So the coupon got removed from the SO since there were no discount lines left
@@ -777,9 +774,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self.assertEqual(order.amount_untaxed, 0.0, "The untaxed amount should not go below 0")
         self.assertEqual(order.amount_total, 13.5, "The promotion program should not make the order total go below 0")
 
-        order.order_line[3:].unlink() #remove all coupon
-        order._remove_program_from_points(coupon_program)
-        order._remove_program_from_points(self.p1)
+        self._clear_rewards(order)
 
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(len(order.order_line), 3, "The promotion program should be removed")
@@ -865,9 +860,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self.assertEqual(order.amount_total, 8.18, "The promotion program should not be altered after recomputation")
         self.assertEqual(order.amount_tax, 8.18)
 
-        order.order_line[3:].unlink() #remove all coupon
-        order._remove_program_from_points(coupon_program)
-        order._remove_program_from_points(self.p1)
+        self._clear_rewards(order)
 
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(len(order.order_line), 3, "The promotion program should be removed")
@@ -1412,7 +1405,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._apply_promo_code(order, 'test_10pc')
         self.assertEqual(order.amount_total, 9, "The total should be 9$.")
         # Now the order way around
-        order.order_line.filtered('reward_id').unlink()
+        self._clear_rewards(order)
         self._apply_promo_code(order, 'test_10pc')
         self.assertEqual(order.amount_total, 18, "The total should be 9$.")
         self._auto_rewards(order, programs)

--- a/addons/website_sale_loyalty/tests/test_sale_coupon_multiwebsite.py
+++ b/addons/website_sale_loyalty/tests/test_sale_coupon_multiwebsite.py
@@ -29,7 +29,7 @@ class TestSaleCouponMultiwebsite(TestSaleCouponNumbersCommon):
         })
 
         def _remove_reward():
-            order.order_line.filtered('is_reward_line').unlink()
+            self._clear_rewards(order)
             self.assertEqual(len(order.order_line.ids), 1, "Program should have been removed")
 
         def _apply_code(code, backend=True):


### PR DESCRIPTION
Currently on checkout a user claims a reward from the available options on the cart summary. Now consider he changes his mind and removes the program to choose another one.

Before this commit, he would have to again add the code to fetch the offers.

For better cart navigation on removal, this commits stops removing the coupon from the order, which has the effect of falling back to the previous screen so that he can make a choice again.

task-4369412

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
