### PR TITLE
[FIX] account_peppol: key was never sent right so remove its use

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -127,7 +127,6 @@ class AccountEdiProxyClientUser(models.Model):
                     enc_key = content["enc_key"]
                     document_content = content["document"]
                     filename = content["filename"] or 'attachment'  # default to attachment, which should not usually happen
-                    partner_endpoint = content["accounting_supplier_party"]
                     decoded_document = edi_user._decrypt_data(document_content, enc_key)
                     attachment_vals = {
                         'name': f'{filename}.xml',
@@ -145,11 +144,7 @@ class AccountEdiProxyClientUser(models.Model):
                                 default_peppol_message_uuid=uuid,
                             )\
                             ._create_document_from_attachment(attachment.id)
-                        if partner_endpoint:
-                            move._message_log(body=_(
-                                'Peppol document has been received successfully. Sender endpoint: %s', partner_endpoint))
-                        else:
-                            move._message_log(body=_('Peppol document has been received successfully'))
+                        move._message_log(body=_('Peppol document has been received successfully'))
                     # pylint: disable=broad-except
                     except Exception:  # noqa: BLE001
                         # if the invoice creation fails for any reason,


### PR DESCRIPTION
`accounting_supplier_party` was never sent right from IAP, it was always 'None'.
So, we could never log it.
But the information was in fact always useless. 
This information is already in the UBL file.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
