### PR TITLE
[FIX] point_of_sale: remove receipt scrollbar

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
@@ -10,8 +10,7 @@
 .pos-receipt {
     .product-name {
         -webkit-line-clamp: unset;
-        overflow: auto;
-        overflow-wrap: break-word;
+        overflow-wrap: anywhere;
     }
 }
 


### PR DESCRIPTION
Receipt printed with short names would have a scrollbar shown on it The issue was added in this previous commit: https://github.com/odoo/odoo/pull/192544

opw-4414311
