### PR TITLE
[IMP] sale: improve product sequence in catalog

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -269,6 +269,21 @@ class ProductProduct(models.Model):
         for record in self:
             record.tax_string = record.product_tmpl_id._construct_tax_string(record.lst_price)
 
+    @api.model
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
+        """
+        Returns the products in a prioritized sequence for the purchase order line product selection.
+        First, it lists all products that have been invoiced to the specified customer,
+        sorted from the most recent to the oldest invoice date.
+        Afterward, it includes the remaining products in their default order of display.
+        """
+        domain = domain or []
+        if not name and self.env.context.get('partner_id') and self.env.context.get('move_type') == 'out_invoice':
+            products = self.env['product.template'].get_prioritized_product_and_time(journal_type='sale', is_product=True, domain=domain, limit=limit)
+            return [(product.id, product.display_name) for product in products]
+        else:
+            return super().name_search(name, domain, operator, limit)
+
     # -------------------------------------------------------------------------
     # EDI
     # -------------------------------------------------------------------------

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -29,7 +29,14 @@
             </t>
             <t t-else="">
                 <div class="d-flex align-items-center gap-1">
-                    <Many2One t-props="this.m2oProps" cssClass="'w-100'"/>
+                    <Many2One t-props="this.m2oProps" cssClass="'w-100'">
+                        <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                            <span class="d-flex justify-content-between">
+                                <div t-esc="autoCompleteItemScope.record.display_name"/>
+                                <div t-esc="computeTime()" class="text-muted"/>
+                            </span>
+                        </t>
+                    </Many2One>
                     <t t-if="!props.readonly and columnIsProductAndLabel.value and !label">
                         <button
                             class="btn fa fa-bars text-start o_external_button px-1"

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1127,6 +1127,8 @@
                                            'default_currency_id': currency_id or company_currency_id,
                                            'default_display_type': 'product',
                                            'quick_encoding_vals': quick_encoding_vals,
+                                           'move_type': move_type,
+                                           'partner_id': partner_id,
                                        }" readonly="state != 'draft'">
                                     <list name="journal_items" editable="bottom" string="Journal Items" default_order="sequence, id">
                                         <control>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -253,7 +253,7 @@
                                         widget="product_label_section_and_note_field"
                                         readonly="state in ('purchase', 'to approve', 'cancel') or is_downpayment"
                                         required="not display_type and not is_downpayment"
-                                        context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id}"
+                                        context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id, 'is_purchase': True}"
                                         force_save="1" domain="[('purchase_ok', '=', True), '|', ('company_id', '=', False), ('company_id', 'parent_of', parent.company_id)]"/>
                                     <field name="name" widget="section_and_note_text" optional="show"/>
                                     <field name="date_planned" optional="hide" required="not display_type and not is_downpayment" force_save="1" readonly="is_downpayment"/>

--- a/addons/purchase_product_matrix/models/__init__.py
+++ b/addons/purchase_product_matrix/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import purchase
+from . import product_template

--- a/addons/purchase_product_matrix/models/product_template.py
+++ b/addons/purchase_product_matrix/models/product_template.py
@@ -1,0 +1,20 @@
+from odoo import models, api
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    @api.model
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
+        """
+        Returns the products in a prioritized sequence for the purchase order line product selection.
+        First, it lists all products that have been invoiced to the specified customer,
+        sorted from the most recent to the oldest invoice date.
+        Afterward, it includes the remaining products in their default order of display.
+        """
+        domain = domain or []
+        if not name and self.env.context.get('partner_id') and self.env.context.get('is_purchase'):
+            product_templates = self.env['product.template'].get_prioritized_product_and_time(journal_type='purchase', domain=domain, limit=limit)
+            return [(product_template.id, product_template.display_name) for product_template in product_templates]
+        else:
+            return super().name_search(name, domain, operator, limit)

--- a/addons/purchase_product_matrix/views/purchase_views.xml
+++ b/addons/purchase_product_matrix/views/purchase_views.xml
@@ -14,7 +14,7 @@
                     string="Product"
                     readonly="state in ('purchase', 'to approve', 'cancel')"
                     required="not display_type"
-                    context="{'partner_id': parent.partner_id}"
+                    context="{'partner_id': parent.partner_id, 'is_purchase': True}"
                     widget="pol_product_many2one"/>
                 <field name="product_template_attribute_value_ids" column_invisible="1"/>
                 <field name="product_no_variant_attribute_value_ids" column_invisible="1"/>

--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -80,6 +80,7 @@ This module contains all the common features of Sales Management and eCommerce.
             'sale/static/src/js/sale_product_field.js',
             'sale/static/src/js/sale_product_field.scss',
             'sale/static/src/js/sale_utils.js',
