### PR TITLE
[IMP] hr_timesheet: Fix `subtotal_footer` mobile alignment on page_timesheets task  form view

### DIFF
--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -65,36 +65,61 @@
                         </kanban>
                     </field>
                     <group invisible="not analytic_account_active">
-                        <group class="oe_subtotal_footer" name="project_hours">
-                            <span class="o_td_label float-start">
-                                <label class="fw-bold" for="effective_hours" string="Time Spent"/>
-                            </span>
-                            <field name="effective_hours" widget="timesheet_uom" nolabel="1"/>
-                            <button name="action_view_subtask_timesheet" type="object" class="ps-0 border-0 oe_inline oe_link mb-2 o_td_label float-start" invisible="subtask_effective_hours == 0.0" context="{'is_project_sharing': True}">
-                                <span class="text-nowrap">Time Spent on Sub-tasks:</span>
-                            </button>
-                            <field name="subtask_effective_hours" class="mt-2" widget="timesheet_uom"
-                                  invisible="subtask_effective_hours == 0.0" nolabel="1"/>
-                            <span id="total_hours_spent_label" invisible="subtask_effective_hours == 0.0" class="o_td_label float-start">
-                                <label class="fw-bold" for="total_hours_spent" string="Total Time Spent"
-                                      invisible="encode_uom_in_days"/>
-                                <label class="fw-bold" for="total_hours_spent" string="Total Days Spent"
-                                      invisible="not encode_uom_in_days"/>
-                            </span>
-                            <field name="total_hours_spent" widget="timesheet_uom" class="oe_subtotal_footer_separator" nolabel="1"
-                                  invisible="subtask_effective_hours == 0.0" />
-                            <span class="o_td_label float-start">
-                                <label class="fw-bold" for="remaining_hours" string="Time Remaining"
-                                       invisible="allocated_hours == 0.0 or encode_uom_in_days or remaining_hours &lt; 0"/>
-                                <label class="fw-bold" for="remaining_hours" string="Days Remaining"
-                                       invisible="allocated_hours == 0.0 or not encode_uom_in_days or remaining_hours &lt; 0"/>
-                                <label class="fw-bold text-danger" for="remaining_hours" string="Time Remaining"
-                                       invisible="allocated_hours == 0.0 or encode_uom_in_days or remaining_hours &gt;= 0"/>
-                                <label class="fw-bold text-danger" for="remaining_hours" string="Days Remaining"
-                                       invisible="allocated_hours == 0.0 or not encode_uom_in_days or remaining_hours &gt;= 0"/>
-                            </span>
-                            <field name="remaining_hours" widget="timesheet_uom" class="oe_subtotal_footer_separator"
-                                  invisible="allocated_hours == 0.0" nolabel="1"/>
+                        <group class="oe_subtotal_footer d-flex justify-content-end mb-0" name="project_hours">
+                            <div class="container">
+                                <!-- Time Spent -->
+                                <div class="row align-items-center mb-2">
+                                    <div class="col-8">
+                                        <label class="fw-bold" for="effective_hours">Time Spent</label>
+                                    </div>
+                                    <div class="col-4">
+                                        <field name="effective_hours" widget="timesheet_uom" nolabel="1" />
+                                    </div>
+                                </div>
+
+                                <!-- Time Spent on Sub-tasks -->
+                                <div class="row align-items-center mb-2" invisible="subtask_effective_hours == 0.0">
+                                    <div class="col-8">
+                                        <button name="action_view_subtask_timesheet" type="object" class="ps-0 border-0 oe_inline oe_link mb-2 o_td_label text-start">
+                                        Time Spent on Sub-tasks:
+                                        </button>
+                                    </div>
+                                    <div class="col-4">
+                                        <field name="subtask_effective_hours" widget="timesheet_uom" class="mt-2" nolabel="1" />
+                                    </div>
+                                </div>
+
+                                <!-- Total Hours Spent -->
+                                <div id="total_hours_spent_div" class="row align-items-center mb-2" invisible="subtask_effective_hours == 0.0">
+                                    <div id="total_hours_spent_label" class="col-8" >
+                                        <label class="fw-bold" for="total_hours_spent" invisible="not encode_uom_in_days">Total Hours Spent</label>
+                                        <label class="fw-bold" for="total_hours_spent" invisible="encode_uom_in_days">Total Days Spent</label>
+                                    </div>
+                                    <div class="col-4">
+                                        <field name="total_hours_spent" widget="timesheet_uom" class="oe_subtotal_footer_separator" nolabel="1" />
+                                    </div>
+                                </div>
+
+                                <!-- Remaining Hours -->
+                                <div id="remaining_hours_div" class="row align-items-center mb-2" invisible="allocated_hours == 0.0">
+                                    <div class="col-8">
+                                        <label class="fw-bold" for="remaining_hours" string="Time Remaining"
+                                        invisible="allocated_hours == 0.0 or encode_uom_in_days or remaining_hours &lt; 0"/>
+                                        <label class="fw-bold" for="remaining_hours" string="Days Remaining"
+                                            invisible="allocated_hours == 0.0 or not encode_uom_in_days or remaining_hours &lt; 0"/>
+                                        
+                                        <label class="fw-bold text-danger" for="remaining_hours" string="Time Remaining"
+                                            invisible="allocated_hours == 0.0 or encode_uom_in_days or remaining_hours &gt;= 0"/>
+                                        <label class="fw-bold text-danger" for="remaining_hours" string="Days Remaining"
+                                            invisible="allocated_hours == 0.0 or not encode_uom_in_days or remaining_hours &gt;= 0"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <field name="remaining_hours" widget="timesheet_uom" class="oe_subtotal_footer_separator"
+                                            invisible="allocated_hours == 0.0" nolabel="1"/>
+                                    </div>
+                                </div>
+                            </div>
+
                         </group>
                     </group>
                 </page>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -91,32 +91,52 @@
                         </form>
                     </field>
                     <group invisible="not analytic_account_active">
