### PR TITLE
[ADD] l10n_in_hr_holidays: added sandwich days into payslip

### DIFF
--- a/addons/l10n_in_hr_holidays/models/__init__.py
+++ b/addons/l10n_in_hr_holidays/models/__init__.py
@@ -3,4 +3,5 @@
 from . import hr_leave
 from . import hr_work_entry_type
 from . import hr_employee
+from . import hr_version
 from . import l10n_in_hr_leave_optional_holiday

--- a/addons/l10n_in_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_in_hr_holidays/models/hr_leave.py
@@ -94,7 +94,15 @@ class HrLeave(models.Model):
             current += timedelta(days=step)
         return count
 
-    def _l10n_in_find_linked_leave(self, start_date, public_holiday_dates, resource_calendar, leaves_by_date, reverse=False):
+    def _l10n_in_find_linked_leave(
+        self,
+        start_date,
+        public_holiday_dates,
+        resource_calendar,
+        leaves_by_date,
+        reverse=False,
+        check_extendability=False,
+    ):
         step = -1 if reverse else 1
         current_date = start_date
         for _ in range(30):
@@ -104,7 +112,40 @@ class HrLeave(models.Model):
         linked_leave = leaves_by_date.get(current_date, self.env["hr.leave"])
         if linked_leave and not linked_leave._l10n_in_is_full_day_request():
             return self.env["hr.leave"]
-        return linked_leave
+        if not linked_leave:
+            return linked_leave
+        if not check_extendability:
+            return linked_leave
+
+        # If linked leave itself is not sandwich, we can keep it as a valid link.
+        if not linked_leave.l10n_in_contains_sandwich_leaves:
+            return linked_leave
+
+        # For sandwich leaves, check linkability on the same side:
+        linked_side_date = linked_leave.request_date_from if reverse else linked_leave.request_date_to
+        side_linked_leave = linked_leave._l10n_in_find_linked_leave(
+            linked_side_date,
+            public_holiday_dates,
+            linked_leave.resource_calendar_id,
+            leaves_by_date,
+            reverse=reverse,
+            check_extendability=False,
+        )
+        if side_linked_leave:
+            return linked_leave
+
+        # No linked leave on that side: keep it only if it still has adjacent
+        # non-working days in that direction, otherwise drop it.
+        if any(
+            not linked_leave._l10n_in_is_working(
+                linked_leave.request_date_from + timedelta(days=x),
+                public_holiday_dates,
+                linked_leave.resource_calendar_id
+            )
+            for x in range((linked_leave.request_date_to - linked_leave.request_date_from).days + 1)
+        ):
+            return linked_leave
+        return self.env["hr.leave"]
 
     def _l10n_in_get_linked_leaves(self, leaves_dates_by_employee, public_holidays_date_by_company):
         linked_before = self.env["hr.leave"]

--- a/addons/l10n_in_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_in_hr_holidays/models/hr_leave.py
@@ -154,10 +154,10 @@ class HrLeave(models.Model):
         for leave in self:
             public_holiday_dates = public_holidays_date_by_company.get(leave.company_id, {})
             leaves_by_date = leaves_dates_by_employee.get(leave.employee_id, {})
