### PR TITLE
[MOV] hr_payroll: move fields from hr_payroll/resource_calendar to resource/resource_calendar

### DIFF
--- a/addons/hr_contract/views/resource_calendar_views.xml
+++ b/addons/hr_contract/views/resource_calendar_views.xml
@@ -7,7 +7,6 @@
         <field name="arch" type="xml">
             <field name="company_id" position="after">
                 <field name="contracts_count"/>
-                <field name="full_time_required_hours" widget="float_time" optional="hide"/>
             </field>
         </field>
     </record>

--- a/addons/hr_work_entry_contract/models/__init__.py
+++ b/addons/hr_work_entry_contract/models/__init__.py
@@ -6,3 +6,4 @@ from . import hr_employee
 from . import hr_work_entry
 from . import hr_work_intervals
 from . import resource_calendar
+from . import resource_calendar_attendance

--- a/addons/hr_work_entry_contract/models/resource_calendar.py
+++ b/addons/hr_work_entry_contract/models/resource_calendar.py
@@ -1,10 +1,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import api, models
 
 
 class ResourceCalendar(models.Model):
     _inherit = 'resource.calendar'
+
+    # Override the method to add 'attendance_ids.work_entry_type_id.is_leave' to the dependencies
+    @api.depends('attendance_ids.work_entry_type_id.is_leave')
+    def _compute_hours_per_week(self):
+        super()._compute_hours_per_week()
 
     def _get_global_attendances(self):
         return super()._get_global_attendances().filtered(lambda a: not a.work_entry_type_id.is_leave)

--- a/addons/hr_work_entry_contract/models/resource_calendar_attendance.py
+++ b/addons/hr_work_entry_contract/models/resource_calendar_attendance.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ResourceCalendarAttendance(models.Model):
+    _inherit = 'resource.calendar.attendance'
+
+    def _is_work_period(self):
+        return not self.work_entry_type_id.is_leave and super()._is_work_period()

--- a/addons/resource/models/resource_calendar_attendance.py
+++ b/addons/resource/models/resource_calendar_attendance.py
@@ -105,3 +105,6 @@ class ResourceCalendarAttendance(models.Model):
             'display_type': self.display_type,
             'sequence': self.sequence,
         }
+
+    def _is_work_period(self):
+        return self.day_period != 'lunch'

--- a/addons/resource/views/resource_calendar_views.xml
+++ b/addons/resource/views/resource_calendar_views.xml
@@ -9,6 +9,9 @@
                <field name="company_id" groups="base.group_multi_company"/>
                <separator/>
                <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
+               <group expand='0'>
+                    <filter name="groupby_company" context="{'group_by': 'company_id'}"/>
+                </group>
            </search>
         </field>
     </record>
@@ -56,10 +59,16 @@
                             <label for="full_time_required_hours" invisible="flexible_hours"/>
                             <label for="full_time_required_hours" string="Hours per Week" invisible="not flexible_hours"/>
                             <div>
-                                <field name="full_time_required_hours" style="width: 10%" widget="float_time"/>
-                                <span> hours/week</span>
+                                <field name="full_time_required_hours" style="width: 6ch;" widget="float_time"/>
+                                <span>hours/week</span>
                             </div>
                             <field name="hours_per_day" widget="float_time" readonly="not flexible_hours"/>
+                            <label for="work_time_rate" string="Work Time Rate" invisible="flexible_hours"/>
+                            <div invisible="flexible_hours">
+                                <field name="work_time_rate" nolabel="1"  style="width: 5ch;"/>
+                                <span class="ms-1">%</span>
+                            </div>
+                            <field name="is_fulltime" invisible="1"/>
                         </group>
                         <group name="resource_company">
                             <field name="active" invisible="1"/>
@@ -72,6 +81,13 @@
                         <page string="Working Hours" name="working_hours" invisible="flexible_hours">
                             <field name="two_weeks_explanation" invisible="not two_weeks_calendar"/>
                             <field name="attendance_ids" widget="section_one2many"/>
+                            <group class="oe_subtotal_footer">
+                                <label for="hours_per_week" string="Total"/>
+                                <div class="d-flex">
+                                    <field name="hours_per_week" nolabel="1" widget="float_time"/>
+                                    <span class="ms-2">hours/week</span>
+                                </div>
+                            </group>
                         </page>
                     </notebook>
                 </sheet>
