### PR TITLE
[IMP] account: Allow Powerpoint attachment from mail alias

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -66,6 +66,9 @@ ALLOWED_MIMETYPES = {
     'application/vnd.oasis.opendocument.spreadsheet',
     'application/msword',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.ms-powerpoint',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'application/vnd.oasis.opendocument.presentation',
 }
 
 EMPTY = object()


### PR DESCRIPTION
Problem
---------
Currently, powerpoints attachments received by a mail alias are deleted. We want to allow them.

Solution
---------
Add the relevant mimetypes to the white list.

no-task
no-opw

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
