### PR TITLE
[FIX] account_edi_ubl_cii: default company currency for currency not found

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -458,7 +458,7 @@ class AccountEdiCommon(models.AbstractModel):
     def _import_currency(self, tree, xpath):
         logs = []
         currency_name = tree.findtext(xpath)
-        currency = self.env['res.currency']
+        currency = self.env.company.currency_id
         if currency_name is not None:
             currency = currency.with_context(active_test=False).search([
                 ('name', '=', currency_name),


### PR DESCRIPTION
This error occurs when uploading a ``factur-x.xml`` file that lacks currency information or when the ``factur-x.xml`` file we generate does not include any currency.

Steps to reproduce:
---
- Install ``account_edi_ubl_cii`` module
- Invoicing > Customers > Invoices
- Click ``Upload`` button and upload [file](https://drive.google.com/drive/u/0/folders/1TrG7xBUdwdq04KueZi0WdxHxm_g0vfW_)

Traceback:
---
NotNullViolation: null value in column "currency_id" of relation "account_move_line" violates not-null constraint DETAIL:  Failing row contains (50, 50, 9, 1, 125, 100, 205, null, 56, null, null, null, null, null, null, null, null, null, null, null, 2, 2, null, null, null, NEWS9141525, null, product, null, null, null, null, null, 0.00, 0.00, 0.00, 0.0, null, null, null, 1.00, 109.72, null, null, 0.00000000000000000000000000000000000000000000000000000000000000..., null, null, null, null, null, 2025-01-02 01:03:08.880424, 2025-01-02 01:03:08.880424, null, null, null, null, null, null, null, null, null).

This commit resolves the issue by adding the default company currency when no currency is found in the file.

sentry-6056586239

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
