### PR TITLE
[FIX] l10n_in_hr_holidays: fix sandwich leave warning sign

### DIFF
--- a/addons/l10n_in_hr_holidays/views/hr_leave_views.xml
+++ b/addons/l10n_in_hr_holidays/views/hr_leave_views.xml
@@ -10,7 +10,7 @@
                 <field name="l10n_in_contains_sandwich_leaves" invisible="1" />
             </xpath>
             <xpath expr="//field[@name='duration_display']" position="after">
-                <div name="l10n_in_contains_sandwich_leaves" invisible="not l10n_in_contains_sandwich_leaves" class="w-md-75 float-end ps-3 alert alert-warning" role="alert">
+                <div name="l10n_in_contains_sandwich_leaves" invisible="not l10n_in_contains_sandwich_leaves" colspan="2" class="w-md-75 float-end ps-3 alert alert-warning" role="alert">
                     The requested time considers the sandwich leave policy.
                 </div>
             </xpath>


### PR DESCRIPTION
Steps to reproduce:
- Install India - Time Off
- Create a new time off type in the Indian company and enable sandwich leave
- Create two time offs around the weekends
- The sandwich leave warning appears

Issue:
There is a visual issue with the sandwich leave warning sign.

Cause:
The group contains two columns: one for labeling and one for input.

Solution:
Added colspan="2" to a single div element to occupy the entire space.

task-4435090
