### PR TITLE
[FIX] purchase_stock,stock_dropshipping: add dropship product to PO

### DIFF
--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -256,12 +256,16 @@ class PurchaseOrder(models.Model):
             self.env['stock.warehouse']._warehouse_redirect_warning()
         return picking_type[:1]
 
+    def _prepare_group_vals(self):
+        self.ensure_one()
+        return {
+            'name': self.name,
+            'partner_id': self.partner_id.id,
+        }
+
     def _prepare_picking(self):
         if not self.group_id:
-            self.group_id = self.group_id.create({
-                'name': self.name,
-                'partner_id': self.partner_id.id
-            })
+            self.group_id = self.group_id.create(self._prepare_group_vals())
         if not self.partner_id.property_stock_supplier.id:
             raise UserError(_("You must set a Vendor Location for this partner %s", self.partner_id.name))
         return {

--- a/addons/stock_dropshipping/models/purchase.py
+++ b/addons/stock_dropshipping/models/purchase.py
@@ -22,3 +22,10 @@ class PurchaseOrder(models.Model):
 
     def action_view_dropship(self):
         return self._get_action_view_picking(self.picking_ids.filtered(lambda p: p.is_dropship))
+
+    def _prepare_group_vals(self):
+        res = super()._prepare_group_vals()
+        sale_orders = self.order_line.sale_order_id
+        if len(sale_orders) == 1:
+            res['sale_id'] = sale_orders.id
+        return res

--- a/addons/stock_dropshipping/models/sale.py
+++ b/addons/stock_dropshipping/models/sale.py
@@ -57,3 +57,15 @@ class SaleOrderLine(models.Model):
             for line in self:
                 if line.purchase_line_count > 0:
                     line.product_updatable = False
+
+    def _purchase_service_prepare_order_values(self, supplierinfo):
+        res = super()._purchase_service_prepare_order_values(supplierinfo)
+        dropship_operation = self.env['stock.picking.type'].search([
+            ('company_id', '=', res['company_id']),
+            ('default_location_src_id.usage', '=', 'supplier'),
+            ('default_location_dest_id.usage', '=', 'customer'),
+        ], limit=1, order='sequence')
+        if dropship_operation:
+            res['dest_address_id'] = self.order_id.partner_shipping_id.id
+            res['picking_type_id'] = dropship_operation.id
+        return res

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -296,3 +296,57 @@ class TestDropship(common.TransactionCase):
         self.assertTrue(purchase, "an RFQ should have been created by the scheduler")
         self.assertTrue((purchase.date_planned - purchase.date_order).days == 10, "The first supplier has a delay of 10 days")
         self.assertTrue(purchase.amount_untaxed == 8, "The price should be 4 * 2")
+
+    def test_add_dropship_product_to_subcontracted_service_po(self):
+        """
+        P1, a service product subcontracted to vendor V
+        P2, a dropshipped product provided by V
+        Confirm a SO with 1 x P1. On the generated PO, add 1 x P2 and confirm.
+        It should create a dropship picking. Process the picking. It should add
+        one SOL for P2.
+        """
+        supplier = self.dropship_product.seller_ids.partner_id
+        delivery_addr = self.env['res.partner'].create({
+            'name': 'Super Address',
+            'type': 'delivery',
+            'parent_id': self.customer.id,
+        })
+
+        subcontracted_service = self.env['product.product'].create({
+            'name': 'SuperService',
+            'type': 'service',
+            'service_to_purchase': True,
+            'seller_ids': [(0, 0, {'partner_id': supplier.id})],
+        })
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'partner_shipping_id': delivery_addr.id,
+            'order_line': [(0, 0, {
+                'product_id': subcontracted_service.id,
+                'product_uom_qty': 1.00,
+            })],
+        })
+        so.action_confirm()
+        po = so._get_purchase_orders()
+        self.assertTrue(po)
+
+        po.order_line = [(0, 0, {
+            'product_id': self.dropship_product.id,
+            'product_qty': 1.00,
+            'product_uom': self.dropship_product.uom_id.id,
+        })]
+        po.button_confirm()
+        dropship = po.picking_ids
+        self.assertTrue(dropship.is_dropship)
+        self.assertRecordValues(dropship.move_ids, [
+            {'product_id': self.dropship_product.id, 'partner_id': delivery_addr.id},
+        ])
+
+        dropship.move_ids.quantity = 1
+        dropship.button_validate()
+        self.assertEqual(dropship.state, 'done')
+        self.assertRecordValues(so.order_line, [
+            {'product_id': subcontracted_service.id, 'product_uom_qty': 1.0, 'qty_delivered': 0.0},
+            {'product_id': self.dropship_product.id, 'product_uom_qty': 0.0, 'qty_delivered': 1.0},
+        ])


