### PR TITLE
[FIX] point_of_sale: ensure instant reflection of product edits from frontend

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -3,7 +3,7 @@ import { useService } from "@web/core/utils/hooks";
 import { useBarcodeReader } from "@point_of_sale/app/barcode/barcode_reader_hook";
 import { _t } from "@web/core/l10n/translation";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
-import { Component, onMounted, useState, reactive } from "@odoo/owl";
+import { Component, onMounted, useState, reactive, useEffect } from "@odoo/owl";
 import { CategorySelector } from "@point_of_sale/app/generic_components/category_selector/category_selector";
 import { Input } from "@point_of_sale/app/generic_components/inputs/input/input";
 import {
@@ -55,6 +55,14 @@ export class ProductScreen extends Component {
             previousSearchWord: "",
             currentOffset: 0,
         });
+        useEffect(
+            () => {
+                if (this.pos.renderProductScreen) {
+                    this.pos.renderProductScreen = false;
+                }
+            },
+            () => [this.pos.renderProductScreen]
+        );
         onMounted(() => {
             this.pos.openCashControl();
 

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -430,3 +430,52 @@ registry.category("web_tour.tours").add("PosSaveOrderlinesIndexedDB", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("frontendCreateUpdateProduct", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            Chrome.clickMenuOption("Create Product"),
+
+            // Verify that the "New Product" dialog is displayed.
+            Dialog.is({ title: "New Product" }),
+
+            // Create a new product from frontend.
+            ProductScreen.createProductFromFrontend(
+                "Test Frontend Product",
+                "710535977349",
+                "20.0",
+                "Chair test"
+            ),
+            Dialog.confirm(),
+
+            // Click on the category button for "Chair test" to verify the product's addition.
+            {
+                trigger: '.category-button:eq(1) > span:contains("Chair test")',
+                run: "click",
+            },
+            ProductScreen.productIsDisplayed("Test Frontend Product"),
+
+            // Open the product's information popup.
+            ProductScreen.clickInfoProduct("Test Frontend Product"),
+            Dialog.confirm("Edit", ".btn-secondary"),
+
+            // Verify that the "Edit Product" dialog is displayed.
+            Dialog.is({ title: "Edit Product" }),
+
+            // Edit the product with new details.
+            ProductScreen.editProductFromFrontend(
+                "Test Frontend Product Edited",
+                "710535977348",
+                "50.0"
+            ),
+            Dialog.confirm(),
+            {
+                trigger: '.category-button:eq(1) > span:contains("Chair test")',
+                run: "click",
+            },
+            ProductScreen.productIsDisplayed("Test Frontend Product Edited"),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -607,3 +607,50 @@ export function checkTaxAmount(amount) {
         trigger: `.tax:contains(${amount})`,
     };
 }
+
+function productInputSteps(name, barcode, list_price) {
+    return [
+        {
+            content: "Enter product name.",
+            trigger: 'div[name="name"] input',
+            run: `edit ${name}`,
+        },
+        {
+            content: "Enter barcode to fetch product data using barcodelookup.",
+            trigger: 'div[name="barcode"] input',
+            run: `edit ${barcode}`,
+        },
+        {
+            content: "Enter list_price.",
+            trigger: 'div[name="list_price"] input',
+            run: `edit ${list_price}`,
+        },
+    ];
+}
+
+export function createProductFromFrontend(name, barcode, list_price, category) {
+    return [
+        ...productInputSteps(name, barcode, list_price),
+        {
+            content: "Open category selector.",
+            trigger: 'div[name="pos_categ_ids"] input',
+            run: "click",
+        },
+        {
+            isActive: ["desktop"],
+            content: "Select category.",
+            trigger: `.o_input_dropdown .o-autocomplete--dropdown-menu li:contains(${category})`,
+            run: "click",
+        },
+        {
+            isActive: ["mobile"],
+            content: "Select category.",
+            trigger: `.o_kanban_renderer .o_kanban_record span:contains(${category})`,
+            run: "click",
+        },
+    ];
+}
+
+export function editProductFromFrontend(name, barcode, list_price) {
+    return productInputSteps(name, barcode, list_price);
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1643,6 +1643,28 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'LotTour', login="pos_user")
 
+    def test_product_create_update_from_frontend(self):
+        '''This test used to product creation and update product details from the POS frontend.'''
+        self.pos_admin.write({
+            'groups_id': [Command.link(self.env.ref('base.group_system').id)],
+        })
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour('/pos/ui?config_id=%d' % self.main_pos_config.id, 'frontendCreateUpdateProduct', login='pos_admin')
+
+        # In the frontend, a product was created during the tour with the following details:
+        # - Product name: Test Frontend Product
+        # - Barcode: 710535977349
+        # - List price: 20.0
+
+        #  Ensure that the original product created in the frontend ('Test Frontend Product') has been edited to ('Test Frontend Product Edited').
+        frontend_created_product = self.env['product.product'].search_count([('name', '=', 'Test Frontend Product')])
+        frontend_created_product_edited = self.env['product.product'].search([('name', '=', 'Test Frontend Product Edited')])
+
+        self.assertEqual(frontend_created_product, 0)
+        self.assertEqual(frontend_created_product_edited.name, 'Test Frontend Product Edited')
+        self.assertEqual(frontend_created_product_edited.barcode, '710535977348')
+        self.assertEqual(frontend_created_product_edited.list_price, 50.0)
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Before this commit:
====================
Product edits made from the POS frontend were not immediately reflected on the
product screen. Changes became visible only after a page refresh or when the
product was added to the cart.

After this commit:
====================
Product edits now instantly update and reflect on the product screen without
requiring a page refresh or additional user actions.

Task-4431596