### PR TITLE
[FIX] mail: do not store env on Discuss JS Model classes

### DIFF
--- a/addons/mail/static/src/model/make_store.js
+++ b/addons/mail/static/src/model/make_store.js
@@ -11,7 +11,6 @@ export function makeStore(env, { localRegistry } = {}) {
     const recordByLocalId = reactive(new Map());
     // fake store for now, until it becomes a model
     /** @type {import("models").Store} */
-    Store.env = env;
     let store = new Store();
     store.env = env;
     store.Model = Store;
@@ -144,7 +143,6 @@ export function makeStore(env, { localRegistry } = {}) {
         Model._ = markRaw(new ModelInternal());
         Object.assign(Model, {
             Class,
-            env,
             records: reactive({}),
         });
         Models[Model.getName()] = Model;


### PR DESCRIPTION
They were added on Model classes to make them easily available in case business code was putting static method code in the models, and accessing the env is very handy e.g. to invoke service calls.

This approach was dismissed, because static methods do not work well with the relational approach. However, the storing of env in models has been mistakenly kept, which makes debugging memleak harder because Models keeping env means they keep services in memory.

This commit removes the unused env stored on JS model classes.
