### PR TITLE
[IMP] html_builder, website: enable vertical alignment in snippets

### DIFF
--- a/addons/html_builder/static/src/plugins/vertical_alignment_option.js
+++ b/addons/html_builder/static/src/plugins/vertical_alignment_option.js
@@ -2,7 +2,7 @@ import { BaseVerticalAlignmentOption } from "./base_vertical_alignment_option";
 
 export class VerticalAlignmentOption extends BaseVerticalAlignmentOption {
     static selector =
-        ".s_text_image, .s_image_text, .s_three_columns, .s_showcase, .s_numbers, .s_faq_collapse, .s_references, .s_accordion_image, .s_shape_image, .s_reviews_wall";
+        ".s_text_image, .s_image_text, .s_three_columns, .s_showcase, .s_numbers, .s_faq_collapse, .s_references, .s_accordion_image, .s_shape_image, .s_reviews_wall, .s_key_images, .s_cards_soft, .s_cards_grid";
     static applyTo = ".row";
     static name = "verticalAlignmentOption";
 }

--- a/addons/html_builder/static/src/plugins/vertical_alignment_option.xml
+++ b/addons/html_builder/static/src/plugins/vertical_alignment_option.xml
@@ -4,7 +4,7 @@
 <t t-name="html_builder.VerticalAlignmentOption">
     <t t-if="!isActiveItem('grid_mode')">
         <!-- TODO add title tooltip row Vertical Alignment-->
-        <BuilderRow label.translate="Vert. Alignment" level="this.level">
+        <BuilderRow label.translate="Vert. Alignment" tooltip.translate="Vertical Alignment" level="this.level">
             <BuilderButtonGroup action="'setVerticalAlignment'">
                 <BuilderButton actionParam="'align-items-start'" title.translate="Align Top" iconImg="'/html_builder/static/img/snippets_options/align_top.svg'"/>
                 <BuilderButton actionParam="'align-items-center'" title.translate="Align Middle" iconImg="'/html_builder/static/img/snippets_options/align_middle.svg'"/>

--- a/addons/html_builder/static/src/plugins/vertical_alignment_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/vertical_alignment_option_plugin.js
@@ -13,6 +13,48 @@ export class VerticalAlignmentOptionPlugin extends Plugin {
             SetVerticalAlignmentAction,
         },
     };
+
+    setup() {
+        this.upgradeContainers();
+    }
+
+    // TODO: Remove once data-vxml="number" snippet comparison is restored.
+    upgradeContainers() {
+        // Upgrade legacy card snippets for visual consistency on new versions.
+        const snippetEls = this.document.querySelectorAll(
+            ".s_cards_soft:not([data-vxml]), .s_cards_grid:not([data-vxml])"
+        );
+
+        for (const snippetEl of snippetEls) {
+            // Handle all cards inside the section
+            for (const cardEl of snippetEl.querySelectorAll(".s_card")) {
+                const rowEl = cardEl.closest(".row");
+                // Preserve top alignment for cards that originally lacked h-100
+                if (!rowEl?.classList.contains("align-items-start")) {
+                    rowEl.classList.add("align-items-start");
+                }
+
+                // Ensure each card stretches fully
+                cardEl.classList.add("h-100");
+
+                // Additional handling for .s_cards_grid
+                if (snippetEl.classList.contains("s_cards_grid")) {
+                    const colAncestor = cardEl.closest("[class*='col-']");
+                    if (colAncestor) {
+                        colAncestor.classList.add("d-flex", "flex-column");
+                    }
+
+                    const cardImg = cardEl.querySelector(".o_card_img, img");
+                    if (cardImg) {
+                        cardImg.classList.add("object-fit-cover");
+                    }
+                }
+            }
+
+            // Once all cards in this section are updated, mark it as vxml 001
+            snippetEl.dataset.vxml = "001";
+        }
+    }
 }
 
 export class SetVerticalAlignmentAction extends ClassAction {

--- a/addons/website/static/tests/builder/website_builder/snippet_layout.test.js
+++ b/addons/website/static/tests/builder/website_builder/snippet_layout.test.js
@@ -1,0 +1,26 @@
+import { expect, test } from "@odoo/hoot";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilderWithSnippet,
+} from "@website/../tests/builder/website_helpers";
+import { contains } from "@web/../tests/web_test_helpers";
+import { queryOne } from "@odoo/hoot-dom";
+
+defineWebsiteModels();
+
+test("snippet vertical alignment", async () => {
+    const snippets = ["s_key_images", "s_cards_soft", "s_cards_grid"];
+    await setupWebsiteBuilderWithSnippet(["s_cards_soft", "s_key_images", "s_cards_grid"]);
+    for (const snippet of snippets) {
+        await contains(`:iframe .${snippet}`).click();
+        const snippetRow = queryOne(`:iframe .${snippet} .row`);
+        await contains("[data-action-param='align-items-start']").click();
+        expect(snippetRow).toHaveClass("align-items-start");
+        await contains("[data-action-param='align-items-center']").click();
+        expect(snippetRow).toHaveClass("align-items-center");
+        await contains("[data-action-param='align-items-end']").click();
+        expect(snippetRow).toHaveClass("align-items-end");
+        await contains("[data-action-param='align-items-stretch']").click();
+        expect(snippetRow).toHaveClass("align-items-stretch");
+    }
+});

