### PR TITLE
[FIX] base: keep old behavior of ir.model import

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -47,7 +47,6 @@ def load_data(env: Environment, idref, mode: str, kind: str, package: Node) -> b
     :returns: Whether a file was loaded
     :rtype: bool
     """
-    env = env(context=dict(env.context, install_mode=True))
 
     def _get_files_of_kind(kind: str) -> list[str]:
         if kind == 'demo':

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1180,7 +1180,6 @@ class BaseModel(metaclass=MetaModel):
         sp = cr.savepoint(flush=False)
 
         fields = [fix_import_export_id_paths(f) for f in fields]
-        fg = self.fields_get()
 
         ids = []
         messages = []

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -343,6 +343,7 @@ form: module.record_id""" % (xml_id,)
 
         if self.xml_filename and rec_id:
             model = model.with_context(
+                install_mode=True,
                 install_module=self.module,
                 install_filename=self.xml_filename,
                 install_xmlid=rec_id,
@@ -652,6 +653,7 @@ def convert_csv_import(env, module, fname, csvcontent, idref=None, mode='init',
     context = {
         'mode': mode,
         'module': module,
+        'install_mode': True,
         'install_module': module,
         'install_filename': fname,
         'noupdate': noupdate,


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/176227, we moved where we set `install_mode` in context from the low-level import records method `_load_records` to the `load_data` method.

Unfortunately, when we load an industry module, we don't use `load_data`, but mimic its behavior in `_import_zipfile` -> `_import_module`. For example, `_default_field_id` now has a different behavior when we install from a zip module or from the command line. And this can cause the import of the industry module to crash.

To avoid this situation, move where `install_mode` is set to `convert_csv_import` and `xml_import`. These are both used by `_import_module` and `load_data` at some point, but not by a user import (the purpose of the first PR).

##### [REM] core: remove unnecessary `fields_get` call in `load

`fg` are unused and `fields_get` can be expensive for large models. Remove this unnecessary line.