### PR TITLE
[IMP] mrp: remove manual consumption from BOM

### DIFF
--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -317,7 +317,6 @@
         <record id="mrp_bom_line_wood_panel" model="mrp.bom.line">
             <field name="product_id" ref="product_product_wood_panel"/>
             <field name="product_qty">2</field>
-            <field name="manual_consumption">True</field>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">1</field>
             <field name="bom_id" ref="mrp_bom_table_top"/>

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -622,11 +622,6 @@ class MrpBomLine(models.Model):
         compute='_compute_child_line_ids')
     attachments_count = fields.Integer('Attachments Count', compute='_compute_attachments_count')
     tracking = fields.Selection(related='product_id.tracking')
-    manual_consumption = fields.Boolean(
-        'Highlight Consumption', default=False,
-        readonly=False, store=True, copy=True,
-        help="When activated, then the registration of consumption for that component is recorded manually exclusively.\n"
-             "If not activated, and any of the components consumption is edited manually on the manufacturing order, Odoo assumes manual consumption also.")
 
     _bom_qty_zero = models.Constraint(
         'CHECK (product_qty>=0)',

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -725,7 +725,7 @@ class StockMove(models.Model):
 
     @api.model
     def _determine_is_manual_consumption(self, bom_line):
-        return bom_line and (bom_line.manual_consumption or bom_line.operation_id)
+        return bom_line and bom_line.operation_id
 
     def _get_relevant_state_among_moves(self):
         res = super()._get_relevant_state_among_moves()

--- a/addons/mrp/tests/common.py
+++ b/addons/mrp/tests/common.py
@@ -40,8 +40,8 @@ class TestMrpCommon(TestStockCommon):
             'type': 'normal',
             'consumption': consumption if consumption else 'flexible',
             'bom_line_ids': [
-                (0, 0, {'product_id': product_to_use_2.id, 'product_qty': qty_base_2, 'manual_consumption': tracking_base_2 != 'none'}),
-                (0, 0, {'product_id': product_to_use_1.id, 'product_qty': qty_base_1, 'manual_consumption': tracking_base_1 != 'none'})
+                (0, 0, {'product_id': product_to_use_2.id, 'product_qty': qty_base_2}),
+                (0, 0, {'product_id': product_to_use_1.id, 'product_qty': qty_base_1})
             ]})
         mo_form = Form(cls.env['mrp.production'])
         mo_form.product_id = product_to_build

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -2476,39 +2476,6 @@ class TestBoM(TestMrpCommon):
             mo_form.bom_id = bom_2
         self.assertEqual(set(mo.workorder_ids.mapped('name')), {'op3', 'op4', 'new op'})
 
-    def test_manual_consumption_bom_line(self):
-        """
-        1. Create a BOM with two lines
-        2. Attach an operation to the first BOM line
-        3. Create an MO
-        4. Check that the move with BOM line attached will be treated as a manual consumption move despite the BOM line being automatic consumption
-        """
-        common_vals = {'is_storable': True}
-        finished_product = self.env['product.product'].create(dict(common_vals, name="Monster in Jar"))
-        component_1 = self.env['product.product'].create(dict(common_vals, name="Monster"))
-        component_2 = self.env['product.product'].create(dict(common_vals, name="Jar"))
-        bom = self.env['mrp.bom'].create({
-            'product_tmpl_id': finished_product.product_tmpl_id.id,
-            'product_qty': 1.0,
-            'bom_line_ids': [Command.create({'product_id': p.id, 'product_qty': 1}) for p in [component_1, component_2]],
-            'operation_ids': [
-                Command.create({'name': 'OP1', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 10, 'sequence': 1}),
-                Command.create({'name': 'OP2', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 15, 'sequence': 2}),
-            ],
-        })
-        bom.bom_line_ids[0].operation_id = bom.operation_ids[0].id
-        # Creates a MO and confirms it.
-        mo_form = Form(self.env['mrp.production'])
-        mo_form.bom_id = bom
-        mo_1 = mo_form.save()
-        mo_1.action_confirm()
-
-        move_with_bom_line_op = mo_1.all_move_raw_ids[0]
-        move_without_bom_line_op = mo_1.all_move_raw_ids[1]
-
-        self.assertTrue(move_with_bom_line_op._is_manual_consumption())
-        self.assertFalse(move_without_bom_line_op._is_manual_consumption())
-
     def test_archive_operation(self):
         """ Checks that archiving an operation having both a bom line and a byproduct line linked to it properly unlinks them.
         """

