### PR TITLE
[FIX] html_editor: ctrl+click on styled link should open the link

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -188,12 +188,13 @@ export class LinkPlugin extends Plugin {
     setup() {
         this.overlay = this.dependencies.overlay.createOverlay(LinkPopover, {}, { sequence: 50 });
         this.addDomListener(this.editable, "click", (ev) => {
-            if (ev.target.tagName === "A" && ev.target.isContentEditable) {
+            const target = closestElement(ev.target, "a");
+            if (target?.isContentEditable) {
                 if (ev.ctrlKey || ev.metaKey) {
-                    window.open(ev.target.href, "_blank");
+                    window.open(target.href, "_blank");
                 }
                 ev.preventDefault();
-                this.toggleLinkTools({ link: ev.target });
+                this.toggleLinkTools({ link: target });
             }
         });
         // link creation is added to the command service because of a shortcut conflict,


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

Ctrl+clicking on a styled link is ineffective since the target is the styled element.

Desired behavior after PR is merged:

Ensure the target is the closest anchor tag.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
