### PR TITLE
[REF] hw_drivers: simplify printers detection/configuration

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface_L.py
@@ -18,56 +18,26 @@ class PrinterInterface(Interface):
     printer_devices = {}
 
     def get_devices(self):
-        discovered_devices = {}
         with cups_lock:
             printers = conn.getPrinters()
-            devices = conn.getDevices()
-            for printer_name, printer in printers.items():
-                path = printer.get('device-uri', False)
-                if printer_name != self.get_identifier(path):
-                    device_class = 'direct' if 'usb' in printer.get('device-uri') else 'network'
-                    printer.update({
-                        'supported': True,
-                        'device-class': device_class,
-                        'device-make-and-model': printer_name,  # give name set in Cups
-                        'device-id': '',
-                    })
-                    devices.update({printer_name: printer})
 
-        for path, device in devices.items():
-            identifier = self.get_identifier(path)
-            device.update({
-                'identifier': identifier,
-                'url': path,
-                'disconnect_counter': 0,
-            })
-            discovered_devices.update({identifier: device})
-        self.printer_devices.update(discovered_devices)
-        # Deal with devices which are on the list but were not found during this call of "get_devices"
-        # If they aren't detected 3 times consecutively, remove them from the list of available devices
-        for device in list(self.printer_devices):
-            if not discovered_devices.get(device):
-                disconnect_counter = self.printer_devices.get(device).get('disconnect_counter')
-                if disconnect_counter >= 2:
-                    self.printer_devices.pop(device, None)
-                else:
-                    self.printer_devices[device].update({'disconnect_counter': disconnect_counter + 1})
-        return dict(self.printer_devices)
+        discovered_printers = {
+            printer_name: {
+                'identifier': printer_name,
+                'name': printer_info['printer-info'],
+                'connection_type': 'direct' if 'usb' in printer_info['device-uri'] else 'network',
+                'url': printer_info['device-uri'],
+                'disconnect_counter': self.printer_devices.get(printer_name, {}).get('disconnect_counter', 0),
+                'protocol': printer_info.get('device-id', ''),
+            }
+            for printer_name, printer_info in printers.items()
+            if printer_info['printer-info'] != 'unknown'
+        }
 
-    def get_identifier(self, path):
-        """
-        Necessary because the path is not always a valid Cups identifier,
-        as it may contain characters typically found in URLs or paths.
-
-          - Removes characters: ':', '/', '.', '\', and space.
-          - Removes the exact strings: "uuid=" and "serial=".
-
-        Example 1:
-            Input: "ipp://printers/printer1:1234/abcd"
-            Output: "ippprintersprinter11234abcd"
-
-        Example 2:
-            Input: "uuid=1234-5678-90ab-cdef"
-            Output: "1234-5678-90ab-cdef
-        """
-        return sub(r'[:\/\.\\ ]|(uuid=)|(serial=)', '', path)
+        # If old devices are not detected 3 times consecutively, they are made unavailable
+        self.printer_devices.update(discovered_printers)
+        return {
+            name: printer
+            for name, printer in self.printer_devices.items()
+            if name in discovered_printers or printer['disconnect_counter'] < 3
+        }


### PR DESCRIPTION
We used to detect printers mixing cups detected "printers" and "devices". As `getDevices` is deprecated and the code is hard to maintain, this commit aims to simplify both interface and driver.
