### PR TITLE
[FIX] point_of_sale: set confirm button as default in number popup

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/input_popups/number_popup.xml
+++ b/addons/point_of_sale/static/src/app/utils/input_popups/number_popup.xml
@@ -12,7 +12,7 @@
             <div t-if="props.feedback(this.state.buffer)" class="p-2 mx-auto" t-esc="props.feedback(this.state.buffer)" />
             <Numpad buttons="props.buttons" class="'mx-auto my-3 w-75 max-width-325px'"/>
             <t t-set-slot="footer">
-                <button t-att-disabled="!props.isValid(state.buffer)" class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>
+                <button t-att-disabled="!props.isValid(state.buffer)" class="btn btn-primary o-default-button" tabindex="1" t-on-click="confirm">Ok</button>
             </t>
         </Dialog>
     </t>

--- a/addons/pos_hr/static/src/app/select_cashier_mixin.js
+++ b/addons/pos_hr/static/src/app/select_cashier_mixin.js
@@ -52,7 +52,10 @@ export function useCashierSelector(
                 });
             }
         }
-        if (!inputPin || employee._pin !== Sha1.hash(inputPin)) {
+        if (!inputPin && typeof inputPin !== "string") {
+            return false;
+        }
+        if (employee._pin !== Sha1.hash(inputPin)) {
             dialog.add(AlertDialog, {
                 title: _t("Incorrect Password"),
                 body: _t("Please try again."),


### PR DESCRIPTION
Before this commit, when the number popup was opened, pressing any key would select the "1" button by default. This caused the number "1" to be added to the buffer when pressing "Enter" while typing numbers with the keyboard.

This behavior was particularly problematic when entering the PIN code for employee login, leading to incorrect entries.

Additionally, a small modification was made to prevent the incorrect password alert from appearing when the popup is closed.

opw-4428481

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
