### PR TITLE
[FIX] account: hide validate button on payment without oustanding

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -909,7 +909,7 @@ class AccountPayment(models.Model):
     def write(self, vals):
         if vals.get('state') in ('in_process', 'paid') and not vals.get('move_id'):
             self.filtered(lambda p: not p.move_id)._generate_journal_entry()
-            self.move_id.action_post()
+            self.move_id.filtered(lambda m: m.state == 'draft').action_post()
 
         res = super().write(vals)
         if self.move_id:

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -142,7 +142,7 @@
                         <button name="action_post" string="Confirm" type="object" class="oe_highlight"
                                 invisible="state != 'draft'" data-hotkey="q"/>
                         <button name="action_validate" string="Validate" type="object" class="oe_highlight"
-                                invisible="state != 'in_process'" data-hotkey="q"/>
+                                invisible="state != 'in_process' or move_id" data-hotkey="q"/>
                         <button name="action_reject" string="Reject" type="object" class="oe_highlight"
                                 invisible="state != 'in_process' or not is_sent" data-hotkey="q"/>
                         <button name="action_draft" string="Reset To Draft" type="object" class="btn btn-secondary"


### PR DESCRIPTION
This button is only useful for marking payments as paid when the matching doesn't do it automatically, which can only happen if there is no reconciliation being done, which only happens when there is no outstanding account used.

opw-4445889
