### PR TITLE
[IMP] orm: deprecate Registry.manage_changes

### DIFF
--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -970,6 +970,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
     @contextmanager
     def manage_changes(self):
         """ Context manager to signal/discard registry and cache invalidations. """
+        warnings.warn("Since 19.0, use signal_changes() and reset_changes() directly", DeprecationWarning)
         try:
             yield self
             self.signal_changes()

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -78,13 +78,17 @@ def dispatch(method, params):
     threading.current_thread().dbname = db
     threading.current_thread().uid = uid
     registry = Registry(db).check_signaling()
-    with registry.manage_changes():
+    try:
         if method == 'execute':
             res = execute(db, uid, *params[3:])
         elif method == 'execute_kw':
             res = execute_kw(db, uid, *params[3:])
         else:
-            raise NameError("Method not available %s" % method)
+            raise NameError(f"Method not available {method}")  # noqa: TRY301
+        registry.signal_changes()
+    except Exception:
+        registry.reset_changes()
+        raise
     return res
 
 


### PR DESCRIPTION
The function is used only once. In all other occurrences, `check_signaling`, `signal_changes` and `reset_changes` are called.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
