### PR TITLE
[IMP] uom: add float handling methods

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -433,8 +433,7 @@ class MrpBom(models.Model):
             else:
                 # We round up here because the user expects that if he has to consume a little more, the whole UOM unit
                 # should be consumed.
-                rounding = current_line.product_uom_id.rounding
-                line_quantity = float_round(line_quantity, precision_rounding=rounding, rounding_method='UP')
+                line_quantity = current_line.product_uom_id.round(line_quantity, rounding_method='UP')
                 lines_done.append((current_line, {'qty': line_quantity, 'product': current_product, 'original_qty': quantity, 'parent_line': parent_line}))
 
         return boms_done, lines_done

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -370,7 +370,7 @@ class MrpProduction(models.Model):
         # Force to prefetch more than 1000 by 1000
         all_raw_moves._fields['forecast_availability'].compute_value(all_raw_moves)
         for production in productions:
-            if any(float_compare(move.forecast_availability, 0 if move.state == 'draft' else move.product_qty, precision_rounding=move.product_id.uom_id.rounding) == -1 for move in production.move_raw_ids):
+            if any(move.product_id.uom_id.compare(move.forecast_availability, 0 if move.state == 'draft' else move.product_qty) == -1 for move in production.move_raw_ids):
                 production.components_availability = _('Not Available')
                 production.components_availability_state = 'unavailable'
             else:
@@ -431,7 +431,7 @@ class MrpProduction(models.Model):
             moves = production.move_raw_ids.filtered(lambda move: move.unit_factor and move.product_id.type != 'consu')
             if moves:
                 production_capacity = min(moves.mapped(lambda move: move.product_id.uom_id._compute_quantity(move.product_id.qty_available, move.product_uom) / move.unit_factor))
-                production.production_capacity = min(production.product_qty, float_round(production_capacity, precision_rounding=production.product_id.uom_id.rounding))
+                production.production_capacity = min(production.product_qty, production.product_id.uom_id.round(production_capacity))
 
     @api.depends('move_finished_ids.date_deadline')
     def _compute_date_deadline(self):
@@ -550,11 +550,11 @@ class MrpProduction(models.Model):
                 production.state = 'done'
             elif production.workorder_ids and all(wo_state in ('done', 'cancel') for wo_state in production.workorder_ids.mapped('state')):
                 production.state = 'to_close'
-            elif not production.workorder_ids and float_compare(production.qty_producing, production.product_qty, precision_rounding=production.product_uom_id.rounding) >= 0:
+            elif not production.workorder_ids and production.product_uom_id.compare(production.qty_producing, production.product_qty) >= 0:
                 production.state = 'to_close'
             elif any(wo_state in ('progress', 'done') for wo_state in production.workorder_ids.mapped('state')):
                 production.state = 'progress'
-            elif production.product_uom_id and not float_is_zero(production.qty_producing, precision_rounding=production.product_uom_id.rounding):
+            elif production.product_uom_id and not production.product_uom_id.is_zero(production.qty_producing):
                 production.state = 'progress'
             elif any(production.move_raw_ids.mapped('picked')):
                 production.state = 'progress'
@@ -620,7 +620,7 @@ class MrpProduction(models.Model):
             if production.state in ('draft', 'done', 'cancel'):
                 production.reservation_state = False
                 continue
-            relevant_move_state = production.move_raw_ids.filtered(lambda m: not (m.picked or float_is_zero(m.product_uom_qty, precision_rounding=m.product_uom.rounding)))._get_relevant_state_among_moves()
+            relevant_move_state = production.move_raw_ids.filtered(lambda m: not (m.picked or m.product_uom.is_zero(m.product_uom_qty)))._get_relevant_state_among_moves()
             # Compute reservation state according to its component's moves.
             if relevant_move_state == 'partially_available':
                 if production.workorder_ids.operation_id and production.bom_id.ready_to_produce == 'asap':
@@ -1275,7 +1275,7 @@ class MrpProduction(models.Model):
             if move.sudo()._should_bypass_set_qty_producing():
                 continue
 
-            new_qty = float_round((self.qty_producing - self.qty_produced) * move.unit_factor, precision_rounding=move.product_uom.rounding)
+            new_qty = move.product_uom.round((self.qty_producing - self.qty_produced) * move.unit_factor)
             move._set_quantity_done(new_qty)
             if not move.manual_consumption or pick_manual_consumption_moves:
                 move.picked = True
@@ -1289,7 +1289,7 @@ class MrpProduction(models.Model):
         update_info = []
         for move in self.move_raw_ids.filtered(lambda m: m.state not in ('done', 'cancel')):
             old_qty = move.product_uom_qty
-            new_qty = float_round(old_qty * factor, precision_rounding=move.product_uom.rounding, rounding_method='UP')
+            new_qty = move.product_uom.round(old_qty * factor, rounding_method='UP')
             if new_qty > 0:
                 # procurement and assigning is now run in write
                 move.write({'product_uom_qty': new_qty})
@@ -1618,9 +1618,8 @@ class MrpProduction(models.Model):
             done_qty_by_product = defaultdict(float)
             for move in order.move_raw_ids:
                 quantity = move.product_uom._compute_quantity(move._get_picked_quantity(), move.product_id.uom_id)
-                rounding = move.product_id.uom_id.rounding
                 # extra lines with non-zero qty picked
-                if move.product_id not in expected_qty_by_product and move.picked and not float_is_zero(quantity, precision_rounding=rounding):
+                if move.product_id not in expected_qty_by_product and move.picked and not move.product_id.uom_id.is_zero(quantity):
                     issues.append((order, move.product_id, quantity, 0.0))
                     continue
                 done_qty_by_product[move.product_id] += quantity if move.picked else 0.0
@@ -1628,7 +1627,7 @@ class MrpProduction(models.Model):
             # origin lines from bom with different qty
             for product, qty_to_consume in expected_qty_by_product.items():
                 quantity = done_qty_by_product.get(product, 0.0)
-                if float_compare(qty_to_consume, quantity, precision_rounding=product.uom_id.rounding) != 0:
+                if product.uom_id.compare(qty_to_consume, quantity) != 0:
                     issues.append((order, product, quantity, qty_to_consume))
 
         return issues
@@ -1657,7 +1656,7 @@ class MrpProduction(models.Model):
         if self.env.context.get('skip_backorder', False):
             return quantity_issues
         for order in self:
-            if not float_is_zero(order._get_quantity_to_backorder(), precision_rounding=order.product_uom_id.rounding):
+            if not order.product_uom_id.is_zero(order._get_quantity_to_backorder()):
                 quantity_issues.append(order)
         return quantity_issues
 
@@ -1754,7 +1753,7 @@ class MrpProduction(models.Model):
             finish_moves = order.move_finished_ids.filtered(lambda m: m.product_id == order.product_id and m.state not in ('done', 'cancel'))
             # the finish move can already be completed by the workorder.
             for move in finish_moves:
-                move.quantity = float_round(order.qty_producing - order.qty_produced, precision_rounding=order.product_uom_id.rounding, rounding_method='HALF-UP')
+                move.quantity = order.product_uom_id.round(order.qty_producing - order.qty_produced, rounding_method='HALF-UP')
                 extra_vals = order._prepare_finished_extra_vals()
                 if extra_vals:
                     move.move_line_ids.write(extra_vals)
@@ -1829,7 +1828,7 @@ class MrpProduction(models.Model):
                 amounts[production] = _default_amounts(production)
                 continue
             total_amount = sum(mo_amounts)
-            diff = float_compare(production.product_qty, total_amount, precision_rounding=production.product_uom_id.rounding)
+            diff = production.product_uom_id.compare(production.product_qty, total_amount)
             if diff > 0 and not cancel_remaining_qty:
                 amounts[production].append(production.product_qty - total_amount)
                 has_backorder_to_ignore[production] = True
@@ -1940,7 +1939,7 @@ class MrpProduction(models.Model):
             if not initial_move.picked:
                 for move_line in initial_move.move_line_ids.sorted(key=lambda ml: ml._sorting_move_lines()):
                     available_qty = move_line.product_uom_id._compute_quantity(move_line.quantity, product_uom, rounding_method="HALF-UP")
-                    if float_compare(available_qty, 0, precision_rounding=product_uom.rounding) <= 0:
+                    if product_uom.compare(available_qty, 0) <= 0:
                         continue
                     ml_by_move.append((available_qty, move_line, move_line.copy_data()[0]))
 
@@ -1952,7 +1951,7 @@ class MrpProduction(models.Model):
             for index, (quantity, move_line, ml_vals) in enumerate(ml_by_move):
                 taken_qty = min(quantity, move_qty_to_reserve)
                 taken_qty_uom = product_uom._compute_quantity(taken_qty, move_line.product_uom_id, rounding_method="HALF-UP")
