### PR TITLE
[FIX] point_of_sale: fix pos preset name without partner

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1784,7 +1784,7 @@ export class PosStore extends WithLazyGetterTrap {
 
             order.setPreset(preset);
             if (preset.identification === "name" && !order.floating_order_name && !order.table_id) {
-                order.floating_order_name = order.getPartner().name;
+                order.floating_order_name = order.getPartner()?.name;
                 if (!order.floating_order_name) {
                     this.editFloatingOrderName(order);
                 }


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/192154, selecting a preset indentified by name without a partner raise a traceback as we try to access the name of the partner which is undefined.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
