### PR TITLE
[REF] point_of_sale: hook function for account move values

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -791,6 +791,13 @@ class PosSession(models.Model):
             or self.env['account.account']
         )
 
+    def _prepare_account_move_vals(self):
+        return {
+            'journal_id': self.config_id.journal_id.id,
+            'date': fields.Date.context_today(self),
+            'ref': self.name,
+        }
+
     def _create_account_move(self, balancing_account=False, amount_to_balance=0, bank_payment_method_diffs=None):
         """ Create account.move and account.move.line records for this session.
 
@@ -798,11 +805,7 @@ class PosSession(models.Model):
             - setting self.move_id to the created account.move record
             - reconciling cash receivable lines, invoice receivable lines and stock output lines
         """
-        account_move = self.env['account.move'].create({
-            'journal_id': self.config_id.journal_id.id,
-            'date': fields.Date.context_today(self),
-            'ref': self.name,
-        })
+        account_move = self.env['account.move'].create(self._prepare_account_move_vals())
         self.write({'move_id': account_move.id})
 
         data = {'bank_payment_method_diffs': bank_payment_method_diffs or {}}


### PR DESCRIPTION
before this commit, if user need to adjust any value of account move, 
there is no direct hook available

scenario: change the accounting entry date, based on
custom config: session opening date or closing date

after this commit, this hook can be used to pass any new value or to 
modify any existing value passed to the create method

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
