### PR TITLE
[IMP] im_livechat: leave live chat instead of unpinning

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -45,7 +45,7 @@ class DiscussChannel(models.Model):
             "chatbot_current_step",
             Store.One("country_id", ["code", "name"], rename="anonymous_country"),
             Store.One(
-                "livechat_operator_id", ["user_livechat_username", "write_date"], rename="operator"
+                "livechat_operator_id", ["user_livechat_username", "write_date"], rename="operator", sudo=True
             ),
         ]
         if self.env.user._is_internal():
@@ -243,3 +243,6 @@ class DiscussChannel(models.Model):
 
     def _types_allowing_seen_infos(self):
         return super()._types_allowing_seen_infos() + ["livechat"]
+
+    def _types_allowing_unfollow(self):
+        return super()._types_allowing_unfollow() + ["livechat"]

--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -24,15 +24,11 @@ patch(Thread.prototype, {
         return this.channel_type === "livechat" || super.hasMemberList;
     },
     get canLeave() {
-        return this.channel_type !== "livechat" && super.canLeave;
-    },
-    get canUnpin() {
         if (this.channel_type === "livechat") {
             return !this.selfMember || this.selfMember.message_unread_counter === 0;
         }
-        return super.canUnpin;
+        return super.canLeave;
     },
-
     get correspondents() {
         return super.correspondents.filter((correspondent) => !correspondent.is_bot);
     },

--- a/addons/im_livechat/static/src/embed/common/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/store_service_patch.js
@@ -12,13 +12,16 @@ patch(Store.prototype, {
         await livechatInitialized.ready;
         const livechatService = this.env.services["im_livechat.livechat"];
         if (livechatService.state === SESSION_STATE.PERSISTED) {
-            await super.initialize();
-            livechatService.thread ??= this.store.Thread.get({
-                id: livechatService.savedState?.store["discuss.channel"][0].id,
-                model: "discuss.channel",
-            });
-            if (!livechatService.thread) {
-                livechatService.leave({ notifyServer: false });
+            try {
+                await super.initialize();
+                livechatService.thread ??= this.store.Thread.get({
+                    id: livechatService.savedState?.store["discuss.channel"][0].id,
+                    model: "discuss.channel",
+                });
+            } finally {
+                if (!livechatService.thread) {
+                    livechatService.leave({ notifyServer: false });
+                }
             }
             return;
         }

--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -33,6 +33,7 @@ test("from the discuss app", async () => {
         ],
         livechat_channel_id: livechatChannelId,
         livechat_operator_id: serverState.partnerId,
+        create_uid: serverState.publicUserId,
     });
     await start();
     await openDiscuss();
@@ -42,7 +43,7 @@ test("from the discuss app", async () => {
     await click("[title='Join HR']", {
         parent: [".o-mail-DiscussSidebarCategory-livechat", { text: "HR" }],
     });
-    await click("[title='Unpin Conversation']", {
+    await click("[title='Leave Channel']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "Visitor" }],
     });
     await click("[title='Leave HR']", {

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -338,7 +338,7 @@ test("Active category item should be visible even if the category is closed", as
     await contains(".o-mail-DiscussSidebarChannel", { text: "Visitor 11" });
 });
 
-test("Clicking on unpin button unpins the channel", async () => {
+test("Clicking on leave button leaves the channel", async () => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
@@ -348,11 +348,12 @@ test("Clicking on unpin button unpins the channel", async () => {
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
+        create_uid: serverState.publicUserId,
     });
     await start();
     await openDiscuss();
-    await click(".o-mail-DiscussSidebarChannel [title='Unpin Conversation']");
-    await contains(".o_notification", { text: "You unpinned your conversation with Visitor 11" });
+    await click(".o-mail-DiscussSidebarChannel [title='Leave Channel']");
+    await contains(".o_notification", { text: "You unsubscribed from Visitor 11." });
 });
 
 test("Message unread counter", async () => {
@@ -397,6 +398,7 @@ test("unknown livechat can be displayed and interacted with", async () => {
         ],
         channel_type: "livechat",
         livechat_operator_id: partnerId,
+        create_uid: serverState.publicUserId,
     });
     const env = await start();
     await openDiscuss();
@@ -412,7 +414,7 @@ test("unknown livechat can be displayed and interacted with", async () => {
     await waitNotifications([env, "discuss.channel/new_message"]);
     await click("button", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel:not(.o-active)", { text: "Jane" });
-    await click("[title='Unpin Conversation']", {
+    await click("[title='Leave Channel']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "Jane" }],
     });
     await contains(".o-mail-DiscussSidebarCategory-livechat", { count: 0 });

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1107,6 +1107,11 @@ class DiscussChannel(models.Model):
         on the channel """
         return ["chat", "group"]
 
+    def _types_allowing_unfollow(self):
+        """ Return the channel types which allow leaving the channel, channel will be unpinned
+        otherwise """
+        return ["channel", "group"]
+
     def channel_fetched(self):
         """ Broadcast the channel_fetched notification to channel members
         """
@@ -1342,7 +1347,7 @@ class DiscussChannel(models.Model):
         return msg
 
     def execute_command_leave(self, **kwargs):
-        if self.channel_type in ('channel', 'group'):
+        if self.channel_type in self._types_allowing_unfollow():
             self.action_unfollow()
         else:
             self.channel_pin(False)

--- a/addons/mail/static/src/discuss/core/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_model_patch.js
@@ -17,7 +17,7 @@ const messagePatch = {
             compute() {
                 // compute for caching the value and not re-rendering all
                 // messages when new_message_separator changes
-                return this.thread?.selfMember.new_message_separator === this.id;
+                return this.thread?.selfMember?.new_message_separator === this.id;
             },
         });
         this.hasSomeoneFetched = Record.attr(false, {


### PR DESCRIPTION
Live chat operators currently cannot leave live chats, and visitors do not systematically leave chats either. This poses an issue when a limit on the number of concurrent sessions is set, as operators cannot free up sessions.

This PR replaces the unpin action with an unfollow action, allowing operators to leave live chats.

task-4440366

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
