### PR TITLE
[FIX] account: save manually printed PDF in invoice PDF fields

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -11,6 +11,16 @@ from odoo.tools.pdf import PdfReadError, PdfStreamError
 class IrActionsReport(models.Model):
     _inherit = 'ir.actions.report'
 
+    def _prepare_pdf_report_attachment_vals_list(self, report, streams):
+        """ Save the reference to the new attachment in invoice's `invoice_pdf_report_*` fields """
+        attachment_vals_list = super()._prepare_pdf_report_attachment_vals_list(report, streams)
+
+        if self._is_invoice_report(report):
+            for attachment_vals in attachment_vals_list:
+                attachment_vals['res_field'] = 'invoice_pdf_report_file'
+
+        return attachment_vals_list
+
     def _render_qweb_pdf_prepare_streams(self, report_ref, data, res_ids=None):
         # Custom behavior for 'account.report_original_vendor_bill'.
         if self._get_report(report_ref).report_name != 'account.report_original_vendor_bill':

--- a/addons/account/tests/test_account_move_attachment.py
+++ b/addons/account/tests/test_account_move_attachment.py
@@ -1,9 +1,10 @@
 from odoo import http
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged, HttpCase
 
 
 @tagged("-at_install", "post_install")
-class TestAccountMoveAttachment(HttpCase):
+class TestAccountMoveAttachmentHttp(HttpCase):
 
     def test_preserving_manually_added_attachments(self):
         """ Preserve attachments manually added (not coming from emails) to an invoice """
@@ -23,3 +24,25 @@ class TestAccountMoveAttachment(HttpCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertTrue(invoice.attachment_ids)
+
+
+@tagged("-at_install", "post_install")
+class TestAccountMoveAttachmentInvoicing(AccountTestInvoicingCommon):
+
+    def test_save_manually_printed_attachments(self):
+        """
+        When manually printing invoice's attachment (via the cog button),
+        and when the "Save as Attachment Prefix" setting is saved for that action,
+        the new attachment should also be saved in the invoice field that refers this attachment: 'invoice_pdf_report_file'
+        """
+        invoice_report = self.env['ir.actions.report'].search([('report_name', '=', 'account.report_invoice_with_payments')])
+        invoice_report.attachment = "object.name"  # activate setting to save as attachment when printing
+
+        # Create invoice and print the PDF manually
+        invoice = self.init_invoice('out_invoice', amounts=[1000], post=True)
+        self.env['ir.actions.report'] \
+            .with_context(force_report_rendering=True) \
+            ._render_qweb_pdf(invoice_report, invoice.ids)
+
+        self.assertTrue(invoice.invoice_pdf_report_file)
+        self.assertTrue(invoice.invoice_pdf_report_id)


### PR DESCRIPTION
When generating an invoice PDF manually through the cog button in the invoice form, the printed result are normally not saved in the invoice, unless we specifically specify in the "manual print" report action that the attachment should be saved.

However, when that setting is activated, the PDF are saved as an attachments of the invoice but not at the invoice's pdf file pointer field (`invoice_pdf_report_file`, `invoice_pdf_report_id`).

This leads to weird behavior whenever we get the values of the invoice PDF fields, because on these manually printed invoices, the attachment exists but `invoice_pdf_report_*` fields is empty/`False`.

One example is in the portal website, when opening invoice with manually printed PDF attachment, it will generate and show the fallback PDF ("Proforma" invoice PDF) wrongfully (because it thought that the invoice doesn't have any attachment yet; by looking at the False invoice PDF field values)

[additional information] why `17.0`? in `16.0`, the `invoice_pdf_report_*` fields has not existed yet. The above examples works without issue in `16.0`

opw-4443613