### PR TITLE
[FIX] account: creating a bank statement from the transaction list view

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -122,7 +122,7 @@ class AccountBankStatement(models.Model):
 
     @api.depends('create_date')
     def _compute_name(self):
-        for stmt in self:
+        for stmt in self.filtered(lambda s: not s.name):
             stmt.name = _("%(journal_code)s Statement %(date)s", journal_code=stmt.journal_id.code, date=stmt.date)
 
     @api.depends('line_ids.internal_index', 'line_ids.state')


### PR DESCRIPTION
Step to reproduce
* open the reconcilation widget and toggle the list view
* multi edit bank statement lines and assign them a new bank statement with name 'BLABLA 1'
* click save and see how Odoo just didn't keep your name at all

The reason is that during the initial creation of the statement, a value is given to end_date which triggers to recomputation of the name, regardless of if the statement already had a name or not.

So to fix that, we simply only try to compute the name for statements that don't have one yet

ticket-4424021

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
