### PR TITLE
[FIX] account,l10n_it_edi: Batch Print & Send when manual sending method.

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -9670,6 +9670,12 @@ msgid ""
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/wizard/account_move_send_batch_wizard.py:0
+msgid "Manually"
+msgstr ""
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_form
 msgid "Mapping"
 msgstr ""

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -625,7 +625,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         self.assertEqual(wizard.move_ids, invoice1 + invoice2)
         self.assertFalse(wizard.alerts)
         self.assertEqual(wizard.summary_data, {
-            'manual': {'count': 1, 'label': 'Download'},
+            'manual': {'count': 1, 'label': 'Manually'},
             'email': {'count': 1, 'label': 'by Email'},
         })
 
@@ -666,7 +666,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         self.assertEqual(wizard.move_ids, invoice1 + invoice2 + invoice3)
         self.assertTrue(wizard.alerts and 'account_pdf_exist' in wizard.alerts)
         self.assertEqual(wizard.summary_data, {
-            'manual': {'count': 2, 'label': 'Download'},
+            'manual': {'count': 2, 'label': 'Manually'},
             'email': {'count': 1, 'label': 'by Email'},
         })
         wizard.action_send_and_print()
@@ -734,7 +734,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
             self.assertEqual(wizard.summary_data, {
                 'edi1': {'count': 2, 'label': 'by EDI 1'},
                 'edi2': {'count': 1, 'label': 'by EDI 2'},
-                'manual': {'count': 1, 'label': 'Download'},
+                'manual': {'count': 1, 'label': 'Manually'},
                 'email': {'count': 1, 'label': 'by Email'},
             })
 

--- a/addons/account/wizard/account_move_send_batch_wizard.py
+++ b/addons/account/wizard/account_move_send_batch_wizard.py
@@ -34,6 +34,7 @@ class AccountMoveSendBatchWizard(models.TransientModel):
     def _compute_summary_data(self):
         extra_edis = self._get_all_extra_edis()
         sending_methods = dict(self.env['res.partner']._fields['invoice_sending_method'].selection)
+        sending_methods['manual'] = _('Manually')  # in batch sending, everything is done asynchronously, we never "Download"
 
         for wizard in self:
             edi_counter = Counter()

--- a/addons/l10n_it_edi/i18n/l10n_it_edi.pot
+++ b/addons/l10n_it_edi/i18n/l10n_it_edi.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-17 09:50+0000\n"
-"PO-Revision-Date: 2024-10-17 09:50+0000\n"
+"POT-Creation-Date: 2025-01-06 11:37+0000\n"
+"PO-Revision-Date: 2025-01-06 11:37+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1061,6 +1061,12 @@ msgstr ""
 msgid ""
 "We are simulating the sending of the e-invoice file %s, as we are in demo "
 "mode."
+msgstr ""
+
+#. module: l10n_it_edi
+#. odoo-python
+#: code:addons/l10n_it_edi/models/account_move.py:0
+msgid "XML FatturaPA"
 msgstr ""
 
 #. module: l10n_it_edi

--- a/addons/l10n_it_edi/models/account_move_send.py
+++ b/addons/l10n_it_edi/models/account_move_send.py
@@ -50,7 +50,7 @@ class AccountMoveSend(models.AbstractModel):
             if errors := invoice._l10n_it_edi_export_data_check():
                 invoice_data['error'] = {
                     'error_title': _("Errors occurred while creating the e-invoice file:"),
-                    'errors': errors,
+                    'errors': [error['message'] for error in errors.values()],
                 }
 
     def _hook_invoice_document_after_pdf_report_render(self, invoice, invoice_data):


### PR DESCRIPTION
## Commit 1: 
### [FIX] account: Batch invoice sending when partner on "Download"

Context:
In 18.0, all batch/multiple invoice sending are processed asynchronously, we never directly
download the generated PDF/XML files. The sending method that is used depends on what is
set on the partner.

Problem:
If you set your partner to "Download" by default, in the batch Send & Print, it
will display "You are about to send: x invoice(s) Download". While it's actually
not downloading, only generating. In 18.1 we changed this to "Manual" which is better but
doesn't go well in a sentence.

Solution:
Let's align everything to "Manually" in batch sending to avoid confusion.

Before:
![image](https://github.com/user-attachments/assets/9048c5bd-0e5f-4c25-a816-3c941bec7fce)

After:
![image](https://github.com/user-attachments/assets/8a4201f4-e4be-4c0d-b801-83815b337352)


opw-4315079

## Commit 2: 
###[IMP] l10n_it_edi: Add possibility to download in batch XML FatturaPA
Context:
In 18.0, when sending invoices in batch, we never download a zip of all generated
files (PDF, XML) since we always process invoices asynchronously with the partner's
sending method set on the partner's form.

Problem:
It's no longer possible to retrieve all XML Fattura PA at once.

Solution:
Add a button under the "Print/Download" button to download them all.

opw-4315079

## Commit 3:
### [FIX] l10n_it_edi: Fix error message display in Print & Send
The italian error dict does not comply to the default format expected
by the generic Print & Send. It displays the key of the error
instead of the message.
Before:
![it_error_msg_pre](https://github.com/user-attachments/assets/22707d0d-95b4-4b74-b31f-b4bc3ba334fd)
After:
![it_error_msg_post](https://github.com/user-attachments/assets/e32eef16-14d5-4462-96cc-c8e5ede5feb7)

task-no
