### PR TITLE
[IMP] account_peppol: notify users about incoming Peppol invoices

### DIFF
--- a/addons/account_peppol/data/cron.xml
+++ b/addons/account_peppol/data/cron.xml
@@ -26,4 +26,14 @@
         <field name="code">model._cron_peppol_get_participant_status()</field>
         <field name="state">code</field>
     </record>
+
+    <record id="ir_cron_notify_incoming_peppol_invoices" model="ir.cron">
+        <field name="name">PEPPOL: Notify incoming invoices</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="model_id" ref="model_account_edi_proxy_client_user"/>
+        <field name="code">model._cron_notify_incoming_peppol_invoices()</field>
+        <field name="state">code</field>
+        <field name="active">True</field>
+    </record>
 </odoo>

--- a/addons/account_peppol/data/mail_templates_email_layouts.xml
+++ b/addons/account_peppol/data/mail_templates_email_layouts.xml
@@ -28,5 +28,23 @@
                 </div>
             </xpath>
         </template>
+        <record id="mail_notification_peppol_incoming_invoices" model="mail.template">
+            <field name="name">Peppol Invoice Notification</field>
+            <field name="email_to">{{ object.company_id.account_peppol_contact_email }}</field>
+            <field name="use_default_to" eval="False"/>
+            <field name="subject">You Have New Peppol Invoices</field>
+            <field name="model_id" ref="model_account_edi_proxy_client_user"/>
+            <field name="body_html" type="html">
+<div style="margin: 0px; padding: 0px;">
+    <p>Dear User,</p>
+    <p>You have received new invoices via Peppol today:</p>
+    <p>Total invoice(s) received: <t t-out="ctx['invoice_count']"/></p>
+    <p>Please review them at your earliest convenience.</p>
+    <p>Best regards,</p>
+    <br/>
+    <t t-out="object.company_id.name"/>
+</div>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -22,6 +22,11 @@ class AccountMove(models.Model):
         string='PEPPOL status',
         copy=False,
     )
+    peppol_notify_pending = fields.Boolean(
+        string="Notify User About Peppol Invoice",
+        default=False,
+        help="Indicates whether this invoice requires user notification about its receipt via Peppol",
+    )
 
     def action_cancel_peppol_documents(self):
         # if the peppol_move_state is processing/done


### PR DESCRIPTION
Now users get a daily email if there are new vendor bills received via Peppol. Invoices are flagged when they come in, and a cron job sends a summary once a day. This helps users stay on top of incoming invoices without having to check manually.

task-4341360