### PR TITLE
[FIX] hr_expense: fix computation of unit amount on expense with attachment

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -299,7 +299,7 @@ class HrExpense(models.Model):
             if expense.state != 'draft':
                 continue
             product_id = expense.product_id
-            if product_id and expense.product_has_cost and not expense.attachment_number or (expense.attachment_number and not expense.unit_amount):
+            if product_id and expense.product_has_cost and (not expense.attachment_number or (expense.attachment_number and not expense.unit_amount)):
                 expense.unit_amount = product_id.price_compute(
                     'standard_price',
                     uom=expense.product_uom_id,

--- a/doc/cla/corporate/acsone.md
+++ b/doc/cla/corporate/acsone.md
@@ -36,3 +36,4 @@ Maxime Franco maxime.franco@acsone.eu https://github.com/FrancoMaxime
 Marie Lejeune marie.lejeune@acsone.eu https://github.com/marielejeune
 Justine Doutreloux justine.doutreloux@acsone.eu https://github.com/jdoutreloux
 Laurent Stukkens laurent.stukkens@acsone.eu https://github.com/it-ideas
+Zina Rasoamanana zina.rasoamanana@acsone.eu https://github.com/AnizR


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

- Computation of 'unit_amount' was creating an error when having an 'hr.expense' that had not product, unit_amount of 0 and an attachment.

- Knowing that the expression of a boolean follows some priorities of operation (_parentheses then, 'and' then, 'or'_), it seems evident that the expression will be evaluated to True when having no 'product_id', 'unit_amount'==0 and an attachment linked. But, the unit_amount needs a product to be computed. Therefore, an error will occur!

## Current behavior before PR:

The cron 'Expense OCR: Update All Status' fails due to computation of 'unit_amount' on 'hr.expense' with not product, unit_amount of 0 and an attachment linked.

## Desired behavior after PR is merged:

No error during execution of 'Expense OCR: Update All Status'.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
