### PR TITLE
[FIX] point_of_sale: allow customization of product image

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -155,9 +155,24 @@ class PosSession(models.Model):
         data[0]['_has_cash_move_perm'] = self.env.user.has_group('account.group_account_invoice')
         data[0]['_has_available_products'] = self._pos_has_valid_product()
         data[0]['_pos_special_products_ids'] = self.env['pos.config']._get_special_products().ids
+        data[0]['_pos_product_view_setting'] = self._get_pos_product_view_setting()
         return {
             'data': data,
             'fields': fields
+        }
+    
+    @api.model
+    def save_product_view_setting(self, setting):
+        IrConfigParameter = self.env['ir.config_parameter'].sudo()
+        for key, value in setting.items():
+            IrConfigParameter.set_param(f'point_of_sale.{key}', value)
+
+    def _get_pos_product_view_setting(self):
+        IrConfigParameter = self.env['ir.config_parameter'].sudo()
+        settings = ['product_cover_mode', 'product_high_resolution']
+        return {
+            setting: IrConfigParameter.get_param(f'point_of_sale.{setting}', default=False)
+            for setting in settings
         }
 
     def load_data(self, models_to_load, only_data=False):

--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.js
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.js
@@ -14,11 +14,13 @@ export class ProductCard extends Component {
         onClick: { type: Function, optional: true },
         onProductInfoClick: { type: Function, optional: true },
         showWarning: { type: Boolean, optional: true },
+        imageFitMode: { type: String, optional: true },
     };
     static defaultProps = {
         onClick: () => {},
         onProductInfoClick: () => {},
         class: "",
         showWarning: false,
+        imageFitMode: "contain",
     };
 }

