### PR TITLE
[FIX] stock: prevent crash in mobile stock move line view

### DIFF
--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -167,6 +167,7 @@
                     <t t-name="kanban-box">
                         <div t-attf-class="oe_kanban_card oe_kanban_global_click">
                             <field name="picking_id" invisible="1"/>
+                            <field name="quant_id" invisible="1"/>
                             <div class="row">
                                 <div class="col-6">
                                     <field name="reference"/>


### PR DESCRIPTION
Steps to reproduce
==================

- Use a mobile viewport
- Go to Inventory > Delivery Orders
- Open any record
- Click on a product
- Click on add

=> TypeError: ml.data.quant_id is undefined

Cause of the issue
==================

On mobile, the quant_id field is not present in the view

opw-4288556