### PR TITLE
[FIX] account: prevent an error when print and send invoices

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -655,7 +655,6 @@ class AccountMoveSend(models.AbstractModel):
         This is a security in case the method is called directly without going through the wizards.
         """
         self._check_move_constrains(moves)
-        assert all(self._get_default_pdf_report_id(move).is_invoice_report for move in moves)
         assert custom_settings['pdf_report'].is_invoice_report if custom_settings.get('pdf_report') else True
         assert all(
             sending_method in dict(self.env['res.partner']._fields['invoice_sending_method'].selection)


### PR DESCRIPTION
Currently, An error occurs when the user print and send invoices  and 'Invoice report' is disabled in reports 'report_invoice_with_payments'.

Step to produce:

- Install the `account` module.
- Go to Settings / Technical / Actions / Reports, Search 'report_invoice_with_payments', and disable the 'Invoice report'.
- Go to Invoicing / Customers / Invoices, Create one invoice add a customer and invoice line, and Confirm it back to the list view of the invoice
- Select this invoice and click on Print & Send.
- After Opening a wizard, click the 'Print & Send' button.

The issue occurs when the user tries to generate and send invoices and the system checks that 'is_invoice_report' is enabled for invoices at [1].

Link [1]: https://github.com/odoo/odoo/blob/658711aa1e1809b267006149ed6a547e548c1f90/addons/account/models/account_move_send.py#L658

To resolve this, we have to remove this comparison [1] as the user can disable 'is_invoice_report' from 'report_invoice_with_payments'.

Sentry-6185986435

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
