### PR TITLE
[FIX] l10n_hu_edi: missing invoice number in new layouts

### DIFF
--- a/addons/l10n_hu_edi/views/report_templates.xml
+++ b/addons/l10n_hu_edi/views/report_templates.xml
@@ -2,15 +2,15 @@
 <odoo>
 
     <template id="external_layout_standard" inherit_id="web.external_layout_standard" >
-        <!-- support for custom header -->
-        <div t-attf-class="header o_company_#{company.id}_layout" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="header o_company_#{company.id}_layout" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout" t-if="custom_header">
+        </xpath>
+
+        <xpath expr="//img/../.." position="after">
+            <div t-if="custom_header">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
         <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
@@ -25,15 +25,15 @@
     </template>
 
     <template id="external_layout_bold" inherit_id="web.external_layout_bold" >
-        <!-- support for custom header -->
-        <div t-attf-class="header o_company_#{company.id}_layout" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="header o_company_#{company.id}_layout" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout" t-if="custom_header">
+        </xpath>
+
+        <xpath expr="//img/../.." position="after">
+            <div t-if="custom_header">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
         <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
@@ -47,15 +47,15 @@
     </template>
 
     <template id="external_layout_boxed" inherit_id="web.external_layout_boxed" >
-        <!-- support for custom header -->
-        <div t-attf-class="header o_company_#{company.id}_layout" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="header o_company_#{company.id}_layout" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout" t-if="custom_header">
+        </xpath>
+
+        <xpath expr="//img/../.." position="after">
+            <div t-if="custom_header">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
         <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
@@ -69,15 +69,15 @@
     </template>
 
     <template id="external_layout_striped" inherit_id="web.external_layout_striped" >
-        <!-- support for custom header -->
-        <div t-attf-class="o_company_#{company.id}_layout header" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="o_company_#{company.id}_layout header" position="after">
-            <div t-attf-class="o_company_#{company.id}_layout header" t-if="custom_header">
+        </xpath>
+
+        <xpath expr="//img/../.." position="after">
+            <div t-if="custom_header">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
         <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">
@@ -91,15 +91,15 @@
     </template>
 
     <template id="external_layout_bubble" inherit_id="web.external_layout_bubble">
-        <!-- support for custom header -->
-        <div t-attf-class="header o_company_#{company.id}_layout {{report_type == 'pdf' and 'pt-5'}}" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="header o_company_#{company.id}_layout {{report_type == 'pdf' and 'pt-5'}}" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout {{report_type == 'pdf' and 'pt-5'}}" t-if="custom_header">
+        </xpath>
+
+        <xpath expr="//img/../.." position="after">
+            <div t-if="custom_header">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
         <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" position="attributes">
@@ -114,14 +114,15 @@
 
     <template id="external_layout_wave" inherit_id="web.external_layout_wave">
         <!-- support for custom header -->
-        <div t-attf-class="header o_company_#{company.id}_layout {{report_type != 'pdf' and 'h-0'}}" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="header o_company_#{company.id}_layout {{report_type != 'pdf' and 'h-0'}}" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout {{report_type != 'pdf' and 'h-0'}}" t-if="custom_header">
+        </xpath>
+
+        <xpath expr="//img/../.." position="after">
+            <div t-if="custom_header">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
         <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}" position="attributes">
@@ -136,14 +137,15 @@
 
     <template id="external_layout_folder" inherit_id="web.external_layout_folder">
         <!-- support for custom header -->
-        <div t-attf-class="header o_company_#{company.id}_layout {{report_type != 'pdf' and 'h-0'}}" position="attributes">
+        <xpath expr="//img/../.." position="attributes">
             <attribute name="t-if">not custom_header</attribute>
-        </div>
-        <div t-attf-class="header o_company_#{company.id}_layout {{report_type != 'pdf' and 'h-0'}}" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout {{report_type != 'pdf' and 'h-0'}}" t-if="custom_header">
+        </xpath>
+
+        <xpath expr="//img/../.." position="after">
+            <div t-if="custom_header">
                 <t t-call="#{custom_header}"/>
             </div>
-        </div>
+        </xpath>
 
         <!-- support for custom footer -->
         <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}" position="attributes">


### PR DESCRIPTION
Since the introduction of new layouts (e.g. folder), the
invoice number is not displayed in Hungary. This is because
the xpath is incorrect because the new layouts now have
two children instead of one.

The old ones only had one child node:

https://github.com/odoo/odoo/blob/4dad76c045f94861632929189baa96d69f662275/addons/web/views/report_templates.xml#L478-L506

Whereas the new ones have two:

https://github.com/odoo/odoo/blob/4dad76c045f94861632929189baa96d69f662275/addons/web/views/report_templates.xml#L535-L550

https://github.com/odoo/odoo/blob/4dad76c045f94861632929189baa96d69f662275/addons/web/views/report_templates.xml#L551-L579

So the problem with the current xpath is that it's replacing
both children, even though only the second one should be.
By 'replacing' the first one (by iffing it),
`layout_document_title` is not displayed anymore and therefore
no invoice number appears on the invoice.

To fix this, we use a different xpath on the `img` parent.
For consistency and maintainability reasons, we apply this
new xpath on all the layouts and not just the new ones.

opw-4397438