### PR DESCRIPTION
If the user adds a product to a PO generated for a sold and
subcontrated service, the picking will be a receipt and the related
SO will not be updated

To reproduce the issue:
1. Create a service S:
   - Add a new vendor V
   - Subcontracted Service: True
2. Create a product P:
   - Vendor V
   - Routes: Dropship
3. Create and confirm a SO with 1 x S
4. Add 1 x P to the PO
5. Confirm the PO
   - Error 01: it generates a receipt while a dropship is expected
6. Process the receipt
   - Error 02: the SO does not change while a new SOL for P1 is expected

If the initial SO had P, it would work correctly. The user could
even add a second dropshipped product before confirming the PO, the
picking would be a dropship and there would be some new SOL for the
dropship products.

When confirming a SO, the process that generates the PO depends on
the SOL. If at least one of them is a product, the stock rule
mechanism will always handle the situation since it is called before
the `super`:
https://github.com/odoo/odoo/blob/899878f8e4d61de6b7bb6e4799a3e97e8d9f4434/addons/sale_stock/models/sale_order.py#L176-L178
while, service side, we generate the PO after `super`
https://github.com/odoo/odoo/blob/706431510110a005618a2acaf6566f2bb61d5114/addons/sale_purchase/models/sale_order.py#L20-L24
And, good news, everything works correctly when the PO is created by
the stock rules.

However, when creating a PO for a sold service, we have few mistakes.
First, we don't provide any operation type:
https://github.com/odoo/odoo/blob/238a41e35280256382f6509182b9e900fb4f7aba/addons/sale_purchase/models/sale_order_line.py#L131-L141
We therefore use the default one, a receipt:
https://github.com/odoo/odoo/blob/f9381a0611207e0fec6b957aef3b160437ecbafb/addons/purchase_stock/models/purchase_order.py#L23
We don't provide any destination address either, as explicitly said
by the comment: "False since only supported in stock". All this
could make sense as long as we don't add any product. If we do, we
will then have an issue with the picking: error 01. The PO has been
created to subcontract a service to a customer. It's a dropship-like
situation. We should therefore anticipate the situation and set some
correct values in case we add some products.

Then, when processing the picking, we update the related SO in some
conditions:
https://github.com/odoo/odoo/blob/84d2c884300f090103b917b8911d82dbeac9279e/addons/sale_stock/models/stock.py#L119-L130
Fixing error 01 solves a part of the conditions: we now have a
correct destination location. However, we still don't have any SO
linked to the picking. This info actually comes from the group:
https://github.com/odoo/odoo/blob/84d2c884300f090103b917b8911d82dbeac9279e/addons/sale_stock/models/stock.py#L87-L90
However, when confirming the PO, it leads to the picking creation.
To do so, we directly create the missing group but we don't provide
any value for `sale_id`:
https://github.com/odoo/odoo/blob/f9381a0611207e0fec6b957aef3b160437ecbafb/addons/purchase_stock/models/purchase_order.py#L259-L264

OPW-4332074