### PR TITLE
[FIX] sale: convert combo product lines into invoice line sections

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1347,6 +1347,14 @@ class SaleOrderLine(models.Model):
         """
         self.ensure_one()
 
+        if self.product_id.type == 'combo':
+            # If the quantity to invoice is a whole number, format it as an integer (with no decimal point)
+            qty_to_invoice = int(self.qty_to_invoice) if self.qty_to_invoice == int(self.qty_to_invoice) else self.qty_to_invoice
+            return {
+                'display_type': 'line_section',
+                'sequence': self.sequence,
+                'name': f'{self.product_id.name} x {qty_to_invoice}',
+            }
         res = {
             'display_type': self.display_type or 'product',
             'sequence': self.sequence,

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -533,6 +533,105 @@ class TestSaleToInvoice(TestSaleCommon):
 
         self.assertEqual(invoice.line_ids[0].display_type, 'line_section')
 
+    def test_invoice_combo_product(self):
+        """ Test creating an invoice for a SO with a combo product. """
+        product_a = self._create_product(name="Horse-meat burger")
+        product_b = self._create_product(name="French fries")
+        combo_a = self.env['product.combo'].create({
+            'name': "Burger",
+            'combo_item_ids': [
+                Command.create({'product_id': product_a.id}),
+            ],
+        })
+        combo_b = self.env['product.combo'].create({
+            'name': "Side",
+            'combo_item_ids': [
+                Command.create({'product_id': product_b.id}),
+            ],
+        })
+        product_combo = self._create_product(
+            name="Meal Menu",
+            list_price=10.0,
+            type='combo',
+            combo_ids=[
+                Command.link(combo_a.id),
+                Command.link(combo_b.id),
+            ],
+        )
+
+        sale_order = self.env['sale.order'].with_context(tracking_disable=True).create({
+            'partner_id': self.partner_a.id,
+            'partner_invoice_id': self.partner_a.id,
+            'partner_shipping_id': self.partner_a.id,
+            'pricelist_id': self.company_data['default_pricelist'].id,
+            'order_line': [
+                Command.create({
+                    'name': 'Meal Menu',
+                    'product_id': product_combo.id,
+                    'product_uom_qty': 3,
+                    'price_unit': 0,
+                    'tax_id': [],
+                }),
+                Command.create({
+                    'name': 'Horse-meat burger',
+                    'product_id': product_a.id,
+                    'product_uom_qty': 3,
+                    'price_unit': 5.0,
+                    'tax_id': [],
+                }),
+                Command.create({
+                    'name': 'French fries',
+                    'product_id': product_b.id,
+                    'product_uom_qty': 3,
+                    'price_unit': 5.0,
+                    'tax_id': [],
+                }),
+            ]
+        })
+
+        # Confirm the SO
+        sale_order.action_confirm()
+
+        # Context
+        self.context = {
+            'active_model': 'sale.order',
+            'active_ids': [sale_order.id],
+            'active_id': sale_order.id,
+            'default_journal_id': self.company_data['default_journal_sale'].id,
+        }
+
+        # Let's do an invoice with invoiceable lines
+        payment = self.env['sale.advance.payment.inv'].with_context(self.context).create({
+            'advance_payment_method': 'delivered'
+        })
+        payment.create_invoices()
+
+        invoice = sale_order.invoice_ids[0]
+
+        self.assertRecordValues(invoice.invoice_line_ids, [
+            {
+                'name': 'Meal Menu x 3',
+                'display_type': 'line_section',
+                'product_id': False,
+                'quantity': 0,
+                'price_unit': 0,
+            },
+            {
+                'name': 'Horse-meat burger',
+                'display_type': 'product',
+                'product_id': product_a.id,
+                'quantity': 3,
+                'price_unit': 5.0
+            },
+            {
+                'name': 'French fries',
+                'display_type': 'product',
+                'product_id': product_b.id,
+                'quantity': 3,
+                'price_unit': 5.0
+            },
+        ])
+
     def test_qty_invoiced(self):
         """Verify uom rounding is correctly considered during qty_invoiced compute"""
         sale_order = self.env['sale.order'].with_context(tracking_disable=True).create({


### PR DESCRIPTION
Before, when invoices were created from a sales order and one of the lines is a combo product, it would create a regular invoice line for that with the combo product, but the price would be zero and no taxes.  The problem with that when sending electronic invoicing documents, is that it will treat that as a zero line.  (and some EDIs might e.g. complain there is no tax on there)

So, that way when creating the invoice line, we define it as a subsection with the product name as description but without product.

opw-4410461

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
