### PR TITLE
[IMP] point_of_sale, bus: Ensure connection is always established

### DIFF
--- a/addons/bus/static/src/services/bus_service.js
+++ b/addons/bus/static/src/services/bus_service.js
@@ -27,6 +27,7 @@ export const busService = {
         const notificationBus = new EventBus();
         const subscribeFnToWrapper = new Map();
         let worker;
+        let workerChannels = [];
         let isActive = false;
         let isInitialized = false;
         let isUsingSharedWorker = browser.SharedWorker && !isIosApp();
@@ -76,6 +77,9 @@ export const busService = {
                     connectionInitializedDeferred.resolve();
                     break;
                 }
+                case "worker_channels_state":
+                    workerChannels = data;
+                    break;
                 case "log_debug": {
                     console.debug(...data);
                     break;
@@ -208,6 +212,7 @@ export const busService = {
             forceUpdateChannels: () => send("force_update_channels"),
             trigger: bus.trigger.bind(bus),
             removeEventListener: bus.removeEventListener.bind(bus),
+            getWorkerChannels: () => send("get_channels"),
             send: (eventName, data) => send("send", { event_name: eventName, data }),
             start: async () => {
                 if (!worker) {
@@ -252,6 +257,9 @@ export const busService = {
                 subscribeFnToWrapper.delete(callback);
             },
             startedAt,
+            get workerChannels() {
+                return workerChannels;
+            },
         };
     },
 };

--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -5,13 +5,13 @@ import { debounce, Deferred } from "@bus/workers/websocket_worker_utils";
 /**
  * Type of events that can be sent from the worker to its clients.
  *
- * @typedef { 'connect' | 'reconnect' | 'disconnect' | 'reconnecting' | 'notification' | 'initialized' | 'outdated' | 'log_debug'} WorkerEvent
+ * @typedef { 'connect' | 'reconnect' | 'disconnect' | 'reconnecting' | 'notification' | 'initialized' | 'outdated' | 'worker_channels_state' | 'log_debug'} WorkerEvent
  */
 
 /**
  * Type of action that can be sent from the client to the worker.
  *
- * @typedef {'add_channel' | 'delete_channel' | 'force_update_channels' | 'initialize_connection' | 'send' | 'leave' | 'stop' | 'start'} WorkerAction
+ * @typedef {'add_channel' | 'delete_channel' | 'force_update_channels' | 'get_channels' | 'initialize_connection' | 'send' | 'leave' | 'stop' | 'start'} WorkerAction
  */
 
 export const WEBSOCKET_CLOSE_CODES = Object.freeze({
@@ -152,6 +152,8 @@ export class WebsocketWorker {
                 return this._unregisterClient(client);
             case "add_channel":
                 return this._addChannel(client, data);
+            case "get_channels":
+                return this._getChannels();
             case "delete_channel":
                 return this._deleteChannel(client, data);
             case "force_update_channels":
@@ -495,5 +497,15 @@ export class WebsocketWorker {
             });
             this.firstSubscribeDeferred.resolve();
         }
+    }
+
+    /**
+     * Return a list of subscribed channels
+     *
+     * @returns {string[]} List of channels.
+     */
+    _getChannels() {
+        const channels = [...this.channelsByClient.values()].flat();
+        this.broadcast("worker_channels_state", channels);
     }
 }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -155,7 +155,7 @@ export class PosStore extends Reactive {
 
     async initServerData() {
         await this.processServerData();
-        this.onNotified = getOnNotified(this.bus, this.config.access_token);
+        this.onNotified = getOnNotified(this.bus, this.config.access_token, this.data.channels);
         this.onNotified("CLOSING_SESSION", this.closingSessionNotification.bind(this));
         this.onNotified("SYNCHRONISATION", this.recordSynchronisation.bind(this));
 

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -86,9 +86,14 @@ export function getMax(entries, { criterion = (x) => x, inverted = false } = {})
 export function getMin(entries, options) {
     return getMax(entries, { ...options, inverted: true });
 }
-export function getOnNotified(bus, channel) {
+export function getOnNotified(bus, channel, cache = {}) {
     bus.addChannel(channel);
-    return (notif, callback) => bus.subscribe(`${channel}-${notif}`, callback);
+    cache[channel] = cache[channel] || {};
+    return (notif, callback) => {
+        const key = `${channel}-${notif}`;
+        cache[channel][notif] = callback;
+        bus.subscribe(key, callback);
+    };
 }
 
 /**


### PR DESCRIPTION
The connection to the bus was sometimes lost in PoS when other Odoo tabs
tabs were open.

To check whether the PoS channels are still connected, we ask the main
worker to return a message with its channels connected.

If the PoS channel is not in the list, we reconnect to the bus.

The `_getChannels` method is added to `websocket_worker.js`.
broadcast the list of channels connected to the various tabs.

In `bus_service.js` a variable called `workerChannels` is added to store
the list of connected channels. Connected channels are sent by the
worker by calling the `getWorkerChannels` method in the bus service.

---

How to reproduce:
- Open the same PoS restaurant in different browsers or profiles.
- Create an order on a table and leave it, you will see the order in the
  other tabs.
- In one of the browsers, open a Meeting Room, this action will close the
  connection to the bus. In the PoS tab.

---

taskId : 4270307