### PR TITLE
[FIX] mrp: display correct date_planned_start

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -157,7 +157,7 @@ class StockRule(models.Model):
 
     def _get_date_planned(self, product_id, company_id, values):
         format_date_planned = fields.Datetime.from_string(values['date_planned'])
-        date_planned = format_date_planned - relativedelta(days=product_id.produce_delay)
+        date_planned = format_date_planned + relativedelta(days=product_id.produce_delay)
         if date_planned == format_date_planned:
             date_planned = date_planned - relativedelta(hours=1)
         return date_planned


### PR DESCRIPTION
Steps to reproduce:
---

- In settings activate the routes
- Set the route to MTO
- Create a BOM for this product
- Set a produce delay
- Make a sale order
- When confirming the MO created has the wrong Scheduled Date

Issue:
---

The Scheduled date is calculted as the current date minus the delay instead of +.

Fix:
---

Change the logic to add the produce_delay instead of minus.

opw-4061809

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
