### PR TITLE
[IMP] mail: make /leave close chat windows

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -10790,6 +10790,12 @@ msgid "You have been invited to #%s"
 msgstr ""
 
 #. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/discuss/core/common/discuss_core_common_service.js:0
+msgid "You left %(channel)s."
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,help:mail.field_mail_template__attachment_ids
 msgid ""
 "You may attach files to this template, to be added to all emails created "

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -31,10 +31,12 @@ export class DiscussCoreCommon {
             const { Thread } = this.store.insert(payload);
             const [thread] = Thread;
             if (thread.notifyOnLeave) {
-                this.notificationService.add(_t("You unsubscribed from %s.", thread.displayName), {
-                    type: "info",
-                });
+                this.notificationService.add(
+                    _t("You left %(channel)s.", { channel: thread.displayName }),
+                    { type: "info" }
+                );
             }
+            thread.closeChatWindow();
         });
         this.busService.subscribe("discuss.channel/delete", (payload, metadata) => {
             const thread = this.store.Thread.insert({
@@ -67,6 +69,7 @@ export class DiscussCoreCommon {
             const thread = this.store.Thread.get({ model: "discuss.channel", id: payload.id });
             if (thread) {
                 thread.is_pinned = false;
+                thread.closeChatWindow();
             }
         });
         this.busService.subscribe("discuss.channel.member/fetched", (payload) => {

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -1091,3 +1091,41 @@ test("open channel in chat window from push notification", async () => {
     );
     await contains(".o-mail-ChatWindow", { text: "General" });
 });
+
+test("Chat window should be closed when leaving the channel", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create({ name: "general" });
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await click(".o-mail-NotificationItem");
+    await contains(".o-mail-ChatWindow", { text: "general" });
+    await insertText(".o-mail-Composer-input", "/leave");
+    await contains(".o-mail-NavigableList-active strong", { text: "leave" });
+    triggerHotkey("Enter");
+    await contains(".o-mail-Composer-input", { value: "/leave " });
+    triggerHotkey("Enter");
+    await contains(".o-mail-ChatWindow", { text: "general", count: 0 });
+});
+
+test("Chat window should be closed when leaving a chat", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
+    pyEnv["res.users"].create({ partner_id: partnerId });
+    pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+        channel_type: "chat",
+    });
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await click(".o-mail-NotificationItem");
+    await contains(".o-mail-ChatWindow", { text: "Demo" });
+    await insertText(".o-mail-Composer-input", "/leave");
+    await contains(".o-mail-NavigableList-active strong", { text: "leave" });
+    triggerHotkey("Enter");
+    await contains(".o-mail-Composer-input", { value: "/leave " });
+    triggerHotkey("Enter");
+    await contains(".o-mail-ChatWindow", { text: "Demo", count: 0 });
+});

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -486,7 +486,7 @@ test("leave command on channel", async () => {
     triggerHotkey("Enter");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "general" });
     await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
-    await contains(".o_notification", { text: "You unsubscribed from general." });
+    await contains(".o_notification", { text: "You left general." });
 });
 
 test("Can handle leave notification from unknown member", async () => {


### PR DESCRIPTION
Before this commit, leaving or unpin a channel kept the chat window open.
This commit forces the closing of the chat window when either action is made.

task-4452932