### PR TITLE
[FIX] account: non updated db don't use name_placeholder in views

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3335,6 +3335,16 @@ class AccountMove(models.Model):
             fields_spec = {key: val for key, val in fields_spec.items() if key != 'line_ids'}
         return super().onchange(values, field_names, fields_spec)
 
+    @api.model
+    def _get_view(self, view_id=None, view_type='form', **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
+        if view_type == 'form':
+            if name_node := arch.xpath("""//field[@name="name"][@invisible="name == '/' and not posted_before and not quick_edit_mode"]"""):
+                name_node[0].set('invisible', "not (name or name_placeholder or quick_edit_mode)")
+            if draft_node := arch.xpath("""//span[@invisible="name == '/' and not posted_before and not quick_edit_mode"]"""):
+                draft_node[0].set('invisible', "name or name_placeholder or quick_edit_mode")
+        return arch, view
+
     # -------------------------------------------------------------------------
     # RECONCILIATION METHODS
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Description of the issue this commit addresses:

Since the deployment of the new dynamic placeholder feature for move names, the code has been deployed on stable versions starting from 18.0 but the views are still only updated if the user manually does it meaning that moves the account move form view might have a unwanted behavior since the lack of change in the view while the code was updated will show the name when we don't want to and the other way around too in some cases.

---

Desired behavior after this commit is merged:

This commit modifies the get_view of the account.move model to make sure the invisible attribute of the name is correctly set.

---

no  task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
