### PR TITLE
[FIX] stock_picking_batch: create a new wave for SML with 0 quantity

### DIFF
--- a/addons/stock_picking_batch/models/stock_move_line.py
+++ b/addons/stock_picking_batch/models/stock_move_line.py
@@ -96,8 +96,7 @@ class StockMoveLine(models.Model):
     def _is_auto_waveable(self):
         self.ensure_one()
         if not self.picking_id \
-           or self.picking_id.state != 'assigned' \
-           or float_is_zero(self.quantity, precision_rounding=self.product_uom_id.rounding) \
+           or (self.picking_id.state != 'assigned' or float_is_zero(self.quantity, precision_rounding=self.product_uom_id.rounding)) and not self.env.context.get('skip_auto_waveable')  \
            or self.batch_id.is_wave \
            or not self.picking_type_id._is_auto_wave_grouped() \
            or (self.picking_type_id.wave_group_by_category and self.product_id.categ_id not in self.picking_type_id.wave_category_ids):  # noqa: SIM103

--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -167,6 +167,7 @@ class StockPicking(models.Model):
         assignable_pickings = self.env['stock.picking'].browse(to_assign_ids)
         for picking in assignable_pickings:
             picking._find_auto_batch()
+        assignable_pickings.move_line_ids.with_context(skip_auto_waveable=True)._auto_wave()
 
         return res
 

--- a/addons/stock_picking_batch/tests/test_auto_waving.py
+++ b/addons/stock_picking_batch/tests/test_auto_waving.py
@@ -318,6 +318,13 @@ class TestAutoWaving(TransactionCase):
         self.assertEqual(len(wave_1.move_line_ids), 3)
         self.assertEqual(wave_1.picking_ids.partner_id, self.us_client)
         self.assertEqual(wave_1.move_line_ids.product_id, self.product_1)
+        # set quantity of a move line to 0 to check if it's correctly moved to another wave.
+        self.assertEqual(wave_1.move_line_ids.mapped('quantity'), [2.0, 3.0, 2.0])
+        modified_move_line = wave_1.move_line_ids[0]
+        modified_move_line.quantity = 0
+        self.assertEqual(wave_1.move_line_ids.mapped('quantity'), [0.0, 3.0, 2.0])
+        wave_1.action_done()
+        self.assertTrue(modified_move_line.batch_id.id not in [wave_1.id, False])
 
         wave_2 = waves.filtered(lambda w: w.description == f'United States, {self.product_2.name}')
         self.assertEqual(len(wave_2), 1)


### PR DESCRIPTION
Steps to reproduce the bug:
- Enable the multi-step route.
- Go to the Delivery Operation Type:
    - Enable "Automatic Batches". - Enable "Wave Grouping". - Product Category: All
- Create two storable products: "P1" and "P2".
- Create a first delivery:
    - One unit of P1.
    - Mark it as "To Do" → a wave transfer is created.
- Create a second delivery:
    - One unit of P2.
    - Mark it as "To Do" → it is added to the first wave.
- Go to the wave:
     - Update the quantity of P2 to 0.
- Validate the wave

Problem:
The picking of P2 is detached but not linked to a new wave.

opw-4444263
