### PR TITLE
[FIX] analytic: force analytic distribution title display nowrap

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.scss
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.scss
@@ -43,6 +43,7 @@
     .analytic_distribution_popup {
         width: 400px;
         max-height: 50vh;
+        white-space: nowrap;
         cursor: default;
 
         .o_input {


### PR DESCRIPTION
**Steps to reproduce:**
- Configure `Analytic Accounting` via `Accounting` module's settings;
- Go to `Analytic Plans` through `Accounting / Configuration / Analytic Accounting`:
    - Select any record and change its name for a really long one;

![Capture d’écran 2025-01-02 à 15 21 40](https://github.com/user-attachments/assets/365a7089-9bb4-4215-8b7d-59ac85abc952)

- Go to `Expenses` app:
    - Select any expense in the list;
    - Open the `Analytic Distribution` widget.

___
**Issue:**
Long `Analytic Plans` names are wrapped and may lead to unreadable texts.

![Capture d’écran 2025-01-02 à 15 22 28](https://github.com/user-attachments/assets/b5ddbd88-1209-4640-a0ce-bf9396871038)

*(from the ticket - Odoo 17)*

![imagem](https://github.com/user-attachments/assets/2f3f0543-b08b-4f16-a4a0-4547369eb478)

___
**Expected:**
A smooth UI should display `Analytic Plans` as when accessed through an invoice line from `Accounting` app.

![Capture d’écran 2025-01-02 à 15 23 16](https://github.com/user-attachments/assets/ef0aa2fd-e8c5-47ba-8c39-ce4538b85380)

___
**Cause:**
The `Analytic Distribution` widget style of the invoice view inherits from the list renderer, forcing a `nowrap` style while the expense view of the same widget does not.

___
**Fix:**
Force a `nowrap` style for that specific widget.

![Capture d’écran 2025-01-02 à 15 22 55](https://github.com/user-attachments/assets/2af26b22-63e2-43fc-b636-f739a0aa094d)

___
opw-4357324

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
