### PR TITLE
[FIX] hw_drivers: missing import for logger

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+import logging
 import os
 import requests
 import subprocess
@@ -15,6 +16,8 @@ from odoo.addons.hw_drivers.main import iot_devices
 from odoo.addons.hw_drivers.tools import helpers, wifi
 from odoo.addons.hw_drivers.tools.helpers import Orientation
 from odoo.tools.misc import file_path
+
+_logger = logging.getLogger(__name__)
 
 
 class DisplayDriver(Driver):


### PR DESCRIPTION
DisplayDriver was missing the logger definition, resulting in a crash when a specific exception occured.
