### PR TITLE
[FIX] mail: fix call record button aspect ratio

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -43,7 +43,6 @@
 .o-mail-Composer-actions {
 
     button {
-        aspect-ratio: 1;
         &.o-small {
             margin: map-get($spacers, 1) / 2 !important;
             padding: map-get($spacers, 1) / 2 !important;
@@ -66,6 +65,9 @@
             .o-mail-Composer.o-focused & {
                 opacity: 40%;
             }
+        }
+        &.rounded-circle {
+            aspect-ratio: 1;
         }
         &.o-sendMessageActive {
             background-color: rgba($o-action, .75);


### PR DESCRIPTION
Purpose of this commit:
The call record button, when active, was unintentionally assigned an aspect ratio of 1, causing its height and width to become equal. This commit fixes the issue.

Before/After
![image](https://github.com/user-attachments/assets/06d95954-8229-4bbe-8e35-8856c8c51502) 
![image](https://github.com/user-attachments/assets/ada42816-95be-4c76-a22d-fb60b4d02780)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
