### PR TITLE
[IMP] product: strengthen combo constraints

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -473,7 +473,14 @@ class ProductTemplate(models.Model):
     def _onchange_type(self):
         if self.type == 'combo':
             if self.attribute_line_ids:
-                raise UserError(_("Combo products can't have attributes"))
+                raise UserError(_("Combo products can't have attributes."))
+            combo_items = self.env['product.combo.item'].sudo().search([
+                ('product_id', 'in', self.product_variant_ids.ids)
+            ])
+            if combo_items:
+                raise UserError(_(
+                    "This product is part of a combo, so its type can't be changed to \"combo\"."
+                ))
             self.purchase_ok = False
         return {}
 


### PR DESCRIPTION
By design, nested combos aren't supported (i.e. products of type `combo` can't be used as combo items). However, since we used a python constraint to enforce this, it was still possible to change the type of a product to `combo` after using it as a combo item. To prevent this, we changed the python constraint to an SQL constraint.