### PR TITLE
[IMP] stock: add a "Return All" button on the picking return wizard

### DIFF
--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -2,7 +2,7 @@
 
 from odoo import _, api, Command, fields, models
 from odoo.exceptions import UserError
-from odoo.tools.float_utils import float_is_zero
+from odoo.tools.float_utils import float_round, float_is_zero
 
 
 class ReturnPickingLine(models.TransientModel):
@@ -182,6 +182,23 @@ class ReturnPicking(models.TransientModel):
             'type': 'ir.actions.act_window',
             'context': self.env.context,
         }
+
+    def action_create_returns_all(self):
+        """ Create a return matching the total delivered quantity and open it.
+        """
+        self.ensure_one()
+        for return_move in self.product_return_moves:
+            stock_move = return_move.move_id
+            if not stock_move or stock_move.state == 'cancel' or stock_move.scrapped:
+                continue
+            quantity = stock_move.quantity
+            for move in stock_move.move_dest_ids:
+                if not move.origin_returned_move_id or move.origin_returned_move_id != stock_move:
+                    continue
+                quantity -= move.quantity
+            quantity = float_round(quantity, precision_rounding=stock_move.product_id.uom_id.rounding)
+            return_move.quantity = quantity
+        return self.action_create_returns()
 
     def action_create_exchanges(self):
         """ Create a return for the active picking, then create a return of

--- a/addons/stock/wizard/stock_picking_return_views.xml
+++ b/addons/stock/wizard/stock_picking_return_views.xml
@@ -25,6 +25,7 @@
                 </field>
                 <footer>
                     <button name="action_create_returns" string="Return" type="object" class="btn-primary" data-hotkey="q"/>
+                    <button name="action_create_returns_all" string="Return All" type="object" class="btn-primary"/>
                     <button name="action_create_exchanges" string="Return for Exchange" type="object" class="btn-primary"/>
                     <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
                 </footer>


### PR DESCRIPTION
### Issue:

Since 57b8b2487def43a1b9c461c0fa4eb02200b5c1ef (18.0), the return picking wizard sets a default quantity of 0. This fits the new design of returns that are no longer exclusively tied to the initial delivery. However, in workflows where you are expected to return all/almost all products of a consequent picking this is both fastidious and error prone to set all the quantities to match the delivered values by hand.

### Solution:

We add a "Return All" button in the wizard view to allow the user to create a return whose quantity matches the delivered quantities.

opw-4416167
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
