### PR TITLE
[IMP] bus add delay before showing the disconnected alert

### DIFF
--- a/addons/bus/static/tests/bus_connection_alert.test.js
+++ b/addons/bus/static/tests/bus_connection_alert.test.js
@@ -31,6 +31,7 @@ test("show warning when bus connection encounters issues", async () => {
         WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE
     );
     await waitForSteps(["reconnecting"]);
+    await runAllTimers();
     const alert = await waitFor(".o-bus-ConnectionAlert");
     expect(alert).toHaveText("Real-time connection lost...");
     await runAllTimers();


### PR DESCRIPTION
Before this PR, the "real-time connection lost" alert was displayed right after the disconnection was detected.
This PR adds a 15s delay to avoid spamming the alert on unstable connexion.

Task-4453176