+            'sale/static/src/product_catalog/**/*',
             'sale/static/src/xml/**/*',
             'sale/static/src/views/**/*',
         ],

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -122,6 +122,21 @@ class ProductProduct(models.Model):
         )
         return bool(so_lines)
 
+    @api.model
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
+        """
+        Returns the products in a prioritized sequence for the purchase order line product selection.
+        First, it lists all products that have been invoiced to the specified customer,
+        sorted from the most recent to the oldest invoice date.
+        Afterward, it includes the remaining products in their default order of display.
+        """
+        domain = domain or []
+        if not name and self.env.context.get('partner_id') and self.env.context.get('is_sale'):
+            products = self.env['product.template'].get_prioritized_product_and_time(journal_type='sale', is_product=True, domain=domain, limit=limit)
+            return [(product.id, product.display_name) for product in products]
+        else:
+            return super().name_search(name, domain, operator, limit)
+
 
 class ProductAttributeCustomValue(models.Model):
     _inherit = "product.attribute.custom.value"

--- a/addons/sale/static/src/product_catalog/kanban_model.js
+++ b/addons/sale/static/src/product_catalog/kanban_model.js
@@ -1,0 +1,28 @@
+import { ProductCatalogKanbanModel } from "@product/product_catalog/kanban_model";
+
+export class SaleProductCatalogKanbanModel extends ProductCatalogKanbanModel {
+
+    async _loadData(params) {
+        const orignal_limit = params.limit || this.initialLimit;
+        const orignal_offset = params.offset || 0;
+        const new_limit = await this.orm.searchCount(params.resModel, params.domain);
+        params.limit = new_limit;
+        params.offset = 0;
+        const result = await super._loadData(...arguments);
+
+        if (!params.isMonoRecord && !params.groupBy.length) {
+            if (result.records.some(record => 'last_invoice_date' in record.productCatalogData)) {
+                const prioritized_products = result.records.filter(obj => obj.productCatalogData.last_invoice_date != false)
+                const remaining_products = result.records.filter(obj => obj.productCatalogData.last_invoice_date == false)
+                result.records = prioritized_products.sort((obj1, obj2) => {
+                    return new Date(obj2.productCatalogData.last_invoice_date || 0) - new Date(obj1.productCatalogData.last_invoice_date || 0);
+                });
+                result.records.push(...remaining_products);
+            }
+        }
+        result.records = result.records.slice(orignal_offset, orignal_limit + orignal_offset);
+        params.limit = orignal_limit;
+        params.offset = orignal_offset;
+        return result;
+    }
+}

--- a/addons/sale/static/src/product_catalog/kanban_record.js
+++ b/addons/sale/static/src/product_catalog/kanban_record.js
@@ -1,0 +1,16 @@
+import { ProductCatalogKanbanRecord } from "@product/product_catalog/kanban_record";
+import { ProductCatalogSaleOrder } from "./sale_order_line/sale_order_line";
+
+export class SaleProductCatalogKanbanRecord extends ProductCatalogKanbanRecord {
+    static components = {
+        ...ProductCatalogKanbanRecord.components,
+        ProductCatalogSaleOrder,
+    };
+
+    get orderLineComponent() {
+        if (this.env.orderResModel === "sale.order") {
+            return ProductCatalogSaleOrder;
+        }
+        return super.orderLineComponent;
+    }
+};

--- a/addons/sale/static/src/product_catalog/kanban_view.js
+++ b/addons/sale/static/src/product_catalog/kanban_view.js
@@ -1,0 +1,20 @@
+import { registry } from "@web/core/registry";
+import { SaleProductCatalogKanbanRecord } from "./kanban_record";
+import { productCatalogKanbanView } from "@product/product_catalog/kanban_view";
+import { ProductCatalogKanbanRenderer } from "@product/product_catalog/kanban_renderer";
+import { SaleProductCatalogKanbanModel } from "./kanban_model";
+
+export class SaleProductCatalogKanbanRenderer extends ProductCatalogKanbanRenderer {
+    static components = {
+        ...ProductCatalogKanbanRenderer.components,
+        KanbanRecord: SaleProductCatalogKanbanRecord,
+    };
+}
+
+export const saleProductCatalogKanbanView = {
+    ...productCatalogKanbanView,
+    Renderer: SaleProductCatalogKanbanRenderer,
+    Model: SaleProductCatalogKanbanModel,
+};
+
+registry.category("views").add("sale_product_kanban_catalog", saleProductCatalogKanbanView);

