### PR TITLE
[FIX] account: matching rules appliance on branches

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -484,7 +484,7 @@ class AccountBankStatementLine(models.Model):
             # Base domain.
             ('display_type', 'not in', ('line_section', 'line_note')),
             ('parent_state', '=', 'posted'),
-            ('company_id', 'child_of', self.company_id.root_id.id),
+            ('company_id', 'child_of', self.company_id.id),  # allow to match invoices from same or children companies to be consistant with what's shown in the interface
             # Reconciliation domain.
             ('reconciled', '=', False),
             # Domain to use the account_move_line__unreconciled_index


### PR DESCRIPTION
The bank reconciliation widget shouldn't be allowed to work/match more than what's possible through the UI.

Steps to reproduce the bug
* create child company CHILD 1, with an invoice $100
* Create child company CHILD 2 with same parent company, a bank journal and a matching rule to fetch bills/invoices of same amount regardless of any other critera (for simplicity)
* make sure the matching rule is applied 1st, create a bank transacation of $100 in CHILD 2 bank journal
* click reconcile from the dashboard, on CHILD 2 bank journal => you get an access error because Odoo is trying to match invoice from CHILD 1 and bank transaction from CHILD 2

ticket-4384481


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
