### PR TITLE
[FIX] pos_sale: separate downpayment for fixed tax

### DIFF
--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -358,8 +358,8 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
     }
 
     _createDownpaymentLines(sale_order, total_down_payment, clickedOrder, down_payment_product) {
-        //This function will create all the downpaymentlines. We will create on downpayment line per unique tax combination
-
+        //This function will create all the downpaymentlines. We will create one downpayment line per unique tax combination
+        const percentage = total_down_payment / sale_order.amount_total;
         const grouped = {};
         sale_order.order_line.forEach((obj) => {
             const sortedTaxes = obj.tax_id.slice().sort((a, b) => a - b);
@@ -369,6 +369,12 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
             }
             grouped[key].push(obj);
         });
+
+        // We need one unique line for the fixed amount taxes
+        let fixed_taxes_downpayment = 0;
+        const fixed_taxes_tab = [];
+        const down_payment_line_to_create = [];
+
         Object.keys(grouped).forEach((key) => {
             const group = grouped[key];
             const tab = group.map((line) => ({
@@ -378,15 +384,34 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
                 total: line.price_total,
             }));
 
-            // Compute the part of the downpayment that should be assigned to this group
-            const total_price = group.reduce((total, line) => (total += line.price_total), 0);
-            const ratio = total_price / sale_order.amount_total;
-            const down_payment_line_price = total_down_payment * ratio;
-
-            // We apply the taxes and keep the same price
-            const taxes_to_apply = group[0].tax_id.filter(id => this.pos.taxes_by_id[id].amount_type !== "fixed").map((id) => {
-                return { ...this.pos.taxes_by_id[id], price_include: true };
+            // We compute the values for the fixed taxes downpayment
+            const fixed_taxes = group[0].tax_id.filter(
+                (id) => this.pos.taxes_by_id[id].amount_type === "fixed"
+            );
+            const total_qty = group.reduce((total, line) => (total += line.product_uom_qty), 0);
+            fixed_taxes.forEach((tax_id) => {
+                const tax = this.pos.taxes_by_id[tax_id];
+                fixed_taxes_downpayment += tax.amount * total_qty * percentage;
+                fixed_taxes_tab.push(tab);
             });
+
+            // We need to remove the amount of the fixed tax as they will have a separate line
+            const fixed_tax_total_amount = fixed_taxes.reduce((total, tax_id) => {
+                const tax = this.pos.taxes_by_id[tax_id];
+                return total + tax.amount;
+            }, 0);
+            const total_price = group.reduce(
+                (total, line) =>
+                    (total += line.price_total - line.product_uom_qty * fixed_tax_total_amount),
+                0
+            );
+            const down_payment_line_price = total_price * percentage;
+            // We apply the taxes and keep the same price
+            const taxes_to_apply = group[0].tax_id
+                .filter((id) => this.pos.taxes_by_id[id].amount_type !== "fixed")
+                .map((id) => {
+                    return { ...this.pos.taxes_by_id[id], price_include: true };
+                });
             const tax_res = this.pos.compute_all(
                 taxes_to_apply,
                 down_payment_line_price,
@@ -397,6 +422,29 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
             new_price += tax_res.taxes
                 .filter((tax) => this.pos.taxes_by_id[tax.id].price_include)
                 .reduce((sum, tax) => (sum += tax.amount), 0);
+            down_payment_line_to_create.push({
+                price: new_price,
+                tab: tab,
+                tax_ids: group[0].tax_id.filter(
+                    (id) => this.pos.taxes_by_id[id].amount_type !== "fixed"
+                ),
+            });
+        });
+
+        if (fixed_taxes_downpayment !== 0) {
+            // We try to merge the fixed taxes in one line that has no tax if possible
+            const line = down_payment_line_to_create.find((line) => !line.tax_ids.length);
+            if (line) {
+                line.price += fixed_taxes_downpayment;
+            } else {
+                down_payment_line_to_create.push({
+                    price: fixed_taxes_downpayment,
+                    tab: fixed_taxes_tab.flat(),
+                    tax_ids: [],
+                });
+            }
+        }
+        for (const down_payment_line of down_payment_line_to_create) {
             this.pos.get_order().add_orderline(
                 new Orderline(
                     { env: this.env },
@@ -404,15 +452,15 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
                         pos: this.pos,
                         order: this.pos.get_order(),
                         product: down_payment_product,
-                        price: new_price,
+                        price: down_payment_line.price,
                         price_type: "automatic",
                         sale_order_origin_id: clickedOrder,
-                        down_payment_details: tab,
-                        tax_ids: group[0].tax_id.filter(id => this.pos.taxes_by_id[id].amount_type !== "fixed"),
+                        down_payment_details: down_payment_line.tab,
+                        tax_ids: down_payment_line.tax_ids,
                     }
                 )
             );
-        });
+        }
     }
 
     async _getSaleOrder(id) {

--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -285,23 +285,6 @@ registry.category("web_tour.tours").add("PosShipLaterNoDefault", {
         ].flat(),
 });
 
