### PR TITLE
[FIX] l10n_latam_base: make Identification Number required for partners

### DIFF
--- a/addons/l10n_latam_base/views/res_partner_view.xml
+++ b/addons/l10n_latam_base/views/res_partner_view.xml
@@ -13,7 +13,7 @@
             <xpath expr="//field[@name='vat']" position="replace">
                 <field name="l10n_latam_identification_type_id" options="{'no_open': True, 'no_create': True}" placeholder="Type" class="oe_inline" domain="country_id and ['|', ('country_id', '=', False), ('country_id', '=', country_id)] or []" required="True" readonly="parent_id"/>
                 <span class="oe_read_only"> - </span>
-                <field name="vat" placeholder="Number" class="oe_inline" readonly="parent_id"/>
+                <field name="vat" placeholder="Number" class="oe_inline" readonly="parent_id" required="l10n_latam_identification_type_id"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
[FIX] l10n_latam_base: make Identification Number required for partners

Following a discussion with the product owner, it was clarified that in Colombia, 
it is mandatory for customers to provide both an Identification Type and an Identification Number (VAT). 
These details are essential for electronic invoicing, as all sales require them to proceed.

Previously, only the Identification Type was required, allowing the Identification Number to be left empty. 
This caused issues during checkout or invoicing, as the server detected the missing Identification Number 
and redirected users back to the address form. However, since the Identification Type and Number were already 
set (with an empty number), the fields did not appear in the form, leading to confusion and failed transactions.

This fix ensures the Identification Number is required whenever the Type is set, preventing these errors and 
ensuring compliance with invoicing regulations.

opw-4309448


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