-                        <group class="oe_subtotal_footer" name="project_hours">
-                            <span class="o_td_label float-start">
-                                <label class="fw-bold" for="effective_hours" string="Time Spent"/>
-                            </span>
-                            <field name="effective_hours" widget="timesheet_uom" nolabel="1"/>
-                            <button name="action_view_subtask_timesheet" type="object" class="ps-0 border-0 oe_inline oe_link mb-2 o_td_label float-start" invisible="subtask_effective_hours == 0.0">
-                                <span class="text-nowrap">Time Spent on Sub-tasks:</span>
-                            </button>
-                            <field name="subtask_effective_hours" class="mt-2" widget="timesheet_uom"
-                                   invisible="subtask_effective_hours == 0.0" nolabel="1"/>
-                            <span invisible="subtask_effective_hours == 0.0" class="o_td_label float-start my-1">
-                                <label class="fw-bold" for="total_hours_spent"
-                                       invisible="subtask_effective_hours == 0.0 or encode_uom_in_days"/>
-                                <label class="fw-bold" for="total_hours_spent"
-                                       invisible="subtask_effective_hours == 0.0 or not encode_uom_in_days"/>
-                            </span>
-                            <field name="total_hours_spent" widget="timesheet_uom" class="oe_subtotal_footer_separator" nolabel="1"
-                                   invisible="subtask_effective_hours == 0.0" />
-                            <span class="o_td_label float-start my-1" invisible="allocated_hours == 0.0">
-                                <label class="fw-bold" for="remaining_hours"
-                                       invisible="remaining_hours &lt; 0"/>
-                                <label class="fw-bold text-danger" for="remaining_hours"
-                                       invisible="remaining_hours &gt;= 0"/>
-                            </span>
-                            <field name="remaining_hours" widget="timesheet_uom" class="oe_subtotal_footer_separator"
-                                   invisible="allocated_hours == 0.0" nolabel="1" decoration-danger="remaining_hours &lt; 0"/>
+                        <group class="oe_subtotal_footer d-flex justify-content-end mb-0" name="project_hours">
+                            <div class="container">
+                                <!-- Time Spent -->
+                                <div class="row align-items-center mb-2">
+                                    <div class="col-8">
+                                        <label class="fw-bold" for="effective_hours">Time Spent</label>
+                                    </div>
+                                    <div class="col-4">
+                                        <field name="effective_hours" widget="timesheet_uom" nolabel="1" />
+                                    </div>
+                                </div>
+
+                                <!-- Time Spent on Sub-tasks -->
+                                <div class="row align-items-center mb-2" invisible="subtask_effective_hours == 0.0">
+                                    <div class="col-8">
+                                        <button name="action_view_subtask_timesheet" type="object" class="ps-0 border-0 oe_inline oe_link mb-2 o_td_label text-start">
+                                        Time Spent on Sub-tasks:
+                                        </button>
+                                    </div>
+                                    <div class="col-4">
+                                        <field name="subtask_effective_hours" widget="timesheet_uom" class="mt-2" nolabel="1" />
+                                    </div>
+                                </div>
+
+                                <!-- Total Hours Spent -->
+                                <div class="row align-items-center mb-2" invisible="subtask_effective_hours == 0.0">
+                                    <div class="col-8">
+                                        <label class="fw-bold" for="total_hours_spent" invisible="not encode_uom_in_days">Total Hours Spent</label>
+                                        <label class="fw-bold" for="total_hours_spent" invisible="encode_uom_in_days">Total Days Spent</label>
+                                    </div>
+                                    <div class="col-4">
+                                        <field name="total_hours_spent" widget="timesheet_uom" class="oe_subtotal_footer_separator" nolabel="1" />
+                                    </div>
+                                </div>
+
+                                <!-- Remaining Hours -->
+                                <div class="row align-items-center mb-2" invisible="allocated_hours == 0.0">
+                                    <div class="col-8">
+                                        <label class="fw-bold" for="remaining_hours" invisible="remaining_hours >= 0">Remaining Hours</label>
+                                        <label class="fw-bold text-danger" for="remaining_hours" invisible="remaining_hours &lt; 0">Overrun Hours</label>
+                                    </div>
+                                    <div class="col-4">
+                                        <field name="remaining_hours" widget="timesheet_uom" class="oe_subtotal_footer_separator" nolabel="1" decoration-danger="remaining_hours &lt; 0" />
+                                    </div>
+                                </div>
+                            </div>
                         </group>
                     </group>
                 </page>

