### PR TITLE
[FIX] point_of_sale: delete silently in localDeleteCascade

### DIFF
--- a/addons/point_of_sale/static/src/app/debug/debug_widget.js
+++ b/addons/point_of_sale/static/src/app/debug/debug_widget.js
@@ -118,7 +118,7 @@ export class DebugWidget extends Component {
                 );
 
                 for (const order of orders) {
-                    this.pos.data.localDeleteCascade(order, true);
+                    this.pos.data.localDeleteCascade(order, !paid);
                 }
 
                 if (!this.pos.get_order()) {

--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -286,7 +286,7 @@ export class PosData extends Reactive {
 
                 for (const id of ids) {
                     if (!serverIds.includes(id)) {
-                        this.localDeleteCascade(this.models["pos.order"].get(id), true);
+                        this.localDeleteCascade(this.models["pos.order"].get(id));
                     }
                 }
             }
@@ -627,14 +627,8 @@ export class PosData extends Reactive {
         return await this.execute({ type: "delete", model, ids, queue });
     }
 
-    localDeleteCascade(record, force = false) {
+    localDeleteCascade(record, removeFromServer = false) {
         const recordModel = record.constructor.pythonModel;
-        if (typeof record.id === "number" && !force) {
-            console.info(
-                `Record ID ${record.id} MODEL ${recordModel}. If you want to delete a record saved on the server, you need to pass the force parameter as true.`
-            );
-            return;
-        }
 
         const relationsToDelete = Object.values(this.relations[recordModel])
             .filter((rel) => this.opts.cascadeDeleteModels.includes(rel.relation))
@@ -648,11 +642,11 @@ export class PosData extends Reactive {
         this.indexedDB.delete(recordModel, [record.uuid]);
         for (const item of recordsToDelete) {
             this.indexedDB.delete(item.model.modelName, [item.uuid]);
-            item.delete();
+            item.delete({ silent: !removeFromServer });
         }
 
         // Delete the main record
-        const result = record.delete();
+        const result = record.delete({ silent: !removeFromServer });
         return result;
     }
 


### PR DESCRIPTION
Before this commit, cancelling an order would result in keeping the removed orderlines in the unlink command, causing issues in different cases when trying to sync a new order.

opw-4403100

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
