### PR TITLE
[FIX] account: draft bill entries in partner ledger

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -13,6 +13,7 @@ from textwrap import shorten
 from odoo import api, fields, models, _, Command
 from odoo.addons.account.tools import format_rf_reference
 from odoo.exceptions import UserError, ValidationError, AccessError, RedirectWarning
+from odoo.tools.misc import clean_context
 from odoo.tools import (
     date_utils,
     email_re,
@@ -29,7 +30,6 @@ from odoo.tools import (
     is_html_empty,
     sql
 )
-
 
 MAX_HASH_VERSION = 3
 
@@ -2141,7 +2141,7 @@ class AccountMove(models.Model):
         if to_delete:
             self.env['account.move.line'].browse(to_delete).with_context(dynamic_unlink=True).unlink()
         if to_create:
-            self.env['account.move.line'].create([
+            self.env['account.move.line'].with_context(clean_context(self.env.context)).create([
                 {**key, **values, 'display_type': line_type}
                 for key, values in to_create.items()
             ])

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4165,3 +4165,15 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         with move_form.invoice_line_ids.new() as invoice_line_form:
             invoice_line_form.display_type = 'line_section'
         move_form.save()
+
+    def test_out_invoice_partner_context(self):
+        """No line should take the partner of the context instead of the one specified in the create vals."""
+        move = self.env['account.move'].with_context(default_partner_id=self.partner_b.id).create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2017-01-01',
+            'invoice_line_ids': [Command.create({
+                'price_unit': 1000.0,
+            })],
+        })
+        self.assertEqual(move.line_ids.partner_id, self.partner_a)


### PR DESCRIPTION
### Before
When creating a new vendor bill through Vendors > 'Example Vendor 1'> Vendor Bills (magic button), if the vendor was changed to 'Example Vendor 2' and the draft saved then it would show up under the 'Example Vendor 1' in the Partner Ledger instead of under the correct 'Example Vendor 2'. 

This is due to the partner_id being defined in the context when going through the 'Example Vendor 1' view. 

### Now
During the creation of the account move lines we use a context without the default_partner_id.

The Partner Ledger now shows the draft bill entry under the right vendor.

opw-4407709