### PR TITLE
[REM] orm: RecordCache becomes read-only

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -36,7 +36,7 @@ import re
 import uuid
 import warnings
 from collections import defaultdict, deque
-from collections.abc import MutableMapping, Callable
+from collections.abc import Callable, Mapping
 from inspect import getmembers
 from operator import attrgetter, itemgetter
 
@@ -7193,8 +7193,8 @@ collections.abc.Set.register(BaseModel)
 collections.abc.Sequence.register(BaseModel)
 
 
-class RecordCache(MutableMapping):
-    """ A mapping from field names to values, to read and update the cache of a record. """
+class RecordCache(Mapping[str, typing.Any]):
+    """ A mapping from field names to values, to read the cache of a record. """
     __slots__ = ['_record']
 
     def __init__(self, record):
@@ -7210,16 +7210,6 @@ class RecordCache(MutableMapping):
         """ Return the cached value of field ``name`` for `record`. """
         field = self._record._fields[name]
         return self._record.env.cache.get(self._record, field)
-
-    def __setitem__(self, name, value):
-        """ Assign the cached value of field ``name`` for ``record``. """
-        field = self._record._fields[name]
-        self._record.env.cache.set(self._record, field, value)
-
-    def __delitem__(self, name):
-        """ Remove the cached value of field ``name`` for ``record``. """
-        field = self._record._fields[name]
-        self._record.env.cache.remove(self._record, field)
 
     def __iter__(self):
         """ Iterate over the field names with a cached value. """


### PR DESCRIPTION
In order to simplify cache management, remove progressively methods that allow updating the cache when it is possible. The `RecordCache` is used mostly for testing/debugging, we do not need to update the cache through there.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
