### PR TITLE
[FIX] l10n_it_edi: prevent error when downloading invoice

### DIFF
--- a/addons/l10n_it_edi/models/account_move_send.py
+++ b/addons/l10n_it_edi/models/account_move_send.py
@@ -73,11 +73,12 @@ class AccountMoveSend(models.AbstractModel):
         moves = self.env['account.move']
         for move, move_data in invoices_data.items():
             if 'it_edi_send' in move_data['extra_edis']:
-                moves |= move
                 if attachment := move.l10n_it_edi_attachment_id:
                     attachments_vals[move] = {'name': attachment.name, 'raw': attachment.raw}
-                else:
-                    attachments_vals[move] = invoices_data[move]['l10n_it_edi_values']
+                    moves |= move
+                elif edi_values := move_data.get('l10n_it_edi_values'):
+                    attachments_vals[move] = edi_values
+                    moves |= move
         moves._l10n_it_edi_send(attachments_vals)
 
     def _link_invoice_documents(self, invoices_data):


### PR DESCRIPTION
This error occurs when an invoice is not initially sent to the tax agency, but we later attempt to print it and send it to the agency.

Steps to reproduce:
---
- Install ``l10n_it_edi`` module
- Switch to ``IT Company``
- Create Customers Invoice > ``Confirm`` > ``Print & Send``
- Disable ``Send to Tax Agency`` > ``Print & Send``
- Now again ``Print & Send`` and ``Print & Send``

Traceback:
---
``KeyError: 'l10n_it_edi_values'``

This commit resolves the error by checking that ``l10n_it_edi_values`` is present in ``move_data``.

sentry-6191573767

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
