### PR TITLE
[FIX] pos_restaurant: pos calling himself

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -61,7 +61,7 @@ patch(PosStore.prototype, {
         }
     },
     async wsSyncTableCount(data) {
-        if (data.login_number === this.session.login_number) {
+        if (data.login_number == this.session.login_number) {
             this.computeTableCount(data);
             return;
         }


### PR DESCRIPTION
When syncing an order, the server sends a notification via websocket to inform the other pos connected to this websocket that they should load the data relative to this order. The problem was that the pos that was sending the information, was also receiving it, and was paying attention to the message when it should not. It was then resending its current order with wrong information.

task-id: 4444255

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
