### PR TITLE
[IMP] website: menu editor enhancements

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -372,7 +372,8 @@ class Website(Home):
         current_website = request.website
 
         matching_pages = []
-        for page in current_website.search_pages(needle, limit=int(limit)):
+        limit = None if limit == "no_limit" else int(limit)
+        for page in current_website.search_pages(needle, limit):
             matching_pages.append({
                 'value': page['loc'],
                 'label': 'name' in page and '%s (%s)' % (page['loc'], page['name']) or page['loc'],
@@ -672,7 +673,13 @@ class Website(Home):
         if website_id:
             website = request.env['website'].browse(int(website_id))
             website._force()
-        page = request.env['website'].new_page(path, add_menu=add_menu, sections_arch=kwargs.get('sections_arch'), **template)
+        page = request.env['website'].new_page(
+            path,
+            add_menu=add_menu,
+            sections_arch=kwargs.get('sections_arch'),
+            page_title=kwargs.get('page_title'),
+            **template
+        )
         url = page['url']
         # In case the page is created through the 404 "Create Page" button, the
         # URL may use special characters which are slugified on page creation.

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1162,7 +1162,7 @@ class Website(models.Model):
                 copy_menu(submenu, new_top_menu)
 
     @api.model
-    def new_page(self, name=False, add_menu=False, template='website.default_page', ispage=True, namespace=None, page_values=None, menu_values=None, sections_arch=None):
+    def new_page(self, name=False, add_menu=False, template='website.default_page', ispage=True, namespace=None, page_values=None, menu_values=None, sections_arch=None, page_title=None):
         """ Create a new website page, and assign it a xmlid based on the given one
             :param name: the name of the page
             :param add_menu: if True, add a menu for that page
@@ -1171,6 +1171,7 @@ class Website(models.Model):
             :param page_values: default values for the page to be created
             :param menu_values: default values for the menu to be created
             :param sections_arch: HTML content of sections
+            :param page_title: if set, it allows using 'name' for the URL and a different title
         """
         if namespace:
             template_module = namespace
@@ -1199,7 +1200,7 @@ class Website(models.Model):
 
         view.with_context(lang=None).write({
             'arch': arch.replace(template, key),
-            'name': name,
+            'name': page_title or name,
         })
         result['view_id'] = view.id
 

--- a/addons/website/static/src/builder/plugins/navbar_link_popover/navbar_link_popover.xml
+++ b/addons/website/static/src/builder/plugins/navbar_link_popover/navbar_link_popover.xml
@@ -2,10 +2,19 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="website.navbarLinkPopover" t-inherit="html_editor.linkPopover">
+        <xpath expr="//div[@data-prevent-closing-overlay]" position="attributes">
+            <attribute name="style"/>
+        </xpath>
+        <xpath expr="//a[hasclass('o_we_url_link')]" position="attributes">
+            <attribute name="class" add="me-3" separator=" "/>
+        </xpath>
         <xpath expr="//a[@title='Remove Link']" position="replace">
-            <a href="#" class="ms-2 js_edit_menu text-dark" t-on-click="onClickEditMenu" title="Edit Menu">
-                <i class="fa fa-sitemap"></i>
-            </a>
+            <button type="button"
+                    class="js_edit_menu btn btn-sm btn-primary"
+                    style="padding: 0px 6px;"
+                    t-on-click="onClickEditMenu" title="Edit Menu">
+                Edit Menu
+            </button>
         </xpath>
     </t>
 

--- a/addons/website/static/src/builder/plugins/options/header/header_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_option_plugin.js
@@ -10,6 +10,7 @@ import { HeaderElementsOption } from "./header_elements_option";
 import { HeaderFontOption } from "./header_font_option";
 import { HeaderTemplateOption } from "./header_template_option";
 import { HeaderIconBackgroundOption } from "./header_icon_background_option";
+import { HeaderTopOptions } from "./header_top_options";
 
 const [
     HEADER_TEMPLATE,
@@ -43,9 +44,19 @@ export const basicHeaderOptionSettings = {
 
 class HeaderOptionPlugin extends Plugin {
     static id = "headerOption";
-    static dependencies = ["customizeWebsite"];
+    static dependencies = ["customizeWebsite", "menuDataPlugin"];
 
     resources = {
+        builder_header_middle_buttons: [
+            {
+                Component: HeaderTopOptions,
+                editableOnly: false,
+                selector: "#wrapwrap > header",
+                props: {
+                    openEditMenu: () => this.dependencies.menuDataPlugin.openEditMenu(),
+                },
+            },
+        ],
         builder_options: [
             withSequence(HEADER_TEMPLATE, {
                 ...basicHeaderOptionSettings,

--- a/addons/website/static/src/builder/plugins/options/header/header_top_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header/header_top_option.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.HeaderTopOptions">
+    <button class="btn btn-primary"
+            title="Open menu editor"
+            aria-label="Open menu editor"
+            t-on-click="this.props.openEditMenu">
+        Edit Menu
+    </button>
+</t>
+
+</templates>

--- a/addons/website/static/src/builder/plugins/options/header/header_top_options.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_top_options.js
@@ -1,0 +1,9 @@
+import { Component } from "@odoo/owl";
+
+export class HeaderTopOptions extends Component {
+    static template = "website.HeaderTopOptions";
+    static props = {
+        openEditMenu: Function,
+    };
+
+}

--- a/addons/website/static/src/client_actions/website_preview/create_page_message.js
+++ b/addons/website/static/src/client_actions/website_preview/create_page_message.js
@@ -1,0 +1,9 @@
+import { Component } from "@odoo/owl";
+
+export class CreatePageMessage extends Component {
+    static template = "website.CreatePageMessage";
+    static props = {
+        createPage: { type: Function },
+    };
+
+}

--- a/addons/website/static/src/client_actions/website_preview/create_page_message.xml
+++ b/addons/website/static/src/client_actions/website_preview/create_page_message.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.CreatePageMessage">
+    <!-- The wrapping <div> is necessary to avoid a traceback due to the dismiss -->
+    <div>
+        <div class="alert alert-warning alert-dismissible m-0 rounded-0 border-0">
+            <div class="container d-flex align-items-center">
+                <i class="fa fa-lg fa-info-circle me-2"></i>
+                <span class="me-auto">This page does not exist yet. Would you like to create it?</span>
+                <a role="button" class="btn btn-primary" t-on-click="this.props.createPage">Create Page</a>
+            </div>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    </div>
+</t>
+</templates>

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
@@ -2,7 +2,9 @@
 <templates xml:space="preserve">
 
 <t t-name="website.WebsiteBuilderClientAction">
-    <div class="d-flex h-100 w-100" t-ref="container">
+    <t t-set="show_404_page_message" t-value="this.state.is404 and !state.isEditing"/>
+    <div class="d-flex h-100 w-100" t-att-class="{'flex-column': show_404_page_message}" t-ref="container">
+        <CreatePageMessage t-if="show_404_page_message" createPage="() => this.onNewPage(true)"/>
         <div class="o_website_preview border-top flex-grow-1" t-ref="website_preview">
             <div class="o_iframe_container">
                 <iframe t-if="!testMode" t-att-src="iframeFallbackUrl"

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -402,9 +402,18 @@ export class AddPageDialog extends Component {
             type: String,
             optional: true,
         },
+        goToPage: {
+            type: Boolean,
+            optional: true,
+        },
+        pageTitle: {
+            type: String,
+            optional: true,
+        },
     };
     static defaultProps = {
         onAddPage: NO_OP,
+        goToPage: true,
     };
     static components = {
         WebsiteDialog,
@@ -441,7 +450,7 @@ export class AddPageDialog extends Component {
             // We also skip the possibility to choose to add in menu in that
             // case (e.g. in creation from 404 page button). The user can still
             // create its menu afterwards if needed.
-            await this.createPage(sectionsArch, this.props.forcedURL);
+            await this.createPage(sectionsArch, this.props.forcedURL, false, this.props.pageTitle);
         } else {
             this.dialogs.add(AddPageConfirmDialog, {
                 createPage: (...args) => this.createPage(sectionsArch, ...args),
@@ -450,7 +459,7 @@ export class AddPageDialog extends Component {
         }
     }
 
-    async createPage(sectionsArch, name = "", addMenu = false) {
+    async createPage(sectionsArch, name = "", addMenu = false, pageTitle = "") {
         // Remove any leading slash.
         const pageName = name.replace(/^\/*/, "") || _t("New Page");
         const data = await this.http.post(`/website/add/${encodeURIComponent(pageName)}`, {
@@ -461,6 +470,7 @@ export class AddPageDialog extends Component {
 
             'website_id': this.props.websiteId,
             'csrf_token': odoo.csrf_token,
+            'page_title': pageTitle,
         });
         if (data.view_id) {
             this.action.doAction({
@@ -470,7 +480,7 @@ export class AddPageDialog extends Component {
                 'type': 'ir.actions.act_window',
                 'view_mode': 'form',
             });
-        } else {
+        } else if (this.props.goToPage) {
             this.website.goToWebsite({path: data.url, edition: true, websiteId: this.props.websiteId});
         }
         this.props.onAddPage();

--- a/addons/website/static/src/components/dialog/dialog.scss
+++ b/addons/website/static/src/components/dialog/dialog.scss
@@ -2,7 +2,25 @@
     label {
         font-weight: $font-weight-bold;
     }
-    .o_nested_sortable_placeholder_realsize {
-        margin-bottom: 4px;
+    ul.oe_menu_editor {
+        &:not(:has(li.o_dragged)) .input-group:hover > * {
+            background-color: $table-hover-bg !important;
+        }
+        li.o_dragged {
+            opacity: 1 !important;
+            box-shadow: 5px 5px 5px -5px rgba(0,0,0,0.2);
+        }
+        .o_nested_sortable_placeholder_realsize {
+            outline: 1px dashed $o-gray-400;
+            @include border-radius($input-border-radius);
+        }
+    }
+    .o_page_not_found {
+        input {
+            padding-right: 23px;
+        }
+        .fa {
+            font-size: 1rem;
+        }
     }
 }

--- a/addons/website/static/src/components/dialog/edit_menu.xml
+++ b/addons/website/static/src/components/dialog/edit_menu.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 <t t-name="website.MenuDialog">
-    <WebsiteDialog title.translate="Add a menu item" closeOnClick="false" primaryClick.bind="this.onClickOk" secondaryClick="props.close">
+    <WebsiteDialog title="title" primaryTitle.translate="Continue" secondaryTitle.translate="Discard"
+        closeOnClick="false" primaryClick.bind="this.onClickOk" secondaryClick="props.close">
         <div class="o_menu_dialog_form mb-3 row">
             <label class="col-form-label col-md-3">
-                Name
+                Title
             </label>
             <div class="col-md-9">
-                <input type="text" t-model="name.input.value" class="form-control" t-att-class="{ 'is-invalid': name.input.hasError }" t-ref="autofocus"/>
+                <input type="text" t-on-input="onTitleInput" t-model="state.name"
+                    class="form-control" t-att-class="{ 'is-invalid': state.missingName }" t-ref="autofocus"/>
             </div>
         </div>
         <div t-if="!props.isMegaMenu" class="mb-3 row">
@@ -15,7 +17,14 @@
                 Url or Email
             </label>
             <div class="col-md-9">
-                <input id="url_input" t-ref="url-input" type="text" t-model="url.input.value" class="form-control" t-att-class="{ 'is-invalid': url.input.hasError }"/>
+                <div class="position-relative" t-att-class="{ 'o_page_not_found': state.pageNotFound }">
+                    <input id="url_input" t-on-input="onUrlInput" t-ref="url-input" type="text"
+                        t-model="state.url" class="form-control"/>
+                    <i t-if="state.pageNotFound"
+                        class="fa fa-info-circle text-warning position-absolute top-50 end-0 translate-middle-y me-2"
+                        data-tooltip="Page not found" data-tooltip-position="top" data-tooltip-delay="0">
+                    </i>
+                </div>
                 <small class="form-text">Hint: Type '/' to search an existing page and '#' to link to an anchor.</small>
             </div>
         </div>
@@ -23,22 +32,31 @@
 </t>
 
 <t t-name="website.MenuRow">
-    <li t-att-data-menu-id="props.menu.fields['id']" t-att-data-is-mega-menu="props.menu.fields['is_mega_menu'] ? 'true' : undefined">
+    <li class="mb-1" t-att-data-menu-id="props.menu.fields['id']" t-att-data-is-mega-menu="props.menu.fields['is_mega_menu'] ? 'true' : undefined">
         <div class="input-group mb-1">
-                <span class="input-group-text bg-view fa fa-bars" role="img" aria-label="Dropdown menu" title="Dropdown menu"/>
-            <span class="form-control d-flex align-items-center bg-view">
-                <span class="js_menu_label o_text_overflow flex-grow-1">
+            <span class="input-group-text bg-view oi oi-draggable align-content-center p-2 border-end-0 text-muted"
+                role="img" aria-label="Dropdown menu" title="Dropdown menu"/>
+            <span class="form-control d-flex align-items-center bg-view ms-0 border-start-0 border-end-0">
+                <span t-on-dblclick="edit" class="js_menu_label o_text_overflow flex-grow-1">
                     <t t-esc="props.menu.fields['name']"/>
                 </span>
-                <span t-if="props.menu.fields['is_mega_menu']" class="badge text-bg-primary">Mega Menu</span>
+                <span t-if="props.menu.fields['is_mega_menu']" class="badge text-bg-primary rounded-pill">Mega Menu</span>
                 <i t-if="props.menu.is_homepage" class="fa fa-home ms-3" role="img" aria-label="Home" title="Home"/>
             </span>
-                <button t-on-click="edit" type="button" class="btn btn-secondary js_edit_menu fa fa-pencil-square-o" aria-label="Edit Menu Item" title="Edit Menu Item"/>
-                <button t-on-click="delete" type="button" class="btn btn-secondary js_delete_menu fa fa-trash-o rounded-start-0" aria-label="Delete Menu Item" title="Delete Menu Item"/>
+            <div class="input-group-text bg-view p-0 ms-0 border-start-0">
+                <button type="button" t-if="props.menu.page_not_found and !props.menu.children.length" t-on-click="createPage"
+                    class="btn btn-sm btn-outline-primary me-1">Create Page</button>
+                <button t-on-click="edit" type="button"
+                    class="btn js_edit_menu fa fa-pencil text-muted px-2 rounded-0 h-100"
+                    aria-label="Edit Menu Item" title="Edit Menu Item"/>
+                <button t-on-click="delete" type="button"
+                    class="btn js_delete_menu fa fa-trash-o text-danger px-2 rounded-0 h-100"
+                    aria-label="Delete Menu Item" title="Delete Menu Item"/>
+            </div>
         </div>
-        <ul t-if="props.menu.children">
+        <ul t-if="props.menu.children.length">
             <t t-foreach="props.menu.children" t-as="submenu" t-key="submenu.fields['id']">
-                <MenuRow menu="submenu" edit="props.edit" delete="props.delete"/>
+                <MenuRow menu="submenu" edit="props.edit" delete="props.delete" createPage="props.createPage"/>
             </t>
         </ul>
     </li>
@@ -48,19 +66,21 @@
     <WebsiteDialog close="props.close" title.translate="Edit Menu" primaryTitle.translate="Save" primaryClick="() => this.onClickSave()">
         <ul t-ref="menu-editor" class="oe_menu_editor list-unstyled">
             <t t-foreach="state.rootMenu.children" t-as="menu" t-key="menu.fields['id']">
-                <MenuRow menu="menu" edit="(id) => this.editMenu(id)" delete="(id) => this.deleteMenu(id)"/>
+                <MenuRow menu="menu" edit="(id) => this.editMenu(id)" delete="(id) => this.deleteMenu(id)" createPage="(id) => this.createPage(id)"/>
             </t>
         </ul>
-        <div class="mt32">
-            <small class="float-end text-muted">
-                Drag to the right to get a submenu
+        <div class="d-flex mt-4 justify-content-between align-items-end">
+            <div class="d-flex flex-column">
+                <a href="#" t-on-click="() => this.addMenu(false)">
+                    <i class="fa fa-plus-circle me-1"/> Add Menu Item
+                </a>
+                <a href="#" t-on-click="() => this.addMenu(true)">
+                    <i class="fa fa-plus-circle me-1"/> Add Mega Menu Item
+                </a>
+            </div>
+            <small class="text-muted">
+                <i class="fa fa-info-circle me-1"/> Drag to the right to get a submenu
             </small>
-            <a href="#" t-on-click="() => this.addMenu(false)">
-                <i class="fa fa-plus-circle"/> Add Menu Item
-            </a><br/>
-            <a href="#" t-on-click="() => this.addMenu(true)">
-                <i class="fa fa-plus-circle"/> Add Mega Menu Item
-            </a>
         </div>
     </WebsiteDialog>
 </t>

--- a/addons/website/static/src/components/dialog/page_properties.xml
+++ b/addons/website/static/src/components/dialog/page_properties.xml
@@ -65,10 +65,10 @@
 
 <t t-name="website.DeletePageDialog">
     <WebsiteDialog title.translate="Delete Page" close="props.close">
-        <p t-if="props.resIds.length > 1">Ready to make these web pages disappear into thin air? Are you sure?\n They will be gone forever!\n
+        <p t-if="props.resIds.length > 1">Ready to make these web pages disappear into thin air? Are you sure?<br/> They will be gone forever!<br/><br/>
             <span class="text-warning">But before deleting, make sure you update all links referring to them. That way, your customers won't bump into the not-so-famous 404 error page.</span>
         </p>
-        <p t-else="">Ready to make this web page disappear into thin air? Are you sure?\n It will be gone forever!\n
+        <p t-else="">Ready to make this web page disappear into thin air? Are you sure?<br/> It will be gone forever!<br/><br/>
             <span class="text-warning">But before deleting, make sure you update all links referring to it. That way, your customers won't bump into the not-so-famous 404 error page.</span>
         </p>  
         <PageDependencies resIds="props.resIds" resModel="props.resModel" mode="'collapse'"/>

--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -598,12 +598,7 @@ class TitleDescription extends Component {
      * @param {InputEvent} ev
      */
     _updateInputValue(ev) {
-        // `NFKD` as in `http_routing` python `slugify()`
-        ev.target.value = ev.target.value.trim().normalize('NFKD').toLowerCase()
-            .replace(/\s+/g, '-') // Replace spaces with -
-            .replace(/[^\w-]+/g, '') // Remove all non-word chars
-            .replace(/--+/g, '-'); // Replace multiple - with single -
-        this.seoContext.seoName = ev.target.value;
+        this.seoContext.seoName = wUtils.slugify(ev.target.value);
     }
 }
 

--- a/addons/website/static/tests/builder/website_builder/menu_data.test.js
+++ b/addons/website/static/tests/builder/website_builder/menu_data.test.js
@@ -40,7 +40,7 @@ describe("NavbarLinkPopover", () => {
         await waitFor(".o-we-linkpopover");
         // remove link button replaced with sitemap button
         expect(".o-we-linkpopover:has(i.fa-chain-broken)").toHaveCount(0);
-        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(1);
+        expect(".o-we-linkpopover:has(button.js_edit_menu)").toHaveCount(1);
         // selection outside a top menu link
         setSelection({ anchorNode: el.querySelector("p"), anchorOffset: 0 });
         await expectElementCount(".o-we-linkpopover", 0);
@@ -59,15 +59,15 @@ describe("NavbarLinkPopover", () => {
                 config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin, SavePlugin] },
             }
         );
-        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(0);
+        expect(".o-we-linkpopover:has(button.js_edit_menu)").toHaveCount(0);
         // open navbar link popover
         setSelection({ anchorNode: el.querySelector(".nav-link > span"), anchorOffset: 0 });
         await waitFor(".o-we-linkpopover");
-        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(1);
+        expect(".o-we-linkpopover:has(button.js_edit_menu)").toHaveCount(1);
         // selection in the same link
         setSelection({ anchorNode: el.querySelector(".nav-link > span"), anchorOffset: 1 });
         await waitFor(".o-we-linkpopover");
-        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(1);
+        expect(".o-we-linkpopover:has(button.js_edit_menu)").toHaveCount(1);
     });
 
     test("should open a navbar popover when the selection is inside a top menu dropdown link", async () => {
@@ -93,11 +93,11 @@ describe("NavbarLinkPopover", () => {
                 config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin, SavePlugin] },
             }
         );
-        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(0);
+        expect(".o-we-linkpopover:has(button.js_edit_menu)").toHaveCount(0);
         // selection in dropdown menu
         setSelection({ anchorNode: el.querySelector(".dropdown-item > span"), anchorOffset: 0 });
         await waitFor(".o-we-linkpopover");
-        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(1);
+        expect(".o-we-linkpopover:has(button.js_edit_menu)").toHaveCount(1);
     });
 
     test("link redirection should be prefixed for links in the nav bar", async () => {
@@ -153,11 +153,17 @@ describe("MenuDialog", () => {
                 this.website.pageDocument = el.ownerDocument;
             },
         });
-        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(0);
+        onRpc("/website/get_suggested_links", () => {
+            return {
+                matching_pages: [],
+                others: [],
+            };
+        });
+        expect(".o-we-linkpopover:has(button.js_edit_menu)").toHaveCount(0);
         // open navbar link popover
         setSelection({ anchorNode: el.querySelector(".nav-link > span"), anchorOffset: 0 });
         await waitFor(".o-we-linkpopover");
-        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(1);
+        expect(".o-we-linkpopover:has(button.js_edit_menu)").toHaveCount(1);
         // click the link edit button
         await click(".o_we_edit_link");
         // check that MenuDialog is open and that name and url have been passed correctly
@@ -195,6 +201,7 @@ describe("EditMenuDialog", () => {
         ],
         is_homepage: false,
     };
+
     beforeEach(() => {
         mockService("website", {
             get currentWebsite() {
@@ -210,7 +217,6 @@ describe("EditMenuDialog", () => {
             },
         });
     });
-
     test("after clicking on edit menu button, an EditMenuDialog should appear", async () => {
         const { el } = await setupEditor(
             `<ul class="top_menu">
@@ -232,11 +238,18 @@ describe("EditMenuDialog", () => {
             return sampleMenuData;
         });
 
-        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(0);
+        onRpc("/website/get_suggested_links", () => {
+            return {
+                matching_pages: [],
+                others: [],
+            };
+        });
+
+        expect(".o-we-linkpopover:has(button.js_edit_menu)").toHaveCount(0);
         // open navbar link popover
         setSelection({ anchorNode: el.querySelector(".nav-link > span"), anchorOffset: 0 });
         await waitFor(".o-we-linkpopover");
-        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(1);
+        expect(".o-we-linkpopover:has(button.js_edit_menu)").toHaveCount(1);
         // click on edit menu button
         await click(".js_edit_menu");
         // check that EditMenuDialog is open with correct values
@@ -272,6 +285,13 @@ describe("EditMenuDialog", () => {
             return sampleMenuData;
         });
 
+        onRpc("/website/get_suggested_links", () => {
+            return {
+                matching_pages: [],
+                others: [],
+            };
+        });
+
         const editor = getEditor();
 
         // add some text
@@ -285,9 +305,9 @@ describe("EditMenuDialog", () => {
 
         // open menu editor and save
         await waitFor(".o-we-linkpopover");
-        await click(queryOne("i.fa-sitemap"));
+        await click(queryOne("button.js_edit_menu"));
         await waitFor("footer.modal-footer");
-        await click(queryOne("button.btn-primary"));
+        await click(queryOne(".modal-footer > button.btn-primary"));
         await waitForNone(".modal");
         expect.verifySteps(["editor_has_saved"]);
     });

--- a/addons/website/static/tests/tours/create_missing_page.js
+++ b/addons/website/static/tests/tours/create_missing_page.js
@@ -1,0 +1,186 @@
+import {
+    clickOnSnippet,
+    registerWebsitePreviewTour,
+    changeOption,
+    clickOnSave,
+} from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour("create_missing_page", {
+    url: "/",
+    edition: true,
+}, () => [
+    ...clickOnSnippet({id: "o_header_standard", name: "Header"}),
+    changeOption("Header", "[aria-label='Open menu editor']"),
+    {
+        content: "Open the link dialog (click 'Add Menu Item')",
+        trigger: ".modal-body a:eq(0)",
+        run: "click",
+    },
+    {
+        content: "Edit the 'Menu Title' input",
+        trigger: ".modal-dialog .o_website_dialog input:eq(0)",
+        run: "edit Zoé’s Diner",
+    },
+    {
+        content: "Check if the 'url' input is correctly slugified.",
+        trigger: ".modal-dialog .o_website_dialog input:eq(1):value('zoe-s-diner')",
+    },
+    {
+        content: "Edit the 'url' input",
+        trigger: ".modal-dialog .o_website_dialog input:eq(1)",
+        run: "edit /contactus",
+    },
+    {
+        content: "Check whether the page is found.",
+        trigger: ".modal-dialog .o_website_dialog main div.position-relative:not(.o_page_not_found)",
+    },
+    {
+        content: "Edit the 'url' input again",
+        trigger: ".modal-dialog .o_website_dialog input:eq(1)",
+        run: "edit zoe-s-diner",
+    },
+    {
+        content: "Check that the page is not found.",
+        trigger: ".modal-dialog .o_website_dialog main div.position-relative.o_page_not_found",
+    },
+    {
+        content: "Confirm the new menu entry",
+        trigger: ".modal-dialog .o_website_dialog .modal-footer .btn-primary:contains(Continue)",
+        run: "click",
+    },
+    // Drag the new menu item to the first position. If this is not done, the
+    // tour fails when the new menu is in the extra menu.
+    {
+        content: "Drag the new menu item at the top",
+        trigger: '.oe_menu_editor li:contains("Zoé’s Diner") .oi-draggable',
+        run(helpers) {
+            return helpers.drag_and_drop('.oe_menu_editor li:contains("Home") .oi-draggable', {
+                position: {
+                    top: 20,
+                },
+                relative: true,
+            });
+        },
+    },
+    {
+        content: "Click on the 'Create Page' button",
+        trigger: ".oe_menu_editor button:contains('Create Page')",
+        run: "click",
+    },
+    {
+        content: "Click on 'Blank Page'",
+        trigger: ".o_page_template .o_button_area:not(:visible)",
+        run: "click",
+    },
+    {
+        content: "Wait to land on '/zoe-s-diner' page",
+        trigger: ':iframe a[href="/zoe-s-diner"].nav-link.active',
+    },
+    {
+        content: "Wait edit mode",
+        trigger: ".o_builder_sidebar_open",
+    },
+    ...clickOnSnippet({id: "o_header_standard", name: "Header"}),
+    changeOption("Header", "[aria-label='Open menu editor']"),
+    {
+        content: "Check that the 'Create Page' button is missing.",
+        trigger: ".oe_menu_editor .js_menu_label:contains('Zoé’s Diner')",
+        run() {
+            if (this.anchor.closest(".form-control")
+                    .querySelector("button")
+                    ?.textContent.includes('Create Page')) {
+                throw new Error("The 'Create Page' button should be missing");
+            }
+        },
+    },
+    {
+        content: "Save the menu",
+        trigger: ".modal-footer .btn-primary",
+        run: "click",
+    },
+    {
+        content: "Check that we are on the new page.",
+        trigger: ":iframe a[href='/zoe-s-diner'].nav-link.active",
+    },
+    {
+        content: "Check that it is not a 404 page.",
+        trigger: ".o_website_preview:not([data-view-xmlid='website.page_404'])",
+    },
+    {
+        content: "Check that the page title has been correctly set.",
+        trigger: ':iframe head title:contains("Zoé’s Diner"):not(:visible)',
+    },
+    {
+        content: "Click on the 'Zoé’s Diner' link.",
+        trigger: ":iframe a[href='/zoe-s-diner'].nav-link.active span",
+        run: "click",
+    },
+    {
+        content: "Click Edit Menu in the popover.",
+        trigger: ".o-we-linkpopover button.js_edit_menu",
+        run: "click",
+    },
+    {
+        content: "Open the link dialog (click 'Add Menu Item')",
+        trigger: ".modal-body a:eq(0)",
+        run: "click",
+    },
+    {
+        content: "Edit the 'Menu Title' input",
+        trigger: ".modal-dialog .o_website_dialog input:eq(0)",
+        run: "edit The Sea Hotel",
+    },
+    {
+        content: "Edit the 'url' input",
+        trigger: ".modal-dialog .o_website_dialog input:eq(1)",
+        run: "edit sea-hotel",
+    },
+    {
+        content: "Confirm the new menu entry",
+        trigger: ".modal-dialog .o_website_dialog .modal-footer .btn-primary:contains(Continue)",
+        run: "click",
+    },
+    // Drag the new menu item to the first position. If this is not done, the
+    // tour fails when the new menu is in the extra menu.
+    {
+        content: "Drag the new menu item at the top",
+        trigger: '.oe_menu_editor li:contains("The Sea Hotel") .oi-draggable',
+        run(helpers) {
+            return helpers.drag_and_drop('.oe_menu_editor li:contains("Zoé’s Diner") .oi-draggable', {
+                position: {
+                    top: 20,
+                },
+                relative: true,
+            });
+        },
+    },
+    {
+        content: "Save the menu",
+        trigger: ".modal-footer .btn-primary",
+        run: "click",
+    },
+    ...clickOnSave(),
+    {
+        content: "Click on the 'The Sea Hotel' link.",
+        trigger: ":iframe a[href='/sea-hotel'].nav-link",
+        run: "click",
+    },
+    {
+        content: "Click on the 'Create Page' alert button.",
+        trigger: ".o_action_manager .alert a.btn",
+        run: "click",
+    },
+    {
+        content: "Click on 'Blank Page'",
+        trigger: ".o_page_template .o_button_area:not(:visible)",
+        run: "click",
+    },
+    {
+        content: "Wait edit mode",
+        trigger: ".o_builder_sidebar_open",
+    },
+    {
+        content: "Wait to land on '/sea-hotel' page",
+        trigger: ':iframe a[href="/sea-hotel"].nav-link.active',
+    },
+]);

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -49,7 +49,7 @@ registerWebsitePreviewTour('edit_megamenu', {
     },
     {
         content: "Confirm the mega menu label",
-        trigger: ".modal .modal-footer button:contains(ok)",
+        trigger: ".modal .modal-footer button:contains(Continue)",
         run: "click",
     },
     {
@@ -128,7 +128,7 @@ registerWebsitePreviewTour("megamenu_active_nav_link", {
     ...openLinkPopup(":iframe .top_menu .nav-item a:contains('Home')", "Home"),
     {
         content: "Click on 'Link' to open Link Dialog",
-        trigger: ".o-we-linkpopover a.js_edit_menu",
+        trigger: ".o-we-linkpopover button.js_edit_menu",
         run: "click",
     },
     {
@@ -146,7 +146,7 @@ registerWebsitePreviewTour("megamenu_active_nav_link", {
     },
     {
         content: "Confirm the mega menu label",
-        trigger: ".modal .modal-footer .btn-primary:contains(ok)",
+        trigger: ".modal .modal-footer .btn-primary:contains(Continue)",
         run: "click",
     },
     {
@@ -198,7 +198,7 @@ registerWebsitePreviewTour('edit_megamenu_big_icons_subtitles', {
     ...openLinkPopup(":iframe .top_menu .nav-item a", "Home"),
     {
         content: "Click on 'Link' to open Link Dialog",
-        trigger: ".o-we-linkpopover a.js_edit_menu",
+        trigger: ".o-we-linkpopover .js_edit_menu",
         run: "click",
     },
     {
@@ -216,7 +216,7 @@ registerWebsitePreviewTour('edit_megamenu_big_icons_subtitles', {
     },
     {
         content: "Confirm the mega menu label",
-        trigger: ".modal .modal-footer .btn-primary:contains(ok)",
+        trigger: ".modal .modal-footer .btn-primary:contains(Continue)",
         run: "click",
     },
     {

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -103,7 +103,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Confirm the mega menu label",
-        trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(ok)",
+        trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(Continue)",
         run: "click",
     },
     {
@@ -130,7 +130,7 @@ registerWebsitePreviewTour('edit_menus', {
     ...openLinkPopup(":iframe .top_menu .nav-item a:contains('Home')", "Home"),
     {
         content: "Click on Edit Menu",
-        trigger: '.o-we-linkpopover a.js_edit_menu',
+        trigger: '.o-we-linkpopover .js_edit_menu',
         run: "click",
     },
     {
@@ -146,7 +146,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Confirm the new menu entry without a label",
-        trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(ok)",
+        trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(Continue)",
         run: "click",
     },
     {
@@ -161,7 +161,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Confirm the new menu entry without a url",
-        trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(ok)",
+        trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(Continue)",
         run: "click",
     },
     {
@@ -171,7 +171,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Confirm the new menu entry with # url",
-        trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(ok)",
+        trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(Continue)",
         run: "click",
     },
     {
@@ -219,7 +219,7 @@ registerWebsitePreviewTour('edit_menus', {
     ...openLinkPopup(":iframe .top_menu .nav-item a:contains('Modnar')", "Modnar"),
     {
         content: "Click on the popover Edit Menu button",
-        trigger: '.o-we-linkpopover a.js_edit_menu',
+        trigger: '.o-we-linkpopover .js_edit_menu',
         run: "click",
     },
     {
@@ -237,7 +237,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Confirm the new menu label",
-        trigger: ".modal:not(.o_inactive_modal) .modal-footer button:contains(ok)",
+        trigger: ".modal:not(.o_inactive_modal) .modal-footer button:contains(Continue)",
         run: "click",
     },
     {
@@ -270,7 +270,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: `Drag "Contact Us" menu below "Home" menu`,
-        trigger: '.oe_menu_editor li:contains("Contact us") .fa-bars',
+        trigger: '.oe_menu_editor li:contains("Contact us") .oi-draggable',
         run(helpers) {
             return helpers.drag_and_drop('.oe_menu_editor li:contains("Home")', {
                 position: {
@@ -283,7 +283,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Drag 'Contact Us' item as a child of the 'Home' item",
-        trigger: '.oe_menu_editor li:contains("Contact us") .fa-bars',
+        trigger: '.oe_menu_editor li:contains("Contact us") .oi-draggable',
         run: 'drag_and_drop .oe_menu_editor li:contains("Contact us") .form-control',
     },
     {
@@ -293,10 +293,10 @@ registerWebsitePreviewTour('edit_menus', {
     // Drag the Mega menu to the first position.
     {
         content: "Drag Mega at the top",
-        trigger: '.oe_menu_editor li:contains("Megaaaaa!") .fa-bars',
+        trigger: '.oe_menu_editor li:contains("Megaaaaa!") .oi-draggable',
         run(helpers) {
-            return helpers.drag_and_drop(".oe_menu_editor li:contains('Home') .fa-bars", {
-                position : {
+            return helpers.drag_and_drop('.oe_menu_editor li:contains("Home") .oi-draggable', {
+                position: {
                     top: 20,
                 },
                 relative: true,
@@ -431,7 +431,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Confirm the new menu entry",
-        trigger: '.modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(ok)',
+        trigger: '.modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(Continue)',
         run: "click",
     },
     {
@@ -455,7 +455,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Confirm the new menu entry",
-        trigger: '.modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(ok)',
+        trigger: '.modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(Continue)',
         run: "click",
     },
     {
@@ -464,21 +464,21 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Nest 'new_nested_menu' under 'new_menu'",
-        trigger: '.oe_menu_editor li:contains("new_nested_menu") .fa-bars',
+        trigger: '.oe_menu_editor li:contains("new_nested_menu") .oi-draggable',
         run: "drag_and_drop .oe_menu_editor li:contains('new_menu') .form-control",
     },
     {
         content: "Drag 'Modnar !!' below 'new_menu'",
-        trigger: '.oe_menu_editor li:contains("Modnar !!") .fa-bars',
+        trigger: '.oe_menu_editor li:contains("Modnar !!") .oi-draggable',
         async run(helpers) {
-            await helpers.drag_and_drop('.oe_menu_editor li:contains("new_menu") .fa-bars', {
+            await helpers.drag_and_drop('.oe_menu_editor li:contains("new_menu") .oi-draggable', {
                 position: "bottom",
             });
         },
     },
     {
         content: "Nest 'Modnar !!' under 'new_menu'",
-        trigger: '.oe_menu_editor li:contains("Modnar !!") .fa-bars',
+        trigger: '.oe_menu_editor li:contains("Modnar !!") .oi-draggable',
         run: "drag_and_drop .oe_menu_editor li:contains('new_menu') .form-control",
     },
     {
@@ -487,9 +487,9 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Move 'Modnar !!' below 'new_nested_menu' inside the 'new_menu'",
-        trigger: '.oe_menu_editor  li:contains("new_menu") > ul > li:contains("Modnar !!") .fa-bars',
+        trigger: '.oe_menu_editor  li:contains("new_menu") > ul > li:contains("Modnar !!") .oi-draggable',
         async run(helpers) {
-            await helpers.drag_and_drop(".oe_menu_editor  li:contains('new_menu') > ul > li:contains('new_nested_menu') .fa-bars", {
+            await helpers.drag_and_drop(".oe_menu_editor  li:contains('new_menu') > ul > li:contains('new_nested_menu') .oi-draggable", {
                 position: "bottom",
             });
         },

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -206,7 +206,7 @@ registerWebsitePreviewTour('link_tools', {
     },
     // 6. Add mega menu with Cards template and edit URL on text-selected card.
     clickOnElement("menu link", ":iframe header .nav-item a"),
-    clickOnElement("'Edit menu' icon", ":iframe .o_edit_menu_popover .fa-sitemap"),
+    clickOnElement("'Edit menu' icon", ":iframe .o_edit_menu_popover .js_edit_menu"),
     {
         trigger: ".o_website_dialog:visible",
     },
@@ -221,15 +221,15 @@ registerWebsitePreviewTour('link_tools', {
         run: "edit Mega",
     },
     {
-        content: "Clicking on the OK button",
-        trigger: ".modal button:contains(ok)",
+        content: "Clicking on the Continue button",
+        trigger: ".modal button:contains(Continue)",
         run: "click",
     },
     {
         content: "Drag Mega at the top",
-        trigger: '.oe_menu_editor li:contains("Mega") .fa-bars',
+        trigger: '.oe_menu_editor li:contains("Mega") .oi-draggable',
         run(helpers) {
-            return helpers.drag_and_drop(".oe_menu_editor li:contains('Home') .fa-bars", {
+            return helpers.drag_and_drop(".oe_menu_editor li:contains('Home') .oi-draggable", {
                 position : {
                     top: 20,
                 },

--- a/addons/website/tests/test_controllers.py
+++ b/addons/website/tests/test_controllers.py
@@ -38,11 +38,11 @@ class TestControllers(tests.HttpCase):
             else:
                 last_5_url_edited.append(new_page.url)
 
-        self.url_open(url=suggested_links_url, json={'params': {'needle': '/'}})
+        self.url_open(url=suggested_links_url, json={'params': {'needle': '/', 'limit': 10}})
         # mark as old
         old_pages._write({'write_date': '2020-01-01'})
 
-        res = self.url_open(url=suggested_links_url, json={'params': {'needle': '/'}})
+        res = self.url_open(url=suggested_links_url, json={'params': {'needle': '/', 'limit': 10}})
         resp = json.loads(res.content)
         assert 'result' in resp
         suggested_links = resp['result']

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -734,3 +734,6 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_systray_items_disappear(self):
         self.start_tour("/", "website_systray_items_disappear", login="admin")
+
+    def test_create_missing_page(self):
+        self.start_tour("/", "create_missing_page", login="admin")

--- a/addons/website_event/models/website.py
+++ b/addons/website_event/models/website.py
@@ -11,7 +11,7 @@ class Website(models.Model):
     _inherit = "website"
 
     @api.model
-    def new_page(self, name=False, add_menu=False, template='website.default_page', ispage=True, namespace=None, page_values=None, menu_values=None, sections_arch=None):
+    def new_page(self, name=False, add_menu=False, template='website.default_page', ispage=True, namespace=None, page_values=None, menu_values=None, sections_arch=None, page_title=None):
         """ Override the page creation in the context of events.
 
          When creating a page for an event, the page needs to be embedded inside the
@@ -42,7 +42,7 @@ class Website(models.Model):
             if website_event_menu:
                 template = "website_event.layout"
 
-        new_page = super().new_page(name, add_menu, template, ispage, namespace, page_values, menu_values, sections_arch)
+        new_page = super().new_page(name, add_menu, template, ispage, namespace, page_values, menu_values, sections_arch, page_title)
 
         if website_event_menu and new_page.get('view_id'):
             website_event_menu.view_id = new_page['view_id']


### PR DESCRIPTION
The goal of this commit helps editors manage site structure more easily
by making page creation and menu editing more accessible and
discoverable.

After this commit:

-----------------
- The design and UX of the menu editor modal have been improved.

   | Before  | After |
   | ------------- | ------------- |
   | ![image](https://github.com/user-attachments/assets/eeca7ad8-64c6-44db-b8c6-a2615287e710)  |  ![image](https://github.com/user-attachments/assets/5f5f6315-8f9e-4f5e-b0e4-5b31896e5b87)  |

-----------------
- A "Edit Menu" button was added in the header options.

<kbd>![image](https://github.com/user-attachments/assets/8c75de01-1ee1-478e-a1b1-6564e3313de3)</kbd>

-----------------
- The "Edit Menu" button shown in the popover when clicking a header
link in edit mode now shows the text "Edit menu" instead of just an icon.

<kbd>![image](https://github.com/user-attachments/assets/59860ca4-d8f1-46bd-b0ed-62e0a466fac6)</kbd>

-----------------
- When a user adds a link to their menu with a URL that doesn't exist, a
"Create Page" button is shown to help them easily create the page.

<kbd>![image](https://github.com/user-attachments/assets/bc8852ec-fe82-4e8c-a982-b8f7b31dd424)</kbd>

-----------------
- When an editor is on a 404 page, a "Create Page" button is displayed
at the top of the page preview.

<kbd>![image](https://github.com/user-attachments/assets/1836e1ce-42aa-47b5-a90b-15df15b80753)</kbd>

-----------------

task-4422810