### PR TITLE
[FIX] l10n_ch: non 256 size barcode has cross centered

### DIFF
--- a/addons/l10n_ch/models/ir_actions_report.py
+++ b/addons/l10n_ch/models/ir_actions_report.py
@@ -21,10 +21,12 @@ class IrActionsReport(models.Model):
 
     @api.model
     def apply_qr_code_ch_cross_mask(self, width, height, barcode_drawing):
+        zoom_x = barcode_drawing.transform[0]
+        zoom_y = barcode_drawing.transform[3]
         cross_width = CH_QR_CROSS_SIZE_RATIO * width
         cross_height = CH_QR_CROSS_SIZE_RATIO * height
         cross_path = Path(__file__).absolute().parent / CH_QR_CROSS_FILE
-        qr_cross = ReportLabImage((width/2 - cross_width/2) / mm, (height/2 - cross_height/2) / mm, cross_width / mm, cross_height / mm, cross_path.as_posix())
+        qr_cross = ReportLabImage((width/2 - cross_width/2) / zoom_x, (height/2 - cross_height/2) / zoom_y, cross_width / zoom_x, cross_height / zoom_y, cross_path.as_posix())
         barcode_drawing.add(qr_cross)
 
     def _render_qweb_pdf_prepare_streams(self, report_ref, data, res_ids=None):

--- a/addons/l10n_ch/tests/test_ch_qr_code.py
+++ b/addons/l10n_ch/tests/test_ch_qr_code.py
@@ -1,5 +1,7 @@
 # -*- coding:utf-8 -*-
 
+from reportlab.graphics.barcode import createBarcodeDrawing
+
 from odoo import Command
 from odoo.tests import tagged
 from odoo.exceptions import UserError
@@ -89,3 +91,23 @@ class TestSwissQRCode(AccountTestInvoicingCommon):
         self._assign_partner_address(self.ch_qr_invoice.partner_id)
         self.ch_qr_invoice._generate_qr_code()
         self.assertEqual(self.ch_qr_invoice.qr_code_method, 'ch_qr', "Swiss QR-code generator should have been chosen for this invoice.")
+
+    def test_ch_qr_code_cross_mask(self):
+        for width, height in ((64, 128), (128, 128), (256, 256), (512, 512)):
+            barcode = createBarcodeDrawing('QR', value='', format='png', width=width, height=height)
+            mask_to_apply = self.env['ir.actions.report'].get_available_barcode_masks()['ch_cross']
+            mask_to_apply(width, height, barcode)
+            zoom_x = width / (32 * (72 / 25.4))
+            zoom_y = height / (32 * (72 / 25.4))
+            self.assertEqual(
+                [zoom_x, 0, 0, zoom_y, 0, 0],
+                barcode.transform,
+            )
+            self.assertEqual(
+                (0, 0, 90.70866141732284, 90.70866141732284),
+                barcode.contents[0].getBounds(),
+            )
+            self.assertEqual(
+                (38.45140157480315, 38.45140157480315, 52.25725984251969, 52.25725984251969),
+                barcode.contents[1].getBounds(),
+            )


### PR DESCRIPTION
Scenario:

- install l10n_ch
- go to /report/barcode/?barcode_type=QR&value=&width=150&height=150&mask=ch_cross

=> the ch_cross mask (swiss cross that should be in the center) is not
in the center

Issue:

Reportlab QrCodeWidget has a fixed size to 32mm (with mm that is 72(ppi)
/ 25.4(1mm to inch) so ~2.83 pixels) and to get the widget to the full
size, a zoom is applied on the Drawing content (so on the QrCodeWidget).

Here are the zoom that are applied for several Drawing size:

- for 100 pixels: 100 / (32 * mm) => 1.012…
- for 256 pixels: 256 / (32 * mm) => 2.822…
- for 400 pixels: 400 / (32 * mm) => 4.409…

But in the code, the zoom is just hardcoded to mm (~2.83) which
corresponds to a barcode size of mm * 32 * mm => 257.127 pixels which is
kind of good enough for 256 pixels, but wrong for most other size.

In base code we only use 256 x 256 pixels so this is not much of an
issue unless someone want to use it for something else.

Fix:

With this commit, we apply the Drawing zoom (on which we have the
QrCodeWidget) to the ch_cross image.

Note:

Without the fix, the added test only fail on the third assertion for
each loop iteration, the farer we are from 257x257 pixels the bigger
the error is, for example for 256x256:

Result:   (38.45140, 38.45140, 52.25725984251969, 52.25725984251969)
Expected: (38.28288, 38.28288, 52.02823111111111, 52.02823111111111)

opw-4307177

PR NOTE: this could be merged in an higher version, and we could also just not fix this since as far as I can tell, we only need to support 256x256 and with and without the fix there is just one pixel of difference in this case.

![a](https://github.com/user-attachments/assets/f38e26ee-a129-4fd1-ae92-a9768274dbbb)