### PR TITLE
[FIX] mail: ease click on quick action of chat window

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -116,7 +116,7 @@
 </t>
 
 <t t-name="mail.ChatWindow.quickAction">
-    <button class="o-mail-ChatWindow-command btn d-flex opacity-100-hover align-items-center" style="aspect-ratio: 1;" t-att-class="{ 'border border-secondary rounded-circle o-small p-2 my-1': ui.isSmall, 'opacity-25': !ui.isSmall }" t-attf-class="{{ itemClass }}" t-att-title="action.name" t-att-disabled="state.actionsDisabled" t-on-click.stop="() => action.onSelect()"><i t-att-class="ui.isSmall ? 'fa-lg' : ''" t-attf-class="{{ action.icon }}"/></button>
+    <button class="o-mail-ChatWindow-command btn d-flex opacity-100-hover align-items-center p-1" style="aspect-ratio: 1;" t-att-class="{ 'border border-secondary rounded-circle o-small p-2 my-1': ui.isSmall, 'opacity-25': !ui.isSmall }" t-attf-class="{{ itemClass }}" t-att-title="action.name" t-att-disabled="state.actionsDisabled" t-on-click.stop="() => action.onSelect()"><i t-att-class="ui.isSmall ? 'fa-lg' : ''" t-attf-class="{{ action.icon }}"/></button>
 </t>
 
 <t t-name="mail.ChatWindow.dropdownAction">


### PR DESCRIPTION
Click on quick ation button in Chat window header was a bit tedious in desktop. This happens because the clickable area is 24px x 24px.

This commit makes it easier by increasing to 28px x 28px, thanks to explicit `p-1` on buttons. This ain't much but this gives less frustration to use chat window quick actions.


<img width="601" alt="Screenshot 2025-01-02 at 18 23 47" src="https://github.com/user-attachments/assets/b0c09d0c-906b-43b9-b8f7-6fb954c34998" />
