### PR TITLE
[IMP] stock: make product field readonly and pre-filled in production…

### DIFF
--- a/addons/stock/views/stock_lot_views.xml
+++ b/addons/stock/views/stock_lot_views.xml
@@ -35,7 +35,7 @@
                 </div>
                 <group name="main_group">
                     <group>
-                        <field name="product_id" context="{'default_is_storable': True, 'default_tracking': 'lot'}" readonly="context.get('set_product_readonly', False)" force_save="1" help="Product this lot/serial number contains. You cannot change it anymore if it has already been moved."/>
+                        <field name="product_id" context="{'default_is_storable': True, 'default_tracking': 'lot'}" readonly="context.get('set_product_readonly', False) or context.get('from_failure_form', False)" force_save="1" help="Product this lot/serial number contains. You cannot change it anymore if it has already been moved."/>
                         <label for="product_qty" invisible="not display_complete"/>
                         <div class="o_row" invisible="not display_complete">
                             <field name="product_qty"/>


### PR DESCRIPTION
… lot form

With this Commit:
======================
When the user opens the production_lot_form from the Quality Check wizard using the 'Create and Edit' option, the Product field in the form is now readonly and pre-filled with the product currently undergoing the Quality Check.

Purpose:
======================
When the user creates a Lot/SN from the Quality Check wizard, it is obvious that the Lot/SN is for the same product currently undergoing the Quality Check.

task-4319628