### PR TITLE
[FIX] account: Fix group by internal group on journal items

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -133,8 +133,11 @@ class AccountAccount(models.Model):
                                     "If not, this account will belong to Trade Receivable/Payable in reports and filters.")
 
     def _field_to_sql(self, alias: str, fname: str, query: (Query | None) = None, flush: bool = True) -> SQL:
+        account_alias = SQL.identifier(self._table)
+        if query is not None and query.table != 'account_account':
+            account_alias = SQL.identifier(next(alias for alias, (_j_type, j_table, _j_cond) in query._joins.items() if j_table == account_alias))
         if fname == 'internal_group':
-            return SQL("split_part(account_account.account_type, '_', 1)", to_flush=self._fields['account_type'])
+            return SQL("split_part(%s.account_type, '_', 1)", account_alias, to_flush=self._fields['account_type'])
         return super()._field_to_sql(alias, fname, query, flush)
 
     @api.constrains('company_id', 'code')


### PR DESCRIPTION
In journal items, when grouping by 'Internal Group', a traceback appears due to referencing a non-existent table `account_account` as it has been joined with `account_move_line`.

This commit ensures the referenced table is correctly updated in the case of joins.

opw-4405281

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