--- a/addons/sale_timesheet/views/project_sharing_views.xml
+++ b/addons/sale_timesheet/views/project_sharing_views.xml
@@ -25,17 +25,22 @@
                 <field name="remaining_hours_available" column_invisible="True"/>
                 <field name="remaining_hours_so" optional="hide" widget="timesheet_uom" column_invisible="not parent.allow_timesheets"/>
             </xpath>
-            <xpath expr="//field[@name='remaining_hours']" position="after">
-                <field name="allow_billable" invisible="1" />
-                <field name="remaining_hours_available" invisible="1"/>
-                <field name="sale_order_id" invisible="1"/>
-                <span id="remaining_hours_so_label" invisible="not allow_billable or not sale_order_id or not partner_id or not sale_line_id or not remaining_hours_available" class="o_td_label float-start">
-                    <label class="fw-bold" for="remaining_hours_so"
+            <xpath expr="//div[@id='remaining_hours_div']" position="after">
+                <div class="row align-items-center mb-2" 
+                    invisible="not allow_billable or not sale_order_id or not partner_id or not sale_line_id or not remaining_hours_available">
+                    <field name="allow_billable" invisible="1" />
+                    <field name="remaining_hours_available" invisible="1"/>
+                    <field name="sale_order_id" invisible="1"/>
+                    <div id="remaining_hours_so_label" class="col-8">
+                        <label class="fw-bold" for="remaining_hours_so"
                             invisible="remaining_hours_so &lt; 0"/>
-                    <label class="fw-bold text-danger" for="remaining_hours_so"
+                        <label class="fw-bold text-danger" for="remaining_hours_so"
                             invisible="remaining_hours_so &gt;= 0"/>
-                </span>
-                <field name="remaining_hours_so" nolabel="1" widget="timesheet_uom" invisible="not allow_billable or not sale_order_id or not partner_id or not sale_line_id or not remaining_hours_available" decoration-danger="remaining_hours_so &lt; 0"></field>
+                    </div>
+                    <div class="col-4">
+                        <field name="remaining_hours_so" nolabel="1" widget="timesheet_uom" decoration-danger="remaining_hours_so &lt; 0"/>
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
- add both label and field on `div class='d-flex'` to take only one cell in the grid to reduce the vertical space taken in the mobile view

Task-4347949

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
