### PR TITLE
[FIX] {purchase_,}stock: merge multi lingual POL created by the same RR

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from operator import itemgetter
 from re import findall as regex_findall
 
-from odoo import _, api, Command, fields, models
+from odoo import SUPERUSER_ID, _, api, Command, fields, models
 from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.osv.expression import OR
@@ -2046,7 +2046,7 @@ Please change the quantity done or the rounding precision of your unit of measur
 
     def _get_lang(self):
         """Determine language to use for translated description"""
-        return self.picking_id.partner_id.lang or self.partner_id.lang or self.env.user.lang
+        return self.picking_id.partner_id.lang or self.partner_id.lang or (self.env.user.id != SUPERUSER_ID and self.env.user.lang) or self.env.context.get('lang') or self.env['res.users'].browse(SUPERUSER_ID).lang
 
     def _get_source_document(self):
         """ Return the move's document, used by `stock.forecasted_product_productt`


### PR DESCRIPTION
### Steps to reproduce:

- In the settings: - Add a second language say FR + Change the language - Enable Multi-step routes
- Put your warehouse in receipt in 2-steps.
- Create a storable product with a different FR name and a set vendor
- Click on the "Reordering Rules" smart button of the product form
- Create a reordering rule using the buy route for your product
- Add a quantity to reorder > "Order Once"
- Open the associated purchase order in a second window
- Repeat the operation of adding a quantity to reorder > "Order Once" ** A new POL is created instead of being merged to the first one**

### Cause of the issue:

Clicking on Order once will trigger a call of the `_run_pull`. At the end of this call, a stock move will be created and confirmed but the user of the env will be replaced by a SUPERUSER_ID for access rights purposes:
https://github.com/odoo/odoo/blob/39d7207aae187d055f19c7bce41df8110c045185/addons/stock/models/stock_rule.py#L283-L286 However, while the move data's were correctly generated using the language of the user that clicked on order once:
https://github.com/odoo/odoo/blob/39d7207aae187d055f19c7bce41df8110c045185/addons/stock/models/stock_rule.py#L278 https://github.com/odoo/odoo/blob/39d7207aae187d055f19c7bce41df8110c045185/addons/stock/models/stock_rule.py#L315 The language that will be used during the action confirm to compare with the picking description in the procurement values will be the language of the new user that is the SUPERUSER_ID in en_US: https://github.com/odoo/odoo/blob/39d7207aae187d055f19c7bce41df8110c045185/addons/stock/models/stock_move.py#L1451-L1456 This will lead to a set (and incorrect) `product_description_variants` on that procurement. However, this value will be used to determine in the `_run_buy` if an existing POL could absorb the newly created need: https://github.com/odoo/odoo/blob/39d7207aae187d055f19c7bce41df8110c045185/addons/purchase_stock/models/stock_rule.py#L131-L135 https://github.com/odoo/odoo/blob/39d7207aae187d055f19c7bce41df8110c045185/addons/purchase_stock/models/purchase_order_line.py#L341-L350 Since already existing POL will not be found to match the incorrect `product_description_variants` a new one will be created on that same PO.

### Fix:

We do not rely on the language of the user in case it is the SUPERUSER_ID.

opw-4397376
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
