### PR TITLE
[UPD] point_of_sale: use prepared domain when use search more button …

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_list/product_list.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_list/product_list.js
@@ -169,15 +169,7 @@ export class ProductsWidget extends Component {
                 "product.product",
                 "search",
                 [
-                    [
-                        "&",
-                        ["available_in_pos", "=", true],
-                        "|",
-                        "|",
-                        ["name", "ilike", searchProductWord],
-                        ["default_code", "ilike", searchProductWord],
-                        ["barcode", "ilike", searchProductWord],
-                    ],
+                    domain
                 ],
                 {
                     offset: this.state.currentOffset,


### PR DESCRIPTION
…to use pos_categ_ids in domain if needed

Description of the issue/feature this PR addresses:
in case of using restricted categories in POS invalid products may come up with the user
Current behavior before PR:
in case of using restricted categories in POS and try to search for a product in a category not in POS it comes up with the user
Desired behavior after PR is merged:
the product should not appear



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
