### PR TITLE
[FIX] purchase_stock: report incoterm layout

### DIFF
--- a/addons/purchase_stock/report/purchase_report_templates.xml
+++ b/addons/purchase_stock/report/purchase_report_templates.xml
@@ -37,7 +37,7 @@
                 </t>
             </t>
         </xpath>
-        <xpath expr="//span[@t-field='o.name']/.." position="after">
+        <xpath expr="//t[@t-set='layout_document_title']" position="after">
             <div id="informations" class="row mt16 mb16">
                 <div t-if="o.incoterm_id" class="col-3 bm-2">
                     <strong>Incoterm:</strong>


### PR DESCRIPTION
Since the [document layout redesign](odoo/odoo@e19efd2f54014425b14defd6015b9a71c1142385), the incoterms in rfq are wrongly displayed.

This is due to the dynamic title which breaks the xpath, xpathing the incoterms in the `<h2>` instead of after it.

This commit fixes the xpath to properly display the incoterms.

opw-4380886
task-4453695 

<h3>Steps to reproduce</h3>

- Choose any document layout
- Have purchase & Inventory installed
- Create a request for quotation
    - In the "other information" tab, choose an incoterm
- Print the RFQ

| Issue | Fix |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/4883af55-3a9a-43a5-88ba-be86cf19bb45) | ![image](https://github.com/user-attachments/assets/f8b9e22e-55cd-4341-9db4-2394cfc8f1e5) | 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
