### PR TITLE
[FIX] base: fix access error to currencies when in child company

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -136,14 +136,13 @@ class Currency(models.Model):
     @api.depends_context('company')
     def _compute_is_current_company_currency(self):
         for currency in self:
-            currency.is_current_company_currency = self.env.company.root_id.currency_id == currency
+            currency.is_current_company_currency = self.env.company.currency_id == currency
 
     @api.depends('rate_ids.rate')
     @api.depends_context('to_currency', 'date', 'company', 'company_id')
     def _compute_current_rate(self):
         date = self._context.get('date') or fields.Date.context_today(self)
         company = self.env['res.company'].browse(self._context.get('company_id')) or self.env.company
-        company = company.root_id
         to_currency = self.browse(self.env.context.get('to_currency')) or company.currency_id
         # the subquery selects the last rate before 'date' for the given currency/company
         currency_rates = (self + to_currency)._get_rates(self.env.company, date)
@@ -306,13 +305,13 @@ class Currency(models.Model):
         """The override of _get_view changing the rate field labels according to the company currency
         makes the view cache dependent on the company currency"""
         key = super()._get_view_cache_key(view_id, view_type, **options)
-        return key + ((self.env['res.company'].browse(self._context.get('company_id')) or self.env.company.root_id).currency_id.name,)
+        return key + ((self.env['res.company'].browse(self._context.get('company_id')) or self.env.company).currency_id.name,)
 
     @api.model
     def _get_view(self, view_id=None, view_type='form', **options):
         arch, view = super()._get_view(view_id, view_type, **options)
         if view_type in ('tree', 'form'):
-            currency_name = (self.env['res.company'].browse(self._context.get('company_id')) or self.env.company.root_id).currency_id.name
+            currency_name = (self.env['res.company'].browse(self._context.get('company_id')) or self.env.company).currency_id.name
             fields_maps = [
                 [['company_rate', 'rate'], _('Unit per %s', currency_name)],
                 [['inverse_company_rate', 'inverse_rate'], _('%s per Unit', currency_name)],
@@ -391,7 +390,7 @@ class CurrencyRate(models.Model):
 
     def _get_last_rates_for_companies(self, companies):
         return {
-            company: company.currency_id.rate_ids.sudo().filtered(lambda x: (
+            company: company.sudo().currency_id.rate_ids.filtered(lambda x: (
                 x.rate
                 and x.company_id == company or not x.company_id
             )).sorted('name')[-1:].rate or 1
@@ -451,7 +450,7 @@ class CurrencyRate(models.Model):
     @api.constrains('company_id')
     def _check_company_id(self):
         for rate in self:
-            if rate.company_id.parent_id:
+            if rate.company_id.sudo().parent_id:
                 raise ValidationError("Currency rates should only be created for main companies")
 
     @api.model
@@ -463,14 +462,14 @@ class CurrencyRate(models.Model):
         """The override of _get_view changing the rate field labels according to the company currency
         makes the view cache dependent on the company currency"""
         key = super()._get_view_cache_key(view_id, view_type, **options)
-        return key + ((self.env['res.company'].browse(self._context.get('company_id')) or self.env.company.root_id).currency_id.name,)
+        return key + ((self.env['res.company'].browse(self._context.get('company_id')) or self.env.company).currency_id.name,)
 
     @api.model
     def _get_view(self, view_id=None, view_type='form', **options):
         arch, view = super()._get_view(view_id, view_type, **options)
         if view_type in ('tree'):
             names = {
-                'company_currency_name': (self.env['res.company'].browse(self._context.get('company_id')) or self.env.company.root_id).currency_id.name,
+                'company_currency_name': (self.env['res.company'].browse(self._context.get('company_id')) or self.env.company).currency_id.name,
                 'rate_currency_name': self.env['res.currency'].browse(self._context.get('active_id')).name or 'Unit',
             }
             for field in [['company_rate', _('%(rate_currency_name)s per %(company_currency_name)s', **names)],


### PR DESCRIPTION
Steps to reproduce (db with Accounting installed):
- create a child company
- give a user (e.g. Marc Demo) access to the child company, set
their "Accounting" rights to "Accountant" and "Administration" to None.
- log as this user and select only the child company in the company
selector.
- try to access "Accounting/Configuration/Accounting/Currencies"
-> Access Error

It is happening as in the `res.currency` model, several methods try to
access the root company, but there's only the child company in
`allowed_company_ids` from the context.

The fix here is to:
1) When accessing the root company in order the get its currency, just
access the currency of the child company, as it is the same.
2) Use sudo when accessing other fields from the root company.

opw-4352595