### PR TITLE
[IMP] module, scaffold, auth_totp: reduce depependecies

### DIFF
--- a/odoo/_monkeypatches/zeep.py
+++ b/odoo/_monkeypatches/zeep.py
@@ -1,8 +1,14 @@
-from zeep.xsd import visitor
-from zeep.xsd.const import xsd_ns
+try:
+    from zeep.xsd import visitor
+    from zeep.xsd.const import xsd_ns
+except ImportError:
+    visitor = None
+    pass
 
 
 def patch_zeep():
+    if visitor is None:
+        return
     # see https://github.com/mvantellingen/python-zeep/issues/1185
     if visitor.tags.notation.localname != 'notation':
         visitor.tags.notation = xsd_ns('notation')

--- a/odoo/cli/scaffold.py
+++ b/odoo/cli/scaffold.py
@@ -2,7 +2,10 @@ import os
 import re
 import sys
 
-import jinja2
+try:
+    import jinja2
+except ImportError:
+    jinja2 = None
 
 from . import Command
 
@@ -81,11 +84,15 @@ def directory(p, create=False):
         die("%s is not a directory" % p)
     return expanded
 
-env = jinja2.Environment()
-env.filters['snake'] = snake
-env.filters['pascal'] = pascal
+if jinja2:
+    env = jinja2.Environment()
+    env.filters['snake'] = snake
+    env.filters['pascal'] = pascal
+
 class template(object):
     def __init__(self, identifier):
+        if not jinja2:
+            raise ImportError("jinja2 is required to use Scaffold templates")
         # TODO: archives (zipfile, tarfile)
         self.id = identifier
         # is identifier a builtin?


### PR DESCRIPTION
Make some packages not required to run odoo

Even is some packages are in the requirements and debian control, they are not strictly necessary to run odoo core.

This commit aims to make some of them not needed in order to allow lighter installations when only the core applications are needed.