--- a/addons/mrp/tests/test_consume_component.py
+++ b/addons/mrp/tests/test_consume_component.py
@@ -171,7 +171,6 @@ class TestConsumeComponentCommon(common.TransactionCase):
         for _ in range(count):
             vals.append(copy.deepcopy(template))
         mos = cls.env['mrp.production'].create(vals)
-        mos.move_raw_ids.mapped('manual_consumption')
         return mos
 
     def executeConsumptionTriggers(self, mrp_productions):

--- a/addons/mrp/tests/test_manual_consumption.py
+++ b/addons/mrp/tests/test_manual_consumption.py
@@ -28,7 +28,7 @@ class TestTourManualConsumption(HttpCase):
             'product_qty': 1,
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {'product_id': product_nt.id, 'product_qty': 1, 'manual_consumption': True}),
+                (0, 0, {'product_id': product_nt.id, 'product_qty': 1}),
             ],
         })
 
@@ -41,7 +41,7 @@ class TestTourManualConsumption(HttpCase):
 
         self.assertEqual(mo.state, 'confirmed')
         move_nt = mo.move_raw_ids
-        self.assertEqual(move_nt.manual_consumption, True)
+        self.assertEqual(move_nt.manual_consumption, False)
         self.assertEqual(move_nt.quantity, 0)
         self.assertFalse(move_nt.picked)
 
@@ -58,62 +58,6 @@ class TestManualConsumption(TestMrpCommon):
         super().setUpClass()
         cls.stock_location = cls.env.ref('stock.stock_location_stock')
         cls.env.ref('base.group_user').write({'implied_ids': [(4, cls.env.ref('stock.group_production_lot').id)]})
