### PR TITLE
[FIX] core: properly export method-defined Selection fields

### DIFF
--- a/addons/test_import_export/tests/test_export_impex.py
+++ b/addons/test_import_export/tests/test_export_impex.py
@@ -236,10 +236,9 @@ class test_selection_function(CreatorCase):
         self.assertEqual(self.export(False), [['']])
 
     def test_value(self):
-        # selection functions export the *value* itself
-        self.assertEqual(self.export('1'), [['1']])
-        self.assertEqual(self.export('3'), [['3']])
-        self.assertEqual(self.export('0'), [['0']])
+        self.assertEqual(self.export('1'), [['Grault']])
+        self.assertEqual(self.export('3'), [['Moog']])
+        self.assertEqual(self.export('0'), [['Corge']])
 
 
 class test_m2o(CreatorCase):

--- a/odoo/orm/fields_selection.py
+++ b/odoo/orm/fields_selection.py
@@ -230,4 +230,4 @@ class Selection(Field[str | typing.Literal[False]]):
         for item in self._description_selection(record.env):
             if item[0] == value:
                 return item[1]
-        return ''
+        return value or ''

--- a/odoo/orm/fields_selection.py
+++ b/odoo/orm/fields_selection.py
@@ -227,9 +227,6 @@ class Selection(Field[str | typing.Literal[False]]):
         raise ValueError("Wrong value for %s: %r" % (self, value))
 
     def convert_to_export(self, value, record):
-        if not isinstance(self.selection, list):
-            # FIXME: this reproduces an existing buggy behavior!
-            return value if value else ''
         for item in self._description_selection(record.env):
             if item[0] == value:
                 return item[1]


### PR DESCRIPTION
The export of Selection fields whose selection list is defined by a method behaves differently: instead of exporting the localized label, it exports the raw value.

> [!NOTE]
> It seems this was done like this by design, a long time ago. It's not clear why, thuogh.
> Nonetheless, IMHO this inconsistency is a buggy behavior. 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
