### PR TITLE
[IMP] html_editor: add 'Clear Content' option to table menu

### DIFF
--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -14,6 +14,8 @@ export class TableMenu extends Component {
         addRow: Function,
         removeRow: Function,
         resetTableSize: Function,
+        clearColumnContent: Function,
+        clearRowContent: Function,
         overlay: Object,
         dropdownState: Object,
         target: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
@@ -85,6 +87,12 @@ export class TableMenu extends Component {
                 text: _t("Reset Size"),
                 action: (target) => this.props.resetTableSize(target.closest("table")),
             },
+            {
+                name: "clear_content",
+                icon: "fa-times-circle",
+                text: _t("Clear content"),
+                action: this.props.clearColumnContent.bind(this),
+            },
         ].filter(Boolean);
     }
 
@@ -125,6 +133,12 @@ export class TableMenu extends Component {
                 icon: "fa-table",
                 text: _t("Reset Size"),
                 action: (target) => this.props.resetTableSize(target.closest("table")),
+            },
+            {
+                name: "clear_content",
+                icon: "fa-times-circle",
+                text: _t("Clear content"),
+                action: (target) => this.props.clearRowContent(target.parentElement),
             },
         ].filter(Boolean);
     }

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -46,6 +46,8 @@ function isUnremovableTableComponent(node, root) {
  * @property { TablePlugin['removeColumn'] } removeColumn
  * @property { TablePlugin['removeRow'] } removeRow
  * @property { TablePlugin['resetTableSize'] } resetTableSize
+ * @property { TablePlugin['clearColumnContent'] } clearColumnContent
+ * @property { TablePlugin['clearRowContent'] } clearRowContent
  */
 
 /**
@@ -64,6 +66,8 @@ export class TablePlugin extends Plugin {
         "moveColumn",
         "moveRow",
         "resetTableSize",
+        "clearColumnContent",
+        "clearRowContent",
     ];
     resources = {
         user_commands: [
@@ -341,6 +345,23 @@ export class TablePlugin extends Plugin {
                 cStyle.width = "";
             }
         });
+    }
+    /**
+     * @param {HTMLTableCellElement} cell
+     */
+    clearColumnContent(cell) {
+        const table = closestElement(cell, "table");
+        const cells = [...closestElement(cell, "tr").querySelectorAll("th, td")];
+        const index = cells.findIndex((td) => td === cell);
+        table
+            .querySelectorAll(`tr td:nth-of-type(${index + 1})`)
+            .forEach((td) => (td.innerHTML = "<p><br></p>"));
+    }
+    /**
+     * @param {HTMLTableRowElement} row
+     */
+    clearRowContent(row) {
+        row.querySelectorAll("td").forEach((td) => (td.innerHTML = "<p><br></p>"));
     }
     deleteTable(table) {
         table =

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -142,12 +142,12 @@ export class TableUIPlugin extends Plugin {
         if (!td) {
             return;
         }
-        const withAddStep = (fn) => {
-            return (...args) => {
+        const withAddStep =
+            (fn) =>
+            (...args) => {
                 fn(...args);
                 this.dependencies.history.addStep();
             };
-        };
         const tableMethods = {
             moveColumn: withAddStep(this.dependencies.table.moveColumn),
             addColumn: withAddStep(this.dependencies.table.addColumn),
@@ -156,6 +156,8 @@ export class TableUIPlugin extends Plugin {
             addRow: withAddStep(this.dependencies.table.addRow),
             removeRow: withAddStep(this.dependencies.table.removeRow),
             resetTableSize: withAddStep(this.dependencies.table.resetTableSize),
+            clearColumnContent: withAddStep(this.dependencies.table.clearColumnContent),
+            clearRowContent: withAddStep(this.dependencies.table.clearRowContent),
         };
         if (td.cellIndex === 0) {
             this.rowMenu.open({

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -141,6 +141,7 @@ test("list of table commands in first column", async () => {
         "insert_left",
         "insert_right",
         "delete",
+        "clear_content",
     ]);
 });
 
@@ -165,6 +166,7 @@ test("list of table commands in second column", async () => {
         "insert_left",
         "insert_right",
         "delete",
+        "clear_content",
     ]);
 });
 
@@ -189,6 +191,7 @@ test("list of table commands in last column", async () => {
         "insert_left",
         "insert_right",
         "delete",
+        "clear_content",
     ]);
 });
 
@@ -220,6 +223,7 @@ test("list of table commands in first row", async () => {
         "insert_above",
         "insert_below",
         "delete",
+        "clear_content",
     ]);
 });
 
