### PR TITLE
[FIX] account: replace type of product in test

### DIFF
--- a/addons/account/tests/test_product.py
+++ b/addons/account/tests/test_product.py
@@ -61,6 +61,6 @@ class TestProduct(AccountTestInvoicingCommon):
     def test_account_manager_user_can_create_product(self):
         """Test that a user with group_account_manager can create a product."""
         product = self.env['product.product'].with_user(self.account_manager_user).create({
-            'name': 'Test Accountant', 'type': 'product', 'list_price': 50.0,
+            'name': 'Test Accountant', 'type': 'consu', 'list_price': 50.0,
         })
         self.assertTrue(product)


### PR DESCRIPTION
Issue:
- run the `test_account_manager_user_can_create_product` with `account`and its dependencies as the only modules installed
- error is given as `product` is not a valid product type (it is added in the `stock` module)

Solution:
- replace `product` with a product type that is defined in one of the dependencies




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
