### PR TITLE
[IMP] project: exclude archived users when duplicating or recurring tasks

### DIFF
--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -406,3 +406,21 @@ class TestProjectFlow(TestProjectCommon, MailCase):
         self.project_pigs.stage_id = stage.id
         project_copy = self.project_pigs.with_context(default_stage_id=stage.id).copy()
         self.assertNotEqual(project_copy.stage_id, self.project_pigs.stage_id, 'Copied project should have lowest sequence stage')
+
+    def test_project_task_copy_without_archive_user(self):
+        self.user_projectuser.action_archive()
+        task = self.task_1.copy()
+        self.assertFalse(task.user_ids)
+        task_b = self.task_2.copy({
+            'name': 'Task B',
+            'user_ids': [Command.set([self.user_projectuser.id, self.user_projectmanager.id])],
+        })
+        self.assertEqual(self.user_projectuser + self.user_projectmanager, task_b.user_ids)
+
+    def test_project_sub_task_copy_without_archive_user(self):
+        self.task_1.write({
+            'child_ids': [self.task_2.id]
+        })
+        self.user_projectmanager.action_archive()
+        task_1_copy = self.task_1.copy()
+        self.assertFalse(task_1_copy.child_ids.user_ids)


### PR DESCRIPTION
Prior to this commit, duplicating or recurring a task results in archived user being assigned to the new task and its associated sub tasks. This change ensures that archived users are excluded from the assignees of the new task and any sub tasks when a task is duplicated or repeated.

task-4419770