### PR TITLE
[IMP] website_blog: blog improvements

### DIFF
--- a/addons/website_blog/static/src/website_builder/new_content.js
+++ b/addons/website_blog/static/src/website_builder/new_content.js
@@ -7,8 +7,29 @@ patch(NewContentModal.prototype, {
         super.setup();
 
         const newBlogElement = this.state.newContentElements.find(element => element.moduleXmlId === 'base.module_website_blog');
-        newBlogElement.createNewContent = () => this.onAddContent('website_blog.blog_post_action_add', true);
+        newBlogElement.createNewContent = () =>
+            this.onAddContent(
+                "website_blog.blog_post_action_add",
+                true,
+                this.getCurrentBlogContext()
+            );
         newBlogElement.status = MODULE_STATUS.INSTALLED;
         newBlogElement.model = 'blog.post';
+    },
+
+    getCurrentBlogContext() {
+        // Using iframe to access mainObject to check if we are on blog page
+        const iframeEl = document.querySelector("iframe").contentDocument;
+        const isBlogPage = iframeEl.documentElement.dataset.mainObject?.startsWith("blog");
+
+        if (isBlogPage) {
+            const blogEl = iframeEl.querySelector("#wrap.website_blog [data-oe-model='blog.blog']");
+            const blogId = parseInt(blogEl?.dataset.oeId);
+
+            if (blogId) {
+                return { default_blog_id: blogId };
+            }
+        }
+        return null;
     },
 });

--- a/addons/website_blog/static/tests/tours/blog_context.js
+++ b/addons/website_blog/static/tests/tours/blog_context.js
@@ -1,0 +1,81 @@
+import {
+    clickOnEditAndWaitEditMode,
+    clickOnSnippet,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "blog_context_and_social_media",
+    {
+        url: "/blog",
+    },
+    () => [
+        {
+            content: "Ensure we are in blog page",
+            trigger: ":iframe html[data-view-xmlid='website_blog.blog_post_short']",
+        },
+        {
+            content: "Click on 'aaa Blog Test' Blog",
+            trigger: ":iframe .website_blog nav .nav-item a:contains('aaa Blog Test')",
+            run: "click",
+        },
+        {
+            content: "Check that 'aaa Blog Test' Blog is open",
+            trigger: ":iframe .website_blog nav .nav-item a.active:contains('aaa Blog Test')",
+        },
+        {
+            content: "Click on New Post",
+            trigger: ".o_menu_systray .o_new_content_container button",
+            run: "click",
+        },
+        {
+            content: "Click on Blog Post",
+            trigger: "#o_new_content_menu_choices button[title='Blog Post']",
+            run: "click",
+        },
+        {
+            content: "Check in dialog current Selected Blog is 'aaa Blog Test'",
+            trigger: ".modal-dialog .o_field_widget[name='blog_id'] .o_input",
+            run: function () {
+                if (this.anchor.value !== "aaa Blog Test") {
+                    console.error("Current selected blog should be 'aaa Blog Test'");
+                }
+            },
+        },
+        {
+            content: "Click on Discard",
+            trigger: ".modal-footer .o_form_button_cancel",
+            run: "click",
+        },
+        {
+            content: "Click away to close the modal",
+            trigger: "#o_new_content_menu_choices",
+            run: "click",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "Check that SideBar is enabled",
+            trigger: ":iframe #wrap #o_wblog_sidebar",
+            run: "click",
+        },
+        ...clickOnSnippet("#o_wblog_sidebar .s_social_media"),
+        {
+            content: "Check Social Media Options are available",
+            trigger: ".o_customize_tab table.o_social_media_list",
+        },
+        {
+            content: "Click on Discard",
+            trigger: ".o-snippets-top-actions [data-action='cancel']",
+            run: "click",
+        },
+        {
+            content: "Click on the first article",
+            trigger: ":iframe article[name='blog_post'] a",
+            run: "click",
+        },
+        {
+            content: "Check the blog info is available",
+            trigger: ":iframe #o_wblog_post_info",
+        },
+    ]
+);

--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -49,8 +49,8 @@ class TestBlogPerformance(UtilPerf):
             blog_tags = blog_tags[:-1]
         self.assertEqual(self._get_url_hot_query('/blog'), 10)
         self.assertLessEqual(self._get_url_hot_query('/blog', cache=False), 33)