@@ -246,6 +250,7 @@ test("list of table commands in second row", async () => {
         "insert_above",
         "insert_below",
         "delete",
+        "clear_content",
     ]);
 });
 
@@ -272,6 +277,7 @@ test("list of table commands in last row", async () => {
         "insert_above",
         "insert_below",
         "delete",
+        "clear_content",
     ]);
 });
 
@@ -352,6 +358,51 @@ test("basic delete column operation", async () => {
     );
 });
 
+test("basic clear column content operation", async () => {
+    const { el, editor } = await setupEditor(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a"><p>1[]</p></td><td class="b"><p>2</p></td></tr>
+                <tr><td class="c"><p>3</p></td><td class="d"><h1>4</h1></td></tr>
+            </tbody>
+        </table>`)
+    );
+    expect(".o-we-table-menu").toHaveCount(0);
+
+    // hover on td to show col ui
+    await hover(el.querySelector("td.b"));
+    await waitFor(".o-we-table-menu");
+
+    // click on it to open dropdown
+    await click(".o-we-table-menu");
+    await waitFor("div[name='clear_content']");
+
+    // clear content of the column
+    await click("div[name='clear_content']");
+    // not sure about selection...
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a"><p>1[]</p></td><td class="b"><p><br></p></td></tr>
+                <tr><td class="c"><p>3</p></td><td class="d"><p><br></p></td></tr>
+            </tbody>
+        </table>`)
+    );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a"><p>1[]</p></td><td class="b"><p>2</p></td></tr>
+                <tr><td class="c"><p>3</p></td><td class="d"><h1>4</h1></td></tr>
+            </tbody>
+        </table>`)
+    );
+});
+
 test("basic delete row operation", async () => {
     const { el, editor } = await setupEditor(
         unformat(`
@@ -391,6 +442,51 @@ test("basic delete row operation", async () => {
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
+});
+
+test("basic clear row content operation", async () => {
+    const { el, editor } = await setupEditor(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a"><p>1[]</p></td><td class="b"><p>2</p></td></tr>
+                <tr><td class="c"><p>3</p></td><td class="d"><h2>4</h2></td></tr>
+            </tbody>
+        </table>`)
+    );
+    expect(".o-we-table-menu").toHaveCount(0);
+
+    // hover on td to show col ui
+    await hover(el.querySelector("td.c"));
+    await waitFor(".o-we-table-menu");
+
+    // click on it to open dropdown
+    await click(".o-we-table-menu");
+    await waitFor("div[name='clear_content']");
+
+    // clear content of the row
+    await click("div[name='clear_content']");
+    // not sure about selection...
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a"><p>1[]</p></td><td class="b"><p>2</p></td></tr>
+                <tr><td class="c"><p><br></p></td><td class="d"><p><br></p></td></tr>
+            </tbody>
+        </table>`)
+    );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a"><p>1[]</p></td><td class="b"><p>2</p></td></tr>
+                <tr><td class="c"><p>3</p></td><td class="d"><h2>4</h2></td></tr>
             </tbody>
         </table>`)
     );


### PR DESCRIPTION
Description of the feature this PR addresses:

Introduce a 'Clear Content' option in the table UI, enabling users to clear the content of a specific row or column.

task-4442525

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
