### PR TITLE
[FIX] pos_loyalty: prevent access error in multi-company gift card use

### DIFF
--- a/addons/pos_loyalty/models/loyalty_card.py
+++ b/addons/pos_loyalty/models/loyalty_card.py
@@ -19,7 +19,7 @@ class LoyaltyCard(models.Model):
         return super()._get_default_template()
 
     def _get_mail_partner(self):
-        return super()._get_mail_partner() or self.source_pos_order_id.partner_id
+        return super()._get_mail_partner() or self.sudo().source_pos_order_id.partner_id
 
     def _get_signature(self):
         return self.source_pos_order_id.user_id.signature or super()._get_signature()


### PR DESCRIPTION
Before this commit, if a gift card was created in another company and the gift card program was not assigned to any company, using the gift card in another company resulted in an error.

opw-4422730

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
