### PR TITLE
[IMP] web: clean warn_future

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -157,6 +157,8 @@ export class DateTimeField extends Component {
         this.openPicker = dateTimePicker.open;
 
         onWillRender(() => this.triggerIsDirty());
+
+        this.futureWarningMsg = _t("This date is in the future");
     }
 
     //-------------------------------------------------------------------------

--- a/addons/web/static/src/views/fields/datetime/datetime_field.xml
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.xml
@@ -21,16 +21,12 @@
                     t-ref="start-date"
                     type="text"
                     t-att-id="showSeparator ? props.endDateField and props.id : props.id"
-                    class="o_input cursor-pointer"
+                    t-att-class="'o_input cursor-pointer ' + (props.warnFuture and isDateInTheFuture(0) ? 'text-danger' : '')"
                     autocomplete="off"
                     t-att-placeholder="props.placeholder"
                     t-att-data-field="startDateField"
                     t-on-input="onInput"
-                />
-                <span
-                    t-if="props.warnFuture and isDateInTheFuture(0)"
-                    class="fa fa-exclamation-triangle text-danger"
-                    title="This date is on the future. Make sure it is what you expected."
+                    t-att-title="props.warnFuture and isDateInTheFuture(0) ? futureWarningMsg : ''"
                 />
             </t>
 
@@ -58,16 +54,12 @@
                         t-ref="end-date"
                         type="text"
                         t-att-id="props.startDateField and props.id"
-                        class="o_input cursor-pointer"
+                        t-att-class="'o_input cursor-pointer ' + (props.warnFuture and isDateInTheFuture(1) ? 'text-danger' : '')"
                         autocomplete="off"
                         t-att-placeholder="props.placeholder"
                         t-att-data-field="endDateField"
                         t-on-input="onInput"
-                    />
-                    <span
-                        t-if="props.warnFuture and isDateInTheFuture(1)"
-                        class="fa fa-exclamation-triangle text-danger"
-                        title="This date is on the future. Make sure it is what you expected."
+                        t-att-title="props.warnFuture and isDateInTheFuture(1) ? futureWarningMsg : ''"
                     />
                 </t>
             </t>

--- a/addons/web/static/tests/views/fields/date_field.test.js
+++ b/addons/web/static/tests/views/fields/date_field.test.js
@@ -251,9 +251,9 @@ test("date field with warn_future option ", async () => {
     await contains(getPickerCell("2020")).click();
     await contains(getPickerCell("Dec")).click();
     await contains(getPickerCell("22")).click();
-    expect(".fa-exclamation-triangle").toHaveCount(1);
+    expect(".o_field_date input").toHaveClass("text-danger");
     await fieldInput("date").clear();
-    expect(".fa-exclamation-triangle").toHaveCount(0);
+    expect(".o_field_date input").not.toHaveClass("text-danger");
 });
 
 test("date field with warn_future option: do not overwrite datepicker option", async () => {


### PR DESCRIPTION
Purpose:
- When a date was set in the future, an exclamation icon was displayed, indicating that the date is in the future.that is not very clear.

Specification:
- The exclamation icon has been removed. now, if a date is set in the future, it is displayed in red, with a tooltip on hover stating that the date is in the future.

Task-4365095

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
