### PR TITLE
[FIX] hr_timesheet_attendance: fix the timezone related issue

### DIFF
--- a/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report.py
+++ b/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report.py
@@ -40,7 +40,13 @@ class TimesheetAttendance(models.Model):
                     resource_resource.user_id AS user_id,
                     hr_attendance.worked_hours AS attendance,
                     NULL AS timesheet,
-                    hr_attendance.check_in::date AS date,
+                    CAST(hr_attendance.check_in
+                            at time zone 'utc'
+                            at time zone
+                                (SELECT calendar.tz FROM resource_calendar as calendar
+                                INNER JOIN hr_employee as employee ON employee.id = employee_id
+                                WHERE calendar.id = employee.resource_calendar_id)
+                    as DATE) as date,
                     resource_resource.company_id as company_id
                 FROM hr_attendance
                 LEFT JOIN hr_employee ON hr_employee.id = hr_attendance.employee_id


### PR DESCRIPTION
Steps:
	- Install hr_timesheet_attendance.
	- Set the timezone (for both user and calendar) to Europe/Zurich.
	- Create Attendance records: [03/01/2025: 00:25:36, 03/01/2025: 10:25:59]
	- Create a Timesheet for 03/01/2025.
	- Open the Timesheet Attendance Report and group by day.
	- Check Attendance Hours and Timesheet Hours: Attendance Hours : Timesheet Hours
		02/01/2025:	10	     :       00
	        03/01/2025:	00           :       08

Issue:
	Attendance was shown as one day earlier than expected.

Reason:
	The check_in date was incorrect because it was using UTC instead of the employee's local time zone.
Fix:
	Converted check_in to the employee's local time zone before extracting the date.

issue:https://github.com/odoo/odoo/issues/169592

task-4320477
