### PR TITLE
[FIX] point_of_sale: product card not updated according to order

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
+++ b/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
@@ -12,7 +12,7 @@ class ListContainerDialog extends Component {
     };
     static template = xml`
         <Dialog title.translate="Choose an order" footer="false">
-            <div class="d-flex p-2 flex-wrap" style="gap: 0.5rem;">
+            <div class="list-container-items d-flex p-2 flex-wrap" style="gap: 0.5rem;">
                 <t t-foreach="props.items" t-as="item" t-key="item_index">
                     <t t-slot="default" item="item" />
                 </t>
@@ -40,7 +40,7 @@ export class ListContainer extends Component {
             <button t-if="this.sizing.isLarger or props.forceSmall" t-on-click="toggle"
                 class="btn btn-secondary mx-1 fa fa-caret-down" />
             <div class="overflow-hidden w-100 position-relative">
-                <div t-ref="container" class="d-flex w-100">
+                <div t-ref="container" class="list-container-items d-flex w-100">
                     <div t-if="!props.forceSmall" t-foreach="props.items" t-as="item" t-key="item_index" t-att-class="{'invisible': shouldBeInvisible(item_index)}">
                         <t t-slot="default" item="item"/>
                     </div>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -96,7 +96,7 @@ export class ProductScreen extends Component {
                     return acc;
                 }, {});
             },
-            () => [this.currentOrder.totalQuantity]
+            () => [this.currentOrder, this.currentOrder.totalQuantity]
         );
     }
     getAncestorsAndCurrent() {

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -153,6 +153,26 @@ registry.category("web_tour.tours").add("ProductScreenTour", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("FloatingOrderTour", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            ProductScreen.orderIsEmpty(),
+            ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1.0", "5.10"),
+            ProductScreen.clickDisplayedProduct("Desk Organizer", true, "2.0", "10.20"),
+            ProductScreen.productCardQtyIs("Desk Organizer", "2.0"),
+            Chrome.createFloatingOrder(),
+            ProductScreen.clickDisplayedProduct("Letter Tray", true, "1.0", "5.28"),
+            ProductScreen.clickDisplayedProduct("Letter Tray", true, "2.0", "10.56"),
+            ProductScreen.selectFloatingOrder(0),
+            ProductScreen.productCardQtyIs("Desk Organizer", "2.0"),
+            ProductScreen.isShown(),
+            ProductScreen.selectFloatingOrder(1),
+            ProductScreen.productCardQtyIs("Letter Tray", "2.0"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("FiscalPositionNoTax", {
     checkDelay: 50,
     steps: () =>

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -25,6 +25,19 @@ export function clickReview() {
         run: "click",
     };
 }
+export function selectFloatingOrder(index) {
+    return [
+        {
+            isActive: ["mobile"],
+            trigger: ".fa-caret-down",
+            run: "click",
+        },
+        {
+            trigger: `.list-container-items .btn:eq(${index})`,
+            run: "click",
+        },
+    ];
+}
 /**
  * Generates a sequence of actions to click on a displayed product, with optional additional
  * checks based on specific needs such as the next quantity and the next price.

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -582,6 +582,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'pos_basic_order_01_multi_payment_and_change', login="pos_user")
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'pos_basic_order_02_decimal_order_quantity', login="pos_user")
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'pos_basic_order_03_tax_position', login="pos_user")
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FloatingOrderTour', login="pos_user")
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ProductScreenTour', login="pos_user")
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenTour', login="pos_user")
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ReceiptScreenTour', login="pos_user")


### PR DESCRIPTION
Steps to reproduce:
1. Create a new free order and add 2 quantities of any product.
2. Create another free order and add 2 quantities of any product different from 1st order.
3. Switch to orders 1 and 2, and you'll see the same product and quantity loading in both orders.

Issue:
- Both free orders show same product card if quantity is same.

Fix:
- UseEffect was set to update on order rather than quantity.

task-4438675
