### PR TITLE
[FIX] web: not export readonly fields in import-compatible export

### DIFF
--- a/addons/test_import_export/tests/test_export.py
+++ b/addons/test_import_export/tests/test_export.py
@@ -127,6 +127,23 @@ class TestExport(XlsxCreatorCase):
                           {'field_type': 'char', 'id': 'login', 'string': 'Login'},
                           {'field_type': 'boolean', 'id': 'active', 'string': 'Active'}])
 
+    def test_import_compatible_export(self):
+        test_model = 'res.company'
+
+        res = self.url_open(
+            "/web/export/get_fields",
+            data=json.dumps({"params": {"model": test_model,
+                                        'import_compat': True,
+                                        'domain': []}}),
+            headers={"Content-Type": "application/json"}
+        )
+        res = json.loads(res.content)['result']
+
+        model_fields = self.env['ir.model.fields'].search([('model', '=', test_model)])
+        expected_fields = set(f.name for f in model_fields.filtered(lambda field: field.readonly == False)) | {'id'}
+
+        self.assertEqual(expected_fields, set(field['id'] for field in res))
+
 
 @tagged('-at_install', 'post_install')
 class TestGroupedExport(XlsxCreatorCase):

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -364,7 +364,7 @@ class Export(http.Controller):
         fields = Model.fields_get(
             attributes=[
                 'type', 'string', 'required', 'relation_field', 'default_export_compatible',
-                'relation', 'definition_record', 'definition_record_field',
+                'relation', 'definition_record', 'definition_record_field', 'exportable', 'readonly',
             ],
         )
 


### PR DESCRIPTION
Issue
-----
Read-only fields appear in the export menu when the "I want to update data (import-compatible export)" checkbox is active.

Cause
-----
The `readonly` key is missing from the field dictionnary leading to all fields being considered as not read-only.
https://github.com/odoo/odoo/blob/a546e2e5a87c311bef054ca4a6909e63d70c91fd/addons/web/controllers/export.py#L389-L390 Issue from 2b87effeb461acddf327884dd72c00ee22a4c9aa since only some attributes of the fields are fetched.

opw-4446090
