### PR TITLE
[IMP] mail: adding role to mail template layout header

### DIFF
--- a/addons/mail/data/mail_templates_email_layouts.xml
+++ b/addons/mail/data/mail_templates_email_layouts.xml
@@ -104,7 +104,7 @@
 <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 24px; background-color: white; color: #454748; border-collapse:separate;">
 <tbody>
     <!-- HEADER -->
-    <tr>
+    <tr role="header">
         <td align="center" style="min-width: 590px;">
             <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: white; padding: 0; border-collapse:separate;">
                 <tr><td valign="middle">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Difficulties to target the header of the mail template when overriding 
Current behavior before PR:
No role attribute was present in the header
Desired behavior after PR is merged:
A role attribute with the value "header" is present in the header row of the the mail template table



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

task-id: 4423436
