### PR TITLE
[FIX] account: prevent error when downloading pdf of an invoice

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -17015,6 +17015,12 @@ msgstr ""
 
 #. module: account
 #. odoo-python
+#: code:addons/account/models/account_move.py:0
+msgid "You can't Download invoices that are not posted."
+msgstr ""
+
+#. module: account
+#. odoo-python
 #: code:addons/account/models/account_move_send.py:0
 msgid "You can't Print & Send invoices that are not posted."
 msgstr ""

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5134,6 +5134,8 @@ class AccountMove(models.Model):
         return report_action
 
     def action_invoice_download_pdf(self):
+        if any(move.state != 'posted' for move in self):
+            raise UserError(_("You can't Download invoices that are not posted."))
         return {
             'type': 'ir.actions.act_url',
             'url': f'/account/download_invoice_documents/{",".join(map(str, self.ids))}/pdf',


### PR DESCRIPTION
When the user downloads the pdf of a draft invoice,
a traceback will appear.

Steps to reproduce the error:
- Create a new invoice > Don't confirm it
- Go to list view of invoices
- Select that invoice > Download > PDF

Traceback:
```
File "addons/account/controllers/download_docs.py", line 52, in download_invoice_documents_filetype
    doc_data = invoice._get_invoice_legal_documents(filetype, allow_fallback=allow_fallback)
  File "addons/account_edi_ubl_cii/models/account_move.py", line 45, in _get_invoice_legal_documents
    return super()._get_invoice_legal_documents(filetype, allow_fallback=allow_fallback)
  File "addons/account/models/account_move.py", line 5712, in _get_invoice_legal_documents
    return self._get_invoice_pdf_proforma()
  File "addons/account/models/account_move.py", line 5686, in _get_invoice_pdf_proforma
    filename = self._get_invoice_proforma_pdf_report_filename()
  File "addons/account/models/account_move.py", line 5744, in _get_invoice_proforma_pdf_report_filename
    return f"{self.name.replace('/', '_')}_proforma.pdf"
AttributeError: 'bool' object has no attribute 'replace'
```

https://github.com/odoo/odoo/blob/36e4b6f93bf2123557947e910e1be651c5357319/addons/account/models/account_move.py#L5744
When the customer downloads the pdf a draft invoice, ``self.name`` will be False,
So it will lead to the above traceback.

sentry-6191644587

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
