### PR TITLE
[FIX] hw_drivers: landscape report printing on windows

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
@@ -112,12 +112,12 @@ class PrinterDriver(Driver):
         printer = self.device_name
 
         args = [
-            "-dPrinted", "-dBATCH", "-dNOPAUSE", "-dNOPROMPT"
+            "-dPrinted", "-dBATCH", "-dNOPAUSE", "-dNOPROMPT", "-dNORANGEPAGESIZE",
             "-q",
             "-sDEVICE#mswinpr2",
             f'-sOutputFile#%printer%{printer}',
             f'{file_name}'
-            ]
+        ]
 
         ghostscript.Ghostscript(*args)
 


### PR DESCRIPTION
On Virtual IoT Boxes, a landscape report was still printed in portrait.
We added the argument required to handle landscape printing.

opw-4081884