### PR TITLE
[FIX] base_vat: Fix ID vat check

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -763,10 +763,16 @@ class ResPartner(models.Model):
         introduced in January 2024."""
         vat = clean(vat, ' -.').strip()
 
-        if len(vat) not in (15, 16) or not vat[0:15].isdecimal() or not vat[-1].isdecimal():
+        if len(vat) not in (15, 16) or not vat.isdecimal():
             return False
 
-        # VAT is only digits and of the right length, check the Luhn checksum.
+        # VAT could be 15 (old numbers) or 16 digits. If there are 15 digits long, the 10th digit is a luhn checksum
+        # In some cases, the 15 digits can be transformed in a 16-digit by adding a 0 in front. In such case, we
+        # we can verify the luhn checksum like for the 15 digits by removing the 0. 
+        # However, for newly created VAT 16-digits VAT number, there is no checksum.
+        if (len(vat) == 16 and vat[0] != '0'):
+            return True
+
         try:
             luhn.validate(vat[0:9] if len(vat) == 15 else vat[1:10])
         except (InvalidFormat, InvalidChecksum):


### PR DESCRIPTION
STEPS
-----------
1. Install Contact and 'base_vat'
2. Create a new Indonasian contact with VAT as ID1234567890123456
3. Save -> Connot save whilst the VAT is correct

PROBLEM
-----------
VAT could be 15 (old numbers) or 16 digits. If there are 15 digits long, the 10th digit is a luhn checksum. In some cases, the 15 digits can be transformed into a 16-digit by adding a 0 in front. In such case, we can verify the luhn checksum like for the 15 digits by removing the 0.

However, for newly created VAT 16-digits VAT number, there is no checksum.

SOLUTION
-----------
Allow 16-digit VAT that only contains numbers and does not start with a 0.

opw-4402514

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
