### PR TITLE
[REV] l10n_cl: create EDI document for credit note (code 61)

### DIFF
--- a/addons/l10n_cl/models/l10n_latam_document_type.py
+++ b/addons/l10n_cl/models/l10n_latam_document_type.py
@@ -35,7 +35,7 @@ class L10nLatamDocumentType(models.Model):
         return document_number.zfill(6)
 
     def _is_doc_type_vendor(self):
-        return self.country_id.code == 'CL' and self.code in ('46', '61')
+        return self.code == '46'
 
     def _is_doc_type_export(self):
         return self.code in ['110', '111', '112'] and self.country_id.code == 'CL'


### PR DESCRIPTION
This reverts commit ff3702651a30fd7a6ee3007988df953dda911e41 
After which customer credit notes share the sequence with supplier credit notes.

Steps to reproduce:

- Open Vendor Bills journal and enable 'Use Documents?'
- Create a Bill with document type '(46) Factura de Compra Electrónica'
- Create the credit note
- In the Wizard: select 'Full Refund', Document Type 61, Confirm
- Document name will be 'N/C 000001'
- Now create an invoice with document type '(33) Factura Electrónica'
- Add a credit note for the invoice

Issue: Credit note name will be 'N/C 000002' but sequences should be unique for move type

opw-4268371
