### PR TITLE
[FIX] point_of_sale: kitchen receipt long name

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
@@ -7,6 +7,14 @@
     object-fit: contain;
 }
 
+.pos-receipt {
+    .product-name {
+        -webkit-line-clamp: unset;
+        overflow: auto;
+        overflow-wrap: break-word;
+    }
+}
+
 .product-name {
 
     box-sizing: border-box;


### PR DESCRIPTION
When printing long product names with long variants, the lines were overlapping.

Steps to reproduce:
-------------------
* Create a product with some long variant names
* Setup a kitchen printer
* Add the order to a PoS order
* Print the order on the kitchen printer
> Observation: The product name and variant name are overlapping

Before:
![before](https://github.com/user-attachments/assets/d16022b0-4f87-48aa-adc4-1c246b173431)


After:
![after](https://github.com/user-attachments/assets/495632de-e4d2-424c-b19d-fb386a3eb356)


opw-4414311