### PR TITLE
[IMP] point_of_sale: allow defining custom field to sort products

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -155,6 +155,7 @@ class PosSession(models.Model):
         data[0]['_has_cash_move_perm'] = self.env.user.has_group('account.group_account_invoice')
         data[0]['_has_available_products'] = self._pos_has_valid_product()
         data[0]['_pos_special_products_ids'] = self.env['pos.config']._get_special_products().ids
+        data[0]['_pos_product_sort_int_field'] = self.env['product.product'].get_custom_pos_sort_int_field()
         return {
             'data': data,
             'fields': fields

--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -106,11 +106,15 @@ class ProductProduct(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return [
+        fields = [
             'id', 'display_name', 'lst_price', 'list_price', 'standard_price', 'categ_id', 'pos_categ_ids', 'taxes_id', 'barcode', 'name',
             'default_code', 'to_weight', 'uom_id', 'description_sale', 'description', 'product_tmpl_id', 'tracking', 'type', 'service_tracking', 'is_storable',
             'write_date', 'available_in_pos', 'attribute_line_ids', 'active', 'image_128', 'combo_ids', 'product_template_variant_value_ids', 'product_tag_ids'
         ]
+        custom_sort_field = self.get_custom_pos_sort_int_field()
+        if custom_sort_field and custom_sort_field not in fields:
+            fields.append(custom_sort_field)
+        return fields
 
     def _load_pos_data(self, data):
         config_id = self.env['pos.config'].browse(data['pos.config']['data'][0]['id'])
@@ -267,6 +271,12 @@ class ProductProduct(models.Model):
             'variants': variant_list,
             'total_qty_available': self.product_tmpl_id.qty_available
         }
+
+    def get_custom_pos_sort_int_field(self):
+        field_name = self.env['ir.config_parameter'].sudo().get_param('point_of_sale.product_sort_field')
+        if field_name and self._fields.get(field_name) and self._fields.get(field_name).type == 'integer':
+            return field_name
+        return False
 
 
 class ProductAttribute(models.Model):

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -339,9 +339,16 @@ export class ProductScreen extends Component {
             }
         }
 
+        const customSearchField = this.pos.session._pos_product_sort_int_field;
+
         return this.searchWord !== ""
             ? filteredList
-            : filteredList.sort((a, b) => a.display_name.localeCompare(b.display_name));
+            : filteredList.sort((a, b) => {
+                  if (customSearchField) {
+                      return a[customSearchField] - b[customSearchField];
+                  }
+                  return a.display_name.localeCompare(b.display_name);
+              });
     }
 
     getProductsBySearchWord(searchWord) {


### PR DESCRIPTION
Before this commit, products were sorted based on the display_name, and it wasn't possible to change the order of the products. In some cases, users want to use a custom sorting. With this commit, it's possible to set an integer field with the `point_of_sale.product_sort_field` system parameter to sort the products based on that field.

opw-4439280

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
