### PR TITLE
[FIX] hr_attendance: Auto Check-Out Checking Out Spuriously

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -707,7 +707,7 @@ class HrAttendance(models.Model):
             to_verify_company = to_verify.filtered(lambda a: a.employee_id.company_id.id == company.id)
 
             # Attendances where Last open attendance worked time + previously worked time on that day + tolerance greater than the planned worked hours in his calendar
-            to_check_out = to_verify_company.filtered(lambda a: (fields.Datetime.now() - a.check_in).seconds + mapped_previous_duration[a.employee_id][a.check_in.date()] - max_tol > (sum(a.employee_id.resource_calendar_id.attendance_ids.filtered(lambda att: att.dayofweek == str(a.check_in.weekday())).mapped('duration_hours'))))
+            to_check_out = to_verify_company.filtered(lambda a: (fields.Datetime.now() - a.check_in).seconds / 3600 + mapped_previous_duration[a.employee_id][a.check_in.date()] - max_tol > (sum(a.employee_id.resource_calendar_id.attendance_ids.filtered(lambda att: att.dayofweek == str(a.check_in.weekday())).mapped('duration_hours'))))
             body = _('This attendance was automatically checked out because the employee exceeded the allowed time for their scheduled work hours.')
 
             for att in to_check_out:

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -399,6 +399,12 @@ class TestHrAttendanceOvertime(TransactionCase):
             'employee_id': self.employee.id,
             'check_in': datetime(2024, 2, 1, 14, 0)
         })
+        
+        # Based on the employee's working calendar, they should be within the allotted hours.
+        attendance_utc_pending_within_allotted_hours = self.env['hr.attendance'].create({
+            'employee_id': self.europe_employee.id,
+            'check_in': datetime(2024, 2, 1, 20, 0, 0)
+        })
 
         attendance_utc_done = self.env['hr.attendance'].create({
             'employee_id': self.other_employee.id,
@@ -412,12 +418,14 @@ class TestHrAttendanceOvertime(TransactionCase):
         })
 
         self.assertEqual(attendance_utc_pending.check_out, False)
+        self.assertEqual(attendance_utc_pending_within_allotted_hours.check_out, False)
         self.assertEqual(attendance_utc_done.check_out, datetime(2024, 2, 1, 17, 0))
         self.assertEqual(attendance_jpn_pending.check_out, False)
 
         self.env['hr.attendance']._cron_auto_check_out()
 
         self.assertEqual(attendance_utc_pending.check_out, datetime(2024, 2, 1, 19, 0))
+        self.assertEqual(attendance_utc_pending_within_allotted_hours.check_out, False)
         self.assertEqual(attendance_utc_done.check_out, datetime(2024, 2, 1, 17, 0))
         self.assertEqual(attendance_jpn_pending.check_out, datetime(2024, 2, 1, 21, 0))
 


### PR DESCRIPTION
When "Automatic Check-Out" was enabled for the Attendance app, a scheduled action will run every given interval to clock out employees who are still clocked-in after their defined work hours for a day (typically 8 hours.) The issue is that this action was clocking every employee out every time it ran because the condition was comparing a value in seconds to a value in hours, where the former would dominate every time.

This change fixes this by normalizing the units to hours in all calculations.

This can be tested on Runbot by following these steps: 
1) In Attendances > Configuration, check the "Automatic Check-Out" box and set the tolerance to 0. The tolerance won't make much of a difference here because it is measured in hours and we'll find later that we are calculating time in seconds, but this is the tolerance that the customer has set.)

2) In Attendances > Overview, create a new attendance record for any given employee by clicking "New." Set the check-in date and time to be the current time to simulate a small interval of working time. Delete the check-out date entirely so that we functionally have a "checked-in" employee. (You could also clock this employee in using other methods like the kiosk, but I think this way is clear and easy too.)

3) Now that there is a short interval of time for this employee, navigate to Settings > Scheduled Actions > "Attendance: Automatically check-out employees" and run it manually to simulate what would happen when it should run 4 hours later.

4) Observe that the employee has not been clocked out because they have not gone over their allotted work hours for the day: BUG SQUASHED. 💥🐛

opw-4383268