### PR TITLE
[FIX] web_editor: properly insert link in mass_mailing after url choice

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2462,7 +2462,9 @@ const Wysiwyg = Widget.extend({
         }
         const closestDialog = e.target.closest('.o_dialog, .o_web_editor_dialog');
         if (
-            e.target.closest('.oe-toolbar,.oe-powerbox-wrapper,.o_we_crop_widget') ||
+            // TODO the autocomplete part is a website thing, move that as a
+            // website customization.
+            e.target.closest('.oe-toolbar,.oe-powerbox-wrapper,.o_we_crop_widget,.ui-autocomplete') ||
             (closestDialog && closestDialog.querySelector('.o_select_media_dialog, .o_link_dialog'))) {
             this._shouldDelayBlur = true;
         } else {


### PR DESCRIPTION
Backport of [1]. Note that in 16.0, to reproduce the bug, you first have to enter *website* edit mode, leave it, then go to mass mailing. Indeed, there is another bug, fixed by [2] in 17.0 but it was decided to ignore it in 16.0 as it is not critical and fixing it in 16.0 would be too risky regarding custo and other things, as it requires to split/move files from existing assets.

[1]: https://github.com/odoo/odoo/commit/94a03db995decc8170cdbe2e0dec58ea60a92b4d
[2]: https://github.com/odoo/odoo/commit/dcf0880f836423ee82f3d283ffbf940a804bc13b
