### PR TITLE
[FIX] account: prevent double currency column when multiple active currencies exist

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -405,7 +405,7 @@
                     <field name="move_type" column_invisible="True"/>
                     <field name="is_same_currency" column_invisible="True"/>
                     <field name="is_account_reconcile" column_invisible="True"/>
-                    <field name="currency_id" groups="base.group_multi_currency" invisible="1"/>
+                    <field name="currency_id" groups="!base.group_multi_currency" column_invisible="True"/>
                     <groupby name="partner_id">
                         <button name="edit" type="edit" icon="fa-edit" title="Edit"/>
                     </groupby>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR addresses the issue where the currency column repeats in view_move_line_payment_tree view when there are multiple active currencies. This can lead to confusion and clutter in the user interface.

Current behavior before PR:
Before this PR, when multiple active currencies are set up, the currency column is duplicated in view_move_line_payment_tree view, displaying the same information multiple times.

Desired behavior after PR is merged:
After merging this PR, the currency column will appear only once when the optional hide setting is enabled, even with multiple active currencies, resulting in a cleaner and more readable report.

[Video](https://drive.google.com/file/d/1bL8L88y81HomX6Q9MkErmOGVDWHdE4_r/view)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
