### PR TITLE
[IMP] mrp: always run a procurement for materials demand modification

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -431,7 +431,7 @@ class StockMove(models.Model):
             # when updating consumed qty need to update related pickings
             # context no_procurement means we don't want the qty update to modify stock i.e create new pickings
             # ex. when spliting MO to backorders we don't want to move qty from pre prod to stock in 2/3 step config
-            self.filtered(lambda m: m.raw_material_production_id.state == 'confirmed')._run_procurement(old_demand)
+            self.filtered(lambda m: m.raw_material_production_id.state in ('confirmed', 'progress', 'to_close'))._run_procurement(old_demand)
         return res
 
     def _run_procurement(self, old_qties=False):


### PR DESCRIPTION

With this commit:
====================

- Currently, a procurement is requested each time we change the component
  demand but only when the MO state is 'confirmed' and not started yet.
  However, there is no reason to have this behaviour only before
  starting the MO. So we make it more generic and check if we need a
  supply each time we modify the quantities.



Task - [4438482](https://www.odoo.com/odoo/my-tasks/4438482)

