### PR TITLE
[IMP] web: check permission for onchange call

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -862,6 +862,13 @@ class Base(models.AbstractModel):
         cache = env.cache
         first_call = not field_names
 
+        if not (self and self._name == 'res.users'):
+            # res.users defines SELF_WRITEABLE_FIELDS to give access to the user
+            # to modify themselves, we skip the check in that case because the
+            # user does not have write permission on themselves
+            # TODO update res.users
+            self.check_access('write' if self else 'create')
+
         if any(fname not in self._fields for fname in field_names):
             return {}
 

--- a/addons/web/tests/test_partner.py
+++ b/addons/web/tests/test_partner.py
@@ -1,15 +1,16 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import io
 import logging
 import unittest
 import zipfile
-from odoo.fields import Command
-
-from odoo.tests.common import HttpCase, tagged
 from base64 import b64decode
 
+from odoo.addons.base.tests.common import TransactionCaseWithUserPortal
+from odoo.exceptions import AccessError
+from odoo.fields import Command
+from odoo.tests.common import HttpCase, tagged
 from odoo.tools import mute_logger
+
 _logger = logging.getLogger(__name__)
 
 try:
@@ -17,6 +18,16 @@ try:
 except ImportError:
     _logger.warning("`vobject` Python module not found, vcard file generation disabled. Consider installing this module if you want to generate vcard files")
     vobject = None
+
+
+class TestPartnerPrivate(TransactionCaseWithUserPortal):
+    def test_access_onchange(self):
+        partner = self.partner_portal.with_user(self.user_portal)
+        self.assertEqual(partner.has_access('read'), True)
+        self.assertEqual(partner.has_access('write'), False)
+
+        with self.assertRaises(AccessError):
+            partner.onchange({}, ['name'], {'name': {}})
 
 
 @tagged('-at_install', 'post_install')


### PR DESCRIPTION
Check that the user has access to the model when running `onchange` so that users that do not have access cannot use that feature. An exception is made for res.users where some fields are editable by the users themselves which are defined in SELF_WRITEABLE_FIELDS. This is probably something that we should change in the future.

odoo/enterprise#76342

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
