### PR TITLE
[FIX] html_editior: prevent key error when content-type is missing

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -254,7 +254,7 @@ class HTML_Editor(http.Controller):
             # only supported image types are incorporated into the data.
             response = requests.head(url, timeout=10)
             if response.status_code == 200:
-                mime_type = response.headers['content-type']
+                mime_type = response.headers.get('content-type')
                 if mime_type in SUPPORTED_IMAGE_MIMETYPES:
                     attachment_data['mimetype'] = mime_type
         else:


### PR DESCRIPTION
This error occurs when ``content-type`` is not found in the response when attaching any file with the type ``URL``.

Traceback:
---
```
KeyError: 'content-type'
  File "odoo/http.py", line 2366, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1894, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1957, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1924, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2171, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 329, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 727, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/html_editor/controllers/main.py", line 355, in add_url
    attachment = self._attachment_create(url=url, res_id=res_id, res_model=res_model)
  File "addons/html_editor/controllers/main.py", line 256, in _attachment_create
    mime_type = response.headers['content-type']
  File "requests/structures.py", line 52, in __getitem__
    return self._store[key.lower()][1]
```

https://github.com/odoo/odoo/blob/2fe55ae592e5812c5ee5e39ed1e8332bde608cb2/addons/html_editor/controllers/main.py#L257

sentry-6015024235

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
