### PR TITLE
[FIX] sale_project: fix issue with SQL constraint causing to create SOL without product

### DIFF
--- a/addons/sale_project/i18n/sale_project.pot
+++ b/addons/sale_project/i18n/sale_project.pot
@@ -612,6 +612,12 @@ msgstr ""
 
 #. module: sale_project
 #. odoo-python
+#: code:addons/sale_project/models/sale_order_line.py:0
+msgid "The Sale Order Item should contain a service product."
+msgstr ""
+
+#. module: sale_project
+#. odoo-python
 #: code:addons/sale_project/models/product_template.py:0
 msgid ""
 "The product %s should not have a global project since it will generate a "

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -4,7 +4,7 @@
 from collections import defaultdict
 
 from odoo import api, Command, fields, models, _
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, ValidationError
 from odoo.tools import format_amount
 from odoo.tools.sql import column_exists, create_column
 
@@ -76,12 +76,17 @@ class SaleOrderLine(models.Model):
 
     @api.model
     def name_create(self, name):
+        ensure_is_service_product = False
         # To get the right product when creating a SOL on the fly, we need to get
         # the name that was entered in the field from the `default_get` method.
         # The easiest way of doing that is to store it in the context.
         if self.env.context.get('form_view_ref') == 'sale_project.sale_order_line_view_form_editable' and not self.env.context.get('action_view_sols'):
             self = self.with_context(sol_product_name=name)
-        return super().name_create(name)
+            ensure_is_service_product = True
+        result = super().name_create(name)
+        if ensure_is_service_product and result and not self.browse(result[0]).is_service:
+            raise ValidationError(_("The Sale Order Item should contain a service product."))
+        return result
 
     @api.model
     def _add_missing_default_values(self, values):


### PR DESCRIPTION
Steps to reproduce:

- In any of the SOL Many2one field with create=True.
- Create a SOL using create option in dropdown.

Issue:

- A SOL is created without product.

Reason:

- Incorrect SQL constraint passed .

Fix:

- Adding a validation error which is tapped in if Many2one quick create i.e.,
Create option fails and opens the Many2X form.

- We cant change the SQL contraint because it is only applied when module
is intalled/updated/reinstalled.

---
Why the SQL contsraint fails

"CHECK(display_type IS NOT NULL OR is_downpayment OR (product_id IS NOT NULL AND product_uom IS NOT NULL))"

Also is_downpayment doesnt have a default value.

Here consider we dont event send a single value all as nulls then result would
be

CHECK(NULL IS NOT NULL OR NULL OR (NULL IS NOT NULL AND NULL IS NOT NULL))

CHECK(FALSE OR NULL OR (FALSE AND FALSE)

CHECK(FALSE OR NULL OR FALSE)

CHECK(NULL)

SQL doesn't categorize NULL into truthy or falsy value.

For example a SQL constraint as
CHECK (row1 NOT NULL OR row2 ...(and N number of conditions)) -- will always
pass the check (even if you pass all the rows as NULL)

NULL OR NULL -- TRUE (passes the empty NULL column value as [null])
FALSE OR NULL -- TRUE (passes the empty NULL column value as [null])
TRUE OR NULL -- TRUE

It there is another column which has value it glady create a row with values
and [null]/empty value for others.

task-4441043

Co-Authored By - @xavierbol 