### PR TITLE
[IMP] base: remove address from name for partner in mobile view in kanban card

### DIFF
--- a/addons/base_setup/views/res_partner_views.xml
+++ b/addons/base_setup/views/res_partner_views.xml
@@ -6,7 +6,7 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.res_partner_kanban_view"/>
             <field name="arch" type="xml">
-                <xpath expr="//main//field[@name='display_name']" position="after">
+                <xpath expr="//main//field[@name='complete_name']" position="after">
                     <field name="category_id" widget="many2many_tags" options="{'color_field': 'color'}" class="m-0"/>
                 </xpath>
             </field>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -365,7 +365,7 @@
                             </aside>
                             <main class="ps-2 ps-md-0">
                                 <div class="mb-1">
-                                    <field name="display_name" class="mb-0 fw-bold fs-5"/>
+                                    <field name="complete_name" class="mb-0 fw-bold fs-5"/>
                                     <field t-if="record.parent_id.raw_value and !record.function.raw_value" class="text-muted" name="parent_id"/>
                                     <field t-elif="!record.parent_id.raw_value and record.function.raw_value" class="text-muted" name="function"/>
                                     <div t-elif="record.parent_id.raw_value and record.function.raw_value" class="text-muted">


### PR DESCRIPTION
 Before this commit:
  - The `show_address` context was initially used to display the partner's address along with their  name in the desired form view.

  - However, when clicking "Search More" for partners, the same context was passed,affecting the kanban view of `res.partner`. This resulted in kanban cards on mobile devices showing the name combined with the address, leading to a cluttered appearance.

In this commit, we used the complete_name field instead of display_name, so only the company name and customer are displayed.

task-4385096
