### PR TITLE
[FIX] website_sale, delivery: add missing terms in `location_selector`

### DIFF
--- a/addons/delivery/i18n/delivery.pot
+++ b/addons/delivery/i18n/delivery.pot
@@ -178,7 +178,7 @@ msgstr ""
 #. module: delivery
 #. odoo-javascript
 #: code:addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js:0
-#: code:addons/delivery/static/src/js/location_selector/map_container/map_container.xml:0
+#: code:addons/delivery/static/src/js/location_selector/map_container/map_container.js:0
 msgid "Choose this location"
 msgstr ""
 
@@ -543,13 +543,13 @@ msgstr ""
 
 #. module: delivery
 #. odoo-javascript
-#: code:addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml:0
+#: code:addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js:0
 msgid "List view"
 msgstr ""
 
 #. module: delivery
 #. odoo-javascript
-#: code:addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml:0
+#: code:addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js:0
 msgid "Loading..."
 msgstr ""
 
@@ -571,7 +571,7 @@ msgstr ""
 
 #. module: delivery
 #. odoo-javascript
-#: code:addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml:0
+#: code:addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js:0
 msgid "Map view"
 msgstr ""
 
@@ -629,7 +629,7 @@ msgstr ""
 
 #. module: delivery
 #. odoo-javascript
-#: code:addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml:0
+#: code:addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js:0
 msgid "No result"
 msgstr ""
 
@@ -641,8 +641,8 @@ msgstr ""
 
 #. module: delivery
 #. odoo-javascript
-#: code:addons/delivery/static/src/js/location_selector/location/location.xml:0
-#: code:addons/delivery/static/src/js/location_selector/map_container/map_container.xml:0
+#: code:addons/delivery/static/src/js/location_selector/location/location.js:0
+#: code:addons/delivery/static/src/js/location_selector/map_container/map_container.js:0
 msgid "Opening hours"
 msgstr ""
 
@@ -868,7 +868,7 @@ msgstr ""
 
 #. module: delivery
 #. odoo-javascript
-#: code:addons/delivery/static/src/js/location_selector/map_container/map_container.xml:0
+#: code:addons/delivery/static/src/js/location_selector/map_container/map_container.js:0
 msgid "There was an error loading the map"
 msgstr ""
 

--- a/addons/delivery/static/src/js/location_selector/location/location.js
+++ b/addons/delivery/static/src/js/location_selector/location/location.js
@@ -4,6 +4,7 @@ import {
     LocationSchedule
 } from '@delivery/js/location_selector/location_schedule/location_schedule';
 import { Component } from '@odoo/owl';
