### PR TITLE
[FIX] web_editor: Add option to prevent pasting files in HTML fields

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -743,6 +743,7 @@ export const htmlField = {
             minHeight: options.minHeight,
             maxHeight: options.maxHeight,
             resizable: 'resizable' in options ? options.resizable : false,
+            allowPastingFiles: 'allowPastingFiles' in options ? options.allowPastingFiles : true,
         };
         if ('collaborative' in options) {
             wysiwygOptions.collaborative = options.collaborative;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -274,6 +274,7 @@ export class OdooEditor extends EventTarget {
                 showResponsiveFontSizesBadges: false,
                 showExtendedTextStylesOptions: false,
                 autoActivateContentEditable: true,
+                allowPastingFiles: true,
                 // TODO probably move `getCSSVariableValue` and
                 // `convertNumericToUnit` as odoo-editor utils to avoid this
                 getCSSVariableValue: () => null,
@@ -5155,11 +5156,13 @@ export class OdooEditor extends EventTarget {
             // table can be included in the clipboard as an image file. In that
             // particular case the html table is given a higher priority than
             // the clipboard picture.
-            if (files.length && !clipboardElem.querySelector('table')) {
+            if (files.length && this.options.allowPastingFiles && !clipboardElem.querySelector('table')) {
                 this.addImagesFiles(files).then(html => {
                     this._applyCommand('insert', html);
                 });
             } else {
+                if (!this.options.allowPastingFiles)
+                    clipboardElem.querySelectorAll('img').forEach(img => img.remove());
                 if (closestElement(sel.anchorNode, 'a')) {
                     this._applyCommand('insert', clipboardElem.textContent);
                 }

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -430,6 +430,7 @@ export class Wysiwyg extends Component {
             defaultLinkAttributes: this.options.userGeneratedContent ? {rel: 'ugc' } : {},
             allowCommandVideo: this.options.allowCommandVideo,
             allowInlineAtRoot: this.options.allowInlineAtRoot,
+            allowPastingFiles: 'allowPastingFiles' in this.options ? this.options.allowPastingFiles : true,
             getYoutubeVideoElement: getYoutubeVideoElement,
             getContextFromParentRect: options.getContextFromParentRect,
             getScrollContainerRect: () => {


### PR DESCRIPTION
Introduced a configurable option `preventPastingFiles` to restrict users from pasting files, such as images, into the editor. This allows better control over field behavior in specific use cases, such as portal users or other restricted contexts.

the option can be explicitly set in the view
to enable this restriction where necessary.

As part of this improvement, a utility function was created to recursively remove specific nodes from a root element, enabling clean and efficient node management when needed.

This change is linked to PR in enterprise.

The enhancement provides flexibility and ensures
proper behavior in scenarios where file pasting needs to be blocked.

OPW-4246752


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
