### PR TITLE
[FIX] hr: added domain to show activity plans by selected company or globally

### DIFF
--- a/addons/hr/views/mail_activity_plan_views.xml
+++ b/addons/hr/views/mail_activity_plan_views.xml
@@ -68,7 +68,7 @@
             <field name="view_mode">tree,kanban,form</field>
             <field name="search_view_id" ref="mail.mail_activity_plan_view_search"/>
             <field name="context">{'default_res_model': 'hr.employee'}</field>
-            <field name="domain">[('res_model', '=', 'hr.employee')]</field>
+            <field name="domain">[('res_model', '=', 'hr.employee'), '|', ('company_id', 'in', allowed_company_ids), ('company_id', '=', False)]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     Create an Activity Plan

--- a/addons/mail/views/mail_activity_plan_views.xml
+++ b/addons/mail/views/mail_activity_plan_views.xml
@@ -61,7 +61,7 @@
                                 <field name="res_model"/>
                             </group>
                             <group name="company_id" groups="base.group_multi_company">
-                                <field name="company_id"/>
+                                <field name="company_id" domain="[('id', '=', allowed_company_ids)]"/>
                             </group>
                         </group>
                         <notebook>


### PR DESCRIPTION

Steps:
- Go to the 'Activity Plans' section.
- Select a company in the company widget.
- Activity plans were not filtered based on the selected company.

Issues:
- Activity plans were not filtered correctly by the selected company, showing plans from unrelated companies.

Fix:
- Added domain to display activity plans assigned to the selected company.
- Added domain to display global activity plans when no company is selected.

Task - 4441838

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:
