### PR TITLE
[FIX] mail: screen share after rejoining

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -868,6 +868,8 @@ export class Rtc extends Record {
         this.state.screenTrack?.stop();
         closeStream(this.state.sourceCameraStream);
         this.state.sourceCameraStream = null;
+        closeStream(this.state.sourceScreenStream);
+        this.state.sourceScreenStream = null;
         if (this.blurManager) {
             this.blurManager.close();
             this.blurManager = undefined;


### PR DESCRIPTION
Current behavior before PR:

If a user shares their screen during a call, leaves, and then rejoins the call, attempting to share their screen again results in a black screen being shared.

Desired behavior after PR is merged:

Screen sharing functions correctly even after rejoining a call.

task-id:[4441751](https://www.odoo.com/odoo/my-tasks/4441751)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
