### PR TITLE
[FIX] point_of_sale: prevent self synchronization on closing

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -239,7 +239,7 @@ export class PosStore extends Reactive {
     }
 
     async closingSessionNotification(data) {
-        if (data.login_number === this.session.login_number) {
+        if (data.login_number == odoo.login_number) {
             return;
         }
 


### PR DESCRIPTION
When entering the method `closingSessionNotification`, the method checks if `data.login_number === this.session.login_number` but `data.login_number` can be a string or a number so the comparison should be `data.login_number == odoo.login_number` to prevent self calling.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
