### PR TITLE
[FIX] sale,website_sale: pricelist valid dates not applied

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -428,7 +428,7 @@ class SaleOrderLine(models.Model):
                     line.product_id,
                     line.product_uom_qty or 1.0,
                     uom=line.product_uom,
-                    date=line.order_id.date_order,
+                    date=line._get_order_date(),
                 )
 
     @api.depends('product_id', 'product_uom', 'product_uom_qty')
@@ -451,6 +451,10 @@ class SaleOrderLine(models.Model):
                     ),
                     fiscal_position=line.order_id.fiscal_position_id,
                 )
+
+    def _get_order_date(self):
+        self.ensure_one()
+        return self.order_id.date_order
 
     def _get_display_price(self):
         """Compute the displayed unit price for a given line.
@@ -487,7 +491,7 @@ class SaleOrderLine(models.Model):
         self.product_id.ensure_one()
 
         pricelist_rule = self.pricelist_item_id
-        order_date = self.order_id.date_order or fields.Date.today()
+        order_date = self._get_order_date() or fields.Date.today()
         product = self.product_id.with_context(**self._get_product_price_context())
         qty = self.product_uom_qty or 1.0
         uom = self.product_uom or self.product_id.uom_id
@@ -531,7 +535,7 @@ class SaleOrderLine(models.Model):
         self.product_id.ensure_one()
 
         pricelist_rule = self.pricelist_item_id
-        order_date = self.order_id.date_order or fields.Date.today()
+        order_date = self._get_order_date() or fields.Date.today()
         product = self.product_id.with_context(**self._get_product_price_context())
         qty = self.product_uom_qty or 1.0
         uom = self.product_uom

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -48,6 +48,14 @@ class SaleOrderLine(models.Model):
     def get_description_following_lines(self):
         return self.name.splitlines()[1:]
 
+    def _get_order_date(self):
+        self.ensure_one()
+        if self.order_id.website_id and self.state == 'draft':
+            # cart prices must always be computed based on the current time, not on the order
+            # creation date.
+            return fields.Datetime.now()
+        return super()._get_order_date()
+
     def _get_shop_warning(self, clear=True):
         self.ensure_one()
         warn = self.shop_warning

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -3,6 +3,8 @@
 
 import logging
 
+from datetime import datetime, timedelta
+from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo.fields import Command
@@ -341,6 +343,51 @@ class TestWebsitePriceList(TransactionCase):
         product_template.product_variant_ids[0].standard_price = 20
         price = product_template._get_sales_prices(pricelist)[product_template.id]['price_reduce']
         self.assertEqual(price, 18, msg)
+
+    def test_pricelist_item_validity_period(self):
+        """ Test that if a cart was created before a validity period,
+            the correct prices will still apply.
+        """
+        today = datetime.today()
+        tomorrow = today + timedelta(days=1)
+        pricelist = self.env['product.pricelist'].create({
+            'name': 'Pricelist with validity period',
+            'item_ids': [Command.create({
+                    'compute_price': 'formula',
+                    'base': 'list_price',
+                    'price_discount': 20,
+                    'date_start': tomorrow,
+            })]
+        })
+        product = self.env['product.product'].create({
+            'name': 'Super Product',
+            'list_price': 100,
+            'taxes_id': False,
+        })
+        current_website = self.env['website'].get_current_website()
+        current_website.pricelist_id = pricelist
+        with freeze_time(today) as frozen_time:
+            so = self.env['sale.order'].create({
+                'partner_id': self.env.user.partner_id.id,
+                'pricelist_id': pricelist.id,
+                'order_line': [(0, 0, {
+                    'name': product.name,
+                    'product_id': product.id,
+                    'product_uom_qty': 1,
+                    'product_uom': product.uom_id.id,
+                    'price_unit': product.list_price,
+                    'tax_id': False,
+                })],
+                'website_id': current_website.id,
+            })
+            sol = so.order_line
+            self.assertEqual(sol.price_total, 100.0)
+
+            frozen_time.move_to(tomorrow + timedelta(seconds=10))
+            with MockRequest(self.env, website=current_website, sale_order_id=so.id):
+                so._cart_update(product_id=product.id, line_id=sol.id, set_qty=2)
+            self.assertEqual(sol.price_unit, 80.0, 'Reduction should be applied')
+            self.assertEqual(sol.price_total, 160)
 
 def simulate_frontend_context(self, website_id=1):
     # Mock this method will be enough to simulate frontend context in most methods


### PR DESCRIPTION
If you create a pricelist rule with a discount that has a valid date range, that discount is only applied if the SO was created in that range. Even if it is confirmed within the valid date range.

Fix:
For website_sale orders we consider the date to be the current time when computing the price.

opw-4375643

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