-registry.category("web_tour.tours").add("PoSDownPaymentLinesPerFixedTax", {
-    test: true,
-    steps: () =>
-        [
-            ProductScreen.confirmOpeningPopup(),
-            ProductScreen.clickQuotationButton(),
-            ProductScreen.downPayment20PercentFirstOrder(),
-            Order.hasLine({
-                productName: "Down Payment",
-                quantity: "1.0",
-                price: "22",
-            }),
-            Order.hasNoTax(),
-            ProductScreen.totalAmountIs(22.0), 
-        ].flat(),
-});
-
 registry.category("web_tour.tours").add("PoSDownPaymentAmount", {
     test: true,
     steps: () =>
@@ -353,5 +336,24 @@ registry.category("web_tour.tours").add("PosSettleOrderShipLater", {
             PaymentScreen.remainingIs('0.0'),
             PaymentScreen.clickValidate(),
             ReceiptScreen.isShown(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PoSDownPaymentFixedTax", {
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickQuotationButton(),
+            ProductScreen.downPayment20PercentFirstOrder(),
+            Order.hasLine({
+                productName: "Down Payment",
+                quantity: "1.0",
+                price: "1.00",
+            }),
+            Order.hasLine({
+                productName: "Down Payment",
+                quantity: "1.0",
+                price: "22.00",
+            }),
         ].flat(),
 });

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -721,47 +721,6 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosShipLaterNoDefault', login="accountman")
 
-    def test_downpayment_with_fixed_taxed_product(self):
-        tax_1 = self.env['account.tax'].create({
-            'name': '10',
-            'amount_type': 'fixed',
-            'amount': 10,
-        })
-
-        product_a = self.env['product.product'].create({
-            'name': 'Product A',
-            'available_in_pos': True,
-            'type': 'product',
-            'lst_price': 100.0,
-            'taxes_id': [tax_1.id],
-        })
-
-        partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
-
-        sale_order = self.env['sale.order'].create({
-            'partner_id': partner_test.id,
-            'order_line': [Command.create({
-                'product_id': product_a.id,
-                'name': product_a.name,
-                'product_uom_qty': 1,
-                'product_uom': product_a.uom_id.id,
-                'price_unit': product_a.lst_price,
-            })],
-        })
-        sale_order.action_confirm()
-
-        self.downpayment_product = self.env['product.product'].create({
-            'name': 'Down Payment',
-            'available_in_pos': True,
-            'type': 'service',
-            'taxes_id': [],
-        })
-        self.main_pos_config.write({
-            'down_payment_product_id': self.downpayment_product.id,
-        })
-        self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSDownPaymentLinesPerFixedTax', login="accountman")
-
     def test_downpayment_amount_to_invoice(self):
         product_a = self.env['product.product'].create({
             'name': 'Product A',
@@ -968,3 +927,65 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         downpayment_invoice.action_post()
         self.user.groups_id = all_groups
         self.assertEqual(downpayment_line.price_unit, 100)
+
+    def test_downpayment_with_fixed_taxed_product(self):
+        """This test will make sure that a unique downpayment line will be created for the fixed tax"""
+        tax_1 = self.env['account.tax'].create({
+            'name': '10',
+            'amount': 10,
+            'amount_type': 'fixed',
+        })
+
+        tax_2 = self.env['account.tax'].create({
+            'name': '5 incl',
+            'amount': 5,
+            'price_include': True,
+        })
+
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 100.0,
+            'taxes_id': [tax_1.id],
+        })
+
+        product_b = self.env['product.product'].create({
+            'name': 'Product B',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 5.0,
+            'taxes_id': [tax_2.id],
+        })
+
+        partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_test.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'name': product_a.name,
+                'product_uom_qty': 1,
+                'product_uom': product_a.uom_id.id,
+                'price_unit': product_a.lst_price,
+            }), (0, 0, {
+                'product_id': product_b.id,
+                'name': product_b.name,
+                'product_uom_qty': 1,
+                'product_uom': product_b.uom_id.id,
+                'price_unit': product_b.lst_price,
+            })],
+        })
+        sale_order.action_confirm()
+
+        self.downpayment_product = self.env['product.product'].create({
+            'name': 'Down Payment',
+            'available_in_pos': True,
+            'type': 'service',
+            'taxes_id': [],
+        })
+        self.main_pos_config.write({
+            'down_payment_product_id': self.downpayment_product.id,
+        })
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSDownPaymentFixedTax', login="accountman")


### PR DESCRIPTION
When a product has a fixed tax, there should be a separate downpayment line for the fixed tax amount.

Steps to reproduce:
-------------------
* Create a fixed tax of 1€
* Assign this tax to any product
* Create a sale order with this product
* Open PoS and make a downpayment of 10%
> Observation: There is only one downpayment line with the total amount
  of the product and the fixed tax combined.

opw-4252104