### PR TITLE
[IMP] rpc: serialize 64-bits signed int in xmlrpc

### DIFF
--- a/odoo/addons/test_rpc/models.py
+++ b/odoo/addons/test_rpc/models.py
@@ -11,7 +11,6 @@ class Test_RpcModel_A(models.Model):
     field_b1 = fields.Many2one("test_rpc.model_b", string="required field", required=True)
     field_b2 = fields.Many2one("test_rpc.model_b", string="restricted field", ondelete="restrict")
 
-    @api.model
     @api.private
     def read_group(self, *a, **kw):
         return super().read_group(*a, **kw)
@@ -26,6 +25,14 @@ class Test_RpcModel_A(models.Model):
     @api.model
     def not_depending_on_id(self, vals=None):
         return f"got {vals}"
+
+    @api.model
+    def int8(self):
+        return 1 << 32
+
+    @api.model
+    def bigint(self):
+        return 1 << 64
 
 
 class Test_RpcModel_B(models.Model):

--- a/odoo/addons/test_rpc/tests/__init__.py
+++ b/odoo/addons/test_rpc/tests/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
+from . import test_bigint
 from . import test_error

--- a/odoo/addons/test_rpc/tests/test_bigint.py
+++ b/odoo/addons/test_rpc/tests/test_bigint.py
@@ -1,0 +1,22 @@
+from functools import partial
+
+from odoo.tests import HttpCase, get_db_name, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestXmlRpcBigInt(HttpCase):
+
+    def setUp(self):
+        super().setUp()
+        uid = self.ref('base.user_admin')
+        self.rpc = partial(self.xmlrpc_object.execute, get_db_name(), uid, 'admin')
+
+    def test_xmlrpc_int8(self):
+        self.assertEqual(self.env['test_rpc.model_a'].int8(), 1 << 32)
+        int8 = self.rpc('test_rpc.model_a', 'int8')
+        self.assertEqual(int8, 1 << 32)
+
+    def test_xmlrpc_bigint(self):
+        self.assertEqual(self.env['test_rpc.model_a'].bigint(), 1 << 64)
+        bigint = self.rpc('test_rpc.model_a', 'bigint')
+        self.assertEqual(bigint, 1 << 64)


### PR DESCRIPTION
At the moment, the xmlrpc layer refuses to serialize integers that wouldn't fit in a 32 bits signed integers. This is as per the latest xmlrpc standard[^1] (2003) which documents serialization of integers up to 32 bits integers. Larger integers (i.e. larger than 2e9) are not supported, and python's xmlrpc raises an OverflowError for them.

This is problematic as we now have several models with several billion records, where many record ids don't fit in 32 bits signed integers.

In this work we overload the xmlrpc serialiation of python's `int()` to serialize integers that don't fit in 32 bits using some unofficial but well supported extended data types: `<i8>` and `<biginteger>`.

* `<i8>` stores 64 bits signed integers (Java Long, C int32_t).
* `<biginteger>` stores un-limited integers (Python int).

Enabling serialization of bigger integers server-side is a required step to allow clients compatiblity, but because they are not part of the 2003 standard, those data types might not be recognized by all clients. See the compatibility matrix bellow[^2]:

language             | i8  | biginteger
-------------------- | --- | ----------
[python3]            | yes | yes
[ruby-xmlrpc]        | yes | no
[javascript jayson]  | no  | no
[php laminas-xmlrpc] | yes | no
[java apache-xmlrpc] | yes | no

[python3]: https://docs.python.org/3/library/xmlrpc.html
[ruby-xmlrpc]: https://packages.ubuntu.com/jammy/ruby-xmlrpc
[javascript jayson]: https://www.npmjs.com/package/jayson
[php laminas-xmlrpc]: https://github.com/laminas/laminas-xmlrpc
[java apache-xmlrpc]: https://ws.apache.org/xmlrpc/index.html
[^1]: https://xmlrpc.com/spec.md
[^2]: crude study of the source code of each library