-                if float_is_zero(taken_qty_uom, precision_rounding=move_line.product_uom_id.rounding):
+                if move_line.product_uom_id.is_zero(taken_qty_uom):
                     continue
                 move_line.write({
                     'quantity': taken_qty_uom,
@@ -1961,19 +1960,19 @@ class MrpProduction(models.Model):
                 move_qty_to_reserve -= taken_qty
                 ml_by_move[index] = (quantity - taken_qty, move_line, ml_vals)
 
-                if float_compare(move_qty_to_reserve, 0, precision_rounding=move.product_uom.rounding) <= 0:
+                if move.product_uom.compare(move_qty_to_reserve, 0) <= 0:
                     assigned_moves.add(move.id)
                     move = moves and moves.pop(0)
                     move_qty_to_reserve = move and move.product_qty or 0
 
             for quantity, move_line, ml_vals in ml_by_move:
-                while float_compare(quantity, 0, precision_rounding=product_uom.rounding) > 0 and move:
+                while product_uom.compare(quantity, 0) > 0 and move:
                     # Do not create `stock.move.line` if there is no initial demand on `stock.move`
                     taken_qty = min(move_qty_to_reserve, quantity)
                     taken_qty_uom = product_uom._compute_quantity(taken_qty, move_line.product_uom_id, rounding_method="HALF-UP")
                     if move == initial_move:
                         move_line.quantity += taken_qty_uom
-                    elif not float_is_zero(taken_qty_uom, precision_rounding=move_line.product_uom_id.rounding):
+                    elif not move_line.product_uom_id.is_zero(taken_qty_uom):
                         new_ml_vals = dict(
                             ml_vals,
                             quantity=taken_qty_uom,
@@ -1983,7 +1982,7 @@ class MrpProduction(models.Model):
                     quantity -= taken_qty
                     move_qty_to_reserve -= taken_qty
 
-                    if float_compare(move_qty_to_reserve, 0, precision_rounding=move.product_uom.rounding) <= 0:
+                    if move.product_uom.compare(move_qty_to_reserve, 0) <= 0:
                         assigned_moves.add(move.id)
                         move = moves and moves.pop(0)
                         move_qty_to_reserve = move and move.product_qty or 0
@@ -2167,7 +2166,7 @@ class MrpProduction(models.Model):
         self._button_mark_done_sanity_checks()
         productions_auto = set()
         for production in self:
-            if not float_is_zero(production.qty_producing, precision_rounding=production.product_uom_id.rounding):
+            if not production.product_uom_id.is_zero(production.qty_producing):
                 production.move_raw_ids.filtered(
                     lambda move: move.manual_consumption and not move.picked
                 ).picked = True
@@ -2608,7 +2607,7 @@ class MrpProduction(models.Model):
             if move.has_tracking != 'serial' or move.product_id == self.product_id:
                 continue
             for move_line in move.move_line_ids:
-                if float_is_zero(move_line.quantity, precision_rounding=move_line.product_uom_id.rounding):
+                if move_line.product_uom_id.is_zero(move_line.quantity):
                     continue
                 if self._is_finished_sn_already_produced(move_line.lot_id, excluded_sml=move_line):
                     raise UserError(_('The serial number %(number)s used for byproduct %(product_name)s has already been produced',
@@ -2620,8 +2619,7 @@ class MrpProduction(models.Model):
             if move.has_tracking != 'serial' or not move.picked:
                 continue
             for move_line in move.move_line_ids:
-                if not move_line.picked or float_is_zero(move_line.quantity, precision_rounding=move_line.product_uom_id.rounding) or\
-                        not move_line.lot_id:
+                if not move_line.picked or move_line.product_uom_id.is_zero(move_line.quantity) or not move_line.lot_id:
                     continue
                 sml_sn = move_line.lot_id
                 message = _('The serial number %(number)s used for component %(component)s has already been consumed',
@@ -2751,7 +2749,7 @@ class MrpProduction(models.Model):
         missing_lot_id_products = ""
         if self.product_tracking in ('lot', 'serial') and not self.lot_producing_id:
             self.action_generate_serial()
-        if self.product_tracking == 'serial' and float_compare(self.qty_producing, 1, precision_rounding=self.product_uom_id.rounding) == 1:
+        if self.product_tracking == 'serial' and self.product_uom_id.compare(self.qty_producing, 1) == 1:
             self.qty_producing = 1
         else:
             self.qty_producing = self.product_qty - self.qty_produced

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -552,11 +552,11 @@ class MrpProduction(models.Model):
                 production.state = 'to_close'
             elif not production.workorder_ids and production.product_uom_id.compare(production.qty_producing, production.product_qty) >= 0:
                 production.state = 'to_close'
-            elif any(wo_state in ('progress', 'done') for wo_state in production.workorder_ids.mapped('state')):
-                production.state = 'progress'
-            elif production.product_uom_id and not production.product_uom_id.is_zero(production.qty_producing):
-                production.state = 'progress'
-            elif any(production.move_raw_ids.mapped('picked')):
+            elif (
+                any(wo_state in ('progress', 'done') for wo_state in production.workorder_ids.mapped('state'))
+                or production.product_uom_id and not production.product_uom_id.is_zero(production.qty_producing)
+                or any(production.move_raw_ids.mapped('picked'))
+            ):
                 production.state = 'progress'
 
     @api.depends('bom_id', 'product_id', 'product_qty', 'product_uom_id', 'never_product_template_attribute_value_ids')

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -203,7 +203,7 @@ class MrpUnbuild(models.Model):
             original_move = move in produce_moves and self.mo_id.move_raw_ids or self.mo_id.move_finished_ids
             original_move = original_move.filtered(lambda m: m.product_id == move.product_id)
             if not original_move:
-                move.quantity = float_round(move.product_uom_qty, precision_rounding=move.product_uom.rounding)
+                move.quantity = move.product_uom.round(move.product_uom_qty)
                 continue
             needed_quantity = move.product_uom_qty
             moves_lines = original_move.mapped('move_line_ids')
@@ -212,7 +212,7 @@ class MrpUnbuild(models.Model):
             for move_line in moves_lines:
                 # Iterate over all move_lines until we unbuilded the correct quantity.
                 taken_quantity = min(needed_quantity, move_line.quantity - qty_already_used[move_line])
-                taken_quantity = float_round(taken_quantity, precision_rounding=move.product_uom.rounding)
+                taken_quantity = move.product_uom.round(taken_quantity)
                 if taken_quantity:
                     move_line_vals = self._prepare_move_line_vals(move, move_line, taken_quantity)
                     self.env["stock.move.line"].create(move_line_vals)

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -83,7 +83,7 @@ class ProductTemplate(models.Model):
 
     def _compute_mrp_product_qty(self):
         for template in self:
-            template.mrp_product_qty = float_round(sum(template.mapped('product_variant_ids').mapped('mrp_product_qty')), precision_rounding=template.uom_id.rounding)
+            template.mrp_product_qty = template.uom_id.round(sum(template.mapped('product_variant_ids').mapped('mrp_product_qty')))
 
     def action_view_mos(self):
         action = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_production_action")
@@ -247,7 +247,7 @@ class ProductProduct(models.Model):
             if not product.id:
                 product.mrp_product_qty = 0.0
                 continue
-            product.mrp_product_qty = float_round(mapped_data.get(product.id, 0), precision_rounding=product.uom_id.rounding)
+            product.mrp_product_qty = product.uom_id.round(mapped_data.get(product.id, 0))
 
     def _compute_quantities_dict(self, lot_id, owner_id, package_id, from_date=False, to_date=False):
         """ When the product is a kit, this override computes the fields :
@@ -296,7 +296,7 @@ class ProductProduct(models.Model):
                 component = component.with_context(mrp_compute_quantities=qties).with_prefetch(prefetch_component_ids)
                 qty_per_kit = 0
                 for bom_line, bom_line_data in bom_sub_lines:
-                    if not component.is_storable or float_is_zero(bom_line_data['qty'], precision_rounding=bom_line.product_uom_id.rounding):
+                    if not component.is_storable or bom_line.product_uom_id.is_zero(bom_line_data['qty']):
                         # As BoMs allow components with 0 qty, a.k.a. optionnal components, we simply skip those
                         # to avoid a division by zero. The same logic is applied to non-storable products as those
                         # products have 0 qty available.
@@ -305,30 +305,29 @@ class ProductProduct(models.Model):
                     qty_per_kit += bom_line.product_uom_id._compute_quantity(uom_qty_per_kit, bom_line.product_id.uom_id, round=False, raise_if_failure=False)
                 if not qty_per_kit:
                     continue
-                rounding = component.uom_id.rounding
                 component_res = (
                     qties.get(component.id)
                     if component.id in qties
                     else {
-                        "virtual_available": float_round(component.virtual_available, precision_rounding=rounding),
-                        "qty_available": float_round(component.qty_available, precision_rounding=rounding),
-                        "incoming_qty": float_round(component.incoming_qty, precision_rounding=rounding),
-                        "outgoing_qty": float_round(component.outgoing_qty, precision_rounding=rounding),
-                        "free_qty": float_round(component.free_qty, precision_rounding=rounding),
+                        "virtual_available": component.uom_id.round(component.virtual_available),
+                        "qty_available": component.uom_id.round(component.qty_available),
+                        "incoming_qty": component.uom_id.round(component.incoming_qty),
+                        "outgoing_qty": component.uom_id.round(component.outgoing_qty),
+                        "free_qty": component.uom_id.round(component.free_qty),
                     }
                 )
-                ratios_virtual_available.append(float_round(component_res["virtual_available"] / qty_per_kit, precision_rounding=rounding))
-                ratios_qty_available.append(float_round(component_res["qty_available"] / qty_per_kit, precision_rounding=rounding))
-                ratios_incoming_qty.append(float_round(component_res["incoming_qty"] / qty_per_kit, precision_rounding=rounding))
-                ratios_outgoing_qty.append(float_round(component_res["outgoing_qty"] / qty_per_kit, precision_rounding=rounding))
-                ratios_free_qty.append(float_round(component_res["free_qty"] / qty_per_kit, precision_rounding=rounding))
+                ratios_virtual_available.append(component.uom_id.round(component_res["virtual_available"] / qty_per_kit))
+                ratios_qty_available.append(component.uom_id.round(component_res["qty_available"] / qty_per_kit))
+                ratios_incoming_qty.append(component.uom_id.round(component_res["incoming_qty"] / qty_per_kit))
+                ratios_outgoing_qty.append(component.uom_id.round(component_res["outgoing_qty"] / qty_per_kit))
+                ratios_free_qty.append(component.uom_id.round(component_res["free_qty"] / qty_per_kit))
             if bom_sub_lines and ratios_virtual_available:  # Guard against all cnsumable bom: at least one ratio should be present.
                 res[product.id] = {
-                    'virtual_available': float_round(min(ratios_virtual_available) * bom_kits[product].product_qty, precision_rounding=rounding) // 1,
-                    'qty_available': float_round(min(ratios_qty_available) * bom_kits[product].product_qty, precision_rounding=rounding) // 1,
-                    'incoming_qty': float_round(min(ratios_incoming_qty) * bom_kits[product].product_qty, precision_rounding=rounding) // 1,
-                    'outgoing_qty': float_round(min(ratios_outgoing_qty) * bom_kits[product].product_qty, precision_rounding=rounding) // 1,
-                    'free_qty': float_round(min(ratios_free_qty) * bom_kits[product].product_qty, precision_rounding=rounding) // 1,
+                    'virtual_available': component.uom_id.round(min(ratios_virtual_available) * bom_kits[product].product_qty) // 1,
+                    'qty_available': component.uom_id.round(min(ratios_qty_available) * bom_kits[product].product_qty) // 1,
+                    'incoming_qty': component.uom_id.round(min(ratios_incoming_qty) * bom_kits[product].product_qty) // 1,
+                    'outgoing_qty': component.uom_id.round(min(ratios_outgoing_qty) * bom_kits[product].product_qty) // 1,
+                    'free_qty': component.uom_id.round(min(ratios_free_qty) * bom_kits[product].product_qty) // 1,
                 }
             else:
                 res[product.id] = {

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -611,9 +611,7 @@ class StockMove(models.Model):
         if self.state in ('done', 'cancel'):
             return True
         # Do not update extra product quantities
-        if self.product_uom.is_zero(self.product_uom_qty):
-            return True
-        return False
+        return self.product_uom.is_zero(self.product_uom_qty)
 
     def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
         vals = super()._prepare_move_line_vals(quantity, reserved_quant)

--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -91,7 +91,7 @@ class StockWarehouseOrderpoint(models.Model):
             ratios_total = []
             for bom_line, bom_line_data in bom_sub_lines:
                 component = bom_line.product_id
-                if not component.is_storable or float_is_zero(bom_line_data['qty'], precision_rounding=bom_line.product_uom_id.rounding):
+                if not component.is_storable or bom_line.product_uom_id.is_zero(bom_line_data['qty']):
                     continue
                 uom_qty_per_kit = bom_line_data['qty'] / bom_line_data['original_qty']
                 qty_per_kit = bom_line.product_uom_id._compute_quantity(uom_qty_per_kit, bom_line.product_id.uom_id, raise_if_failure=False)

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -43,7 +43,7 @@ class StockRule(models.Model):
     def _run_manufacture(self, procurements):
         new_productions_values_by_company = defaultdict(lambda: defaultdict(list))
         for procurement, rule in procurements:
-            if float_compare(procurement.product_qty, 0, precision_rounding=procurement.product_uom.rounding) <= 0:
+            if procurement.product_uom.compare(procurement.product_qty, 0) <= 0:
                 # If procurement contains negative quantity, don't create a MO that would be for a negative value.
                 continue
             bom = rule._get_matching_bom(procurement.product_id, procurement.company_id, procurement.values)
@@ -58,7 +58,7 @@ class StockRule(models.Model):
                 if batch_size <= 0:
                     batch_size = procurement_qty
                 vals = rule._prepare_mo_vals(*procurement, bom)
-                while float_compare(procurement_qty, 0, precision_rounding=procurement.product_uom.rounding) > 0:
+                while procurement.product_uom.compare(procurement_qty, 0) > 0:
                     current_qty = min(procurement_qty, batch_size)
                     new_productions_values_by_company[procurement.company_id.id]['values'].append({
                         **vals,
@@ -94,7 +94,7 @@ class StockRule(models.Model):
             if rule.picking_type_id == warehouse_id.sam_type_id or (
                 warehouse_id.sam_loc_id and warehouse_id.sam_loc_id.parent_path in rule.location_src_id.parent_path
             ):
-                if float_compare(procurement.product_qty, 0, precision_rounding=procurement.product_uom.rounding) < 0:
+                if procurement.product_uom.compare(procurement.product_qty, 0) < 0:
                     procurement.values['group_id'] = procurement.values['group_id'].stock_move_ids.filtered(
                         lambda m: m.state not in ['done', 'cancel']).move_orig_ids.group_id[:1]
                     continue

--- a/addons/mrp/wizard/change_production_qty.py
+++ b/addons/mrp/wizard/change_production_qty.py
@@ -52,7 +52,7 @@ class ChangeProductionQty(models.TransientModel):
 
     @api.model
     def _need_quantity_propagation(self, move, qty):
-        return move.move_dest_ids and not float_is_zero(qty, precision_rounding=move.product_uom.rounding)
+        return move.move_dest_ids and not move.product_uom.is_zero(qty)
 
     def change_prod_qty(self):
         precision = self.env['decimal.precision'].precision_get('Product Unit')
@@ -76,8 +76,7 @@ class ChangeProductionQty(models.TransientModel):
             production._log_manufacture_exception(documents)
             self._update_finished_moves(production, new_production_qty, old_production_qty)
             production.write({'product_qty': new_production_qty})
-            if not float_is_zero(production.qty_producing, precision_rounding=production.product_uom_id.rounding) and\
-               not production.workorder_ids:
+            if not production.product_uom_id.is_zero(production.qty_producing) and not production.workorder_ids:
                 production.qty_producing = new_production_qty
                 production._set_qty_producing()
 

--- a/addons/mrp/wizard/mrp_consumption_warning.py
+++ b/addons/mrp/wizard/mrp_consumption_warning.py
@@ -3,7 +3,6 @@
 
 from odoo import _, fields, models, api
 from odoo.exceptions import UserError
-from odoo.tools import float_compare, float_is_zero
 
 
 class MrpConsumptionWarning(models.TransientModel):
@@ -46,7 +45,7 @@ class MrpConsumptionWarning(models.TransientModel):
                     if line.product_id != move.product_id:
                         continue
                     qty_expected = line.product_uom_id._compute_quantity(line.product_expected_qty_uom, move.product_uom)
-                    qty_compare_result = float_compare(qty_expected, move.quantity, precision_rounding=move.product_uom.rounding)
+                    qty_compare_result = move.product_uom.compare(qty_expected, move.quantity)
                     if qty_compare_result != 0:
                         move.quantity = qty_expected
                     # move should be set to picked to correctly consume the product
@@ -54,7 +53,7 @@ class MrpConsumptionWarning(models.TransientModel):
                     # in case multiple lines with same product => set others to 0 since we have no way to know how to distribute the qty done
                     line.product_expected_qty_uom = 0
                 # move was deleted before confirming MO or force deleted somehow
-                if not float_is_zero(line.product_expected_qty_uom, precision_rounding=line.product_uom_id.rounding):
+                if not line.product_uom_id.is_zero(line.product_expected_qty_uom):
                     missing_move_vals.append({
                         'product_id': line.product_id.id,
                         'product_uom': line.product_uom_id.id,

--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, Command
-from odoo.tools import float_round, float_compare
+from odoo.tools import float_round
 
 
 class MrpProductionSplitMulti(models.TransientModel):
@@ -57,8 +57,7 @@ class MrpProductionSplit(models.TransientModel):
                     'user_id': wizard.production_id.user_id.id,
                     'date': wizard.production_id.date_start,
                 }))
-                remaining_qty = float_round(remaining_qty - qty, precision_rounding=wizard.product_uom_id.rounding)
-
+                remaining_qty = wizard.product_uom_id.round(remaining_qty - qty)
             wizard.production_detailed_vals_ids = commands
 
     @api.depends('production_detailed_vals_ids')
@@ -66,7 +65,7 @@ class MrpProductionSplit(models.TransientModel):
         self.valid_details = False
         for wizard in self:
             if wizard.production_detailed_vals_ids:
-                wizard.valid_details = float_compare(wizard.product_qty, sum(wizard.production_detailed_vals_ids.mapped('quantity')), precision_rounding=wizard.product_uom_id.rounding) == 0
+                wizard.valid_details = wizard.product_uom_id.compare(wizard.product_qty, sum(wizard.production_detailed_vals_ids.mapped('quantity'))) == 0
 
     def action_split(self):
         productions = self.production_id._split_productions({self.production_id: [detail.quantity for detail in self.production_detailed_vals_ids]})

--- a/addons/mrp_account/report/mrp_report_mo_overview.py
+++ b/addons/mrp_account/report/mrp_report_mo_overview.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
-from odoo.tools import float_is_zero
 
 
 class ReportMrpReport_Mo_Overview(models.AbstractModel):
@@ -11,7 +10,7 @@ class ReportMrpReport_Mo_Overview(models.AbstractModel):
     def _get_unit_cost(self, move):
         valuation_layers = move.sudo().stock_valuation_layer_ids
         layers_quantity = sum(valuation_layers.mapped('quantity'))
-        if valuation_layers and not float_is_zero(layers_quantity, precision_rounding=valuation_layers.uom_id.rounding):
+        if valuation_layers and not valuation_layers.uom_id.is_zero(layers_quantity):
             unit_price = sum(valuation_layers.mapped('value')) / layers_quantity
             return move.product_id.uom_id._compute_price(unit_price, move.product_uom)
         return super()._get_unit_cost(move)

--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -75,7 +75,7 @@ class MrpProduction(models.Model):
         self.move_raw_ids.picked = True
         if not self._get_subcontract_move():
             raise UserError(_("This MO isn't related to a subcontracted move"))
-        if float_is_zero(self.qty_producing, precision_rounding=self.product_uom_id.rounding):
+        if self.product_uom_id.is_zero(self.qty_producing):
             return {'type': 'ir.actions.act_window_close'}
 
         if self.move_raw_ids and not any(self.move_raw_ids.mapped('quantity')):
@@ -142,7 +142,7 @@ class MrpProduction(models.Model):
                         'lot_id': self.lot_producing_id and self.lot_producing_id.id,
                     })
 
-            if float_compare(quantity, 0, precision_rounding=self.product_uom_id.rounding) > 0:
+            if self.product_uom_id.compare(quantity, 0) > 0:
                 self.env['stock.move.line'].create({
                     'move_id': subcontract_move_id.id,
                     'picking_id': subcontract_move_id.picking_id.id,

--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -72,7 +72,7 @@ class StockPicking(models.Model):
                 raise UserError(_("There shouldn't be multiple productions to record for the same subcontracted move."))
             # Manage additional quantities
             quantity_done_move = move.product_uom._compute_quantity(move.quantity, production.product_uom_id)
-            if float_compare(production.product_qty, quantity_done_move, precision_rounding=production.product_uom_id.rounding) == -1:
+            if production.product_uom_id.compare(production.product_qty, quantity_done_move) == -1:
                 change_qty = self.env['change.production.qty'].create({
                     'mo_id': production.id,
                     'product_qty': quantity_done_move
@@ -175,7 +175,7 @@ class StockPicking(models.Model):
             if move.move_orig_ids.production_id:
                 continue
             quantity = move.product_qty or move.quantity
-            if float_compare(quantity, 0, precision_rounding=move.product_uom.rounding) <= 0:
+            if move.product_uom.compare(quantity, 0) <= 0:
                 # If a subcontracted amount is decreased, don't create a MO that would be for a negative value.
                 continue
 

--- a/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
+++ b/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models, _, fields
-from odoo.tools import float_compare
 
 
 class ReportMrpReport_Bom_Structure(models.AbstractModel):
@@ -91,7 +90,7 @@ class ReportMrpReport_Bom_Structure(models.AbstractModel):
                     'route_detail': supplier.display_name,
                     'lead_time': rules_delay,
                     'supplier': supplier,
-                    'route_alert': float_compare(qty_supplier_uom, supplier.min_qty, precision_rounding=product.uom_id.rounding) < 0,
+                    'route_alert': product.uom_id.compare(qty_supplier_uom, supplier.min_qty) < 0,
                     'qty_checked': quantity,
                     'bom': bom,
                 }

--- a/addons/mrp_subcontracting_purchase/models/account_move_line.py
+++ b/addons/mrp_subcontracting_purchase/models/account_move_line.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
-from odoo.tools import float_is_zero
 
 
 class AccountMoveLine(models.Model):
@@ -14,7 +13,7 @@ class AccountMoveLine(models.Model):
             subcontract_production = self.purchase_line_id.move_ids._get_subcontract_production()
             components_cost -= sum(subcontract_production.move_raw_ids.stock_valuation_layer_ids.mapped('value'))
             qty = sum(mo.product_uom_id._compute_quantity(mo.qty_producing, self.product_uom_id) for mo in subcontract_production if mo.state == 'done')
-            if not float_is_zero(qty, precision_rounding=self.product_uom_id.rounding):
+            if not self.product_uom_id.is_zero(qty):
                 price_unit_val_dif = price_unit_val_dif + components_cost / qty
         return price_unit_val_dif, relevant_qty
 

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1520,7 +1520,7 @@ class PosOrderLine(models.Model):
             ('location_id', 'in', src_loc.child_internal_location_ids.ids),
         ])
         available_lots = src_loc_quants.\
-            filtered(lambda q: float_compare(q.quantity, 0, precision_rounding=q.product_id.uom_id.rounding) > 0).\
+            filtered(lambda q: q.product_id.uom_id.compare(q.quantity, 0) > 0).\
             mapped('lot_id')
 
         return available_lots.read(['id', 'name', 'product_qty'])

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -32,7 +32,7 @@ class StockPicking(models.Model):
         """We'll create some picking based on order_lines"""
 
         pickings = self.env['stock.picking']
-        stockable_lines = lines.filtered(lambda l: l.product_id.type == 'consu' and not float_is_zero(l.qty, precision_rounding=l.product_id.uom_id.rounding))
+        stockable_lines = lines.filtered(lambda l: l.product_id.type == 'consu' and not l.product_id.uom_id.is_zero(l.qty))
         if not stockable_lines:
             return pickings
         positive_lines = stockable_lines.filtered(lambda l: l.qty > 0)

--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -94,7 +94,7 @@ class PosOrder(models.Model):
                     if not picking.state in ['waiting', 'confirmed', 'assigned']:
                         continue
                     new_qty = so_line.product_uom_qty - so_line.qty_delivered
-                    if float_compare(new_qty, 0, precision_rounding=stock_move.product_uom.rounding) <= 0:
+                    if stock_move.product_uom.compare(new_qty, 0) <= 0:
                         new_qty = 0
                     stock_move.product_uom_qty = so_line.compute_uom_qty(new_qty, stock_move, False)
                     # If the product is delivered with more than one step, we need to update the quantity of the other steps
@@ -104,7 +104,7 @@ class PosOrder(models.Model):
                     waiting_picking_ids.add(picking.id)
 
             def is_product_uom_qty_zero(move):
-                return float_is_zero(move.product_uom_qty, precision_rounding=move.product_uom.rounding)
+                return move.product_uom.is_zero(move.product_uom_qty)
 
             # cancel the waiting pickings if each product_uom_qty of move is zero
             for picking in self.env['stock.picking'].browse(waiting_picking_ids):

--- a/addons/purchase/models/product.py
+++ b/addons/purchase/models/product.py
@@ -30,7 +30,7 @@ class ProductTemplate(models.Model):
 
     def _compute_purchased_product_qty(self):
         for template in self:
-            template.purchased_product_qty = float_round(sum([p.purchased_product_qty for p in template.product_variant_ids]), precision_rounding=template.uom_id.rounding)
+            template.purchased_product_qty = template.uom_id.round(sum(p.purchased_product_qty for p in template.product_variant_ids))
 
     def _get_backend_root_menu_ids(self):
         return super()._get_backend_root_menu_ids() + [self.env.ref('purchase.menu_purchase_root').id]
@@ -76,7 +76,7 @@ class ProductProduct(models.Model):
             if not product.id:
                 product.purchased_product_qty = 0.0
                 continue
-            product.purchased_product_qty = float_round(purchased_data.get(product.id, 0), precision_rounding=product.uom_id.rounding)
+            product.purchased_product_qty = product.uom_id.round(purchased_data.get(product.id, 0))
 
     @api.depends_context('order_id')
     def _compute_is_in_purchase_order(self):

--- a/addons/purchase_mrp/models/stock_move.py
+++ b/addons/purchase_mrp/models/stock_move.py
@@ -53,6 +53,6 @@ class StockMove(models.Model):
             }
             valuation_total_qty = self._compute_kit_quantities(related_aml.product_id, order_qty, kit_bom, filters)
             valuation_total_qty = kit_bom.product_uom_id._compute_quantity(valuation_total_qty, related_aml.product_id.uom_id)
-            if float_is_zero(valuation_total_qty, precision_rounding=related_aml.product_uom_id.rounding or related_aml.product_id.uom_id.rounding):
+            if related_aml.product_uom_id.rounding or related_aml.product_id.uom_id.is_zero(valuation_total_qty):
                 raise UserError(_('Odoo is not able to generate the anglo saxon entries. The total valuation of %s is zero.', related_aml.product_id.display_name))
         return valuation_price_unit_total, valuation_total_qty

--- a/addons/purchase_mrp/report/mrp_report_bom_structure.py
+++ b/addons/purchase_mrp/report/mrp_report_bom_structure.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models
-from odoo.tools import float_compare
 
 
 class ReportMrpReport_Bom_Structure(models.AbstractModel):
@@ -28,7 +27,7 @@ class ReportMrpReport_Bom_Structure(models.AbstractModel):
                     'lead_time': supplier.delay + rules_delay + purchase_lead,
                     'supplier_delay': supplier.delay + rules_delay + purchase_lead,
                     'supplier': supplier,
-                    'route_alert': float_compare(qty_supplier_uom, supplier.min_qty, precision_rounding=product.uom_id.rounding) < 0,
+                    'route_alert': product.uom_id.compare(qty_supplier_uom, supplier.min_qty) < 0,
                     'qty_checked': quantity,
                 }
         return res

--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -131,14 +131,14 @@ class AccountMove(models.Model):
 
         for product, company in unique((svl.product_id, svl.company_id) for svl in stock_valuation_layers):
             product = product.with_company(company.id)
-            if not float_is_zero(product.quantity_svl, precision_rounding=product.uom_id.rounding):
+            if not product.uom_id.is_zero(product.quantity_svl):
                 product.sudo().with_context(disable_auto_svl=True).write({'standard_price': product.value_svl / product.quantity_svl})
 
         for lot, company in unique((svl.lot_id, svl.company_id) for svl in stock_valuation_layers):
             if not lot:
                 continue
             lot = lot.with_company(company.id)
-            if not float_is_zero(lot.quantity_svl, precision_rounding=lot.product_id.uom_id.rounding):
+            if not lot.product_id.uom_id.is_zero(lot.quantity_svl):
                 lot.sudo().with_context(disable_auto_svl=True).write({'standard_price': lot.value_svl / lot.quantity_svl})
 
         posted = super(AccountMove, self.with_context(skip_cogs_reconciliation=True))._post(soft)

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -97,7 +97,7 @@ class PurchaseOrder(models.Model):
             for order in self:
                 to_log = {}
                 for order_line in order.order_line:
-                    if pre_order_line_qty.get(order_line, False) and order_line.product_uom_id.compare(pre_order_line_qty[order_line], order_line.product_qty) > 0:
+                    if pre_order_line_qty.get(order_line) and order_line.product_uom_id.compare(pre_order_line_qty[order_line], order_line.product_qty) > 0:
                         to_log[order_line] = (order_line.product_qty, pre_order_line_qty[order_line])
                 if to_log:
                     order._log_decrease_ordered_quantity(to_log)

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -97,7 +97,7 @@ class PurchaseOrder(models.Model):
             for order in self:
                 to_log = {}
                 for order_line in order.order_line:
-                    if pre_order_line_qty.get(order_line, False) and float_compare(pre_order_line_qty[order_line], order_line.product_qty, precision_rounding=order_line.product_uom_id.rounding) > 0:
+                    if pre_order_line_qty.get(order_line, False) and order_line.product_uom_id.compare(pre_order_line_qty[order_line], order_line.product_qty) > 0:
                         to_log[order_line] = (order_line.product_qty, pre_order_line_qty[order_line])
                 if to_log:
                     order._log_decrease_ordered_quantity(to_log)

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -57,7 +57,7 @@ class StockMove(models.Model):
         received_qty = line.qty_received
         if self.state == 'done':
             received_qty -= self.product_uom._compute_quantity(self.quantity, line.product_uom_id, rounding_method='HALF-UP')
-        if line.product_id.purchase_method == 'purchase' and float_compare(line.qty_invoiced, received_qty, precision_rounding=line.product_uom_id.rounding) > 0:
+        if line.product_id.purchase_method == 'purchase' and line.product_uom_id.compare(line.qty_invoiced, received_qty) > 0:
             move_layer = line.move_ids.sudo().stock_valuation_layer_ids
             invoiced_layer = line.sudo().invoice_lines.stock_valuation_layer_ids
             # value on valuation layer is in company's currency, while value on invoice line is in order's currency
@@ -109,7 +109,7 @@ class StockMove(models.Model):
             # https://github.com/odoo/odoo/blob/2f789b6863407e63f90b3a2d4cc3be09815f7002/addons/stock/models/stock_move.py#L36
             convert_date = fields.Date.context_today(self)
             # use currency rate at bill date when invoice before receipt
-            if float_compare(line.qty_invoiced, received_qty, precision_rounding=line.product_uom_id.rounding) > 0:
+            if line.product_uom_id.compare(line.qty_invoiced, received_qty) > 0:
                 convert_date = max(line.sudo().invoice_lines.move_id.filtered(lambda m: m.state == 'posted').mapped('invoice_date'), default=convert_date)
             price_unit = order.currency_id._convert(
                 price_unit, order.company_id.currency_id, order.company_id, convert_date, round=False)
@@ -187,7 +187,7 @@ class StockMove(models.Model):
         move = (self | returned_move).with_prefetch(self._prefetch_ids)
         pdiff_exists = bool(move.stock_valuation_layer_ids.stock_valuation_layer_ids.account_move_line_id)
 
-        if not am_vals_list or not self.purchase_line_id or pdiff_exists or float_is_zero(qty, precision_rounding=self.product_id.uom_id.rounding):
+        if not am_vals_list or not self.purchase_line_id or pdiff_exists or self.product_id.uom_id.is_zero(qty):
             return am_vals_list
 
         layer = self.env['stock.valuation.layer'].browse(svl_id)
@@ -267,7 +267,7 @@ class StockMove(models.Model):
                 layers_values, to_curr, related_aml.company_id, valuation_date, round=False,
             )
             valuation_total_qty += layers_qty
-        if float_is_zero(valuation_total_qty, precision_rounding=related_aml.product_uom_id.rounding or related_aml.product_id.uom_id.rounding):
+        if related_aml.product_uom_id.rounding or related_aml.product_id.uom_id.is_zero(valuation_total_qty):
             raise UserError(
                 _('Odoo is not able to generate the anglo saxon entries. The total valuation of %s is zero.',
                   related_aml.product_id.display_name))

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -108,7 +108,7 @@ class StockRule(models.Model):
             po = self.env['purchase.order'].sudo().search([dom for dom in domain], limit=1)
             company_id = rules[0].company_id or procurements[0].company_id
             if not po:
-                positive_values = [p.values for p in procurements if float_compare(p.product_qty, 0.0, precision_rounding=p.product_uom.rounding) >= 0]
+                positive_values = [p.values for p in procurements if p.product_uom.compare(p.product_qty, 0.0) >= 0]
                 if positive_values:
                     # We need a rule to generate the PO. However the rule generated
                     # the same domain for PO and the _prepare_purchase_order method
@@ -148,7 +148,7 @@ class StockRule(models.Model):
                         procurement.values, po_line)
                     po_line.sudo().write(vals)
                 else:
-                    if float_compare(procurement.product_qty, 0, precision_rounding=procurement.product_uom.rounding) <= 0:
+                    if procurement.product_uom.compare(procurement.product_qty, 0) <= 0:
                         # If procurement contains negative quantity, don't create a new line that would contain negative qty
                         continue
                     # If it does not exist a PO line for current procurement.

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -38,7 +38,7 @@ class ProductProduct(models.Model):
             if not product.id:
                 product.sales_count = 0.0
                 continue
-            product.sales_count = float_round(r.get(product.id, 0), precision_rounding=product.uom_id.rounding)
+            product.sales_count = product.uom_id.round(r.get(product.id, 0))
         return r
 
     @api.onchange('type')

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -103,7 +103,7 @@ class ProductTemplate(models.Model):
     @api.depends('product_variant_ids.sales_count')
     def _compute_sales_count(self):
         for product in self:
-            product.sales_count = float_round(sum([p.sales_count for p in product.with_context(active_test=False).product_variant_ids]), precision_rounding=product.uom_id.rounding)
+            product.sales_count = product.uom_id.round(sum(p.sales_count for p in product.with_context(active_test=False).product_variant_ids))
 
     @api.constrains('company_id')
     def _check_sale_product_company(self):

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -1038,7 +1038,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         self.assertEqual(kit_parent_wh1.virtual_available, 1)
 
         # Check there arn't enough quantities available for the sale order
-        self.assertTrue(float_compare(order_line.virtual_available_at_date - order_line.product_uom_qty, 0, precision_rounding=line.product_uom_id.rounding) == -1)
+        self.assertTrue(line.product_uom_id.compare(order_line.virtual_available_at_date - order_line.product_uom_qty, 0) == -1)
 
         # We receive enoug of each component in Warehouse 2 to make 3 kit_parent
         qty_to_process = {
@@ -1061,7 +1061,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         self.assertEqual(kit_parent_wh1.virtual_available, 1)
 
         # Check there arn't enough quantities available for the sale order
-        self.assertTrue(float_compare(order_line.virtual_available_at_date - order_line.product_uom_qty, 0, precision_rounding=line.product_uom_id.rounding) == -1)
+        self.assertTrue(line.product_uom_id.compare(order_line.virtual_available_at_date - order_line.product_uom_qty, 0) == -1)
 
         # We receive enough of each component in Warehouse 2 to make 7 kit_parent
         qty_to_process = {
@@ -1273,7 +1273,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         self.assertEqual(virtual_available_wh_order, 1)
 
         # Check there arn't enough quantities available for the sale order
-        self.assertTrue(float_compare(order_line.virtual_available_at_date - order_line.product_uom_qty, 0, precision_rounding=line.product_uom_id.rounding) == -1)
+        self.assertTrue(line.product_uom_id.compare(order_line.virtual_available_at_date - order_line.product_uom_qty, 0) == -1)
 
         # We receive enough of each component in Warehouse 1 to make 3 kit_uom_in_kit.
         # Moves are created instead of only updating the quant quantities in order to trigger every compute fields.
@@ -1286,7 +1286,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         self._create_move_quantities(qty_to_process, components, warehouse_1)
 
         # Check there arn't enough quantities available for the sale order
-        self.assertTrue(float_compare(order_line.virtual_available_at_date - order_line.product_uom_qty, 0, precision_rounding=line.product_uom_id.rounding) == -1)
+        self.assertTrue(line.product_uom_id.compare(order_line.virtual_available_at_date - order_line.product_uom_qty, 0) == -1)
         kit_uom_in_kit.with_context(warehouse_id=warehouse_1.id)._compute_quantities()
         virtual_available_wh_order = kit_uom_in_kit.virtual_available
         self.assertEqual(virtual_available_wh_order, 3)

--- a/addons/stock/models/product_strategy.py
+++ b/addons/stock/models/product_strategy.py
@@ -171,7 +171,7 @@ class StockPutawayRule(models.Model):
                             return location
                         else:
                             checked_locations.add(location)
-                elif float_compare(qty_by_location[location.id], 0, precision_rounding=product.uom_id.rounding) > 0:
+                elif product.uom_id.compare(qty_by_location[location.id], 0) > 0:
                     if location._check_can_be_used(product, quantity, location_qty=qty_by_location[location.id]):
                         return location
                     else:

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -438,7 +438,7 @@ class StockLocation(models.Model):
                     return False
                 if product_capacity and quantity + location_qty > product_capacity.quantity:
                     return False
-            positive_quant = self.quant_ids.filtered(lambda q: float_compare(q.quantity, 0, precision_rounding=q.product_id.uom_id.rounding) > 0)
+            positive_quant = self.quant_ids.filtered(lambda q: q.product_id.uom_id.compare(q.quantity, 0) > 0)
             # check if only allow new product when empty
             if self.storage_category_id.allow_new_product == "empty" and positive_quant:
                 return False

--- a/addons/stock/models/stock_package_level.py
+++ b/addons/stock/models/stock_package_level.py
@@ -64,7 +64,7 @@ class StockPackage_Level(models.Model):
                                 qty = min(to_dispatch, ml.move_id.product_qty) if len(corresponding_mls) > 1 else to_dispatch
                                 to_dispatch = to_dispatch - qty
                                 ml_update_dict[ml] += qty
-                                if float_is_zero(to_dispatch, precision_rounding=ml.product_id.uom_id.rounding):
+                                if ml.product_id.uom_id.is_zero(to_dispatch):
                                     break
                         else:
                             corresponding_move = package_level.move_ids.filtered(lambda m: m.product_id == quant.product_id)[:1]

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -242,7 +242,7 @@ class StockRule(models.Model):
     def _push_prepare_move_copy_values(self, move_to_copy, new_date):
         company_id = self.company_id.id
         copied_quantity = move_to_copy.quantity
-        if float_compare(move_to_copy.product_uom_qty, 0, precision_rounding=move_to_copy.product_uom.rounding) < 0:
+        if move_to_copy.product_uom.compare(move_to_copy.product_uom_qty, 0) < 0:
             copied_quantity = move_to_copy.product_uom_qty
         if not company_id:
             company_id = self.sudo().warehouse_id and self.sudo().warehouse_id.company_id.id or self.sudo().picking_type_id.warehouse_id.company_id.id
@@ -280,7 +280,7 @@ class StockRule(models.Model):
                 raise ProcurementException([(procurement, msg)])
 
         # Prepare the move values, adapt the `procure_method` if needed.
-        procurements = sorted(procurements, key=lambda proc: float_compare(proc[0].product_qty, 0.0, precision_rounding=proc[0].product_uom.rounding) > 0)
+        procurements = sorted(procurements, key=lambda proc: proc[0].product_uom.compare(proc[0].product_qty, 0.0) > 0)
         for procurement, rule in procurements:
             procure_method = rule.procure_method
             if rule.procure_method == 'mts_else_mto':
@@ -341,7 +341,7 @@ class StockRule(models.Model):
                 move_dest.partner_id = self.location_src_id.warehouse_id.partner_id or self.company_id.partner_id
 
         # If the quantity is negative the move should be considered as a refund
-        if float_compare(product_qty, 0.0, precision_rounding=product_uom.rounding) < 0:
+        if product_uom.compare(product_qty, 0.0) < 0:
             values['to_refund'] = True
 
         move_values = {

--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -208,8 +208,7 @@ class StockScrap(models.Model):
 
     def action_validate(self):
         self.ensure_one()
-        if float_is_zero(self.scrap_qty,
-                         precision_rounding=self.product_uom_id.rounding):
+        if self.product_uom_id.is_zero(self.scrap_qty):
             raise UserError(_('You can only enter positive quantities.'))
         if self.check_available_qty():
             return self.do_scrap()

--- a/addons/stock/report/report_stock_reception.py
+++ b/addons/stock/report/report_stock_reception.py
@@ -111,7 +111,7 @@ class ReportStockReport_Reception(models.AbstractModel):
                 quantity = 0
                 for move_in_qty, move_in in product_to_qty_to_assign[out.product_id]:
                     moves_in_ids.append(move_in.id)
-                    if float_compare(quantity + move_in_qty, qty_to_reserve, precision_rounding=product_uom.rounding) <= 0:
+                    if product_uom.compare(quantity + move_in_qty, qty_to_reserve) <= 0:
                         qty_to_add = move_in_qty
                         move_in_qty = 0
                     else:
@@ -122,16 +122,15 @@ class ReportStockReport_Reception(models.AbstractModel):
                         product_to_qty_to_assign[out.product_id][0] = (move_in_qty, move_in)
                     else:
                         product_to_qty_to_assign[out.product_id] = product_to_qty_to_assign[out.product_id][1:]
-                    if float_compare(qty_to_reserve, quantity, precision_rounding=product_uom.rounding) == 0:
+                    if product_uom.compare(qty_to_reserve, quantity) == 0:
                         break
 
-                if not float_is_zero(quantity, precision_rounding=product_uom.rounding):
+                if not product_uom.is_zero(quantity):
                     sources_to_lines[source].append(self._prepare_report_line(quantity, product_id, out, source[0], move_ins=self.env['stock.move'].browse(moves_in_ids)))
 
                 # draft qtys can be shown but not assigned
                 qty_expected = product_to_qty_draft.get(product_id, 0)
-                if float_compare(qty_to_reserve, quantity, precision_rounding=product_uom.rounding) > 0 and\
-                        not float_is_zero(qty_expected, precision_rounding=product_uom.rounding):
+                if product_uom.compare(qty_to_reserve, quantity) > 0 and not product_uom.is_zero(qty_expected):
                     to_expect = min(qty_expected, qty_to_reserve - quantity)
                     sources_to_lines[source].append(self._prepare_report_line(to_expect, product_id, out, source[0], is_qty_assignable=False))
                     product_to_qty_draft[product_id] -= to_expect
@@ -143,7 +142,7 @@ class ReportStockReport_Reception(models.AbstractModel):
             out_moves = moves_in.move_dest_ids
 
             for out_move in out_moves:
-                if float_is_zero(total_assigned, precision_rounding=out_move.product_id.uom_id.rounding):
+                if out_move.product_id.uom_id.is_zero(total_assigned):
                     # it is possible there are different in moves linked to the same out moves due to batch
                     # => we guess as to which outs correspond to this report...
                     continue
@@ -222,7 +221,7 @@ class ReportStockReport_Reception(models.AbstractModel):
         out_to_new_out = OrderedDict()
         new_move_vals = []
         for out, qty_to_link in zip(outs, qtys):
-            if float_compare(out.product_qty, qty_to_link, precision_rounding=out.product_id.uom_id.rounding) == 1:
+            if out.product_id.uom_id.compare(out.product_qty, qty_to_link) == 1:
                 new_move = out._split(out.product_qty - qty_to_link)
                 if new_move:
                     new_move[0]['reservation_date'] = out.reservation_date
@@ -255,13 +254,13 @@ class ReportStockReport_Reception(models.AbstractModel):
                             new_move_line.quantity -= out.product_id.uom_id._compute_quantity(move_line_id.quantity_product_uom, out.product_uom, rounding_method='HALF-UP')
                         move_line_id.move_id = out
                         assigned_amount += move_line_id.quantity_product_uom
-                        if float_compare(assigned_amount, qty_to_link, precision_rounding=out.product_id.uom_id.rounding) == 0:
+                        if out.product_id.uom_id.compare(assigned_amount, qty_to_link) == 0:
                             break
 
             for in_move in reversed(potential_ins):
                 move_quantity = in_move.product_qty or in_move.product_uom._compute_quantity(in_move.quantity, in_move.product_id.uom_id, rounding_method='HALF-UP')
                 quantity_remaining = move_quantity - sum(in_move.move_dest_ids.mapped('product_qty'))
-                if in_move.product_id != out.product_id or float_compare(0, quantity_remaining, precision_rounding=in_move.product_id.uom_id.rounding) >= 0:
+                if in_move.product_id != out.product_id or in_move.product_id.uom_id.compare(0, quantity_remaining) >= 0:
                     # in move is already completely linked (e.g. during another assign click) => don't count it again
                     potential_ins = potential_ins[1:]
                     continue
@@ -272,7 +271,7 @@ class ReportStockReport_Reception(models.AbstractModel):
                 out.procure_method = 'make_to_order'
                 quantity_remaining -= linked_qty
                 qty_to_link -= linked_qty
-                if float_is_zero(qty_to_link, precision_rounding=out.product_id.uom_id.rounding):
+                if out.product_id.uom_id.is_zero(qty_to_link):
                     break  # we have satistfied the qty_to_link
 
         (outs | new_outs)._recompute_state()
@@ -297,7 +296,7 @@ class ReportStockReport_Reception(models.AbstractModel):
             in_move.move_dest_ids -= out
             self._action_unassign(in_move, out)
             amount_unassigned += min(qty, move_quantity)
-            if float_compare(qty, amount_unassigned, precision_rounding=out.product_id.uom_id.rounding) <= 0:
+            if out.product_id.uom_id.compare(qty, amount_unassigned) <= 0:
                 break
         if out.move_orig_ids and out.state != 'done':
             # annoying use cases where we need to split the out move:

--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -147,7 +147,7 @@ class StockForecasted_Product_Product(models.AbstractModel):
             },
             'replenishment_filled': replenishment_filled,
             'is_late': is_late,
-            'quantity': float_round(quantity, precision_rounding=product.uom_id.rounding),
+            'quantity': product.uom_id.round(quantity),
             'move_out': move_out,
             'move_in': move_in,
             'reservation': self._get_reservation_data(reserved_move) if reserved_move else False,
@@ -209,7 +209,7 @@ class StockForecasted_Product_Product(models.AbstractModel):
                 if move.location_id.id in wh_stock_sub_location_ids:
                     currents[out.product_id.id, wh_stock_location.id] -= reserved
                 currents[(out.product_id.id, move.location_id.id)] -= reserved
-                if float_compare(reserved_out, out.product_qty, precision_rounding=move.product_id.uom_id.rounding) >= 0:
+                if move.product_id.uom_id.compare(reserved_out, out.product_qty) >= 0:
                     break
 
             return {
@@ -230,7 +230,7 @@ class StockForecasted_Product_Product(models.AbstractModel):
                 demand = max(move.product_qty - reserved, 0)
                 # to make sure we don't demand more than the out (useful when same pick/pack goes to multiple out)
                 demand = min(demand, demand_out)
-                if float_is_zero(demand, precision_rounding=move.product_id.uom_id.rounding):
+                if move.product_id.uom_id.is_zero(demand):
                     continue
                 # check available qty for move if chained, move available is what was move by orig moves
                 if move.move_orig_ids:

--- a/addons/stock/wizard/product_label_layout.py
+++ b/addons/stock/wizard/product_label_layout.py
@@ -48,11 +48,11 @@ class ProductLabelLayout(models.TransientModel):
 
         quantities = defaultdict(int)
         uom_unit = self.env.ref('uom.product_uom_unit', raise_if_not_found=False)
-        if self.move_quantity == 'move' and self.move_ids and all(float_is_zero(ml.quantity, precision_rounding=ml.product_uom_id.rounding) for ml in self.move_ids.move_line_ids):
+        if self.move_quantity == 'move' and self.move_ids and all(ml.product_uom_id.is_zero(ml.quantity) for ml in self.move_ids.move_line_ids):
             for move in self.move_ids:
-                use_reserved = float_compare(move.quantity, 0, precision_rounding=move.product_uom.rounding) > 0
+                use_reserved = move.product_uom.compare(move.quantity, 0) > 0
                 useable_qty = move.quantity if use_reserved else move.product_uom_qty
-                if not float_is_zero(useable_qty, precision_rounding=move.product_uom.rounding):
+                if not move.product_uom.is_zero(useable_qty):
                     quantities[move.product_id.id] += useable_qty
             data['quantity_by_product'] = {p: int(q) for p, q in quantities.items()}
         elif self.move_quantity == 'move' and self.move_ids.move_line_ids:

--- a/addons/stock/wizard/stock_backorder_confirmation.py
+++ b/addons/stock/wizard/stock_backorder_confirmation.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
-from odoo.tools.float_utils import float_compare
 
 
 class StockBackorderConfirmationLine(models.TransientModel):
@@ -42,9 +41,7 @@ class StockBackorderConfirmation(models.TransientModel):
             moves_to_log = {}
             for move in pick_id.move_ids:
                 picked_qty = move._get_picked_quantity()
-                if float_compare(move.product_uom_qty,
-                                 picked_qty,
-                                 precision_rounding=move.product_uom.rounding) > 0:
+                if move.product_uom.compare(move.product_uom_qty, picked_qty) > 0:
                     moves_to_log[move] = (picked_qty, move.product_uom_qty)
             if moves_to_log:
                 pick_id._log_less_quantities_than_expected(moves_to_log)

--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -2,7 +2,6 @@
 
 from odoo import _, api, Command, fields, models
 from odoo.exceptions import UserError
-from odoo.tools.float_utils import float_round, float_is_zero
 
 
 class StockReturnPickingLine(models.TransientModel):
@@ -42,7 +41,7 @@ class StockReturnPickingLine(models.TransientModel):
 
     def _process_line(self, new_picking):
         self.ensure_one()
-        if not float_is_zero(self.quantity, precision_rounding=self.uom_id.rounding):
+        if not self.uom_id.is_zero(self.quantity):
             vals = self._prepare_move_default_values(new_picking)
 
             if self.move_id:
@@ -215,7 +214,7 @@ class StockReturnPicking(models.TransientModel):
                 if not move.origin_returned_move_id or move.origin_returned_move_id != stock_move:
                     continue
                 quantity -= move.quantity
-            quantity = float_round(quantity, precision_rounding=stock_move.product_id.uom_id.rounding)
+            quantity = stock_move.product_id.uom_id.round(quantity)
             return_move.quantity = quantity
         return self.action_create_returns()
 

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -57,7 +57,7 @@ class StockReplenishmentInfo(models.TransientModel):
                 'product_max_qty': self.env['ir.qweb.field.float'].value_to_html(orderpoint.product_max_qty, {'decimal_precision': 'Product Unit'}),
                 'product_uom_name': orderpoint.product_uom_name,
                 'virtual': orderpoint.trigger == 'manual' and orderpoint.create_uid.id == SUPERUSER_ID,
-                'visibility_days': orderpoint.visibility_days if float_compare(orderpoint.qty_forecast, orderpoint.product_min_qty, precision_rounding=orderpoint.product_uom.rounding) < 0 else 0,
+                'visibility_days': orderpoint.visibility_days if orderpoint.product_uom.compare(orderpoint.qty_forecast, orderpoint.product_min_qty) < 0 else 0,
                 'visibility_days_date': format_date(self.env, replenishment_report.orderpoint_id.lead_days_date + relativedelta(days=orderpoint.visibility_days))
             })
 

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -278,7 +278,7 @@ class AccountMoveLine(models.Model):
         return self.product_id.is_storable and self.product_id.valuation == 'real_time'
 
     def _get_gross_unit_price(self):
-        if float_is_zero(self.quantity, precision_rounding=self.product_uom_id.rounding):
+        if self.product_uom_id.is_zero(self.quantity):
             return self.price_unit
 
         price_unit = self.price_unit * (1 - self.discount / 100) if self.discount else\

--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -79,7 +79,7 @@ class StockMoveLine(models.Model):
             return
         product_uom = self.product_id.uom_id
         added_uom_qty = self.product_uom_id._compute_quantity(added_qty, product_uom, rounding_method='HALF-UP')
-        if float_is_zero(added_uom_qty, precision_rounding=product_uom.rounding):
+        if product_uom.is_zero(added_uom_qty):
             return
         self._create_correction_svl(self.move_id, added_uom_qty)
 

--- a/addons/stock_account/models/stock_quant.py
+++ b/addons/stock_account/models/stock_quant.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.tools.float_utils import float_is_zero
 from odoo.tools.misc import groupby
 
 
@@ -55,7 +54,7 @@ class StockQuant(models.Model):
             if not quant.location_id or not quant.product_id or\
                     not quant.location_id._should_be_valued() or\
                     quant._should_exclude_for_valuation() or\
-                    float_is_zero(quant.quantity, precision_rounding=quant.product_id.uom_id.rounding):
+                    quant.product_id.uom_id.is_zero(quant.quantity):
                 continue
             if quant.product_id.lot_valuated:
                 quantity = quant.lot_id.with_company(quant.company_id).quantity_svl
@@ -63,7 +62,7 @@ class StockQuant(models.Model):
             else:
                 quantity = quant.product_id.with_company(quant.company_id).quantity_svl
                 value_svl = quant.product_id.with_company(quant.company_id).value_svl
-            if float_is_zero(quantity, precision_rounding=quant.product_id.uom_id.rounding):
+            if quant.product_id.uom_id.is_zero(quantity):
                 continue
             quant.value = quant.quantity * value_svl / quantity
 

--- a/addons/stock_account/report/stock_forecasted.py
+++ b/addons/stock_account/report/stock_forecasted.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
-from odoo.tools.float_utils import float_is_zero, float_repr
+from odoo.tools.float_utils import float_repr
 
 
 class StockForecasted_Product_Product(models.AbstractModel):
@@ -28,7 +28,7 @@ class StockForecasted_Product_Product(models.AbstractModel):
         currency = svl.currency_id or self.env.company.currency_id
         total_quantity = sum(svl.mapped('quantity'))
         # Because we can have negative quantities, `total_quantity` may be equal to zero even if the warehouse's `quantity` is positive.
-        if svl and not float_is_zero(total_quantity, precision_rounding=svl.product_id.uom_id.rounding):
+        if svl and not svl.product_id.uom_id.is_zero(total_quantity):
             value = sum(svl.mapped('value')) * (sum(quants.mapped('quantity')) / total_quantity)
         else:
             value = 0

--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -186,11 +186,11 @@ class StockLandedCost(models.Model):
             # batch standard price computation avoid recompute quantity_svl at each iteration
             products = self.env['product.product'].browse(p.id for p in cost_to_add_byproduct.keys()).with_company(cost.company_id)
             for product in products:  # iterate on recordset to prefetch efficiently quantity_svl
-                if not float_is_zero(product.quantity_svl, precision_rounding=product.uom_id.rounding):
+                if not product.uom_id.is_zero(product.quantity_svl):
                     product.sudo().with_context(disable_auto_svl=True).standard_price += cost_to_add_byproduct[product] / product.quantity_svl
                 if product.lot_valuated:
                     for lot, value in cost_to_add_bylot[product].items():
-                        if float_is_zero(lot.quantity_svl, precision_rounding=product.uom_id.rounding):
+                        if product.uom_id.is_zero(lot.quantity_svl):
                             continue
                         lot.sudo().with_context(disable_auto_svl=True).standard_price += value / lot.quantity_svl
 

--- a/addons/stock_picking_batch/models/stock_move_line.py
+++ b/addons/stock_picking_batch/models/stock_move_line.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 
 from odoo import _, Command, fields, models
 from odoo.osv import expression
-from odoo.tools.float_utils import float_is_zero
 from odoo.tools.misc import OrderedSet
 
 
@@ -61,7 +60,7 @@ class StockMoveLine(models.Model):
             if lines == picking.move_line_ids and lines.move_id == picking.move_ids:
                 add_all_moves = True
                 for move, qty in qty_by_move.items():
-                    if float_is_zero(qty, precision_rounding=move.product_uom.rounding):
+                    if move.product_uom.is_zero(qty):
                         add_all_moves = False
                         break
                 if add_all_moves:
@@ -97,7 +96,7 @@ class StockMoveLine(models.Model):
     def _is_auto_waveable(self):
         self.ensure_one()
         if not self.picking_id \
-           or (self.picking_id.state != 'assigned' or float_is_zero(self.quantity, precision_rounding=self.product_uom_id.rounding)) and not self.env.context.get('skip_auto_waveable')  \
+           or (self.picking_id.state != 'assigned' or self.product_uom_id.is_zero(self.quantity)) and not self.env.context.get('skip_auto_waveable')  \
            or self.batch_id.is_wave \
            or not self.picking_type_id._is_auto_wave_grouped() \
            or (self.picking_type_id.wave_group_by_category and self.product_id.categ_id not in self.picking_type_id.wave_category_ids):  # noqa: SIM103

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -228,10 +228,10 @@ class StockPickingBatch(models.Model):
 
     def action_done(self):
         def has_no_quantity(picking):
-            return all(not m.picked or float_is_zero(m.quantity, precision_rounding=m.product_uom.rounding) for m in picking.move_ids if m.state not in ('done', 'cancel'))
+            return all(not m.picked or m.product_uom.is_zero(m.quantity) for m in picking.move_ids if m.state not in ('done', 'cancel'))
 
         def is_empty(picking):
-            return all(float_is_zero(m.quantity, precision_rounding=m.product_uom.rounding) for m in picking.move_ids if m.state not in ('done', 'cancel'))
+            return all(m.product_uom.is_zero(m.quantity) for m in picking.move_ids if m.state not in ('done', 'cancel'))
 
         self.ensure_one()
         self._check_company()

--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from __future__ import annotations
@@ -6,11 +5,11 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING, Literal
 
-from odoo import api, fields, tools, models, _
+from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError
 
-
 if TYPE_CHECKING:
+    from odoo.orm.types import Self
     from odoo.tools.float_utils import RoundingMethod
 
 
@@ -98,7 +97,14 @@ class UomUom(models.Model):
         digits = self.env['decimal.precision'].precision_get('Product Unit')
         return tools.float_is_zero(value, precision_digits=digits)
 
-    def _compute_quantity(self, qty, to_unit, round=True, rounding_method='UP', raise_if_failure=True):
+    def _compute_quantity(
+        self,
+        qty: float,
+        to_unit: Self,
+        round: bool = True,
+        rounding_method: RoundingMethod = 'UP',
+        raise_if_failure: bool = True,
+    ) -> float:
         """ Convert the given quantity from the current UoM `self` into a given one
             :param qty: the quantity to convert
             :param to_unit: the destination UomUom record (uom.uom)
@@ -122,7 +128,7 @@ class UomUom(models.Model):
 
         return amount
 
-    def _compute_price(self, price, to_unit):
+    def _compute_price(self, price: float, to_unit: Self) -> float:
         self.ensure_one()
         if not self or not price or not to_unit or self == to_unit:
             return price
@@ -159,7 +165,7 @@ class UomUom(models.Model):
         else:
             return self.browse(set(linked_model_data.mapped('res_id')))
 
-    def _has_common_reference(self, other_uom):
+    def _has_common_reference(self, other_uom: Self) -> bool:
         """ Check if `self` and `other_uom` have a common reference unit """
         self.ensure_one()
         other_uom.ensure_one()


### PR DESCRIPTION
In the same spirit than [ResCurrency's util methods](https://github.com/odoo/odoo/blob/350d11482367e7078c35c9002bf2e127ea3f51ff/odoo/addons/base/models/res_currency.py#L217-L262), this PR introduces float utils directly in the UoM, which leads to easier to read and write code

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
