### PR TITLE
[IMP] l10n_in_edi_ewaybill: stop e-waybill for credit notes

### DIFF
--- a/addons/l10n_in_edi_ewaybill/models/account_move.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_move.py
@@ -52,7 +52,7 @@ class AccountMove(models.Model):
         if not edi_format:
             self.l10n_in_edi_ewaybill_show_send_button = False
             return
-        posted_moves = self.filtered(lambda x: x.is_invoice() and x.state == 'posted' and x.country_code == "IN")
+        posted_moves = self.filtered(lambda x: x.move_type in ('out_invoice', 'in_invoice', 'in_refund') and x.state == 'posted' and x.country_code == "IN")
         for move in posted_moves:
             already_sent = move.edi_document_ids.filtered(lambda x: x.edi_format_id == edi_format and x.state in ('sent', 'to_cancel', 'to_send'))
             if already_sent:

--- a/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
+++ b/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
@@ -11,7 +11,6 @@ class TestEdiEwaybillJson(TestEdiJson):
             self.invoice.id,
             self.invoice_full_discount.id,
             self.invoice_zero_qty.id,
-            self.invoice_reverse.id,
         )).write({
             "l10n_in_type_id": self.env.ref("l10n_in_edi_ewaybill.type_tax_invoice_sub_type_supply"),
             "l10n_in_distance": 20,
@@ -80,36 +79,6 @@ class TestEdiEwaybillJson(TestEdiJson):
             "totInvValue": 1999.59
         }
         self.assertDictEqual(json_value, expected, "Indian EDI send json value is not matched")
-
-        # =================================== Credit Note Test =============================================
-        credit_note_expected = expected.copy()
-        credit_note_expected.update({
-            'docDate': '25/12/2023',
-            'docNo': 'RINV/2023/00001',
-            'supplyType': 'I',
-            "fromGstin": expected['toGstin'],
-            "fromTrdName": expected['toTrdName'],
-            "fromAddr1": expected['toAddr1'],
-            "fromAddr2": expected['toAddr2'],
-            "fromPlace": expected['toPlace'],
-            "fromPincode": expected['toPincode'],
-            "fromStateCode": expected['toStateCode'],
-            "actFromStateCode": expected['actToStateCode'],
-            "toGstin": expected['fromGstin'],
-            "toTrdName": expected['fromTrdName'],
-            "toAddr1": expected['fromAddr1'],
-            "toAddr2": expected['fromAddr2'],
-            "toPlace": expected['fromPlace'],
-            "toPincode": expected['fromPincode'],
-            "toStateCode": expected['fromStateCode'],
-            "actToStateCode": expected['actFromStateCode'],
-        })
-        self.assertDictEqual(
-            self.env.ref(
-                'l10n_in_edi_ewaybill.edi_in_ewaybill_json_1_03'
-            )._l10n_in_edi_ewaybill_generate_json(self.invoice_reverse),
-            credit_note_expected,
-        )
 
         #=================================== Full discount test =====================================
         json_value = self.env["account.edi.format"]._l10n_in_edi_ewaybill_generate_json(self.invoice_full_discount)

--- a/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
+++ b/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
@@ -11,7 +11,7 @@
             </xpath>
             <xpath expr="//notebook/page[@name='other_info']" position="before">
                 <page string="eWayBill" name="l10n_in_edi_ewaybill_page"
-                    invisible="move_type == 'entry' or country_code != 'IN'">
+                    invisible="move_type in ('entry', 'out_refund') or country_code != 'IN'">
                     <field name="l10n_in_edi_ewaybill_direct_api" invisible="1"/>
                     <group name="ewaybill_group">
                         <group string="Transaction Details" name="Transaction_group" 

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -568,7 +568,7 @@ class Ewaybill(models.Model):
                 ),
                 "transDistance": str(self.distance),
                 "docNo": self.document_number,
-                "docDate": self.document_date.strftime("%d/%m/%Y"),
+                "docDate": (self.document_date or fields.Datetime.now()).strftime("%d/%m/%Y"),
                 # bill details
                 **prepare_details(
                     key_paired_function={

--- a/addons/l10n_in_ewaybill_stock/models/stock_picking.py
+++ b/addons/l10n_in_ewaybill_stock/models/stock_picking.py
@@ -25,9 +25,14 @@ class StockPicking(models.Model):
         if self.l10n_in_ewaybill_id:
             raise UserError(_("Ewaybill already created for this picking."))
         action = self._get_l10n_in_ewaybill_form_action()
+        type_xml_trailing_id = (
+            'type_delivery_challan_sub_sales_return'
+            if self.picking_type_code == 'incoming'
+            else 'type_delivery_challan_sub_others'
+        )
         ewaybill = self.env['l10n.in.ewaybill'].create({
             'picking_id': self.id,
-            'type_id': self.env.ref('l10n_in_ewaybill_stock.type_delivery_challan_sub_others').id,
+            'type_id': self.env.ref(f'l10n_in_ewaybill_stock.{type_xml_trailing_id}').id,
         })
         action['res_id'] = ewaybill.id
         return action

--- a/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
@@ -42,7 +42,7 @@
                         <group>
                             <field name="ewaybill_date" invisible="not ewaybill_date"/>
                             <field name="document_number"/>
-                            <field name="document_date" readonly="1"/>
+                            <field name="document_date" invisible="picking_type_code == 'incoming'" readonly="1"/>
                         </group>
                     </group>
                     <group name="partners" string="Address Details">

--- a/addons/l10n_in_ewaybill_stock/views/stock_picking_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/stock_picking_views.xml
@@ -9,7 +9,11 @@
                 <button string="Create e-Waybill / Challan"
                         type="object"
                         name="action_l10n_in_ewaybill_create"
-                        invisible="country_code != 'IN' or l10n_in_ewaybill_id or state != 'done'"
+                        invisible="
+                            country_code != 'IN'
+                            or l10n_in_ewaybill_id
+                            or (picking_type_code == 'incoming' and state not in ('done', 'assigned'))
+                            or (picking_type_code != 'incoming' and state != 'done')"
                         data-hotkey="e"
                         groups="stock.group_stock_manager"/>
             </xpath>


### PR DESCRIPTION
Following the fixes - https://github.com/odoo/odoo/commit/ce92dedea0fd3cdc73da6366c20b8052bb04f7e9 & https://github.com/odoo/odoo/commit/4dc901e77dc7e2873a94ea3a541450fc9fb2eb5e

Investing more into the issues, we found out that E-waybill portal, doesn't allow generation of E-waybill as Inwards (Tax Invoice) type for Sales Return, Only Challan Type is accepted it means that the Sales Return, E-waybill should be generated by the E-waybill on Stock/Inventory. Not through the Invoice/Account App.

This commit intends to do a soft block for generation of E-waybill through Sales Credit Note


task-4441603
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
