### PR TITLE
[FIX] base: fix lang install

### DIFF
--- a/odoo/addons/base/data/res_lang_data.xml
+++ b/odoo/addons/base/data/res_lang_data.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <function name="install_lang" model="res.lang"/>
-    </data>
-    <data>
-        <!-- /my is for the portal -->
-        <record id="base.lang_my" model="res.lang">
-            <field name="url_code">mya</field>
-        </record>
-    </data>
-    <data noupdate="1">
         <!-- es_419 is the new "generic" spanish -->
         <record id="base.lang_es" model="res.lang">
             <field name="url_code">es_ES</field>
@@ -17,8 +8,13 @@
         <record id="base.lang_es_419" model="res.lang">
             <field name="url_code">es</field>
         </record>
+        <function name="install_lang" model="res.lang"/>
     </data>
     <data>
+        <!-- /my is for the portal -->
+        <record id="base.lang_my" model="res.lang">
+            <field name="url_code">mya</field>
+        </record>
         <record id="base.lang_ar" model="res.lang">
             <field name="flag_image" type="base64" file="base/static/img/lang_flags/lang_ar.png"/>
         </record>


### PR DESCRIPTION
**Steps to reproduce:**

1. Initialize a new database with `odoo -d langdb --stop -i base --load-language=es_AR`

**Result:**

```
2025-01-03 11:41:28,054 54 INFO langdb odoo.modules.loading: loading base/data/res_bank.xml
2025-01-03 11:41:28,057 54 INFO langdb odoo.modules.loading: loading base/data/res.lang.csv
2025-01-03 11:41:28,076 54 INFO langdb odoo.modules.loading: loading base/data/res_lang_data.xml
2025-01-03 11:41:28,091 54 ERROR langdb odoo.sql_db: bad query: b' UPDATE "res_lang"\n
    SET "url_code" = "__tmp"."url_code"::VARCHAR, "write_date" = "__tmp"."write_date"::timestamp, "write_uid" = "__tmp"."write_uid"::int4\n
    FROM (VALUES (68, \'es\', \'2025-01-03T11:41:26.517428\'::timestamp, 1)) AS "__tmp"("id", "url_code", "write_date", "write_uid")\n
    WHERE "res_lang"."id" = "__tmp"."id"\n'
ERROR: duplicate key value violates unique constraint "res_lang_url_code_uniq"
DETAIL:  Key (url_code)=(es) already exists.
```

**Explanation:**

When initializing a new database with a specific language, the language is activated on `install_lang`, and since it's the only active language of the "es_*" family, its url_code is set to the short version. [^1]

By the time the url_code switch in `res_lang_data.xml` is executed, the `base.lang_es` language is no longer the one with "es" as url_code. It's actually the recently activated es_AR language.

**Solution:**

We must perform the `url_code` switch before calling `install_lang`

[^1]: https://github.com/odoo/odoo/blob/c042e1ba/odoo/addons/base/models/res_lang.py#L339-L356


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
