### PR TITLE
[FIX] mail: can dismiss 'Turn on notifications' in messaging menu

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -10,6 +10,7 @@ import { debounce } from "@web/core/utils/timing";
 import { session } from "@web/session";
 import { _t } from "@web/core/l10n/translation";
 import { cleanTerm, prettifyMessageContent } from "@mail/utils/common/format";
+import { browser } from "@web/core/browser/browser";
 
 /**
  * @typedef {{isSpecial: boolean, channel_types: string[], label: string, displayName: string, description: string}} SpecialMention
@@ -148,6 +149,26 @@ export class Store extends BaseStore {
             init_messaging: {},
         };
     }
+
+    isNotificationPermissionDismissed = Record.attr(false, {
+        compute() {
+            return (
+                browser.localStorage.getItem("mail.user_setting.push_notification_dismissed") ===
+                "true"
+            );
+        },
+        /** @this {import("models").DiscussApp} */
+        onUpdate() {
+            if (this.isNotificationPermissionDismissed) {
+                browser.localStorage.setItem(
+                    "mail.user_setting.push_notification_dismissed",
+                    "true"
+                );
+            } else {
+                browser.localStorage.removeItem("mail.user_setting.push_notification_dismissed");
+            }
+        },
+    });
 
     messagePostMutex = new Mutex();
 
@@ -495,8 +516,14 @@ export class Store extends BaseStore {
      * Get the parameters to pass to the message post route.
      */
     async getMessagePostParams({ body, postData, thread }) {
-        const { attachments, cannedResponseIds, emailAddSignature, isNote, mentionedChannels, mentionedPartners } =
-            postData;
+        const {
+            attachments,
+            cannedResponseIds,
+            emailAddSignature,
+            isNote,
+            mentionedChannels,
+            mentionedPartners,
+        } = postData;
         const subtype = isNote ? "mail.mt_note" : "mail.mt_comment";
         const validMentions = this.getMentionsFromText(body, {
             mentionedChannels,

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -93,7 +93,10 @@ patch(MessagingMenu.prototype, {
             displayName: _t("Turn on notifications"),
             iconSrc: this.store.odoobot.avatarUrl,
             partner: this.store.odoobot,
-            isShown: this.store.discuss.activeTab === "main" && this.shouldAskPushPermission,
+            isShown:
+                this.store.discuss.activeTab === "main" &&
+                this.shouldAskPushPermission &&
+                !this.store.isNotificationPermissionDismissed,
         };
     },
     get tabs() {

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -76,6 +76,7 @@
                         <a t-if="ui.isSmall" class="btn fa fa-bell" />
                         <t t-else="">
                             <a class="btn btn-primary px-2 py-1 smaller">Enable</a>
+                            <span t-if="!hasTouch()" t-on-click.stop="() => this.store.isNotificationPermissionDismissed = true" class="text-dark bg-transparent oi oi-close opacity-50 opacity-100-hover" title="Dismiss"></span>
                         </t>
                     </t>
                 </NotificationItem>

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -98,6 +98,18 @@ test("rendering with chat push notification default permissions", async () => {
     await contains(".o-mail-NotificationItem", { text: "Turn on notifications" });
 });
 
+test("can quickly dismiss 'Turn on notification' suggestion", async () => {
+    patchBrowserNotification("default");
+    await start();
+    await contains(".o-mail-MessagingMenu-counter");
+    await contains(".o-mail-MessagingMenu-counter", { text: "1" });
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await contains(".o-mail-NotificationItem");
+    await contains(".o-mail-NotificationItem", { text: "Turn on notifications" });
+    await click(".o-mail-NotificationItem:contains(Turn on notifications) [title='Dismiss']");
+    await contains(".o-mail-NotificationItem", { text: "Turn on notifications", count: 0 });
+});
+
 test("rendering with chat push notification permissions denied", async () => {
     patchBrowserNotification("denied");
     await start();


### PR DESCRIPTION
This commit adds a "X" next to "Turn on notifications" to quickly dismiss the suggestion to enable push notifications.

Note that this keeps the push permission to "Ask", as it cannot be changed programmatically. So if the user wants to change the push permissions, it should be manually changed to "Allow" or "Denied" from browser settings or should clear the local storage content in order to display "Turn on notifications" in messaging menu again.

Task-4446924

Before
![Screenshot 2025-01-03 at 14 39 22](https://github.com/user-attachments/assets/154f86f7-fa74-4c1f-b4db-71d2c1693bee)

After
![Screenshot 2025-01-03 at 14 37 44](https://github.com/user-attachments/assets/93a51e2c-bc9e-4cc3-9f5b-d2ea538be1ef)
