### PR TITLE
[FIX] point_of_sale: currency of journal items corresponding to payments

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -141,7 +141,9 @@ class ProductTemplate(models.Model):
         different_currency = config_id.currency_id != self.env.company.currency_id
         for product in products:
             if different_currency:
-                product['lst_price'] = self.env.company.currency_id._convert(product['lst_price'], config_id.currency_id, self.env.company, fields.Date.today())
+                product['list_price'] = self.env.company.currency_id._convert(product['list_price'], config_id.currency_id, self.env.company, fields.Date.today())
+                product['standard_price'] = self.env.company.currency_id._convert(product['standard_price'], config_id.currency_id, self.env.company, fields.Date.today())
+
             product['image_128'] = bool(product['image_128'])
 
             if len(taxes_by_company) > 1 and len(product['taxes_id']) > 1:

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -732,8 +732,34 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
             # We allow partial checks of the lines of the account move if `line_ids_predicate` is specified.
             # This means that only those that satisfy the predicate are compared to the expected account move line_ids.
             line_ids_predicate = expected_account_move_vals.pop('line_ids_predicate', lambda _: True)
-            self.assertRecordValues(account_move.line_ids.filtered(line_ids_predicate), expected_account_move_vals.pop('line_ids'))
+            line_ids = expected_account_move_vals.pop('line_ids')
+            reconciliation_statuses = []
+            for line in line_ids:
+                partially_reconciled = line.pop('partially_reconciled', False)
+                if partially_reconciled is True:
+                    reconciliation_statuses.append('partially_reconciled')
+                else:
+                    reconciliation_statuses.append('fully_reconciled' if line.get('reconciled') else 'not_reconciled')
+            account_move_line_ids = account_move.line_ids.filtered(line_ids_predicate)
+            self.assertRecordValues(account_move_line_ids, line_ids)
             self.assertRecordValues(account_move, [expected_account_move_vals])
+
+            # Check reconciliation status
+            for line, reconciliation_status in zip(account_move_line_ids, reconciliation_statuses):
+                # See 'account_move_line._compute_amount_residual'  for more explanation
+                if reconciliation_status == 'fully_reconciled':
+                    if line.matching_number:
+                        self.assertTrue(line.full_reconcile_id)
+                    self.assertAlmostEqual(line.amount_residual, 0)
+                elif reconciliation_status == 'partially_reconciled':
+                    self.assertFalse(line.full_reconcile_id)
+                    if line.reconciled:
+                        self.assertAlmostEqual(line.amount_residual, 0)
+                    else:
+                        self.assertGreater(abs(line.amount_residual), 0)
+                elif reconciliation_status == 'not_reconciled':
+                    self.assertFalse(line.full_reconcile_id)
+                    self.assertFalse(line.reconciled)
         else:
             # if the expected_account_move_vals is falsy, the account_move should be falsy.
             self.assertFalse(account_move)

--- a/addons/point_of_sale/tests/test_pos_simple_invoiced_orders.py
+++ b/addons/point_of_sale/tests/test_pos_simple_invoiced_orders.py
@@ -234,14 +234,13 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                     'invoice': {
                         'line_ids': [
                             {'account_id': self.sales_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True, 'partially_reconciled': True},
                         ]
                     },
                     'payments': [
                         ((self.cash_pm1, 200), {
                             'line_ids': [
-                                # needs to check the residual because it's supposed to be partial reconciled
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'amount_residual': -100},
+                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'partially_reconciled': True, 'amount_residual': -100},
                                 {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
                             ]
                         }),
@@ -278,14 +277,13 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                     'invoice': {
                         'line_ids': [
                             {'account_id': self.sales_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True, 'partially_reconciled': True},
                         ]
                     },
                     'payments': [
                         ((self.bank_pm1, 200), {
                             'line_ids': [
-                                # needs to check the residual because it's supposed to be partial reconciled
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'amount_residual': -100},
+                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'partially_reconciled': True, 'amount_residual': -100},
                                 {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
                             ]
                         }),
