### PR TITLE
[FIX] base, account, sale: use RUC as VAT label for Panama

### DIFF
--- a/addons/account/i18n/es_PA.po
+++ b/addons/account/i18n/es_PA.po
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server saas~17.4+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-06 10:44+0000\n"
+"PO-Revision-Date: 2025-01-06 10:44+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account
+#: model_terms:ir.ui.view,arch_db:account.report_invoice_document
+msgid "Tax ID"
+msgstr "RUC"

--- a/addons/sale/i18n/es_PA.po
+++ b/addons/sale/i18n/es_PA.po
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server saas~17.4+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-06 13:55+0000\n"
+"PO-Revision-Date: 2025-01-06 13:55+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale
+#: model_terms:ir.ui.view,arch_db:sale.report_saleorder_document
+msgid "Tax ID"
+msgstr "RUC"

--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -1110,6 +1110,7 @@
             <field name="currency_id" ref="PAB" />
             <field eval="507" name="phone_code" />
             <field name="address_format" eval="'%(street)s\n%(street2)s\n%(city)s %(state_name)s %(zip)s\n%(country_name)s'" />
+            <field name="vat_label">RUC</field>
         </record>
         <record id="pe" model="res.country">
             <field name="name">Peru</field>


### PR DESCRIPTION
In Panama, the Tax ID is the Registro Único de Contribuyentes (RUC) and not the Número de Identificación Fiscal (NIF).

This is a double fix:
1. Update the `vat_label` to use "RUC" instead of "Tax ID", but this will only be available for new created DBs (because of noupdate)
2. Update the translation of Tax ID for Panama which only requires to update the translations to have the correct translation of Tax ID.

opw-4388758
