### PR TITLE
[FIX] l10n_de_skr03,l10n_de_skr_04: domestic fiscal position

### DIFF
--- a/addons/l10n_de_skr03/data/account_tax_fiscal_position_data.xml
+++ b/addons/l10n_de_skr03/data/account_tax_fiscal_position_data.xml
@@ -1942,6 +1942,7 @@
         <field name="chart_template_id" ref="l10n_de_chart_template"/>
         <field name="auto_apply" eval="True"/>
         <field name="country_id" ref="base.de"/>
+        <field name="vat_required" eval="True"/>
     </record>
     <record id="fiscal_position_non_eu_partner_service_skr03" model="account.fiscal.position.template">
         <field name="sequence">6</field>

--- a/addons/l10n_de_skr04/data/account_tax_fiscal_position_data.xml
+++ b/addons/l10n_de_skr04/data/account_tax_fiscal_position_data.xml
@@ -1939,6 +1939,7 @@
         <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
         <field name="auto_apply" eval="True"/>
         <field name="country_id" ref="base.de"/>
+        <field name="vat_required" eval="True"/>
     </record>
     <record id="fiscal_position_non_eu_partner_service_skr04" model="account.fiscal.position.template">
         <field name="sequence">6</field>


### PR DESCRIPTION
When creating an invoice with a german customer, the domestic fiscal position is not applied. Instead, it's the european one which cause the invoice to have 0% taxes by default.

opw-4448821




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