@@ -322,14 +320,13 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                     'invoice': {
                         'line_ids': [
                             {'account_id': self.sales_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True, 'partially_reconciled': True},
                         ]
                     },
                     'payments': [
                         ((self.cash_split_pm1, 200), {
                             'line_ids': [
-                                # needs to check the residual because it's supposed to be partial reconciled
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'amount_residual': -100},
+                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'partially_reconciled': True, 'amount_residual': -100},
                                 {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
                             ]
                         }),
@@ -366,14 +363,13 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                     'invoice': {
                         'line_ids': [
                             {'account_id': self.sales_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True, 'partially_reconciled': True},
                         ]
                     },
                     'payments': [
                         ((self.bank_split_pm1, 200), {
                             'line_ids': [
-                                # needs to check the residual because it's supposed to be partial reconciled
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'amount_residual': -100},
+                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'partially_reconciled': True, 'amount_residual': -100},
                                 {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
                             ]
                         }),
@@ -632,14 +628,13 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                     'invoice': {
                         'line_ids': [
                             {'account_id': self.sales_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False, 'amount_residual': 0},
-                            # needs to check the residual because it's supposed to be partial reconciled
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False, 'amount_residual': 50},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False, 'partially_reconciled': True, 'amount_residual': 50},
                         ]
                     },
                     'payments': [
                         ((self.cash_pm1, 50), {
                             'line_ids': [
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
+                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True, 'partially_reconciled': True},
                                 {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': False},
                             ]
                         }),
@@ -676,14 +671,13 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                     'invoice': {
                         'line_ids': [
                             {'account_id': self.sales_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False, 'amount_residual': 0},
-                            # needs to check the residual because it's supposed to be partial reconciled
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False, 'amount_residual': 50},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False, 'partially_reconciled': True, 'amount_residual': 50},
                         ]
                     },
                     'payments': [
                         ((self.bank_pm1, 50), {
                             'line_ids': [
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
+                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True, 'partially_reconciled': True},
                                 {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': False},
                             ]
                         }),
@@ -720,14 +714,13 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                     'invoice': {
                         'line_ids': [
                             {'account_id': self.sales_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False, 'amount_residual': 0},
-                            # needs to check the residual because it's supposed to be partial reconciled
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False, 'amount_residual': 50},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False, 'partially_reconciled': True, 'amount_residual': 50},
                         ]
                     },
                     'payments': [
                         ((self.bank_split_pm1, 50), {
                             'line_ids': [
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
+                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True, 'partially_reconciled': True},
                                 {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': False},
                             ]
                         }),
@@ -764,14 +757,13 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                     'invoice': {
                         'line_ids': [
                             {'account_id': self.sales_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False, 'amount_residual': 0},
-                            # needs to check the residual because it's supposed to be partial reconciled
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False, 'amount_residual': 50},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False, 'partially_reconciled': True, 'amount_residual': 50},
                         ]
                     },
                     'payments': [
                         ((self.cash_split_pm1, 50), {
                             'line_ids': [
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
+                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True, 'partially_reconciled': True},
                                 {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': False},
                             ]
                         }),


### PR DESCRIPTION
Issue:
When the POS has a different currency than the company, the journal entry created after an order contains receivable lines for each payment method used, but their amounts are incorrect.

Steps to reproduce:
- Setup a pos.config that uses a journal that has different currency than the company.  E.g. company currency = $, pos journal currency = euro. This means that the shop will be in a different currency than the containing company.
- Make sure that the payment method points to a journal that has no specific currency. ( The default payment methods has that.)
- Open a session, make an order and close the session.
- [ISSUE] The journal entry contains receivable lines per payment method used but it's amount is wrong. It is in the currency of the company but with wrong value. We should make sure that the amount is correct and that it's properly reconciled to the payment object.

Solution:
This commit ensures that product and variant prices are converted to the correct currency, and that cash bank statement line amounts are converted to the journal currency when needed.

task-4398787
task-4409966

