### PR TITLE
[FIX] account: translate tax tags

### DIFF
--- a/addons/account/models/account_account_tag.py
+++ b/addons/account/models/account_account_tag.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo import api, fields, models, _
 from odoo import osv
+from odoo.tools.sql import SQL
 from odoo.exceptions import UserError
 
 
@@ -28,6 +29,13 @@ class AccountAccountTag(models.Model):
             if tag.applicability == "taxes" and tag.country_id and tag.country_id != self.env.company.account_fiscal_country_id:
                 name = _("%s (%s)", tag.name, tag.country_id.code)
             tag.display_name = name
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        tags = super().create(vals_list)
+        if tax_tags := tags.filtered(lambda tag: tag.applicability == 'taxes'):
+            self._translate_tax_tags(tag_ids=tax_tags.ids)
+        return tags
 
     @api.model
     def _get_tax_tags(self, tag_name, country_id):
@@ -78,3 +86,23 @@ class AccountAccountTag(models.Model):
             master_tag = self.env.ref(f"account.{master_xmlid}", raise_if_not_found=False)
             if master_tag and master_tag in self:
                 raise UserError(_("You cannot delete this account tag (%s), it is used on the chart of account definition.", master_tag.name))
+
+    def _translate_tax_tags(self, langs=None, tag_ids=None):
+        """Translate tax tags having the same name as report lines."""
+        langs = langs or (code for code, _name in self.env['res.lang'].get_installed() if code != 'en_US')
+        for lang in langs:
+            self.env.cr.execute(SQL(
+                """
+                UPDATE account_account_tag tag
+                   SET name = tag.name || jsonb_build_object(%(lang)s, substring(tag.name->>'en_US' FOR 1) || (report_line.name->>%(lang)s))
+                  FROM account_report_line report_line
+                  JOIN account_report report ON report.id = report_line.report_id
+                 WHERE tag.applicability = 'taxes'
+                   AND tag.country_id = report.country_id
+                   AND tag.name->>'en_US' = substring(tag.name->>'en_US' FOR 1) || (report_line.name->>'en_US')
+                   AND tag.name->>%(lang)s != substring(tag.name->>'en_US' FOR 1) || (report_line.name->>%(lang)s)
+                   %(and_tag_ids)s
+                """,
+                lang=lang,
+                and_tag_ids=SQL('AND tag.id IN %s', tuple(tag_ids)) if tag_ids else SQL(''),
+            ))

--- a/addons/account/models/ir_module.py
+++ b/addons/account/models/ir_module.py
@@ -77,6 +77,7 @@ class IrModule(models.Model):
         if 'account' in modules:
             def load_account_translations(env):
                 env['account.chart.template']._load_translations(langs=langs)
+                env['account.account.tag']._translate_tax_tags(langs=langs)
             if self.env.registry.loaded:
                 load_account_translations(self.env)
             else:


### PR DESCRIPTION
The tax tags are translatable but never translated automatically because they are generated dynamically from the tax report.

This commit aims at improving this by translating automatically the tags that match exactly the name of the tax report line, for instance in Israel.