### PR TITLE
[FIX] web: hide tooltip on html fields in calendar popover

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
@@ -48,7 +48,8 @@
                 <t t-foreach="slot.record.fieldNames" t-as="fieldName" t-key="fieldName">
                     <t t-if="!slot.record.isInvisible(fieldName)">
                         <t t-set="fieldInfo" t-value="props.model.popoverFields[fieldName]" />
-                        <li class="list-group-item d-flex text-nowrap align-items-center" t-att-class="fieldInfo.rawAttrs.class" t-att-data-tooltip="getFormattedValue(fieldName, slot.record)">
+                        <t t-set="fieldType" t-value="props.model.fields[fieldName].type" />
+                        <li class="list-group-item d-flex text-nowrap align-items-center" t-att-class="fieldInfo.rawAttrs.class" t-att-data-tooltip="fieldType === 'html' ? '' : getFormattedValue(fieldName, slot.record)">
                             <strong class="me-2">
                                 <t t-if="fieldInfo.options.icon">
                                     <b>

--- a/addons/web/static/tests/views/calendar/calendar_view_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_view_tests.js
@@ -5066,4 +5066,38 @@ QUnit.module("Views", ({ beforeEach }) => {
             assert.containsOnce(target, ".o_view_sample_data", "should have sample data");
         }
     );
+
+    QUnit.test("html field on calendar shouldn't have a tooltip", async (assert) => {
+        serverData.models.event.fields.description = { string: "Description", type: "html" };
+        serverData.models.event.records.push({
+            id: 8,
+            user_id: uid,
+            partner_id: 1,
+            name: "event with html",
+            start: "2016-12-12 12:00:00",
+            stop: "2016-12-12 12:00:00",
+            allday: false,
+            partner_ids: [1, 2, 3],
+            type: 1,
+            is_hatched: false,
+            description: "<h1>description</h1>",
+        });
+        await makeView({
+            type: "calendar",
+            resModel: "event",
+            serverData,
+            arch: `
+                <calendar date_start="start">
+                    <field name="description"/>
+                </calendar>
+            `,
+        });
+
+        await clickEvent(target, 8);
+        const descriptionField = target.querySelector(
+            '.o_cw_popover_field .o_field_widget[name="description"]'
+        );
+        const parentLi = descriptionField.closest("li");
+        assert.strictEqual(parentLi.getAttribute("data-tooltip"), "");
+    });
 });


### PR DESCRIPTION
To reproduce:
=============
- create an event on calendar with description containing html
- on calendar view, click on the event to open the popover and hover on the description field
-> the tooltip is displayed with raw html content

Fix:
====
hide the tooltip on html fields in calendar popover as it's not needed

opw-4356581
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
