### PR TITLE
[FIX] *: wait modal is show before continue the tour

### DIFF
--- a/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
@@ -88,9 +88,8 @@ const registerSteps = [
         run: "click",
     },
     {
-        content: "Fill attendees details",
-        trigger: '.modal form[id="attendee_registration"] .btn[type=submit]',
-        run: "hover",
+        content: "Wait the modal is shown before continue",
+        trigger: ".modal.modal_shown.show form[id=attendee_registration]",
     },
     {
         trigger: ".modal input[name*='1-name']",

--- a/addons/website_event/static/tests/tours/tickets_questions.js
+++ b/addons/website_event/static/tests/tours/tickets_questions.js
@@ -29,6 +29,10 @@ registry.category("web_tour.tours").add("test_tickets_questions", {
             run: "click",
         },
         {
+            content: "Wait the modal is shown before continue",
+            trigger: ".modal.modal_shown.show form[id=attendee_registration]",
+        },
+        {
             trigger: 'div.o_wevent_registration_question_global select[name*="0-simple_choice"]',
             run: "selectByLabel A friend",
         },

--- a/addons/website_event_sale/static/tests/tours/website_event_sale.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale.js
@@ -41,9 +41,8 @@ registry.category("web_tour.tours").add("event_buy_tickets", {
             run: "click",
         },
         {
-            content: "Fill attendees details",
-            trigger: '.modal form[id="attendee_registration"] .btn[type=submit]',
-            run: "hover",
+            content: "Wait the modal is shown before continue",
+            trigger: ".modal.modal_shown.show form[id=attendee_registration]",
         },
         {
             trigger: ".modal#modal_attendees_registration input[name*='1-email']",

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
@@ -23,8 +23,8 @@ registry.category("web_tour.tours").add("event_sale_pricelists_different_currenc
             run: "click",
         },
         {
-            trigger: '.modal form[id="attendee_registration"] .btn[type=submit]',
-            run: "hover",
+            content: "Wait the modal is shown before continue",
+            trigger: ".modal.modal_shown.show form[id=attendee_registration]",
         },
         {
             trigger:

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -67,7 +67,7 @@ registerBackendAndFrontendTour("question", {
 },
 {
     isActive: ["auto"],
-    trigger: ".modal .modal-header button.btn-close",
+    trigger: ".modal.modal_shown.show:contains(thanks for posting!) button.btn-close",
     run: "click",
 },
 {
@@ -97,7 +97,7 @@ registerBackendAndFrontendTour("question", {
 },
 {
     isActive: ["auto"],
-    trigger: ".modal:contains(thanks for posting!) .modal-header button.btn-close",
+    trigger: ".modal.modal_shown.show:contains(thanks for posting!) button.btn-close",
     run: "click",
 }, {
     trigger: ".o_wforum_validate_toggler[data-karma]:first",

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -50,7 +50,7 @@ registry.category("web_tour.tours").add('forum_question', {
     },
     {
         content: "Close modal once modal animation is done.",
-        trigger: ".modal:contains(thanks for posting!) .modal-header button.btn-close",
+        trigger: ".modal.modal_shown.show:contains(thanks for posting!) button.btn-close",
         run: "click",
     },
     {

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_edition.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_edition.js
@@ -5,7 +5,6 @@ import {
     insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
-import snippetNewsletterPopupUseTour from "@website_mass_mailing/../tests/tours/snippet_newsletter_popup_use";
 
 registerWebsitePreviewTour("snippet_newsletter_popup_edition", {
     url: "/",
@@ -23,7 +22,6 @@ registerWebsitePreviewTour("snippet_newsletter_popup_edition", {
     ...clickOnSave(),
     {
         content: "Check the modal has been saved, closed",
-        trigger: ':iframe body:has(.o_newsletter_popup)',
-        run: snippetNewsletterPopupUseTour.ensurePopupNotVisible,
+        trigger: ':iframe body:has(.o_newsletter_popup:not(:visible) .modal)',
     }
 ]);

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_use.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_use.js
@@ -1,48 +1,26 @@
 /** @odoo-module **/
 
-import { isVisible } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
-
-function ensurePopupNotVisible() {
-    const modals = this.anchor.querySelectorAll(".o_newsletter_popup .modal");
-    if (modals.length !== 1) {
-        // Avoid the tour to succeed if the modal can't be found while
-        // it should. Indeed, if the selector ever becomes wrong and the
-        // expected element is actually not found anymore, the test
-        // won't be testing anything anymore as the visible check will
-        // always be truthy on empty jQuery element.
-        console.error("Modal couldn't be found in the DOM. The tour is not working as expected.");
-    }
-    if (isVisible(Array.from(modals).at(0))) {
-        console.error("Modal should not be opened.");
-    }
-}
 
 registry.category("web_tour.tours").add('snippet_newsletter_popup_use', {
     url: '/',
     steps: () => [
     {
         content: "Check the modal is not yet opened and force it opened",
-        trigger: 'body:has(.o_newsletter_popup)',
-        run: ensurePopupNotVisible,
+        trigger: 'body:has(.o_newsletter_popup:not(:visible) .modal)',
     },
     {
         content: "Check the modal is now opened and enter text in the subscribe input",
-        trigger: '.o_newsletter_popup .modal input',
+        trigger: '.o_newsletter_popup .modal.modal_shown input',
         run: "edit hello@world.com",
     },
     {
         content: "Subscribe",
-        trigger: '.modal-dialog .btn-primary',
+        trigger: '.modal.modal_shown.show .btn-primary:contains(subscribe)',
         run: "click",
     },
     {
         content: "Check the modal is now closed",
-        trigger: 'body:not(.modal-open)',
-        run: ensurePopupNotVisible,
+        trigger: 'body:has(.o_newsletter_popup:not(:visible) .modal)',
     }
 ]});
-
-export default {
-    ensurePopupNotVisible: ensurePopupNotVisible,
-};


### PR DESCRIPTION
In this commit, we wait the modal is shown (managed by jQuery) before to continue the tour. In these modals, if we don't wait for the modal is shown, as the tour engine can be too much fast, element in modal can be not focusable when we try to target it.
This fix add classes to ensure modal is shown before continuing the tour.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
