### PR TITLE
[FIX] hr_expense: fill the delivered quantity on SO from expense

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -818,6 +818,7 @@ class HrExpense(models.Model):
             'tax_tag_ids': to_update['tax_tag_ids'],
             'amount_currency': amount_currency,
             'currency_id': self.currency_id.id,
+            'quantity': self.quantity,
         }
         move_lines.append(base_move_line)
         total_tax_line_balance = 0.0


### PR DESCRIPTION
### Steps to reproduce:
- In Sale create an empty sale order and confirm
- In Expense > Configuration > Expense Categories > Mileage set the price per km to be 1 and "Re-Invoice Expenses" to "Sales price"
- Create a new expense
- Change the category to "Mileage"
- Set a quantity >1
- In "Customer to Reinvoice" select the one from the quotation
- Click "Create Report" > "Submit to Manager" > "Validate" > "Post Journal Entries"
- Return to the sale order
- The number under "Delivered" is 1, it should be the same as the quantity

### Cause:
When creating the move from the expense, the quantity is not given and defaults to 1.

### Solution:
Add the quantity to the `payments_vals`.

opw-4389303