### PR TITLE
[IMP] mass_mailing,web_editor: replace stars command with rating snippet

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_wysiwyg.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_wysiwyg.js
@@ -1,3 +1,4 @@
+import { _t } from "@web/core/l10n/translation";
 import { loadBundle } from "@web/core/assets";
 import { Wysiwyg } from "@web_editor/js/wysiwyg/wysiwyg";
 import { closestElement } from "@web_editor/js/editor/odoo-editor/src/OdooEditor";
@@ -199,9 +200,52 @@ export class MassMailingWysiwyg extends Wysiwyg {
      * @override
      */
     _getEditorOptions() {
+        const [powerboxItems, powerboxCategories] = this._getSnippetsPowerboxItems();
         const options = super._getEditorOptions(...arguments);
-        const finalOptions = { ...options, autoActivateContentEditable: false, allowCommandVideo: false };
+        const finalOptions = {
+            ...options,
+            autoActivateContentEditable: false,
+            allowCommandVideo: false,
+            powerboxItems,
+            powerboxCategories,
+        };
         return finalOptions;
+    }
+
+    /**
+     * Returns the snippets commands for the powerbox
+     *
+     * @private
+     */
+    _getSnippetsPowerboxItems() {
+        const snippetCommandCallback = (selector) => {
+            const range = this.getDeepRange();
+            const block = this.closestElement(
+                range.endContainer,
+                "p, div, ol, ul, cl, h1, h2, h3, h4, h5, h6"
+            );
+            if (block) {
+                this.snippetsMenuBus.trigger("INSERT_SNIPPET", {
+                    snippetSelector: selector,
+                    block,
+                });
+            }
+        };
+        const commands = [
+            {
+                category: _t("Mass mailing"),
+                name: _t("Rating"),
+                priority: 90,
+                description: _t("Insert a rating snippet"),
+                keywords: ["rate", "star"],
+                fontawesome: "fa-star-half-o",
+                isDisabled: () => !this.odooEditor.isSelectionInBlockRoot(),
+                callback: () => {
+                    snippetCommandCallback(".oe_snippet_body[data-snippet='s_rating']");
+                },
+            },
+        ];
+        return [commands, [{ name: _t("Mass mailing"), priority: 20 }]];
     }
 }
 

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -632,32 +632,6 @@ export class OdooEditor extends EventTarget {
                         this.execCommand('setTag', 'P');
                     },
                 },
-                {
-                    category: this.options._t('Widgets'),
-                    name: this.options._t('3 Stars'),
-                    priority: 20,
-                    description: this.options._t('Insert a rating over 3 stars'),
-                    fontawesome: 'fa-star-o',
-                    callback: () => {
-                        let html = '\u200B<span contenteditable="false" class="o_stars o_three_stars">';
-                        html += Array(3).fill().map(() => '<i class="fa fa-star-o"></i>').join('');
-                        html += '</span>\u200B';
-                        this.execCommand('insert', parseHTML(this.document, html));
-                    },
-                },
-                {
-                    category: this.options._t('Widgets'),
-                    name: this.options._t('5 Stars'),
-                    priority: 10,
-                    description: this.options._t('Insert a rating over 5 stars'),
-                    fontawesome: 'fa-star',
-                    callback: () => {
-                        let html = '\u200B<span contenteditable="false" class="o_stars o_five_stars">';
-                        html += Array(5).fill().map(() => '<i class="fa fa-star-o"></i>').join('');
-                        html += '</span>\u200B';
-                        this.execCommand('insert', parseHTML(this.document, html));
-                    },
-                },
                 ...(this.options.commands || []),
                 ...(!this.options.commands || !this.options.commands.find(c => c.name === this.options._t('Separator')) ? [
                     {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -8090,42 +8090,6 @@ X[]
                 });
             });
         });
