### PR TITLE
[FIX] iot_box_image: odoo directory git permissions

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -120,6 +120,9 @@ adduser --disabled-password --gecos "" --shell /usr/sbin/nologin odoo
 mv /etc/sudoers.d/010_pi-nopasswd /etc/sudoers.d/010_odoo-nopasswd
 sed -i 's/pi/odoo/g' /etc/sudoers.d/010_odoo-nopasswd
 
+# Allow "sudo" git commands even if Odoo directory is owned by odoo user
+git config --global --add safe.directory /home/pi/odoo
+
 # copy the odoo.conf file to the overwrite directory
 mv -v "/home/pi/odoo/addons/iot_box_image/configuration/odoo.conf" "/home/pi/"
 chown odoo:odoo "/home/pi/odoo.conf"


### PR DESCRIPTION
As `/home/pi/odoo` is now owned by `odoo` user, git commands as `pi` were failing, requiring to mark `/home/pi/odoo` as safe in pi's git configuration.
As commands would still fail not using `sudo` even after this fix, the fix is only applied to sudo's git configuration.

Task: 4443342
