### PR TITLE
[IMP] im_livechat: sort sessions by creation date

### DIFF
--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -44,7 +44,7 @@
             <field name="name">discuss.channel.kanban</field>
             <field name="model">discuss.channel</field>
             <field name="arch" type="xml">
-                <kanban js_class="im_livechat.discuss_channel_kanban" class="o_kanban_mobile" sample="1" quick_create="false">
+                <kanban js_class="im_livechat.discuss_channel_kanban" class="o_kanban_mobile" sample="1" quick_create="false" default_order="create_date desc">
                     <templates>
                         <t t-name="card">
                             <div class="d-flex">


### PR DESCRIPTION
This commit changes the order of livechat sessions in the kanban view to sort them descending by their `create_date`.

task-4452928