### PR TITLE
[FIX] purchase_requisition: remove existing currency rate in tests

### DIFF
--- a/addons/purchase_requisition/tests/test_purchase_requisition.py
+++ b/addons/purchase_requisition/tests/test_purchase_requisition.py
@@ -13,6 +13,11 @@ from odoo.tests.common import tagged
 @tagged('post_install', '-at_install')
 class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestPurchaseRequisition, cls).setUpClass()
+        cls.env['res.currency.rate'].search([]).unlink()
+
     def test_00_purchase_requisition_users(self):
         self.assertTrue(self.user_purchase_requisition_manager, 'Manager Should be created')
         self.assertTrue(self.user_purchase_requisition_user, 'User Should be created')


### PR DESCRIPTION
This commit removes the existing currency rate before creating the new ones as there is a unicity constrains on the currency rate date.

runbot-error: 111437

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
