### PR TITLE
[IMP] sale_loyalty: available rewards notification

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -135,12 +135,23 @@ class SaleOrder(models.Model):
         return new_orders
 
     def action_confirm(self):
+        """
+        Override to validate and update coupon rewards.
+
+        If called with one SO, checks if there exists rewards that are available but not claimed,
+        and if so returns a notification action.
+
+        :raises ValidationError: A coupon gave a negative amount of points.
+        :return: True or a notification action
+        :rtype: bool | dict
+        """
         for order in self:
             all_coupons = order.applied_coupon_ids | order.coupon_point_ids.coupon_id | order.order_line.coupon_id
             if any(order._get_real_points_for_coupon(coupon) < 0 for coupon in all_coupons):
                 raise ValidationError(_("One or more rewards on the sale order is invalid. Please check them."))
             order._update_programs_and_rewards()
             order._add_loyalty_history_lines()
+        has_claimable_rewards = len(self) == 1 and bool(self._get_claimable_rewards())
 
         # Remove any coupon from 'current' program that don't claim any reward.
         # This is to avoid ghost coupons that are lost forever.
@@ -153,6 +164,18 @@ class SaleOrder(models.Model):
         for coupon, change in self.filtered(lambda s: s.state != 'sale')._get_point_changes().items():
             coupon.points += change
         res = super().action_confirm()
+        # Prioritize any action from super()
+        if isinstance(res, bool) and has_claimable_rewards:
+            res = {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'type': 'info',
+                    'title': _("Rewards Available"),
+                    'message': _("There are available rewards not added to this order."),
+                    'next': {'type': 'ir.actions.act_window_close'},
+                },
+            }
         self._send_reward_coupon_mail()
         return res
 


### PR DESCRIPTION
At the moment it is not possible currently to know if there are
available rewards or not on a SO. This meant a salesman could forget to
check the available rewards.

This commits displays a notification on the form when confirming an SO
to warn the salesman if available rewards are available.

task-4414973

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