-
-    def test_manual_consumption_backorder(self):
-        """Test when use_auto_consume_components_lots is set, manual consumption
-        of the backorder is correctly set.
-        """
-        picking_type = self.env['stock.picking.type'].search([('code', '=', 'mrp_operation')])[0]
-
-        mo, _, _final, c1, c2 = self.generate_mo('none', 'lot', 'none', qty_final=2)
-
-        self.assertTrue(mo.move_raw_ids.filtered(lambda m: m.product_id == c1).manual_consumption)
-        self.assertFalse(mo.move_raw_ids.filtered(lambda m: m.product_id == c2).manual_consumption)
-
-        lot = self.env['stock.lot'].create({
-            'name': 'lot',
-            'product_id': c1.id,
-        })
-        self.env['stock.quant']._update_available_quantity(c1, self.stock_location, 8, lot_id=lot)
-        self.env['stock.quant']._update_available_quantity(c2, self.stock_location, 2)
-
-        mo.action_assign()
-        mo_form = Form(mo)
-        mo_form.qty_producing = 1
-        mo_form.save()
-        self.assertEqual(sum(mo.move_raw_ids.filtered(lambda m: m.product_id.id == c1.id).mapped("quantity")), 4)
-        self.assertEqual(sum(mo.move_raw_ids.filtered(lambda m: m.product_id.id == c2.id).mapped("quantity")), 1)
-
-        action = mo.button_mark_done()
-        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
-        backorder.save().action_backorder()
-        backorder_mo = mo.procurement_group_id.mrp_production_ids[-1]
-
-        self.assertTrue(backorder_mo.move_raw_ids.filtered(lambda m: m.product_id == c1).manual_consumption)
-        self.assertFalse(backorder_mo.move_raw_ids.filtered(lambda m: m.product_id == c2).manual_consumption)
-
-    def test_manual_consumption_split_merge_00(self):
-        """Test manual consumption is correctly set after split or merge.
-        """
-        # Create a mo for 10 products
-        mo, _, _, p1, p2 = self.generate_mo('none', 'lot', 'none', qty_final=10)
-        self.assertTrue(mo.move_raw_ids.filtered(lambda m: m.product_id == p1).manual_consumption)
-        self.assertFalse(mo.move_raw_ids.filtered(lambda m: m.product_id == p2).manual_consumption)
-
-        # Split in 3 parts
-        action = mo.action_split()
-        wizard = Form.from_action(self.env, action)
-        wizard.max_batch_size = 4
-        action = wizard.save().action_split()
-        for production in mo.procurement_group_id.mrp_production_ids:
-            self.assertTrue(production.move_raw_ids.filtered(lambda m: m.product_id == p1).manual_consumption)
-            self.assertFalse(production.move_raw_ids.filtered(lambda m: m.product_id == p2).manual_consumption)
-
-        # Merge them back
-        action = mo.procurement_group_id.mrp_production_ids.action_merge()
-        mo = self.env[action['res_model']].browse(action['res_id'])
-        self.assertTrue(mo.move_raw_ids.filtered(lambda m: m.product_id == p1).manual_consumption)
-        self.assertFalse(mo.move_raw_ids.filtered(lambda m: m.product_id == p2).manual_consumption)
 
     def test_manual_consumption_with_different_component_price(self):
         """
@@ -174,7 +118,7 @@ class TestManualConsumption(TestMrpCommon):
             'type': 'normal',
             'bom_line_ids': [
                 (0, 0, {'product_id': product_auto_consumption.id, 'product_qty': 1}),
-                (0, 0, {'product_id': product_manual_consumption.id, 'product_qty': 1, 'manual_consumption': True}),
+                (0, 0, {'product_id': product_manual_consumption.id, 'product_qty': 1}),
             ],
         })
 
@@ -199,12 +143,12 @@ class TestManualConsumption(TestMrpCommon):
         self.assertEqual(move_auto.manual_consumption, False)
         self.assertEqual(move_auto.quantity, 5)
         self.assertTrue(move_auto.picked)
-        self.assertEqual(move_manual.manual_consumption, True)
+        self.assertEqual(move_manual.manual_consumption, False)
         self.assertEqual(move_manual.quantity, 5)
-        self.assertFalse(move_manual.picked)
+        self.assertTrue(move_manual.picked)
 
-        # Pick manual move
-        move_manual.picked = True
+        move_manual.quantity = 6
+        move_manual._onchange_quantity()
 
         # Now we change quantity to 7. Automatic move will change quantity, but manual move will still be 5 because it has been already picked.
         mo_form = Form(mo)
@@ -212,7 +156,7 @@ class TestManualConsumption(TestMrpCommon):
         mo = mo_form.save()
 
         self.assertEqual(move_auto.quantity, 7)
-        self.assertEqual(move_manual.quantity, 5)
+        self.assertEqual(move_manual.quantity, 6)
 
         # Bypass consumption issues wizard and create backorders
         action = mo.button_mark_done()
@@ -226,7 +170,7 @@ class TestManualConsumption(TestMrpCommon):
         # Check that backorders move have the same manual consumption values as BoM
         move_auto, move_manual = get_moves(backorder)
         self.assertEqual(move_auto.manual_consumption, False)
-        self.assertEqual(move_manual.manual_consumption, True)
+        self.assertEqual(move_manual.manual_consumption, False)
 
     def test_update_manual_consumption_00(self):
         """

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -294,16 +294,17 @@ class TestMrpOrder(TestMrpCommon):
         details_operation_form = Form(mo.move_raw_ids[1], view=self.env.ref('stock.view_stock_move_operations'))
         with details_operation_form.move_line_ids.edit(0) as ml:
             ml.lot_id = lot_1
-            ml.quantity = 20
+            ml.quantity = 21
         details_operation_form.save()
         mo.move_raw_ids[1].picked = True
