### PR TITLE
[FIX][16.0] mrp_subcontracting_dropshipping: Fix test with freeze_time

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -4,6 +4,7 @@
 from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
 from odoo import Command
 from odoo.tests import tagged, Form
+from freezegun import freeze_time
 
 
 @tagged('post_install', '-at_install')
@@ -207,6 +208,7 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
             ]
         )
 
+    @freeze_time('2024-05-12')
     def test_account_line_entry_kit_bom_dropship(self):
         """ An order delivered via dropship for some kit bom product variant should result in
         accurate journal entries in the expense and stock output accounts if the cost on the


### PR DESCRIPTION
Due to the document name being based on the invoice date, the test fails at the start of a new year.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
