### PR TITLE
[FIX] l10n_es_edi_{facturae,sii}: FechaOperacion / OperationDate

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -317,6 +317,10 @@ class AccountMove(models.Model):
         if self.move_type == "entry":
             return False
 
+        operation_date = None
+        if self.delivery_date and self.delivery_date != self.invoice_date:
+            operation_date = self.delivery_date.isoformat()
+
         eur_curr = self.env['res.currency'].search([('name', '=', 'EUR')])
         inv_curr = self.currency_id
         legal_literals = self.narration.striptags() if self.narration else False
@@ -368,6 +372,7 @@ class AccountMove(models.Model):
                 'InvoiceClass': 'OO',
                 'Corrective': self._l10n_es_edi_facturae_get_corrective_data(),
                 'InvoiceIssueData': {
+                    'OperationDate': operation_date,
                     'ExchangeRateDetails': need_conv,
                     'ExchangeRate': f"{round(conversion_rate, 4):.4f}",
                     'LanguageName': self._context.get('lang', 'en_US').split('_')[0],

--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -285,6 +285,8 @@ class AccountEdiFormat(models.Model):
 
             # === Invoice ===
 
+            if invoice.delivery_date and invoice.delivery_date != invoice.invoice_date:
+                invoice_node['FechaOperacion'] = invoice.delivery_date.strftime('%d-%m-%Y')
             invoice_node['DescripcionOperacion'] = invoice.invoice_origin[:500] if invoice.invoice_origin else 'manual'
             if invoice.is_sale_document():
                 nif = invoice.company_id.vat[2:] if invoice.company_id.vat.startswith('ES') else invoice.company_id.vat


### PR DESCRIPTION
Currently the folllowing fields are not set / given in the SII / FaturaE XMLs respectively:
  * `FechaOperacion` (l10n_es_edi_sii)
  * `OperationDate` (l10n_es_edi_facturae)

After this commit they will give the delivery date in case the delivery date is different from the invoice date.

This is basically the same as it was done for TicketBat (l10n_es_edi_tbai) in commit 1451f589895f0867cd40add66e5e6bcbb5ba4a6e already.

opw-4367470

Enterprise PR: https://github.com/odoo/enterprise/pull/76523