### PR TITLE
[FIX] web_editor: fix video option in media dialog

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1689,7 +1689,7 @@ export class Wysiwyg extends Component {
             close: () => restoreSelection(),
             ...this.options.mediaModalParams,
             ...params,
-            noVideos: !this.options.allowCommandVideo,
+            noVideos: !this.options.allowCommandVideo || params.noVideos,
         });
     }
     // todo: test me


### PR DESCRIPTION
After merging of this PR [1], video tab will not be visible in media dialog in report as `allowCommandVideo` is false. But this will override `noVideos` option from `params` to false if `allowCommandVideo` is true and video tab will be visible even if `noVideos` is `true`.

This PR makes sure that `noVideos` property from `params` should be checked if `allowCommandVideo` is true.

[1]: 187251



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
