### PR TITLE
[FIX] l10n_in_edi: filter tags based on reverse charge condition

### DIFF
--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -568,7 +568,10 @@ class AccountEdiFormat(models.Model):
         def l10n_in_grouping_key_generator(base_line, tax_data):
             invl = base_line['record']
             tax = tax_data['tax']
-            tags = tax.invoice_repartition_line_ids.tag_ids
+            if tax_data.get('is_reverse_charge'):
+                tags = tax.invoice_repartition_line_ids.filtered(lambda l: l.factor_percent < 0).tag_ids
+            else:
+                tags = tax.invoice_repartition_line_ids.filtered(lambda l: l.factor_percent >= 0).tag_ids
             line_code = "other"
             if not invl.currency_id.is_zero(tax_data['tax_amount_currency']):
                 if any(tag in tags for tag in self.env.ref("l10n_in.tax_tag_cess")):


### PR DESCRIPTION
This PR modifies the tag assignment logic for taxes based on whether the tax
is marked as a reverse charge:

- For reverse charges, it selects tags from `invoice_repartition_line_ids` where
the `factor_percent` is less than 0.
- For non-reverse charges, it filters tags where `factor_percent` is greater
than or equal to 0.

This ensures accurate tagging of tax lines according to the reverse charge
criteria, improving consistency and correctness in tax reporting.