### PR TITLE
[FIX] web_editor: prohibits words overflowing on table view

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -141,6 +141,7 @@ html, body {
     // use table-bordered...)
     table.table.table-bordered {
         table-layout: fixed;
+        overflow-wrap: break-word;
         td {
             min-width: 20px;
         }


### PR DESCRIPTION
When you add a table via "/table" when you're in editing mode,
and if there's a lot of content, then the content overlaps.
This is noticable in the small devices as well as bigger devices.
We'll stop the overflow by using overflow-wrap: break-word.

Steps To Reproduce on Runbot:
1. Go to editor via website/elearning.
2. Add table via command "/table"
4. Make the table like size 11*2, and keep
typing on a cell, eventually the text will start overflowing.

opw-4317744