### PR TITLE
[FIX] base: no properties in server action path

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -678,7 +678,11 @@ class IrActionsServer(models.Model):
             return ''
         model = self.env[self.model_id.model]
         pretty_path = []
+        field = None
         for field_name in path.split('.'):
+            if field and field.type == 'properties':
+                pretty_path.append(field_name)
+                continue
             field = model._fields[field_name]
             field_id = self.env['ir.model.fields']._get(model._name, field_name)
             if field.relational:

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 from odoo import Command
 
-from odoo.exceptions import AccessError, UserError
+from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.osv import expression
 from odoo.tests.common import Form, TransactionCase, users
 from odoo.tools import mute_logger, get_lang
@@ -1700,6 +1700,23 @@ class PropertiesCase(TestPropertiesMixin):
         self.assertEqual(values[0]['attributes'][0]['value'], 'red')
         values = email.message.read(['attributes'])
         self.assertEqual(values[0]['attributes'][0]['value'], 'red')
+
+    def test_properties_server_action_path_traversal(self):
+        action = self.env['ir.actions.server'].create({
+            'name': 'TestAction',
+            'model_id': self.env['ir.model'].search([
+                ('model', '=', 'test_new_api.emailmessage'),
+            ]).id,
+            'model_name': 'test_new_api.emailmessage',
+            'state': 'object_write',
+        })
+        with self.assertRaises(ValidationError):
+            action.update_path = 'attributes.discussion_color_code'
+            # call _stringify_path directly because it's only called for
+            # server action linked to a base_automation
+            self.assertEqual(action._stringify_path(),
+                'Properties > discussion_color_code'
+            )
 
 
 class PropertiesSearchCase(TestPropertiesMixin):


### PR DESCRIPTION
Scenario: create a server action that updates a properties
Result: traceback error is raised

Issue: server action does not handle updating record properties Fix: ignore the error in _stringify_path method, so the more legible
     ValidationError from _traverse_path is raised instead.

Note: without the fix, the added test failed with "KeyError: 'discussion_color_code'", with the fix it doesn't fail (and there is a "ValidationError: 'The path to the field to update contains a non-relational field (attributes) that is not the last field in …'").

opw-4339633