### PR TITLE
[IMP] bus add delay before showing the disconnected alert

### DIFF
--- a/addons/bus/static/src/components/bus_connection_alert.js
+++ b/addons/bus/static/src/components/bus_connection_alert.js
@@ -1,3 +1,4 @@
+import { CONNECTION_STATUS } from "@bus/services/bus_monitoring_service";
 import { Component, useState } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
@@ -12,6 +13,7 @@ export class BusConnectionAlert extends Component {
 
     setup() {
         this.busMonitoring = useState(useService("bus.monitoring_service"));
+        this.CONNECTION_STATUS = CONNECTION_STATUS;
     }
 
     /**

--- a/addons/bus/static/src/components/bus_connection_alert.scss
+++ b/addons/bus/static/src/components/bus_connection_alert.scss
@@ -11,8 +11,11 @@ $o-bus-ConnectionAlert-color: mix($white, $warning, 40%);
 
 .o-bus-ConnectionAlert-failure {
     width: fit-content;
-    animation: o-bus-ConnectionAlert-failureAnimation ease-in-out .5s forwards;
     padding: map-get($spacers, 1) * 1.5;
+
+    &.o-long {
+        animation: o-bus-ConnectionAlert-failureAnimation ease-in-out .5s forwards;
+    }
 }
 
 .o-bus-ConnectionAlert-icon {

--- a/addons/bus/static/src/components/bus_connection_alert.xml
+++ b/addons/bus/static/src/components/bus_connection_alert.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="bus.BusConnectionAlert">
-        <div t-if="busMonitoring.isConnectionLost" class="o-bus-ConnectionAlert position-absolute top-0 bottom-0 end-0 start-0 pe-none" t-att-class="{'o-bus-ConnectionAlert-border': showBorderOnFailure}">
-            <div class="o-bus-ConnectionAlert-failure small d-flex align-items-baseline m-0 position-absolute bottom-0 end-0 rounded-3 rounded-bottom-0 rounded-end-0 z-1" role="alert">
-                <i class="o-bus-ConnectionAlert-icon fa fa-warning me-1 text-warning"/>
-                <span class="o-bus-ConnectionAlert-label ms-1 lh-1 fw-bold">Real-time connection lost...</span>
+        <div t-if="busMonitoring.connectionStatus" class="o-bus-ConnectionAlert position-absolute top-0 bottom-0 end-0 start-0 pe-none" t-att-class="{'o-bus-ConnectionAlert-border': showBorderOnFailure and busMonitoring.connectionStatus === CONNECTION_STATUS.CONNECTION_LOST_LONG}">
+            <div class="o-bus-ConnectionAlert-failure small d-flex align-items-baseline m-0 position-absolute bottom-0 end-0 rounded-3 rounded-bottom-0 rounded-end-0 z-1" t-att-class="{ 'o-long': busMonitoring.connectionStatus === CONNECTION_STATUS.CONNECTION_LOST_LONG }" role="alert">
+                <t t-if="busMonitoring.connectionStatus === CONNECTION_STATUS.CONNECTION_LOST">
+                    <i class="fa fa-spin fa-circle-o-notch opacity-25"/>
+                </t>
+                <t t-elif="busMonitoring.connectionStatus === CONNECTION_STATUS.CONNECTION_LOST_LONG">
+                    <i class="o-bus-ConnectionAlert-icon fa fa-warning me-1 text-warning"/>
+                    <span class="o-bus-ConnectionAlert-label ms-1 lh-1 fw-bold">Real-time connection lost...</span>
+                </t>
             </div>
         </div>
     </t>

--- a/addons/bus/static/src/services/bus_monitoring_service.js
+++ b/addons/bus/static/src/services/bus_monitoring_service.js
@@ -3,12 +3,15 @@ import { reactive } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 
+export const CONNECTION_LOST_WARNING_DELAY = 15000;
+
 /**
  * Detect lost connections to the bus. A connection is considered as lost if it
  * couldn't be established after a reconnect attempt.
  */
 export class BusMonitoringService {
     isConnectionLost = false;
+    timeout;
 
     constructor(env, services) {
         const reactiveThis = reactive(this);
@@ -44,12 +47,20 @@ export class BusMonitoringService {
             case WORKER_STATE.CONNECTED: {
                 this.isReconnecting = false;
                 this.isConnectionLost = false;
+                if (this.timeout) {
+                    clearTimeout(this.timeout);
+                    this.timeout = undefined;
+                }
                 break;
             }
             case WORKER_STATE.DISCONNECTED: {
                 if (this.isReconnecting) {
-                    this.isConnectionLost = true;
                     this.isReconnecting = false;
+                }
+                if (!this.timeout) {
+                    this.timeout = browser.setTimeout(() => {
+                        this.isConnectionLost = true;
+                    }, CONNECTION_LOST_WARNING_DELAY);
                 }
                 break;
             }

--- a/addons/bus/static/tests/bus_connection_alert.test.js
+++ b/addons/bus/static/tests/bus_connection_alert.test.js
@@ -31,6 +31,7 @@ test("show warning when bus connection encounters issues", async () => {
         WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE
     );
     await waitForSteps(["reconnecting"]);
+    await runAllTimers();
     const alert = await waitFor(".o-bus-ConnectionAlert");
     expect(alert).toHaveText("Real-time connection lost...");
     await runAllTimers();

--- a/addons/bus/static/tests/bus_monitoring_service.test.js
+++ b/addons/bus/static/tests/bus_monitoring_service.test.js
@@ -6,6 +6,7 @@ import {
 import {
     busMonitoringservice,
     CONNECTION_LOST_WARNING_DELAY,
+    CONNECTION_STATUS,
 } from "@bus/services/bus_monitoring_service";
 import { WEBSOCKET_CLOSE_CODES, WORKER_STATE } from "@bus/workers/websocket_worker";
 import { describe, expect, test } from "@odoo/hoot";
@@ -26,16 +27,17 @@ function stepConnectionStateChanges() {
     patchWithCleanup(busMonitoringservice, {
         start() {
             const api = super.start(...arguments);
-            Object.defineProperty(api, "isConnectionLost", {
+            api._connectionStatus = api.connectionStatus;
+            Object.defineProperty(api, "connectionStatus", {
                 get() {
-                    return this._isConnectionLost;
+                    return this._connectionStatus;
                 },
                 set(value) {
-                    if (value === this._isConnectionLost) {
+                    if (value === this._connectionStatus) {
                         return;
                     }
-                    this._isConnectionLost = value;
-                    asyncStep(`isConnectionLost - ${value}`);
+                    this._connectionStatus = value;
+                    asyncStep(`connectionStatus - ${value}`);
                 },
                 configurable: true,
                 enumerable: true,
@@ -59,19 +61,21 @@ test("connection considered as lost after failed reconnect attempt", async () =>
     });
     unlockBus();
     await env.services.bus_service.start();
-    await waitForSteps(["isConnectionLost - false", "connect"]);
+    await waitForSteps(["connect"]);
     const unlockWebsocket = lockWebsocketConnect();
     MockServer.current.env["bus.bus"]._simulateDisconnection(
         WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE
     );
     await def;
-    await advanceTime(CONNECTION_LOST_WARNING_DELAY);
-    await waitForSteps([`isConnectionLost - true`]);
+    await advanceTime(CONNECTION_LOST_WARNING_DELAY - 1000);
+    await waitForSteps([`connectionStatus - ${CONNECTION_STATUS.CONNECTION_LOST}`]);
+    await advanceTime(1000);
+    await waitForSteps([`connectionStatus - ${CONNECTION_STATUS.CONNECTION_LOST_LONG}`]);
     unlockWebsocket();
-    await waitForSteps([`isConnectionLost - false`]);
+    await waitForSteps([`connectionStatus - ${CONNECTION_STATUS.CONNECTED}`]);
 });
 
-test("brief disconect not considered lost", async () => {
+test("brief disconnect not considered lost", async () => {
     stepConnectionStateChanges();
     const unlockBus = lockBusServiceStart();
     const env = await makeMockEnv();
@@ -79,9 +83,13 @@ test("brief disconect not considered lost", async () => {
     env.services.bus_service.addEventListener("reconnect", () => asyncStep("reconnect"));
     unlockBus();
     await env.services.bus_service.start();
-    await waitForSteps(["isConnectionLost - false", "connect"]);
+    await waitForSteps(["connect"]);
     MockServer.current.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.SESSION_EXPIRED);
-    await waitForSteps(["reconnect"]); // Only reconnect step, which means the monitoring state didn't change.
+    await waitForSteps([
+        `connectionStatus - ${CONNECTION_STATUS.CONNECTION_LOST}`,
+        `connectionStatus - ${CONNECTION_STATUS.CONNECTED}`,
+        "reconnect",
+    ]); // Only reconnect step, which means the monitoring state didn't change.
 });
 
 test("computer sleep doesn't mark connection as lost", async () => {
@@ -93,7 +101,7 @@ test("computer sleep doesn't mark connection as lost", async () => {
     env.services.bus_service.addEventListener("reconnect", () => asyncStep("reconnect"));
     unlockBus();
     await env.services.bus_service.start();
-    await waitForSteps(["isConnectionLost - false", "connect"]);
+    await waitForSteps(["connect"]);
     patchWithCleanup(navigator, { onLine: false });
     browser.dispatchEvent(new Event("offline")); // Offline event is triggered when the computer goes to sleep.
     const unlockWebsocket = lockWebsocketConnect();
@@ -103,5 +111,7 @@ test("computer sleep doesn't mark connection as lost", async () => {
     unlockWebsocket();
     await runAllTimers();
     await waitForSteps(["connect"]);
-    expect(env.services["bus.monitoring_service"].isConnectionLost).toBe(false);
+    expect(env.services["bus.monitoring_service"].connectionStatus).toBe(
+        CONNECTION_STATUS.CONNECTED
+    );
 });


### PR DESCRIPTION
Before this PR, the "real-time connection lost" alert was displayed right after the disconnection was detected.
This PR adds a 15s delay to avoid spamming the alert on unstable connexion.

Task-4453176