### PR TITLE
[FIX] pos_loyalty: remove the +1 -1 order lines in promo products

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -731,7 +731,7 @@ export class PosOrderline extends Base {
     }
     get orderDisplayProductName() {
         return {
-            name: this.product_id?.name,
+            name: this.getFullProductName(),
             attributeString: constructAttributeString(this),
         };
     }

--- a/addons/pos_loyalty/static/src/app/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order_line.js
@@ -87,4 +87,12 @@ patch(PosOrderline.prototype, {
             "fst-italic": this.is_reward_line,
         };
     },
+    getFullProductName() {
+        if (this.is_reward_line && this.reward_id) {
+            return (
+                this.reward_id.discount_line_product_id?.display_name || this.reward_id.description
+            );
+        }
+        return super.getFullProductName();
+    },
 });

--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -410,9 +410,10 @@ patch(PosStore.prototype, {
             vals.price_unit = opt.price_unit;
             delete opt.price_unit;
         }
-
-        const result = await super.addLineToCurrentOrder(vals, opt, configure);
-
+        var line;
+        if (rewardsToApply.length != 1) {
+            line = await super.addLineToCurrentOrder(vals, opt, configure);
+        }
         await this.updatePrograms();
         if (rewardsToApply.length == 1) {
             const reward = rewardsToApply[0];
@@ -423,7 +424,7 @@ patch(PosStore.prototype, {
         }
         this.updateRewards();
 
-        return result;
+        return line || true;
     },
     /**
      * Sets up the options for the gift card product.

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -28,8 +28,8 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
             ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "2"),
             // At this point, AAA Test Partner has 4 points.
             PosLoyalty.isRewardButtonHighlighted(true),
-            ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "3"),
-            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1"),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "0", "1"),
             PosLoyalty.isRewardButtonHighlighted(false),
             PosLoyalty.orderTotalIs("6.40"),
             PosLoyalty.finalizeOrder("Cash", "10"),
@@ -45,7 +45,7 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
             ProductScreen.clickCustomer("AAA Test Partner"),
             PosLoyalty.isRewardButtonHighlighted(true),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
-            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "0", "1"),
             PosLoyalty.isRewardButtonHighlighted(false),
             ProductScreen.clickNumpad("⌫"),
             // At this point, the reward line should have been automatically removed
@@ -56,11 +56,8 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
             ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "2"),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "3"),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
-            PosLoyalty.isRewardButtonHighlighted(false),
-            ProductScreen.selectedOrderlineHas("Whiteboard Pen", "4"),
             PosLoyalty.isRewardButtonHighlighted(true),
-
-            PosLoyalty.orderTotalIs("12.80"),
+            PosLoyalty.orderTotalIs("12.8"),
             PosLoyalty.finalizeOrder("Cash", "20"),
         ].flat(),
 });
@@ -80,7 +77,7 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram2", {
             ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
             PosLoyalty.isRewardButtonHighlighted(true),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
-            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "0", "1"),
             PosLoyalty.isRewardButtonHighlighted(false),
             PosLoyalty.orderTotalIs("3.20"),
             PosLoyalty.finalizeOrder("Cash", "10"),
@@ -124,12 +121,12 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram2", {
             ProductScreen.clickCustomer("CCC Test Partner"),
             PosLoyalty.isRewardButtonHighlighted(true),
             PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
-            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "0", "1"),
             ProductScreen.clickPartnerButton(),
             // This deselects the customer.
             PosLoyalty.unselectPartner(),
             PosLoyalty.customerIs("Customer"),
-            PosLoyalty.orderTotalIs("6.40"),
+            PosLoyalty.orderTotalIs("3.20"),
             PosLoyalty.finalizeOrder("Cash", "10"),
         ].flat(),
 });
@@ -144,10 +141,11 @@ registry.category("web_tour.tours").add("PosLoyaltyChangeRewardQty", {
             ProductScreen.addOrderline("Desk Organizer", "1"),
             PosLoyalty.isRewardButtonHighlighted(true),
             PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
-            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "0", "25"),
+            ProductScreen.clickLine("Free Product", 25),
             ProductScreen.clickNumpad("Qty"),
             ProductScreen.clickNumpad("1"),
-            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "0", "1"),
         ].flat(),
 });
 
@@ -166,7 +164,7 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram3", {
             // The reward button should be highlighted.
             PosLoyalty.isRewardButtonHighlighted(true, true),
             PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
-            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-1.00", "1"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "0", "2"),
 
             PosLoyalty.orderTotalIs("10.2"),
             PosLoyalty.finalizeOrder("Cash", "10.2"),

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
@@ -15,18 +15,12 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
             ProductScreen.addOrderline("Desk Organizer", "2"),
 
             // At this point, the free_product program is triggered.
-            // The reward button should be highlighted.
-            PosLoyalty.isRewardButtonHighlighted(true),
+            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "0", "1"),
             // Since the reward button is highlighted, clicking the reward product should be added as reward.
-            ProductScreen.clickDisplayedProduct("Desk Organizer", "3"),
-            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-5.10", "1"),
             // In the succeeding 2 clicks on the product, it is considered as a regular product.
-            // In the third click, the product will be added as reward.
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
-            PosLoyalty.isRewardButtonHighlighted(true),
-            ProductScreen.clickDisplayedProduct("Desk Organizer", true, "6"),
-            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-10.20", "2"),
+            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "0", "2"),
 
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             PosLoyalty.isRewardButtonHighlighted(false),
@@ -35,44 +29,38 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
             PosLoyalty.finalizeOrder("Cash", "30"),
 
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1"),
-            ProductScreen.clickDisplayedProduct("Desk Organizer", true, "2"),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
-            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-5.10", "1"),
+            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "0", "1"),
             ProductScreen.clickNumpad("⌫"),
             ProductScreen.selectedOrderlineHas("Desk Organizer", "0"),
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1"),
-            ProductScreen.clickDisplayedProduct("Desk Organizer", true, "2"),
-            PosLoyalty.isRewardButtonHighlighted(true),
+            ProductScreen.clickDisplayedProduct("Desk Organizer"),
+            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "0", "1"),
             // Finalize order but without the reward.
             // This step is important. When syncing the order, no reward should be synced.
+            PosLoyalty.removeRewardLine("Free Product - Desk Organizer", true),
             PosLoyalty.orderTotalIs("10.20"),
             PosLoyalty.finalizeOrder("Cash", "20"),
 
             ProductScreen.addOrderline("Magnetic Board", "2"),
             PosLoyalty.isRewardButtonHighlighted(false),
             ProductScreen.clickDisplayedProduct("Magnetic Board"),
-            PosLoyalty.isRewardButtonHighlighted(true),
-            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "0", "1"),
             PosLoyalty.isRewardButtonHighlighted(false),
-            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1"),
-            ProductScreen.clickOrderline("Magnetic Board", "3"),
             ProductScreen.selectedOrderlineHas("Magnetic Board", "3"),
             ProductScreen.clickNumpad("6"),
             ProductScreen.selectedOrderlineHas("Magnetic Board", "6"),
-            PosLoyalty.isRewardButtonHighlighted(true),
-            PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
             PosLoyalty.isRewardButtonHighlighted(false),
-            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-6.40", "2"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "0", "2"),
             // Finalize order that consumed a reward.
             PosLoyalty.orderTotalIs("11.88"),
             PosLoyalty.finalizeOrder("Cash", "20"),
 
             ProductScreen.addOrderline("Magnetic Board", "6"),
-            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
-            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1"),
-            PosLoyalty.isRewardButtonHighlighted(true),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "0", "2"),
+            PosLoyalty.isRewardButtonHighlighted(false),
 
-            ProductScreen.clickOrderline("Magnetic Board", "6"),
+            ProductScreen.selectedOrderlineHas("Magnetic Board", "6"),
             ProductScreen.clickNumpad("⌫"),
             // At this point, the reward should have been removed.
             PosLoyalty.isRewardButtonHighlighted(false),
@@ -83,7 +71,7 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
             ProductScreen.selectedOrderlineHas("Magnetic Board", "2"),
             ProductScreen.clickDisplayedProduct("Magnetic Board"),
             ProductScreen.selectedOrderlineHas("Magnetic Board", "3"),
-            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "0", "1"),
             PosLoyalty.isRewardButtonHighlighted(false),
 
             PosLoyalty.orderTotalIs("5.94"),
@@ -96,32 +84,27 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
             PosLoyalty.isRewardButtonHighlighted(false),
             ProductScreen.clickDisplayedProduct("Small Shelf"),
             ProductScreen.selectedOrderlineHas("Small Shelf", "1"),
-            PosLoyalty.isRewardButtonHighlighted(true),
             // Click reward product. Should be automatically added as reward.
             ProductScreen.clickDisplayedProduct("Desk Pad"),
-            PosLoyalty.isRewardButtonHighlighted(false),
-            PosLoyalty.hasRewardLine("Free Product", "-1.98", "1"),
+            PosLoyalty.hasRewardLine("Free Product", "0", "1"),
             // Remove the reward line. The next steps will check if cashier
             // can select from the different reward products.
-            ProductScreen.clickNumpad("⌫"),
-            ProductScreen.clickNumpad("⌫"),
+            PosLoyalty.removeRewardLine("Free Product", true),
             PosLoyalty.isRewardButtonHighlighted(true),
             PosLoyalty.claimReward("Free Product - [Desk Pad, Monitor Stand]"),
             SelectionPopup.has("Monitor Stand"),
             SelectionPopup.has("Desk Pad"),
             SelectionPopup.has("Desk Pad", { run: "click" }),
             PosLoyalty.isRewardButtonHighlighted(false),
-            PosLoyalty.hasRewardLine("Free Product", "-1.98", "1"),
-            ProductScreen.clickNumpad("⌫"),
-            ProductScreen.clickNumpad("⌫"),
+            PosLoyalty.hasRewardLine("Free Product", "0", "1"),
+            PosLoyalty.removeRewardLine("Free Product", true),
             PosLoyalty.isRewardButtonHighlighted(true),
             PosLoyalty.claimReward("Free Product - [Desk Pad, Monitor Stand]"),
             SelectionPopup.has("Monitor Stand"),
             SelectionPopup.has("Desk Pad"),
             SelectionPopup.has("Monitor Stand", { run: "click" }),
             PosLoyalty.isRewardButtonHighlighted(false),
-            ProductScreen.selectedOrderlineHas("Monitor Stand", "1", "3.19"),
-            PosLoyalty.hasRewardLine("Free Product", "-3.19", "1"),
+            PosLoyalty.hasRewardLine("Free Product", "0", "1"),
             PosLoyalty.orderTotalIs("4.81"),
             PosLoyalty.finalizeOrder("Cash", "10"),
         ].flat(),
@@ -140,7 +123,7 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour2", {
             PosLoyalty.isRewardButtonHighlighted(true, true),
             ProductScreen.clickControlButton("Reward"),
             SelectionPopup.has("Free Product - Test Product A", { run: "click" }),
-            PosLoyalty.hasRewardLine("Free Product - Test Product A", "-11.50", "1"),
+            PosLoyalty.hasRewardLine("Free Product - Test Product A", "0", "1"),
             PosLoyalty.isRewardButtonHighlighted(false),
         ].flat(),
 });
@@ -179,13 +162,7 @@ registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithFreeProdu
             ProductScreen.clickDisplayedProduct("Test Product A"),
             ProductScreen.clickDisplayedProduct("Test Product C"),
             PosLoyalty.orderTotalIs("130.00"),
-            PosLoyalty.isRewardButtonHighlighted(true, false),
-            {
-                content: `click Reward button`,
-                trigger: ProductScreen.controlButtonTrigger("Reward"),
-                run: "click",
-            },
-            Dialog.cancel(),
+            PosLoyalty.hasRewardLine("Free Product - Test Product B", "0", "1"),
             PosLoyalty.orderTotalIs("130.00"),
         ].flat(),
 });
@@ -216,26 +193,26 @@ registry.category("web_tour.tours").add("PosLoyaltyRewardProductTag", {
 
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
-            PosLoyalty.isRewardButtonHighlighted(true, true),
+            PosLoyalty.isRewardButtonHighlighted(false, true),
             PosLoyalty.claimReward("Free Product - [Product A, Product B]"),
             SelectionPopup.has("Product A", { run: "click" }),
-            PosLoyalty.hasRewardLine("Free Product", "-2", "1"),
-            PosLoyalty.isRewardButtonHighlighted(false, true),
+
+            PosLoyalty.hasRewardLine("Free Product", "0", "1"),
 
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
-            PosLoyalty.isRewardButtonHighlighted(true, true),
+            PosLoyalty.isRewardButtonHighlighted(false, true),
             PosLoyalty.claimReward("Free Product - [Product A, Product B]"),
             SelectionPopup.has("Product B", { run: "click" }),
-            PosLoyalty.hasRewardLine("Free Product", "-5", "1"),
-            PosLoyalty.isRewardButtonHighlighted(false, true),
+
+            PosLoyalty.hasRewardLine("Free Product", "0", "2"),
 
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
-            PosLoyalty.isRewardButtonHighlighted(true, true),
-            PosLoyalty.claimReward("Free Product - [Product A, Product B]"),
-            SelectionPopup.has("Product B", { run: "click" }),
-            PosLoyalty.hasRewardLine("Free Product", "-10", "2"),
             PosLoyalty.isRewardButtonHighlighted(false, true),
+            PosLoyalty.claimReward("Free Product - [Product A, Product B]"),
+            SelectionPopup.has("Product A", { run: "click" }),
+
+            PosLoyalty.hasRewardLine("Free Product", "0", "3"),
         ].flat(),
 });

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -46,7 +46,7 @@ registry.category("web_tour.tours").add("PosLoyaltyTour1", {
             PosLoyalty.enterCode("invalid_code"),
             Notification.has("invalid_code"),
             PosLoyalty.enterCode("1234"),
-            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-15.30"),
+            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "0"),
             PosLoyalty.finalizeOrder("Cash", "50"),
 
             // Use coupon but eventually remove the reward
@@ -57,9 +57,9 @@ registry.category("web_tour.tours").add("PosLoyaltyTour1", {
             PosLoyalty.hasRewardLine("90% on the cheapest product", "-4.59"),
             PosLoyalty.orderTotalIs("62.43"),
             PosLoyalty.enterCode("5678"),
-            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-15.30"),
-            PosLoyalty.orderTotalIs("47.13"),
-            PosLoyalty.removeRewardLine("Free Product"),
+            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "0"),
+            PosLoyalty.orderTotalIs("62.43"),
+            PosLoyalty.removeRewardLine("Free Product", true),
             PosLoyalty.orderTotalIs("62.43"),
             PosLoyalty.finalizeOrder("Cash", "90"),
 
@@ -117,17 +117,17 @@ registry.category("web_tour.tours").add("PosLoyaltyTour2", {
             // the discount should change after having free products
             // it should go back to cheapest discount as it is higher
             PosLoyalty.enterCode("5678"),
-            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-20.40"),
+            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "0", "4"),
             PosLoyalty.hasRewardLine("90% on the cheapest product", "-4.59"),
             // set quantity to 18
             // free qty stays the same since the amount of points on the card only allows for 4 free products
             ProductScreen.clickNumpad("⌫", "8"),
-            PosLoyalty.hasRewardLine("10% on your order", "-6.68"),
-            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-20.40"),
+            PosLoyalty.hasRewardLine("10% on your order", "-8.72"),
+            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "0", "4"),
             // scan the code again and check notification
             PosLoyalty.enterCode("5678"),
-            PosLoyalty.orderTotalIs("60.13"),
-            PosLoyalty.finalizeOrder("Cash", "65"),
+            PosLoyalty.orderTotalIs("78.49"),
+            PosLoyalty.finalizeOrder("Cash", "80"),
 
             // Specific products discount (with promocode) and free product (1357)
             // Applied programs:
@@ -139,9 +139,9 @@ registry.category("web_tour.tours").add("PosLoyaltyTour2", {
             PosLoyalty.enterCode("promocode"),
             PosLoyalty.hasRewardLine("50% on specific products", "-15.30"),
             PosLoyalty.enterCode("1357"),
-            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-10.20"),
-            PosLoyalty.hasRewardLine("50% on specific products", "-10.20"),
-            PosLoyalty.orderTotalIs("10.20"),
+            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "0", "2"),
+            PosLoyalty.hasRewardLine("50% on specific products", "-15.30"),
+            PosLoyalty.orderTotalIs("15.30"),
             PosLoyalty.finalizeOrder("Cash", "20"),
 
             // Check reset program
@@ -251,7 +251,6 @@ registry.category("web_tour.tours").add("PosLoyaltyTour8", {
             Dialog.confirm("Open Register"),
 
             ProductScreen.clickDisplayedProduct("Product B"),
-            ProductScreen.clickDisplayedProduct("Product A"),
             ProductScreen.totalAmountIs("50.00"),
         ].flat(),
 });
@@ -296,17 +295,16 @@ registry.category("web_tour.tours").add("PosLoyaltyTour10", {
             ProductScreen.clickCustomer("AAA Partner"),
             PosLoyalty.customerIs("AAA Partner"),
             ProductScreen.clickDisplayedProduct("Product Test"),
-            ProductScreen.totalAmountIs("1.00"),
-            ProductScreen.selectedOrderlineHas("Product Test", "1"),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            ProductScreen.totalAmountIs("2.00"),
+            ProductScreen.selectedOrderlineHas("Product Test", "2"),
             PosLoyalty.isRewardButtonHighlighted(true),
             PosLoyalty.claimReward("Free Product B"),
-            {
-                content: `click on reward item`,
-                trigger: `.selection-item:contains("Free Product B")`,
-                run: "click",
-            },
-            PosLoyalty.hasRewardLine("Free Product B", "-1.00"),
-            ProductScreen.totalAmountIs("1.00"),
+            SelectionPopup.has("Free Product B", { run: "click" }),
+            PosLoyalty.isRewardButtonHighlighted(false),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            PosLoyalty.hasRewardLine("Free Product B", "0"),
+            ProductScreen.totalAmountIs("3.00"),
             PosLoyalty.isRewardButtonHighlighted(false),
         ].flat(),
 });
@@ -337,10 +335,7 @@ registry.category("web_tour.tours").add("PosLoyaltyTour11.2", {
             ProductScreen.totalAmountIs("50.00"),
             PosLoyalty.isRewardButtonHighlighted(false),
             PosLoyalty.enterCode("123456"),
-            PosLoyalty.isRewardButtonHighlighted(true),
-            PosLoyalty.claimReward("Free Product"),
-            PosLoyalty.hasRewardLine("Free Product", "-3.00"),
-            PosLoyalty.isRewardButtonHighlighted(false),
+            PosLoyalty.hasRewardLine("Free Product", "0"),
             ProductScreen.totalAmountIs("50.00"),
             PosLoyalty.finalizeOrder("Cash", "50"),
         ].flat(),
@@ -374,17 +369,17 @@ registry.category("web_tour.tours").add("PosLoyaltyTour12", {
             ProductScreen.addOrderline("Free Product A", "2"),
             ProductScreen.clickDisplayedProduct("Free Product A"),
             ProductScreen.totalAmountIs("2.00"),
-            PosLoyalty.hasRewardLine("Free Product", "-1.00"),
+            PosLoyalty.hasRewardLine("Free Product", "0"),
             ProductScreen.addOrderline("Free Product B", "2"),
             ProductScreen.clickDisplayedProduct("Free Product B"),
             ProductScreen.totalAmountIs("12.00"),
-            PosLoyalty.hasRewardLine("Free Product", "-5.00"),
+            PosLoyalty.hasRewardLine("Free Product", "0"),
             ProductScreen.clickDisplayedProduct("Free Product B"),
             ProductScreen.clickDisplayedProduct("Free Product B"),
             ProductScreen.clickDisplayedProduct("Free Product B"),
-            ProductScreen.selectedOrderlineHas("Free Product B", "6"),
+            ProductScreen.selectedOrderlineHas("Free Product B", "4"),
             ProductScreen.totalAmountIs("22.00"),
-            PosLoyalty.hasRewardLine("Free Product", "-10.00"),
+            PosLoyalty.hasRewardLine("Free Product", "0"),
         ].flat(),
 });
 

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -33,10 +33,6 @@ export function claimReward(rewardName) {
     return [
         ...ProductScreen.clickControlButton("Reward"),
         {
-            // There should be description because a program always has a name.
-            trigger: ".selection-item span:nth-child(2)",
-        },
-        {
             content: "select reward",
             trigger: `.selection-item:contains("${rewardName}")`,
             run: "click",
@@ -128,8 +124,13 @@ export function finalizeOrder(paymentMethod, amount) {
         ...ReceiptScreen.clickNextOrder(),
     ];
 }
-export function removeRewardLine(name) {
-    return [selectRewardLine(name), ProductScreen.clickNumpad("⌫"), Dialog.confirm()].flat();
+export function removeRewardLine(name, double = false) {
+    return [
+        selectRewardLine(name),
+        ProductScreen.clickNumpad("⌫"),
+        ...(double ? [ProductScreen.clickNumpad("⌫")] : []),
+        Dialog.confirm(),
+    ].flat();
 }
 
 export function checkAddedLoyaltyPoints(points) {

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -402,7 +402,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         aaa_loyalty_card = loyalty_program.coupon_ids.filtered(lambda coupon: coupon.partner_id.id == partner_aaa.id)
 
         self.assertEqual(loyalty_program.pos_order_count, 1)
-        self.assertAlmostEqual(aaa_loyalty_card.points, 5.2)
+        self.assertAlmostEqual(aaa_loyalty_card.points, 0.2)
 
     def test_pos_loyalty_tour_max_amount(self):
         """Test the loyalty program with a maximum amount and product with different taxe."""
@@ -2139,8 +2139,8 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.env['loyalty.program'].search([]).write({'active': False})
 
         free_product_tag = self.env['product.tag'].create({'name': 'Free Product Tag'})
-        self.product_a.write({'product_tag_ids': [(4, free_product_tag.id)], 'lst_price': 2, 'taxes_id': None, 'name': 'Product A'})
-        self.product_b.write({'product_tag_ids': [(4, free_product_tag.id)], 'lst_price': 5, 'taxes_id': None, 'name': 'Product B'})
+        self.product_a.write({'available_in_pos': True, 'product_tag_ids': [(4, free_product_tag.id)], 'list_price': 2, 'taxes_id': None, 'name': 'Product A'})
+        self.product_b.write({'available_in_pos': True, 'product_tag_ids': [(4, free_product_tag.id)], 'list_price': 5, 'taxes_id': None, 'name': 'Product B'})
 
         self.env['loyalty.program'].create({
             'name': 'Buy 2 Take 1 Free Product',


### PR DESCRIPTION
This commit addresses the issue where adding a product with a (buy_x_get_y) promotion or purchasing loyalty products with loyalty points results in duplicate order lines in the cart.
One order line has a positive price for the product, while the other has a negative price for the promotion or loyalty product.
This fix removes the order line with the negative price from the cart, ensuring that only the correct order line remains.

Task ID: 3999896



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
