### PR TITLE
[IMP] mail: remove useless getter

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -329,10 +329,6 @@ export class Composer extends Component {
         );
     }
 
-    get hasSendButtonNonEditing() {
-        return !this.extended;
-    }
-
     get hasSuggestions() {
         return Boolean(this.suggestion?.state.items);
     }


### PR DESCRIPTION
Since odoo#186084, the `hasSendButtonNonEditing` getter has been removed from the composer template. This commit removes that getter, as it's now dead code.

Enterprise PR: odoo/enterprise#76335

