### PR TITLE
[FIX] pos_sale: prevent double consumption repair

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -102,7 +102,7 @@ class StockPicking(models.Model):
 
     def _link_owner_on_return_picking(self, lines):
         """This method tries to retrieve the owner of the returned product"""
-        if lines[0].order_id.refunded_order_id.picking_ids:
+        if lines and lines[0].order_id.refunded_order_id.picking_ids:
             returned_lines_picking = lines[0].order_id.refunded_order_id.picking_ids
             returnable_qty_by_product = {}
             for move_line in returned_lines_picking.move_line_ids:

--- a/addons/pos_sale/models/stock_picking.py
+++ b/addons/pos_sale/models/stock_picking.py
@@ -16,4 +16,4 @@ class StockPicking(models.Model):
                 continue
             lines_to_unreserve |= line
         lines_to_unreserve.sale_order_line_id.move_ids.filtered(lambda ml: ml.state not in ['cancel', 'done'])._do_unreserve()
-        return super()._create_move_from_pos_order_lines(lines)
+        return super()._create_move_from_pos_order_lines(lines.filtered(lambda l: not l.sale_order_line_id or l.sale_order_line_id.has_valued_move_ids()))

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -944,8 +944,10 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.repair1.action_repair_start()
         self.repair1.action_repair_end()
         self.repair1.action_create_sale_order()
+        self.assertEqual(len(self.product_1.stock_move_ids.ids), 2, "There should be 2 stock moves for the product created by the repair order")
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosRepairSettleOrder', login="pos_user")
+        self.assertEqual(len(self.product_1.stock_move_ids.ids), 2, "Paying for the order in PoS should not create new stock moves")
 
     def test_settle_order_ship_later_delivered_qty(self):
         """This test create an order, settle it in the PoS and ship it later.


### PR DESCRIPTION
When creating a repair order, and paying it with a POS order, the product from the repair order would be consumed twice, once when creating the repair order, and once when validating the POS order. So we end up with 2 stock moves for the same product.

Steps to reproduce:
-------------------
* Create a repair order for any product
* Add product A to the part list
* Start and end the repair (at this point one stock move is created)
* Create a quotation for the repair order
* Open PoS and settle the quotation
* Validate the PoS order, and check the stock moves for the product A
> Observation: You can see one more stock move for the product A
coming from the PoS order

Why the fix:
------------
We make a similar fix as this one https://github.com/odoo/odoo/pull/186812 to prevent the creation of stock moves when the product is coming from a repair order.

opw-4351266