### PR TITLE
[FIX] account,l10n{latam_invoice_document,hu_edi}: layout header & footer issues

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -195,11 +195,11 @@
                     <t t-if="error or warning" t-call="account.portal_invoice_error"/>
                     <t t-if="success and (not error and not warning)" t-call="account.portal_invoice_success"/>
 
-                    <div class="o_portal_html_view position-relative bg-white shadow p-3 overflow-hidden">
+                    <div class="o_portal_html_view position-relative bg-white shadow overflow-hidden">
                         <div class="o_portal_html_loader text-center">
                             <i class="fa fa-circle-o-notch fa-spin fa-2x fa-fw text-black-50"></i>
                         </div>
-                        <iframe id="invoice_html" class="position-relative my-2" width="100%" height="100%" frameborder="0" scrolling="no" t-att-src="invoice.get_portal_url(report_type='html')"/>
+                        <iframe id="invoice_html" class="position-relative d-block" width="100%" height="100%" frameborder="0" scrolling="no" t-att-src="invoice.get_portal_url(report_type='html')"/>
                     </div>
                     <!-- chatter -->
                     <div id="invoice_communication" class="mt-4">

--- a/addons/l10n_hu_edi/views/report_templates.xml
+++ b/addons/l10n_hu_edi/views/report_templates.xml
@@ -7,18 +7,19 @@
         </xpath>
 
         <xpath expr="//img/../.." position="after">
-            <div t-if="custom_header">
+            <div t-if="custom_header and company.account_fiscal_country_id.code == 'HU'">
                 <t t-call="#{custom_header}"/>
             </div>
         </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
+        <div class="o_footer_content d-flex border-top pt-2" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
 
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" t-if="custom_footer">
+        <div class="o_footer_content d-flex border-top pt-2" position="after">
+            <div class="o_footer_content border-top pt-2"
+                 t-if="custom_footer and company.account_fiscal_country_id.code == 'HU'">
                 <t t-out="custom_footer"/>
             </div>
         </div>
@@ -30,17 +31,18 @@
         </xpath>
 
         <xpath expr="//img/../.." position="after">
-            <div t-if="custom_header">
+            <div t-if="custom_header and company.account_fiscal_country_id.code == 'HU'">
                 <t t-call="#{custom_header}"/>
             </div>
         </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
+        <div class="o_footer_content row border-top pt-2" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" t-if="custom_footer">
+        <div class="o_footer_content row border-top pt-2" position="after">
+            <div class="o_footer_content row border-top pt-2"
+                 t-if="custom_footer and company.account_fiscal_country_id.code == 'HU'">
                 <t t-out="custom_footer"/>
             </div>
         </div>
@@ -52,17 +54,18 @@
         </xpath>
 
         <xpath expr="//img/../.." position="after">
-            <div t-if="custom_header">
+            <div t-if="custom_header and company.account_fiscal_country_id.code == 'HU'">
                 <t t-call="#{custom_header}"/>
             </div>
         </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
+        <div class="o_footer_content row border-top pt-2" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" t-if="custom_footer">
+        <div class="o_footer_content row border-top pt-2" position="after">
+            <div class="o_footer_content row border-top pt-2"
+                 t-if="custom_footer and company.account_fiscal_country_id.code == 'HU'">
                 <t t-out="custom_footer"/>
             </div>
         </div>
@@ -74,17 +77,18 @@
         </xpath>
 
         <xpath expr="//img/../.." position="after">
-            <div t-if="custom_header">
+            <div t-if="custom_header and company.account_fiscal_country_id.code == 'HU'">
                 <t t-call="#{custom_header}"/>
             </div>
         </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
+        <div class="o_footer_content border-top pt-2 text-center" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" t-if="custom_footer">
+        <div class="o_footer_content border-top pt-2 text-center" position="after">
+            <div class="o_footer_content border-top pt-2 text-center"
+                 t-if="custom_footer and company.account_fiscal_country_id.code == 'HU'">
                 <t t-out="custom_footer"/>
             </div>
         </div>
@@ -96,17 +100,18 @@
         </xpath>
 
         <xpath expr="//img/../.." position="after">
-            <div t-if="custom_header">
+            <div t-if="custom_header and company.account_fiscal_country_id.code == 'HU'">
                 <t t-call="#{custom_header}"/>
             </div>
         </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" position="attributes">
+        <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-4 text-center" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" t-if="custom_footer">
+        <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-4 text-center" position="after">
+            <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-4 text-center"
+                 t-if="custom_footer and company.account_fiscal_country_id.code == 'HU'">
                 <t t-out="custom_footer"/>
             </div>
         </div>
