### PR TITLE
[FIX] project: project grouped by stages now respects the pagination

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1108,7 +1108,7 @@ class Task(models.Model):
     @api.model
     def _read_group_stage_ids(self, stages, domain, order):
         search_domain = [('id', 'in', stages.ids)]
-        if 'default_project_id' in self.env.context:
+        if 'default_project_id' in self.env.context and 'project_kanban' in self.env.context:
             search_domain = ['|', ('project_ids', '=', self.env.context['default_project_id'])] + search_domain
 
         stage_ids = stages._search(search_domain, order=order, access_rights_uid=SUPERUSER_ID)

--- a/addons/project/static/src/project_sharing/views/kanban/kanban_view.js
+++ b/addons/project/static/src/project_sharing/views/kanban/kanban_view.js
@@ -1,0 +1,19 @@
+/** @odoo-module */
+
+import { kanbanView } from "@web/views/kanban/kanban_view";
+import { KanbanDynamicGroupList, KanbanModel } from "@web/views/kanban/kanban_model";
+
+export class ProjectSharingTaskKanbanDynamicGroupList extends KanbanDynamicGroupList {
+    get context() {
+        return {
+            ...super.context,
+            project_kanban: true,
+        };
+    }
+}
+
+export class ProjectSharingTaskKanbanModel extends KanbanModel {}
+
+ProjectSharingTaskKanbanModel.DynamicGroupList = ProjectSharingTaskKanbanDynamicGroupList;
+
+kanbanView.Model = ProjectSharingTaskKanbanModel;

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_dynamic_group_list.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_dynamic_group_list.js
@@ -7,6 +7,7 @@ import { session } from '@web/session';
 export class ProjectTaskKanbanDynamicGroupList extends KanbanDynamicGroupList {
     get context() {
         const context = super.context;
+        context.project_kanban = true;
         if (context.createPersonalStageGroup) {
             context.default_user_id = context.uid;
             delete context.createPersonalStageGroup;


### PR DESCRIPTION
Steps to reproduce
==================

- Open any project
- Create many project stages (80+)
- Switch to the list view
- Group by stage
- Switch to to next page => The pager keeps increasing

Cause of the issue
==================

`stage_id` has a group_expand: `_read_group_stage_ids`

This method is used to include empty stages in the result for the kanban view, so that we can drag tasks to an empty stage.

Solution
========

Add a context key `project_kanban` and only add empty stages in that case.

opw-4408061