### PR TITLE
[IMP] website_sale: add hidden image size option for product grid

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -42,6 +42,12 @@ $input-border-color: $gray-400;
     .o_wsale_context_thumb_2_3 {
         --o-wsale-card-thumb-aspect-ratio: 2/3;
     }
+    #o_wsale_products_grid.o_wsale_context_thumb_hidden {
+        .oe_product_image {
+            display: none;
+        }
+        grid-auto-rows: unset;
+    }
     .o_wsale_context_thumb_cover {
         --o-wsale-card-thumb-fill-mode: cover;
     }
@@ -336,9 +342,11 @@ $input-border-color: $gray-400;
         }
 
         .oe_product:not(.oe_product_size_stretch) {
-            .o_wsale_product_btn {
-                @include o-position-absolute(auto, auto, calc(100% + #{map-get($spacers, 2)}), map-get($spacers, 2));
-                z-index: 2;
+            &:not(#o_wsale_products_grid.o_wsale_context_thumb_hidden .oe_product) {
+                .o_wsale_product_btn {
+                    @include o-position-absolute(auto, auto, calc(100% + #{map-get($spacers, 2)}), map-get($spacers, 2));
+                    z-index: 2;
+                }
             }
 
             &:not(:hover) .o_wsale_product_btn {

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -86,6 +86,12 @@
                            data-customize-website-views="website_sale.products_thumb_2_3">
                            Vertical (2/3)
                 </we-button>
+                <we-button
+                    data-select-class="o_wsale_context_thumb_hidden"
+                    data-customize-website-views="website_sale.products_thumb_hidden"
+                >
+                    Hidden
+                </we-button>
             </we-select>
             <we-button-group string="Fill" class="o_we_sublevel_2" data-variable="thumb_size">
                 <we-button data-select-class=""

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -221,7 +221,6 @@
                 </div>
                 <div class="o_wsale_product_sub d-flex justify-content-between align-items-end gap-2 flex-wrap">
                     <t t-set="template_price_vals" t-value="get_product_prices(product)"/>
-                    <div class="o_wsale_product_btn d-flex gap-2"/>
                     <div class="product_price" itemprop="offers" itemscope="itemscope" itemtype="http://schema.org/Offer">
                         <span class="h6 mb-0"
                               t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale"
@@ -237,6 +236,7 @@
                         <span itemprop="price" style="display:none;" t-esc="template_price_vals['price_reduce']" />
                         <span itemprop="priceCurrency" style="display:none;" t-esc="website.currency_id.name" />
                     </div>
+                    <div class="o_wsale_product_btn d-flex gap-2"/>
                 </div>
             </div>
         </form>
@@ -550,6 +550,11 @@
         <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
             <attribute name="t-attf-class" add="o_wsale_context_thumb_2_3" separator=" "/>
         </xpath>
+    </template>
+    <template id="products_thumb_hidden" name="thumb_hidden" inherit_id="website_sale.products" active="False">
+        <section id="o_wsale_products_grid" position="attributes">
+            <attribute name="t-attf-class" add="o_wsale_context_thumb_hidden" separator=" "/>
+        </section>
     </template>
 
     <!-- (Option) Products: Define products' images filling mode -->


### PR DESCRIPTION
**Prior this commit:**
- The /shop page displayed product images for all grid items by default, with no option to hide them.
- The Images Size selector did not include a 'hidden' option for cases where the user doesn't want to show images

**Post this commit:**
- Added a `Hidden` option in the `Images Size` selector on the /shop page to hide images and only display product details.

**Affected Version-** master
**Task**-4422640