--- a/addons/website/views/snippets/s_cards_grid.xml
+++ b/addons/website/views/snippets/s_cards_grid.xml
@@ -2,14 +2,14 @@
 <odoo>
 
 <template id="s_cards_grid" name="Cards Grid">
-    <section class="s_cards_grid o_colored_level o_cc o_cc2 pt64 pb64">
+    <section class="s_cards_grid o_colored_level o_cc o_cc2 pt64 pb64" data-vxml="001">
         <div class="container">
             <h2 class="h3-fs">Features that set us apart</h2>
             <div class="row">
-                <div data-name="Card" class="col-lg-6">
-                    <div class="s_card o_card_img_horizontal o_cc o_cc1 card flex-lg-row" data-vxml="001" data-snippet="s_card" data-name="Card" style="--card-img-size-h: 25%;">
+                <div data-name="Card" class="col-lg-6 d-flex flex-column">
+                    <div class="s_card o_card_img_horizontal o_cc o_cc1 card flex-lg-row h-100" data-vxml="001" data-snippet="s_card" data-name="Card" style="--card-img-size-h: 25%;">
                         <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
-                            <img class="o_card_img rounded-start" src="/web/image/website.s_key_images_default_image_1" alt=""/>
+                            <img class="o_card_img rounded-start object-fit-cover" src="/web/image/website.s_key_images_default_image_1" alt=""/>
                         </figure>
                         <div class="card-body">
                             <h3 class="card-title h5-fs">Quality and Excellence</h3>
@@ -17,10 +17,10 @@
                         </div>
                     </div>
                 </div>
-                <div data-name="Card" class="col-lg-6">
-                    <div class="s_card o_card_img_horizontal o_cc o_cc1 card flex-lg-row" data-vxml="001" data-snippet="s_card" data-name="Card" style="--card-img-size-h: 25%;">
+                <div data-name="Card" class="col-lg-6 d-flex flex-column">
+                    <div class="s_card o_card_img_horizontal o_cc o_cc1 card flex-lg-row h-100" data-vxml="001" data-snippet="s_card" data-name="Card" style="--card-img-size-h: 25%;">
                         <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
-                            <img class="o_card_img rounded-start" src="/web/image/website.s_key_images_default_image_2" alt=""/>
+                            <img class="o_card_img rounded-start object-fit-cover" src="/web/image/website.s_key_images_default_image_2" alt=""/>
                         </figure>
                         <div class="card-body">
                             <h3 class="card-title h5-fs">Expertise and Knowledge</h3>
@@ -28,10 +28,10 @@
                         </div>
                     </div>
                 </div>
-                <div data-name="Card" class="col-lg-6">
-                    <div class="s_card o_card_img_horizontal o_cc o_cc1 card flex-lg-row" data-vxml="001" data-snippet="s_card" data-name="Card" style="--card-img-size-h: 25%;">
+                <div data-name="Card" class="col-lg-6 d-flex flex-column">
+                    <div class="s_card o_card_img_horizontal o_cc o_cc1 card flex-lg-row h-100" data-vxml="001" data-snippet="s_card" data-name="Card" style="--card-img-size-h: 25%;">
                         <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
