### PR TITLE
[IMP] l10n_in_*: enhance API token management based on GSTIN

### DIFF
--- a/addons/l10n_in/i18n/l10n_in.pot
+++ b/addons/l10n_in/i18n/l10n_in.pot
@@ -1123,6 +1123,14 @@ msgid "sgst"
 msgstr ""
 
 #. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/company.py:0
+msgid ""
+"Updating the GSTIN will require re-establishing the connection for the "
+"following APIs: %s"
+msgstr ""
+
+#. module: l10n_in
 #: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_view_partner_form
 #: model_terms:ir.ui.view,arch_db:l10n_in.view_company_form
 msgid "update it"

--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -84,3 +84,16 @@ class ResCompany(models.Model):
     def action_update_state_as_per_gstin(self):
         self.ensure_one()
         self.partner_id.action_update_state_as_per_gstin()
+
+    def _get_l10n_in_api_list(self):
+        return []
+
+    @api.onchange('vat')
+    def _onchange_vat(self):
+        if self.account_fiscal_country_id.code == 'IN' and (api_list := self._get_l10n_in_api_list()):
+            return {
+                'warning': {
+                    'title': _('Warning!'),
+                    'message': _('Updating the GSTIN will require re-establishing the connection for the following APIs: %s', ', '.join(api_list))
+                }
+            }

--- a/addons/l10n_in_edi/i18n/l10n_in_edi.pot
+++ b/addons/l10n_in_edi/i18n/l10n_in_edi.pot
@@ -131,6 +131,12 @@ msgid "Duplicate"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/res_company.py:0
+msgid "e-invoice"
+msgstr ""
+
+#. module: l10n_in_edi
 #: model:ir.model.fields,field_description:l10n_in_edi.field_res_company__l10n_in_edi_production_env
 msgid "E-invoice (IN) Is production OSE environment"
 msgstr ""

--- a/addons/l10n_in_edi/models/res_company.py
+++ b/addons/l10n_in_edi/models/res_company.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import _, api, fields, models
 
 
 class ResCompany(models.Model):
@@ -9,11 +9,34 @@ class ResCompany(models.Model):
 
     l10n_in_edi_username = fields.Char("E-invoice (IN) Username", groups="base.group_system")
     l10n_in_edi_password = fields.Char("E-invoice (IN) Password", groups="base.group_system")
-    l10n_in_edi_token = fields.Char("E-invoice (IN) Token", groups="base.group_system")
-    l10n_in_edi_token_validity = fields.Datetime("E-invoice (IN) Valid Until", groups="base.group_system")
+    l10n_in_edi_token = fields.Char(
+        string="E-invoice (IN) Token",
+        groups="base.group_system",
+        compute="_compute_l10n_in_edi_token_and_edi_token_validity",
+        store=True,
+    )
+    l10n_in_edi_token_validity = fields.Datetime(
+        string="E-invoice (IN) Valid Until",
+        groups="base.group_system",
+        compute="_compute_l10n_in_edi_token_and_edi_token_validity",
+        store=True,
+    )
+
+    @api.depends('vat', 'l10n_in_edi_username')
+    def _compute_l10n_in_edi_token_and_edi_token_validity(self):
+        filtered_set = self.filtered(
+            lambda c: c.account_fiscal_country_id.code == 'IN' and c.l10n_in_edi_token and c.l10n_in_edi_token_validity
+        )
+        filtered_set.sudo().l10n_in_edi_token = False
+        filtered_set.sudo().l10n_in_edi_token_validity = False
 
     def _l10n_in_edi_token_is_valid(self):
         self.ensure_one()
         if self.l10n_in_edi_token and self.l10n_in_edi_token_validity > fields.Datetime.now():
             return True
         return False
+
+    def _get_l10n_in_api_list(self):
+        api_list = super()._get_l10n_in_api_list()
+        api_list.append(_("e-invoice"))
+        return api_list

--- a/addons/l10n_in_edi_ewaybill/i18n/l10n_in_edi_ewaybill.pot
+++ b/addons/l10n_in_edi_ewaybill/i18n/l10n_in_edi_ewaybill.pot
@@ -442,6 +442,12 @@ msgstr ""
 
 #. module: l10n_in_edi_ewaybill
 #. odoo-python
+#: code:addons/l10n_in_edi_ewaybill/models/res_company.py:0
+msgid "e-waybill"
+msgstr ""
+
+#. module: l10n_in_edi_ewaybill
+#. odoo-python
 #: code:addons/l10n_in_edi_ewaybill/models/error_codes.py:0
 msgid ""
 "E Way Bill should be generated as part of IRN generation or with reference "

--- a/addons/l10n_in_edi_ewaybill/models/res_company.py
+++ b/addons/l10n_in_edi_ewaybill/models/res_company.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import _, api, fields, models
 
 
 class ResCompany(models.Model):
@@ -9,10 +9,26 @@ class ResCompany(models.Model):
 
     l10n_in_edi_ewaybill_username = fields.Char("E-Waybill (IN) Username", groups="base.group_system")
     l10n_in_edi_ewaybill_password = fields.Char("E-Waybill (IN) Password", groups="base.group_system")
-    l10n_in_edi_ewaybill_auth_validity = fields.Datetime("E-Waybill (IN) Valid Until", groups="base.group_system")
+    l10n_in_edi_ewaybill_auth_validity = fields.Datetime(
+        string="E-Waybill (IN) Valid Until",
+        groups="base.group_system",
+        compute="_compute_l10n_in_edi_ewaybill_auth_validity",
+        store=True,
+    )
+
+    @api.depends('vat', 'l10n_in_edi_ewaybill_username')
+    def _compute_l10n_in_edi_ewaybill_auth_validity(self):
+        self.filtered(
+            lambda c: c.account_fiscal_country_id.code == 'IN' and c.l10n_in_edi_ewaybill_auth_validity
+        ).sudo().l10n_in_edi_ewaybill_auth_validity = False
 
     def _l10n_in_edi_ewaybill_token_is_valid(self):
         self.ensure_one()
         if self.l10n_in_edi_ewaybill_auth_validity and self.l10n_in_edi_ewaybill_auth_validity > fields.Datetime.now():
             return True
         return False
+
+    def _get_l10n_in_api_list(self):
+        api_list = super()._get_l10n_in_api_list()
+        api_list.append(_("e-waybill"))
+        return api_list


### PR DESCRIPTION
This **PR** refines the API token management system for l10n_in by introducing a dependency on the GSTIN number and on API's credentials. Consequently, whenever the GSTIN number or API's credentials are updated, all associated tokens and
their validity are reset. New tokens must then be generated to ensure continued functionality.

As part of this **PR** following will be affected:
1) edi_token used for E-Invoicing.
2) auth_validity of E-Waybill authentication.

Additionally, a warning is added on GSTIN change, notifying users that re-establishing the connection for the APIs is required after updating the GSTIN.

**task**-4430663
**IAP PR**: https://github.com/odoo/iap-apps/pull/971
**Enterprise PR**: https://github.com/odoo/enterprise/pull/76373