### PR TITLE
[FIX] point_of_sale: print suggested tips in early receipt printed

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -127,7 +127,10 @@ export class ReceiptScreen extends Component {
         const isPrinted = await this.printer.print(
             OrderReceipt,
             {
-                data: this.pos.get_order().export_for_printing(),
+                data: {
+                    ...this.pos.get_order().export_for_printing(),
+                    isBill: this.isBill,
+                },
                 formatCurrency: this.env.utils.formatCurrency,
             },
             { webPrintFallback: true }
@@ -178,6 +181,9 @@ export class ReceiptScreen extends Component {
             orderPartner,
             ticketImage,
         ]);
+    }
+    get isBill() {
+        return false;
     }
 }
 


### PR DESCRIPTION
Before this commit, when tips were enabled after payment and early receipt printing was enabled, clicking on Bill would show the suggested tips on the Bill screen, but they were not included when printing the receipt.

opw-4455884

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
