### PR TITLE
[FIX] l10n_es: missing lines for agricultural fiscal position

### DIFF
--- a/addons/l10n_es/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_es/data/account_fiscal_position_template_data.xml
@@ -4051,6 +4051,16 @@
             <field name="tax_src_id" ref="account_tax_template_p_iva0_s_bc"/>
             <field name="tax_dest_id" ref="account_tax_template_p_irpf2"/>
         </record>
+        <record id="fptt_reagyp_a_4b_6" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_reagyp_a"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva2_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva12_agr"/>
+        </record>
+        <record id="fptt_reagyp_a_4b_7" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_reagyp_a"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva2_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_irpf2"/>
+        </record>
         <record id="fptt_reagyp_gp_4b_1" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_reagyp_gp"/>
             <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva4_bc"/>


### PR DESCRIPTION
Two lines that were missing from the "REAGYP - Agricultura" Fiscal Position Tax Mapping have been added.

task-4342206