### PR TITLE
[IMP] payment, _*: add fpx for razorpay

### DIFF
--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -330,12 +330,13 @@
         <field name="payment_method_ids"
                eval="[Command.set([
                          ref('payment.payment_method_card'),
+                         ref('payment.payment_method_emi_india'),
+                         ref('payment.payment_method_fpx'),
                          ref('payment.payment_method_netbanking'),
+                         ref('payment.payment_method_paylater_india'),
+                         ref('payment.payment_method_paynow'),
                          ref('payment.payment_method_upi'),
                          ref('payment.payment_method_wallets_india'),
-                         ref('payment.payment_method_paylater_india'),
-                         ref('payment.payment_method_emi_india'),
-                         ref('payment.payment_method_paynow'),
                      ])]"
         />
     </record>

--- a/addons/payment_razorpay/const.py
+++ b/addons/payment_razorpay/const.py
@@ -115,9 +115,15 @@ DEFAULT_PAYMENT_METHOD_CODES = {
 
 # The codes of payment methods that are not recognized by the orders API.
 FALLBACK_PAYMENT_METHOD_CODES = {
-    'wallets_india',
-    'paylater_india',
     'emi_india',
+    'fpx',
+    'paylater_india',
+    'wallets_india',
+}
+
+# The codes of payment methods that require redirection back to the website
+REDIRECT_PAYMENT_METHOD_CODES = {
+    'fpx',
 }
 
 # Mapping of payment method codes to Razorpay codes.

--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -6,12 +6,14 @@ import time
 from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
+from werkzeug.urls import url_encode, url_join
 
 from odoo import _, api, models
 from odoo.exceptions import UserError, ValidationError
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment_razorpay import const
+from odoo.addons.payment_razorpay.controllers.main import RazorpayController
 
 
 _logger = logging.getLogger(__name__)
@@ -45,6 +47,11 @@ class PaymentTransaction(models.Model):
             'razorpay_customer_id': customer_id,
             'is_tokenize_request': self.tokenize,
             'razorpay_order_id': order_id,
+            'callback_url': url_join(
+                self.provider_id.get_base_url(),
+                f'{RazorpayController._return_url}?{url_encode({"reference": self.reference})}'
+            ),
+            'redirect': self.payment_method_id.code in const.REDIRECT_PAYMENT_METHOD_CODES,
         }
 
     def _razorpay_create_customer(self):


### PR DESCRIPTION
_* = payment_razorpay

This commit introduces support for FPX as a payment method in the Razorpay.

Why this solution?
When using the Razorpay Orders API, specifying fpx as the payment method in the payload results in an error: 'currency should be INR when method is fpx'. This limitation prevents FPX from being used directly in the API call.

What is the solution?
To address this, FPX has been added to the FALLBACK_PAYMENT_METHOD_CODES. This adjustment ensures that no specific payment method is included in the API payload, allowing Razorpay to present the user with a payment form listing all available methods. From there, the user can select FPX as their preferred payment method.

task-4364895

See also:
- https://github.com/odoo/upgrade/pull/7033
