### PR TITLE
[IMP] hr_contract: fix contract count on stat button

### DIFF
--- a/addons/hr_contract/models/resource.py
+++ b/addons/hr_contract/models/resource.py
@@ -30,7 +30,7 @@ class ResourceCalendar(models.Model):
 
     def _compute_contracts_count(self):
         count_data = self.env['hr.contract']._read_group(
-            [('resource_calendar_id', 'in', self.ids)],
+            [('resource_calendar_id', 'in', self.ids), ('employee_id', '!=', False)],
             ['resource_calendar_id'],
             ['resource_calendar_id'])
         mapped_counts = {cd['resource_calendar_id'][0]: cd['resource_calendar_id_count'] for cd in count_data}
@@ -40,5 +40,5 @@ class ResourceCalendar(models.Model):
     def action_open_contracts(self):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("hr_contract.action_hr_contract")
-        action.update({'domain': [('resource_calendar_id', '=', self.id)]})
+        action.update({'domain': [('resource_calendar_id', '=', self.id), ('employee_id', '!=', False)]})
         return action


### PR DESCRIPTION
- add check on `employee_id` to the contract domain to exclude templates from the contract count on the stat buttons as it gives misleading info about the real contracts count

Task: 4402795

