### PR TITLE
[FIX] mail: correct h-padding for "record created" message

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -201,7 +201,7 @@
 </t>
 
 <t t-name="mail.Message.bodyAsNotification">
-    <div class="o-mail-Message-body text-break mb-0 w-100">
+    <div class="o-mail-Message-body text-break mb-0 w-100" t-att-class="{'o-note': message.message_type == 'notification'}">
         <t t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
     </div>
 </t>


### PR DESCRIPTION
Before this commit, the "Record created" message, shown as the very 1st message of chatter, had some horizontal start padding in text content. This was unaligned with header and looks off.

This was happening because the message looks like a logged note, but it didn't have the `.o-note` modifier class to put the appropriate padding for the body of message with such a look. Due to the missing `.o-note` classname, this was assuming the style was the one with a bubble around, which needs extra padding, hence the problematic padding.

This commit fixes the issue by adding `.o-note` in classname of such message notification that looks like a logged note, so that the padding matches the one with logged note.

task-4291913

Before / After
<img width="245" alt="Screenshot 2025-01-08 at 12 51 17" src="https://github.com/user-attachments/assets/8e388a88-705f-4c19-a6ec-d2168f1e6e56" /> <img width="243" alt="Screenshot 2025-01-08 at 12 50 48" src="https://github.com/user-attachments/assets/092b1508-d663-4336-900a-b55875437c05" />

