### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: minor fixes

### DIFF
--- a/addons/account_edi_ubl_cii/wizard/account_move_send.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send.py
@@ -242,6 +242,7 @@ class AccountMoveSend(models.TransientModel):
                 xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
                 xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
                 <cbc:ID>{escape(filename)}</cbc:ID>
+                <cbc:IssueDate>{invoice.invoice_date}</cbc:IssueDate>
                 {doc_type_node}
                 <cac:Attachment>
                     <cbc:EmbeddedDocumentBinaryObject

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_invoice.xml
@@ -14,6 +14,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_refund.xml
@@ -13,6 +13,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case1.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case1.xml
@@ -17,6 +17,7 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
+        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">___ignore___</cbc:EmbeddedDocumentBinaryObject>
         </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case2.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case2.xml
@@ -17,6 +17,7 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
+        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">___ignore___</cbc:EmbeddedDocumentBinaryObject>
         </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case3.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case3.xml
@@ -17,6 +17,7 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
+        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">___ignore___</cbc:EmbeddedDocumentBinaryObject>
         </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case4.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case4.xml
@@ -17,6 +17,7 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
+        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">___ignore___</cbc:EmbeddedDocumentBinaryObject>
         </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_export_with_changed_taxes.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_export_with_changed_taxes.xml
@@ -14,6 +14,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cac:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice.xml
@@ -14,6 +14,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_negative_unit_price.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_negative_unit_price.xml
@@ -17,6 +17,7 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
+        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">
                 ___ignore___

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_1.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_1.xml
@@ -14,6 +14,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_2.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_2.xml
@@ -14,6 +14,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_quantity_and_or_unit_price_zero.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_quantity_and_or_unit_price_zero.xml
@@ -14,6 +14,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_rounding.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_rounding.xml
@@ -17,6 +17,7 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
+        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">
                 ___ignore___

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_tax_exempt.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_tax_exempt.xml
@@ -14,6 +14,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cac:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_refund.xml
@@ -13,6 +13,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term.xml
@@ -17,6 +17,7 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
+        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">
                 ___ignore___

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_discount.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_discount.xml
@@ -14,6 +14,7 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
+        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cac:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">
                 ___ignore___

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_ecotax.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_ecotax.xml
@@ -17,6 +17,7 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
+        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">
                 ___ignore___

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
@@ -14,6 +14,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
    </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
@@ -18,6 +18,7 @@
   </cac:BillingReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice.xml
@@ -14,6 +14,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
    </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice_without_vat.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice_without_vat.xml
@@ -14,6 +14,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
    </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_refund.xml
@@ -13,6 +13,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
    </cbc:Attachment>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
@@ -15,6 +15,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:DocumentTypeCode listAgencyID="6" listID="UN/ECE 1001">380</cbc:DocumentTypeCode>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_fr.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_fr.xml
@@ -15,6 +15,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:DocumentTypeCode listAgencyID="6" listID="UN/ECE 1001">380</cbc:DocumentTypeCode>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_partner_dk.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_partner_dk.xml
@@ -15,6 +15,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:DocumentTypeCode listAgencyID="6" listID="UN/ECE 1001">380</cbc:DocumentTypeCode>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_refund_foreign_partner_fr.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_refund_foreign_partner_fr.xml
@@ -14,6 +14,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
     <cbc:ID>RINV_2017_00001.pdf</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:DocumentTypeCode listAgencyID="6" listID="UN/ECE 1001">381</cbc:DocumentTypeCode>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="RINV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
@@ -14,6 +14,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
     <cbc:ID>RINV_2017_00001.pdf</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:DocumentTypeCode listAgencyID="6" listID="UN/ECE 1001">381</cbc:DocumentTypeCode>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="RINV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice.xml
@@ -15,6 +15,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cac:Attachment>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_different_currency.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_different_currency.xml
@@ -15,6 +15,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cac:Attachment>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
@@ -15,6 +15,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cac:Attachment>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund.xml
@@ -14,6 +14,7 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
     <cbc:ID>RINV_2017_00001.pdf</cbc:ID>
+    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:DocumentTypeCode>50</cbc:DocumentTypeCode>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="RINV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -63,7 +63,8 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         # EXTENDS account.edi.xml.ubl_21
         vals = super()._get_partner_address_vals(partner)
         vals.update({
-            'city_subdivision_name ': partner.state_id.name,
+            'city_subdivision_name ': partner.city,
+            'city_name': partner.state_id.name,
             'country_subentity': False,
             'country_subentity_code': False,
         })

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -83,6 +83,7 @@ class AccountMove(models.Model):
             )
 
             if response.status_code == 200:
+                self.is_move_sent = True
                 self.l10n_tr_nilvera_send_status = 'sent'
             elif response.status_code in {401, 403}:
                 raise UserError(_("Oops, seems like you're unauthorised to do this. Try another API key with more rights or contact Nilvera."))
@@ -95,7 +96,7 @@ class AccountMove(models.Model):
                     return self._l10n_tr_nilvera_submit_document(xml_file, endpoint, post_series=False)
                 raise UserError(error_message)
             elif response.status_code == 500:
-                return UserError(_("Server error from Nilvera, please try again later."))
+                raise UserError(_("Server error from Nilvera, please try again later."))
 
             self.message_post(body=_("The invoice has been successfully sent to Nilvera."))
 

--- a/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py
@@ -93,6 +93,12 @@ class AccountMoveSend(models.TransientModel):
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS
     # -------------------------------------------------------------------------
+    def _link_invoice_documents(self, invoice, invoice_data):
+        # EXTENDS 'account'
+        super()._link_invoice_documents(invoice, invoice_data)
+        # The move needs to be put as sent only if sent by Nilvera
+        if invoice.company_id.country_code == 'TR':
+            invoice.is_move_sent = invoice.l10n_tr_nilvera_send_status == 'sent'
 
     @api.model
     def _call_web_service_before_invoice_pdf_render(self, invoices_data):
@@ -101,9 +107,12 @@ class AccountMoveSend(models.TransientModel):
 
         for invoice, invoice_data in invoices_data.items():
             if invoice_data.get('l10n_tr_nilvera_einvoice_xml'):
-                attachment_values = invoice_data.get('ubl_cii_xml_attachment_values')
-                xml_file = BytesIO(attachment_values.get('raw'))
-                xml_file.name = attachment_values.get('name')
+                if attachment_values := invoice_data.get('ubl_cii_xml_attachment_values'):
+                    xml_file = BytesIO(attachment_values.get('raw'))
+                    xml_file.name = attachment_values['name']
+                else:
+                    xml_file = BytesIO(invoice.ubl_cii_xml_id.raw or b'')
+                    xml_file.name = invoice.ubl_cii_xml_id.name or ''
 
                 if not invoice.partner_id.l10n_tr_nilvera_customer_alias_id:
                     # If no alias is saved, the user is either an E-Archive user or we haven't checked before. Check again


### PR DESCRIPTION
- Incorrect "Sent" Status:
When generating the XML with the UBL checkbox selected but without checking the
Nilvera option, the move was incorrectly marked as "Sent" (is_move_sent).  This
behavior has been corrected.

- Traceback During Send and Print with Nilvera:
In the flow where the XML is first generated with UBL, and then the Send and
Print action is performed with Nilvera, a traceback appeared since the
ubl_cii_xml_attachment_values was not in the invoice_data anymore.
Also Nilvera didn't accept the xml because they needed the issues date of the
document to accept it.

- City Name and Subdivision Inversion in XML
The values in the CitySubDivisionName and CityName elements of the XML were
inverted. This has been corrected to align with the expected structure.

task-4457092



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
