### PR TITLE
[FIX] im_livechat: fix chatbot question selection

### DIFF
--- a/addons/im_livechat/controllers/__init__.py
+++ b/addons/im_livechat/controllers/__init__.py
@@ -4,5 +4,6 @@
 from . import attachment
 from . import chatbot
 from . import main
+from . import thread
 from . import webclient
 from . import cors

--- a/addons/im_livechat/controllers/thread.py
+++ b/addons/im_livechat/controllers/thread.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import request, route
+from odoo.addons.mail.controllers import thread
+
+
+class ThreadController(thread.ThreadController):
+    @route()
+    def mail_message_post(self, thread_model, thread_id, post_data, context=None, **kwargs):
+        if selected_answer_id := kwargs.pop("selected_answer_id", None):
+            request.update_context(selected_answer_id=selected_answer_id)
+        return super().mail_message_post(thread_model, thread_id, post_data, context, **kwargs)

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -216,14 +216,41 @@ class DiscussChannel(models.Model):
         """
         This method is called just before _notify_thread() method which is calling the _to_store()
         method. We need a 'chatbot.message' record before it happens to correctly display the message.
-        It's created only if the mail channel is linked to a chatbot step.
+        It's created only if the mail channel is linked to a chatbot step. We also need to save the
+        user answer if the current step is a question selection.
         """
         if self.chatbot_current_step_id:
-            self.env['chatbot.message'].sudo().create({
-                'mail_message_id': message.id,
-                'discuss_channel_id': self.id,
-                'script_step_id': self.chatbot_current_step_id.id,
-            })
+            selected_answer = (
+                self.env["chatbot.script.answer"]
+                .browse(self.env.context.get("selected_answer_id"))
+                .exists()
+            )
+            if selected_answer in self.chatbot_current_step_id.answer_ids:
+                # sudo - chatbot.message: finding the question message to update the user answer is allowed.
+                question_msg = (
+                    self.env["chatbot.message"]
+                    .sudo()
+                    .search(
+                        [
+                            ("discuss_channel_id", "=", self.id),
+                            ("script_step_id", "=", self.chatbot_current_step_id.id),
+                        ],
+                        order="id DESC",
+                        limit=1,
+                    )
+                )
+                question_msg.user_script_answer_id = selected_answer
+                if store := self.env.context.get("message_post_store"):
+                    store.add(question_msg.mail_message_id)
+
+            self.env["chatbot.message"].sudo().create(
+                {
+                    "mail_message_id": message.id,
+                    "discuss_channel_id": self.id,
+                    "script_step_id": self.chatbot_current_step_id.id,
+                }
+            )
+
         return super()._message_post_after_hook(message, msg_vals)
 
     def _chatbot_restart(self, chatbot_script):

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -2,7 +2,6 @@ import { AND, Record } from "@mail/core/common/record";
 import { rpc } from "@web/core/network/rpc";
 import { browser } from "@web/core/browser/browser";
 import { debounce } from "@web/core/utils/timing";
