### PR TITLE
[FIX] account_peppol: fix demo mode

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -164,8 +164,8 @@ class AccountEdiProxyClientUser(models.Model):
             params['domain']['receiver_identifier'] = edi_user.edi_identification
             try:
                 # request all messages that haven't been acknowledged
-                messages = edi_user._make_request(
-                    url=f"{edi_user._get_server_url()}/api/peppol/1/get_all_documents",
+                messages = edi_user._call_peppol_proxy(
+                    "/api/peppol/1/get_all_documents",
                     params=params,
                 )
             except AccountEdiProxyError as e:
@@ -183,9 +183,9 @@ class AccountEdiProxyClientUser(models.Model):
             for uuids in split_every(BATCH_SIZE, message_uuids):
                 proxy_acks = []
                 # retrieve attachments for filtered messages
-                all_messages = edi_user._make_request(
-                    f"{edi_user._get_server_url()}/api/peppol/1/get_document",
-                    {'message_uuids': uuids},
+                all_messages = edi_user._call_peppol_proxy(
+                    "/api/peppol/1/get_document",
+                    params={'message_uuids': uuids},
                 )
 
                 for uuid, content in all_messages.items():
@@ -209,9 +209,9 @@ class AccountEdiProxyClientUser(models.Model):
                 if not tools.config['test_enable']:
                     self.env.cr.commit()
                 if proxy_acks:
-                    edi_user._make_request(
-                        f"{edi_user._get_server_url()}/api/peppol/1/ack",
-                        {'message_uuids': proxy_acks},
+                    edi_user._call_peppol_proxy(
+                        "/api/peppol/1/ack",
+                        params={'message_uuids': proxy_acks},
                     )
 
     def _peppol_get_message_status(self):
@@ -225,9 +225,9 @@ class AccountEdiProxyClientUser(models.Model):
 
             message_uuids = {move.peppol_message_uuid: move for move in edi_user_moves}
             for uuids in split_every(BATCH_SIZE, message_uuids.keys()):
-                messages_to_process = edi_user._make_request(
-                    f"{edi_user._get_server_url()}/api/peppol/1/get_document",
-                    {'message_uuids': uuids},
+                messages_to_process = edi_user._call_peppol_proxy(
+                    "/api/peppol/1/get_document",
+                    params={'message_uuids': uuids},
                 )
 
                 for uuid, content in messages_to_process.items():
@@ -253,16 +253,15 @@ class AccountEdiProxyClientUser(models.Model):
                     move.peppol_move_state = content['state']
                     move._message_log(body=_('Peppol status update: %s', content['state']))
 
-                edi_user._make_request(
-                    f"{edi_user._get_server_url()}/api/peppol/1/ack",
-                    {'message_uuids': uuids},
+                edi_user._call_peppol_proxy(
+                    "/api/peppol/1/ack",
+                    params={'message_uuids': uuids},
                 )
 
     def _peppol_get_participant_status(self):
         for edi_user in self:
             try:
-                proxy_user = edi_user._make_request(
-                    f"{edi_user._get_server_url()}/api/peppol/2/participant_status")
+                proxy_user = edi_user._call_peppol_proxy("/api/peppol/2/participant_status")
             except AccountEdiProxyError as e:
                 _logger.error('Error while updating Peppol participant status: %s', e)
                 continue
@@ -380,9 +379,8 @@ class AccountEdiProxyClientUser(models.Model):
         for receiver in receivers:
             try:
                 receiver._call_peppol_proxy(
-                    "/api/peppol/2/add_services", {
-                        'document_identifiers': supported_identifiers,
-                    },
+                    '/api/peppol/2/add_services',
+                    params={'document_identifiers': supported_identifiers},
                 )
             # Broad exception case, so as not to block execution of the rest of the _post_init hook.
             except (AccountEdiProxyError, UserError) as exception:
@@ -409,9 +407,8 @@ class AccountEdiProxyClientUser(models.Model):
         for receiver in receivers:
             try:
                 receiver._call_peppol_proxy(
-                    "/api/peppol/2/remove_services", {
-                        'document_identifiers': unsupported_identifiers,
-                    },
+                    '/api/peppol/2/remove_services',
+                    params={'document_identifiers': unsupported_identifiers},
                 )
             except (AccountEdiProxyError, UserError) as exception:
                 _logger.error(

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -167,8 +167,8 @@ class AccountMoveSend(models.AbstractModel):
             lambda u: u.proxy_type == 'peppol')
 
         try:
-            response = edi_user._make_request(
-                f"{edi_user._get_server_url()}/api/peppol/1/send_document",
+            response = edi_user._call_peppol_proxy(
+                "/api/peppol/1/send_document",
                 params=params,
             )
         except AccountEdiProxyError as e:

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -81,6 +81,8 @@ def _mock_call_peppol_proxy(func, self, *args, **kwargs):
         'get_document': _mock_get_document,
         'participant_status': lambda _user, _args, _kwargs: {'peppol_state': 'receiver'},
         'send_document': _mock_send_document,
+        'add_services': lambda _user, _args, _kwargs: {},
+        'remove_services': lambda _user, _args, _kwargs: {},
     }[endpoint](self, args, kwargs)
 
 


### PR DESCRIPTION
With previous refactor, we simplified the demo mode by trying to mock the fewer methods possible.
In particular, we are aligning all calls to proxy to go through the `_call_peppol_proxy(...)`. This should simplify future refactoring work to get rid of account_edi_x models.

Some calls to make_request were still existing, since it's no longer mocked in demo mode, an error is raised. Replace all those calls to use the `_call_peppol_proxy` method.

task-no