### PR TITLE
[FIX] point_of_sale: add default logs location fallback to IoT log do…

### DIFF
--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -82,13 +82,11 @@ class DriverController(http.Controller):
         """
         Downloads the log file
         """
-        log_path = tools.config['logfile']
-        if not log_path:
-            raise InternalServerError("Log file configuration is not set")
+        log_path = tools.config['logfile'] or "/var/log/odoo/odoo-server.log"
         try:
             stat = os.stat(log_path)
         except FileNotFoundError:
-            raise InternalServerError("Log file has not been found")
+            raise InternalServerError("Log file has not been found. Check your Log file configuration.")
         check = adler32(log_path.encode())
         log_file_name = f"iot-odoo-{gethostname()}-{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.log"
         # intentionally don't use Stream.from_path as the path used is not in the addons path


### PR DESCRIPTION
…wnload

Current behavior before PR:
 When using the "Download logs" button, from the IoT box form view, an Internal Server Error is raised every time.
```py
Internal Server Error : Log file configuration is not set
```

Description of the issue/feature this PR addresses:
New IoT Box images are missing the default `logfile` parameter in their config. This parameter is required for log downloading, and cannot be left empty.

The `logfile` parameter has been removed from the `odoo.conf` config file in PR #169633. However, it is still explicitly mentioned as `/var/log/odoo/odoo-server.log` in two other files: https://github.com/odoo/odoo/blob/451a956a22015034b8c35bd0d9a860b78442af7f/addons/hw_posbox_homepage/controllers/homepage.py#L74 and
https://github.com/odoo/odoo/blob/451a956a22015034b8c35bd0d9a860b78442af7f/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh#L28 As such, a fallback to the default `/var/log/odoo/odoo-server.log` is added.

Desired behavior after PR is merged:
The Logs can be downloaded from the IoT box form view without receiving an Internal Server Error.

opw-4443593

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
