### PR TITLE
[IMP] website_event: use turnstile when available

### DIFF
--- a/addons/website_cf_turnstile/__manifest__.py
+++ b/addons/website_cf_turnstile/__manifest__.py
@@ -16,6 +16,7 @@ This module implements Cloudflare Turnstile so that you can prevent bot spam on 
         'web.assets_frontend': [
             'website_cf_turnstile/static/src/js/turnstile.js',
             'website_cf_turnstile/static/src/js/error_handler.js',
+            'website_cf_turnstile/static/src/xml/turnstile.xml',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/website_cf_turnstile/static/src/js/turnstile.js
+++ b/addons/website_cf_turnstile/static/src/js/turnstile.js
@@ -2,44 +2,57 @@
 
 import "@website/snippets/s_website_form/000";  // force deps
 import publicWidget from '@web/legacy/js/public/public_widget';
+import { renderToElement } from "@web/core/utils/render";
 import { session } from "@web/session";
 
 export const turnStile = {
     addTurnstile: function (action) {
-        if (!this.isEditable && !this.$(".s_turnstile").length) {
+        if (!this.isEditable) {
             const mode = new URLSearchParams(window.location.search).get('cf') == 'show' ? 'always' : 'interaction-only';
-            return $(`<div class="s_turnstile cf-turnstile float-end"
-                        style="display: none;"
-                        data-action="${action}"
-                        data-appearance="${mode}"
-                        data-response-field-name="turnstile_captcha"
-                        data-sitekey="${session.turnstile_site_key}"
-                        data-error-callback="throwTurnstileError"
-                        data-callback="turnstileSuccess"
-                        data-before-interactive-callback="turnstileBecomeVisible"
-                ></div>
-                <script class="s_turnstile">
-                    // Rethrow the error, or we only will catch a "Script error" without any info
-                    // because of the script api.js originating from a different domain.
-                    function throwTurnstileError(code) {
-                        const error = new Error("Turnstile Error");
-                        error.code = code;
-                        throw error;
-                    }
-                    function turnstileSuccess() {
-                        const form = this.wrapper.parentElement.parentElement;
-                        const spinner = form.querySelector("i.turnstile-spinner");
-                        const button = spinner.parentElement;
-                        button.disabled = false;
-                        button.classList.remove('disabled');
-                        spinner.remove();
-                    }
-                    function turnstileBecomeVisible() {
-                        this.wrapper.parentElement.style.display = '';
-                    }
-                </script>
-                <script class="s_turnstile" src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>
-            `);
+            const turnstileContainer = renderToElement("website_cf_turnstile.turnstile_container", {
+                action: action,
+                appearance: mode,
+                additionalClasses: "float-end",
+                beforeInteractiveGlobalCallback: "turnstileBecomeVisible",
+                errorGlobalCallback: "throwTurnstileErrorCode",
+                executeGlobalCallback: "turnstileSuccess",
+                sitekey: session.turnstile_site_key,
+                style: "display: none;",
+            });
+            let toInsert = $(turnstileContainer);
+
+            // Rethrow the error, or we only will catch a "Script error" without any info
+            // because of the script api.js originating from a different domain.
+            globalThis.throwTurnstileErrorCode = function (code) {
+                const error = new Error("Turnstile Error");
+                error.code = code;
+                throw error;
+            };
+            // `this` is bound to the turnstile widget calling the callback
+            globalThis.turnstileSuccess = function () {
+                const turnstileContainer = this.wrapper.parentElement;
+                const form = turnstileContainer.parentElement;
+                const spinner = form.querySelector("i.turnstile-spinner");
+                const button = spinner.parentElement;
+                button.disabled = false;
+                button.classList.remove("disabled");
+                spinner.remove();
+            };
+            globalThis.turnstileBecomeVisible = function () {
+                const turnstileContainer = this.wrapper.parentElement;
+                turnstileContainer.style.display = "";
+            };
+
+            // on first load of the remote script, all turnstile containers are rendered
+            // if render=explicit is not set in the script url.
+            // For subsequent insertion of turnstile containers, we need to call turnstile.render on the container
+            // see `renderTurnstile`.
+            if (!window.turnstile?.render) {
+                const turnstileScript = renderToElement("website_cf_turnstile.turnstile_remote_script");
+                toInsert = toInsert.add($(turnstileScript));
+            }
+
+            return toInsert;
         }
     },
 
@@ -61,9 +74,50 @@ export const turnStile = {
         this._super(...arguments);
     },
 
-    addSpinner(button) {
+    /**
+     * Take the result of `addTurnstile` and render it if needed
+     */
+    renderTurnstile: function (turnstileNodes) {
+        turnstileNodes = turnstileNodes.toArray();
+        const turnstileContainer = turnstileNodes.filter((node) =>
+            node.classList.contains("s_turnstile_container")
+        )[0];
+        const turnstileScript = turnstileNodes.filter(
+            (node) => node.id === "s_turnstile_remote_script"
+        )[0];
+        // there should only be a remote script if it was loaded for the first time
+        if (turnstileScript) {
+            return;
+        }
+        if (
+            window.turnstile?.render &&
+            turnstileContainer &&
+            !turnstileContainer.querySelector("iframe")
+        ) {
+            window.turnstile.render(turnstileContainer);
+        }
+    },
+
+    _createSpinner() {
         const spinner = document.createElement("i");
         spinner.classList.add("fa", "fa-refresh", "fa-spin", "turnstile-spinner");
+        return spinner;
+    },
+
+    /**
+     * same as addSpinner but does not set innerText
+     */
+    addSpinnerNoMangle(button) {
+        const spinner = this._createSpinner();
+        spinner.classList.add("me-1");
+        button.disabled = true;
+        button.classList.add("disabled");
+        button.prepend(spinner);
+    },
+
+    addSpinner(button) {
+        const spinner = this._createSpinner();
+        // avoids double-spacing if the button already contains a space
         button.innerText = " " + button.innerText;
         button.disabled = true;
         button.classList.add("disabled");
@@ -82,7 +136,9 @@ const signupTurnStile = {
         const button = this.el.querySelector('button[type="submit"]');
         this.addSpinner(button);
         this.cleanTurnstile();
-        this.addTurnstile(this.action)?.insertBefore(button);
+        const turnstileNodes = this.addTurnstile(this.action);
+        turnstileNodes?.insertBefore(button);
+        this.renderTurnstile(turnstileNodes);
     },
 };
 
@@ -98,7 +154,9 @@ publicWidget.registry.s_website_form.include({
             const button = this.el.querySelector(".s_website_form_send, .o_website_form_send");
             this.addSpinner(button);
             this.cleanTurnstile();
-            this.addTurnstile("website_form")?.insertAfter(button);
+            const turnstileNodes = this.addTurnstile("website_form");
+            turnstileNodes?.insertAfter(button);
+            this.renderTurnstile(turnstileNodes);
         }
         return res;
     },

--- a/addons/website_cf_turnstile/static/src/xml/turnstile.xml
+++ b/addons/website_cf_turnstile/static/src/xml/turnstile.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="website_cf_turnstile.turnstile_container">
+        <div
+            t-attf-class="s_turnstile s_turnstile_container cf-turnstile {{additionalClasses}}"
+            t-att-data-action="action"
+            t-att-data-appearance="appeareance || 'interaction-only'"
+            t-att-data-before-interactive-callback="beforeInteractiveGlobalCallback || '() => {}'"
+            t-att-data-callback="executeGlobalCallback || '() => {}'"
+            t-att-data-error-callback="errorGlobalCallback || '() => {}'"
+            data-response-field-name="turnstile_captcha"
+            t-att-data-sitekey="sitekey"
+            t-att-style="style"
+        ></div>
+    </t>
+    <t t-name="website_cf_turnstile.turnstile_remote_script">
+        <script id="s_turnstile_remote_script" class="s_turnstile" src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>
+    </t>
+</templates>

--- a/addons/website_event/static/src/js/website_event.js
+++ b/addons/website_event/static/src/js/website_event.js
@@ -4,6 +4,7 @@ import publicWidget from "@web/legacy/js/public/public_widget";
 import { _t } from "@web/core/l10n/translation";
 import { ReCaptcha } from "@google_recaptcha/js/recaptcha";
 import { jsonrpc } from "@web/core/network/rpc_service";
+import { session } from "@web/session";
 
 // Catch registration form event, because of JS for attendee details
 var EventRegistrationForm = publicWidget.Widget.extend({
@@ -15,6 +16,11 @@ var EventRegistrationForm = publicWidget.Widget.extend({
         this._super(...arguments);
         this._recaptcha = new ReCaptcha();
         this.notification = this.bindService("notification");
+        // dynamic get rather than import as we don't depend on this module
+        if (session.turnstile_site_key) {
+            const { turnStile } = odoo.loader.modules.get("@website_cf_turnstile/js/turnstile");
+            this._turnstile = turnStile;
+        }
     },
 
     /**
@@ -79,6 +85,8 @@ var EventRegistrationForm = publicWidget.Widget.extend({
                 return false;
             }
             var $modal = $(modal);
+            const form = $modal[0].querySelector("form#attendee_registration");
+            self._addTurnstile(form);
             $modal.find('.modal-body > div').removeClass('container'); // retrocompatibility - REMOVE ME in master / saas-19
             $modal.appendTo(document.body);
             const modalBS = new Modal($modal[0], {backdrop: 'static', keyboard: false});
@@ -99,6 +107,23 @@ var EventRegistrationForm = publicWidget.Widget.extend({
                 ev.currentTarget.appendChild(tokenInput);
             })
         });
+    },
+
+    _addTurnstile: function (form) {
+        if (!this._turnstile) {
+            return false;
+        }
+
+        const turnstileNodes = this._turnstile.addTurnstile("website_event_registration");
+
+        const modalFooter = form.querySelector("div.modal-footer");
+        const formButton = form.querySelector("button[type=submit]");
+
+        this._turnstile.addSpinnerNoMangle(formButton);
+        turnstileNodes.prependTo(modalFooter);
+        this._turnstile.renderTurnstile(turnstileNodes);
+
+        return true;
     },
 });
 


### PR DESCRIPTION
We recently enabled recaptcha on the registration form in [1]

Turnstile can be implemented on top of it by just invoking the turnstile script in js.

As it's implicitly checked when recaptcha is checked, this also avoids any issue with the form potentially not working if turnstile is enabled.

[1]: bafa915f85fb8fc6ca2ae7d194a4593cb2463c2e

task-4335141
