### PR TITLE
[FIX] stock: track returned and unreturned products from customer report

### DIFF
--- a/addons/stock/tests/test_stock_return_picking.py
+++ b/addons/stock/tests/test_stock_return_picking.py
@@ -209,3 +209,68 @@ class TestReturnPicking(TestStockCommon):
         return_picking = self.env['stock.picking'].browse(res['res_id'])
         self.assertTrue(return_picking)
         self.assertEqual(len(return_picking.move_ids), 1)
+
+    def test_stock_picking_report_has_return(self):
+        """
+        Ensures that only returned serialized products are marked as returned.
+
+        Scenario:
+        - A delivery of two serialized units
+        - One unit is returned
+
+        Expected:
+        - The stock lot report lists two entries
+        - Only the returned unit has `has_return = True`, the other remains `False`
+        """
+        wh_stock = self.env['stock.location'].browse(self.stock_location)
+        partner = self.env['res.partner'].create({'name': 'Test Customer'})
+
+        product_serial = self.env['product.product'].create({
+            'name': 'Tracked by SN',
+            'is_storable': True,
+            'tracking': 'serial',
+        })
+
+        serial_1 = self.env['stock.lot'].create({'name': 'SN1', 'product_id': product_serial.id})
+        serial_2 = self.env['stock.lot'].create({'name': 'SN2', 'product_id': product_serial.id})
+
+        self.env['stock.quant']._update_available_quantity(product_serial, wh_stock, 1.0, lot_id=serial_1)
+        self.env['stock.quant']._update_available_quantity(product_serial, wh_stock, 1.0, lot_id=serial_2)
+
+        picking = self.PickingObj.create({
+            'partner_id': partner.id,
+            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location,
+            'location_dest_id': self.customer_location,
+            'move_ids': [(0, 0, {
+                'name': 'Move SN',
+                'product_id': product_serial.id,
+                'product_uom_qty': 2,
+                'product_uom': product_serial.uom_id.id,
+                'location_id': self.stock_location,
+                'location_dest_id': self.customer_location,
+            })],
+        })
+
+        picking.action_confirm()
+        picking.action_assign()
+        picking.move_ids.picked = True
+        picking.button_validate()
+
+        return_wizard = self.env['stock.return.picking'].with_context(active_id=picking.id, active_model='stock.picking').create({})
+        return_wizard.product_return_moves.quantity = 1
+        res = return_wizard.action_create_returns()
+        return_picking = self.PickingObj.browse(res["res_id"])
+
+        return_picking.action_confirm()
+        return_picking.move_ids.picked = True
+        return_picking.button_validate()
+        self.env['stock.move.line'].flush_model()
+
+        lot_report = self.env['stock.lot.report'].search([
+            ('partner_id', '=', partner.id),
+        ], order='id')
+        self.assertRecordValues(lot_report, [
+            {'lot_id': serial_1.id, 'has_return': True},
+            {'lot_id': serial_2.id, 'has_return': False},
+        ])


### PR DESCRIPTION
**Steps to reproduce:**
In Inventory > Settings > Traceability, enable Lots & Serial Numbers
- Create a product P1 tracked by unique serial number
- Update on-hand quantities: 2 x P1
- Create a quotation with 2 units of P1
- Deliver products (assign the two serial numbers)
- Return only 1 product
- Go to the Customer view, click Lot/Serial Numbers, and remove all filters.

**Issue:**
When returning just one product from a delivery containing multiple products, all products in the picking appear as returned.

**Expected:**
Only the product that was actually returned should be marked as returned.

**Cause:**
The logic that sets `has_return` relies solely on the `return_id` field, incorrectly marking all items in the picking as returned if one item is returned.

opw-4417716

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
