### PR TITLE
[FIX] web_editor: reset selection when editable is empty

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4465,6 +4465,16 @@ export class OdooEditor extends EventTarget {
         // Ignore any changes that might have happened before this point.
         this.observer.takeRecords();
 
+        // Reset selection when editable is empty.
+        const selection = this.document.getSelection();
+        if (!selection.isCollapsed) {
+            const range = selection.getRangeAt(0);
+            const rangeContentChildNodes = range.cloneContents().childNodes;
+            if (rangeContentChildNodes.length === 1 && rangeContentChildNodes[0].nodeName === 'BR') {
+                setSelection(selection.anchorNode, 0, selection.anchorNode, 0);
+            }
+        }
+
         const node = ev.target;
         // handle checkbox lists
         if (node.tagName == 'LI' && getListMode(node.parentElement) == 'CL') {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -7735,6 +7735,19 @@ X[]
                     contentAfter: '<table></table><p>[]<br></p><table></table>'
                 });
             });
+            it('should reset selection on mousedown on empty editable', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[<br>]</p>',
+                    stepFunction: async editor => {
+                        const paragraph = editor.editable.querySelector('p');
+                        await triggerEvent(paragraph, 'mousedown');
+                        await nextTick();
+                        await triggerEvent(paragraph, 'mouseup');
+                        triggerEvent(paragraph, 'click');
+                    },
+                    contentAfter: '<p>[]<br></p>'
+                });
+            });
         });
         describe('no arrow key press or mouse click', () => {
             it('should remove selection', async () => {


### PR DESCRIPTION
**Problem**:
When selecting all content (`Ctrl+A`) in an empty editable area, the selection includes only a `<br>` element. This causes issues when interacting with non-selectable content inside the selection, leading to unexpected behavior.

**Solution**:
If the selection contains only on `br` element, reset the selection on click to avoid inconsistent states.

**Steps to Reproduce**:
1. Open the editor.
2. Press `Ctrl+A` to select all.
3. Click anywhere within the editable area to hide the toolbar.
4. Observe that the toolbar remains visible, and the selection state does not update.

opw-4438513

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