-            linked_before |= self._l10n_in_find_linked_leave(
+            linked_before |= leave._l10n_in_find_linked_leave(
                 leave.request_date_from, public_holiday_dates, leave.resource_calendar_id, leaves_by_date, reverse=True
             )
-            linked_after |= self._l10n_in_find_linked_leave(
+            linked_after |= leave._l10n_in_find_linked_leave(
                 leave.request_date_to, public_holiday_dates, leave.resource_calendar_id, leaves_by_date, reverse=False
             )
         return linked_before, linked_after
@@ -242,49 +242,74 @@ class HrLeave(models.Model):
             current_date += timedelta(days=1)
         return total_leaves
 
-    def _l10n_in_apply_sandwich_rule(self, public_holidays_date_by_company, leaves_dates_by_employee):
-        self.ensure_one()
-        if not (self.request_date_from and self.request_date_to):
-            return 0
+    def _l10n_in_compute_sandwich_spans(self, leaves_dates_by_employee, public_holidays_date_by_company):
+        """
+            Compute the effective sandwich span for the given leaves.
+            Returns a dict keyed by leave id with:
+                - start/end dates of the effective span
+                - days count within the span
+                - whether the span contains non-working days
+                - linkage flags and included public holiday dates
+        """
+        span_data = {}
+        for leave in self:
+            resource_calendar = leave.resource_calendar_id
+            public_holiday_dates = public_holidays_date_by_company.get(leave.company_id, {})
+            leaves_by_date = leaves_dates_by_employee.get(leave.employee_id, {})
+            date_from = leave.request_date_from
+            date_to = leave.request_date_to
 
-        date_from = self.request_date_from
-        date_to = self.request_date_to
-        public_holiday_dates = public_holidays_date_by_company.get(self.company_id, {})
-        is_non_working_from = not self._l10n_in_is_working(date_from, public_holiday_dates, self.resource_calendar_id)
-        is_non_working_to = not self._l10n_in_is_working(date_to, public_holiday_dates, self.resource_calendar_id)
+            is_non_working_from = not leave._l10n_in_is_working(date_from, public_holiday_dates, resource_calendar)
+            is_non_working_to = not leave._l10n_in_is_working(date_to, public_holiday_dates, resource_calendar)
 
-        if is_non_working_from and is_non_working_to and not any(
-            self._l10n_in_is_working(date_from + timedelta(days=x), public_holiday_dates, self.resource_calendar_id)
-            for x in range(1, (date_to - date_from).days)
-        ):
-            return 0
+            if is_non_working_from and is_non_working_to and not any(
+                leave._l10n_in_is_working(date_from + timedelta(days=x), public_holiday_dates, resource_calendar)
+                for x in range(1, (date_to - date_from).days)
+            ):
+                continue
 
-        total_leaves = self._l10n_in_count_days_by_sandwich_policy(date_from, date_to, public_holiday_dates)
-        linked_before, linked_after = self._l10n_in_get_linked_leaves(leaves_dates_by_employee, public_holidays_date_by_company)
-        linked_before_leave = linked_before[:1]
-        linked_after_leave = linked_after[:1]
-        # Only expand the current leave when the linked record starts before it.
-        has_previous_link = bool(linked_before_leave and linked_before_leave.request_date_from < date_from)
-        has_next_link = bool(linked_after_leave and linked_after_leave.request_date_from > date_to)
-
-        if has_previous_link:
-            total_leaves += self._l10n_in_count_adjacent_non_working(
-                date_from, public_holiday_dates, self.resource_calendar_id, reverse=True
+            linked_before_leave = leave._l10n_in_find_linked_leave(
+                date_from, public_holiday_dates, resource_calendar, leaves_by_date, reverse=True, check_extendability=True,
             )
-        elif is_non_working_from:
-            total_leaves -= self._l10n_in_count_adjacent_non_working(
-                date_from, public_holiday_dates, self.resource_calendar_id, include_start=True,
+            linked_after_leave = leave._l10n_in_find_linked_leave(
+                date_to, public_holiday_dates, resource_calendar, leaves_by_date, reverse=False, check_extendability=True,
             )
+            span_start = date_from
+            if linked_before_leave:
+                span_start -= timedelta(days=leave._l10n_in_count_adjacent_non_working(
+                    date_from, public_holiday_dates, resource_calendar, reverse=True,
+                ))
+            elif is_non_working_from:
+                span_start += timedelta(days=leave._l10n_in_count_adjacent_non_working(
+                    date_from, public_holiday_dates, resource_calendar, include_start=True,
+                ))
 
-        if has_next_link:
-            total_leaves += self._l10n_in_count_adjacent_non_working(
-                date_to, public_holiday_dates, self.resource_calendar_id
-            )
-        elif is_non_working_to:
-            total_leaves = total_leaves - self._l10n_in_count_adjacent_non_working(
-                date_to, public_holiday_dates, self.resource_calendar_id, reverse=True, include_start=True,
-            )
-        return total_leaves
+            span_end = date_to
+            if linked_after_leave:
+                span_end += timedelta(days=leave._l10n_in_count_adjacent_non_working(
+                    date_to, public_holiday_dates, resource_calendar,
+                ))
+            elif is_non_working_to:
+                span_end -= timedelta(days=leave._l10n_in_count_adjacent_non_working(
+                    date_to, public_holiday_dates, resource_calendar, reverse=True, include_start=True,
+                ))
+
+            if span_end < span_start:
+                continue
+
+            span_days = leave._l10n_in_count_days_by_sandwich_policy(span_start, span_end, public_holiday_dates)
+            non_working_dates = {
+                span_start + timedelta(days=offset)
+                for offset in range((span_end - span_start).days + 1)
+                if not leave._l10n_in_is_working(span_start + timedelta(days=offset), public_holiday_dates, resource_calendar)
+            }
+            span_data[leave.id] = {
+                'start': span_start,
+                'end': span_end,
+                'days': span_days,
+                'has_non_working': bool(non_working_dates),
+            }
+        return span_data
 
     def _get_durations(self, check_work_entry_type=True, resource_calendar=None, additional_domain=None):
         result = super()._get_durations(check_work_entry_type=check_work_entry_type, resource_calendar=resource_calendar, additional_domain=additional_domain)
@@ -293,6 +318,7 @@ class HrLeave(models.Model):
         if not indian_leaves:
             return result
 
+        span_data = indian_leaves._l10n_in_compute_sandwich_spans(leaves_dates_by_employee, public_holidays_date_by_company)
         for leave in indian_leaves:
             leave_days, hours = result[leave.id]
             if not leave_days or (
@@ -300,17 +326,19 @@ class HrLeave(models.Model):
                 and not self.env.user.has_group("hr_holidays.group_hr_holidays_user")
             ):
                 continue
+            span_info = span_data.get(leave.id)
+            if not span_info:
+                leave.l10n_in_contains_sandwich_leaves = False
+                continue
             default_hours = leave._l10n_in_get_default_leave_hours()
             if not leave._l10n_in_is_full_day_request(hours=hours, default_hours=default_hours):
                 leave.l10n_in_contains_sandwich_leaves = False
                 continue
-            updated_days = leave._l10n_in_apply_sandwich_rule(public_holidays_date_by_company, leaves_dates_by_employee)
+            updated_days = span_info['days']
             if updated_days and updated_days != leave_days:
                 updated_hours = (updated_days * (hours / leave_days)) if leave_days else hours
                 result[leave.id] = (updated_days, updated_hours)
-                leave.l10n_in_contains_sandwich_leaves = True
-            else:
-                leave.l10n_in_contains_sandwich_leaves = False
+            leave.l10n_in_contains_sandwich_leaves = span_info['has_non_working']
         return result
 
     def _l10n_in_update_neighbors_duration_after_change(self):
@@ -334,6 +362,7 @@ class HrLeave(models.Model):
             check_work_entry_type=True,
             resource_calendar=None,
         )
+        span_data = neighbors._l10n_in_compute_sandwich_spans(leaves_dates_by_employee, public_holidays_dates_by_company)
 
         for neighbor in neighbors:
             base_days, base_hours = base_map.get(neighbor.id, (neighbor.number_of_days, neighbor.number_of_hours))
@@ -345,23 +374,15 @@ class HrLeave(models.Model):
                     'l10n_in_contains_sandwich_leaves': False,
                 })
                 continue
-            updated_days = neighbor._l10n_in_apply_sandwich_rule(
-                public_holidays_date_by_company=public_holidays_dates_by_company,
-                leaves_dates_by_employee=leaves_dates_by_employee,
-            )
-            if updated_days and updated_days != base_days:
-                new_hours = (updated_days * (base_hours / base_days)) if base_days else base_hours
-                neighbor.write({
-                    'number_of_days': updated_days,
-                    'number_of_hours': new_hours,
-                    'l10n_in_contains_sandwich_leaves': True,
-                })
-            else:
-                neighbor.write({
-                    'number_of_days': base_days,
-                    'number_of_hours': base_hours,
-                    'l10n_in_contains_sandwich_leaves': False,
-                })
+            span_info = span_data.get(neighbor.id)
+            updated_days = span_info['days'] if span_info else base_days
+            updated_hours = (updated_days * (base_hours / base_days)) if base_days and updated_days else base_hours
+            has_non_working = span_info['has_non_working'] if span_info else False
+            neighbor.write({
+                'number_of_days': updated_days,
+                'number_of_hours': updated_hours,
+                'l10n_in_contains_sandwich_leaves': has_non_working,
+            })
 
     @api.ondelete(at_uninstall=False)
     def _ondelete_refresh_neighbors(self):

--- a/addons/l10n_in_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_in_hr_holidays/models/hr_leave.py
@@ -152,12 +152,16 @@ class HrLeave(models.Model):
         linked_after = self.env["hr.leave"]
 
         for leave in self:
-            public_holiday_dates = leave._l10n_in_get_public_holiday_dates(public_holidays_date_by_company)
+            public_holiday_dates = (
+                {}
+                if leave.work_entry_type_id.include_public_holidays_in_duration
+                else public_holidays_date_by_company.get(leave.company_id, {})
+            )
             leaves_by_date = leaves_dates_by_employee.get(leave.employee_id, {})
-            linked_before |= self._l10n_in_find_linked_leave(
+            linked_before |= leave._l10n_in_find_linked_leave(
                 leave.request_date_from, public_holiday_dates, leave.resource_calendar_id, leaves_by_date, reverse=True
             )
-            linked_after |= self._l10n_in_find_linked_leave(
+            linked_after |= leave._l10n_in_find_linked_leave(
                 leave.request_date_to, public_holiday_dates, leave.resource_calendar_id, leaves_by_date, reverse=False
             )
         return linked_before, linked_after
@@ -220,71 +224,89 @@ class HrLeave(models.Model):
 
         return indian_leaves, leaves_dates_by_employee, public_holidays_dates_by_company
 
-    def _l10n_in_count_days_by_sandwich_policy(self, date_from, date_to, public_holiday_dates):
-        self.ensure_one()
-        policy = self.work_entry_type_id.l10n_in_sandwich_policy or "full"
-        calendar = self.resource_calendar_id
+    def _l10n_in_compute_sandwich_spans(self, leaves_dates_by_employee, public_holidays_date_by_company):
+        """
+            Compute the effective sandwich span for the given leaves.
+            Returns a dict keyed by leave id with:
+                - start/end dates of the effective span
+                - days count within the span
+                - whether the span contains non-working days
+                - linkage flags and included public holiday dates
+        """
+        span_data = {}
+        for leave in self:
+            resource_calendar = leave.resource_calendar_id
+            public_holiday_dates = (
+                {}
+                if leave.work_entry_type_id.include_public_holidays_in_duration
+                else public_holidays_date_by_company.get(leave.company_id, {})
+            )
+            leaves_by_date = leaves_dates_by_employee.get(leave.employee_id, {})
+            date_from = leave.request_date_from
+            date_to = leave.request_date_to
 
-        total_leaves = 0
-        current_date = date_from
+            is_non_working_from = not leave._l10n_in_is_working(date_from, public_holiday_dates, resource_calendar)
+            is_non_working_to = not leave._l10n_in_is_working(date_to, public_holiday_dates, resource_calendar)
 
-        while current_date <= date_to:
-            is_weekend = not calendar._works_on_date(current_date)
-            is_public_holiday = current_date in public_holiday_dates
-            if (
-                policy == "full"
-                or (not is_weekend and not is_public_holiday)
-                or (policy == "weekend" and is_weekend)
-                or (policy == "public_holiday" and is_public_holiday)
+            if is_non_working_from and is_non_working_to and not any(
+                leave._l10n_in_is_working(date_from + timedelta(days=x), public_holiday_dates, resource_calendar)
+                for x in range(1, (date_to - date_from).days)
             ):
-                total_leaves += 1
+                continue
 
-            current_date += timedelta(days=1)
-        return total_leaves
-
-    def _l10n_in_apply_sandwich_rule(self, public_holidays_date_by_company, leaves_dates_by_employee):
-        self.ensure_one()
-        if not (self.request_date_from and self.request_date_to):
-            return 0
-
-        date_from = self.request_date_from
-        date_to = self.request_date_to
-        public_holiday_dates = self._l10n_in_get_public_holiday_dates(public_holidays_date_by_company)
-        is_non_working_from = not self._l10n_in_is_working(date_from, public_holiday_dates, self.resource_calendar_id)
-        is_non_working_to = not self._l10n_in_is_working(date_to, public_holiday_dates, self.resource_calendar_id)
-
-        if is_non_working_from and is_non_working_to and not any(
-            self._l10n_in_is_working(date_from + timedelta(days=x), public_holiday_dates, self.resource_calendar_id)
-            for x in range(1, (date_to - date_from).days)
-        ):
-            return 0
-
-        total_leaves = self._l10n_in_count_days_by_sandwich_policy(date_from, date_to, public_holiday_dates)
-        linked_before, linked_after = self._l10n_in_get_linked_leaves(leaves_dates_by_employee, public_holidays_date_by_company)
-        linked_before_leave = linked_before[:1]
-        linked_after_leave = linked_after[:1]
-        # Only expand the current leave when the linked record starts before it.
-        has_previous_link = bool(linked_before_leave and linked_before_leave.request_date_from < date_from)
-        has_next_link = bool(linked_after_leave and linked_after_leave.request_date_from > date_to)
-
-        if has_previous_link:
-            total_leaves += self._l10n_in_count_adjacent_non_working(
-                date_from, public_holiday_dates, self.resource_calendar_id, reverse=True
+            linked_before_leave = leave._l10n_in_find_linked_leave(
+                date_from, public_holiday_dates, resource_calendar, leaves_by_date, reverse=True, check_extendability=True,
             )
-        elif is_non_working_from:
-            total_leaves -= self._l10n_in_count_adjacent_non_working(
-                date_from, public_holiday_dates, self.resource_calendar_id, include_start=True,
+            linked_after_leave = leave._l10n_in_find_linked_leave(
+                date_to, public_holiday_dates, resource_calendar, leaves_by_date, reverse=False, check_extendability=True,
             )
+            span_start = date_from
+            if linked_before_leave:
+                span_start -= timedelta(days=leave._l10n_in_count_adjacent_non_working(
+                    date_from, public_holiday_dates, resource_calendar, reverse=True,
+                ))
+            elif is_non_working_from:
+                span_start += timedelta(days=leave._l10n_in_count_adjacent_non_working(
+                    date_from, public_holiday_dates, resource_calendar, include_start=True,
+                ))
 
-        if has_next_link:
-            total_leaves += self._l10n_in_count_adjacent_non_working(
-                date_to, public_holiday_dates, self.resource_calendar_id
-            )
-        elif is_non_working_to:
-            total_leaves = total_leaves - self._l10n_in_count_adjacent_non_working(
-                date_to, public_holiday_dates, self.resource_calendar_id, reverse=True, include_start=True,
-            )
-        return total_leaves
+            span_end = date_to
+            if linked_after_leave:
+                span_end += timedelta(days=leave._l10n_in_count_adjacent_non_working(
+                    date_to, public_holiday_dates, resource_calendar,
+                ))
+            elif is_non_working_to:
+                span_end -= timedelta(days=leave._l10n_in_count_adjacent_non_working(
+                    date_to, public_holiday_dates, resource_calendar, reverse=True, include_start=True,
+                ))
+
+            if span_end < span_start:
+                continue
+
+            policy = leave.work_entry_type_id.l10n_in_sandwich_policy or "full"
+            span_days = 0
+            has_non_working = False
+            current_date = span_start
+            while current_date <= span_end:
+                is_weekend = not resource_calendar._works_on_date(current_date)
+                is_public_holiday = current_date in public_holiday_dates
+                if (
+                    policy == "full"
+                    or (not is_weekend and not is_public_holiday)
+                    or (policy == "weekend" and is_weekend)
+                    or (policy == "public_holiday" and is_public_holiday)
+                ):
+                    span_days += 1
+                if not leave._l10n_in_is_working(current_date, public_holiday_dates, resource_calendar):
+                    has_non_working = True
+                current_date += timedelta(days=1)
+            span_data[leave.id] = {
+                'start': span_start,
+                'end': span_end,
+                'days': span_days,
+                'has_non_working': has_non_working,
+            }
+        return span_data
 
     def _get_durations(self, check_work_entry_type=True, resource_calendar=None, additional_domain=None):
         result = super()._get_durations(check_work_entry_type=check_work_entry_type, resource_calendar=resource_calendar, additional_domain=additional_domain)
@@ -293,6 +315,7 @@ class HrLeave(models.Model):
         if not indian_leaves:
             return result
 
+        span_data = indian_leaves._l10n_in_compute_sandwich_spans(leaves_dates_by_employee, public_holidays_date_by_company)
         for leave in indian_leaves:
             leave_days, hours = result[leave.id]
             if not leave_days or (
@@ -300,23 +323,20 @@ class HrLeave(models.Model):
                 and not self.env.user.has_group("hr_holidays.group_hr_holidays_user")
             ):
                 continue
+            span_info = span_data.get(leave.id)
+            if not span_info:
+                leave.l10n_in_contains_sandwich_leaves = False
+                continue
             default_hours = leave._l10n_in_get_default_leave_hours()
             if not leave._l10n_in_is_full_day_request(hours=hours, default_hours=default_hours):
                 leave.l10n_in_contains_sandwich_leaves = False
                 continue
-            updated_days = leave._l10n_in_apply_sandwich_rule(public_holidays_date_by_company, leaves_dates_by_employee)
+            updated_days = span_info['days']
             if updated_days and updated_days != leave_days:
                 updated_hours = (updated_days * (hours / leave_days)) if leave_days else hours
                 result[leave.id] = (updated_days, updated_hours)
-                leave.l10n_in_contains_sandwich_leaves = True
-            else:
-                leave.l10n_in_contains_sandwich_leaves = False
+            leave.l10n_in_contains_sandwich_leaves = span_info['has_non_working']
         return result
-
-    def _l10n_in_get_public_holiday_dates(self, public_holidays_date_by_company):
-        if self.work_entry_type_id.include_public_holidays_in_duration:
-            return {}
-        return public_holidays_date_by_company.get(self.company_id, {})
 
     def _l10n_in_update_neighbors_duration_after_change(self):
         indian_leaves, leaves_dates_by_employee, public_holidays_dates_by_company = self._l10n_in_prepare_sandwich_context()
@@ -339,6 +359,7 @@ class HrLeave(models.Model):
             check_work_entry_type=True,
             resource_calendar=None,
         )
+        span_data = neighbors._l10n_in_compute_sandwich_spans(leaves_dates_by_employee, public_holidays_dates_by_company)
 
         for neighbor in neighbors:
             base_days, base_hours = base_map.get(neighbor.id, (neighbor.number_of_days, neighbor.number_of_hours))
@@ -350,23 +371,15 @@ class HrLeave(models.Model):
                     'l10n_in_contains_sandwich_leaves': False,
                 })
                 continue
-            updated_days = neighbor._l10n_in_apply_sandwich_rule(
-                public_holidays_date_by_company=public_holidays_dates_by_company,
-                leaves_dates_by_employee=leaves_dates_by_employee,
-            )
-            if updated_days and updated_days != base_days:
-                new_hours = (updated_days * (base_hours / base_days)) if base_days else base_hours
-                neighbor.write({
-                    'number_of_days': updated_days,
-                    'number_of_hours': new_hours,
-                    'l10n_in_contains_sandwich_leaves': True,
-                })
-            else:
-                neighbor.write({
-                    'number_of_days': base_days,
-                    'number_of_hours': base_hours,
-                    'l10n_in_contains_sandwich_leaves': False,
-                })
+            span_info = span_data.get(neighbor.id)
+            updated_days = span_info['days'] if span_info else base_days
+            updated_hours = (updated_days * (base_hours / base_days)) if base_days and updated_days else base_hours
+            has_non_working = span_info['has_non_working'] if span_info else False
+            neighbor.write({
+                'number_of_days': updated_days,
+                'number_of_hours': updated_hours,
+                'l10n_in_contains_sandwich_leaves': has_non_working,
+            })
 
     @api.ondelete(at_uninstall=False)
     def _ondelete_refresh_neighbors(self):

--- a/addons/l10n_in_hr_holidays/models/hr_version.py
+++ b/addons/l10n_in_hr_holidays/models/hr_version.py
@@ -1,0 +1,194 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from collections import defaultdict
+from datetime import UTC, timedelta
+
+from odoo import models
+
+
+class HrVersion(models.Model):
+    _inherit = 'hr.version'
+
+    @staticmethod
+    def _l10n_in_to_utc(dt):
+        return dt.replace(tzinfo=UTC) if not dt.tzinfo else dt.astimezone(UTC)
+
+    @classmethod
+    def _l10n_in_get_entry_date(cls, work_entry_vals):
+        if work_entry_vals.get('date'):
+            return work_entry_vals['date']
+        if work_entry_vals.get('date_start'):
+            return cls._l10n_in_to_utc(work_entry_vals['date_start']).date()
+        return False
+
+    @staticmethod
+    def _l10n_in_is_date_included_by_sandwich_policy(leave, check_date, public_holiday_dates):
+        policy = leave.work_entry_type_id.l10n_in_sandwich_policy or 'full'
+        is_weekend = not leave.resource_calendar_id._works_on_date(check_date)
+        is_public_holiday = check_date in public_holiday_dates
+
+        return (
+            policy == "full"
+            or (not is_weekend and not is_public_holiday)
+            or (policy == "weekend" and is_weekend)
+            or (policy == "public_holiday" and is_public_holiday)
+        )
+
+    @staticmethod
+    def _l10n_in_is_non_working_sandwich_date(check_date, attendance_dates, public_holiday_dates):
+        return check_date in public_holiday_dates or check_date not in attendance_dates
+
+    def _l10n_in_get_sandwich_leaves_by_employee(self, start_dt, end_dt):
+        grouped_leaves = self.env['hr.leave']._read_group(
+            domain=[
+                ('employee_id', 'in', self.employee_id.ids),
+                ('state', '=', 'validate'),
+                ('date_from', '<=', end_dt.replace(tzinfo=None)),
+                ('date_to', '>=', start_dt.replace(tzinfo=None)),
+                ('work_entry_type_id.l10n_in_is_sandwich_leave', '=', True),
+            ],
+            groupby=['employee_id'],
+            aggregates=['id:recordset'],
+        )
+
+        leaves_per_employee_dict = dict(grouped_leaves)
+        leaves_dates_by_employee = {}
+
+        for employee, leaves in grouped_leaves:
+            full_day_leaves = leaves.filtered(lambda leave: leave._l10n_in_is_full_day_request())
+            if not full_day_leaves:
+                continue
+            leaves_dates_by_employee[employee] = {
+                (leave.request_date_from + timedelta(days=offset)): leave
+                for leave in leaves
+                for offset in range((leave.request_date_to - leave.request_date_from).days + 1)
+            }
+
+        return leaves_dates_by_employee, leaves_per_employee_dict
+
+    def _l10n_in_prepare_sandwich_span_data(self, leaves_per_employee_dict, leaves_dates_by_employee):
+        sandwich_leaves = sum(leaves_per_employee_dict.values(), self.env['hr.leave'])
+        indian_leaves, _, public_holiday_dates_by_company = sandwich_leaves._l10n_in_prepare_sandwich_context()
+        span_data = indian_leaves._l10n_in_compute_sandwich_spans(
+            leaves_dates_by_employee,
+            public_holiday_dates_by_company,
+        )
+        return span_data, public_holiday_dates_by_company
+
+    def _l10n_in_get_attendance_dates_by_employee(self, start_dt, end_dt):
+        attendance_intervals_by_calendar = {
+            calendar: calendar._attendance_intervals_batch(
+                start_dt,
+                end_dt,
+                resources_per_tz=versions._get_resources_per_tz(),
+            )
+            for calendar, versions in self.grouped('resource_calendar_id').items()
+        }
+
+        attendance_dates_by_employee = {}
+        for version in self:
+            employee = version.employee_id
+            calendar = version.resource_calendar_id
+            resource = employee.resource_id
+
+            attendance_intervals = attendance_intervals_by_calendar.get(calendar, {}).get(resource.id, [])
+            attendance_dates_by_employee[employee.id] = {
+                interval[0].date()
+                for interval in attendance_intervals
+            }
+
+        return attendance_dates_by_employee
+
+    def _l10n_in_prepare_existing_work_entries(self, result):
+        updatable_entries_by_employee_date = defaultdict(lambda: defaultdict(list))
+        occupied_dates_by_employee = defaultdict(set)
+
+        for work_entry_vals in result:
+            employee = work_entry_vals.get('employee_id')
+            employee_id = employee.id if employee else False
+            entry_date = self._l10n_in_get_entry_date(work_entry_vals)
+
+            if not employee_id or not entry_date:
+                continue
+
+            occupied_dates_by_employee[employee_id].add(entry_date)
+
+            if not work_entry_vals.get('leave_ids'):
+                updatable_entries_by_employee_date[employee_id][entry_date].append(work_entry_vals)
+
+        return updatable_entries_by_employee_date, occupied_dates_by_employee
+
+    def _get_version_work_entries_values(self, date_start, date_stop):
+        result = super()._get_version_work_entries_values(date_start, date_stop)
+        in_versions = self.filtered(lambda version: version.company_id.country_id.code == 'IN')
+        if not in_versions:
+            return result
+
+        start_dt = self._l10n_in_to_utc(date_start)
+        end_dt = self._l10n_in_to_utc(date_stop)
+
+        leaves_dates_by_employee, leaves_per_employee_dict = in_versions._l10n_in_get_sandwich_leaves_by_employee(start_dt, end_dt)
+        if not leaves_dates_by_employee:
+            return result
+
+        span_data, public_holiday_dates_by_company = self._l10n_in_prepare_sandwich_span_data(leaves_per_employee_dict, leaves_dates_by_employee)
+        if not span_data:
+            return result
+
+        attendance_dates_by_employee = in_versions._l10n_in_get_attendance_dates_by_employee(start_dt, end_dt)
+        updatable_entries_by_employee_date, occupied_dates_by_employee = self._l10n_in_prepare_existing_work_entries(result)
+
+        for version in in_versions:
+            employee = version.employee_id
+            employee_id = employee.id
+            attendance_dates = attendance_dates_by_employee.get(employee_id, set())
+            occupied_dates = occupied_dates_by_employee[employee_id]
+            updatable_entries_by_date = updatable_entries_by_employee_date[employee_id]
+
+            for leave in leaves_per_employee_dict.get(employee, self.env['hr.leave']):
+                span_info = span_data.get(leave.id)
+                if not span_info or not span_info.get('has_non_working'):
+                    continue
+
+                leave_start_date = max(span_info['start'], start_dt.date())
+                leave_end_date = min(span_info['end'], end_dt.date())
+                if leave_end_date < leave_start_date:
+                    continue
+
+                leave_work_entry_type = leave.work_entry_type_id
+                public_holiday_per_company = public_holiday_dates_by_company.get(leave.company_id, set())
+                for offset in range((leave_end_date - leave_start_date).days + 1):
+                    span_date = leave_start_date + timedelta(days=offset)
+
+                    if not self._l10n_in_is_date_included_by_sandwich_policy(leave, span_date, public_holiday_per_company):
+                        continue
+
+                    is_non_working_sandwich = self._l10n_in_is_non_working_sandwich_date(
+                        span_date,
+                        attendance_dates,
+                        public_holiday_per_company,
+                    )
+                    if updatable_entries := updatable_entries_by_date.pop(span_date, []):
+                        for work_entry_vals in updatable_entries:
+                            work_entry_vals.update({
+                                'work_entry_type_id': leave_work_entry_type,
+                                'leave_ids': leave,
+                                'l10n_in_is_sandwich_non_working': is_non_working_sandwich,
+                            })
+                        continue
+
+                    if span_date in attendance_dates or span_date in occupied_dates:
+                        continue
+
+                    result.append({
+                        'date': span_date,
+                        'duration': version.resource_calendar_id.hours_per_day,
+                        'work_entry_type_id': leave_work_entry_type,
+                        'employee_id': employee,
+                        'company_id': version.company_id,
+                        'version_id': version,
+                        'leave_ids': leave,
+                        'l10n_in_is_sandwich_non_working': is_non_working_sandwich,
+                    })
+                    occupied_dates.add(span_date)
+        return result

--- a/addons/l10n_in_hr_holidays/models/hr_version.py
+++ b/addons/l10n_in_hr_holidays/models/hr_version.py
@@ -1,0 +1,152 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from collections import defaultdict
+from datetime import UTC, timedelta
+
+from odoo import models
+
+
+class HrVersion(models.Model):
+    _inherit = 'hr.version'
+
+    def _get_version_work_entries_values(self, date_start, date_stop):
+        result = super()._get_version_work_entries_values(date_start, date_stop)
+        in_versions = self.filtered(lambda version: version.company_id.country_id.code == 'IN')
+        if not in_versions:
+            return result
+
+        start_dt = date_start.replace(tzinfo=UTC) if not date_start.tzinfo else date_start.astimezone(UTC)
+        end_dt = date_stop.replace(tzinfo=UTC) if not date_stop.tzinfo else date_stop.astimezone(UTC)
+
+        grouped_leaves = self.env['hr.leave']._read_group(
+            domain=[
+                ('employee_id', 'in', in_versions.employee_id.ids),
+                ('state', '=', 'validate'),
+                ('date_from', '<=', end_dt.replace(tzinfo=None)),
+                ('date_to', '>=', start_dt.replace(tzinfo=None)),
+                ('work_entry_type_id.l10n_in_is_sandwich_leave', '=', True),
+            ],
+            groupby=['employee_id'],
+            aggregates=['id:recordset'],
+        )
+
+        leaves_per_employee_dict = dict(grouped_leaves)
+        leaves_dates_by_employee = {}
+        for employee, leaves in grouped_leaves:
+            full_day_leaves = leaves.filtered(lambda leave: leave._l10n_in_is_full_day_request())
+            if not full_day_leaves:
+                continue
+            leaves_dates_by_employee[employee] = {
+                (leave.request_date_from + timedelta(days=offset)): leave
+                for leave in full_day_leaves
+                for offset in range((leave.request_date_to - leave.request_date_from).days + 1)
+            }
+
+        if not leaves_dates_by_employee:
+            return result
+
+        sandwich_leaves = sum(leaves_per_employee_dict.values(), self.env['hr.leave'])
+        indian_leaves, _, public_holiday_dates_by_company = sandwich_leaves._l10n_in_prepare_sandwich_context()
+        span_data = indian_leaves._l10n_in_compute_sandwich_spans(
+            leaves_dates_by_employee,
+            public_holiday_dates_by_company,
+        )
+        if not span_data:
+            return result
+
+        attendance_intervals_by_calendar = {
+            calendar: calendar._attendance_intervals_batch(
+                start_dt,
+                end_dt,
+                resources_per_tz=versions._get_resources_per_tz(),
+            )
+            for calendar, versions in in_versions.grouped('resource_calendar_id').items()
+        }
+
+        attendance_dates_by_employee = {}
+        for version in in_versions:
+            employee = version.employee_id
+            resource = employee.resource_id
+            attendance_intervals = attendance_intervals_by_calendar.get(version.resource_calendar_id, {}).get(resource.id, [])
+            attendance_dates_by_employee[employee.id] = {
+                interval[0].date()
+                for interval in attendance_intervals
+            }
+
+        updatable_entries_by_employee_date = defaultdict(lambda: defaultdict(list))
+        occupied_dates_by_employee = defaultdict(set)
+        for work_entry_vals in result:
+            employee = work_entry_vals.get('employee_id')
+            employee_id = employee.id if employee else False
+            entry_date = work_entry_vals.get('date')
+            if not entry_date and work_entry_vals.get('date_start'):
+                date_start = work_entry_vals['date_start']
+                entry_date = (date_start.replace(tzinfo=UTC) if not date_start.tzinfo else date_start.astimezone(UTC)).date()
+
+            if not employee_id or not entry_date:
+                continue
+
+            occupied_dates_by_employee[employee_id].add(entry_date)
+
+            if not work_entry_vals.get('leave_ids'):
+                updatable_entries_by_employee_date[employee_id][entry_date].append(work_entry_vals)
+
+        for version in in_versions:
+            employee = version.employee_id
+            employee_id = employee.id
+            attendance_dates = attendance_dates_by_employee.get(employee_id, set())
+            occupied_dates = occupied_dates_by_employee[employee_id]
+            updatable_entries_by_date = updatable_entries_by_employee_date[employee_id]
+            employee_leaves = leaves_per_employee_dict.get(employee, self.env['hr.leave'])
+
+            for leave in employee_leaves:
+                span_info = span_data.get(leave.id)
+                if not span_info or not span_info.get('has_non_working'):
+                    continue
+
+                leave_start_date = max(span_info['start'], start_dt.date())
+                leave_end_date = min(span_info['end'], end_dt.date())
+                if leave_end_date < leave_start_date:
+                    continue
+
+                leave_work_entry_type = leave.work_entry_type_id
+                public_holiday_per_company = public_holiday_dates_by_company.get(leave.company_id, set())
+                for offset in range((leave_end_date - leave_start_date).days + 1):
+                    span_date = leave_start_date + timedelta(days=offset)
+
+                    policy = leave.work_entry_type_id.l10n_in_sandwich_policy or 'full'
+                    is_weekend = not leave.resource_calendar_id._works_on_date(span_date)
+                    is_public_holiday = span_date in public_holiday_per_company
+                    if not (
+                        policy == "full"
+                        or (not is_weekend and not is_public_holiday)
+                        or (policy == "weekend" and is_weekend)
+                        or (policy == "public_holiday" and is_public_holiday)
+                    ):
+                        continue
+
+                    is_non_working_sandwich = span_date in public_holiday_per_company or span_date not in attendance_dates
+                    if updatable_entries := updatable_entries_by_date.pop(span_date, []):
+                        for work_entry_vals in updatable_entries:
+                            work_entry_vals.update({
+                                'work_entry_type_id': leave_work_entry_type,
+                                'leave_ids': leave,
+                                'l10n_in_is_sandwich_non_working': is_non_working_sandwich,
+                            })
+                        continue
+
+                    if span_date in attendance_dates or span_date in occupied_dates:
+                        continue
+
+                    result.append({
+                        'date': span_date,
+                        'duration': version.resource_calendar_id.hours_per_day,
+                        'work_entry_type_id': leave_work_entry_type,
+                        'employee_id': employee,
+                        'company_id': version.company_id,
+                        'version_id': version,
+                        'leave_ids': leave,
+                        'l10n_in_is_sandwich_non_working': is_non_working_sandwich,
+                    })
+                    occupied_dates.add(span_date)
+        return result

--- a/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
+++ b/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
@@ -161,6 +161,34 @@ class TestSandwichLeave(TransactionCase):
         self.assertEqual(holiday_leave.number_of_days, 4)
 
     @freeze_time('2025-01-15')
+    def test_updating_older_leave_does_not_reclaim_sandwich_days(self):
+        friday_leave = self.env['hr.leave'].create({
+            'name': 'Friday Leave',
+            'employee_id': self.rahul_emp.id,
+            'work_entry_type_id': self.work_entry_type_day.id,
+            'request_date_from': "2025-01-17",
+            'request_date_to': "2025-01-17",
+        })
+        monday_leave = self.env['hr.leave'].create({
+            'name': 'Monday Leave',
+            'employee_id': self.rahul_emp.id,
+            'work_entry_type_id': self.work_entry_type_day.id,
+            'request_date_from': "2025-01-20",
+            'request_date_to': "2025-01-20",
+        })
+        self.assertTrue(monday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(monday_leave.number_of_days, 3)
+
+        friday_leave.write({
+            'request_date_from': "2025-01-16",
+            'request_date_to': "2025-01-17",
+        })
+        self.assertFalse(friday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(friday_leave.number_of_days, 2)
+        self.assertTrue(monday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(monday_leave.number_of_days, 3)
+
+    @freeze_time('2025-01-15')
     def test_sandwich_leave_saturday_monday(self):
         holiday_leave = self.env['hr.leave'].create({
             'name': 'Test Leave',
@@ -758,3 +786,53 @@ class TestSandwichLeave(TransactionCase):
         wed_leave.action_approve()
         self.assertEqual(fri_mon_leave.number_of_days, 4)
         self.assertEqual(wed_leave.number_of_days, 2)
+
+    @freeze_time('2026-03-10')
+    def test_sandwich_leave_multi_public_holiday_bridge(self):
+        self.env['resource.calendar.leaves'].create([{
+            'name': "Public Holiday 17 March",
+            'date_from': "2026-03-17 00:00:00",
+            'date_to': "2026-03-17 23:59:59",
+            'resource_id': False,
+            'company_id': self.indian_company.id,
+        }, {
+            'name': "Public Holiday 19 March",
+            'date_from': "2026-03-19 00:00:00",
+            'date_to': "2026-03-19 23:59:59",
+            'resource_id': False,
+            'company_id': self.indian_company.id,
+        }])
+
+        self.env['hr.leave'].create({
+            'name': "Before Leave",
+            'employee_id': self.rahul_emp.id,
+            'work_entry_type_id': self.work_entry_type_day.id,
+            'request_date_from': "2026-03-13",
+            'request_date_to': "2026-03-13",
+        })
+        after_leave = self.env['hr.leave'].create({
+            'name': "After Leave",
+            'employee_id': self.rahul_emp.id,
+            'work_entry_type_id': self.work_entry_type_day.id,
+            'request_date_from': "2026-03-14",
+            'request_date_to': "2026-03-17",
+        })
+        self.assertEqual(after_leave.number_of_days, 3)
+
+        leave_20_23 = self.env['hr.leave'].create({
+            'name': "Leave 20 to 23 March",
+            'employee_id': self.rahul_emp.id,
+            'work_entry_type_id': self.work_entry_type_day.id,
+            'request_date_from': "2026-03-20",
+            'request_date_to': "2026-03-23",
+        })
+        self.assertEqual(leave_20_23.number_of_days, 4)
+
+        leave_18 = self.env['hr.leave'].create({
+            'name': "Leave 18 March",
+            'employee_id': self.rahul_emp.id,
+            'work_entry_type_id': self.work_entry_type_day.id,
+            'request_date_from': "2026-03-18",
+            'request_date_to': "2026-03-18",
+        })
+        self.assertEqual(leave_18.number_of_days, 3)

--- a/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
+++ b/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
@@ -1,8 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime
+
 from freezegun import freeze_time
-from odoo.tests import tagged, TransactionCase
+
 from odoo import Command
+from odoo.tests import TransactionCase, tagged
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
@@ -44,7 +47,7 @@ class TestSandwichLeave(TransactionCase):
             'user_id': self.demo_user.id,
         })
 
-        self.work_entry_type_day, self.work_entry_type_half_day, self.work_entry_type_hours, self.work_entry_type_day_without_sl = self.env['hr.work.entry.type'].create([{
+        self.work_entry_type_day, self.work_entry_type_half_day, self.work_entry_type_hours, self.work_entry_type_day_without_sl, self.work_entry_type_public_holiday = self.env['hr.work.entry.type'].create([{
             'name': 'Test Leave Type',
             'code': 'Test Leave Type',
             'request_unit': 'day',
@@ -74,12 +77,22 @@ class TestSandwichLeave(TransactionCase):
             'request_unit': 'day',
             'requires_allocation': False,
             'count_as': 'absence',
+        }, {
+            'name': 'Public Holiday',
+            'code': 'Public Holiday',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+            'requires_allocation': False,
+            'count_as': 'absence',
         }])
         self.rahul_emp = self.env['hr.employee'].create({
             'name': 'Rahul',
             'country_id': self.env.ref('base.in').id,
             'company_id': self.indian_company.id,
             'resource_calendar_id': self.test_calendar.id,
+            'contract_date_start': '2024-12-01',
+            'date_version': '2024-12-01',
+            'wage': 100000,
         })
         self.wednesday_public_holiday = self.env['resource.calendar.leaves'].create({
             'name': 'test public holiday',
@@ -87,7 +100,22 @@ class TestSandwichLeave(TransactionCase):
             'date_to': '2025-01-29 23:59:59',
             'resource_id': False,
             'company_id': self.indian_company.id,
+            'work_entry_type_id': self.work_entry_type_public_holiday.id,
         })
+
+    def _generate_and_search_work_entries(self, employee, date_from, date_to):
+        work_entry_vals = employee.version_id.generate_work_entries(date_from.date(), date_to.date())
+        return sorted([
+            vals for vals in work_entry_vals
+            if vals.get('employee_id') in (employee, employee.id)
+            and date_from.date() <= vals.get('date') <= date_to.date()
+        ], key=lambda vals: vals['date'])
+
+    def _assert_work_entries_type(self, work_entries, expected_work_entry_type):
+        self.assertTrue(work_entries, "Expected generated work entries to validate their type.")
+        for entry in work_entries:
+            work_entry_type = entry.get('work_entry_type_id')
+            self.assertEqual(work_entry_type.id, expected_work_entry_type.id)
 
     def test_approved_leave_does_not_raise_access_error(self):
         """
@@ -120,9 +148,10 @@ class TestSandwichLeave(TransactionCase):
     def test_long_sandwich_leave(self):
         self.env['resource.calendar.leaves'].create({
             'name': "Independence Day",
-            'date_from': "2025-08-15",
-            'date_to': "2025-08-15",
+            'date_from': "2025-08-15 00:00:00",
+            'date_to': "2025-08-15 23:59:59",
             'resource_id': False,
+            'work_entry_type_id': self.work_entry_type_public_holiday.id,
             'company_id': self.indian_company.id,
         })
         holiday_leave = self.env['hr.leave'].create({
@@ -133,6 +162,15 @@ class TestSandwichLeave(TransactionCase):
             'request_date_to': "2025-08-17",
         })
         self.assertEqual(holiday_leave.number_of_days, 2, "The total leaves should be 2")
+        holiday_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 8, 13),
+            datetime(2025, 8, 17),
+        )
+        self.assertEqual(len(work_entries), 3)
+        self._assert_work_entries_type(work_entries[:1], self.work_entry_type_day)
+        self._assert_work_entries_type(work_entries[2:], self.work_entry_type_public_holiday)
 
     def test_half_day_leave(self):
         half_leave = self.env['hr.leave'].create({
@@ -159,6 +197,14 @@ class TestSandwichLeave(TransactionCase):
         })
         self.assertTrue(holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(holiday_leave.number_of_days, 4)
+        holiday_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 17),
+            datetime(2025, 1, 20),
+        )
+        self.assertEqual(len(work_entries), 4)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_updating_older_leave_does_not_reclaim_sandwich_days(self):
@@ -179,7 +225,7 @@ class TestSandwichLeave(TransactionCase):
         self.assertTrue(monday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(monday_leave.number_of_days, 3)
 
-        friday_leave.write({
+        friday_leave.with_context(leave_skip_state_check=True).write({
             'request_date_from': "2025-01-16",
             'request_date_to': "2025-01-17",
         })
@@ -187,6 +233,15 @@ class TestSandwichLeave(TransactionCase):
         self.assertEqual(friday_leave.number_of_days, 2)
         self.assertTrue(monday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(monday_leave.number_of_days, 3)
+
+        (monday_leave + friday_leave)._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 16),
+            datetime(2025, 1, 20),
+        )
+        self.assertEqual(len(work_entries), 5)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_sandwich_leave_saturday_monday(self):
@@ -259,6 +314,15 @@ class TestSandwichLeave(TransactionCase):
         })
         self.assertTrue(holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(holiday_leave.number_of_days, 3)
+        holiday_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 28),
+            datetime(2025, 1, 30),
+        )
+        self.assertEqual(len(work_entries), 3)
+        self._assert_work_entries_type(work_entries[:1], self.work_entry_type_day)
+        self._assert_work_entries_type(work_entries[2:], self.work_entry_type_day)
 
     @freeze_time('2025-03-01')
     def test_sandwich_leave_with_utc_full_day_public_holiday(self):
@@ -306,6 +370,15 @@ class TestSandwichLeave(TransactionCase):
         })
         self.assertFalse(holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(holiday_leave.number_of_days, 1)
+        holiday_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 28),
+            datetime(2025, 1, 29),
+        )
+        self.assertEqual(len(work_entries), 2)
+        self._assert_work_entries_type(work_entries[:1], self.work_entry_type_day)
+        self._assert_work_entries_type(work_entries[1:], self.work_entry_type_public_holiday)
 
     @freeze_time('2025-01-15')
     def test_sandwich_leave_2days_start_with_public_holidays(self):
@@ -318,6 +391,15 @@ class TestSandwichLeave(TransactionCase):
         })
         self.assertFalse(holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(holiday_leave.number_of_days, 1)
+        holiday_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 29),
+            datetime(2025, 1, 30),
+        )
+        self.assertEqual(len(work_entries), 2)
+        self._assert_work_entries_type(work_entries[:1], self.work_entry_type_public_holiday)
+        self._assert_work_entries_type(work_entries[1:], self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_sandwich_leave_public_holidays(self):
@@ -342,6 +424,14 @@ class TestSandwichLeave(TransactionCase):
         })
         self.assertTrue(holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(holiday_leave.number_of_days, 12)
+        holiday_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 18),
+            datetime(2025, 2, 1),
+        )
+        self.assertEqual(len(work_entries), 12)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_sandwich_in_two_part_1(self):
@@ -368,6 +458,14 @@ class TestSandwichLeave(TransactionCase):
         self.assertEqual(before_holiday_leave.number_of_days, 1)
         self.assertTrue(after_holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(after_holiday_leave.number_of_days, 2)
+        (before_holiday_leave + after_holiday_leave)._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 28),
+            datetime(2025, 1, 30),
+        )
+        self.assertEqual(len(work_entries), 3)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_sandwich_in_two_part_2(self):
@@ -414,6 +512,14 @@ class TestSandwichLeave(TransactionCase):
         self.assertEqual(before_holiday_leave.number_of_days, 5)
         self.assertTrue(after_holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(after_holiday_leave.number_of_days, 7)
+        (before_holiday_leave + after_holiday_leave)._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 18),
+            datetime(2025, 2, 1),
+        )
+        self.assertEqual(len(work_entries), 12)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_sandwich_for_work_entry_type_hours(self):
@@ -611,6 +717,7 @@ class TestSandwichLeave(TransactionCase):
             'name': 'Public Holiday',
             'date_from': '2025-07-09 00:00:00',
             'date_to': '2025-07-09 23:59:59',
+            'work_entry_type_id': self.work_entry_type_public_holiday.id,
         })
         before_leave = self.env['hr.leave'].create({
             'name': 'Test Leave Before',
@@ -639,6 +746,14 @@ class TestSandwichLeave(TransactionCase):
         })
         self.assertTrue(middle_sandwich_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(middle_sandwich_leave.number_of_days, 5)
+        (before_leave + middle_sandwich_leave + after_leave)._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 7, 3),
+            datetime(2025, 7, 11),
+        )
+        self.assertEqual(len(work_entries), 9)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-07-15')
     def test_sandwich_when_linked_leave_delete(self):
@@ -703,6 +818,7 @@ class TestSandwichLeave(TransactionCase):
             'date_from': '2026-01-16 00:00:00',  # Friday
             'date_to': '2026-01-16 23:59:59',
             'resource_id': False,
+            'work_entry_type_id': self.work_entry_type_public_holiday.id,
         })
 
         weekend_sandwich_leave = self.env['hr.leave'].create({
@@ -715,6 +831,16 @@ class TestSandwichLeave(TransactionCase):
 
         self.assertTrue(weekend_sandwich_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(weekend_sandwich_leave.number_of_days, 4)
+        weekend_sandwich_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2026, 1, 15),
+            datetime(2026, 1, 19),
+        )
+        self.assertEqual(len(work_entries), 5)
+        self._assert_work_entries_type(work_entries[:1], self.work_entry_type_day)
+        self._assert_work_entries_type(work_entries[1:2], self.work_entry_type_public_holiday)
+        self._assert_work_entries_type(work_entries[2:], self.work_entry_type_day)
 
     def test_sandwich_leave_public_holiday_only_policy(self):
         """
@@ -741,6 +867,14 @@ class TestSandwichLeave(TransactionCase):
 
         self.assertTrue(public_holiday_sandwich_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(public_holiday_sandwich_leave.number_of_days, 3)
+        public_holiday_sandwich_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2026, 1, 15),
+            datetime(2026, 1, 19),
+        )
+        self.assertEqual(len(work_entries), 3)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_sandwich_leave_reapprove(self):
@@ -794,16 +928,18 @@ class TestSandwichLeave(TransactionCase):
             'date_from': "2026-03-17 00:00:00",
             'date_to': "2026-03-17 23:59:59",
             'resource_id': False,
+            'work_entry_type_id': self.work_entry_type_public_holiday.id,
             'company_id': self.indian_company.id,
         }, {
             'name': "Public Holiday 19 March",
             'date_from': "2026-03-19 00:00:00",
             'date_to': "2026-03-19 23:59:59",
             'resource_id': False,
+            'work_entry_type_id': self.work_entry_type_public_holiday.id,
             'company_id': self.indian_company.id,
         }])
 
-        self.env['hr.leave'].create({
+        before_leave = self.env['hr.leave'].create({
             'name': "Before Leave",
             'employee_id': self.rahul_emp.id,
             'work_entry_type_id': self.work_entry_type_day.id,
@@ -814,8 +950,8 @@ class TestSandwichLeave(TransactionCase):
             'name': "After Leave",
             'employee_id': self.rahul_emp.id,
             'work_entry_type_id': self.work_entry_type_day.id,
-            'request_date_from': "2026-03-14",
-            'request_date_to': "2026-03-17",
+            'request_date_from': "2026-03-16",
+            'request_date_to': "2026-03-16",
         })
         self.assertEqual(after_leave.number_of_days, 3)
 
@@ -836,3 +972,11 @@ class TestSandwichLeave(TransactionCase):
             'request_date_to': "2026-03-18",
         })
         self.assertEqual(leave_18.number_of_days, 3)
+        (before_leave + after_leave + leave_20_23 + leave_18)._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2026, 3, 13, 0, 0, 0),
+            datetime(2026, 3, 23, 23, 59, 59),
+        )
+        self.assertEqual(len(work_entries), 11)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)

--- a/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
+++ b/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
@@ -1,8 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime
+
 from freezegun import freeze_time
-from odoo.tests import tagged, TransactionCase
+
 from odoo import Command
+from odoo.tests import TransactionCase, tagged
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
@@ -44,7 +47,7 @@ class TestSandwichLeave(TransactionCase):
             'user_id': self.demo_user.id,
         })
 
