### PR TITLE
[FIX] account: Manual payments try to post already posted moves

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -909,7 +909,8 @@ class AccountPayment(models.Model):
     def write(self, vals):
         if vals.get('state') in ('in_process', 'paid') and not vals.get('move_id'):
             self.filtered(lambda p: not p.move_id)._generate_journal_entry()
-            self.move_id.action_post()
+            if self.move_id.state not in ['posted', 'cancel']:
+                self.move_id.action_post()
 
         res = super().write(vals)
         if self.move_id:


### PR DESCRIPTION
Steps to reproduce:

1. Install account
2. Configure the bank journal so it has an account linked to manual payments
3. Go to Customers -> Payments and create a new payment with a fake user and amount
4. Confirm the payment. Then Validate the payment.
5. An error shows up: "The entry must be in draft."

---

Description of the issue this commit addresses:

When trying to validate a payment (marking it as paid), the move linked to the payment is posted but if the move was already posted or cancelled, an error is raised. This is not a desired behavior.

---

Desired behavior after this commit is merged:

When following the same process, the move is only posted if it is not posted or cancelled yet to make sure it should pass through the posting method.

---

Note on the fix:

Cancelled is taken into account for safety purposes but since the payment is manual, no move at that point in the code should ever have state == 'cancel'.

---

opw-4445889

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
