### PR TITLE
[FIX] stock: quant diff computed when inventory_quantity_set False

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -189,7 +189,7 @@ class StockQuant(models.Model):
 
     @api.depends('inventory_quantity')
     def _compute_inventory_diff_quantity(self):
-        for quant in self:
+        for quant in self.filtered(lambda q: q.inventory_quantity_set):
             quant.inventory_diff_quantity = quant.inventory_quantity - quant.quantity
 
     @api.depends('inventory_quantity')


### PR DESCRIPTION
On the stock.quant, the inventory_diff_quantity is being computed when inventory_quantity_set is False.

Steps to reproduce:
- Create a storable product
- Create a purchase order for 1 unit and receive it
- Go to Inventory / Operations / Physical Inventory, group by product and search the product.
When we group by product, we see the stock.quant has a difference if -1.
The quantity is 1 and the counted quantity is 0, so the difference is -1.
However, inventory_quantity_set is False (as it should be).

The expected behaviour would be to not see a difference of -1 (just like it happens when we set a random counted quantity and then hit the button "clear") and only compute the difference when the inventory_diff_quantity is set.

OPW-4406857