### PR TITLE
[IMP] web: form: more readable margin bottom logic on small screen

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -42,16 +42,6 @@
         }
 
     }
-
-    @include media-breakpoint-down(md) {
-        .o_cell:has(+ :is(.o_wrap_label, .o_wrap_field_boolean)),
-        .o_cell.o_wrap_input,
-        .o_wrap_field_boolean,
-        .o_cell_custom:not(.o_wrap_label),
-        .o_cell:first-child:last-child {
-            margin-bottom: map-get($spacers, 3);
-        }
-    }
 }
 
 

--- a/addons/web/static/src/views/form/form_group/form_group.xml
+++ b/addons/web/static/src/views/form/form_group/form_group.xml
@@ -18,16 +18,19 @@
         </div>
         <t t-foreach="getRows()" t-as="row" t-key="row_index" t-if="row.isVisible">
             <t t-foreach="row" t-as="cell" t-key="cell_index">
-
+                <t t-set="marginOnSmallScreen" t-value="cell_last ? 'mb-3 mb-sm-0' : ''"/>
                 <t t-if="cell.subType === 'item_component'">
-                    <t t-call="web.Form.InnerGroup.ItemComponent"><t t-set="cell" t-value="cell" /></t>
+                    <t t-call="web.Form.InnerGroup.ItemComponent">
+                        <t t-set="cell" t-value="cell" />
+                        <t t-set="marginOnSmallScreen" t-value="marginOnSmallScreen" />
+                    </t>
                 </t>
 
                 <t t-else="">
                     <div
                         class="o_cell o_cell_custom"
                         t-attf-style="{{ cell.itemSpan > 1 ? '--o-grid-column-span: ' + cell.itemSpan + ';' : '' }}"
-                        t-attf-class="{{ cell.subType === 'label' ? 'o_wrap_label text-break text-900' : null }}"
+                        t-attf-class="{{ cell.subType === 'label' ? 'o_wrap_label text-break text-900' : null }} {{ marginOnSmallScreen }}"
                         t-if="cell.isVisible">
                         <t t-slot="{{ cell.name }}" />
                     </div>
@@ -45,12 +48,13 @@
         </div>
         <div
         class="o_cell o_wrap_input text-break"
+        t-attf-class="{{ marginOnSmallScreen }}"
         t-attf-style="{{ cell.itemSpan -1 > 1 ? 'grid-column: span ' + (cell.itemSpan -1) + ';' : '' }}">
             <t t-slot="{{ cell.name }}"/>
         </div>
     </t>
     <t t-else="">
-        <div class="o_wrap_field_boolean d-flex d-sm-contents">
+        <div class="o_wrap_field_boolean d-flex d-sm-contents" t-attf-class="{{ marginOnSmallScreen }}">
             <div class="o_cell o_wrap_label flex-sm-grow-0 text-break text-900">
                 <t t-component="cell.Component" t-if="cell.isVisible" t-props="cell.props"/>
             </div>


### PR DESCRIPTION
Since the removal of the `d-contents d-sm-flex` in the inner group of form views, we have replaced the margin bottom on small screen with a CSS rules.

This commit doesn't change the visual but, move the logic from very long unreadable specific CSS selector to the QWeb template using Bootstrap classes (`mb-3 mb-sm-0`) on the last cell of an inner group's line.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
