### PR TITLE
[FIX] mail, web: emoji picker layout in quick reaction menu

### DIFF
--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -28,7 +28,7 @@ export class QuickReactionMenu extends Component {
         this.store = useService("mail.store");
         this.picker = useEmojiPicker(
             null,
-            { onSelect: this.toggleReaction.bind(this), class: "overflow-hidden rounded-2" },
+            { onSelect: this.toggleReaction.bind(this), class: "overflow-hidden" },
             {
                 position: "bottom-middle",
                 popoverClass: "o-mail-QuickReactionMenu-pickerPopover",

--- a/addons/mail/static/src/core/common/quick_reaction_menu.scss
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.scss
@@ -128,7 +128,9 @@ $quick-reaction-menu-picker-grow-duration: 0.25s;
 
     & .o-EmojiPicker {
         opacity: 0;
-        border: var(--popover-border-width) solid var(--secondary);
+        box-shadow:
+            0 0 0 var(--popover-border-width) var(--secondary), /* Simulates border */
+            var(--popover-box-shadow); /* Shadow for elevation effect */
         transform: scale(0.8);
         transform-origin: var(--originY);
         animation: qrm-pickerGrowAnimation $quick-reaction-menu-picker-grow-duration cubic-bezier(0.25, 0.8, 0.25, 1) forwards;

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -516,7 +516,7 @@ export function usePicker(PickerComponent, ref, props, options = {}) {
     const popover = usePopover(PickerComponent, {
         ...newOptions,
         animation: false,
-        popoverClass: options.popoverClass ?? "" + " bg-100 border border-secondary",
+        popoverClass: options.popoverClass ?? "" + " bg-100 border border-secondary rounded-3",
     });
     props.storeScroll = {
         scrollValue: 0,


### PR DESCRIPTION
Before this commit, when the emoji picker was used in the message quick reaction menu, a border was applied to the picker. This reduced the available space for emojis, causing the last emoji in each row to shift to the next row, resulting in wasted space.

This commit resolves the issue by replacing the border with a box-shadow, which visually replicates the border without consuming extra space.

![image](https://github.com/user-attachments/assets/ad0e6352-b41c-4a8f-af9c-6a0764a6d844) ![image](https://github.com/user-attachments/assets/f2c0dc85-5d02-41b4-98ed-1f036dd0e644)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
