### PR TITLE
[FIX] web: prevent crash with empty calendar color attribute

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -659,7 +659,8 @@ export class CalendarModel extends Model {
         const { colorFieldName } = filterInfo;
         const shouldFetchColor =
             colorFieldName &&
-            `${fieldName}.${colorFieldName}` !== fields[fieldMapping.color].related;
+            (!fieldMapping.color ||
+                `${fieldName}.${colorFieldName}` !== fields[fieldMapping.color].related);
         let rawColors = [];
         if (shouldFetchColor) {
             const relatedIds = rawFilters.map(({ id }) => id);

--- a/addons/web/static/tests/views/calendar/calendar_view_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_view_tests.js
@@ -3225,6 +3225,69 @@ QUnit.module("Views", ({ beforeEach }) => {
         assert.hasClass(findFilterPanelFilter(target, "event_type_id", 3), "o_cw_filter_color_4");
     });
 
+    QUnit.test(`Colors: dynamic filters with no color source`, async (assert) => {
+        serverData.models.event.records = [
+            {
+                id: 8,
+                user_id: 4,
+                partner_id: 3,
+                name: "event 8",
+                start: "2016-12-11 09:00:00",
+                stop: "2016-12-11 10:00:00",
+                allday: false,
+                partner_ids: [1, 2, 3],
+                event_type_id: 3,
+                color_event: 4, // related is not managed by the mock server
+            },
+            {
+                id: 9,
+                user_id: 4,
+                partner_id: 3,
+                name: "event 9",
+                start: "2016-12-11 19:00:00",
+                stop: "2016-12-11 20:00:00",
+                allday: false,
+                partner_ids: [1, 2, 3],
+                event_type_id: 1,
+                color_event: 1, // related is not managed by the mock server
+            },
+            {
+                id: 10,
+                user_id: 4,
+                partner_id: 3,
+                name: "event 10",
+                start: "2016-12-11 12:00:00",
+                stop: "2016-12-11 13:00:00",
+                allday: false,
+                partner_ids: [1, 2, 3],
+                event_type_id: 2,
+                color_event: 2, // related is not managed by the mock server
+            },
+        ];
+        await makeView({
+            type: "calendar",
+            resModel: "event",
+            serverData,
+            arch: `
+                <calendar date_start="start" date_stop="stop">
+                    <field name="partner_ids" write_model="filter_partner" write_field="partner_id" />
+                    <field name="event_type_id" filters="1" color="color_event_type" />
+                </calendar>
+            `,
+            mockRPC(route, { method, model }) {
+                if (method === "search_read" && model === "event_type") {
+                    assert.step("fetching event_type filter colors");
+                }
+            },
+        });
+        assert.verifySteps([]);
+        await toggleSectionFilter(target, "partner_ids");
+        assert.verifySteps(["fetching event_type filter colors"]);
+        assert.hasClass(findFilterPanelFilter(target, "event_type_id", 1), "o_cw_filter_color_1");
+        assert.hasClass(findFilterPanelFilter(target, "event_type_id", 2), "o_cw_filter_color_2");
+        assert.hasClass(findFilterPanelFilter(target, "event_type_id", 3), "o_cw_filter_color_4");
+    });
+
     QUnit.test(`create event with filters`, async (assert) => {
         serverData.models.event.fields.user_id.default = 5;
         serverData.models.event.fields.partner_id.default = 3;


### PR DESCRIPTION
Steps to reproduce
==================

- Install industry_fsm,web_studio
- Go to Field Service
- Switch to the calendar view
- Open studio
- Unset the color

=> fields[fieldMapping.color] is undefined

Cause of the issue
==================

We have a field that has the color attribute with a value of color.

```xml
<field name="worksheet_template_id" attrs="{'invisible': [('worksheet_template_id', '=', False)]}" filters="1" color="color"/>
```

`shouldFetchColor` checks if the filter color is the same one as the calendar record color.

Solution
========

Since it's possible to have a color filter without a record color, we should fetch the filter colors in that case.

opw-4443497