### PR TITLE
[FIX] project : Portal project's task access limitation

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -35,7 +35,7 @@ class ProjectCustomerPortal(CustomerPortal):
         domain = [('project_id', '=', project.id)]
         # pager
         url = "/my/projects/%s" % project.id
-        values = self._prepare_tasks_values(page, date_begin, date_end, sortby, search, search_in, groupby, url, domain, su=bool(access_token), project=project)
+        values = self._prepare_tasks_values(page, date_begin, date_end, sortby, search, search_in, groupby, url, domain, su=bool(access_token) and request.env.user.has_group('base.group_public'), project=project)
         # adding the access_token to the pager's url args,
         # so we are not prompted for loging when switching pages
         # if access_token is None, the arg is not present in the URL


### PR DESCRIPTION
### Steps to reproduce:
	- Create a project with a few tasks -> add a portal user as a follower
	- Go to the user's portal -> the user sees the project, but no tasks
	- Give user access to another project so that he has multiple projects in his portal.
	- Open the first project with 0 visible task and use arrows to navigate between the projects.
	- Go back to the first project all tasks are visible

### Cause:
This is happening because when fetching tasks that will be shown we are passing the SU parameter as true if we have access token https://github.com/odoo/odoo/blob/0b315ded0928372d2349b25699f440f4bf969814/addons/project/controllers/portal.py#L38 which leads that we will not create a domain for fetching tasks as SU will by default has access to all tasks.
https://github.com/odoo/odoo/blob/0b315ded0928372d2349b25699f440f4bf969814/addons/project/controllers/portal.py#L372-L373

### Fix:
We are gonna pass the parameter of SU as true only if the env of the request is SU env only.

opw-4410717