### PR TITLE
[FIX] project: fix changeDescriptionContentAndSave

### DIFF
--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -14,21 +14,25 @@ const baseDescriptionContent = "Test project task history version";
 const descriptionField = "div.note-editable.odoo-editor-editable p";
 function changeDescriptionContentAndSave(newContent) {
     const newText = `${baseDescriptionContent} ${newContent}`;
-    return [ {
-        // force focus on editable so editor will create initial p (if not yet done)
-        trigger: "div.note-editable.odoo-editor-editable",
-        run: "click",
-    }, {
-        trigger: descriptionField,
-        run: async function(actions) {
-            const textTriggerElement = this.anchor.querySelector(descriptionField);
-            await actions.editor(newText, textTriggerElement);
-            await new Promise((r) => setTimeout(r, 300));
+    return [
+        {
+            // force focus on editable so editor will create initial p (if not yet done)
+            trigger: "div.note-editable.odoo-editor-editable",
+            run: "click",
         },
-    }, {
-        trigger: "button.o_form_button_save",
-        run: "click",
-    }];
+        {
+            trigger: descriptionField,
+            run: `editor ${newText}`,
+        },
+        {
+            trigger: "button.o_form_button_save",
+            run: "click",
+        },
+        {
+            content: "Wait the form is saved",
+            trigger: ".o_form_saved",
+        },
+    ];
 }
 
 registry.category("web_tour.tours").add("project_task_history_tour", {


### PR DESCRIPTION
When you chain several uses of changeDescriptionContentAndSave() in a tour, you don't necessarily wait for the editor to be actually saved before continuing.
So, it always works for the first use but not for the following ones if the tour engine goes too "fast".
So this fix add a step in which we make sure that the form is actually saved before continuing.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
