### PR TITLE
[FIX] pos_self_order: allow merging lot tracked products

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -321,14 +321,18 @@ export class PosOrderline extends Base {
             // don't merge discounted orderlines
             this.get_discount() === 0 &&
             floatIsZero(price - order_line_price - orderline.get_price_extra(), this.currency) &&
-            !(
-                this.product_id.tracking === "lot" &&
-                (this.pickingType.use_create_lots || this.pickingType.use_existing_lots)
-            ) &&
+            !this.isLotTracked() &&
             this.full_product_name === orderline.full_product_name &&
             isSameCustomerNote &&
             !this.refunded_orderline_id &&
             !orderline.isPartOfCombo()
+        );
+    }
+
+    isLotTracked() {
+        return (
+            this.product_id.tracking === "lot" &&
+            (this.pickingType.use_create_lots || this.pickingType.use_existing_lots)
         );
     }
 

--- a/addons/pos_self_order/static/src/app/models/pos_order_line.js
+++ b/addons/pos_self_order/static/src/app/models/pos_order_line.js
@@ -37,4 +37,7 @@ patch(PosOrderline.prototype, {
         };
         return diff;
     },
+    isLotTracked() {
+        return false;
+    },
 });


### PR DESCRIPTION
Before this commit, adding lot tracked products would result in an error because the picking type was not loaded in self ordering.

opw-4439558

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
