### PR TITLE
[FIX] point_of_sale: correctly load products when searching

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_list/product_list.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_list/product_list.js
@@ -168,17 +168,7 @@ export class ProductsWidget extends Component {
             const ProductIds = await this.orm.call(
                 "product.product",
                 "search",
-                [
-                    [
-                        "&",
-                        ["available_in_pos", "=", true],
-                        "|",
-                        "|",
-                        ["name", "ilike", searchProductWord],
-                        ["default_code", "ilike", searchProductWord],
-                        ["barcode", "ilike", searchProductWord],
-                    ],
-                ],
+                [domain],
                 {
                     offset: this.state.currentOffset,
                     limit: limit,


### PR DESCRIPTION
Before this commit, the domain containing the limited category information was not used correctly, causing products from other categories to be loaded.

opw-4451297

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
