### PR TITLE
[FIX] account: Fix round globally with reverse charge tax

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -110,7 +110,7 @@ class PurchaseOrderLine(models.Model):
             tax_ids=self.taxes_id,
             quantity=self.product_qty,
             partner_id=self.order_id.partner_id,
-            currency_id=self.order_id.currency_id,
+            currency_id=self.order_id.currency_id or self.order_id.company_id.currency_id,
             rate=self.order_id.currency_rate,
         )
 


### PR DESCRIPTION
Before, the rounding was made by counting twice the same base amount that was leading to an extra "delta_base_amount_currency".

See the test in the commit.

opw-4425380

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
