### PR TITLE
[FIX] sale_project: add SaleOrderLine to projectModels

### DIFF
--- a/addons/sale_project/static/tests/project_milestone_form_view.test.js
+++ b/addons/sale_project/static/tests/project_milestone_form_view.test.js
@@ -1,11 +1,10 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { queryFirst } from "@odoo/hoot-dom";
-import { defineModels, mountView } from "@web/../tests/web_test_helpers";
+import { mountView } from "@web/../tests/web_test_helpers";
 import { defineProjectModels } from "@project/../tests/project_models";
-import { ProjectMilestone, SaleOrderLine } from "./project_task_model"
+import { ProjectMilestone } from "./project_task_model"
 
 describe.current.tags("desktop");
-defineModels([SaleOrderLine]);
 defineProjectModels();
 
 beforeEach(() => {

--- a/addons/sale_project/static/tests/project_task_list_sale_line.test.js
+++ b/addons/sale_project/static/tests/project_task_list_sale_line.test.js
@@ -1,13 +1,11 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { check, queryAll, queryOne } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
-import { defineModels, mountView } from "@web/../tests/web_test_helpers";
+import { mountView } from "@web/../tests/web_test_helpers";
 import { mailModels } from "@mail/../tests/mail_test_helpers";
 import { defineProjectModels, projectModels } from "@project/../tests/project_models";
-import { SaleOrderLine } from "./project_task_model";
 
 describe.current.tags("desktop");
-defineModels([SaleOrderLine]);
 defineProjectModels();
 
 test("cannot edit sale_line_id when partners are different", async () => {
@@ -22,7 +20,7 @@ test("cannot edit sale_line_id when partners are different", async () => {
         { id: 2, partner_id: 102, sale_line_id: 2 },
     ];
 
-    SaleOrderLine._records = [
+    projectModels.SaleOrderLine._records = [
         { id: 1, name: "order1" },
         { id: 2, name: "order2" },
     ];

--- a/addons/sale_project/static/tests/project_task_model.js
+++ b/addons/sale_project/static/tests/project_task_model.js
@@ -24,4 +24,5 @@ export class SaleOrderLine extends models.Model {
 Object.assign(projectModels, {
     ProjectMilestone,
     ProjectTask,
+    SaleOrderLine,
 });


### PR DESCRIPTION
We need SaleOrderLine to be part of projectModels, as the field `sale_line_id` of `project.task` is from that model. Otherwise, calling `defineProjectModels` in a module that depends on `sale_project` will lead to an error.

task-4295982




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
