### PR TITLE
[FIX] point_of_sale: fix shipping date showing datetime

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -176,7 +176,10 @@ export class Base extends WithLazyGetterTrap {
         }
     }
 
-    formatDateOrTime(field) {
+    formatDateOrTime(field, type = "datetime") {
+        if (type == "date") {
+            return this[field].toLocaleString(DateTime.DATE_SHORT);
+        }
         return this[field].toLocaleString(DateTime.DATETIME_SHORT);
     }
 

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -128,7 +128,7 @@
             <t t-if="order.shipping_date">
                 <div class="pos-receipt-order-data">
                     Expected delivery:
-                    <div><t t-esc="order.formatDateOrTime('shipping_date')" /></div>
+                    <div><t t-esc="order.formatDateOrTime('shipping_date', 'date')" /></div>
                 </div>
             </t>
 

--- a/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
@@ -178,11 +178,7 @@ export function shippingDateExists() {
 
 export function shippingDateIsToday() {
     // format the date in US, the language used by the tests
-    const expectedDelivery = new Date().toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-    });
+    const expectedDelivery = new Date().toLocaleString("en-US", luxon.DateTime.DATE_SHORT);
 
     return [
         {


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/189879, the shipping date shown on the receipt was showing a datetime instead of a date. The commit also changed the format of the date shown (remove the 0 padding in front of single digit number). This commit fixes this and the test link to it.

runbot-error-id: 111449

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
