### PR TITLE
[FIX] l10n_cl: credit note sequence

### DIFF
--- a/addons/l10n_cl/models/l10n_latam_document_type.py
+++ b/addons/l10n_cl/models/l10n_latam_document_type.py
@@ -34,6 +34,9 @@ class L10nLatamDocumentType(models.Model):
 
         return document_number.zfill(6)
 
+    def _is_doc_type_credit_note(self):
+        return self.code == '61'
+
     def _is_doc_type_vendor(self):
         return self.code == '46'
 


### PR DESCRIPTION
After ff3702651a30fd7a6ee3007988df953dda911e41
Customer credit notes share the sequence with supplier credit notes.

Steps to reproduce:

- Open Vendor Bills journal and enable 'Use Documents?'
- Create a Bill with document type '(46) Factura de Compra Electrónica'
- Create the credit note
- In the Wizard: select 'Full Refund', Document Type 61, Confirm
- Document name will be 'N/C 000001'
- Now create an invoice with document type '(33) Factura Electrónica'
- Add a credit note for the invoice

Issue: Credit note name will be 'N/C 000002' but sequences should be unique

opw-4268371

