### PR TITLE
[FIX] l10n_cz taxable_supply_date logic

### DIFF
--- a/addons/l10n_cz/models/account_move.py
+++ b/addons/l10n_cz/models/account_move.py
@@ -7,9 +7,15 @@ class AccountMove(models.Model):
 
     taxable_supply_date = fields.Date(default=fields.Date.today())
 
-    @api.depends('taxable_supply_date')
+    @api.depends('taxable_supply_date', 'date')
     def _compute_date(self):
         super()._compute_date()
         for move in self:
-            if move.country_code == 'CZ' and move.taxable_supply_date and move.state == 'draft':
-                move.date = move.taxable_supply_date
+            if move.country_code == 'CZ':
+                # In case of sale document, we want to align the date with the taxable supply date (user can change it)
+                if move.is_sale_document(include_receipts=True) and move.taxable_supply_date and move.state == 'draft':
+                    move.date = move.taxable_supply_date
+                # For other documents, we want to align the taxable supply date with the document date
+                # since user can't set up the taxable supply date manually (most forms don't have this field)
+                elif move.date and move.state == 'draft':
+                    move.taxable_supply_date = move.date


### PR DESCRIPTION
Current behavior before PR:
Actual change in Odoo 18.0 breaks logic for documents without taxable supply date on form.
This cause issues with issuing documents to the past for example bank or cash. If you are trying issue document to past it's overwritten to actual date.


Desired behavior after PR is merged:
I can create bank or cash transaction in the past.

Description of the issue/feature this PR addresses:
According to the Czech VAT Act (Act No. 235/2004 Coll., on VAT), the difference between the date of issuance of an invoice (date) and the date of taxable supply (taxable_supply_date) is regulated as follows:

Taxable Supply Date (taxable_supply_date):

This is the day on which the taxable supply (delivery of goods or provision of services) actually took place, unless specified otherwise.
Date of Issuance of the Invoice (date):

The invoice must be issued no later than 15 calendar days from the taxable_supply_date.
This means that the gap between the taxable_supply_date and the date cannot exceed 15 calendar days.
Example:
Taxable_supply_date: January 1, 2025
Date: Must be no later than January 16, 2025


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
