### PR TITLE
[FIX] account_peppol: Fix external calls from tests

### DIFF
--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -208,8 +208,6 @@ def handle_demo(func, self, *args, **kwargs):
     First handle the decision: "Are we in demo mode?", and conditionally decide which function to
     execute.
     """
-    demo_mode = self.env.company._get_peppol_edi_mode() == 'demo'
-
-    if not demo_mode or modules.module.current_test:
-        return func(self, *args, **kwargs)
-    return _demo_behaviour[func.__name__](func, self, *args, **kwargs)
+    if self.env.company._get_peppol_edi_mode() == 'demo':
+        return _demo_behaviour[func.__name__](func, self, *args, **kwargs)
+    return func(self, *args, **kwargs)

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -734,7 +734,7 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
         ]
 
         invoice.action_post()
-        invoice._generate_and_send(mail_template_id=self.move_template.id)
+        invoice._generate_and_send(mail_template_id=self.move_template.id, sending_methods=['manual'])
 
         self.assertRecordValues(invoice, [{
             'amount_untaxed': 600.00,


### PR DESCRIPTION
Context:
In Peppol, we have multiple EDI mode:
- `production` that will call the real Peppol infrastructure,
- `test` that will call the sandbox Peppol,
- `demo` that makes no call at all, everything is mocked.

By default, runbots and demo data are set to `demo`. In tests, the value is therefore also `demo`, which is what we want: No call to external services.

Before this commit, we were doing some weird and useless override in the handling of demo functions, which is useless: if you want to test Odoo in a particular mode, just set it (this is what we do in Peppol tests' `setUpClass`), for all other tests, keeping the default demo mode should be preferred.

This was a problem because tests ran by other modules with Peppol installed were trying to make external calls.

task-no
