### PR TITLE
[17.0] [FIX] fix dbname in shell command

### DIFF
--- a/doc/cla/corporate/phytocontrol-group.md
+++ b/doc/cla/corporate/phytocontrol-group.md
@@ -1,0 +1,15 @@
+France, 2024-07-17
+
+Phytocontrol Group agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Benoît Fontaine benoitfontaine@phytocontrol.com https://github.com/benoit-phytocontrol
+
+List of contributors:
+
+Benoît Fontaine benoitfontaine@phytocontrol.com https://github.com/benoit-phytocontrol

--- a/odoo/cli/shell.py
+++ b/odoo/cli/shell.py
@@ -4,6 +4,7 @@ import logging
 import os
 import signal
 import sys
+import threading
 from pathlib import Path
 
 import odoo
@@ -106,6 +107,7 @@ class Shell(Command):
             'odoo': odoo,
         }
         if dbname:
+            threading.current_thread().dbname = dbname
             registry = odoo.registry(dbname)
             with registry.cursor() as cr:
                 uid = odoo.SUPERUSER_ID


### PR DESCRIPTION
The  context variable is missing in current thread when using the shell command.

see d19478eb03d2

Description of the issue this PR addresses:
Use the `odoo shell -d dbname` command

```
Current behavior before PR:
Traceback (most recent call last):
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/modules/registry.py", line 87, in __new__
    return cls.registries[db_name]
           ~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/bfontaine/Bureau/local/venv17/lib/python3.11/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
        ~~~~~~^^^^^
KeyError: 'db_test'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/modules/registry.py", line 110, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/bfontaine/Bureau/odoo17/addons/phyto_base/loader.py", line 13, in load_modules
    report = odoo.registry()._assertion_report
             ^^^^^^^^^^^^^^^
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/__init__.py", line 105, in registry
    database_name = threading.current_thread().dbname
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: '_MainThread' object has no attribute 'dbname'
Traceback (most recent call last):
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/modules/registry.py", line 87, in __new__
    return cls.registries[db_name]
           ~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/bfontaine/Bureau/local/venv17/lib/python3.11/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
        ~~~~~~^^^^^
KeyError: 'db_test'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/bfontaine/.local/bin/odoo17", line 246, in <module>
    main()
  File "/home/bfontaine/.local/bin/odoo17", line 242, in main
    run()
  File "/home/bfontaine/.local/bin/odoo17", line 233, in run
    odoo.cli.main()
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/cli/command.py", line 66, in main
    o.run(args)
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/cli/shell.py", line 123, in run
    self.shell(config['db_name'])
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/cli/shell.py", line 109, in shell
    registry = odoo.registry(dbname)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/__init__.py", line 106, in registry
    return modules.registry.Registry(database_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/modules/registry.py", line 89, in __new__
    return cls.new(db_name)
           ^^^^^^^^^^^^^^^^
  File "/home/bfontaine/Bureau/local/venv17/lib/python3.11/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/modules/registry.py", line 110, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/bfontaine/Bureau/odoo17/addons/phyto_base/loader.py", line 13, in load_modules
    report = odoo.registry()._assertion_report
             ^^^^^^^^^^^^^^^
  File "/home/bfontaine/Bureau/odoo/17.0/odoo/__init__.py", line 105, in registry
    database_name = threading.current_thread().dbname
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: '_MainThread' object has no attribute 'dbname'. Did you mean: '_name'?
```

Desired behavior after PR is merged:

shell command works



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
