### PR TITLE
[IMP] pos*: identify preset by name and remove default filter orders

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1759,6 +1759,12 @@ export class PosStore extends WithLazyGetterTrap {
             }
 
             order.setPreset(preset);
+            if (preset.identification === "name" && !order.floating_order_name && !order.table_id) {
+                order.floating_order_name = order.getPartner().name;
+                if (!order.floating_order_name) {
+                    this.editFloatingOrderName(order);
+                }
+            }
 
             if (preset.use_timing && !order.preset_time) {
                 await this.syncPresetSlotAvaibility(preset);

--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -54,12 +54,12 @@ class RestaurantFloor(models.Model):
                         )
                     )
             for table in floor.table_ids:
-                # Verify if table number begin by old prefix
-                if table.table_number and str(table.table_number).startswith(str(self.floor_prefix)) and vals.get('floor_prefix'):
-                    table_number_wo_prefix = str(table.table_number)[len(str(self.floor_prefix)):]
+                # Verify if table number begin by old prefix if it is not 0
+                if (self.floor_prefix == 0 or (table.table_number and str(table.table_number).startswith(str(self.floor_prefix)))) and vals.get('floor_prefix') is not None:
+                    table_number_wo_prefix = str(table.table_number)[len(str(self.floor_prefix)):] if self.floor_prefix != 0 else str(table.table_number).zfill(2)
                     table.table_number = str(vals.get('floor_prefix')) + table_number_wo_prefix
 
-        return super(RestaurantFloor, self).write(vals)
+        return super().write(vals)
 
     def rename_floor(self, new_name):
         for floor in self:

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
@@ -554,13 +554,20 @@ export class FloorScreen extends Component {
     _getNewTableNumber() {
         let firstNum = 1;
         const floorPrefix = this.activeFloor.floor_prefix;
-        const floorPrefixLength = floorPrefix.toString().length;
-        const tablesNumber = this.activeTables
-            .filter(
+        let floorPrefixLength = floorPrefix.toString().length;
+        let tablesNumber = [];
+        // Handle special case of prefix being 0
+        if (parseFloat(floorPrefix) === 0) {
+            floorPrefixLength = 0;
+            tablesNumber = this.activeTables;
+        } else {
+            tablesNumber = this.activeTables.filter(
                 (table) =>
                     parseInt(table.table_number.toString().slice(0, floorPrefixLength)) ===
                         floorPrefix && table.table_number.toString().length > floorPrefixLength
-            )
+            );
+        }
+        tablesNumber = tablesNumber
             .map((table) => parseInt(table.table_number.toString().slice(floorPrefixLength)))
             .sort(function (a, b) {
                 return a - b;
@@ -723,10 +730,10 @@ export class FloorScreen extends Component {
                 if (data.floor_prefix && data.name) {
                     await this.pos.data.ormWrite("restaurant.floor", [this.activeFloor.id], {
                         name: data.name,
-                        floor_prefix: data.floor_prefix,
+                        floor_prefix: parseInt(data.floor_prefix),
                     });
                     this.activeFloor.name = data.name;
-                    this.activeFloor.floor_prefix = data.floor_prefix;
+                    this.activeFloor.floor_prefix = parseInt(data.floor_prefix);
                     await this.pos.data.read(
                         "restaurant.table",
                         this.activeFloor.table_ids.map((t) => t.id)

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -364,10 +364,10 @@ patch(PosStore.prototype, {
         return await super.getServerOrders();
     },
     getDefaultSearchDetails() {
-        if (this.selectedTable && this.selectedTable.id) {
+        if (this.config.module_pos_restaurant) {
             return {
                 fieldName: "REFERENCE",
-                searchTerm: this.selectedTable.getName(),
+                searchTerm: "",
             };
         }
         return super.getDefaultSearchDetails();


### PR DESCRIPTION
Preset identified by name now opens a edit floating order name popup if there is no name already set. Also this commit removes the default table search on ticket screen.
task-id: 4432945

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
