### PR TITLE
[IMP] base: unify portal accounts

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -146,6 +146,8 @@ class AuthSignupHome(Home):
         qcontext.update(self.get_auth_signup_config())
         if not qcontext.get('token') and request.session.get('auth_signup_token'):
             qcontext['token'] = request.session.get('auth_signup_token')
+        if qcontext.get('login'):
+            qcontext['login'] = qcontext['login'].strip()
         if qcontext.get('token'):
             try:
                 # retrieve the user info (name, login or email) corresponding to a signup token
@@ -163,6 +165,8 @@ class AuthSignupHome(Home):
             raise UserError(_("The form was not properly filled in."))
         if values.get('password') != qcontext.get('confirm_password'):
             raise UserError(_("Passwords do not match; please retype them."))
+        if not values.get('login', '').strip():
+            raise UserError(_("Please enter a proper login."))
         supported_lang_codes = [code for code, _ in request.env['res.lang'].get_installed()]
         lang = request.env.context.get('lang', '')
         if lang in supported_lang_codes:

--- a/addons/base_import_module/tests/test_import_module.py
+++ b/addons/base_import_module/tests/test_import_module.py
@@ -339,7 +339,7 @@ class TestImportModule(odoo.tests.TransactionCase):
 
     def test_import_and_update_module(self):
         self.test_user = new_test_user(
-            self.env, login='Admin',
+            self.env, login='Admin_',
             groups='base.group_user,base.group_system',
             name='Admin',
         )

--- a/addons/calendar/tests/test_res_users.py
+++ b/addons/calendar/tests/test_res_users.py
@@ -59,8 +59,8 @@ class TestResUsers(TransactionCase):
         not useful tracking these fields for non-internal users.
         """
         username_and_group = {
-            'PORTAL': 'base.group_portal',
-            'PUBLIC': 'base.group_public',
+            'PORTAL0': 'base.group_portal',
+            'PUBLIC0': 'base.group_public',
         }
 
         for username, group in username_and_group.items():

--- a/addons/portal/wizard/portal_wizard.py
+++ b/addons/portal/wizard/portal_wizard.py
@@ -3,7 +3,7 @@
 import logging
 
 from odoo.tools.translate import _, LazyTranslate
-from odoo.tools import email_normalize
+from odoo.tools import email_normalize, single_email_re
 from odoo.exceptions import UserError
 
 from odoo import api, fields, models, Command
@@ -106,7 +106,7 @@ class PortalWizardUser(models.TransientModel):
             if next((user for user in existing_users if self._is_portal_similar_than_user(user, portal_user)), None):
                 portal_user.email_state = 'exist'
             else:
-                portal_user.email_state = 'ok'
+                portal_user.email_state = 'ok' if single_email_re.match(portal_user.email) else 'ko'
 
     @api.depends('partner_id')
     def _compute_user_id(self):

--- a/addons/web/tests/test_login.py
+++ b/addons/web/tests/test_login.py
@@ -63,6 +63,19 @@ class TestWebLogin(TestWebLoginCommon):
         # log in using the above form, it should still be valid
         self.login('internal_user', 'internal_user', csrf_token)
 
+    def test_web_login_case_insensitive(self):
+        # test login is case insensitive
+        login = '  InterNal_User  '
+        res_post = self.login(login, 'internal_user')
+        # ensure we are logged-in
+        self.url_open(
+            '/web/session/check',
+            headers={'Content-Type': 'application/json'},
+            data='{}'
+        ).raise_for_status()
+        # ensure we end up on the right page for internal users.
+        self.assertEqual(res_post.request.path_url, '/odoo')
+
 
 @tagged('post_install', '-at_install')
 class TestUserSwitch(HttpCaseWithUserDemo):

--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -13,21 +13,21 @@ class ResUsers(models.Model):
 
     website_id = fields.Many2one('website', related='partner_id.website_id', store=True, related_sudo=False, readonly=False)
 
-    _login_key = models.Constraint(
-        'unique (login, website_id)',
-        'You can not have two users with the same login!',
+    _login_key = models.UniqueIndex(
+        '(lower(login), website_id)',
+        'You can not have two users with the similar login!',
     )
 
     @api.constrains('login', 'website_id')
     def _check_login(self):
-        """ Do not allow two users with the same login without website """
+        """ Do not allow two users with the similar login without website """
         self.flush_model(['login', 'website_id'])
         self.env.cr.execute(
-            """SELECT login
+            """SELECT lower(login)
                  FROM res_users
-                WHERE login IN (SELECT login FROM res_users WHERE id IN %s AND website_id IS NULL)
+                WHERE lower(login) IN (SELECT lower(login) FROM res_users WHERE id IN %s AND website_id IS NULL)
                   AND website_id IS NULL
-             GROUP BY login
+             GROUP BY lower(login)
                HAVING COUNT(*) > 1
             """,
             (tuple(self.ids),)

--- a/odoo/addons/base/data/base_data.sql
+++ b/odoo/addons/base/data/base_data.sql
@@ -20,7 +20,7 @@ CREATE TABLE res_users (
     partner_id integer, -- references res_partner,
     active boolean default True,
     create_date timestamp without time zone,
-    login varchar(64) NOT NULL UNIQUE,
+    login varchar(64) NOT NULL,
     password varchar default null,
     primary key(id)
 );


### PR DESCRIPTION
This commit adds a validation on the portal user signup. From this commit, new login emails are matched to exisiting logins case-insensitively and by removing the trailing whitespaces.

Task-4247745
