### PR TITLE
[FIX] account: rounding issue in `display_tax_base` computation

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2139,7 +2139,7 @@ class AccountTax(models.Model):
         )
 
         subtotal_order = {}
-        encountered_base_amounts = {amount_untaxed_currency}
+        encountered_base_amounts = {currency.round(amount_untaxed_currency)}
         groups_by_subtotal = defaultdict(list)
         for tax_detail in tax_group_details_list:
             tax_group = tax_detail['tax_group']


### PR DESCRIPTION
Reproduce on runbot:
  1. Create an invoice with 
      line1: quantity = 1, unit price = 14.9, taxes = 15%
      line2: quantity = 1, unit price = 59.7, taxes = 15%
  2. Print the invoice
  3. On the invoice it says:
     Untaxed Amount      | $ 74.60
     Tax 15% on $ 74.60  | $ 11.20
     Total               | $ 85.80

Since 74.60$ is the full base amount we do not want to display the "on $ 74.60" (base amount information) part of the tax information.

Basically we want to display the base amounts only in case there is not just a single base amount.
The error is due to a floating point / rounding issue; some but not all considered base amounts are rounded. (see reproduction example below). This is fixed in this commit by rounding all the amounts.

The logic broke in 17.4 due to the rounding improvement in commit c41b7f76611f05b193ee7739148267dacaaa138a .

opw-4344501