### PR TITLE
[PERF] Fix webclient view cache for not embedded action views

### DIFF
--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -283,7 +283,7 @@ export class View extends Component {
                 {
                     actionId: this.env.config.actionId,
                     embeddedActionId: this.env.config.currentEmbeddedActionId,
-                    embeddedParentResId: context.active_id,
+                    embeddedParentResId: this.env.config.currentEmbeddedActionId && context.active_id,
                     loadActionMenus,
                     loadIrFilters,
                 }


### PR DESCRIPTION
**Steps to reproduce (a bit technical):**

1. Navigate to the "Contacts" kanban view.
2. Open the Network tab in the browser's developer tools.
3. Click on the first contact activities and "Schedule a new activity".
4. Notice a call to `get_views` in the Network tab.
5. Click on a different contact activities, and "Schedule a new activity".
6. Notice a new call to `get_views` in the Network tab.

**Expected:**

The view is already cached, so the webclient should not attempt to load it.

**Explanation:**

This is likely a regression since f983703d, when the embedded actions were introduced. Now, the `embeddedParentResId` is part of the views cache key, and so we get much fewer cache hits.

For most views, there isn't really an `embeddedActionId` set, and yet the `embeddedParentResId` was always set. The later is only used in combination with `embeddedActionId`, so it causes a lot of avoidable cache misses.

The solution is to simply set the `embeddedParentResId` only if there's an `embeddedActionId`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
