### PR TITLE
[IMP] iot_box_image: add vim configuration

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/home/pi/.vimrc
+++ b/addons/iot_box_image/overwrite_before_init/home/pi/.vimrc
@@ -1,3 +1,4 @@
+filetype on
 set all&
 set autoindent
 set backspace=2
@@ -11,7 +12,9 @@ set hidden
 set history=500
 set hlsearch
 set ignorecase
+set laststatus=2
 set modeline
+set mouse=a
 set ruler
 set shiftwidth=4
 set scrolloff=5
@@ -25,3 +28,4 @@ set wrap
 set list
 set listchars=tab:~.,trail:.,extends:>,precedes:<
 set viminfo="NONE"
+syntax on


### PR DESCRIPTION
This PR adds some features to the vim configuration used on the IoT Box (a new image is needed to make it work)
1. `filetype on` allows vim to detect the file extension and adjust syntax highglighting accordingly
2. `set laststatus=2` allows to display useful infobar at the bottom of the editor
3. `set mouse=a` enables the mouse in vim
4. `syntax on` uses colors to highlight code in vim

