### PR TITLE
[FIX] im_livechat, website_livechat: handle optional message.thread

### DIFF
--- a/addons/im_livechat/static/src/core/common/message_patch.js
+++ b/addons/im_livechat/static/src/core/common/message_patch.js
@@ -6,7 +6,7 @@ patch(Message.prototype, {
     get authorName() {
         if (
             this.message.author?.user_livechat_username &&
-            this.message.thread.channel_type === "livechat"
+            this.message.thread?.channel_type === "livechat"
         ) {
             return this.message.author.user_livechat_username;
         }

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -146,3 +146,12 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
 
     def test_user_known_after_reload(self):
         self.start_tour('/', 'website_livechat_user_known_after_reload')
+
+
+@tests.tagged('post_install', '-at_install')
+class TestLivechatBasicFlowHttpCaseMobile(HttpCaseWithUserDemo, TestLivechatCommon):
+    browser_size = '375x667'
+    touch_enabled = True
+
+    def test_mobile_user_interaction(self):
+        self.start_tour('/', 'im_livechat_request_chat_and_send_message', login=None)


### PR DESCRIPTION
On small displays, starting a new website livechat with an operator that has an `user_livechat_username` crashes when rendering the username.

Steps to reproduce
-----
1. Select User Menu Icon > My Profile / Preferences > enter an Online Chat Name
2. On a mobile device or small window, open the livechat on the website
3. Send any new message
4. The following traceback occurs
```
Caused by: TypeError: Cannot read properties of undefined (reading 'channel_type')
    at get authorName
```

Cause
-----
On small displays, `thread` for the default operator message becomes undefined when it is reassigned to the new thread. This causes an error in `get authorName()` when the undefined `thread` is accessed directly to detemine the displayed username.

Solution
-----
Add an optional chain (?) when accessing `this.message.thread` to handle the possible nullish value.

opw-4446208