### PR TITLE
[FIX] spreadsheet: disable public download button

### DIFF
--- a/addons/spreadsheet/views/public_readonly_spreadsheet_templates.xml
+++ b/addons/spreadsheet/views/public_readonly_spreadsheet_templates.xml
@@ -15,7 +15,7 @@
                 <div t-out="spreadsheet_name" class="text-primary fw-bold ps-3"/>
                 <div class="fst-italic flex-fill ps-3">
                     Frozen and copied on <span t-field="share.create_date"/>
-                    <div class="d-inline-flex">
+                    <div class="d-inline-flex" t-if="props['downloadExcelUrl']">
                         <a class="btn btn-secondary btn-block o_download_btn" t-att-href="props['downloadExcelUrl']" title="Download"><i class="fa fa-download"/></a>
                     </div>
                 </div>


### PR DESCRIPTION
Steps to reproduce:

- install Documents
- create a new spreadsheet
- hit the Share button
- change the sharing settings to "Anyone with the link: Viewer / Musty have the link to access"
- open the sharing link in an incognito window
- hit the download button

=> 404 not found

A public user cannot convert a spreadsheet to an excel file and downlaod it because a route needs to be called to create the excel file. This route is currently not allowed for public users.

For frozen spreadsheet, we generate the excel file before-hand (when the internal user shares the spreadsheet). For a regular "live" share though, we cannot pre-generate the excel file since the spreadsheet continues to live and evolve.

The `spreadsheet` module needs to be updated for this bug fix to take effect. (otherwise the download button won't do anything, which is not worse than facing a 404 response)

See also Enterprise PR.

Task: 4440241
opw: 4417519




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
