### PR TITLE
[FIX] *: some field inside group not taking all space

### DIFF
--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -247,7 +247,7 @@
                                 <group name="contract_details" col="2"/>
                                 <group name="contract_details_2"/>
                                 <group name="notes_group" string="Notes">
-                                    <field name="notes" nolabel="1" placeholder="Type in notes about this contract..."/>
+                                    <field name="notes" nolabel="1" colspan="2" placeholder="Type in notes about this contract..."/>
                                 </group>
                             </page>
                         </notebook>

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -71,7 +71,7 @@
                 <group name="purchase" position="inside">
                     <group col="1">
                         <group string="Purchase Description">
-                           <field name="description_purchase" nolabel="1"
+                           <field name="description_purchase" nolabel="1" colspan="2"
                                 placeholder="This note is added to purchase orders."/>
                         </group>
                         <group string="Warning when Purchasing this Product" groups="purchase.group_warning_purchase">

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -151,13 +151,13 @@
                 <page name="inventory" position="inside">
                     <group>
                         <group string="Description for Receipts">
-                            <field name="description_pickingin" nolabel="1" placeholder="This note is added to receipt orders (e.g. where to store the product in the warehouse)."/>
+                            <field name="description_pickingin" nolabel="1" colspan="2" placeholder="This note is added to receipt orders (e.g. where to store the product in the warehouse)."/>
                         </group>
                         <group string="Description for Delivery Orders">
-                            <field name="description_pickingout" nolabel="1" placeholder="This note is added to delivery orders."/>
+                            <field name="description_pickingout" nolabel="1" colspan="2" placeholder="This note is added to delivery orders."/>
                         </group>
                         <group string="Description for Internal Transfers" groups="stock.group_stock_multi_locations">
-                            <field name="description_picking" nolabel="1" placeholder="This note is added to internal transfer orders (e.g. where to pick the product in the warehouse)."/>
+                            <field name="description_picking" nolabel="1" colspan="2" placeholder="This note is added to internal transfer orders (e.g. where to pick the product in the warehouse)."/>
                         </group>
                     </group>
                 </page>

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -94,7 +94,7 @@
                             </group>
                             <group>
                                 <group string="Dependencies">
-                                    <field name="dependencies_id" nolabel="1">
+                                    <field name="dependencies_id" nolabel="1" colspan="2">
                                         <list string="Dependencies">
                                             <field name="name"/>
                                             <field name="state"/>
@@ -102,7 +102,7 @@
                                     </field>
                                 </group>
                                 <group string="Exclusions">
-                                    <field name="exclusion_ids" nolabel="1">
+                                    <field name="exclusion_ids" nolabel="1" colspan="2">
                                         <list string="Exclusions">
                                             <field name="name"/>
                                             <field name="state"/>


### PR DESCRIPTION
This commit fixes some ARCH to fixes some visual issue.

Inside a group (grid) there will be always two columns:
* one smaller on the left (max 150px)
* one taking all the remaining space on the right.

When we add only one element with `nolabel="1"` it will take one part of the grid to take all the space we need to specify it with `colspan="2"`.

task-4416643

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
