### PR TITLE
[IMP] l10n_in: generate credit notes for early payment discount

### DIFF
--- a/addons/l10n_in/__manifest__.py
+++ b/addons/l10n_in/__manifest__.py
@@ -58,6 +58,7 @@ Sheet, now only Vertical format has been permitted Which is Supported By Odoo.
         'views/res_partner_views.xml',
         'views/account_tax_views.xml',
         'views/uom_uom_views.xml',
+        'views/account_payment_term_views.xml',
     ],
     'demo': [
         'demo/product_demo.xml',

--- a/addons/l10n_in/i18n/l10n_in.pot
+++ b/addons/l10n_in/i18n/l10n_in.pot
@@ -299,6 +299,21 @@ msgid "Create TDS Entry"
 msgstr ""
 
 #. module: l10n_in
+#: model:ir.model.fields,field_description:l10n_in.field_account_payment_term__early_pay_credit_note
+msgid "Create Credit Note"
+msgstr ""
+
+#. module: l10n_in
+#: model:ir.model.fields,help:l10n_in.field_account_payment_term__early_pay_credit_note
+msgid "Create Credit Note of early payment discount"
+msgstr ""
+
+#. module: l10n_in
+#: model_terms:ir.ui.view,arch_db:l10n_in.view_payment_term_form
+msgid "Create credit note:"
+msgstr ""
+
+#. module: l10n_in
 #: model:ir.model.fields,field_description:l10n_in.field_l10n_in_port_code__create_uid
 #: model:ir.model.fields,field_description:l10n_in.field_l10n_in_section_alert__create_uid
 #: model:ir.model.fields,field_description:l10n_in.field_l10n_in_withhold_wizard__create_uid
@@ -310,6 +325,19 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_in.field_l10n_in_section_alert__create_date
 #: model:ir.model.fields,field_description:l10n_in.field_l10n_in_withhold_wizard__create_date
 msgid "Created on"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_payment_register.py:0
+msgid ""
+"Creating credit note must be consistently enabled or disabled for payment "
+"terms of all selected invoices."
+msgstr ""
+
+#. module: l10n_in
+#: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
+msgid "Credit Note"
 msgstr ""
 
 #. module: l10n_in
@@ -350,6 +378,8 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_in.field_account_move__display_name
 #: model:ir.model.fields,field_description:l10n_in.field_account_move_line__display_name
 #: model:ir.model.fields,field_description:l10n_in.field_account_payment__display_name
+#: model:ir.model.fields,field_description:l10n_in.field_account_payment_register__display_name
+#: model:ir.model.fields,field_description:l10n_in.field_account_payment_term__display_name
 #: model:ir.model.fields,field_description:l10n_in.field_account_tax__display_name
 #: model:ir.model.fields,field_description:l10n_in.field_iap_account__display_name
 #: model:ir.model.fields,field_description:l10n_in.field_l10n_in_port_code__display_name
@@ -634,6 +664,8 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_in.field_account_move__id
 #: model:ir.model.fields,field_description:l10n_in.field_account_move_line__id
 #: model:ir.model.fields,field_description:l10n_in.field_account_payment__id
+#: model:ir.model.fields,field_description:l10n_in.field_account_payment_register__id
+#: model:ir.model.fields,field_description:l10n_in.field_account_payment_term__id
 #: model:ir.model.fields,field_description:l10n_in.field_account_tax__id
 #: model:ir.model.fields,field_description:l10n_in.field_iap_account__id
 #: model:ir.model.fields,field_description:l10n_in.field_l10n_in_port_code__id
@@ -1019,6 +1051,16 @@ msgstr ""
 #. module: l10n_in
 #: model:ir.model.constraint,message:l10n_in.constraint_l10n_in_section_alert_per_transaction_limit
 msgid "Per transaction limit must be positive"
+msgstr ""
+
+#. module: l10n_in
+#: model:ir.model,name:l10n_in.model_account_payment_register
+msgid "Pay"
+msgstr ""
+
+#. module: l10n_in
+#: model:ir.model,name:l10n_in.model_account_payment_term
+msgid "Payment Terms"
 msgstr ""
 
 #. module: l10n_in

--- a/addons/l10n_in/models/__init__.py
+++ b/addons/l10n_in/models/__init__.py
@@ -16,3 +16,5 @@ from . import account_account
 from . import l10n_in_section_alert
 from . import l10n_in_pan_entity
 from . import l10n_in_report_handler
+from . import account_payment_term
+from . import account_payment_register

--- a/addons/l10n_in/models/account_payment_register.py
+++ b/addons/l10n_in/models/account_payment_register.py
@@ -1,0 +1,68 @@
+from odoo import models, _
+from odoo.exceptions import UserError
+
+
+class AccountPaymentRegister(models.TransientModel):
+    _name = 'account.payment.register'
+    _inherit = 'account.payment.register'
+
+    # -------------------------------------------------------------------------
+    # BUSINESS METHODS
+    # -------------------------------------------------------------------------
+
+    def _create_payment_vals_from_wizard(self, batch_result):
+        # OVERRIDE
+        payment_vals = super()._create_payment_vals_from_wizard(batch_result)
+
+        # Apply early payment discount and create credit notes if applicable
+        self._handle_early_payment_discount(batch_result, payment_vals)
+        return payment_vals
+
+    def _create_payment_vals_from_batch(self, batch_result):
+        # OVERRIDE
+        payment_vals = super()._create_payment_vals_from_batch(batch_result)
+
+        # Apply early payment discount and create credit notes if applicable
+        self._handle_early_payment_discount(batch_result, payment_vals)
+        return payment_vals
+
+    def _handle_early_payment_discount(self, batch_result, payment_vals):
+        """
+        Handles the creation of credit notes for early payment discounts.
+        """
+
+        if self.hide_writeoff_section:
+            if self.group_payment:
+                # Extract all invoices from batch_result lines
+                invoices = self.env['account.move'].browse({line.move_id.id for line in batch_result['lines']})
+
+                # Check if any invoice have early_pay_credit_note set to True then all invoices have `early_pay_credit_note` set to True
+                if any(invoice.invoice_payment_term_id.early_pay_credit_note for invoice in invoices):
+                    if not all(invoice.invoice_payment_term_id.early_pay_credit_note for invoice in invoices):
+                        raise UserError(_(
+                            "Creating credit note must be consistently enabled or disabled for payment terms of all selected invoices."
+                        ))
+
+            for line in batch_result['lines']:
+                invoice = line.move_id
+                if invoice._is_eligible_for_early_payment_discount(self.company_id.currency_id, self.payment_date):
+                    open_amount_currency = (line.amount_residual - line.discount_balance) \
+                                        * (-1 if self.payment_type == 'outbound' else 1)
+                    open_balance = self.currency_id._convert(
+                        open_amount_currency, self.company_id.currency_id, self.company_id, self.payment_date
+                    )
+
+                    invoice._create_credit_note_for_early_payment_discount(
+                        invoice=invoice,
+                        open_balance=open_balance,
+                        payment_vals=payment_vals,
+                    )
+
+    def _create_payments(self):
+        # OVERRIDE
+        payments = super()._create_payments()
+        for payment in payments:
+            for invoice in payment.invoice_ids.reversal_move_ids:
+                message_content_reverse = _('Entry of discounted amount: %s', invoice._get_html_link())
+                payment.message_post(body=message_content_reverse)
+        return payments

--- a/addons/l10n_in/models/account_payment_term.py
+++ b/addons/l10n_in/models/account_payment_term.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class AccountPaymentTerm(models.Model):
+    _name = 'account.payment.term'
+    _inherit = 'account.payment.term'
+
+    early_pay_credit_note = fields.Boolean(string='Create Credit Note', help="Create Credit Note of early payment discount")

--- a/addons/l10n_in/views/account_payment_term_views.xml
+++ b/addons/l10n_in/views/account_payment_term_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_payment_term_form" model="ir.ui.view">
+            <field name="model">account.payment.term</field>
+            <field name="name">view.payment.term.form</field>
+            <field name="inherit_id" ref="account.view_payment_term_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//form/sheet/group/div" position="inside">
+                    <div invisible="not early_discount or 'IN' not in fiscal_country_codes or early_pay_discount_computation != 'included'">
+                        <span> Create credit note:
+                            <field name="early_pay_credit_note" class="ms-1"/>
+                        </span>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
This PR introduces the option to create a credit note for the discounted amount when an early payment discount is applied to an invoice or bill.

When the 'Early Discount' option is enabled in the payment terms, a boolean of 'Create Credit Note' will be visible
If this field is activated, the system will automatically generate a credit note for the discounted amount upon payment.

task-4028948