### PR TITLE
[FIX] web: name_search user manage falsy index

### DIFF
--- a/addons/web/models/res_users.py
+++ b/addons/web/models/res_users.py
@@ -12,7 +12,8 @@ class ResUsers(models.Model):
         # if we have a search with a limit, move current user as the first result
         user_list = super().name_search(name, args, operator, limit)
         uid = self._uid
-        if index := next((i for i, (user_id, _name) in enumerate(user_list) if user_id == uid), False):
+        # index 0 is correct not Falsy in this case, use None to avoid ignoring it
+        if (index := next((i for i, (user_id, _name) in enumerate(user_list) if user_id == uid), None)) is not None:
             # move found user first
             user_tuple = user_list.pop(index)
             user_list.insert(0, user_tuple)

--- a/addons/web/tests/test_res_users.py
+++ b/addons/web/tests/test_res_users.py
@@ -37,6 +37,12 @@ class TestResUsers(TransactionCase):
         jean_paul = self.users[1]
         user_ids = [id_ for id_, __ in ResUsers.with_user(jean_paul).name_search('Jean')]
         self.assertEqual(jean_paul.id, user_ids[0], "The current user, Jean-Paul, should be the first in the result")
+        claude = self.users[4]
+        user_ids = [id_ for id_, __ in ResUsers.with_user(claude).name_search('', limit=2)]
+        self.assertEqual(claude.id, user_ids[0], "The current user, Claude, should be the first in the result.")
+        self.assertNotEqual(claude.id, user_ids[1], "The current user, Claude, should not appear twice in the result")
+        user_ids = [id_ for id_, __ in ResUsers.with_user(claude).name_search('', limit=5)]
+        self.assertEqual(len(user_ids), len(set(user_ids)), "Some user(s), appear multiple times in the result")
 
     def test_change_password(self):
         '''


### PR DESCRIPTION
Steps:
- Login as Mitchell Admin
- Create 8 user (B, C, D, E, F, G, H, I) to reach search limit
- Rename Mitchell Admin to Admin Mitchell to be the first result
- Open a user dropdown (employee form)

Actual result:
- Admin Mitchell appears twice

Expected result:
- Admin Mitchell appears at first position
- Admin Mitchell appears only once

opw-4430590