### PR TITLE
[IMP] sale_project: added profitability section unfold persistance

### DIFF
--- a/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability.js
+++ b/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability.js
@@ -7,6 +7,7 @@ patch(ProjectProfitability, {
         ...ProjectProfitability.props,
         projectId: Number,
         context: Object,
+        sectionState: { type: Object, optional: true },
     },
 
     components: {

--- a/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability.xml
+++ b/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability.xml
@@ -11,6 +11,7 @@
                 onClick="(params) => this.props.onProjectActionClick(params)"
                 projectId="this.props.projectId"
                 context="this.props.context"
+                foldState="props.sectionState?.[revenue.id] || {}"
             />
         </xpath>
     </t>

--- a/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.js
+++ b/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.js
@@ -1,5 +1,5 @@
 import { useService } from "@web/core/utils/hooks";
-import { Component, useState } from "@odoo/owl";
+import { Component, useState, onWillStart } from "@odoo/owl";
 import { formatFloat, formatFloatTime } from "@web/views/fields/formatters";
 
 export class ProjectProfitabilitySection extends Component {
@@ -12,6 +12,7 @@ export class ProjectProfitabilitySection extends Component {
         onClick: Function,
         projectId: Number,
         context: Object,
+        foldState: { type: Object, optional: true },
     };
     static template = "sale_project.ProjectProfitabilitySection";
 
@@ -24,6 +25,14 @@ export class ProjectProfitabilitySection extends Component {
             displayLoadMore: null,
         });
         this.sale_items = [];
+
+        onWillStart(() => {
+            if (Object.keys(this.props.foldState).length && this.state.isFolded) {
+                this.sale_items = [...this.props.foldState.sol_items];
+                this.state.displayLoadMore = this.props.foldState.displayLoadMore;
+                this.state.isFolded = !this.state.isFolded;
+            }
+        });
     }
 
     get revenue() {

--- a/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.xml
+++ b/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="sale_project.ProjectProfitabilitySection">
-        <tr class="opacity-trigger-hover" t-att-class="{ 'table-active': !state.isFolded }">
+        <tr t-att-id="revenue.id" class="opacity-trigger-hover" t-att-class="{ 'table-active': !state.isFolded }">
             <t t-set="revenue_label" t-value="props.labels[revenue.id] or revenue.id"/>
             <td>
                 <div class="position-relative d-flex gap-1">
@@ -30,7 +30,7 @@
         </tr>
         <t t-if="!state.isFolded and this.props.revenue.isSectionFoldable">
             <tr class="table-active">
-                <td colspan="4" class="p-0 m-0">
+                <td colspan="4" class="p-0 m-0" t-att-id="revenue.id + '-unfolded'">
                     <table class="o_rightpanel_subtable table table-sm table-borderless table-hover mb-0 border-bottom">
                         <thead>
                             <tr>
@@ -41,7 +41,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr t-foreach="sale_items" t-as="sale_item" t-key="sale_item.id">
+                            <tr t-foreach="sale_items" t-as="sale_item" t-key="sale_item.id" t-att-id="sale_item.id">
                                 <t t-set="uom_name" t-value="sale_item.product_uom_id and sale_item.product_uom_id[1]"/>
                                 <td class="ps-4">
                                     <a t-if="sale_item.action" href="#" t-on-click="() => this.onSaleItemActionClick(sale_item.action)">

--- a/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.js
+++ b/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.js
@@ -7,3 +7,10 @@ patch(ProjectRightSidePanel.prototype, {
         return super.panelVisible || this.state.data.show_sale_items;
     },
 });
+
+patch(ProjectRightSidePanel, {
+    props: {
+        ...ProjectRightSidePanel.props,
+        sectionState: { type: Object, optional: true },
+    },
+});

--- a/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.xml
+++ b/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.xml
@@ -12,6 +12,7 @@
                 onClick="(params) => this.onProjectActionClick(params)"
                 projectId="projectId"
                 context="context"
+                sectionState="props.sectionState"
             />
         </xpath>
     </t>

--- a/addons/sale_project/static/src/views/hooks.js
+++ b/addons/sale_project/static/src/views/hooks.js
@@ -1,0 +1,37 @@
+import { useSetupAction } from "@web/search/action_hook";
+import { onWillStart } from "@odoo/owl";
+
+export function projectUpdateControllerStatePersistancePatch() {
+    return {
+        /**
+         * @override
+         */
+        setup() {
+            super.setup();
+            this.prevSectionState = this.props?.state?.sectionState || {};
+            useSetupAction({
+                getGlobalState: () => {
+                    const sectionState = {};
+                    this.rootRef.el.querySelectorAll("tr td button.fa-caret-down").forEach((node) => {
+                        const rowId = node.closest("tr").id;
+                        const ids = Array.from(
+                            this.rootRef.el.querySelectorAll(`#${rowId}-unfolded tbody tr`),
+                            (val) => parseInt(val.id)
+                        );
+                        sectionState[rowId] = ids;
+                    });
+                    return { sectionState };
+                },
+            });
+            onWillStart(async () => {
+                if (this.props?.globalState?.sectionState) {
+                    this.prevSectionState = await this.model.orm.call(
+                        "project.project",
+                        "prefetch_sale_items_data",
+                        [this.props.context.active_id, this.props?.globalState?.sectionState]
+                    );
+                }
+            });
+        },
+    };
+}

--- a/addons/sale_project/static/src/views/project_update_kanban/project_update_kanban_controller.js
+++ b/addons/sale_project/static/src/views/project_update_kanban/project_update_kanban_controller.js
@@ -1,0 +1,5 @@
+import { patch } from "@web/core/utils/patch";
+import { ProjectUpdateKanbanController } from "@project/views/project_update_kanban/project_update_kanban_controller";
+import { projectUpdateControllerStatePersistancePatch } from "@sale_project/views/hooks";
+
+patch(ProjectUpdateKanbanController.prototype, projectUpdateControllerStatePersistancePatch());

--- a/addons/sale_project/static/src/views/project_update_kanban/project_update_kanban_controller.xml
+++ b/addons/sale_project/static/src/views/project_update_kanban/project_update_kanban_controller.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="sale_project.ProjectUpdateKanbanView" t-inherit="project.ProjectUpdateKanbanView" t-inherit-mode="extension">
+        <xpath expr="//ProjectRightSidePanel" position="attributes">
+            <attribute name="sectionState">prevSectionState</attribute>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/sale_project/static/src/views/project_update_list/project_update_list_controller.js
+++ b/addons/sale_project/static/src/views/project_update_list/project_update_list_controller.js
@@ -1,0 +1,5 @@
+import { patch } from "@web/core/utils/patch";
+import { ProjectUpdateListController } from "@project/views/project_update_list/project_update_list_controller";
+import { projectUpdateControllerStatePersistancePatch } from "@sale_project/views/hooks";
+
+patch(ProjectUpdateListController.prototype, projectUpdateControllerStatePersistancePatch());

--- a/addons/sale_project/static/src/views/project_update_list/project_update_list_controller.xml
+++ b/addons/sale_project/static/src/views/project_update_list/project_update_list_controller.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="sale_project.ProjectUpdateListView" t-inherit="project.ProjectUpdateListView" t-inherit-mode="extension">
+        <xpath expr="//ProjectRightSidePanel" position="attributes">
+            <attribute name="sectionState">prevSectionState</attribute>
+        </xpath>
+    </t>
+
+</templates>


### PR DESCRIPTION
Before this commit when we unfold the Revenue Sections and switch view or open the records in SOL linked to revenue through the action links. The state of the view is reset the opened section get closed.

After this commit, the profitability revenue section have persistence regarding the section being opened even after switching views and coming back.

task-4398311