### PR TITLE
[FIX] mrp_subcontracting_dropshipping: test ok in 2025 from 862ede4

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -282,8 +282,8 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
             [
                 {'name': 'product_a',           'debit': 0.0,       'credit': 1800.0},
                 {'name': 'Tax 15% (Copy)',      'debit': 0.0,       'credit': 270.0},
-                {'name': 'INV/2024/00001',      'debit': 621.0,     'credit': 0.0},
-                {'name': 'INV/2024/00001',      'debit': 1449.0,    'credit': 0.0},
+                {'name': account_move.name,     'debit': 621.0,     'credit': 0.0},
+                {'name': account_move.name,     'debit': 1449.0,    'credit': 0.0},
                 {'name': 'product_a',           'debit': 0.0,       'credit': 840 * 2},
                 {'name': 'product_a',           'debit': 840 * 2,   'credit': 0.0},
             ]


### PR DESCRIPTION
In 862ede43e5910ae6954f3574f45c213e5d3a1886 the added test depended on
being in year 2024, so it failed in eg. 2025.

With this change we don't harcode the invoice name in assert data.

runbot-error-111390
opw-4050777