### PR TITLE
[FIX] stock: update `quant.inventory_diff_quantity` on `quantity` change

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -187,7 +187,7 @@ class StockQuant(models.Model):
         for quant in self:
             quant.last_count_date = date_by_quant.get((quant.location_id.id, quant.package_id.id, quant.product_id.id, quant.lot_id.id, quant.owner_id.id))
 
-    @api.depends('inventory_quantity')
+    @api.depends('inventory_quantity', 'quantity')
     def _compute_inventory_diff_quantity(self):
         for quant in self:
             quant.inventory_diff_quantity = quant.inventory_quantity - quant.quantity


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Create a new, storable product;
2. create a RFQ for 100 units of this product;
3. validate 75 units on delivery;
4. create a backorder for 25 units;
5. validate the remaining 25 units;
6. go to Inventory / Operations / Inventory Adjustments;
7. export the relevant adjustment in XLSX format;
8. open the file.

Issue
-----
Displayed difference is -75 (counted quantity - quant quantity), which is correct for the first RFQ, but doesn't take the backorder into account.

Cause
-----
The `inventory_diff_quantity` represents the difference between the `inventory_quantity` and `quantity` fields. Currently it is only called when `inventory_quantity` changes. The difference wasn't recomputed after the second RFQ further updated the `quantity` field.

Solution
--------
Add `quantity` as a dependent field to the compute method.

opw-4435925
opw-4435860