### PR TITLE
[FIX] point_of_sale: correct sorting of orderlines by category

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
+++ b/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.OrderDisplay">
-        <t t-if="order.lines.length">
+        <t t-set="lines" t-value="order.getSortedOrderlines()"/>
+        <t t-if="lines.length">
             <div class="d-flex flex-column flex-grow-1 overflow-hidden">
                 <div t-ref="scrollable" class="order-container d-flex flex-column flex-grow-1 overflow-y-auto text-start">
-                    <t t-foreach="order.lines" t-as="line" t-key="line_index">
+                    <t t-foreach="lines" t-as="line" t-key="line_index">
                         <t t-if="props.slots.default" t-slot="default" line="line" />
                         <Orderline t-else="" line="line" mode="this.props.mode" />
                     </t>

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -379,15 +379,7 @@ registry.category("web_tour.tours").add("PosCategoriesOrder", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
-            {
-                trigger: '.category-button:eq(0) > span:contains("AAA")',
-            },
-            {
-                trigger: '.category-button:eq(1) > span:contains("AAB")',
-            },
-            {
-                trigger: '.category-button:eq(2) > span:contains("AAC")',
-            },
+            ProductScreen.verifyCategorySequence(["AAA", "AAB", "AAC"]),
             {
                 trigger: '.category-button:eq(1) > span:contains("AAB")',
                 run: "click",
@@ -455,5 +447,37 @@ registry.category("web_tour.tours").add("ProductSearchTour", {
             ProductScreen.searchProduct("TESTPROD2"),
             ProductScreen.productIsDisplayed("Test Product 1").map(negateStep),
             ProductScreen.productIsDisplayed("Test Product 2"),
+        ].flat(),
+});
+registry.category("web_tour.tours").add("SortOrderlinesByCategories", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            // Verify categories sequence
+            ProductScreen.verifyCategorySequence(["Misc test", "Chair test"]),
+
+            // Add products category wise
+            ProductScreen.selectCategoryAndAddProduct("Misc test", "Product_1 Category sequence 1"),
+            ProductScreen.selectCategoryAndAddProduct(
+                "Chair test",
+                "Product_11 Category sequence 2"
+            ),
+            ProductScreen.selectCategoryAndAddProduct("Misc test", "Product_2 Category sequence 1"),
+            ProductScreen.selectCategoryAndAddProduct(
+                "Chair test",
+                "Product_22 Category sequence 2"
+            ),
+
+            ProductScreen.clickReview(),
+
+            // Verify orderlines sequence
+            ProductScreen.verifyOrderlineSequence([
+                "Product_1 Category sequence 1",
+                "Product_2 Category sequence 1",
+                "Product_11 Category sequence 2",
+                "Product_22 Category sequence 2",
+            ]),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -659,3 +659,29 @@ export function checkTotalAmount(amount) {
         trigger: `.order-summary .total:contains(${amount})`,
     };
 }
+
+export function selectCategoryAndAddProduct(categoryName, productName) {
+    return [
+        {
+            trigger: `.category-button > span:contains(${categoryName})`,
+            run: "click",
+        },
+        ...addOrderline(productName, "1"),
+    ];
+}
+
+export function verifyCategorySequence(categories) {
+    return categories.map((category, index) => ({
+        content: `Verify '${category}' category has sequence number ${index + 1}`,
+        trigger: `.category-button > span:contains("${category}")`,
+    }));
+}
+
+export function verifyOrderlineSequence(products) {
+    return products.map((productName, index) => ({
+        content: `Verify orderline for '${productName}' is at seq ${index + 1}`,
+        trigger: `.order-container .orderline:nth-child(${
+            index + 1
+        }) span:contains("${productName}")`,
+    }));
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1607,6 +1607,46 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ProductSearchTour', login="pos_user")
 
+    def test_sort_orderlines_by_product_categoryies(self):
+        """ Test to ensure orderlines are added to the cart in the correct order based on their categories"""
+        self.pos_desk_misc_test.write({'sequence': 0})
+        self.pos_cat_chair_test.write({'sequence': 1})
+
+        self.product_1_categ_seq_1 = self.env['product.template'].create({
+            'name': 'Product_1 Category sequence 1',
+            'available_in_pos': True,
+            'list_price': 1.00,
+            'taxes_id': False,
+            'pos_categ_ids': [(4, self.pos_desk_misc_test.id)],
+        })
+        self.product_2_categ_seq_1 = self.env['product.template'].create({
+            'name': 'Product_2 Category sequence 1',
+            'available_in_pos': True,
+            'list_price': 2.00,
+            'taxes_id': False,
+            'pos_categ_ids': [(4, self.pos_desk_misc_test.id)],
+        })
+        self.product_11_categ_seq_2 = self.env['product.template'].create({
+            'name': 'Product_11 Category sequence 2',
+            'available_in_pos': True,
+            'list_price': 3.00,
+            'taxes_id': False,
+            'pos_categ_ids': [(4, self.pos_cat_chair_test.id)],
+        })
+        self.product_22_categ_seq_2 = self.env['product.template'].create({
+            'name': 'Product_22 Category sequence 2',
+            'available_in_pos': True,
+            'list_price': 4.00,
+            'taxes_id': False,
+            'pos_categ_ids': [(4, self.pos_cat_chair_test.id)],
+        })
+
+        self.main_pos_config.write({
+            'orderlines_sequence_in_cart_by_category': True,
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'SortOrderlinesByCategories', login="pos_user")
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Before this commit:
====================
The "sort by category" functionality in POS was not working as intended. Orderlines were not being sorted by their assigned categories, failing to meet the expected behaviour.

After this commit:
===================
The "sort by category" functionality now works as expected, properly sorting orderlines based on their categories in the POS interface.

Task-4440339