-        self.work_entry_type_day, self.work_entry_type_half_day, self.work_entry_type_hours, self.work_entry_type_day_without_sl = self.env['hr.work.entry.type'].create([{
+        self.work_entry_type_day, self.work_entry_type_half_day, self.work_entry_type_hours, self.work_entry_type_day_without_sl, self.work_entry_type_public_holiday = self.env['hr.work.entry.type'].create([{
             'name': 'Test Leave Type',
             'code': 'Test Leave Type',
             'request_unit': 'day',
@@ -74,12 +77,22 @@ class TestSandwichLeave(TransactionCase):
             'request_unit': 'day',
             'requires_allocation': False,
             'count_as': 'absence',
+        }, {
+            'name': 'Public Holiday',
+            'code': 'Public Holiday',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+            'requires_allocation': False,
+            'count_as': 'absence',
         }])
         self.rahul_emp = self.env['hr.employee'].create({
             'name': 'Rahul',
             'country_id': self.env.ref('base.in').id,
             'company_id': self.indian_company.id,
             'resource_calendar_id': self.test_calendar.id,
+            'contract_date_start': '2024-12-01',
+            'date_version': '2024-12-01',
+            'wage': 100000,
         })
         self.wednesday_public_holiday = self.env['resource.calendar.leaves'].create({
             'name': 'test public holiday',
@@ -87,7 +100,22 @@ class TestSandwichLeave(TransactionCase):
             'date_to': '2025-01-29 23:59:59',
             'resource_id': False,
             'company_id': self.indian_company.id,
+            'work_entry_type_id': self.work_entry_type_public_holiday.id,
         })
+
+    def _generate_and_search_work_entries(self, employee, date_from, date_to):
+        work_entry_vals = employee.version_id.generate_work_entries(date_from.date(), date_to.date())
+        return sorted([
+            vals for vals in work_entry_vals
+            if vals.get('employee_id') in (employee, employee.id)
+            and date_from.date() <= vals.get('date') <= date_to.date()
+        ], key=lambda vals: vals['date'])
+
+    def _assert_work_entries_type(self, work_entries, expected_work_entry_type):
+        self.assertTrue(work_entries, "Expected generated work entries to validate their type.")
+        for entry in work_entries:
+            work_entry_type = entry.get('work_entry_type_id')
+            self.assertEqual(work_entry_type.id, expected_work_entry_type.id)
 
     def test_approved_leave_does_not_raise_access_error(self):
         """
@@ -120,9 +148,10 @@ class TestSandwichLeave(TransactionCase):
     def test_long_sandwich_leave(self):
         self.env['resource.calendar.leaves'].create({
             'name': "Independence Day",
-            'date_from': "2025-08-15",
-            'date_to': "2025-08-15",
+            'date_from': "2025-08-15 00:00:00",
+            'date_to': "2025-08-15 23:59:59",
             'resource_id': False,
+            'work_entry_type_id': self.work_entry_type_public_holiday.id,
             'company_id': self.indian_company.id,
         })
         holiday_leave = self.env['hr.leave'].create({
@@ -133,6 +162,15 @@ class TestSandwichLeave(TransactionCase):
             'request_date_to': "2025-08-17",
         })
         self.assertEqual(holiday_leave.number_of_days, 2, "The total leaves should be 2")
+        holiday_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 8, 13),
+            datetime(2025, 8, 17),
+        )
+        self.assertEqual(len(work_entries), 3)
+        self._assert_work_entries_type(work_entries[:1], self.work_entry_type_day)
+        self._assert_work_entries_type(work_entries[2:], self.work_entry_type_public_holiday)
 
     def test_half_day_leave(self):
         half_leave = self.env['hr.leave'].create({
@@ -159,6 +197,14 @@ class TestSandwichLeave(TransactionCase):
         })
         self.assertTrue(holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(holiday_leave.number_of_days, 4)
+        holiday_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 17),
+            datetime(2025, 1, 20),
+        )
+        self.assertEqual(len(work_entries), 4)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_updating_older_leave_does_not_reclaim_sandwich_days(self):
@@ -179,7 +225,7 @@ class TestSandwichLeave(TransactionCase):
         self.assertTrue(monday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(monday_leave.number_of_days, 3)
 
-        friday_leave.write({
+        friday_leave.with_context(leave_skip_state_check=True).write({
             'request_date_from': "2025-01-16",
             'request_date_to': "2025-01-17",
         })
@@ -187,6 +233,15 @@ class TestSandwichLeave(TransactionCase):
         self.assertEqual(friday_leave.number_of_days, 2)
         self.assertTrue(monday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(monday_leave.number_of_days, 3)
+
+        (monday_leave + friday_leave)._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 16),
+            datetime(2025, 1, 20),
+        )
+        self.assertEqual(len(work_entries), 5)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_sandwich_leave_saturday_monday(self):
@@ -259,6 +314,15 @@ class TestSandwichLeave(TransactionCase):
         })
         self.assertTrue(holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(holiday_leave.number_of_days, 3)
+        holiday_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 28),
+            datetime(2025, 1, 30),
+        )
+        self.assertEqual(len(work_entries), 3)
+        self._assert_work_entries_type(work_entries[:1], self.work_entry_type_day)
+        self._assert_work_entries_type(work_entries[2:], self.work_entry_type_day)
 
     @freeze_time('2025-03-01')
     def test_sandwich_leave_with_utc_full_day_public_holiday(self):
@@ -306,6 +370,15 @@ class TestSandwichLeave(TransactionCase):
         })
         self.assertFalse(holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(holiday_leave.number_of_days, 1)
+        holiday_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 28),
+            datetime(2025, 1, 29),
+        )
+        self.assertEqual(len(work_entries), 2)
+        self._assert_work_entries_type(work_entries[:1], self.work_entry_type_day)
+        self._assert_work_entries_type(work_entries[1:], self.work_entry_type_public_holiday)
 
     @freeze_time('2025-01-15')
     def test_sandwich_leave_2days_start_with_public_holidays(self):
@@ -318,6 +391,15 @@ class TestSandwichLeave(TransactionCase):
         })
         self.assertFalse(holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(holiday_leave.number_of_days, 1)
+        holiday_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 29),
+            datetime(2025, 1, 30),
+        )
+        self.assertEqual(len(work_entries), 2)
+        self._assert_work_entries_type(work_entries[:1], self.work_entry_type_public_holiday)
+        self._assert_work_entries_type(work_entries[1:], self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_sandwich_leave_public_holidays(self):
@@ -342,6 +424,14 @@ class TestSandwichLeave(TransactionCase):
         })
         self.assertTrue(holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(holiday_leave.number_of_days, 12)
+        holiday_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 18),
+            datetime(2025, 2, 1),
+        )
+        self.assertEqual(len(work_entries), 12)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_sandwich_in_two_part_1(self):
@@ -368,6 +458,14 @@ class TestSandwichLeave(TransactionCase):
         self.assertEqual(before_holiday_leave.number_of_days, 1)
         self.assertTrue(after_holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(after_holiday_leave.number_of_days, 2)
+        (before_holiday_leave + after_holiday_leave)._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 28),
+            datetime(2025, 1, 30),
+        )
+        self.assertEqual(len(work_entries), 3)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_sandwich_in_two_part_2(self):
@@ -414,6 +512,14 @@ class TestSandwichLeave(TransactionCase):
         self.assertEqual(before_holiday_leave.number_of_days, 5)
         self.assertTrue(after_holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(after_holiday_leave.number_of_days, 7)
+        (before_holiday_leave + after_holiday_leave)._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 1, 18),
+            datetime(2025, 2, 1),
+        )
+        self.assertEqual(len(work_entries), 12)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_sandwich_for_work_entry_type_hours(self):
@@ -611,6 +717,7 @@ class TestSandwichLeave(TransactionCase):
             'name': 'Public Holiday',
             'date_from': '2025-07-09 00:00:00',
             'date_to': '2025-07-09 23:59:59',
+            'work_entry_type_id': self.work_entry_type_public_holiday.id,
         })
         before_leave = self.env['hr.leave'].create({
             'name': 'Test Leave Before',
@@ -639,6 +746,14 @@ class TestSandwichLeave(TransactionCase):
         })
         self.assertTrue(middle_sandwich_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(middle_sandwich_leave.number_of_days, 5)
+        (before_leave + middle_sandwich_leave + after_leave)._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2025, 7, 3),
+            datetime(2025, 7, 11),
+        )
+        self.assertEqual(len(work_entries), 9)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-07-15')
     def test_sandwich_when_linked_leave_delete(self):
@@ -703,6 +818,7 @@ class TestSandwichLeave(TransactionCase):
             'date_from': '2026-01-16 00:00:00',  # Friday
             'date_to': '2026-01-16 23:59:59',
             'resource_id': False,
+            'work_entry_type_id': self.work_entry_type_public_holiday.id,
         })
 
         weekend_sandwich_leave = self.env['hr.leave'].create({
@@ -715,6 +831,16 @@ class TestSandwichLeave(TransactionCase):
 
         self.assertTrue(weekend_sandwich_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(weekend_sandwich_leave.number_of_days, 4)
+        weekend_sandwich_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2026, 1, 15),
+            datetime(2026, 1, 19),
+        )
+        self.assertEqual(len(work_entries), 5)
+        self._assert_work_entries_type(work_entries[:1], self.work_entry_type_day)
+        self._assert_work_entries_type(work_entries[1:2], self.work_entry_type_public_holiday)
+        self._assert_work_entries_type(work_entries[2:], self.work_entry_type_day)
 
     def test_sandwich_leave_public_holiday_only_policy(self):
         """
@@ -741,6 +867,14 @@ class TestSandwichLeave(TransactionCase):
 
         self.assertTrue(public_holiday_sandwich_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(public_holiday_sandwich_leave.number_of_days, 3)
+        public_holiday_sandwich_leave._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2026, 1, 15),
+            datetime(2026, 1, 19),
+        )
+        self.assertEqual(len(work_entries), 3)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)
 
     @freeze_time('2025-01-15')
     def test_sandwich_leave_reapprove(self):
@@ -834,16 +968,18 @@ class TestSandwichLeave(TransactionCase):
             'date_from': "2026-03-17 00:00:00",
             'date_to': "2026-03-17 23:59:59",
             'resource_id': False,
+            'work_entry_type_id': self.work_entry_type_public_holiday.id,
             'company_id': self.indian_company.id,
         }, {
             'name': "Public Holiday 19 March",
             'date_from': "2026-03-19 00:00:00",
             'date_to': "2026-03-19 23:59:59",
             'resource_id': False,
+            'work_entry_type_id': self.work_entry_type_public_holiday.id,
             'company_id': self.indian_company.id,
         }])
 
