### PR TITLE
[IMP] mail: enable translations in live chat

### DIFF
--- a/addons/im_livechat/static/src/core/common/message_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/message_model_patch.js
@@ -1,0 +1,16 @@
+import { Message } from "@mail/core/common/message_model";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").Message} */
+const messagePatch = {
+    isTranslatable(thread) {
+        return (
+            super.isTranslatable(thread) ||
+            (this.store.hasMessageTranslationFeature &&
+                thread?.channel_type === "livechat" &&
+                thread?.selfMember.persona.isInternalUser)
+        );
+    },
+};
+patch(Message.prototype, messagePatch);

--- a/addons/im_livechat/static/tests/translation.test.js
+++ b/addons/im_livechat/static/tests/translation.test.js
@@ -1,0 +1,29 @@
+import { describe, test } from "@odoo/hoot";
+import { click, contains, openDiscuss, start, startServer } from "@mail/../tests/mail_test_helpers";
+import { Command, serverState } from "@web/../tests/web_test_helpers";
+import { defineLivechatModels } from "./livechat_test_helpers";
+
+describe.current.tags("desktop");
+defineLivechatModels();
+
+test("message translation in livechat", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        anonymous_name: "Visitor",
+        channel_type: "livechat",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: serverState.publicPartnerId }),
+        ],
+    });
+    pyEnv["mail.message"].create({
+        body: "Mai mettere l'ananas sulla pizza!",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message");
+    await click("[title='Expand']");
+    await contains("[title='Translate']");
+});


### PR DESCRIPTION
With this commit message translation will be available in livechat channels for internal users.

task-4457025
