### PR TITLE
[FIX] pos: self service invoicing TB on portal

### DIFF
--- a/addons/account_peppol/static/src/js/portal.js
+++ b/addons/account_peppol/static/src/js/portal.js
@@ -14,7 +14,7 @@ portalDetails.include({
     },
 
     _showPeppolConfig() {
-        const method = document.querySelector("select[name='invoice_sending_method']").value;
+        const method = document.querySelector("select[name='invoice_sending_method']")?.value;
         const divToToggle = document.querySelectorAll(".portal_peppol_toggle");
         for (const peppolDiv of divToToggle) {
             if (method === "peppol") {


### PR DESCRIPTION
Steps:
- Enable the self-invoicing option from Configuration → Settings → Bills & Receipts.
- Open the POS system.
- Create an order and validate it.
- Scan the QR code for self-invoicing displayed on the receipt.
- The QR code opens the portal.

Issue:
- A traceback error appears when opening the page.

Cause:
- A problem in the `account_peppol` module was causing it to search for an element on the page that wasn’t available.

Fix:
- Included a condition such that If the element isn’t found, it skips the step and assigns a null value to the variable, resolving the error.

Task: 4438885