### PR TITLE
[FIX] project: task search more access rights error in Timesheets

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -136,7 +136,7 @@ class Task(models.Model):
         if 'default_project_id' in self.env.context and not self._context.get('subtask_action') and 'project_kanban' in self.env.context:
             search_domain = ['|', ('project_ids', '=', self.env.context['default_project_id'])] + search_domain
 
-        stage_ids = stages.sudo()._search(search_domain, order=stages._order)
+        stage_ids = stages._search(search_domain, order=stages._order)
         return stages.browse(stage_ids)
 
     @api.model


### PR DESCRIPTION
The sudo function allowed the current user to fetch data (stage IDs) which were used to browse. The user does not have access to this data; therefore, an access error message is triggered 

task-4194357

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
