### PR TITLE
[FIX] mail: composer + actions are aligned (same-width icon)

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -173,7 +173,7 @@
 <t t-name="mail.Composer.dropdownActions">
     <t t-foreach="partitionedActions.other" t-as="action" t-key="action.id">
         <DropdownItem tag="'button'" class="'btn rounded-0 d-flex align-items-center px-2 py-2 m-0'" onSelected="(ev) => action.onClick?.(ev)" attrs="{ 'name': action.id, 'data-hotkey': action.hotkey, 'disabled': action.disabledCondition or areAllActionsDisabled }">
-            <i class="ms-1" t-att-class="action.icon"/>
+            <i class="fa-fw" t-att-class="action.icon"/>
             <span class="mx-2" t-out="action.name"/>
         </DropdownItem>
     </t>


### PR DESCRIPTION
Composer has "+" icon on left with extra actions. Clicking on it shows the item with icon and label.

Before this commit, the icon width was inconsistent between items, so label were not aligned. This commit puts `.fa-fw` so all icons are fixed, thus labels are aligned.

Before
<img width="382" alt="Screenshot 2025-01-06 at 16 58 16" src="https://github.com/user-attachments/assets/0ea5cac1-0f72-40e9-b20b-f4e4d61a4ac6" />

After
<img width="383" alt="Screenshot 2025-01-06 at 16 45 12" src="https://github.com/user-attachments/assets/7d078fcb-ce8f-465e-91c3-d72b537f5809" />
