### PR TITLE
[FIX] l10n_ec: reordering Payment Methods SRI

### DIFF
--- a/addons/l10n_ec/views/l10n_ec_sri_payment.xml
+++ b/addons/l10n_ec/views/l10n_ec_sri_payment.xml
@@ -23,11 +23,11 @@
         <field name="model">l10n_ec.sri.payment</field>
         <field name="type">list</field>
         <field name="arch" type="xml">
-            <list string="Payment Method" create="0" edit="0">
+            <list string="Payment Method" create="0">
                 <field name="sequence" widget="handle"/>
-                <field name="code"/>
-                <field name="name"/>
-                <field name="active" widget="boolean_toggle"/>
+                <field name="code" readonly="1"/>
+                <field name="name" readonly="1"/>
+                <field name="active" widget="boolean_toggle" readonly="1"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
Users cannot use the sequence widget to reorder payment methods

Steps to reproduce:
- Go to Invoicing / Configuration / Ecuadorian SRI / Payment Methods SRI
- Try to reorder the payment methods

Issue: payment methods cannot be reordered

opw-4446472