-                            <img class="o_card_img rounded-start" src="/web/image/website.s_key_images_default_image_3" alt=""/>
+                            <img class="o_card_img rounded-start object-fit-cover" src="/web/image/website.s_key_images_default_image_3" alt=""/>
                         </figure>
                         <div class="card-body">
                             <h3 class="card-title h5-fs">Eco-Friendly Solutions</h3>
@@ -39,10 +39,10 @@
                         </div>
                     </div>
                 </div>
-                <div data-name="Card" class="col-lg-6">
-                    <div class="s_card o_card_img_horizontal o_cc o_cc1 card flex-lg-row" data-vxml="001" data-snippet="s_card" data-name="Card" style="--card-img-size-h: 25%;">
+                <div data-name="Card" class="col-lg-6 d-flex flex-column">
+                    <div class="s_card o_card_img_horizontal o_cc o_cc1 card flex-lg-row h-100" data-vxml="001" data-snippet="s_card" data-name="Card" style="--card-img-size-h: 25%;">
                         <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
-                            <img class="o_card_img rounded-start" src="/web/image/website.s_key_images_default_image_4" alt=""/>
+                            <img class="o_card_img rounded-start object-fit-cover" src="/web/image/website.s_key_images_default_image_4" alt=""/>
                         </figure>
                         <div class="card-body">
                             <h3 class="card-title h5-fs">Tailored Solutions</h3>

--- a/addons/website/views/snippets/s_cards_soft.xml
+++ b/addons/website/views/snippets/s_cards_soft.xml
@@ -2,13 +2,13 @@
 <odoo>
 
 <template id="s_cards_soft" name="Cards Soft">
-    <section class="s_cards_soft o_cc o_cc1 pt48 pb32">
+    <section class="s_cards_soft o_cc o_cc1 pt48 pb32" data-vxml="001">
         <div class="container">
             <h2 style="text-align: center;">Your Journey Begins Here</h2>
             <p class="lead" style="text-align: center;">We make every moment count with solutions designed just for you.</p>
             <div class="row">
                 <div data-name="Card" class="col-lg-4 pt16 pb16">
-                    <div class="s_card card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
+                    <div class="s_card card o_cc o_cc2 h-100" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
                         <div class="card-body">
                             <h3 class="card-title h5-fs">Innovative Ideas</h3>
                             <p class="card-text">Our creativity is at the forefront of everything we do, delivering innovative solutions that make your project stand out while maintaining a balance between originality and functionality.</p>
@@ -17,7 +17,7 @@
                     </div>
                 </div>
                 <div data-name="Card" class="col-lg-4 pt16 pb16">
-                    <div class="s_card card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
+                    <div class="s_card card o_cc o_cc2 h-100" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
                         <div class="card-body">
                             <h3 class="card-title h5-fs">Comprehensive Support</h3>
                             <p class="card-text">From the initial stages to completion, we offer support every step of the way, ensuring you feel confident in your choices and that your project is a success.</p>
@@ -26,7 +26,7 @@
                     </div>
                 </div>
                 <div data-name="Card" class="col-lg-4 pt16 pb16">
-                    <div class="s_card card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
+                    <div class="s_card card o_cc o_cc2 h-100" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
                         <div class="card-body">
                             <h3 class="card-title h5-fs">Timeless Quality</h3>
                             <p class="card-text">Our services are built to last, ensuring that every solution we provide is of the highest quality, bringing lasting value to your investment and ultimate customer satisfaction.</p>


### PR DESCRIPTION
This improvement allows better layout control for card-based snippets.

**Key Changes Made:**

* Added tooltip **“Vertical Alignment”** for the snippet option.
* Added test cases to cover new options and prevent regressions.
* Fixed stretch alignment for `s_cards_soft` and `s_cards_grid`:

  * **`s_cards_grid`**: Updated `.col-lg-6` containers with `d-flex flex-column` and `object-fit-cover` for proper image scaling.
  * **`s_cards_soft`**: Applied `h-100` to cards for consistent height.
* Added backward compatibility through `upgradeContainers` on setup for already dropped snippets to maintain expected behavior.
* Added data attribute `data-vxml="001"` to modified snippets for version tracking.

These changes improve flexibility and visual consistency of card-based snippets, ensuring equal height behavior and proper image rendering regardless of content length.

task-4432821