### PR TITLE
[FIX] portal: invoice layout issue

### DIFF
--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -362,6 +362,11 @@ img, .media_iframe_video, .o_image {
             @include o-position-sticky($top: $spacer * 5);
             z-index: 1;
         }
+
+        span.oe_currency_value {
+            word-break: break-word !important;
+            white-space: normal !important;
+        }
     }
 }
 


### PR DESCRIPTION
This PR addresses the layout issue in the sidebar of the portal, where a preview of the customer's invoice is displayed.

Before this PR, users encountered a broken layout for large invoice amounts, making it difficult to read the total.

This issue is resolved in this PR by adding a rules for the `h2` and `span` fields ensuring proper wrapping for better readability.


Steps to reproduce:

- Login as admin.
- Go to Website app.
- Navigate to "My account" at my/home url.
- Click on "My invoices" or navigate to my/invoices url.
- Click on one invoice in order to see its preview.
- Via the browser tools, edit the amount of on the left sidebar and insert a very big number.

task-4435472

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