-        describe('rating star elements', () => {
-            it('add star elements', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<p>[]</p>',
-                    stepFunction: async editor => {
-                        await insertText(editor,'/');
-                        await insertText(editor, '3star');
-                        await triggerEvent(editor.editable, 'keyup')
-                        await triggerEvent(editor.editable, 'keydown', {key: 'Enter'})
-                        await nextTick()
-                    },
-                    contentAfterEdit: `<p>\u200B<span contenteditable="false" class="o_stars o_three_stars" id="checkId-1"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`,
-                });
-                await testEditor(BasicEditor, {
-                    contentBefore: '<p>[]</p>',
-                    stepFunction: async editor => {
-                        await insertText(editor,'/');
-                        await insertText(editor, '5star');
-                        await triggerEvent(editor.editable, 'keyup')
-                        await triggerEvent(editor.editable, 'keydown', {key: 'Enter'})
-                        await nextTick()
-                    },
-                    contentAfterEdit: `<p>\u200B<span contenteditable="false" class="o_stars o_five_stars" id="checkId-1"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`,
-                });
-            });
-            it('should delete star rating elements when delete is pressed twice', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: `<p>\u200B<span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" id="checkId-1" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" id="checkId-2" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" id="checkId-3" contenteditable="false">\u200B</i></span>\u200B[]</p>`,
-                    stepFunction: async editor => {
-                        await deleteBackward(editor)
-                        await deleteBackward(editor)
-                    },
-                    contentAfter: '<p>\u200B[]<br></p>'
-                });
-            });
-        });
 
         describe('After keydown event', () => {
             it('should keep the selection at the start of the second text node after paragraph break', async () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/powerbox.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/powerbox.test.js
@@ -309,6 +309,46 @@ describe('Powerbox', () => {
             powerbox.destroy();
             editable.remove();
         });
+        it("should filter commands keywords", async () => {
+            const editable = document.createElement("div");
+            editable.classList.add("odoo-editor-editable");
+            document.body.append(editable);
+            editable.append(document.createTextNode("original text"));
+            setSelection(editable.firstChild, 13);
+            const powerbox = new Powerbox({
+                categories: [],
+                commands: [
+                    { category: "a", name: "a2", keywords: ["2", "two"] },
+                    { category: "a", name: "a3", keywords: ["3", "three"] },
+                    { category: "a", name: "a1", keywords: ["1", "one"] },
+                    { category: "b", name: "b2x", keywords: ["2x", "two"] },
+                    { category: "b", name: "b3x", keywords: ["3x", "three"] },
+                    { category: "b", name: "b1y", keywords: ["1y", "b1"] },
+                ],
+                editable,
+            });
+            powerbox.open();
+            window.chai.expect(powerbox._context.initialValue).to.eql("original text");
+            window.chai
+                .expect(getCurrentCommandNames(powerbox))
+                .to.eql(["a1", "a2", "a3", "b1y", "b2x", "b3x"]);
+            // filter: 'one'
+            editable.append(document.createTextNode("one"));
+            await triggerEvent(editable, "keyup");
+            window.chai.expect(getCurrentCommandNames(powerbox)).to.eql(["a1"]);
+            // filter: ''
+            editable.lastChild.remove();
+            await triggerEvent(editable, "keyup");
+            window.chai
+                .expect(getCurrentCommandNames(powerbox))
+                .to.eql(["a1", "a2", "a3", "b1y", "b2x", "b3x"]);
+            // filter: 'two'
+            editable.append(document.createTextNode("two"));
+            await triggerEvent(editable, "keyup");
+            window.chai.expect(getCurrentCommandNames(powerbox)).to.eql(["a2", "b2x"]);
+            powerbox.destroy();
+            editable.remove();
+        });
         it('should close the Powerbox on remove last filter text with Backspace', async () => {
             const editable = document.createElement('div');
             editable.classList.add('odoo-editor-editable');

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -836,6 +836,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
                 priority: 90,
                 description: _t('Insert a rating snippet'),
                 fontawesome: 'fa-star-half-o',
+                keywords: ["rate", "star"],
                 isDisabled: () => !this.odooEditor.isSelectionInBlockRoot(),
                 callback: () => {
                     snippetCommandCallback('.oe_snippet_body[data-snippet="s_rating"]');


### PR DESCRIPTION
With this PR, 

1. Added `/rating` command in `mass_mailing` and removing the `stars` command from the `web_editor` because it is not needed in the `website/mass_mailing` editor.As there is already `rating` snippet and `/rating` command which works like `/3star or /5star` commands.
2. Adding keywords for commands which helps us to search command easily. 

task-4391279