--- a/addons/sale/static/src/product_catalog/sale_order_line/sale_order_line.js
+++ b/addons/sale/static/src/product_catalog/sale_order_line/sale_order_line.js
@@ -1,0 +1,18 @@
+import { ProductCatalogOrderLine } from "@product/product_catalog/order_line/order_line";
+import { formatDuration } from "@web/core/l10n/dates";
+
+export class ProductCatalogSaleOrder extends ProductCatalogOrderLine {
+    static template = "sale.ProductCatalogSaleOrderLine";
+    static props = {
+        ...ProductCatalogOrderLine.props,
+        last_invoice_date: { type: 'datetime', optional: true },
+    }
+
+    get invoice_date() {
+        const duration = (new Date() - new Date(this.props.last_invoice_date)) / 1000
+        if ((duration / (24 * 3600)) > 1) {
+            return formatDuration(duration, false);
+        }
+        return '0d';
+    }
+}

--- a/addons/sale/static/src/product_catalog/sale_order_line/sale_order_line.xml
+++ b/addons/sale/static/src/product_catalog/sale_order_line/sale_order_line.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="sale.ProductCatalogSaleOrderLine"
+       t-inherit="product.ProductCatalogOrderLine"
+       t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('o_product_catalog_quantity')]" position="after">
+            <div t-elif="props.last_invoice_date" class="text-muted">
+                <t t-out="invoice_date"/> ago
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -134,6 +134,19 @@
         </field>
     </record>
 
+    <record id="product_view_kanban_catalog_sale_only" model="ir.ui.view">
+        <field name="name">product.view.kanban.catalog.sale.inherit</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_view_kanban_catalog"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//kanban" position="attributes">
+                    <attribute name="js_class">sale_product_kanban_catalog</attribute>
+                    <attribute name="sample">1</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="view_category_property_form" model="ir.ui.view">
         <field name="name">product.category.property.form.inherit.sale</field>
         <field name="model">product.category</field>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -627,6 +627,8 @@
                                     context="{
                                         'default_lst_price': price_unit,
                                         'default_uom_id': product_uom_id,
+                                        'partner_id': parent.partner_id,
+                                        'is_sale': True
                                     }"
                                     optional="hide"
                                     widget="sol_product_many2one"/>
@@ -637,6 +639,8 @@
                                     context="{
                                         'default_list_price': price_unit,
                                         'default_uom_id': product_uom_id,
+                                        'partner_id': parent.partner_id,
+                                        'is_sale': True
                                     }"
                                     optional="show"
                                     widget="sol_product_many2one"

--- a/addons/sale_stock/static/src/product_catalog/kanban_record.js
+++ b/addons/sale_stock/static/src/product_catalog/kanban_record.js
@@ -1,8 +1,8 @@
-import { ProductCatalogKanbanRecord } from "@product/product_catalog/kanban_record";
+import { SaleProductCatalogKanbanRecord } from "@sale/product_catalog/kanban_record";
 import { ProductCatalogSaleOrderLine } from "./sale_order_line/sale_order_line";
 import { patch } from "@web/core/utils/patch";
 
-patch(ProductCatalogKanbanRecord.prototype, {
+patch(SaleProductCatalogKanbanRecord.prototype, {
     updateQuantity(quantity) {
         if (this.env.orderResModel !== "sale.order" || this.productCatalogData.productType == "service") {
             super.updateQuantity(...arguments);

--- a/addons/sale_stock/static/src/product_catalog/sale_order_line/sale_order_line.js
+++ b/addons/sale_stock/static/src/product_catalog/sale_order_line/sale_order_line.js
@@ -1,9 +1,9 @@
 import { _t } from "@web/core/l10n/translation";
-import { ProductCatalogOrderLine } from "@product/product_catalog/order_line/order_line";
+import { ProductCatalogSaleOrder } from "@sale/product_catalog/sale_order_line/sale_order_line";
 
-export class ProductCatalogSaleOrderLine extends ProductCatalogOrderLine {
+export class ProductCatalogSaleOrderLine extends ProductCatalogSaleOrder {
     static props = {
-        ...ProductCatalogOrderLine.props,
+        ...ProductCatalogSaleOrder.props,
         deliveredQty: Number,
     }
 


### PR DESCRIPTION
A 'Last Bill Date' for products has been introduced in the product catalog view of Sales.

The products in the catalog are now displayed in a specific sequence, determined based on the partner's invoicing history. The sequence is ordered from the latest to the oldest billing date, with remaining products following the default order.

These changes make it easier for customers to find relevant products quickly.

Task ID: 4423839