### PR TITLE
[FIX] point_of_sale: update order properly while ordering

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1460,7 +1460,7 @@ export class PosStore extends WithLazyGetterTrap {
 
         if (order) {
             await this.sendOrderInPreparation(order, cancelled);
-            order.updateLastOrderChange();
+            this.getOrder().updateLastOrderChange();
             this.addPendingOrder([order.id]);
             await this.syncAllOrders();
         }

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
@@ -564,9 +564,11 @@ export class FloorScreen extends Component {
             tablesNumber = this.activeTables.filter(
                 (table) =>
                     parseInt(table.table_number.toString().slice(0, floorPrefixLength)) ===
-                        floorPrefix && table.table_number.toString().length > floorPrefixLength
+                        parseInt(floorPrefix) &&
+                    table.table_number.toString().length > floorPrefixLength
             );
         }
+
         tablesNumber = tablesNumber
             .map((table) => parseInt(table.table_number.toString().slice(floorPrefixLength)))
             .sort(function (a, b) {
@@ -576,8 +578,6 @@ export class FloorScreen extends Component {
         for (let i = 0; i < tablesNumber.length; i++) {
             if (tablesNumber[i] == firstNum) {
                 firstNum += 1;
-            } else {
-                break;
             }
         }
         return parseInt(floorPrefix + firstNum.toString().padStart(2, "0"));


### PR DESCRIPTION
Steps to reproduce:
---------------------------
- Install pos_restaurant.
    1) - Open a table and order something.
    2) - Click on edit plan - Edit prefix of plan and add new tables.

Issue:
--------
- Even after ordering the order button is enabled and shown to be ordered.
- The table number always comes as first table of that prefix.

Cause:
---------
- The order is not referred properly due to which the order isn't updated.
- The condition checking for the new table number was wrong comparing int with string.

Fix:
-----
- Now we are sending the order properly to update.
- The condition is updated correctly.

Task: 4438135