+import { _t } from '@web/core/l10n/translation';
 
 export class Location extends Component {
     static components = { LocationSchedule };
@@ -34,5 +35,9 @@ export class Location extends Component {
      */
     getCityAndZipCode() {
         return `${this.props.zipCode} ${this.props.city}`;
+    }
+
+    get openingHoursLabel() {
+        return _t("Opening hours");
     }
 }

--- a/addons/delivery/static/src/js/location_selector/location/location.xml
+++ b/addons/delivery/static/src/js/location_selector/location/location.xml
@@ -25,7 +25,7 @@
                 </span>
                 <small class="d-flex d-md-none align-items-center gap-1 fw-bold">
                     <i class="fa fa-clock-o" role="img"/>
-                    Opening hours
+                    <t t-out="openingHoursLabel"/>
                     <i class="o_location_selector_hours_caret fa fa-caret-up ms-auto transition-base"/>
                 </small>
 

--- a/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
+++ b/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
@@ -154,6 +154,22 @@ export class LocationSelectorDialog extends Component {
         return _t("Choose this location");
     }
 
+    get listViewButtonLabel() {
+        return _t("List view");
+    }
+
+    get mapViewButtonLabel() {
+        return _t("Map view");
+    }
+
+    get errorMessage() {
+        return _t("No result");
+    }
+
+    get loadingMessage() {
+        return _t("Loading...");
+    }
+
     /**
      *
      * @return {void}

--- a/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml
+++ b/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml
@@ -17,16 +17,14 @@
                         class="o_location_selector_mobile_tab btn flex-grow-1 border-0 border-bottom rounded-0 py-3 bg-transparent"
                         t-att-class="{'active': this.state.viewMode === 'list'}"
                         t-on-click="() => this.state.viewMode = 'list'"
-                    >
-                        List view
-                    </button>
+                        t-out="listViewButtonLabel"
+                    />
                     <button
                         class="o_location_selector_mobile_tab btn flex-grow-1 border-0 border-bottom rounded-0 py-3 bg-transparent"
                         t-att-class="{'active' : this.state.viewMode === 'map'}"
                         t-on-click="() => this.state.viewMode = 'map'"
-                    >
-                        Map view
-                    </button>
+                        t-out="mapViewButtonLabel"
+                    />
                 </div>
 
                 <!-- Component -->
@@ -40,10 +38,10 @@
                         validateSelection.bind="validateSelection"
                     />
                     <t t-else="">
-                        <p t-if="this.state.error" class="p-3 fw-bold">No result</p>
+                        <p t-if="this.state.error" class="p-3 fw-bold" t-out="errorMessage"/>
                         <div t-else="" class="position-absolute start-50 top-50 translate-middle">
                             <div class="spinner-border" role="status">
-                                <span class="visually-hidden">Loading...</span>
+                                <span class="visually-hidden" t-out="loadingMessage"/>
                             </div>
                         </div>
                     </t>
@@ -70,10 +68,10 @@
                         validateSelection.bind="validateSelection"
                     />
                     <t t-else="">
-                        <p t-if="this.state.error" class="p-3 fw-bold">No result</p>
+                        <p t-if="this.state.error" class="p-3 fw-bold" t-out="errorMessage"/>
                         <div t-else="" class="position-absolute start-50 top-50 translate-middle">
                             <div class="spinner-border" role="status">
-                                <span class="visually-hidden">Loading...</span>
+                                <span class="visually-hidden" t-out="loadingMessage"/>
                             </div>
                         </div>
                     </t>

--- a/addons/delivery/static/src/js/location_selector/map_container/map_container.js
+++ b/addons/delivery/static/src/js/location_selector/map_container/map_container.js
@@ -6,6 +6,7 @@ import {
 import { Map } from '@delivery/js/location_selector/map/map';
 import { Component, onWillStart, useState } from '@odoo/owl';
 import { AssetsLoadingError, loadCSS, loadJS } from '@web/core/assets';
+import { _t } from '@web/core/l10n/translation';
 
 export class MapContainer extends Component {
     static components = { LocationSchedule, Map };
@@ -86,5 +87,17 @@ export class MapContainer extends Component {
      */
     get selectedLocation() {
         return this.props.locations.find(l => String(l.id) === this.props.selectedLocationId);
+    }
+
+    get errorMessage() {
+        return _t("There was an error loading the map");
+    }
+
+    get chooseLocationButtonLabel() {
+        return _t("Choose this location");
+    }
+
+    get openingHoursLabel() {
+        return _t("Opening hours");
     }
 }

--- a/addons/delivery/static/src/js/location_selector/map_container/map_container.xml
+++ b/addons/delivery/static/src/js/location_selector/map_container/map_container.xml
@@ -12,7 +12,7 @@
                 t-else=""
                 class="d-flex justify-content-center align-items-center flex-grow-1 w-100 bg-200"
             >
-                <span>There was an error loading the map</span>
+                <span t-out="errorMessage"/>
             </div>
 
             <!-- Desktop infos -->
@@ -34,9 +34,8 @@
                         type="button"
                         class="btn btn-primary d-none d-lg-block mt-3"
                         t-att-disabled="!this.props.selectedLocationId"