-        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url), 16)
-        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 20)
+        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url), 21)
+        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 24)
 
     def test_30_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -55,6 +55,20 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         self.env.ref('website_blog.opt_sidebar_blog_index_follow_us').active = False
         self.start_tour("/blog", 'blog_autocomplete_with_date')
 
+    def test_blog_context_and_social_media(self):
+        self.env.ref('website.default_website').write({
+            'social_facebook': "https://www.facebook.com/Odoo",
+            'social_twitter': 'https://twitter.com/Odoo',
+            'social_linkedin': 'https://www.linkedin.com/company/odoo',
+            'social_youtube': 'https://www.youtube.com/user/OpenERPonline',
+            'social_github': 'https://github.com/odoo',
+            'social_instagram': 'https://www.instagram.com/explore/tags/odoo/',
+            'social_tiktok': 'https://www.tiktok.com/@odoo',
+            'social_discord': 'https://discord.com/servers/discord-town-hall-169256939211980800',
+        })
+        self.env.ref('website_blog.opt_blog_sidebar_show').active = True
+        self.start_tour("/blog", "blog_context_and_social_media", login="admin")
+
     def test_avatar_comment(self):
         mail_message = self.env['mail.message'].create({
             'author_id': self.user_public.partner_id.id,

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -163,6 +163,31 @@
     </nav>
 </template>
 
+<!--  Template: Blog Post Information-->
+<template id="blog_post_info" name="Blog Post Info">
+    <div id="o_wblog_post_info" class="text-muted mb-2">
+        <i class="fa fa-clock-o fa-fw"/>
+        <span t-field="blog_post.post_date" class="text-muted" t-options="{'format': 'long', 'date_only': 'true'}"/>
+        <span style="display: inline-flex">by
+            <t t-call="website_blog.post_author">
+                <t t-set="additionnal_classes" t-value="'d-inline-flex me-2 ms-2'"/>
+                <t t-set="hide_date" t-value="True"/>
+            </t>
+        </span>
+        <t t-if="is_view_active('website_blog.opt_blog_post_comment')">
+            <span t-if="blog_post.message_ids" class="text-nowrap o_not_editable">|
+            <i class="fa fa-comment ms-1 text-muted"/>
+            <a href="#discussion">
+                <t t-out="len(blog_post.message_ids)"/>
+                <t t-if="len(blog_post.message_ids) > 1">Comments</t>
+                <t t-else="">Comment</t>
+            </a>
+            </span>
+            <span t-else="">| No comments yet</span>
+        </t>
+    </div>
+</template>
+
 <!-- ======   Template: Sidebar Blog  ==========================================
 Display sidebar in 'All blogs'/single blog pages.
 
@@ -187,22 +212,12 @@ Options:
 <!-- (Option) Sidebar Blog: Follow Us -->
 <template id="opt_sidebar_blog_index_follow_us" name="Follow Us" priority="1" inherit_id="website_blog.sidebar_blog_index" active="True">
     <xpath expr="//div[@id='o_wblog_sidebar']" position="inside">
-        <div class="o_wblog_sidebar_block pb-5">
+        <div class="o_wblog_sidebar_block pb-5" t-ignore="true">
             <div>
                 <h6 class="text-uppercase pb-2 mb-4 border-bottom fw-bold">Follow Us</h6>
             </div>
-            <div class="o_wblog_social_links d-flex flex-wrap mx-n1 o_not_editable">
-                <t t-set="classes" t-translation="off">bg-100 border mx-1 mb-2 rounded-circle d-flex align-items-center justify-content-center text-decoration-none</t>
-                <a t-if="website.social_facebook" t-att-href="website.social_facebook" aria-label="Facebook" title="Facebook" t-att-class="classes"><i class="fa fa-facebook-square text-facebook"/></a>
-                <a t-if="website.social_twitter" t-att-href="website.social_twitter" t-att-class="classes"><i class="fa fa-twitter text-twitter" aria-label="X" title="X"/></a>
-                <a t-if="website.social_linkedin" t-att-href="website.social_linkedin" t-att-class="classes"><i class="fa fa-linkedin text-linkedin" aria-label="LinkedIn" title="LinkedIn"/></a>
-                <a t-if="website.social_youtube" t-att-href="website.social_youtube" t-att-class="classes"><i class="fa fa-youtube-play text-youtube" aria-label="Youtube" title="Youtube"/></a>
-                <a t-if="website.social_github" t-att-href="website.social_github" t-att-class="classes"><i class="fa fa-github text-github" aria-label="Github" title="Github"/></a>
-                <a t-if="website.social_instagram" t-att-href="website.social_instagram" t-att-class="classes"><i class="fa fa-instagram text-instagram" aria-label="Instagram" title="Instagram"/></a>
-                <a t-if="website.social_tiktok" t-att-href="website.social_tiktok" t-att-class="classes"><i class="fa fa-tiktok text-tiktok" aria-label="TikTok" title="TikTok"/></a>
-                <a t-if="website.social_discord" t-att-href="website.social_discord" t-att-class="classes"><i class="fa fa-discord text-discord" aria-label="Discord" title="Discord"/></a>
-                <a t-if="blog" t-att-href="'/blog/%s/feed' % slug(blog)" t-att-class="classes"><i class="fa fa-rss-square" aria-label="RSS" title="RSS"/></a>
-            </div>
+            <t t-snippet-call="website.s_social_media"/>
+
             <t t-call="website_mail.follow" t-if="blog">
                 <t t-set="email" t-value="user_id.email"/>
                 <t t-set="object" t-value="blog"/>

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -235,6 +235,9 @@ list of filtered posts (by date or tag).
     <t t-if="opt_blog_post_breadcrumb and not opt_blog_post_regular_cover" t-call="website_blog.post_breadcrumbs">
         <t t-set="additionnal_classes" t-value="'mb-3 bg-transparent'"></t>
     </t>
+    <t t-if="not opt_blog_post_regular_cover">
+        <t t-call="website_blog.blog_post_info"/>
+    </t>
     <t t-set="editor_message">WRITE HERE OR DRAG BUILDING BLOCKS</t>
     <div t-field="blog_post.content"
         t-att-data-editor-message="editor_message"
@@ -281,25 +284,7 @@ list of filtered posts (by date or tag).
                         <h1 t-field="blog_post.name" id="o_wblog_post_name" data-oe-expression="blog_post.name" t-att-data-blog-id="blog_post.id" placeholder="Title"/>
                         <div t-field="blog_post.subtitle" id="o_wblog_post_subtitle"  placeholder="Subtitle"/>
                     </div>
-                    <div class="text-muted mb-2">
-                        <i class="fa fa-clock-o fa-fw"/>
-                        <span t-field="blog_post.post_date" class="text-muted" t-options="{'format': 'long', 'date_only': 'true'}"/>
-                        <span>by
-                            <t t-call="website_blog.post_author">
-                                <t t-set="additionnal_classes" t-value="'d-inline-flex me-2'"/>
-                                <t t-set="hide_date" t-value="True"/>
-                            </t>
-                        </span>
-                        <span t-if="len(blog_post.message_ids) > 0" class="text-nowrap ps-2 o_not_editable">|
-                            <i class="fa fa-comment text-muted me-1"/>
-                            <a href="#discussion">
-                                <t t-esc="len(blog_post.message_ids)"/>
-                                <t t-if="len(blog_post.message_ids)>1">Comments</t>
-                                <t t-else="">Comment</t>
-                            </a>
-                        </span>
-                        <span t-elif="is_view_active('website_blog.opt_blog_post_comment')">| No comments yet</span>
-                    </div>
+                    <t t-call="website_blog.blog_post_info"/>
                 </div>
 
                 <t t-call="website.record_cover">


### PR DESCRIPTION
This PR introduce few improvements to website_blog.
Improvements includes :

1. If `New Blog Post` is selected from a specific blog, the pop-up
should default to that blog. For example, selecting it from `Travel`
should default to `Travel` This is made possible by passing the correct
context while calling action for pop-up.

2. Adds functionality to display details like publish date and author
when the `Title Inside Cover` layout is selected. Also adjusted 
performance test for the same as it makes extra queries while
accessing `blog_post` record set.

3. Replaces the static `Follow Us` links in the header with a dynamic
social media snippet, allowing users or blog owners to edit them. This
is also updated for blog post sidebar `Follow Us`.

task-4430868