### PR TITLE
[PERF] web: use count limit on the domain field widget

### DIFF
--- a/addons/web/static/src/views/fields/domain/domain_field.xml
+++ b/addons/web/static/src/views/fields/domain/domain_field.xml
@@ -61,7 +61,7 @@
                         <t t-else="">
                             <t t-if="state.isValid">
                                 <button class="btn btn-sm btn-link o_domain_show_selection_button" type="button" t-on-click.stop="onButtonClick">
-                                    <t t-esc="state.recordCount" /> record(s)
+                                    <t t-esc="state.recordCount" /><t t-if="state.hasLimitedCount">+</t> record(s)
                                 </button>
                             </t>
                             <t t-else="">
@@ -75,7 +75,7 @@
                                     role="img"
                                     aria-label="Refresh"
                                     title="Refresh"
-                                    t-on-click="() => this.checkProps()"
+                                    t-on-click="() => this.fetchCount()"
                                 />
                             </t>
                         </t>

--- a/addons/web/static/tests/core/domain_field.test.js
+++ b/addons/web/static/tests/core/domain_field.test.js
@@ -554,6 +554,88 @@ test("domain field: does not wait for the count to render", async function () {
     expect(".o_domain_show_selection_button").toHaveText("2 record(s)");
 });
 
+test("domain field: have a default count limit of 10000", async function () {
+    serverState.debug = true;
+
+    Partner._fields.bar = fields.Char();
+    Partner._records = [
+        {
+            foo: "[]",
+            bar: "product",
+        },
+    ];
+    Partner._views = {
+        form: `
+                <form>
+                    <field name="bar"/>
+                    <field name="foo" widget="domain" options="{'model': 'bar'}"/>
+                </form>`,
+        search: `<search />`,
+    };
+
+    onRpc("search_count", ({ kwargs }) => {
+        expect.step(kwargs.limit);
+        return 99999;
+    });
+
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction({
+        name: "test",
+        res_id: 1,
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [[false, "form"]],
+    });
+    expect.verifySteps([10001]);
+    expect(".o_domain_show_selection_button").toHaveText("10000+ record(s)");
+
+    // click on the refresh button
+    await contains(".o_refresh_count").click();
+    expect.verifySteps([undefined]);
+    expect(".o_domain_show_selection_button").toHaveText("99999 record(s)");
+});
+
+test("domain field: configurable count limit", async function () {
+    serverState.debug = true;
+
+    Partner._fields.bar = fields.Char();
+    Partner._records = [
+        {
+            foo: "[]",
+            bar: "product",
+        },
+    ];
+    Partner._views = {
+        form: `
+                <form>
+                    <field name="bar"/>
+                    <field name="foo" widget="domain" options="{'model': 'bar', 'count_limit': 10}"/>
+                </form>`,
+        search: `<search />`,
+    };
+
+    onRpc("search_count", ({ kwargs }) => {
+        expect.step(kwargs.limit);
+        return 99999;
+    });
+
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction({
+        name: "test",
+        res_id: 1,
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [[false, "form"]],
+    });
+    expect.verifySteps([11]);
+    expect(".o_domain_show_selection_button").toHaveText("10+ record(s)");
+
+    // click on the refresh button
+    await contains(".o_refresh_count").click();
+    expect.verifySteps([undefined]);
+    expect(".o_domain_show_selection_button").toHaveText("99999 record(s)");
+});
+
 test("domain field: edit domain with dynamic content", async function () {
     expect.assertions(3);
 


### PR DESCRIPTION
Executing a search count on a table with a large number of records can be slow, which is why a limit was added on b37d221e.

The same issue exists on the domain field widget, and so the same solution is applied here.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