-                        t-on-click="this.props.validateSelection">
-                            Choose this location
-                    </button>
+                        t-on-click="this.props.validateSelection"
+                        t-out="chooseLocationButtonLabel"/>
                 </div>
 
                 <!-- Schedule -->
@@ -50,9 +49,8 @@
                     type="button"
                     class="btn btn-primary d-block d-lg-none align-self-stretch ms-lg-4"
                     t-att-disabled="!this.props.selectedLocationId"
-                    t-on-click="this.props.validateSelection">
-                        Choose this location
-                </button>
+                    t-on-click="this.props.validateSelection"
+                    t-out="chooseLocationButtonLabel"/>
             </div>
 
             <!-- Mobile infos -->
@@ -79,7 +77,7 @@
                     </span>
                     <span class="d-flex align-items-center gap-1 small fw-bold">
                         <i class="fa fa-clock-o" role="img"/>
-                        Opening hours
+                        <t t-out="openingHoursLabel"/>
                         <i class="o_location_selector_hours_caret fa fa-caret-up ms-auto transition-base"/>
                     </span>
 

--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -1048,6 +1048,7 @@ msgstr ""
 #. module: website_sale
 #. odoo-javascript
 #: code:addons/website_sale/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js:0
+#: code:addons/website_sale/static/src/js/location_selector/map_container/map_container.js:0
 msgid "Choose this location"
 msgstr ""
 
@@ -2242,6 +2243,18 @@ msgid "List"
 msgstr ""
 
 #. module: website_sale
+#. odoo-javascript
+#: code:addons/website_sale/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js:0
+msgid "List view"
+msgstr ""
+
+#. module: website_sale
+#. odoo-javascript
+#: code:addons/website_sale/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js:0
+msgid "Loading..."
+msgstr ""
+
+#. module: website_sale
 #: model:ir.model.fields.selection,name:website_sale.selection__website__ecommerce_access__logged_in
 msgid "Logged in users"
 msgstr ""
@@ -2279,6 +2292,12 @@ msgstr ""
 #: model:ir.model.fields.selection,name:website_sale.selection__res_config_settings__account_on_checkout__mandatory
 #: model:ir.model.fields.selection,name:website_sale.selection__website__account_on_checkout__mandatory
 msgid "Mandatory (no guest checkout)"
+msgstr ""
+
+#. module: website_sale
+#. odoo-javascript
+#: code:addons/website_sale/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js:0
+msgid "Map view"
 msgstr ""
 
 #. module: website_sale
@@ -2412,6 +2431,12 @@ msgstr ""
 #. module: website_sale
 #: model_terms:ir.actions.act_window,help:website_sale.website_sale_visitor_product_action
 msgid "No product views yet for this visitor"
+msgstr ""
+
+#. module: website_sale
+#. odoo-javascript
+#: code:addons/website_sale/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js:0
+msgid "No result"
 msgstr ""
 
 #. module: website_sale
@@ -2555,6 +2580,13 @@ msgstr ""
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.brand_promotion
 msgid "Open Source eCommerce"
+msgstr ""
+
+#. module: website_sale
+#. odoo-javascript
+#: code:addons/website_sale/static/src/js/location_selector/location/location.js:0
+#: code:addons/website_sale/static/src/js/location_selector/map_container/map_container.js:0
+msgid "Opening hours"
 msgstr ""
 
 #. module: website_sale
@@ -3799,6 +3831,12 @@ msgstr ""
 #: model_terms:ir.actions.act_window,help:website_sale.action_unpaid_orders_ecommerce
 #: model_terms:ir.actions.act_window,help:website_sale.action_view_unpaid_quotation_tree
 msgid "There is no unpaid order from the website yet"
+msgstr ""
+
+#. module: website_sale
+#. odoo-javascript
+#: code:addons/website_sale/static/src/js/location_selector/map_container/map_container.js:0
+msgid "There was an error loading the map"
 msgstr ""
 
 #. module: website_sale

