### PR TITLE
[FIX] html_editor: icon search with uppercase input

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/icon_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/icon_selector.js
@@ -40,7 +40,7 @@ export class IconSelector extends Component {
         } else {
             this.state.fonts = this.props.fonts.map((font) => {
                 const icons = font.icons.filter(
-                    (icon) => icon.alias.indexOf(this.state.needle) >= 0
+                    (icon) => icon.alias.indexOf(this.state.needle.toLowerCase()) >= 0
                 );
                 return { ...font, icons };
             });


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

Searching for icon names in uppercase was not working.

Desired behavior after PR is merged:

Icon search now works correctly when names are entered in uppercase.

task-4452824

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
