### PR TITLE
[FIX] web_editor: correct triple click when applying font size

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -800,6 +800,7 @@ export class OdooEditor extends EventTarget {
                         handle = null;
                         const fontSize = parseInt(fontSizeInput.value);
                         if (fontSize > 0) {
+                            getDeepRange(this.editable, { correctTripleClick: true, select: true });
                             if (!this.isSelectionInEditable()) {
                                 this.historyResetLatestComputedSelection(true);
                             }


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

Triple-clicking to select text, with a nextSibling set as contenteditable false, would reset the selection to its previous state.

Desired behavior after PR is merged:

Correct the triple click selection when applying font-size.

task-4440354

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
