### PR TITLE
[FIX] hr_expense: force analytic distribution title display nowrap

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -241,6 +241,7 @@
                                    groups="account.group_account_readonly" readonly="not is_editable"
                                    context="{'default_company_id': company_id}"/>
                             <field name="analytic_distribution" widget="analytic_distribution"
+                                style="white-space: nowrap;"
                                 groups="analytic.group_analytic_accounting"
                                 options="{'product_field': 'product_id', 'account_field': 'account_id', 'business_domain': 'expense'}"
                                 readonly="not is_editable"/>


### PR DESCRIPTION
**Steps to reproduce:**
- Configure `Analytic Accounting` via `Accounting` module's settings;
- Go to `Analytic Plans` through `Accounting / Configuration / Analytic Accounting`:
    - Select any record and change its name for a really long one;

![Capture d’écran 2025-01-02 à 15 01 13](https://github.com/user-attachments/assets/c77a4588-37b1-4217-a65f-3e3f8ea5f857)

- Go to `Expenses` app:
    - Select any expense in the list;
    - Open the `Analytic Distribution` widget.

___
**Issue:**
Long `Analytic Plans` names are wrapped and may lead to unreadable texts.

![Capture d’écran 2025-01-02 à 15 01 56](https://github.com/user-attachments/assets/3e007cc0-822e-4a40-a23f-deced631668e)

___
**Expected:**
A smooth UI should display `Analytic Plans` as when accessed through an invoice line from `Accounting` app.

![Capture d’écran 2025-01-02 à 15 01 29](https://github.com/user-attachments/assets/e4b79c06-0fe0-4e87-bfcf-077b7b0c8354)

___
**Cause:**
The `Analytic Distribution` widget style of the invoice view inherits from the list renderer, forcing a `nowrap` style while the expense view of the same widget does not.

___
**Fix:**
Force a `nowrap` style for that specific widget.
![Capture d’écran 2025-01-02 à 15 02 14](https://github.com/user-attachments/assets/8d281ae8-5701-4158-83a0-ce3c73928eeb)

___
opw-4357324

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
