### PR TITLE
[FIX] mrp: finished date of unplanned work order

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -246,7 +246,8 @@ class MrpWorkorder(models.Model):
                     'date_to': wo.date_finished,
                 })
             elif wo.date_start:
-                wo.date_finished = wo._calculate_date_finished()
+                if not wo.date_finished:
+                    wo.date_finished = wo._calculate_date_finished()
                 wo.leave_id = wo.env['resource.calendar.leaves'].create({
                     'name': wo.display_name,
                     'calendar_id': wo.workcenter_id.resource_calendar_id.id,

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4396,6 +4396,25 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(mo.state, 'done')
         self.assertEqual(mo.workorder_ids[0].duration_expected, 1440.0)
 
+    def test_wo_date_finished_on_done_unplanned_mo(self):
+        """
+        Checks that the work order's date_finished and leave_id.date_to fields are equal to
+        the date_finished field on a done manufacturing order that was not planned.
+        """
+        production_form = Form(self.env['mrp.production'])
+        production_form.bom_id = self.bom_4
+        production = production_form.save()
+
+        production.action_confirm()
+
+        self.assertFalse(production.workorder_ids[0].date_finished)
+        self.assertFalse(production.workorder_ids[0].leave_id)
+
+        production.button_mark_done()
+
+        self.assertEqual(production.workorder_ids[0].date_finished, production.date_finished)
+        self.assertEqual(production.workorder_ids[0].leave_id.date_to, production.date_finished)
+
 @tagged('post_install', '-at_install')
 class TestMrpSynchronization(HttpCase):
 


### PR DESCRIPTION
Problem: When a manufacturing order with a work order that was not planned is completed, a resource.calendar.leave is created for the work order. During this process the work order’s date_finished field is recalculated. This means that this work order reserves a slot in the work center to be finished in the future even though it has already been completed.

Purpose: If the work order already has a date_finished value, then that value should be used instead of it being recalculated based on the availability of the work center. This will help ensure that completed work orders are not reserving time in a work center when it has already been completed.

Steps to Reproduce on Runbot:

1. Create a new storable product.
2. Create a BoM for this product and navigate to the Operations tab and add an operation.
3. Create a manufacturing order, confirm it, and then produce all without planning it.
4. Navigate to the completed work order and observe the finished date is in the future.
5. Navigate to the work centers working hours’ time off and find the record associated with the work order.
6. Observe that the end date is in the future.

opw-4393301

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
