### PR TITLE
[FIX] sale: skip combo test if menu is not accessible

### DIFF
--- a/addons/sale/tests/test_sale_combo_configurator.py
+++ b/addons/sale/tests/test_sale_combo_configurator.py
@@ -10,6 +10,9 @@ from odoo.addons.sale.tests.common import SaleCommon
 class TestSaleComboConfigurator(HttpCase, SaleCommon):
 
     def test_sale_combo_configurator(self):
+        if self.env['ir.module.module']._get('sale_management').state != 'installed':
+            self.skipTest("Sale App is not installed, Sale menu is not accessible.")
+
         no_variant_attribute = self.env['product.attribute'].create({
             'name': "No variant attribute",
             'create_variant': 'no_variant',

--- a/doc/cla/individual/jhemono.md
+++ b/doc/cla/individual/jhemono.md
@@ -1,0 +1,11 @@
+France, 2025-01-02
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Julien Hémono julien@hemono.fr https://github.com/jhemono


### PR DESCRIPTION
### Description of the issue this PR addresses:

Test TestSaleComboConfigurator.test_sale_combo_configurator (introduced with #186645) depends on the Sale menu being shown, but it isn't if the sale_management module is not installed. This change skips this test in this case.

### Current behavior before PR:

The test fails on odoo.sh with custom modules that only depend on sale and not sale_management.

### Desired behavior after PR is merged:

The test succeeds in the condition mentionned above.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
