### PR TITLE
[FIX] html_editor: fix traceback in html external link preview

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -561,7 +561,7 @@ class HTML_Editor(http.Controller):
     @http.route('/html_editor/link_preview_external', type="json", auth="public", methods=['POST'])
     def link_preview_metadata(self, preview_url):
         link_preview_data = link_preview.get_link_preview_from_url(preview_url)
-        if link_preview_data['og_description']:
+        if link_preview_data and link_preview_data.get('og_description'):
             link_preview_data['og_description'] = html.fromstring(link_preview_data['og_description']).text_content()
         return link_preview_data
 


### PR DESCRIPTION
Currently, a traceback occurs when the user tries to preview an external link.

Steps to produce:

1) Create an email template and add any text in content.
2) Convert text to a URL with a random URL like 'test'
3) error will occur in log

Error:- 
```
TypeError: 'bool' object is not subscriptable
  File "odoo/http.py", line 2366, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1894, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1957, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 137, in retrying
    result = func()
  File "odoo/http.py", line 1924, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2171, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 329, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 727, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/html_editor/controllers/main.py", line 564, in link_preview_metadata
    if link_preview_data['og_description']:
```

This error occurs in the following lines when the link_preview_data value is False, leading to the traceback:

https://github.com/odoo/odoo/blob/36e4b6f93bf2123557947e910e1be651c5357319/addons/html_editor/controllers/main.py#L563-L564

The get_link_preview_from_url method may return False from multiple places.

https://github.com/odoo/odoo/blob/36e4b6f93bf2123557947e910e1be651c5357319/addons/mail/tools/link_preview.py#L30-L35

Therefore, an additional check is needed to verify the value of `link_preview_data` before accessing its value.

Adding this extra check will make the code more robust and prevent the 
unnecessary tracebacks from occurring.

sentry-6199384889
