### PR TITLE
[FIX] mail: correct systray call menu styling in community

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_menu.js
+++ b/addons/mail/static/src/discuss/call/common/call_menu.js
@@ -11,6 +11,7 @@ export class CallMenu extends Component {
         super.setup();
         this.rtc = useState(useService("discuss.rtc"));
         this.callActions = useCallActions();
+        this.isEnterprise = odoo.info && odoo.info.isEnterprise;
     }
 
     get icon() {

--- a/addons/mail/static/src/discuss/call/common/call_menu.scss
+++ b/addons/mail/static/src/discuss/call/common/call_menu.scss
@@ -1,10 +1,20 @@
 .o-discuss-CallMenu-buttonContent {
     max-width: 150px;
     @include o-mail-call-bordered(.7);
+
+    &.o-isOdooCommunity {
+        height: $o-navbar-height - 20px !important; // same button height as in enterprise.
+        overflow: hidden;
+        color: $o-action !important;
+    }
 }
 
 .o-discuss-CallMenu-animation {
     animation: flash 2s;
     animation-direction: alternate;
     animation-iteration-count: 2;
+
+    &.o-isOdooCommunity {
+        transform: translateY(10px);
+    }
 }

--- a/addons/mail/static/src/discuss/call/common/call_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_menu.xml
@@ -4,11 +4,11 @@
     <t t-name="discuss.CallMenu">
         <div class="dropdown" t-attf-class="{{ className }}" t-ref="root">
             <button t-if="rtc.state.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="rtc.state.channel.open">
-                <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center o-gap-0_5 rounded-3 opacity-75 opacity-100-hover px-1">
+                <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center o-gap-0_5 rounded-3 opacity-75 opacity-100-hover px-1" t-att-class="{ 'o-isOdooCommunity': !isEnterprise }">
                     <span class="position-relative small bg-inherit">
                         <i class="me-2 fa fa-fw" t-att-class="icon" />
                         <small class="d-flex position-absolute top-0 end-0 smaller bg-inherit">
-                            <i class="o-discuss-CallMenu-animation fa fa-volume-up o-discuss-inCallIconColor bg-inherit"/>
+                            <i class="o-discuss-CallMenu-animation fa fa-volume-up o-discuss-inCallIconColor bg-inherit" t-att-class="{ 'o-isOdooCommunity': !isEnterprise }"/>
                         </small>
                     </span>
                     <span class="text-truncate fw-bold pe-1" t-esc="rtc.state.channel.displayName"/>


### PR DESCRIPTION
**Current behavior before PR:**
The Systray Call menu in the community edition displayed 
incorrect styles due to improperly written CSS.

**Desired behavior after PR is merged:**
The issue is resolved by applying the correct conditions in the CSS.

Before / After
![image](https://github.com/user-attachments/assets/76006b75-ec99-48db-aef5-4533a6d8c39d)
![image](https://github.com/user-attachments/assets/15638110-d2ae-4040-bca8-5881c2c1d0b4)

Task-[4458263](https://www.odoo.com/odoo/my-tasks/4458263)
Enterprise-https://github.com/odoo/enterprise/pull/76910


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
