### PR TITLE
[IMP] hr_recruitment: improve applicant follower list

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -317,6 +317,9 @@ class HrApplicant(models.Model):
         applicants = super().create(vals_list)
         applicants.sudo().interviewer_ids._create_recruitment_interviewers()
 
+        department_manager_partner = applicants.department_id.manager_id._get_related_partners()
+        applicants.message_unsubscribe(partner_ids=department_manager_partner.ids)
+
         if (applicants.interviewer_ids.partner_id - self.env.user.partner_id):
             for applicant in applicants:
                 interviewers_to_notify = applicant.interviewer_ids.partner_id - self.env.user.partner_id

--- a/addons/hr_recruitment/tests/test_recruitment_process.py
+++ b/addons/hr_recruitment/tests/test_recruitment_process.py
@@ -212,3 +212,38 @@ Hello, I want to work for you.
             application_3.candidate_id,
             "Application 1 and 3 should not have the same candidate",
         )
+
+    def test_applicant_unsubscribe_manager_partner(self):
+        """
+        Ensure that a department manager's related partner is unsubscribed
+        from an applicant's messages.
+        """
+        department_manager = self.env['hr.employee'].create({
+            'name': 'Test Manager',
+            'email': 'manager@example.com'
+        })
+
+        test_department = self.env['hr.department'].create({
+            'name': 'Test Department',
+            'manager_id': department_manager.id
+        })
+
+        test_job = self.env['hr.job'].create({
+            'name': 'Experienced Developer',
+            'department_id': test_department.id,
+            'no_of_recruitment': 5,
+        })
+
+        test_applicant = self.env['hr.applicant'].create({
+            'candidate_id': self.env['hr.candidate'].create({'partner_name': 'Test Applicant'}).id,
+            'job_id': test_job.id
+        })
+
+        manager_related_partners = department_manager._get_related_partners()
+        remaining_subscribed_partners = test_applicant.message_partner_ids
+
+        self.assertNotIn(
+            manager_related_partners.id,
+            remaining_subscribed_partners.ids,
+            "Manager's related partner should be unsubscribed from the applicant's messages."
+        )


### PR DESCRIPTION
This PR improves the applicant follower list by excluding the department manager's partner from being automatically added as a follower. Including the department manager as a follower generates excessive email notifications, leading to potential disruptions. To address this, the department manager is now excluded from the applicant's follower list.

task-4433002
