### PR TITLE
[FIX] hr_recruitment, hr_recruitment_sms: apply missing dependency of…

### DIFF
--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -439,20 +439,6 @@
         </field>
     </record>
 
-    <record id="action_hr_applicant_mass_sms" model="ir.actions.act_window">
-        <field name="name">Send SMS</field>
-        <field name="res_model">sms.composer</field>
-        <field name="view_mode">form</field>
-        <field name="target">new</field>
-        <field name="context">{
-            'default_composition_mode': 'mass',
-            'default_mass_keep_log': True,
-            'default_res_ids': active_ids,
-        }</field>
-        <field name="binding_model_id" ref="hr_recruitment.model_hr_applicant"/>
-        <field name="binding_view_types">tree</field>
-    </record>
-
     <record model="ir.actions.act_window" id="action_hr_applicant_new">
         <field name="res_model">hr.applicant</field>
         <field name="view_mode">form</field>

--- a/addons/hr_recruitment_sms/__init__.py
+++ b/addons/hr_recruitment_sms/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/hr_recruitment_sms/__manifest__.py
+++ b/addons/hr_recruitment_sms/__manifest__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Recruitment - SMS',
+    'version': '1.0',
+    'summary': 'Mass mailing sms to job applicants',
+    'description': 'Mass mailing sms to job applicants',
+    'category': 'Hidden',
+    'depends': ['hr_recruitment', 'sms'],
+    'data': [
+        'views/hr_applicant_views.xml',
+    ],
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/hr_recruitment_sms/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_sms/views/hr_applicant_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="action_hr_applicant_mass_sms" model="ir.actions.act_window">
+        <field name="name">Send SMS</field>
+        <field name="res_model">sms.composer</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="context">{
+            'default_composition_mode': 'mass',
+            'default_mass_keep_log': True,
+            'default_res_ids': active_ids,
+        }</field>
+        <field name="binding_model_id" ref="hr_recruitment.model_hr_applicant"/>
+        <field name="binding_view_types">tree</field>
+    </record>
+</odoo>


### PR DESCRIPTION
… hr_recruitment on sms in a glue module

Missing dependency caused errors when uninstalling sms after installing hr_recruitment. The glue module approach is implemented for the benefit of users who decide to opt out of IAP services. Resolves #191635

Description of the issue/feature this PR addresses:

Current behavior before PR:
[Issue 191635](https://github.com/odoo/odoo/issues/191635)
Desired behavior after PR is merged:
You will be able to uninstall sms module safely which will in turn uninstall the new module hr_recruitment_sms without causing issues with hr_recruitment.

Runbot Templates is failing because new modules typically shouldn't be added in stable.
An exception can be given after review and approval.

A similar buggy sms action in hr.candidate was introduced later in #169955 
I'll create a new PR targeting 18.0 once this one is forward ported.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