@@ -85,7 +101,10 @@
         <field name="arch" type="xml">
             <list string="Working Time">
                 <field name="name" string="Working Time"/>
+                <field name="work_time_rate" invisible="flexible_hours"/>
+                <field name="flexible_hours"/>
                 <field name="company_id" groups="base.group_multi_company"/>
+                <field name="full_time_required_hours" widget="float_time" optional="hide"/>
             </list>
         </field>
     </record>

--- a/addons/test_resource/tests/test_resource.py
+++ b/addons/test_resource/tests/test_resource.py
@@ -593,6 +593,104 @@ class TestCalendar(TestResourceCommon):
         self.assertEqual(leave.calendar_id, self.calendar_jules, "Leave calendar should update")
         self.assertEqual(holiday.calendar_id, self.calendar_jean, "Global leave shouldn't change")
 
+    def test_compute_work_time_rate_with_one_week_calendar(self):
+        """Test Case: check if the computation of the work time rate in the resource.calendar is correct."""
+        # Define a mid time
+        resource_calendar = self.env['resource.calendar'].create({
+            'name': 'Calendar Mid-Time',
+            'tz': "Europe/Brussels",
+            'two_weeks_calendar': False,
+            'full_time_required_hours': 40,
+            'attendance_ids': [
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Monday Lunch', 'dayofweek': '0', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Tuesday Lunch', 'dayofweek': '1', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'})
+            ]
+        })
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 50, 2)
+
+        # Define a 4/5
+        resource_calendar.write({
+            'name': 'Calendar (4 / 5)',
+            'attendance_ids': [
+                (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Thursday Lunch', 'dayofweek': '3', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                (0, 0, {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'})
+            ]
+        })
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 80, 2)
+
+        # Define a 9/10
+        resource_calendar.write({
+            'name': 'Calendar (9 / 10)',
+            'attendance_ids': [(0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'})]
+        })
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 90, 2)
+
+        # Define a Full-Time
+        resource_calendar.write({
+            'name': 'Calendar Full-Time',
+            'attendance_ids': [(0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'})]
+        })
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 100, 2)
+
+    def test_compute_work_time_rate_with_two_weeks_calendar(self):
+        """Test Case: check if the computation of the work time rate in the resource.calendar is correct."""
+        def create_attendance_ids(attendance_list):
+            return [(0, 0, {'week_type': str(i), **attendance}) for i in range(0, 2) for attendance in attendance_list]
+
+        attendance_list = [
+            {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'},
+            {'name': 'Monday Lunch', 'dayofweek': '0', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'},
+            {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'},
+            {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'},
+            {'name': 'Tuesday Lunch', 'dayofweek': '1', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'},
+            {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'},
+            {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}
+        ]
+
+        # Define a mid time
+        resource_calendar = self.env['resource.calendar'].create({
+            'name': 'Calendar Mid-Time',
+            'tz': "Europe/Brussels",
+            'two_weeks_calendar': True,
+            'full_time_required_hours': 40,
+            'attendance_ids': create_attendance_ids(attendance_list)
+        })
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 50, 2)
+
+        attendance_list = [
+            {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'},
+            {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'},
+            {'name': 'Thursday Lunch', 'dayofweek': '3', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'},
+            {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}
+        ]
+
+        # Define a 4/5
+        resource_calendar.write({
+            'name': 'Calendar (4 / 5)',
+            'attendance_ids': create_attendance_ids(attendance_list)
+        })
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 80, 2)
+
+        # Define a 9/10
+        resource_calendar.write({
+            'name': 'Calendar (9 / 10)',
+            'attendance_ids': create_attendance_ids([{'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}])
+        })
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 90, 2)
+
+        # Define a Full-Time
+        resource_calendar.write({
+            'name': 'Calendar Full-Time',
+            'attendance_ids': create_attendance_ids([{'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}])
+        })
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 100, 2)
 
 class TestResMixin(TestResourceCommon):
 


### PR DESCRIPTION
Different modules could use the fields defined in hr_payroll/resource_calendar. However, these modules shouldn't require the payroll app to be installed in order to be able to use those fields.

Hence the fields hours_per_week, full_time_required_hours, is_fulltime, work_time_rate over are moved to the base resource model.

task-4448549