### PR TITLE
[FIX] project: fix project_tour tour

### DIFF
--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -251,7 +251,7 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "edit Newer Sub-task && click body",
 }, {
     isActive: ["auto"],
-    trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_list_row:first-child .o_field_project_task_state_selection button",
+    trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_list_row:contains(newer sub-task) .o_field_project_task_state_selection button",
     content: _t("You can change the sub-task state here!"),
     run: "click",
 },


### PR DESCRIPTION
In this commit, we fix the project tour. In the kanban view, we click on the first subtask_list_row but it is not yet (still) the newer subtask. We can therefore click on the first element even though it is not yet created. The DOM re-renders ... and the dropdown menu disappears.
By specifying (:contains()) that we want to click on the newer subtask, we wait for it to be created, for it to be rendered and then we click on it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