+        mo.move_raw_ids[1]._onchange_quantity()
         update_quantity_wizard = self.env['change.production.qty'].create({
             'mo_id': mo.id,
             'product_qty': 4,
         })
         update_quantity_wizard.change_prod_qty()
 
-        self.assertEqual(mo.move_raw_ids.filtered(lambda m: m.product_id == p1).quantity, 20, 'Update the produce quantity should not impact already produced quantity.')
+        self.assertEqual(mo.move_raw_ids.filtered(lambda m: m.product_id == p1).quantity, 21, 'Update the produce quantity should not impact already produced quantity.')
         self.assertEqual(mo.move_finished_ids.product_uom_qty, 4)
         mo.button_mark_done()
 
@@ -4278,8 +4279,8 @@ class TestMrpOrder(TestMrpCommon):
             ],
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {'product_id': self.product_2.id, 'product_qty': 2, 'manual_consumption': True}),
-                (0, 0, {'product_id': self.product_1.id, 'product_qty': 4, 'manual_consumption': True})
+                (0, 0, {'product_id': self.product_2.id, 'product_qty': 2}),
+                (0, 0, {'product_id': self.product_1.id, 'product_qty': 4})
             ]})
         mo = mo_form.save()
         mo.action_confirm()

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -104,7 +104,6 @@
                                     <field name="bom_product_template_attribute_value_ids" optional="hide" widget="many2many_tags" options="{'no_create': True}" column_invisible="parent.product_id" groups="product.group_product_variant"/>
                                     <field name="allowed_operation_ids" column_invisible="True"/>
                                     <field name="operation_id" groups="mrp.group_mrp_routings" optional="hidden" column_invisible="parent.type not in ('normal', 'phantom')" options="{'no_quick_create':True,'no_create_edit':True}"/>
-                                    <field name="manual_consumption" optional="hide" force_save="1"/>
                                 </list>
                             </field>
                         </page>

--- a/addons/mrp/wizard/mrp_batch_produce.py
+++ b/addons/mrp/wizard/mrp_batch_produce.py
@@ -116,6 +116,7 @@ class MrpBatchProduce(models.TransientModel):
         if not productions.product_id.tracking == 'serial':
             for production in reversed(productions):
                 production.qty_producing = production.product_uom_qty
+                production.move_raw_ids.manual_consumption = True
                 production.set_qty_producing()
 
         if mark_done:

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -173,7 +173,6 @@ class TestMrpAccount(TestMrpCommon):
         quants.action_apply_inventory()
 
         bom = self.mrp_bom_desk.copy()
-        bom.bom_line_ids.manual_consumption = False
         bom.operation_ids = False
         production_table_form = Form(self.env['mrp.production'])
         production_table_form.product_id = self.dining_table

--- a/addons/mrp_product_expiry/tests/test_mrp_product_expiry.py
+++ b/addons/mrp_product_expiry/tests/test_mrp_product_expiry.py
@@ -50,7 +50,7 @@ class TestStockLot(TestStockCommon):
             'consumption': 'flexible',
             'type': 'normal',
             'bom_line_ids': [
-                (0, 0, {'product_id': cls.product_apple.id, 'product_qty': 3, 'manual_consumption': True}),
+                (0, 0, {'product_id': cls.product_apple.id, 'product_qty': 3}),
             ]})
 
         cls.location_stock = cls.env['stock.location'].browse(cls.stock_location)

--- a/addons/purchase_mrp/views/mrp_bom_views.xml
+++ b/addons/purchase_mrp/views/mrp_bom_views.xml
@@ -5,7 +5,7 @@
         <field name="model">mrp.bom</field>
         <field name="inherit_id" ref="mrp.mrp_bom_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='bom_line_ids']/list//field[@name='manual_consumption']" position="after">
+            <xpath expr="//field[@name='bom_line_ids']/list//field[@name='operation_id']" position="after">
                 <field name="cost_share" optional="hidden" column_invisible="parent.type != 'phantom'"/>
             </xpath>
         </field>


### PR DESCRIPTION
We no longer support the manual consumption checkbox on the BOM.
Instead, the user can use "consumed in operation" to show a stock.move on a specific WO.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
