### PR TITLE
[FIX] hr_recruitment: candidate uniqueness across companies issue

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -591,15 +591,18 @@ class Applicant(models.Model):
         self = self.with_context(default_user_id=False, mail_notify_author=True)  # Allows sending stage updates to the author
         stage = False
         candidate_defaults = {}
+        company_id = self.env.company
         if custom_values and 'job_id' in custom_values:
             job = self.env['hr.job'].browse(custom_values['job_id'])
             stage = job._get_first_stage()
             candidate_defaults['company_id'] = job.company_id.id
+            company_id = job.company_id
 
         partner_name, email_from_normalized = tools.parse_contact_from_email(msg.get('from'))
         candidate = self.env["hr.candidate"].search(
             [
                 ("email_from", "=", email_from_normalized),
+                ("company_id", "=", company_id.id)
             ],
             limit=1,
         ) or self.env["hr.candidate"].create(

--- a/doc/cla/individual/abdo-mongy.md
+++ b/doc/cla/individual/abdo-mongy.md
@@ -1,0 +1,11 @@
+Egypt, 2025-01-04
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Abdulrahman-Mongy abdo.mongytrad@gmail.com https://github.com/abdo-mongy


### PR DESCRIPTION
In version 18.0, due to this PR: https://github.com/odoo/odoo/pull/190334/commits/b28dbc7faeac1095fe01d75e1783d7395, applying to jobs in different companies using the same email will not create separate candidates. This behavior raises the following error: https://github.com/odoo/odoo/blob/75571a661c5fa1dd80299bb110d9297219b7f465/addons/hr_recruitment/models/hr_applicant.py#L351.

This PR aims to fix the issue by ensuring that candidates are unique per company.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
