### PR TITLE
[FIX] l10n_in: hide QR if upi id is not set

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -144,7 +144,7 @@ class AccountMove(models.Model):
 
     def _generate_qr_code(self, silent_errors=False):
         self.ensure_one()
-        if self.company_id.country_code == 'IN':
+        if self.company_id.country_code == 'IN' and self.company_id.l10n_in_upi_id:
             payment_url = 'upi://pay?pa=%s&pn=%s&am=%s&tr=%s&tn=%s' % (
                 self.company_id.l10n_in_upi_id,
                 self.company_id.name,

--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -33,10 +33,10 @@
         </xpath>
 
         <xpath expr="//div[@id='qrcode_info']" position="after">
-            <t t-if="o.company_id.account_fiscal_country_id.code == 'IN'">
+            <t t-if="o.company_id.account_fiscal_country_id.code == 'IN' and o.company_id.l10n_in_upi_id">
                 <div style="display:-webkit-flex;" class="flex-column">
                     <strong>PAYMENT QR CODE</strong>
-                    <div t-if="o.company_id.l10n_in_upi_id" class="mt-1 mb-1">
+                    <div class="mt-1 mb-1">
                         <p class="mb-0">UPI ID:</p>
                         <span class="mb-0" t-field="o.company_id.l10n_in_upi_id"/>
                     </div>


### PR DESCRIPTION
**Steps to reproduce:**
1) Select the QR Codes option in settings (IN Company)
2) Do not enter an upi id in the company profile.
3) Go to invoice and preview/print the invoice.
4) Show that QR code without upi id and upi logos visible.

**Cause:**
- The condition of the upi id is not properly set to hide the block if upi is not set.

**Fix:**
- With this PR, the upi QR code and upi logos will not be visible if the upi id is not set.

**task**-4426634