### PR TITLE
[FIX] stock: reset `final_barcode` template variable

### DIFF
--- a/addons/stock/report/product_templates.xml
+++ b/addons/stock/report/product_templates.xml
@@ -47,6 +47,7 @@
 ^FO100,100
 ^A0N,44,33^FDLN/SN: <t t-out="lot['name']"/>^FS
                     <t t-if="env.user.has_group('stock.group_stock_lot_print_gs1')">
+                        <t t-set="final_barcode" t-value="''" />
                         <t t-if="lot['lot_record'].product_id.valid_ean" t-set="final_barcode" t-value="'01' + '0' * (14 - len(lot['lot_record'].product_id.barcode)) + lot['lot_record'].product_id.barcode"/>
                         <!-- TODO: must keep lot/sn as last value in barcode because we cannot pad '0's without changing lot/sn name until we can scan in FNC1. -->
                         <t t-if="lot['lot_record'].product_id.tracking == 'lot'" name="datamatrix_lot" t-set="final_barcode" t-value="(final_barcode or '') + '10' + lot['name']"/>


### PR DESCRIPTION
**Problem**:
When `lot['lot_record'].product_id.valid_ean` is `False`, the `final_barcode` variable retains the value from the previous iteration. This leads to incorrect concatenation with the current `lot['name']` when `lot['lot_record'].product_id.tracking == 'lot'`.

**Solution**:
Reset the `final_barcode` variable at the start of each iteration.

**Steps to Reproduce**:
1. Go to Inventory > Settings and enable "Print GS1 Barcodes for Lots & Serial Numbers".
2. Navigate to Inventory > Products > Lots/Serial Numbers.
3. Select all records and click Print > Lot/Serial Number (ZPL).
4. Observe that some barcodes incorrectly include the previous barcode as a prefix.

opw-4437745

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
