### PR TITLE
[FIX] iot_box_image: zerofree blocked by build cleanup

### DIFF
--- a/addons/iot_box_image/build_image.sh
+++ b/addons/iot_box_image/build_image.sh
@@ -181,19 +181,17 @@ find "${MOUNT_POINT}"/ -type f -name "*.iotpatch"|while read iotpatch; do
     done
 done
 
-# cleanup
-umount -fv "${MOUNT_POINT}"/boot/
-umount -lv "${MOUNT_POINT}"/
-rm -rfv "${MOUNT_POINT}"
-kpartx -dv "${LOOP_IOT_PATH}"  # /dev/loop1
-losetup -d "${LOOP_IOT_PATH}"  # /dev/loop1
-
 echo "Running zerofree..."
 zerofree -v "${LOOP_IOT_ROOT}" || true
 
 sleep 10
 
-kpartx -dv "${LOOP_IOT_PATH}"
+# cleanup
+umount -fv "${MOUNT_POINT}"/boot/
+umount -lv "${MOUNT_POINT}"/
+rm -rfv "${MOUNT_POINT}"
 kpartx -dv "${LOOP_RASPIOS_PATH}"
+kpartx -dv "${LOOP_IOT_PATH}"  # /dev/loop1
+losetup -d "${LOOP_IOT_PATH}"  # /dev/loop1
 
 echo "Image build finished."


### PR DESCRIPTION
We previously improved image build cleanup. As this cleanup was running too soon, the script was trying to perform `zerofree` on a non existing partition, and failing.
