### PR TITLE
[FIX] web: clear changes on urgent save

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -1016,7 +1016,10 @@ export class Record extends DataPoint {
             const data = { jsonrpc: "2.0", method: "call", params };
             const blob = new Blob([JSON.stringify(data)], { type: "application/json" });
             const succeeded = navigator.sendBeacon(route, blob);
-            if (!succeeded) {
+            if (succeeded) {
+                this._changes = markRaw({});
+                this.dirty = false;
+            } else {
                 this.model._closeUrgentSaveNotification = this.model.notification.add(
                     markup(
                         _t(

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -12549,7 +12549,7 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("Auto save: save on closing tab/browser", async function (assert) {
-        assert.expect(4);
+        assert.expect(5);
 
         const sendBeaconDef = makeDeferred();
         mockSendBeacon((route, blob) => {
@@ -12589,6 +12589,10 @@ QUnit.module("Views", (hooks) => {
         await nextTick();
         await sendBeaconDef;
         assert.verifySteps(["save"], "should not prevent unload");
+        // With all changes saved, the save/discard buttons should now be invisible.
+        // While it typically doesn't matter when leaving a page, an urgent save may get triggered
+        // by a user action that remains on the page, e.g. opening a VoIP client (see opw 4308954).
+        assert.containsOnce(target, ".o_form_status_indicator_buttons.invisible");
     });
 
     QUnit.test(


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Download a VoIP provider like Skype or Linphone to open tel:* urls;
2. use a browser that supports this (FireFox works for me, but Chrome doesn't);
3. with Studio, edit the Sales Order form to add the customer phone;
4. create a new Sales Order with one order line;
5. save the form;
6. add a second line;
7. click on the phone number to start the VoIP app;
8. save the Sales Order form.

Issue
-----
The 2nd line is duplicated.

Cause
-----
Starting VoIP initiates an "urgent" web save, saving the first time. Usually this only happens when leaving the page, so it doesn't clear the changes to be saved.

In this scenario however, we remain on the page, and the changes are saved again when clicking the save button.

Solution
--------
Clear the saved changes if the urgent save succeeded.

opw-4308954