### PR TITLE
[FIX] pos_razorpay: traceback when terminal payment done on floor screen

### DIFF
--- a/addons/pos_razorpay/static/src/app/payment_razorpay.js
+++ b/addons/pos_razorpay/static/src/app/payment_razorpay.js
@@ -122,6 +122,11 @@ export class PaymentRazorpay extends PaymentInterface {
             //Clear previous timeout before setting a new one
             clearTimeout(this.pollingTimeout);
 
+            // If the user navigates to another screen, stop the polling
+            if (this.pos.mainScreen.component.name !== "PaymentScreen") {
+                return;
+            }
+
             //Within 90 seconds, inactivity will result in transaction cancellation and payment termination.
             if (this.payment_stopped) {
                 this._razorpay_cancel().then(() => {


### PR DESCRIPTION
Steps to Reproduce:
=========
- Install the modules: pos_razorpay, l10n_in, and pos_restaurant.
- Create a payment method for the Razorpay terminal.
- Open a restaurant register linked to an Indian company with the added Razorpay terminal payment method.
- Create an order, add a Razorpay payment line, and navigate to the floor screen.

Issue:
==========
- A traceback occurs when completing a payment.

Cause:
=========
- Polling for the Razorpay terminal continues even after leaving the payment screen and navigating to the floor screen.

Fix:
=========
- Stop the polling process when the user leaves the payment screen.
- Resume polling only when the user returns to the payment screen.

task-4414016