### PR TITLE
[FIX] html_editor: fix avatar flicker on collaborative updates

### DIFF
--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
@@ -141,7 +141,9 @@ export class CollaborationSelectionAvatarPlugin extends Plugin {
         }
     }
     refreshSelection() {
-        this.avatarOverlay.replaceChildren();
+        if (!this.selectionInfos.size) {
+            this.avatarOverlay.replaceChildren();
+        }
         this.avatarsCountersOverlay.replaceChildren();
         for (const selection of this.selectionInfos.values()) {
             this.drawPeerAvatar(selection);


### PR DESCRIPTION
### Steps to reproduce:

- Open the same document in two tabs.
- Press Enter multiple times in one tab.
- Observe the avatar flickers on the other tab with each Enter press.

### Description of the issue/feature this PR addresses:

- `refreshSelection` replaced `this.avatarOverlay` children and re-appended the avatar element in `drawPeerAvatar`, causing flicker.

### Desired behavior after PR is merged:

- The avatar no longer flickers when pressing Enter.

task-4367144