### PR TITLE
[FIX] l10n_ar_website_sale: Invoice date

### DIFF
--- a/addons/l10n_ar_website_sale/__init__.py
+++ b/addons/l10n_ar_website_sale/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import controllers
 from . import models
+from . import tests

--- a/addons/l10n_ar_website_sale/models/__init__.py
+++ b/addons/l10n_ar_website_sale/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import website
+from . import sale_order

--- a/addons/l10n_ar_website_sale/models/sale_order.py
+++ b/addons/l10n_ar_website_sale/models/sale_order.py
@@ -1,0 +1,30 @@
+import pytz
+
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _prepare_invoice(self):
+        """ Necessary because if someone creates an invoice after 9 pm Argentina time, if the invoice is created
+        automatically, then it is created with the date of the next day (UTC date) instead of today.
+
+        This fix is necessary because it causes problems validating invoices in ARCA (ex AFIP), since when generating
+        the invoice with the date of the next day, no more invoices could be generated with today's date.
+
+        We took the same approach that was used in the POS module to set the date, in this case always forcing the
+        Argentina timezone """
+        res = super()._prepare_invoice()
+
+        # Find the invoice journal (given, or default one)
+        journal_id = res.get('journal_id')
+        journal = self.env['account.journal'].browse(journal_id) if journal_id else \
+            self.env['account.journal'].search([('type', '=', 'sale')], limit=1)
+
+        if journal.country_code == 'AR':
+            timezone = pytz.timezone('America/Buenos_Aires')
+            context_today_ar = fields.Datetime.now().astimezone(timezone).date()
+            res.update({'invoice_date': context_today_ar})
+
+        return res

--- a/addons/l10n_ar_website_sale/tests/__init__.py
+++ b/addons/l10n_ar_website_sale/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_invoice

--- a/addons/l10n_ar_website_sale/tests/test_invoice.py
+++ b/addons/l10n_ar_website_sale/tests/test_invoice.py
@@ -1,0 +1,45 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+from freezegun import freeze_time
+
+from odoo.addons.account_payment.tests.common import AccountPaymentCommon
+from odoo.addons.sale.tests.common import SaleCommon
+from odoo.addons.l10n_ar.tests.common import TestAr
+
+
+@tagged('-at_install', 'post_install', 'post_install_l10n')
+class TestWebsiteSaleInvoice(AccountPaymentCommon, SaleCommon, TestAr):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.website = cls.env['website'].create({'name': 'Test AR Website'})
+
+    def test_website_automatic_invoice_date(self):
+        # Set automatic invoice
+        self.env['ir.config_parameter'].sudo().set_param('sale.automatic_invoice', 'True')
+        self.frozen_today = "2025-01-24T21:10:00"
+        with freeze_time(self.frozen_today, tz_offset=3):
+
+            # Prepare values needed for AR invoice generation: Tax in all lines, and AFIP responsibility partner
+            self.sale_order.order_line.write({'tax_id': self.company_data['default_tax_sale']})
+            self.sale_order.partner_id = self.partner_cf
+            self.sale_order.currency_id = self.env.ref('base.ARS')
+
+            # Create SO on Test Website
+            self.sale_order.website_id = self.website.id
+
+            # Create the payment and invoices
+            self.amount = self.sale_order.amount_total
+            tx = self._create_transaction(flow='redirect', sale_order_ids=[self.sale_order.id], state='done')
+            with mute_logger('odoo.addons.sale.models.payment_transaction'):
+                tx.with_context(l10n_ar_invoice_skip_commit=True)._reconcile_after_done()
+
+            invoice = self.sale_order.invoice_ids
+            self.assertTrue(invoice, "Do not create the invoice")
+            self.assertEqual(invoice.state, "posted", "the invoice was not posted")
+            self.assertEqual(fields.Datetime.now().date().strftime("%Y-%m-%d"), '2025-01-25', "UCT should be next day")
+            self.assertEqual(invoice.invoice_date.strftime('%Y-%m-%d'), '2025-01-24', "Should be AR current date")


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

If someone creates an invoice after 9 pm Argentina time, if the invoice is created automatically, then it is created with the date of the next day (UTC date) instead of today. This causes problems validating invoices in ARCA (ex AFIP), since when generating the invoice with the next day's date, no more invoices could be generated with today's date.

### Current behavior before PR:

1. Make e-commerce sales after 9 PM local time AR in a website set as automatic invoicing = True (journal by default it is an electronic journal)
2. Try to generate another invoice after that day, A simple way to test it is to make an invoice and then validate it.
3. We will receive ARCA (ex-AFIP) error telling us that we can not generate the invoice with today's date, we can only validate invoices with a date equal to or greater than tomorrow. 

### Desired behavior after PR is merged:

1. Make e-commerce sales after 9 PM local time AR in a website set as automatic invoicing = True (journal by default it is an electronic journal)
2. Try to generate another invoice after that day, A simple way to test it is to make an invoice and then validate it.
3. Manual invoice will be generated and validated in AFIP with today's date as the invoice date.


NOTE: We took the same approach that was used in the [POS module](https://github.com/odoo/odoo/blob/16.0/addons/point_of_sale/models/pos_order.py#L615-L631) to set the date, in this case, always forcing the Argentina timezone

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
