### PR TITLE
[FIX] l10n_es_edi_tbai: only use regime key 52 for simplified invoice

### DIFF
--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -389,13 +389,13 @@ class AccountEdiFormat(models.Model):
 
         if is_oss:
             values['regime_key'] = ['17']
+        elif invoice._is_l10n_es_tbai_simplified():
+            values['regime_key'] = ['52']  # code for simplified invoices
         elif not com_partner.country_id or com_partner.country_id.code in self.env.ref('base.europe').country_ids.mapped('code'):
             values['regime_key'] = ['01']
         else:
             values['regime_key'] = ['02']
 
-        if invoice._is_l10n_es_tbai_simplified():
-            values['regime_key'].append(52)  # code for simplified invoices
         values['nosujeto_causa'] = 'IE' if is_oss else 'RL'
 
         return values


### PR DESCRIPTION
**Steps to reproduce:**
- Install l10n_es_edi_tbai
- Switch to a Spanish company (e.g. ES Company)
- Create an invoice with "Simplified Invoice Partner (ES)" as customer
- Confirm the invoice
- Process the invoice with "TicketBAI (ES)" service

**Issue:**
The generated XML has 2 regime keys (02 and 52) for <ClaveRegimenIvaOpTrascendencia> that are not compatible with each other.
From the documentation, regime key "52" (for simplified invoices) can only be associated with regime key "51", which is not supported for the moment.

**Solution:**
If the "Simplified Invoice Partner" is used, only the regime key "52" is used.

opw-4332052
opw-4355424




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