--- a/addons/website_sale/static/src/js/location_selector/location/location.js
+++ b/addons/website_sale/static/src/js/location_selector/location/location.js
@@ -1,0 +1,12 @@
+import {
+    Location
+} from '@delivery/js/location_selector/location/location';
+import { patch } from '@web/core/utils/patch';
+import { _t } from '@web/core/l10n/translation';
+
+patch(Location.prototype, {
+    get openingHoursLabel() {
+        // The original definition of this getter is in `delivery` module which is not a frontend module. This problem happens in the context of the website. So, it should be repeated here as translations are only fetched in the context of a frontend module, which is `website_sale` in this case.
+        return _t("Opening hours");
+    },
+});

--- a/addons/website_sale/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
+++ b/addons/website_sale/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
@@ -32,4 +32,24 @@ patch(LocationSelectorDialog.prototype, {
         // The original definition of this getter is in `delivery` module which is not a frontend module. This problem happens in the context of the website. So, it should be repeated here as translations are only fetched in the context of a frontend module, which is `website_sale` in this case.
         return _t("Choose this location");
     },
+
+    get listViewButtonLabel() {
+        // The original definition of this getter is in `delivery` module which is not a frontend module. This problem happens in the context of the website. So, it should be repeated here as translations are only fetched in the context of a frontend module, which is `website_sale` in this case.
+        return _t("List view");
+    },
+
+    get mapViewButtonLabel() {
+        // The original definition of this getter is in `delivery` module which is not a frontend module. This problem happens in the context of the website. So, it should be repeated here as translations are only fetched in the context of a frontend module, which is `website_sale` in this case.
+        return _t("Map view");
+    },
+
+    get errorMessage() {
+        // The original definition of this getter is in `delivery` module which is not a frontend module. This problem happens in the context of the website. So, it should be repeated here as translations are only fetched in the context of a frontend module, which is `website_sale` in this case.
+        return _t("No result");
+    },
+
+    get loadingMessage() {
+        // The original definition of this getter is in `delivery` module which is not a frontend module. This problem happens in the context of the website. So, it should be repeated here as translations are only fetched in the context of a frontend module, which is `website_sale` in this case.
+        return _t("Loading...");
+    },
 });

--- a/addons/website_sale/static/src/js/location_selector/map_container/map_container.js
+++ b/addons/website_sale/static/src/js/location_selector/map_container/map_container.js
@@ -1,0 +1,22 @@
+import {
+    MapContainer
+} from '@delivery/js/location_selector/map_container/map_container';
+import { patch } from '@web/core/utils/patch';
+import { _t } from '@web/core/l10n/translation';
+
+patch(MapContainer.prototype, {
+    get errorMessage() {
+        // The original definition of this getter is in `delivery` module which is not a frontend module. This problem happens in the context of the website. So, it should be repeated here as translations are only fetched in the context of a frontend module, which is `website_sale` in this case.
+        return _t("There was an error loading the map");
+    },
+
+    get chooseLocationButtonLabel() {
+        // The original definition of this getter is in `delivery` module which is not a frontend module. This problem happens in the context of the website. So, it should be repeated here as translations are only fetched in the context of a frontend module, which is `website_sale` in this case.
+        return _t("Choose this location");
+    },
+
+    get openingHoursLabel() {
+        // The original definition of this getter is in `delivery` module which is not a frontend module. This problem happens in the context of the website. So, it should be repeated here as translations are only fetched in the context of a frontend module, which is `website_sale` in this case.
+        return _t("Opening hours");
+    },
+});


### PR DESCRIPTION
There are some terms that are defined in `delivery` module but are not translated when you see them on the website. This happens because these strings are defined in the `delivery` module, which is not a frontend module. This commit redefines those strings in the `website_sale` module, which is a frontend module.

Task-4328208
OPW-4403072
OPW-4326840
