### PR TITLE
[FIX] {sale_purchase_,}stock: capture accurate dest. location in forecast

### DIFF
--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import date, timedelta
+
 from odoo import Command
 from odoo.tests import Form, TransactionCase
 
@@ -277,3 +279,50 @@ class TestSalePurchaseStockFlow(TransactionCase):
         self.assertRecordValues(new_delivery.move_ids, [
             {'product_id': self.mto_product.id, 'product_uom_qty': 1.0},
         ])
+
+    def test_two_step_delivery_forecast_after_first_picking(self):
+        """ When a product is moved with 2-step delivery, the first of the two pickings associated
+        with that delivery (upon completion) should have the actual physical location to which the
+        product was delivered as its destination in `report.stock.quantity`: prior, irrespective of
+        the move's state, it would have its location_dest_id and location_final_id coalesced. This
+        meant that the location that the StockMove had actually moved product to was not
+        necessarily the destination location reflected in the generated report row, which lead to
+        an incorrect forecast.
+        """
+        wh = self.env.user._get_default_warehouse_id()
+        wh.delivery_steps = 'pick_ship'
+        product = self.mto_product
+        in_move = self.env['stock.move'].create({
+            'name': 'in move',
+            'product_id': product.id,
+            'product_uom_qty': 2,
+            'product_uom': product.uom_id.id,
+            'location_id': self.env.ref('stock.stock_location_suppliers').id,
+            'location_dest_id': wh.lot_stock_id.id,
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+        })
+        in_move._action_confirm()
+        in_move._action_assign()
+        in_move.move_line_ids.quantity = 2
+        in_move.picked = True
+        in_move._action_done()
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({'product_id': product.id,'product_uom_qty': 2})],
+        })
+        sale_order.action_confirm()
+        pick_picking = sale_order.picking_ids[0]
+        pick_picking.button_validate()
+
+        forecasted_qty = self.env['report.stock.quantity'].with_context(fill_temporal=False).read_group(
+            domain=[
+                ('state', '=', 'forecast'),
+                ('warehouse_id', '=', wh.id),
+                ('product_tmpl_id', '=', product.product_tmpl_id.id),
+                ('date', '=', date.today() - timedelta(days=20)),
+            ],
+            fields=['__count', 'product_qty:sum'],
+            groupby=['date:day', 'product_id'],
+        )
+        self.assertEqual(forecasted_qty[0]['product_qty'], 0)

--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -56,7 +56,11 @@ WITH
         SELECT m.id, m.product_id, pt.id, m.product_qty, m.date, m.state, m.company_id, source.w_id, dest.w_id
         FROM stock_move m
         LEFT JOIN warehouse_cte source ON source.sl_id = m.location_id
-        LEFT JOIN warehouse_cte dest ON dest.sl_id = COALESCE(m.location_final_id, m.location_dest_id)
+        LEFT JOIN warehouse_cte dest ON
+            CASE
+                WHEN m.state != 'done' THEN dest.sl_id = COALESCE(m.location_final_id, m.location_dest_id)
+                WHEN m.state = 'done' THEN dest.sl_id = m.location_dest_id
+            END
         LEFT JOIN product_product pp on pp.id=m.product_id
         LEFT JOIN product_template pt on pt.id=pp.product_tmpl_id
         WHERE pt.is_storable = true AND


### PR DESCRIPTION
**Current behavior:**
The `report.stock.quantity` view may attribute and incorrect
destination location with a move when building the report:

Specifically, it will coalesce a move's `location_dest_id` and
`location_final_id` regardless of the state of the move and
where the product qty was actually transferred to.

**Expected behavior:**
If the move is completed, the actual location of where it moved
product should be used to fill in the destination location.

**Steps to reproduce:**
1. Enable 2-step delivery

2. Create an in move for some tracked productA -> validate

3. Create a sale order for the same productA, confirm, then
validate the first picking in the chain

4. Look at the forecast for productA, observe that it has the
positive quantity from the in move furter in the past then it
should

**Cause of the issue:**
When a StockMove was completed, it's `location_final_id` was
taken over its `location_dest_id`, which meant the actual
location that the move transferred product to was not reflected
in the quantity report, meaning you could have a case as
described above where the forecast quantity becomes imbalanced
because it is not properly counting moves against would-be
offsetting ones.

**Fix:**
Don't prefer `location_final_id` when `move.state == 'done'`.

opw-4311583