-import { escape } from "@web/core/utils/strings";
 
 export class Chatbot extends Record {
     static id = AND("script", "thread");
@@ -143,18 +142,7 @@ export class Chatbot extends Record {
      * @returns {Promise<boolean>} Whether the script is ready to go to the next step.
      */
     async _processAnswerQuestionSelection(message) {
-        if (this.currentStep.selectedAnswer) {
-            return true;
-        }
-        const answer = this.currentStep.answers.find(({ name }) =>
-            message.body.includes(escape(name))
-        );
-        this.currentStep.selectedAnswer = answer;
-        await rpc("/chatbot/answer/save", {
-            channel_id: this.thread.id,
-            message_id: this.currentStep.message.id,
-            selected_answer_id: answer.id,
-        });
+        const answer = this.currentStep.selectedAnswer;
         if (!answer.redirect_link) {
             return true;
         }

--- a/addons/im_livechat/static/src/embed/common/message_patch.js
+++ b/addons/im_livechat/static/src/embed/common/message_patch.js
@@ -19,6 +19,6 @@ patch(Message.prototype, {
      * @param {import("@im_livechat/embed/common/chatbot/chatbot_step_model").StepAnswer} answer
      */
     answerChatbot(answer) {
-        return this.props.message.thread.post(answer.name);
+        return this.props.message.thread.post(answer.name, {}, { selected_answer_id: answer.id });
     },
 });

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -28,14 +28,25 @@ patch(Thread.prototype, {
             },
         });
         this.chatbot = Record.one("Chatbot");
+        this._startChatbot = Record.attr(false, {
+            compute() {
+                return (
+                    this.chatbot?.thread?.eq(
+                        this.store.env.services["im_livechat.livechat"].thread
+                    ) && this.isLoaded
+                );
+            },
+            onUpdate() {
+                if (this._startChatbot) {
+                    this.store.env.services["im_livechat.chatbot"].start();
+                }
+            },
+        });
         this.requested_by_operator = false;
     },
 
     get isLastMessageFromCustomer() {
-        if (this.channel_type !== "livechat") {
-            return super.isLastMessageFromCustomer;
-        }
-        return this.newestMessage?.isSelfAuthored;
+        return this.newestPersistentOfAllMessage?.isSelfAuthored;
     },
 
     get membersThatCanSeen() {

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -40,7 +40,7 @@ class ChatbotCase(common.HttpCase):
             cls.step_dispatch_operator,
             cls.step_dispatch_documentation,
         ] = cls.env['chatbot.script.answer'].sudo().create([{
-            'name': 'I want to buy the software',
+            'name': 'I\'d like to buy the software',
             'script_step_id': cls.step_dispatch.id,
         }, {
             'name': 'Pricing Question',

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -28,7 +28,7 @@ class ChatbotCase(chatbot_common.ChatbotCase):
 
         self.assertNotEqual(step_email_copy, self.step_email)
         self.assertEqual(len(step_email_copy.triggering_answer_ids), 1)
-        self.assertEqual(step_email_copy.triggering_answer_ids.name, 'I want to buy the software')
+        self.assertEqual(step_email_copy.triggering_answer_ids.name, 'I\'d like to buy the software')
         self.assertNotEqual(step_email_copy.triggering_answer_ids, self.step_dispatch_buy_software)
 
     def test_chatbot_is_forward_operator_child(self):

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -116,6 +116,8 @@ class ThreadController(http.Controller):
         guest.env["ir.attachment"].browse(post_data.get("attachment_ids", []))._check_attachments_access(
             kwargs.get("attachment_tokens")
         )
+        store = Store()
+        request.update_context(message_post_store=store)
         if context:
             request.update_context(**context)
         canned_response_ids = tuple(cid for cid in kwargs.get('canned_response_ids', []) if isinstance(cid, int))
@@ -148,7 +150,7 @@ class ThreadController(http.Controller):
             }
         # sudo: mail.thread - users can post on accessible threads
         message = thread.sudo().message_post(**self._prepare_post_data(post_data, thread, **kwargs))
-        return Store(message, for_current_user=True).get_result()
+        return store.add(message, for_current_user=True).get_result()
 
     @http.route("/mail/message/update_content", methods=["POST"], type="json", auth="public")
     @add_guest_to_context

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -657,12 +657,12 @@ export class Thread extends Record {
         try {
             const { data, messages } = await this.fetchMessagesData({ after, around, before });
             this.store.insert(data, { html: true });
-            this.isLoaded = true;
             return this.store.Message.insert(messages.reverse());
         } catch (e) {
             this.hasLoadingFailed = true;
             throw e;
         } finally {
+            this.isLoaded = true;
             this.status = "ready";
         }
     }

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -30,7 +30,7 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             },
         },
         {
-            trigger: '.o-livechat-root:shadow li:contains("I want to buy the software")',
+            trigger: '.o-livechat-root:shadow li:contains("I\'d like to buy the software")',
             run: "click",
         },
         {
@@ -40,7 +40,7 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             async run() {
                 await contains(".o-mail-Message-actions [title='Add a Reaction']", {
                     target: this.anchor.getRootNode(),
-                    parent: [".o-mail-Message", { text: "I want to buy the software" }],
+                    parent: [".o-mail-Message", { text: "I'd like to buy the software" }],
                 });
             },
         },

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
@@ -25,7 +25,7 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_test_page_tour
             run: "click",
         },
         {
-            trigger: '.o-livechat-root:shadow li:contains("I want to buy the software")',
+            trigger: '.o-livechat-root:shadow li:contains("I\'d like to buy the software")',
             run: "click",
         },
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_question_selection_overlapping_answers.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_question_selection_overlapping_answers.js
@@ -1,0 +1,36 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("website_livechat.question_selection_overlapping_answers", {
+    steps: () => [
+        {
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
+            run: "click",
+        },
+        { trigger: ".o-livechat-root:shadow .o-mail-Message:contains(Choose an option)" },
+        {
+            trigger: ".o-livechat-root:shadow li:eq(0)",
+            run: "click",
+        },
+        { trigger: ".o-livechat-root:shadow .o-mail-Message:contains(You selected not X)" },
+        {
+            trigger: ".o-livechat-root:shadow button[title='Restart Conversation']",
+            run: "click",
+        },
+        { trigger: ".o-livechat-root:shadow .o-mail-Message:contains(Choose an option)" },
+        {
+            trigger: ".o-livechat-root:shadow li:eq(1)",
+            run: "click",
+        },
+        { trigger: ".o-livechat-root:shadow .o-mail-Message:contains(You selected X)" },
+        {
+            trigger: ".o-livechat-root:shadow button[title='Restart Conversation']",
+            run: "click",
+        },
+        { trigger: ".o-livechat-root:shadow .o-mail-Message:contains(Choose an option)" },
+        {
+            trigger: ".o-livechat-root:shadow li:eq(2)",
+            run: "click",
+        },
+        { trigger: ".o-livechat-root:shadow .o-mail-Message:contains(You selected maybe X)" },
+    ],
+});

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -45,7 +45,7 @@ class TestLivechatChatbotUI(TestImLivechatCommon, TestWebsiteLivechatCommon, Cha
             # next message would normally have 'self.step_dispatch_buy_software' as answer
             # but it's wiped when restarting the script
             ("How can I help you?", operator, False),
-            ("I want to buy the software", False, False),
+            ("I\'d like to buy the software", False, False),
             ("Can you give us your email please?", operator, False),
             ("No, you won't get my email!", False, False),
             ("'No, you won't get my email!' does not look like a valid email. Can you please try again?", operator, False),
@@ -221,3 +221,59 @@ class TestLivechatChatbotUI(TestImLivechatCommon, TestWebsiteLivechatCommon, Cha
         channel = self.livechat_channel.channel_ids[0]
         self.assertIn(channel.channel_member_ids.partner_id.user_ids, en_op)
         self.assertNotIn(channel.channel_member_ids.partner_id.user_ids, fr_op)
+
+    def test_question_selection_overlapping_answers(self):
+        chatbot_script = self.env["chatbot.script"].create({"title": "Question selection bot"})
+        question_1 = self.env["chatbot.script.step"].create(
+            [
+                {
+                    "chatbot_script_id": chatbot_script.id,
+                    "message": "Choose an option",
+                    "step_type": "question_selection",
+                },
+            ]
+        )
+        not_x_answer = self.env["chatbot.script.answer"].create({
+            "name": "not X",
+            "script_step_id": question_1.id,
+        })
+        x_answer = self.env["chatbot.script.answer"].create({
+            "name": "X",
+            "script_step_id": question_1.id,
+        })
+        maybe_x_answer = self.env["chatbot.script.answer"].create({
+            "name": "Maybe X",
+            "script_step_id": question_1.id,
+        })
+        self.env["chatbot.script.step"].create(
+            [
+                {
+                    "chatbot_script_id": chatbot_script.id,
+                    "step_type": "text",
+                    "triggering_answer_ids": [not_x_answer.id],
+                    "message": "You selected not X",
+                },
+                {
+                    "chatbot_script_id": chatbot_script.id,
+                    "step_type": "text",
+                    "triggering_answer_ids": [x_answer.id],
+                    "message": "You selected X",
+                },
+                {
+                    "chatbot_script_id": chatbot_script.id,
+                    "step_type": "text",
+                    "triggering_answer_ids": [maybe_x_answer.id],
+                    "message": "You selected maybe X",
+                },
+            ]
+        )
+        self.livechat_channel.rule_ids = self.env["im_livechat.channel.rule"].create(
+            [
+                {
+                    "channel_id": self.livechat_channel.id,
+                    "chatbot_script_id": chatbot_script.id,
+                    "regex_url": "/",
+                },
+            ]
+        )
+        self.start_tour("/", "website_livechat.question_selection_overlapping_answers")


### PR DESCRIPTION
The question_selection steps of the chatbot suffer from several issues. In [1], a fix was made to make the chatbot work with answers containing ampersands, but this fix broke other special characters such as "'".

This step also does not handle well answers containing a subset of words, such as "X"/"not X". This occurs because the client code tries to guess which answer was selected after posting the answer.

This PR updates the flow to  save the answer when the message is posted. As a result, there is no need to guess which answer was selected anymore, and all these issues are fixed.

[1]: https://github.com/odoo/odoo/pull/189313

opw-4369966,4436567.