### PR TITLE
[FIX] project: remove project field always invisible in task form view

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -327,7 +327,6 @@
                     <field name="allow_milestones" invisible="1" />
                     <field name="parent_id" invisible="1"/>
                     <field name="company_id" invisible="1"/>
-                    <field name="project_id" invisible="1"/>
                     <field name="is_closed" invisible="1"/>
                     <field name="depend_on_count" invisible="1"/>
                     <field name="closed_depend_on_count" invisible="1"/>


### PR DESCRIPTION
Before this commit, when we do an xpath to place something around the project field in the task form view, the xpath will select the first field found and the project field is actually defined twice in the task form view, once always invisible outside the content of the form view and the other is displayed in the view.

This commit removes the first project field defined in the task form view since it is not really needed to have that field in invisible since the project field is always visible and so always available in the task form view.

task-4420743
