### PR TITLE
[FIX] iot_box_image: image builder for new release

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/DisplayInterface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/DisplayInterface_L.py
@@ -45,8 +45,11 @@ class DisplayInterface(Interface):
 
         try:
             os.environ['DISPLAY'] = ':0'
-            for x_screen, monitor in enumerate(screeninfo.get_monitors()):
-                display_devices[monitor.name] = self._add_device(monitor.name, x_screen)
+            display_devices = {
+                monitor.name: self._add_device(monitor.name, x_screen)
+                for x_screen, monitor in enumerate(screeninfo.get_monitors())
+                if "DUMMY" not in monitor.name
+            }
             return display_devices or dummy_display
         except screeninfo.common.ScreenInfoError:
             # If no display is connected, screeninfo raises an error, we return the distant display

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -383,7 +383,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Logger level updated',
         }
 
-    @http.route('/hw_posbox_homepage/update_git_tree', auth="none", type="json", methods=['POST'], cors='*')
+    @http.route('/hw_posbox_homepage/update_git_tree', auth="none", type="jsonrpc", methods=['POST'], cors='*')
     def update_git_tree(self):
         helpers.check_git_branch()
         return {

--- a/addons/iot_box_image/build_image.sh
+++ b/addons/iot_box_image/build_image.sh
@@ -31,6 +31,19 @@ OVERWRITE_FILES_AFTER_INIT_DIR="${__dir}/overwrite_after_init"
 VERSION=17.0
 VERSION_IOTBOX=24.10
 
+if [[ "${1:-}" == "-c" || "${1:-}" == "--cleanup" ]]; then
+    echo "Cleaning up..."
+    umount -fv "${MOUNT_POINT}/boot/" > /dev/null 2>&1 || true
+    umount -lv "${MOUNT_POINT}/" > /dev/null 2>&1 || true
+    rm -rfv "${MOUNT_POINT}"
+    rm -rf overwrite_before_init/usr
+    rm -rf overwrite_before_init/home/pi/odoo
+    rm -rfv iotbox.img
+    sudo kpartx -d /dev/loop1 > /dev/null 2>&1 || true
+    losetup -d /dev/loop1 > /dev/null 2>&1 || true
+    echo "Cleanup done."
+    exit 0
+fi
 
 # ask user for the branch/version
 current_branch="$(git branch --show-current)"
@@ -69,6 +82,7 @@ addons/point_of_sale/tools/posbox/configuration
 odoo/
 odoo-bin" | tee --append .git/info/sparse-checkout > /dev/null
     git read-tree -mu HEAD
+    git remote set-url origin "https://github.com/odoo/odoo.git" # ensure remote is the original repo
 fi
 
 cd "${__dir}"
@@ -167,17 +181,17 @@ find "${MOUNT_POINT}"/ -type f -name "*.iotpatch"|while read iotpatch; do
     done
 done
 
-# cleanup
-umount -fv "${MOUNT_POINT}"/boot/
-umount -lv "${MOUNT_POINT}"/
-rm -rfv "${MOUNT_POINT}"
-
 echo "Running zerofree..."
 zerofree -v "${LOOP_IOT_ROOT}" || true
 
 sleep 10
 
-kpartx -dv "${LOOP_IOT_PATH}"
+# cleanup
+umount -fv "${MOUNT_POINT}"/boot/
+umount -lv "${MOUNT_POINT}"/
+rm -rfv "${MOUNT_POINT}"
 kpartx -dv "${LOOP_RASPIOS_PATH}"
+kpartx -dv "${LOOP_IOT_PATH}"  # /dev/loop1
+losetup -d "${LOOP_IOT_PATH}"  # /dev/loop1
 
 echo "Image build finished."

--- a/addons/iot_box_image/overwrite_after_init/etc/X11/xorg.conf
+++ b/addons/iot_box_image/overwrite_after_init/etc/X11/xorg.conf
@@ -1,7 +1,41 @@
-Section "OutputClass"
-  Identifier "vc4"
-  MatchDriver "vc4"
-  Driver "modesetting"
-  Option "PrimaryGPU" "true"
-  Option "PageFlip" "false"
+Section "ServerLayout"
+    Identifier  "Multihead"
+    Screen      0 "Screen0" 0 0
+    Screen      1 "Screen1" RightOf "Screen0"
+EndSection
+
+Section "Monitor"
+    Identifier  "Monitor0"
+EndSection
+
+Section "Monitor"
+    Identifier  "Monitor1"
+EndSection
+
+Section "Device"
+    Identifier  "VC4"
+    Driver      "modesetting"
+EndSection
+
+Section "Device"
+    Identifier  "DummyDevice"
+    Driver      "dummy"
+EndSection
+
+Section "Screen"
+    Identifier  "Screen0"
+    Device      "VC4"
+    Monitor     "Monitor0"
+    SubSection "Display"
+        Modes   "1920x1080"
+    EndSubSection
+EndSection
+
+Section "Screen"
+    Identifier  "Screen1"
+    Device      "DummyDevice"
+    Monitor     "Monitor1"
+    SubSection "Display"
+        Modes   "1920x1080"
+    EndSubSection
 EndSection

--- a/addons/iot_box_image/overwrite_after_init/etc/lightdm/lightdm.conf
+++ b/addons/iot_box_image/overwrite_after_init/etc/lightdm/lightdm.conf
@@ -1,8 +1,7 @@
-
 [LightDM]
 user-authority-in-system-dir=true
 
-[SeatDefaults]
+[Seat:*]
 xserver-command=/usr/bin/X -s 0 -layout Multihead dpms -nolisten tcp
 greeter-hide-users=false
 autologin-user=odoo

--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -214,6 +214,9 @@ adduser --disabled-password --gecos "" --shell /usr/sbin/nologin odoo
 mv /etc/sudoers.d/010_pi-nopasswd /etc/sudoers.d/010_odoo-nopasswd
 sed -i 's/pi/odoo/g' /etc/sudoers.d/010_odoo-nopasswd
 
+# Allow "sudo" git commands even if Odoo directory is owned by odoo user
+git config --global --add safe.directory /home/pi/odoo
+
 # copy the odoo.conf file to the overwrite directory
 mv -v "/home/pi/odoo/addons/iot_box_image/configuration/odoo.conf" "/home/pi/"
 chown odoo:odoo "/home/pi/odoo.conf"

--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -220,6 +220,7 @@ chown odoo:odoo "/home/pi/odoo.conf"
 
 groupadd usbusers
 usermod -a -G usbusers odoo
+usermod -a -G video odoo
 usermod -a -G lp odoo
 usermod -a -G input lightdm
 usermod -a -G pi odoo


### PR DESCRIPTION
As we merged lots of new IoT Box image improvements in `saas-18.1` by the time it was `master`, and fixed the related bugs and issues in `master` (soon to be `saas-18.2`), we now need to backport important fixes, so we can release a new image in `saas-18.1`.

Backport of:

- https://github.com/odoo/odoo/pull/191688,
- https://github.com/odoo/odoo/pull/192165,
- https://github.com/odoo/odoo/pull/191879,
- https://github.com/odoo/odoo/pull/192161,
- https://github.com/odoo/odoo/pull/191340.