### PR TITLE
[IMP] web: show fields in display order during export

### DIFF
--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.js
@@ -408,9 +408,15 @@ export class ExportDataDialog extends Component {
     }
 
     async setDefaultExportList() {
-        this.state.exportList = Object.values(this.knownFields).filter(
-            (e) => e.default_export || this.props.defaultExportList.find((i) => i.name === e.id)
+        const defaultExportList = this.props.defaultExportList
+            .map((defaultField) => this.knownFields[defaultField.name])
+            .filter((field) => field);
+
+        const defaultExportfields = Object.values(this.knownFields).filter(
+            (field) => field.default_export
         );
+
+        this.state.exportList = unique([...defaultExportList, ...defaultExportfields]);
     }
 
     setFormat(ev) {

--- a/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
@@ -1105,3 +1105,39 @@ test("Export dialog: no column_invisible fields in default export list", async (
     expect(".modal .o_export_field").toHaveCount(1);
     expect(".modal .o_export_field").toHaveText("Foo");
 });
+
+test("Export dialog: fields displayed in same Order as list view when export", async () => {
+    Partner._fields.abc = fields.Char();
+    Partner._fields.demo = fields.Char();
+    onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
+    onRpc("/web/export/get_fields", async (request) => [
+        ...fetchedFields.root,
+        {
+            id: "abc",
+            string: "Abc",
+        },
+        {
+            id: "demo",
+            string: "Demo",
+        },
+    ]);
+
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: `
+            <list>
+                <field name="demo"/>
+                <field name="abc"/>
+            </list>`,
+        loadActionMenus: true,
+    });
+
+    await openExportDialog();
+    expect(".modal .o_export_field:first-child").toHaveText("Demo", {
+        message: "Field demo should appear first in the export list",
+    });
+    expect(".modal .o_export_field:nth-child(2)").toHaveText("Abc", {
+        message: "Field abc should appear second in the export list",
+    });
+});


### PR DESCRIPTION
Before this commit:
- when users select records for export, fields are listed in alphabetical order by default.

After this commit:
- fields are now displayed based on their display order during export.

task-4354280

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
