### PR TITLE
[FIX] l10n_gcc_pos: Prevent duplicate 'Served by' text in POS receipt for GCC countries.

### DIFF
--- a/addons/l10n_gcc_pos/static/src/overrides/pos_store.js
+++ b/addons/l10n_gcc_pos/static/src/overrides/pos_store.js
@@ -3,11 +3,16 @@ import { PosStore } from "@point_of_sale/app/store/pos_store";
 
 patch(PosStore.prototype, {
     getReceiptHeaderData(order) {
+        const result = super.getReceiptHeaderData(...arguments);
+        const is_gcc_country = ["SA", "AE", "BH", "OM", "QA", "KW"].includes(
+            this.company.country_id?.code
+        );
         return {
-            ...super.getReceiptHeaderData(...arguments),
-            is_gcc_country: ["SA", "AE", "BH", "OM", "QA", "KW"].includes(
-                this.company.country_id?.code
-            ),
+            ...result,
+            is_gcc_country: is_gcc_country,
+            cashier: is_gcc_country
+                ? order?.getCashierName() || this.get_cashier()?.name
+                : result.cashier,
         };
     },
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In GCC countries, the POS receipt displays duplicate "Served by" text due to inconsistent handling of the cashier field in the getReceiptHeaderData method.

Current behavior before PR:
1. The "Served by" text is duplicated on POS receipts for GCC countries.
2. The issue arises from both the base implementation and the l10n_gcc_pos module adding the "Served by" prefix.

Desired behavior after PR is merged:
1. The POS receipt correctly displays the cashier's name without duplication.
2. For GCC countries, the "Served by" prefix is removed, and only the cashier's name is displayed.
3. Non-GCC countries remain unaffected.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