-        self.env['hr.leave'].create({
+        before_leave = self.env['hr.leave'].create({
             'name': "Before Leave",
             'employee_id': self.rahul_emp.id,
             'work_entry_type_id': self.work_entry_type_day.id,
@@ -854,8 +990,8 @@ class TestSandwichLeave(TransactionCase):
             'name': "After Leave",
             'employee_id': self.rahul_emp.id,
             'work_entry_type_id': self.work_entry_type_day.id,
-            'request_date_from': "2026-03-14",
-            'request_date_to': "2026-03-17",
+            'request_date_from': "2026-03-16",
+            'request_date_to': "2026-03-16",
         })
         self.assertEqual(after_leave.number_of_days, 3)
 
@@ -876,3 +1012,11 @@ class TestSandwichLeave(TransactionCase):
             'request_date_to': "2026-03-18",
         })
         self.assertEqual(leave_18.number_of_days, 3)
+        (before_leave + after_leave + leave_20_23 + leave_18)._action_validate()
+        work_entries = self._generate_and_search_work_entries(
+            self.rahul_emp,
+            datetime(2026, 3, 13, 0, 0, 0),
+            datetime(2026, 3, 23, 23, 59, 59),
+        )
+        self.assertEqual(len(work_entries), 11)
+        self._assert_work_entries_type(work_entries, self.work_entry_type_day)


### PR DESCRIPTION
In this PR,

Indian sandwich leave duration can include linked non-working days such
as weekends or public holidays. These days were reflected in the leave
duration calculation, but not in the work entry values generated for
payslips.

Reuse the sandwich span computation while generating work entries so the
same sandwich days are also included in payslip worked day values. Mark
non-working sandwich days separately so payroll can adjust paid/unpaid
amounts correctly.

Task-4430044