--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
@@ -4,7 +4,14 @@
 
 .product-img img {
     height: 100px;
+}
+
+.object-contain img {
     object-fit: contain;
+}
+
+.object-cover img {
+    object-fit: cover;
 }
 
 .pos-receipt {

--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -11,7 +11,7 @@
             <div t-if="props.productInfo" class="product-information-tag" t-on-click.stop="props.onProductInfoClick" t-att-class="{'red-tag' : props.showWarning}">
                 <i class="product-information-tag-logo fa fa-info" role="img" aria-label="Product Information" title="Product Information" />
             </div>
-            <div t-if="props.imageUrl" class="product-img">
+            <div t-if="props.imageUrl" t-attf-class="{{props.imageFitMode === 'contain' ? 'object-contain' : 'object-cover'}} product-img">
                 <img class="w-100" t-att-src="props.imageUrl" t-att-alt="props.name" />
             </div>
             <div class="product-content d-flex flex-column justify-content-between h-100 mx-2 py-1">

--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -185,18 +185,20 @@ export class ProductProduct extends Base {
         const rules = !pricelist ? [] : this.cachedPricelistRules[pricelist?.id] || [];
         return rules.find((rule) => !rule.min_quantity || quantity >= rule.min_quantity);
     }
-    getImageUrl() {
+    getImageUrl(high_resolution = false) {
+        const imageField = high_resolution ? "image_256" : "image_128";
         return (
             (this.image_128 &&
-                `/web/image?model=product.product&field=image_128&id=${this.id}&unique=${this.write_date}`) ||
+                `/web/image?model=product.product&field=${imageField}&id=${this.id}&unique=${this.write_date}`) ||
             ""
         );
     }
 
-    getTemplateImageUrl() {
+    getTemplateImageUrl(high_resolution = false) {
+        const imageField = high_resolution ? "image_256" : "image_128";
         return (
             (this.image_128 &&
-                `/web/image?model=product.template&field=image_128&id=${this.raw.product_tmpl_id}&unique=${this.write_date}`) ||
+                `/web/image?model=product.template&field=${imageField}&id=${this.raw.product_tmpl_id}&unique=${this.write_date}`) ||
             ""
         );
     }

--- a/addons/point_of_sale/static/src/app/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.xml
@@ -53,6 +53,14 @@
                         <DropdownItem t-if="this.env.debug" onSelected="() => debug.toggleWidget()">
                             Debug Window
                         </DropdownItem>
+                        <DropdownItem t-if="this.env.debug" onSelected="() => pos.toggleProductCoverMode()">
+                            <t t-if="pos.productCoverMode">Fit Image Inside</t>
+                            <t t-else="">Fill Image to Edges</t>
+                        </DropdownItem>
+                        <DropdownItem t-if="this.env.debug" onSelected="() => pos.toggleProductHighResolution()">
+                            <t t-if="pos.productHighResolution">Show Low Resolution Images</t>
+                            <t t-else="">Show High Resolution Images</t>
+                        </DropdownItem>
                     </t>
                 </Dropdown>
             </div>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -297,7 +297,7 @@ export class ProductScreen extends Component {
     }
 
     getProductImage(product) {
-        return product.getTemplateImageUrl();
+        return product.getTemplateImageUrl(this.pos.productHighResolution);
     }
 
     get searchWord() {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -34,7 +34,8 @@
                             imageUrl="pos.config.show_product_images and this.getProductImage(product)"
                             onClick.bind="() => this.addProductToOrder(product)"
                             productInfo="true"
-                            onProductInfoClick.bind="() => this.onProductInfoClick(product)" />
+                            onProductInfoClick.bind="() => this.onProductInfoClick(product)"
+                            imageFitMode="pos.productCoverMode ? 'cover' : 'contain'" />
                     </div>
                     <div t-else="" class="flex-grow-1 text-center mt-5">
                         <p t-if="searchWord">No products found for <b>"<t t-esc="searchWord"/>"</b> in this category.</p>

--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.js
@@ -132,4 +132,8 @@ export class ComboConfiguratorPopup extends Component {
         this.props.getPayload(this.getSelectedComboLines());
         this.props.close();
     }
+
+    get showHighResolutionImages() {
+        return this.pos.showHighResolutionImages;
+    }
 }

--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
@@ -23,7 +23,7 @@
                                     productId="product.id"
                                     product="product"
                                     price="formattedComboPrice(combo_line)"
-                                    imageUrl="product.getImageUrl()"
+                                    imageUrl="product.getImageUrl(showHighResolutionImages)"
                                     onClick="(ev) => this.onClickProduct({ product, combo_line }, ev)" />
                             </label>
                         </div>

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -137,6 +137,7 @@ export class PosStore extends Reactive {
         }
         this.closeOtherTabs();
         this.showScreen(this.firstScreen);
+        this.productViewSetting = this.session._pos_product_view_setting;
     }
 
     get firstScreen() {
@@ -496,6 +497,24 @@ export class PosStore extends Reactive {
         } else {
             return "flex-row-reverse justify-content-between m-1";
         }
+    }
+    toggleProductCoverMode() {
+        this.productViewSetting.product_cover_mode = !this.productViewSetting.product_cover_mode;
+        this.saveProductViewSetting();
+    }
+    toggleProductHighResolution() {
+        this.productViewSetting.product_high_resolution =
+            !this.productViewSetting.product_high_resolution;
+        this.saveProductViewSetting();
+    }
+    saveProductViewSetting() {
+        this.data.call("pos.session", "save_product_view_setting", [this.productViewSetting]);
+    }
+    get productCoverMode() {
+        return this.productViewSetting.product_cover_mode;
+    }
+    get productHighResolution() {
+        return this.productViewSetting.product_high_resolution;
     }
     getProductPriceFormatted(product, p) {
         const formattedUnitPrice = this.env.utils.formatCurrency(this.getProductPrice(product, p));


### PR DESCRIPTION
Before this commit, it wasn't possible to load the image_256 for better resolution. Additionally, it wasn't possible to change the image fit setting.

opw-4381313

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
