### PR TITLE
[FIX] stock_account: compute SVL vals using only current company records

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -169,7 +169,7 @@ will update the cost of every lot/serial number in stock."),
         company_id = self.env.company
         self.company_currency_id = company_id.currency_id
         domain = [
-            *self._check_company_domain(company_id),
+            *self.env['stock.valuation.layer']._check_company_domain(company_id),
             ('product_id', 'in', self.ids),
         ]
         if self.env.context.get('to_date'):

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -105,7 +105,7 @@ class TestStockValuationBase(TransactionCase):
             ('account_id', '=', self.stock_valuation_account.id),
         ], order='date, id')
 
-    def _make_in_move(self, product, quantity, unit_cost=None):
+    def _make_in_move(self, product, quantity, unit_cost=None, location_dest_id=False, picking_type_id=False):
         """ Helper to create and validate a receipt move.
         """
         unit_cost = unit_cost or product.standard_price
@@ -113,11 +113,11 @@ class TestStockValuationBase(TransactionCase):
             'name': 'in %s units @ %s per unit' % (str(quantity), str(unit_cost)),
             'product_id': product.id,
             'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.env.ref('stock.stock_location_stock').id,
+            'location_dest_id': location_dest_id or self.env.ref('stock.stock_location_stock').id,
             'product_uom': self.env.ref('uom.product_uom_unit').id,
             'product_uom_qty': quantity,
             'price_unit': unit_cost,
-            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'picking_type_id': picking_type_id or self.env.ref('stock.picking_type_in').id,
         })
 
         in_move._action_confirm()
@@ -4280,3 +4280,24 @@ class TestStockValuation(TestStockValuationBase):
 
         self.assertEqual(move.quantity, 24)
         self.assertRecordValues(move.stock_valuation_layer_ids, [{'quantity': 12}, {'quantity': 12}])
+
+    def test_stock_valuation_layer_revaluation_with_branch_company(self):
+        """
+        Test that the product price is updated in the branch company
+        by taking into account only the stock valuation layer of the branch company.
+        """
+        self.assertEqual(self.product1.standard_price, 0)
+        self.product1.categ_id.property_cost_method = 'average'
+        self._make_in_move(self.product1, 1, unit_cost=20)
+        self.assertEqual(self.product1.standard_price, 20)
+        # create a branch company
+        branch = self.env['res.company'].create({
+            'name': "Branch A",
+            'parent_id': self.env.company.id,
+        })
+        # Create a move in the branch company
+        self.env.company = branch
+        self.product1.with_company(branch).categ_id.property_cost_method = 'average'
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', branch.id)], limit=1)
+        self._make_in_move(self.product1, 1, unit_cost=30, location_dest_id=warehouse.lot_stock_id.id, picking_type_id=warehouse.in_type_id.id)
+        self.assertEqual(self.product1.with_company(branch).standard_price, 30)


### PR DESCRIPTION
Steps to reproduce the bug:
- Log in as Company A
- Create a branch company: Branch 1.
- Create a storable product P1 with the following configuration::
    - Costing method: AVCO

- Create a receipt for 1 unit of P1:
    - Unit Price: $300.
- Confirm the receipt:
- The standard price of P1 is updated to $300.

- Log in as Branch 1
- The standard price of P1 is $0.
- Create a receipt for 1 unit of P1:
    - Unit Price: $100.
- Confirm the reception

Problem:
The standard price of P1 is incorrectly updated to $225 → ((300 + 100) / 2) instead of $100. This happens because the stock valuation layer computation values includes records from the parent company instead of only the current company:

https://github.com/odoo/odoo/blob/989a78b3fc04e7b5b79e165fda8539be5f091b8c/addons/stock_account/models/stock_move.py#L306-L307

https://github.com/odoo/odoo/blob/41a234890c91e9b0c9771a2b0fe50d4b525079f3/addons/stock_account/models/product.py#L123-L126

https://github.com/odoo/odoo/blob/989a78b3fc04e7b5b79e165fda8539be5f091b8c/addons/stock_account/models/stock_move.py#L323-L324


This issue occurs because the search considers both the current company
and its parent companies. This happens because `self` refers to the
`product.product` model which has
"_check_company_domain = models.check_company_domain_parent_of",
On the other hand, `self.env['stock.valuation.layer']` is a model that
is limited to the current company:

https://github.com/odoo/odoo/blob/8189f053fb4bf219093279c18eebdad01c305385/addons/product/models/product_product.py#L21

opw-4417559
