### PR TITLE
[FIX] mail: accent issue on preview

### DIFF
--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -20,7 +20,7 @@ class TestLinkPreview(MailCommon):
         cls.test_partner = cls.env['res.partner'].create({'name': 'a partner'})
         cls.existing_message = cls.test_partner.message_post(body='Test')
         cls.title = 'Test title'
-        cls.og_title = 'Test OG title'
+        cls.og_title = 'Le carousel ne démarre pas.webm'
         cls.og_description = 'Test OG description'
         cls.og_image = 'https://dummy-image-url.nothing'
         cls.source_url = 'https://thisdomainedoentexist.nothing'
@@ -35,6 +35,7 @@ class TestLinkPreview(MailCommon):
         response = requests.Response()
         response.status_code = 200
         response._content = content
+        response.encoding = 'utf-8'
         # To handle chunks read on stream requests
         response.raw = io.BytesIO(response._content)
         response.headers["Content-Type"] = content_type
@@ -45,7 +46,7 @@ class TestLinkPreview(MailCommon):
         <html>
         <head>
         <title>Test title</title>
-        <meta property="og:title" content="Test OG title">
+        <meta property="og:title" content="Le carousel ne d\xc3\xa9marre pas.webm">
         <meta property="og:description" content="Test OG description">
         <meta property="og:image" content="https://dummy-image-url.nothing">
         </head>

--- a/addons/mail/tools/link_preview.py
+++ b/addons/mail/tools/link_preview.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from lxml import html
+import chardet
 import requests
 from urllib3.exceptions import LocationParseError
 
@@ -65,7 +66,14 @@ def get_link_preview_from_html(url, response):
 
     if not content:
         return False
-    tree = html.fromstring(content)
+
+    encoding = response.encoding or chardet.detect(content).get("encoding", "utf-8")
+    try:
+        decoded_content = content.decode(encoding)
+    except (UnicodeDecodeError, TypeError) as e:
+        decoded_content = content.decode("utf-8", errors="ignore")
+
+    tree = html.fromstring(decoded_content)
     og_title = tree.xpath('//meta[@property="og:title"]/@content')
     if og_title:
         og_title = og_title[0]


### PR DESCRIPTION
### Steps to reproduce:

- Open the To-do app.
- Paste the link into the editor (e.g., https://drive.google.com/file/d/1oNZsDWEUjxpwbB8tkv1CRCfp-pcKHhGG/edit).
- Click on the link to open the preview.
- Notice that accents are displayed incorrectly.

### Solution:

- Retrieved encoding from the response or detected it using `chardet`.
- Decoded the content using the detected encoding or fell back to UTF-8 if decoding failed.
- Processed the decoded content to parse the HTML tree.

### Description of the issue/feature this PR addresses:

Accents were not displayed correctly on the preview due to encoding mismatches.

### Desired behavior after PR is merged:

Accents in the preview are displayed correctly as the content is decoded using the appropriate encoding, with a fallback to UTF-8 if needed.

task-4435229