### PR TITLE
[IMP] {sale_,}project, {hr,sale}_timesheet: hide SOL from non-billable projects

### DIFF
--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -214,7 +214,8 @@ class ProjectProject(models.Model):
 
     def action_project_timesheets(self):
         action = self.env['ir.actions.act_window']._for_xml_id('hr_timesheet.act_hr_timesheet_line_by_project')
-        action['display_name'] = _("%(name)s's Timesheets", name=self.name)
+        if not self.env.context.get('from_embedded_action'):
+            action['display_name'] = _("%(name)s's Timesheets", name=self.name)
         return action
 
     # ----------------------------

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -513,8 +513,11 @@
             <field name="parent_res_model">project.project</field>
             <field name="sequence">20</field>
             <field name="parent_action_id" ref="project.act_project_project_2_project_task_all"/>
-            <field name="action_id" ref="hr_timesheet.act_hr_timesheet_line_by_project"/>
+            <field name="action_id" eval="False"/>
+            <field name="name">Timesheets</field>
+            <field name="python_method">action_project_timesheets</field>
             <field name="domain">[('allow_timesheets', '=', True)]</field>
+            <field name="context">{'from_embedded_action': true}</field>
             <field name="groups_ids" eval="[(4, ref('hr_timesheet.group_hr_timesheet_user'))]" />
         </record>
 
@@ -522,8 +525,11 @@
             <field name="parent_res_model">project.project</field>
             <field name="sequence">30</field>
             <field name="parent_action_id" ref="project.project_update_all_action"/>
-            <field name="action_id" ref="hr_timesheet.act_hr_timesheet_line_by_project"/>
+            <field name="action_id" eval="False"/>
+            <field name="name">Timesheets</field>
+            <field name="python_method">action_project_timesheets</field>
             <field name="domain">[('allow_timesheets', '=', True)]</field>
+            <field name="context">{'from_embedded_action': true}</field>
             <field name="groups_ids" eval="[(4, ref('hr_timesheet.group_hr_timesheet_user'))]" />
         </record>
 

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -824,6 +824,7 @@ class ProjectProject(models.Model):
 
         action = super().action_view_tasks()
         action['context']['hide_partner'] = self._get_hide_partner()
+        action['context']['hide_sale_line'] = not self.allow_billable
         return action
 
     def action_open_project_vendor_bills(self):

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -262,8 +262,8 @@
         <field name="inherit_id" ref="project.project_task_view_tree_base"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='partner_id']" position="after">
-                <field name="sale_line_id" optional="hide" groups="sales_team.group_sale_salesman" options="{'no_create': True}"/>
-                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman"/>
+                <field name="sale_line_id" optional="hide" groups="sales_team.group_sale_salesman" options="{'no_create': True}" column_invisible="context.get('hide_sale_line')"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="context.get('hide_sale_line')"/>
             </xpath>
         </field>
     </record>

--- a/addons/sale_timesheet/models/project_project.py
+++ b/addons/sale_timesheet/models/project_project.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
 import json
 
 from odoo import api, fields, models
@@ -280,6 +281,16 @@ class ProjectProject(models.Model):
                 action['res_id'] = res_id
             return action
         return super().action_profitability_items(section_name, domain, res_id)
+
+    def action_project_timesheets(self):
+        action = super().action_project_timesheets()
+        if not self.allow_billable:
+            context = action['context'].replace('active_id', str(self.id))
+            action['context'] = {
+                **ast.literal_eval(context),
+                'hide_so_line': True,
+            }
+        return action
 
     # ----------------------------
     #  Project Updates

--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -42,7 +42,7 @@
                 <field name="commercial_partner_id" column_invisible="True" groups="sales_team.group_sale_salesman"/>
                 <field name="is_so_line_edited" column_invisible="True" groups="sales_team.group_sale_salesman"/>
                 <field name="allow_billable" column_invisible="True" groups="sales_team.group_sale_salesman"/>
-                <field name="so_line" widget="so_line_field" optional="show" options="{'no_create': True, 'no_open': True}" context="{'create': False, 'edit': False, 'delete': False}" invisible="not allow_billable" readonly="readonly_timesheet" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
+                <field name="so_line" widget="so_line_field" optional="show" options="{'no_create': True, 'no_open': True}" context="{'create': False, 'edit': False, 'delete': False}" invisible="not allow_billable" readonly="readonly_timesheet" column_invisible="context.get('hide_so_line')" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
In this commit, we remove the SOL field of tasks and timesheets from the list views of non-billable projects.

task-4443654

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