@@ -119,17 +124,18 @@
         </xpath>
 
         <xpath expr="//img/../.." position="after">
-            <div t-if="custom_header">
+            <div t-if="custom_header and company.account_fiscal_country_id.code == 'HU'">
                 <t t-call="#{custom_header}"/>
             </div>
         </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" position="attributes">
+        <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" t-if="custom_footer">
+        <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center" position="after">
+            <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center"
+                 t-if="custom_footer and company.account_fiscal_country_id.code == 'HU'">
                 <t t-out="custom_footer"/>
             </div>
         </div>
@@ -142,17 +148,18 @@
         </xpath>
 
         <xpath expr="//img/../.." position="after">
-            <div t-if="custom_header">
+            <div t-if="custom_header and company.account_fiscal_country_id.code == 'HU'">
                 <t t-call="#{custom_header}"/>
             </div>
         </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
+        <div class="o_footer_content d-flex border-top pt-2" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" t-if="custom_footer">
+        <div class="o_footer_content d-flex border-top pt-2" position="after">
+            <div class="o_footer_content border-top pt-2"
+                 t-if="custom_footer and company.account_fiscal_country_id.code == 'HU'">
                 <t t-out="custom_footer"/>
             </div>
         </div>

--- a/addons/l10n_latam_invoice_document/views/report_templates.xml
+++ b/addons/l10n_latam_invoice_document/views/report_templates.xml
@@ -3,22 +3,24 @@
 
     <template id="external_layout_standard" inherit_id="web.external_layout_standard" >
         <!-- support for custom header -->
-        <div t-attf-class="header o_company_#{company.id}_layout" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="header o_company_#{company.id}_layout" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout" t-if="custom_header">
+        </xpath>
+        <xpath expr="//img/../.." position="after">
+            <div t-attf-class="header o_company_#{company.id}_layout"
+                 t-if="custom_header and company._localization_use_documents()">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
+        <div class="o_footer_content d-flex border-top pt-2" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
 
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" t-if="custom_footer">
+        <div class="o_footer_content d-flex border-top pt-2" position="after">
+            <div class="o_footer_content border-top pt-2"
+                 t-if="custom_footer and company._localization_use_documents()">
                 <t t-out="custom_footer"/>
             </div>
         </div>
@@ -26,21 +28,22 @@
 
     <template id="external_layout_bold" inherit_id="web.external_layout_bold" >
         <!-- support for custom header -->
-        <div t-attf-class="header o_company_#{company.id}_layout" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="header o_company_#{company.id}_layout" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout" t-if="custom_header">
+        </xpath>
+        <xpath expr="//img/../.." position="after">
+            <div t-if="custom_header and company._localization_use_documents()">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
+        <div class="o_footer_content row border-top pt-2" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout" t-if="custom_footer">
+        <div class="o_footer_content row border-top pt-2" position="after">
+            <div class="o_footer_content row border-top pt-2"
+                 t-if="custom_footer and company._localization_use_documents()">
                 <t t-out="custom_footer"/>
             </div>
         </div>
@@ -48,21 +51,22 @@
 
     <template id="external_layout_boxed" inherit_id="web.external_layout_boxed" >
         <!-- support for custom header -->
-        <div t-attf-class="header o_company_#{company.id}_layout" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="header o_company_#{company.id}_layout" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout" t-if="custom_header">
+        </xpath>
+        <xpath expr="//img/../.." position="after">
+            <div t-if="custom_header and company._localization_use_documents()">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
+        <div class="o_footer_content row border-top pt-2" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" t-if="custom_footer">
+        <div class="o_footer_content row border-top pt-2" position="after">
+            <div class="o_footer_content row border-top pt-2"
+                 t-if="custom_footer and company._localization_use_documents()">
                 <t t-out="custom_footer"/>
             </div>
         </div>
@@ -70,21 +74,23 @@
 
     <template id="external_layout_striped" inherit_id="web.external_layout_striped" >
         <!-- support for custom header -->
-        <div t-attf-class="o_company_#{company.id}_layout header" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="o_company_#{company.id}_layout header" position="after">
-            <div t-attf-class="o_company_#{company.id}_layout header" t-if="custom_header">
+        </xpath>
+        <xpath expr="//img/../.." position="after">
+            <div t-attf-class="o_company_#{company.id}_layout header"
+                 t-if="custom_header and company._localization_use_documents()">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
+        <div class="o_footer_content border-top pt-2 text-center" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" t-if="custom_footer">
+        <div class="o_footer_content border-top pt-2 text-center" position="after">
+            <div class="o_footer_content border-top pt-2 text-center"
+                 t-if="custom_footer and company._localization_use_documents()">
                 <t t-out="custom_footer"/>
             </div>
         </div>
