### PR TITLE
[FIX] account: bank statement download action

### DIFF
--- a/addons/account/static/src/views/account_move_list/account_move_list_controller.js
+++ b/addons/account/static/src/views/account_move_list/account_move_list_controller.js
@@ -18,11 +18,14 @@ export class AccountMoveListController extends FileUploadListController {
     }
 
     get actionMenuProps() {
-        return {
+        const actionMenuProps = {
             ...super.actionMenuProps,
             printDropdownTitle: _t("Download"),
-            loadExtraPrintItems: this.loadExtraPrintItems.bind(this),
         };
+        if (this.props.resModel === "account.move") {
+            actionMenuProps.loadExtraPrintItems = this.loadExtraPrintItems.bind(this);
+        }
+        return actionMenuProps;
     }
 
     async loadExtraPrintItems() {


### PR DESCRIPTION
In Bank Statement list view users may select a statement and
download a pdf report. However, currently, users have 2 download action,
one of which is downloading a seemingly random account move

Steps to reproduce:
- In Accounting Dashboard, from a bank journal card, 3 dots > Statements
- Select a line
- Download > PDF

Issue: PDF target is loaded via the `loadExtraPrintItems` method
However, the request is done to the `account.move` model using the id of
the bank statement, so it may retrieve an invoice, or fail

Note: Download > Statement is working properly

A solution is to avoid loading extra print item with loadExtraPrintItems
if we are not in the `account.move` model

opw-4388554