### PR TITLE
[IMP] project: project_ids visible by default in task stages

### DIFF
--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -64,7 +64,7 @@
                     <field name="sequence" widget="handle" optional="show"/>
                     <field name="name" placeholder="e.g. To Do"/>
                     <field name="mail_template_id" optional="hide"/>
-                    <field name="project_ids" required="1" optional="hide" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    <field name="project_ids" required="1" optional="show" widget="many2many_tags" options="{'color_field': 'color'}"/>
                     <field name="fold" optional="show"/>
                 </list>
             </field>


### PR DESCRIPTION
Changed the visibility of the project_ids to be visible by default in the task stage list view.

Task: 4273764