@@ -92,21 +98,22 @@
 
     <template id="external_layout_bubble" inherit_id="web.external_layout_bubble">
         <!-- support for custom header -->
-        <div t-attf-class="header o_company_#{company.id}_layout {{report_type == 'pdf' and 'pt-5'}}" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="header o_company_#{company.id}_layout {{report_type == 'pdf' and 'pt-5'}}" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout {{report_type == 'pdf' and 'pt-5'}}" t-if="custom_header">
+        </xpath>
+        <xpath expr="//img/../.." position="after">
+            <div t-if="custom_header and company._localization_use_documents()">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" position="attributes">
+        <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-4 text-center" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" t-if="custom_footer">
+        <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-4 text-center" position="after">
+            <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-4 text-center"
+                 t-if="custom_footer and company._localization_use_documents()">
                 <t t-out="custom_footer"/>
             </div>
         </div>
@@ -114,21 +121,22 @@
 
     <template id="external_layout_wave" inherit_id="web.external_layout_wave">
         <!-- support for custom header -->
-        <div t-attf-class="header o_company_#{company.id}_layout {{report_type != 'pdf' and 'h-0'}}" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="header o_company_#{company.id}_layout {{report_type != 'pdf' and 'h-0'}}" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout {{report_type != 'pdf' and 'h-0'}}" t-if="custom_header">
+        </xpath>
+        <xpath expr="//img/../.." position="after">
+            <div t-if="custom_header and company._localization_use_documents()">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" position="attributes">
+        <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" t-if="custom_footer">
+        <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center" position="after">
+            <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center"
+                 t-if="custom_footer and company._localization_use_documents()">
                 <t t-out="custom_footer"/>
             </div>
         </div>
@@ -136,21 +144,22 @@
 
     <template id="external_layout_folder" inherit_id="web.external_layout_folder">
         <!-- support for custom header -->
-        <div t-attf-class="header o_company_#{company.id}_layout {{report_type != 'pdf' and 'h-0'}}" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="header o_company_#{company.id}_layout {{report_type != 'pdf' and 'h-0'}}" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout {{report_type != 'pdf' and 'h-0'}}" t-if="custom_header">
+        </xpath>
+        <xpath expr="//img/../.." position="after">
+            <div t-if="custom_header and company._localization_use_documents()">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
+        <div class="o_footer_content d-flex border-top pt-2" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
         </div>
-        <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="after">
-            <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" t-if="custom_footer">
+        <div class="o_footer_content d-flex border-top pt-2" position="after">
+            <div class="o_footer_content border-top pt-2"
+                 t-if="custom_footer and company._localization_use_documents()">
                 <t t-out="custom_footer"/>
             </div>
         </div>


### PR DESCRIPTION
[FIX] l10n{latam_invoice_document,hu_edi}: layout header & footer issues

Bubble and wave layout footer content of l10n_ar edi invoice qr code
was a little bit cut off in preview. In addition when you had both,
`l10n_hu_edi` and `l10n_latam_invoice_document` installed, you would
have a double header/footer. And the header of bubble/wave layout
does not have the bubble/wave. Last, there is some space between the 
document and the "shadow" of the document in portal preview which 
looks weird when the selected layout is bubble or wave which normally 
goes all the way until the margins.

How to reproduce:
- install l10n_latam_invoice_document
- move to (AR) Responsable Inscripto" company
- Switch Document Layout to "Bubble" format
- Create an invoice with B2B customer
- make sure the Document Type is set to "(1) INVOICES A".
- Make sure the Journal is "Electronic Invoice"
- Validate the invoice
- Click on Preview button

What's wrong here:
1. At the bottom of the invoice, the CAE and CAE Due Date fields are
   cropped
2. Also if you installed l10n_hu_edi, you will have a double
   header/footer
3. The header does not have the bubble
4. The bubble doesn't go all way until the margins in portal preview

Regarding the first issue, this commit fixes it by moving
the custom footer to `o_content_footer` instead of it replacing the
whole footer. This was done for all `l10n_hu_edi` layouts as well as
`l10n_latam_invoice_document` layouts for consistency

For the second double header/footer issue, added a check before
overriding:
- company._name == 'res.company' to avoid breaking Configure Document
  Layout wizard (there the `comptany` is of model `base.document.layout`
- only override if fiscal country corresponds to that of the localisation

And for the last issue with header not rendering as expected, this
commit uses another xpath for header overriding as in
[#192650](https://github.com/odoo/odoo/pull/192650)

opw-4411237