### PR TITLE
[FIX] product: always compute zoomable with `bin_size=False`

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -184,7 +184,7 @@ class ProductTemplate(models.Model):
 
     @api.depends('image_1920', 'image_1024')
     def _compute_can_image_1024_be_zoomed(self):
-        for template in self:
+        for template in self.with_context(bin_size=False):
             template.can_image_1024_be_zoomed = template.image_1920 and tools.is_image_size_above(template.image_1920, template.image_1024)
 
     @api.depends(


### PR DESCRIPTION
Changing a product template's image with the `can_image_1024_be_zoomed` field present in the view produces a crash on save.

**STEPS TO REPRODUCE**
1. Open a product form view
2. Using studio, add the `can_image_1024_be_zoomed` field
3. Change the image and save

The product will be updated, but this error will be thrown:

```
binascii.Error: Incorrect padding
```

**CAUSE**
https://github.com/odoo/odoo/blob/a74684777c27e26639b75b0668bb15afadb78c4f/addons/product/models/product_template.py#L186-L188

In the `RecordSet`'s context, `bin_size=True`, so accessing `image_<size>` returns a size instead of a binary. `_compute_can_image_1024_be_zoomed` calls `tools.is_image_size_above` with this binary size, while the method expects the full base64 encoded image. Ultimately, this causes `base64.b64decode` to crash with the above error.

**FIX** Update the `RecordSet`'s context to `bin_size=False`. Accessing `image_<size>` from the `RecordSet` will then return the full binary instead of the size.

**NOTES**
In versions <17.0, read and write were done in separate network calls causing the recompute to happen during the flush of the write, which doesn't have `bin_size=True` in the context. Because the field is stored, the read will not cause a recompute and thus avoids any error. In >=17.0, because the read occurs before the flush, and the write has invalidated the field, the recompute will occur with the context of the read (`bin_size=True`), causing the issue.

opw-4413647