### PR TITLE
[FIX] point_of_sale: add default filter pos order

### DIFF
--- a/addons/point_of_sale/views/pos_order_report_view.xml
+++ b/addons/point_of_sale/views/pos_order_report_view.xml
@@ -52,6 +52,7 @@
                     <separator/>
                     <filter string="Invoiced" name="invoiced" domain="[('state','=',('invoiced'))]"/>
                     <filter string="Not Invoiced" name="not_invoiced" domain="[('state','in',['paid', 'done'])]"/>
+                    <filter string="Not Cancelled" name="not_cancelled" domain="[('state','!=','cancel')]"/>
                     <separator/>
                     <filter name="filter_date" date="date"/>
                     <field name="config_id"/>
@@ -83,7 +84,7 @@
             <field name="res_model">report.pos.order</field>
             <field name="view_mode">graph,pivot</field>
             <field name="search_view_id" ref="view_report_pos_order_search"/>
-            <field name="context">{'group_by':[]}</field>
+            <field name="context">{'group_by':[], 'search_default_not_cancelled': 1}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No data yet!


### PR DESCRIPTION
Cancelled order should be ignored by default in the POS order report.

Steps to reproduce:
-------------------
* Open PoS create an order and go back to the backedn
* Open the PoS again and close the PoS, it will cancel the order
> Observation: Open PoS order report, it will include the cancelled
order, that can be missleading.

Why the fix:
------------
We add a new default filter that apply a domain to exclude the cancelled order from the report.

opw-4257734