### PR TITLE
[IMP] web: use orm call to update currencies instead of session_info

### DIFF
--- a/addons/pos_self_order/controllers/self_entry.py
+++ b/addons/pos_self_order/controllers/self_entry.py
@@ -14,7 +14,7 @@ class PosSelfKiosk(http.Controller):
                 {
                     'session_info': {
                         **request.env["ir.http"].get_frontend_session_info(),
-                        'currencies': request.env["ir.http"].get_currencies(),
+                        'currencies': request.env["res.currency"].get_all_currencies(),
                         'data': {
                             'config_id': pos_config.id,
                             'access_token': config_access_token,

--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -156,7 +156,7 @@ class ProjectCustomerPortal(CustomerPortal):
                 },
             },
             # FIXME: See if we prefer to give only the currency that the portal user just need to see the correct information in project sharing
-            currencies=request.env['ir.http'].get_currencies(),
+            currencies=request.env['res.currency'].get_all_currencies(),
         )
         session_info['user_context']['allow_milestones'] = project.allow_milestones
         return session_info

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -2,11 +2,12 @@
 
 import hashlib
 import json
+import warnings
 
 import odoo
 from odoo import api, models, fields
 from odoo.http import request, DEFAULT_MAX_CONTENT_LENGTH
-from odoo.tools import ormcache, config
+from odoo.tools import config
 from odoo.tools.misc import str2bool
 
 
@@ -121,7 +122,7 @@ class IrHttp(models.AbstractModel):
                     mods, request.session.context['lang']
                 ) if session_uid else None,
             },
-            "currencies": self.sudo().get_currencies(),
+            "currencies": self.env['res.currency'].get_all_currencies(),
             'bundle_params': {
                 'lang': request.session.context['lang'],
             },
@@ -172,7 +173,7 @@ class IrHttp(models.AbstractModel):
             'profile_collectors': request.session.get('profile_collectors'),
             'profile_params': request.session.get('profile_params'),
             'show_effect': bool(request.env['ir.config_parameter'].sudo().get_param('base_setup.show_effect')),
-            'currencies': self.get_currencies(),
+            'currencies': self.env['res.currency'].get_all_currencies(),
             'bundle_params': {
                 'lang': request.session.context['lang'],
             },
@@ -188,11 +189,6 @@ class IrHttp(models.AbstractModel):
             })
         return session_info
 
-    @ormcache()
     def get_currencies(self):
-        Currency = self.env['res.currency']
-        currencies = Currency.search_fetch([], ['symbol', 'position', 'decimal_places'])
-        return {
-            c.id: {'symbol': c.symbol, 'position': c.position, 'digits': [69, c.decimal_places]}
-            for c in currencies
-        }
+        warnings.warn("Deprecated since 19.0, use get_all_currencies on 'res.currency'", DeprecationWarning)
+        return self.env['res.currency'].get_all_currencies()

--- a/addons/web/static/src/webclient/currency_service.js
+++ b/addons/web/static/src/webclient/currency_service.js
@@ -1,19 +1,20 @@
-import { rpc, rpcBus } from "@web/core/network/rpc";
+import { rpcBus } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { currencies } from "@web/core/currency";
 import { UPDATE_METHODS } from "@web/core/orm_service";
 
 export const currencyService = {
-    start() {
+    dependencies: ["orm"],
+    start(env, { orm }) {
         /**
          * Reload the currencies (initially given in session_info)
          */
         async function reloadCurrencies() {
-            const result = await rpc("/web/session/get_session_info");
+            const result = await orm.call("res.currency", "get_all_currencies");
             for (const k in currencies) {
                 delete currencies[k];
             }
-            Object.assign(currencies, result?.currencies);
+            Object.assign(currencies, result);
         }
         rpcBus.addEventListener("RPC:RESPONSE", (ev) => {
             const { data, error } = ev.detail;

--- a/addons/web/static/tests/webclient/currency_service.test.js
+++ b/addons/web/static/tests/webclient/currency_service.test.js
@@ -12,6 +12,11 @@ import { rpcBus } from "@web/core/network/rpc";
 
 class Currency extends models.Model {
     _name = "res.currency";
+    get_all_currencies() {
+        return {
+            1: { symbol: "$", position: "before", digits: 2 },
+        };
+    }
 }
 class Notcurrency extends models.Model {}
 
@@ -21,15 +26,6 @@ test("reload currencies when updating a res.currency", async () => {
     onRpc(({ route }) => {
         expect.step(route);
     });
-    onRpc("/web/session/get_session_info", ({ url }) => {
-        expect.step(new URL(url).pathname);
-        return {
-            uid: 1,
-            currencies: {
-                7: { symbol: "$", position: "before", digits: 2 },
-            },
-        };
-    });
     await makeMockEnv();
     expect.verifySteps([]);
     await getService("orm").read("res.currency", [32]);
@@ -37,15 +33,15 @@ test("reload currencies when updating a res.currency", async () => {
     await getService("orm").unlink("res.currency", [32]);
     expect.verifySteps([
         "/web/dataset/call_kw/res.currency/unlink",
-        "/web/session/get_session_info",
+        "/web/dataset/call_kw/res.currency/get_all_currencies",
     ]);
     await getService("orm").unlink("notcurrency", [32]);
     expect.verifySteps(["/web/dataset/call_kw/notcurrency/unlink"]);
-    expect(Object.keys(currencies)).toEqual(["7"]);
+    expect(Object.keys(currencies)).toEqual(["1"]);
 });
 
 test("do not reload webclient when updating a res.currency, but there is an error", async () => {
-    onRpc("/web/session/get_session_info", ({ url }) => {
+    onRpc("/web/dataset/call_kw/res.currency/get_all_currencies", ({ url }) => {
         expect.step(new URL(url).pathname);
     });
     await makeMockEnv();
@@ -55,7 +51,7 @@ test("do not reload webclient when updating a res.currency, but there is an erro
         settings: {},
         result: {},
     });
-    expect.verifySteps(["/web/session/get_session_info"]);
+    expect.verifySteps(["/web/dataset/call_kw/res.currency/get_all_currencies"]);
     rpcBus.trigger("RPC:RESPONSE", {
         data: { params: { model: "res.currency", method: "write" } },
         settings: {},


### PR DESCRIPTION
*: base, post_self_order, project

When a change is detected on the res.currency model, the webclient reloads currencies. Before this commit, it was done by reloading the whole session_info, which contains a bunch of other stuff, and thus doesn't really make sense.

This commit instead directly calls the brand new `get_all_currencies` method from the res.currency model. With the introduction of this method, we deprecate the `get_currencies` method from ir.http.py. It makes more sense on the res.currency model than on the ir.http model.

task-4492366


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
