### PR TITLE
[FIX] web: test_visible_menu_ids querycount

### DIFF
--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -61,11 +61,11 @@ class TestPerfSessionInfo(common.HttpCase):
     def test_visible_menu_ids(self):
         self.env.registry.clear_all_caches()
         self.env.invalidate_all()
-        # cold ormcache (only web: 5, all module: 14)
-        with self.assertQueryCount(14):
+        # cold ormcache (only web: 5, all module: 14, has group_account_readonly: 16)
+        with self.assertQueryCount(16):
             self.env['ir.ui.menu']._visible_menu_ids()
 
-        # cold fields cache - warm orm cache (only web: 0, all module: 0)
+        # cold fields cache - warm orm cache (only web: 0, all module: 0, has group_account_readonly: 1)
         self.env.invalidate_all()
-        with self.assertQueryCount(0):
+        with self.assertQueryCount(1):
             self.env['ir.ui.menu']._visible_menu_ids()


### PR DESCRIPTION
When user has 'account.group_account_readonly' group, _visible_menu_ids function calls for _xmlid_to_res_id to find hidden_menu_ids. This increases the querycount of the function. We are updating test_visible_menu_ids in accordance to this change.

[link to broken builds](https://runbot.odoo.com/odoo/runbot.build.error/109492)


Speedscope image when user has 'account.group_account_readonly' group
![withxmlids](https://github.com/user-attachments/assets/e0d94710-a587-4876-90dd-1173acdb1ac5)

Speedscope image when user does not have 'account.group_account_readonly' group

![withoutxml](https://github.com/user-attachments/assets/94ee85a8-4a2b-4375-b984-2b1fee8cb8c3)
