### PR TITLE
[FIX] mrp: raise for bulk generation of mrp order

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1765,6 +1765,15 @@ class MrpProduction(models.Model):
         has_backorder_to_ignore = defaultdict(lambda: False)
         for production in self:
             mo_amounts = amounts.get(production)
+            if production.product_id.tracking == 'serial' and \
+                production.product_qty * sum(production.move_raw_ids.mapped('product_uom_qty')) > 50000000:
+                raise UserError(
+                    "You are about to create a very large number of Manufacturing Orders "
+                    f"for product {production.product_id.display_name} because it is "
+                    "tracked by serial number with high quantity. This may lead to "
+                    "performance issues. Please consider splitting your order into multiple "
+                    "batches or use a different tracking approach."
+                )
             if not mo_amounts:
                 amounts[production] = _default_amounts(production)
                 continue


### PR DESCRIPTION
Steps To reproduce:
----

- Create A MO on a product tracked by serial number
- Add Extremely high values for the quantity to produce
- OR add a large number of component to product with high quantities

Issue:
-----

Since the product are tracked there is as much MO as quantity resulting in the system 'crashing'.

Fix:
---

Raise an error so the user can reduce the size of the product created, the user can still split its MO in many other.

opw-4351629

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
