### PR TITLE
[FIX] core: update attributes of non-text items

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1985,10 +1985,10 @@ class _String(Field[str | typing.Literal[False]]):
                     matches = get_close_matches(old_term_text, text2terms, 1, 0.9)
                     if matches:
                         closest_term = get_close_matches(old_term, text2terms[matches[0]], 1, 0)[0]
-                        if closest_term in translation_dictionary:
-                            continue
                         old_is_text = is_text(old_term)
                         closest_is_text = is_text(closest_term)
+                        if closest_term in translation_dictionary and closest_is_text:
+                            continue
                         if old_is_text or not closest_is_text:
                             if not closest_is_text and records.env.context.get("install_mode") and lang == 'en_US' and term_adapter:
                                 adapter = term_adapter(closest_term)


### PR DESCRIPTION
We cannot skip the update always. It is only safe to do so when the
element is text, in other cases we still need to update the attributes
to avoid upgrade issues.

For example, this term
https://github.com/odoo/odoo/blame/03434f42d2b1d96d2cf8315154f16f9fa01c1ae3/addons/account/i18n/fr.po#L1129
which at the time of this patch has no translation yet, won't be updated
even if we add the right translation
```
msgid ""
"<span invisible=\"name or name_placeholder or quick_edit_mode\">Draft</span>"
msgstr ""
"<span invisible=\"name or name_placeholder or quick_edit_mode\">Brouillon</span>"
```

The reason is that the check
```py
if closest_term in translation_dictionary:
    continue
```
would skip the update. Here we propose to restrict the skip only to text
elements.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
