### PR TITLE
[FIX] account: creating a bank statement from the transaction list view

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -74,7 +74,6 @@ class AccountBankStatement(models.Model):
         comodel_name='account.bank.statement.line',
         inverse_name='statement_id',
         string='Statement lines',
-        required=True,
     )
 
     # A statement assumed to be complete when the sum of encoded lines is equal to the difference between start and

--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -123,7 +123,10 @@ class AccountBankStatement(models.Model):
     @api.depends('create_date')
     def _compute_name(self):
         for stmt in self:
-            stmt.name = _("%(journal_code)s Statement %(date)s", journal_code=stmt.journal_id.code, date=stmt.date)
+            name = ''
+            if stmt.journal_id:
+                name = stmt.journal_id.code + ' '
+            stmt.name = name +_("Statement %(date)s", date=stmt.date or fields.Date.to_date(stmt.create_date))
 
     @api.depends('line_ids.internal_index', 'line_ids.state')
     def _compute_date_index(self):


### PR DESCRIPTION
Step to reproduce
* open the reconcilation widget and toggle the list view
* multi edit bank statement lines and assign them a new bank statement with name 'BLABLA 1'
* click save and see how Odoo just didn't keep your name at all

The reason is that the module account_bank_statement_extract forces the recomputation of the name when the statement's date changes which happens at the creation (and triggers our bug) but also when the OCR fills that value (in which case we still want that).

So to fix that,
* the default name of the statement line now check if the statement date is falsy, to avoid having a default name as 'BNK1 Statement False', and fallback on the create_date
* when filling the OCR values, we check if the statement still has the same structure, we can assume it wasn't manually changed and we can safely replace the default name

ticket-4424021

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
