### PR TITLE
[FIX] mail: trash icon on attachments

### DIFF
--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -34,6 +34,9 @@ export class Attachment extends FileModelMixin(Record) {
     create_date = Record.attr(undefined, { type: "datetime" });
 
     get isDeletable() {
+        if (this.message && !this.store.self.isInternalUser) {
+            return this.message.editable;
+        }
         return true;
     }
 


### PR DESCRIPTION
Portal users don't have access to delete attachments created by others. In this case, the trash icon shouldn't be displayed. This PR removes this icon from the attachment of a message when the message is not editable by the current user.

