### PR TITLE
[FIX] account_edi_ubl_cii: allow the use of IBANID

### DIFF
--- a/addons/account_edi_ubl_cii/data/cii_22_templates.xml
+++ b/addons/account_edi_ubl_cii/data/cii_22_templates.xml
@@ -239,10 +239,10 @@
                             <ram:TypeCode>42</ram:TypeCode>
                             <ram:PayeePartyCreditorFinancialAccount>
                                 <ram:IBANID
-                                    t-if="record.partner_bank_id.sanitized_acc_number == 'iban'"
+                                    t-if="record.partner_bank_id.acc_type == 'iban'"
                                     t-out="record.partner_bank_id.sanitized_acc_number"/>
                                 <ram:ProprietaryID
-                                    t-if="record.partner_bank_id.sanitized_acc_number != 'iban'"
+                                    t-if="record.partner_bank_id.acc_type != 'iban'"
                                     t-out="record.partner_bank_id.sanitized_acc_number"/>
                             </ram:PayeePartyCreditorFinancialAccount>
                         </ram:SpecifiedTradeSettlementPaymentMeans>


### PR DESCRIPTION
Due to an error in the condition, `ProprietaryID` was always used, even if IBANID should be used instead. That lead to customers missing information (`ProprietaryID` is not always picked up by other software, while IBANID is).

Ticket link: https://odoo.com/odoo/69/tasks/4414985
opw-4414985