### PR TITLE
[FIX] web: fix webclient view cache for not embedded action views

### DIFF
--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -278,16 +278,16 @@ export class View extends Component {
         if (loadView || loadSearchView) {
             // view description (or search view description if required) is incomplete
             // a loadViews is done to complete the missing information
-            const result = await this.viewService.loadViews(
-                { context, resModel, views },
-                {
-                    actionId: this.env.config.actionId,
-                    embeddedActionId: this.env.config.currentEmbeddedActionId,
-                    embeddedParentResId: context.active_id,
-                    loadActionMenus,
-                    loadIrFilters,
-                }
-            );
+            const options = {
+                actionId: this.env.config.actionId,
+                loadActionMenus,
+                loadIrFilters,
+            };
+            if (this.env.config.currentEmbeddedActionId) {
+                options.embeddedActionId = this.env.config.currentEmbeddedActionId;
+                options.embeddedParentResId = context.active_id;
+            }
+            const result = await this.viewService.loadViews({ context, resModel, views }, options);
             // Note: if props.views is different from views, the cached descriptions
             // will certainly not be reused! (but for the standard flow this will work as
             // before)

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -2585,6 +2585,38 @@ test("action and get_views rpcs are cached", async () => {
     expect.verifySteps(["/web/action/load", "web_search_read"]);
 });
 
+test("get_views rpcs are cached (different context.active_id)", async () => {
+    class IrActionsAct_Window extends models.Model {
+        _name = "ir.actions.act_window";
+    }
+    defineModels([IrActionsAct_Window]);
+
+    stepAllNetworkCalls();
+
+    await mountWithCleanup(WebClient);
+    expect.verifySteps(["/web/webclient/translations", "/web/webclient/load_menus"]);
+
+    await getService("action").doAction({
+        name: "Partner",
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [[false, "kanban"]],
+        context: { active_id: 33 },
+    });
+    expect(".o_kanban_view").toHaveCount(1);
+    expect.verifySteps(["get_views", "web_search_read"]);
+
+    await getService("action").doAction({
+        name: "Partner",
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [[false, "kanban"]],
+        context: { active_id: 44 },
+    });
+    expect(".o_kanban_view").toHaveCount(1);
+    expect.verifySteps(["web_search_read"]);
+});
+
 test.tags("desktop");
 test("pushState also changes the title of the tab", async () => {
     await mountWithCleanup(WebClient);


### PR DESCRIPTION
Steps to reproduce (a bit technical):

1. Navigate to the "Contacts" kanban view.
2. Open the Network tab in the browser's developer tools.
3. Click on the first contact activities and "Schedule a new activity".
4. Notice a call to `get_views` in the Network tab.
5. Click on a different contact activities, and "Schedule a new activity".
6. Notice a new call to `get_views` in the Network tab.

Expected:

The view is already cached, so the webclient should not attempt to load it.

Explanation:

This is likely a regression since f983703d, when the embedded actions were introduced. Now, the `embeddedParentResId` is part of the views cache key, and so we get much fewer cache hits.

For most views, there isn't really an `embeddedActionId` set, and yet the `embeddedParentResId` was always set. The later is only used in combination with `embeddedActionId`, so it causes a lot of avoidable cache misses.

The solution is to simply set the `embeddedParentResId` only if there's an `embeddedActionId`.

Closes odoo/odoo#192261

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
