### PR TITLE
[FIX] base_import: fix selector with an empty string

### DIFF
--- a/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
+++ b/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
@@ -53,7 +53,7 @@
                         t-att-name="`${option[0]}-${option_index}`"
                         t-on-change="(ev) => this.setOptionValue(option[0], ev.target.value)"
                     >
-                        <option t-foreach="option[1].options" t-as="opt" t-key="opt_index" t-att-value="opt.value or opt" t-att-selected="opt.value ? opt.value === option[1].value : opt === option[1].value">
+                        <option t-foreach="option[1].options" t-as="opt" t-key="opt_index" t-att-value="opt.value or opt.value === '' ? opt.value : opt" t-att-selected="opt.value or opt.value === '' ? opt.value === option[1].value : opt === option[1].value">
                             <t t-esc="opt.label ? opt.label : opt" />
                         </option>
                     </select>


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- On Accounting dashboard, click on "Import File" button of Bank journal
- Select a CSV file with bank statements
- On the left menu, select "No Separator" as "Thousands Separator"

**Issue:**
"Comma" is displayed as selected instead the first time.
The second time "No Separator" stays as selected.
However, the value sent when testing or importing is not the correct one.

**Cause:**
"No Separator" option should have an empty string as value.
However, during the generation of the "select" element, the value for the "option" element is evaluated with:
`opt.value or opt`
As `opt.value` is the empty string (evaluated to False), `opt` is used instead, even if it is an object, which is not correct.
The main issue is that the empty string is not handled as a valid value.

**Solution:**
Handle the empty string as an acceptable value.

opw-4325310




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
