### PR TITLE
[IMP] stock: hide the unreserve button from list and kanban views

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -450,7 +450,7 @@
             <field name="name">Unreserve</field>
             <field name="model_id" ref="stock.model_stock_picking"/>
             <field name="binding_model_id" ref="stock.model_stock_picking"/>
-            <field name="binding_view_types">list,kanban,form</field>
+            <field name="binding_view_types">form</field>
             <field name="state">code</field>
             <field name="code">
             if records:


### PR DESCRIPTION
* Redundant 'Unreserve' action removed from the actions menu in the deliveries list/kanban view.
* ~~Snoozing a product now returns the view to the list of remaining unsnoozed replenishments of the given product.~~ Moved to #199792.

Task ID: [4037390](https://www.odoo.com/odoo/project/966/tasks/4037390)