### PR TITLE
[FIX] mail: error on mention click by guest

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -429,22 +429,9 @@ export class Store extends BaseStore {
             ev.preventDefault();
             this.openChat({ partnerId: id });
             return true;
-        } else if (ev.target.tagName === "A" && model && id) {
-            ev.preventDefault();
-            Promise.resolve(
-                this.env.services.action.doAction({
-                    type: "ir.actions.act_window",
-                    res_model: model,
-                    views: [[false, "form"]],
-                    res_id: id,
-                })
-            ).then(() => this.onLinkFollowed(thread));
-            return true;
         }
         return false;
     }
-
-    onLinkFollowed(fromThread) {}
 
     setup() {
         super.setup();

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -126,5 +126,28 @@ const StorePatch = {
         this.store.starred.messages = [];
         await this.env.services.orm.call("mail.message", "unstar_all");
     },
+    handleClickOnLink(ev, thread) {
+        const model = ev.target.dataset.oeModel;
+        const id = Number(ev.target.dataset.oeId);
+        const isLinkHandledBySuper = super.handleClickOnLink(...arguments);
+        if (!isLinkHandledBySuper && ev.target.tagName === "A" && id && model) {
+            ev.preventDefault();
+            Promise.resolve(
+                this.env.services.action.doAction({
+                    type: "ir.actions.act_window",
+                    res_model: model,
+                    views: [[false, "form"]],
+                    res_id: id,
+                })
+            ).then(() => this.onLinkFollowed(thread));
+            return true;
+        }
+        return false;
+    },
+    onLinkFollowed(fromThread) {
+        if (!this.env.isSmall && fromThread?.model === "discuss.channel") {
+            fromThread.open(true, { autofocus: false });
+        }
+    },
 };
 patch(Store.prototype, StorePatch);

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -6,12 +6,6 @@ const storeServicePatch = {
     get onlineMemberStatuses() {
         return ["away", "bot", "online"];
     },
-    onLinkFollowed(fromThread) {
-        super.onLinkFollowed(...arguments);
-        if (!this.env.isSmall && fromThread?.model === "discuss.channel") {
-            fromThread.open(true, { autofocus: false });
-        }
-    },
     sortMembers(m1, m2) {
         return m1.persona.name?.localeCompare(m2.persona.name) || m1.id - m2.id;
     },


### PR DESCRIPTION
Purpose of this commit:
When an operator mentions someone in an ongoing live chat conversation and the guest clicks on it, a traceback error is raised. This occurs because clicking on the mention attempts to execute an action to open the mentioned partner's record. Since the guest user lacks access to the action services in the services registry, the error is triggered. This commit resolves the issue.

task-4459050





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
