### PR TITLE
[FIX] digest: convert kpi to users company currency

### DIFF
--- a/addons/account/tests/test_digest.py
+++ b/addons/account/tests/test_digest.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from lxml import html
+from freezegun import freeze_time
+from datetime import datetime, timedelta
+
 from odoo.addons.digest.tests.common import TestDigestCommon
 from odoo.tools import mute_logger
 from odoo.tests import tagged
+from odoo import Command
 
 
 @tagged('post_install', '-at_install')
@@ -63,4 +68,130 @@ class TestAccountDigest(TestDigestCommon):
             int(self.digest_3.with_company(self.company_2).kpi_account_total_revenue_value),
             -2,
             msg='When no company is set, the KPI must be computed based on the current company',
+        )
+
+    @freeze_time("2025-01-30")
+    def test_kpi_currency_follows_recipients_company_currency(self):
+        """ Ensure that in the following setup EU Recipient receives a digest in his currency.
+
+           ODOO two company setup
+         ┌────────────┌────────────────┐
+         │ US Branch  │   EU Branch    │
+         │   $$$      │     €€€        │
+         │            │                │
+         │   Sales    │                │
+         │            │                │
+         │ US Digest ─├─►EU Recipient │
+         │            │                │
+         └────────────└────────────────┘
+        """
+        def _record_revenue(for_amount=100, when='in '):
+            if when == 'in past 24h':
+                move_date = datetime.now().strftime('%Y-%m-%d')
+            elif when == 'in past week':
+                move_date = (datetime.now() - timedelta(days=3)).strftime('%Y-%m-%d')
+            elif when == 'in past month':
+                move_date = (datetime.now() - timedelta(days=15)).strftime('%Y-%m-%d')
+            else:
+                move_date = when  # Assume it's a valid date string in 'YYYY-MM-DD' format
+
+            move = self.env['account.move'].with_company(us_branch).create({
+                'date': move_date,
+                'line_ids': [
+                    Command.create({
+                        'account_id': income_account.id,
+                        'credit': for_amount,
+                    }),
+                    Command.create({
+                        'account_id': receivable_account.id,
+                        'debit': for_amount,
+                    }),
+                ],
+            })
+            move.action_post()
+            return move
+
+        eu_currency = self.env['res.currency'].create({
+            'name': 'eu_currency',
+            'symbol': '€€€',
+            'rounding': 0.01,
+            'decimal_places': 2,
+        })
+
+        eu_branch = self.env['res.company'].create({'name': 'eu_branch', 'currency_id': eu_currency.id})
+
+        eu_recipient = self.env['res.users'].create({
+            'name': 'eu_recipient',
+            'login': 'eu_recipient@example.com',
+            'email': 'eu_recipient@example.com',
+            'company_id': eu_branch.id,
+            'company_ids': [(4, eu_branch.id)],
+            'groups_id': [
+                Command.set([self.env.ref('base.group_user').id]),
+                Command.set([self.env.ref('account.group_account_invoice').id]),
+            ]
+        })
+
+        us_currency = self.env['res.currency'].create({
+            'name': 'us_currency',
+            'symbol': '$$$',
+            'rounding': 0.01,
+            'decimal_places': 2,
+        })
+
+        self.env['res.currency.rate'].create({
+            'name': '2025-01-01',
+            'currency_id': us_currency.id,
+            'rate': 0.5,
+            'company_id': eu_branch.id,
+        })
+
+        us_branch = self.env['res.company'].create({'name': 'us_branch', 'currency_id': us_currency.id})
+
+        us_digest = self.env['digest.digest'].with_company(us_branch).create({
+            'name': 'Test Digest',
+            'user_ids': [(4, eu_recipient.id)],
+            'kpi_account_total_revenue': True,  # Enable the revenue KPI
+        })
+
+        income_account = self.env['account.account'].create({
+            'name': 'Income Account',
+            'code': '400000',
+            'account_type': 'income',
+            'company_id': us_branch.id,
+        })
+        receivable_account = self.env['account.account'].create({
+            'name': 'Receivable Account',
+            'account_type': 'asset_receivable',
+            'code': '1210',
+            'company_id': us_branch.id,
+        })
+        self.env['account.journal'].create({
+            'name': 'Test Journal',
+            'type': 'general',
+            'code': 'TJ',
+            'company_id': us_branch.id,
+        })
+
+        _record_revenue(for_amount=1, when='in past 24h')  # =2€€€ cumulatively
+        _record_revenue(for_amount=9, when='in past week')  # =20€€€ cumulatively
+        _record_revenue(for_amount=90, when='in past month')  # =200€€€ cumulatively
+
+        self.env['account.move.line'].flush_model()
+
+        us_digest.flush_recordset()
+        with self.mock_mail_gateway():
+            us_digest.action_send()
+
+        self.assertEqual(len(self._new_mails), 1, "A new mail.mail should have been created")
+        mail = self._new_mails[0]
+        self.assertEqual(mail.email_to, eu_recipient.email_formatted)
+
+        kpi_xpath = '//span[contains(@class, "kpi_value") and contains(@class, "kpi_border_col")]/text()'
+        kpi_message_values = html.fromstring(mail.body_html).xpath(kpi_xpath)
+
+        self.assertEqual(
+            [t.strip() for t in kpi_message_values],
+            ['2€€€', '20€€€', '200€€€'],
+            "The digest should display the KPI values in the recipient's company currency"
         )

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -292,8 +292,12 @@ class Digest(models.Model):
                     continue
                 margin = self._get_margin_value(compute_value, previous_value)
                 if self._fields['%s_value' % field_name].type == 'monetary':
-                    converted_amount = tools.format_decimalized_amount(compute_value)
-                    compute_value = self._format_currency_amount(converted_amount, company.currency_id)
+                    if self.company_id.currency_id != company.currency_id:  # Perform currency conversion if necessary
+                        compute_value = self.company_id.currency_id._convert(
+                            compute_value, company.currency_id, company, fields.Date.today()
+                        )
+                    decimalized_value = tools.format_decimalized_amount(compute_value)
+                    compute_value = self._format_currency_amount(decimalized_value, company.currency_id)
                 elif self._fields['%s_value' % field_name].type == 'float':
                     compute_value = "%.2f" % compute_value
 


### PR DESCRIPTION
Assuming that incoming kps are given in the digest.company.currency field and that we want to give them in the user.company.currency (recipient's company's currency) we need to convert them to the user's company currency before sending the digest email.

Reproduce
---

- have two companies
	- usd_company (currency set to USD)
		- usd_company has usd_user
	- aed_company (currency set to AED)
		- aed_company uses "United Arab Emirates" Fiscal Package
		- aed_company has a aed_usd_digest (in aed company but sent to "usd users"):
			- all_digest KPIs are "all sales" and "revenue"
			- usd_user is a recipient of the aed_usd_digest
- admin makes a sale order for 100 AED (105 with tax), confirms it and creates an invoice
- Digest email is sent to usd_user, recent revenue is shown in USD which is desired, but it isn't converted correctly (105 AED is around 28 USD )

opw-4399055

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
