### PR TITLE
[FIX] point_of_sale: don't translate /pos/ticket

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
@@ -21,4 +21,7 @@ export class OrderReceipt extends Component {
     doesAnyOrderlineHaveTaxLabel() {
         return this.props.data.orderlines.some((line) => line.taxGroupLabels);
     }
+    getPortalURL() {
+        return `${this.props.data.base_url}/pos/ticket`;
+    }
 }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -95,7 +95,7 @@
 
             <div t-if="['url', 'qr_code_and_url'].includes(props.data.headerData.company.point_of_sale_ticket_portal_url_display_mode) and props.data.pos_qr_code">
                 <div class="pos-receipt-order-data" t-attf-class="{{ props.data.ticket_portal_url_display_mode === 'qr_code_and_url' ? 'mt-3' : '' }}">
-                    Portal URL: <t t-out="props.data.base_url"/>/pos/ticket
+                    Portal URL: <t t-esc="getPortalURL()"/>
                 </div>
             </div>
 


### PR DESCRIPTION
In the template, /pos/ticket is concatenated to the base_url. But because /pos/ticket is a normal string inside the template, it is translated.

ticket-4447566

