### PR TITLE
[FIX] product_margin: useless write during _read_group

### DIFF
--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -72,9 +72,11 @@ class ProductProduct(models.Model):
         base_aggregates = [*(agg for agg in aggregates if agg not in self._SPECIAL_SUM_AGGREGATES), 'id:recordset']
         base_result = super()._read_group(domain, groupby, base_aggregates, having, offset, limit, order)
 
-        # Force the compute with all records
+        # Force the compute of all records to bypass the limit compute batching (PREFETCH_MAX)
         all_records = self.browse().union(*(item[-1] for item in base_result))
-        all_records._compute_product_margin_fields_values()
+        # This line will compute all fields having _compute_product_margin_fields_values
+        # as compute method.
+        self._fields['turnover'].compute_value(all_records)
 
         # base_result = [(a1, b1, records), (a2, b2, records), ...]
         result = []


### PR DESCRIPTION
When we aggregate one of the field of "product.product" introduced by 'product_margin' module, it will generate a SQL update on all records read. It is because we call the compute method manually without protecting computed fields, which will lead to call BaseModel.write() that update write_date/write_uid.

Fix it by calling `compute_value` of one of the field.





### Notes

- Should we backport it in 17.0 but then we need to backport https://github.com/odoo/odoo/pull/155585 too ? Also for the 16.0 ?
- For master: remove the return of `_compute_product_margin_fields_values`, people shouldn't call that manually too avoid the issue mention in the commit message.