### PR TITLE
[FIX] web: prevent tl locale to be converted to fil

### DIFF
--- a/addons/web/static/src/core/l10n/utils/locales.js
+++ b/addons/web/static/src/core/l10n/utils/locales.js
@@ -4,10 +4,12 @@
  * Most of the time the conversion is simply to replace - with _.
  * Example: fr-BE → fr_BE
  *
- * Exception: Serbian can be written in both Latin and Cyrillic scripts
- * interchangeably, therefore its locale includes a special modifier
- * to indicate which script to use.
- * Example: sr-Latn → sr@latin
+ * Exceptions:
+ *  - Serbian can be written in both Latin and Cyrillic scripts interchangeably,
+ *  therefore its locale includes a special modifier to indicate which script to
+ *  use. Example: sr-Latn → sr@latin
+ *  - Tagalog/Filipino: The "fil" locale is replaced by "tl" for compatibility
+ *  with the Python side (where the "fil" locale doesn't exist).
  *
  * BCP 47 (JS):
  *  language[-extlang][-script][-region][-variant][-extension][-privateuse]
@@ -25,6 +27,10 @@ export function jsToPyLocale(locale) {
     }
     try {
         var { language, script, region } = new Intl.Locale(locale);
+        // new Intl.Locale("tl-PH") produces fil-PH, which one might not expect
+        if (language === "fil") {
+            language = "tl";
+        }
     } catch {
         return locale;
     }

--- a/addons/web/static/tests/l10n/utils.test.js
+++ b/addons/web/static/tests/l10n/utils.test.js
@@ -43,6 +43,8 @@ describe("jsToPyLocale", () => {
     test("already converted locale with script", () =>
         expect(jsToPyLocale("sr@latin")).toBe("sr@latin"));
     test("undefined locale", () => expect(jsToPyLocale(undefined)).toBe(""));
+    test("Tagalog", () => expect(jsToPyLocale("tl-PH")).toBe("tl_PH"));
+    test("Filipino", () => expect(jsToPyLocale("fil-PH")).toBe("tl_PH"));
 });
 
 describe("pyToJsLocale", () => {


### PR DESCRIPTION
Filipino is a standardized version of Tagalog that was created to be the national language of the Philippines.

In Odoo, we use the "tl" locale to refer to Filipino, but this locale is considered "legacy" by standards bodies such as the Unicode Consortium. This is the reason why some APIs, such as the Intl API in the browser, treat "tl" as "fil" and even implicitly replace the former with the latter.

This is a problem in Odoo, since the locale we use on the server side is still tl_PH, which leads to crashes when a converted Filipino locale (fil_PH) is sent to the server.

While waiting for a better solution, this commit forces the tl locale on the client side.

opw-4426799