### PR TITLE
[REF] core: deprecate iteration over SQL object

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -551,9 +551,8 @@ class AccountJournal(models.Model):
             "account_move.company_id",
         ]
         # DRAFTS
-        query, params = sale_purchase_journals._get_draft_sales_purchases_query().select(*bills_field_list)
-        self.env.cr.execute(query, params)
-        query_results_drafts = group_by_journal(self.env.cr.dictfetchall())
+        sql = sale_purchase_journals._get_draft_sales_purchases_query().select(*bills_field_list)
+        query_results_drafts = group_by_journal(self.env.execute_query_dict(sql))
 
         # WAITING AND LATE BILLS AND PAYMENTS
         query_results_to_pay = {}

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -640,10 +640,11 @@ class StockQuant(models.Model):
     def _run_least_packages_removal_strategy_astar(self, domain, qty):
         # Fetch the available packages and contents
         query = self._where_calc(domain)
-        query_str, params = query.select('package_id', 'SUM(quantity - reserved_quantity) AS available_qty')
-        query_str += ' GROUP BY package_id HAVING SUM(quantity - reserved_quantity) > 0 ORDER BY available_qty DESC'
-        self._cr.execute(query_str, params)
-        qty_by_package = self._cr.fetchall()
+        query.groupby = SQL("package_id")
+        query.having = SQL("SUM(quantity - reserved_quantity) > 0")
+        query.order = SQL("available_qty DESC")
+        qty_by_package = self.env.execute_query(
+            query.select('package_id', 'SUM(quantity - reserved_quantity) AS available_qty'))
 
         # Items that do not belong to a package are added individually to the list, any empty packages get removed.
         pkg_found = False

--- a/addons/web/controllers/domain.py
+++ b/addons/web/controllers/domain.py
@@ -1,10 +1,11 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import http, _
 from odoo.http import Controller, request
 from odoo.exceptions import ValidationError
+from odoo.tools import SQL
 from odoo.tools.misc import mute_logger
+
 
 class Domain(Controller):
 
@@ -21,14 +22,14 @@ class Domain(Controller):
             # go through the motions of preparing the final SQL for the domain,
             # so that anything invalid will raise an exception.
             query = Model.sudo()._search(domain)
-            sql, params = query.select()
 
             # Execute the search in EXPLAIN mode, to have the query parser
             # verify it. EXPLAIN will make sure the query is never actually executed
             # An alternative to EXPLAIN would be a LIMIT 0 clause, but the semantics
             # of a falsy `limit` parameter when calling _search() do not permit it.
+            sql = SQL("EXPLAIN %s", query.select())
             with mute_logger('odoo.sql_db'):
-                request.env.cr.execute(f"EXPLAIN {sql}", params)
+                request.env.cr.execute(sql)
             return True
         except Exception:  # pylint: disable=broad-except
             return False

--- a/odoo/addons/base/tests/test_osv.py
+++ b/odoo/addons/base/tests/test_osv.py
@@ -115,17 +115,17 @@ class TestQuery(TransactionCase):
         records = self.env['res.partner.category']
         query = records._as_query()
         self.assertEqual(list(query), records.ids)
-        self.cr.execute(*query.select())
+        self.cr.execute(query.select())
         self.assertEqual([row[0] for row in self.cr.fetchall()], records.ids)
 
         records = self.env['res.partner.category'].search([])
         query = records._as_query()
         self.assertEqual(list(query), records.ids)
-        self.cr.execute(*query.select())
+        self.cr.execute(query.select())
         self.assertEqual([row[0] for row in self.cr.fetchall()], records.ids)
 
         records = records.browse(reversed(records.ids))
         query = records._as_query()
         self.assertEqual(list(query), records.ids)
-        self.cr.execute(*query.select())
+        self.cr.execute(query.select())
         self.assertEqual([row[0] for row in self.cr.fetchall()], records.ids)

--- a/odoo/addons/base/tests/test_sql.py
+++ b/odoo/addons/base/tests/test_sql.py
@@ -81,12 +81,6 @@ class TestSQL(BaseCase):
         sql2 = SQL(sql1)
         self.assertEqual(sql1, sql2)
 
-    def test_sql_unpacking(self):
-        sql = SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 42, 'baz')
-        string, params = sql
-        self.assertEqual(string, "SELECT id FROM table WHERE foo=%s AND bar=%s")
-        self.assertEqual(params, [42, 'baz'])
-
     def test_sql_join(self):
         sql = SQL(" AND ").join([])
         self.assertEqual(sql.code, "")

--- a/odoo/addons/base/tests/test_sql.py
+++ b/odoo/addons/base/tests/test_sql.py
@@ -73,6 +73,9 @@ class TestSQL(BaseCase):
         sql2 = SQL("SELECT id FROM table WHERE foo=%s", 421)
         self.assertNotEqual(sql1, sql2)
 
+    def test_sql_hash(self):
+        hash(SQL("SELECT id FROM table WHERE x=%s", 5))
+
     def test_sql_idempotence(self):
         sql1 = SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 42, 'baz')
         sql2 = SQL(sql1)

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -163,6 +163,7 @@ class SQL:
             sql = SQL(...)
             code, params = sql
         """
+        warnings.warn("Deprecated since 19.0, use code and params properties directly", DeprecationWarning)
         yield self.code
         yield self.params
 

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -152,6 +152,9 @@ class SQL:
     def __eq__(self, other):
         return isinstance(other, SQL) and self.__code == other.__code and self.__params == other.__params
 
+    def __hash__(self):
+        return hash((self.__code, self.__params))
+
     def __iter__(self):
         """ Yields ``self.code`` and ``self.params``. This was introduced for
         backward compatibility, as it enables to access the SQL and parameters


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The iteration over `SQL` was provided for backward-compatibility. However, each time we use it, the code can be made simpler.

Current behavior before PR:
```python
query, param = SQL(...)
self.env.cr.execute(query, param)
```

Desired behavior after PR is merged:
```python
sql = SQL(...)
self.env.cr.execute(sql)
# also the shortcut to get the rows works properly
rows = self.env.execute_query(sql)
```

odoo/enterprise#76622

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
