### PR TITLE
[FIX] sale_stock: inventory installation after so

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -58,15 +58,19 @@ class SaleOrder(models.Model):
         """
         if column_name != "warehouse_id":
             return super(SaleOrder, self)._init_column(column_name)
-        field = self._fields[column_name]
-        default = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
-        value = field.convert_to_write(default, self)
-        value = field.convert_to_column_insert(value, self)
-        if value is not None:
-            _logger.debug("Table '%s': setting default value of new column %s to %r",
-                self._table, column_name, value)
-            query = f'UPDATE "{self._table}" SET "{column_name}" = %s WHERE "{column_name}" IS NULL'
-            self._cr.execute(query, (value,))
+
+        default_warehouse = self.env["stock.warehouse"].search([], limit=1)
+
+        query = f"""
+        UPDATE sale_order so
+        SET warehouse_id = COALESCE(wh.id, %s)
+        FROM stock_warehouse wh
+        WHERE so.company_id = wh.company_id
+        """
+        params = [default_warehouse.id]
+
+        _logger.debug("Initializing column '%s' in table '%s'", column_name, self._table)
+        self._cr.execute(query, params)
 
     @api.depends('picking_ids.date_done')
     def _compute_effective_date(self):


### PR DESCRIPTION
Steps to reproduce:
1. create 2 companies,
2. install sales,
3. create SOs for both companies,
4. install Inventory,
5. Group SOs into warehouse for Company B

Issue:
All so's are under Warehouse A even though Warehouse B is created

Cause:
We take the first available company

Solution:
There should be only one warehouse defined per company
https://github.com/odoo/odoo/blob/c045a5c9d6f6dd52271d9ab6b4265fd849cd53de/addons/stock/models/stock_warehouse.py#L32-L34

opw-4376078