### PR TITLE
[FIX] web: increase z-index of form view statusbar

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -323,7 +323,7 @@
         @include media-breakpoint-up(md) {
             position: sticky;
             top: 0;
-            z-index: 1;
+            z-index: $zindex-modal + 1;
 
             &:not(.modal .o_form_statusbar) {
                 background-color: $body-bg;


### PR DESCRIPTION
Description of the issue this PR addresses:

Steps to reproduce:

1. Open the To-Do/Project app
2. Focus on HTML field and add some empty lines to make it scrollable.
3. Scroll the view and observe that the power buttons scroll above the status
bar.

Current behavior before PR:

A recent commit [1] made the form view statusbar sticky with a z-index of 1, which conflicts with the editor's local overlay.

Desired behavior after PR is merged:

The z-index of the statusbar is increased to 2, ensuring the editor's local overlay scrolls beneath the statusbar.

[1]: https://github.com/odoo/odoo/commit/a3c63413825cf3492a10ade77a2c571c4eeb33a6

task: 4457597

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
