### PR TITLE
[IMP] web: remove try/catch when domain is parsed

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -302,11 +302,7 @@ export class SearchBar extends Component {
         const context = { ...this.env.searchModel.domainEvalContext, ...field.context };
         let domain = [];
         if (searchItem.domain) {
-            try {
-                domain = new Domain(searchItem.domain).toList(context);
-            } catch {
-                // Pass
-            }
+            domain = new Domain(searchItem.domain).toList(context);
         }
         const relation =
             searchItem.type === "field_property"

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1457,18 +1457,7 @@ export class SearchModel extends EventBus {
                 }
             }
         }
-        let context;
-        try {
-            context = makeContext(contexts);
-            return context;
-        } catch (error) {
-            throw new Error(
-                _t("Failed to evaluate the context: %(context)s.\n%(error)s", {
-                    context,
-                    error: error.message,
-                })
-            );
-        }
+        return makeContext(contexts);
     }
 
     /**
@@ -1538,18 +1527,8 @@ export class SearchModel extends EventBus {
             domains.push(this._getSearchPanelDomain());
         }
 
-        let domain;
-        try {
-            domain = Domain.and(domains);
-            return params.raw ? domain : domain.toList(this.domainEvalContext);
-        } catch (error) {
-            throw new Error(
-                _t("Failed to evaluate the domain: %(domain)s.\n%(error)s", {
-                    domain: domain.toString(),
-                    error: error.message,
-                })
-            );
-        }
+        const domain = Domain.and(domains);
+        return params.raw ? domain : domain.toList(this.domainEvalContext);
     }
 
     _getFacets() {
@@ -1966,19 +1945,14 @@ export class SearchModel extends EventBus {
                 // should set {'field1': [value1, value2]} in the context
                 let context = {};
                 if (searchItem.context) {
-                    try {
-                        const self = activeItem.autocompletValues.map(
-                            (autocompleValue) => autocompleValue.value
-                        );
-                        context = evaluateExpr(searchItem.context, { self });
-                        if (typeof context !== "object") {
-                            throw Error();
-                        }
-                    } catch (error) {
+                    const self = activeItem.autocompletValues.map(
+                        (autocompleValue) => autocompleValue.value
+                    );
+                    context = evaluateExpr(searchItem.context, { self });
+                    if (typeof context !== "object") {
                         throw new Error(
-                            _t("Failed to evaluate the context: %(context)s.\n%(error)s", {
+                            _t("Failed to evaluate the context: %(context)s.", {
                                 context: searchItem.context,
-                                error: error.message,
                             })
                         );
                     }

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -1579,6 +1579,24 @@ test("select autocompleted many2one with allowed_company_ids domain", async () =
     ]);
 });
 
+test("throw error when domain can not be parsed", async () => {
+    expect.errors(1);
+    await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field name="bar" domain="[('company', 'in', wrong)]"/>
+            </search>
+        `,
+    });
+
+    await editSearch("rec");
+    await contains(`.o_expand`).click();
+    expect.verifyErrors(["Error: Name 'wrong' is not defined"]);
+});
+
 test("dropdown menu last element is 'Add Custom Filter'", async () => {
     await mountWithSearch(SearchBar, {
         resModel: "partner",


### PR DESCRIPTION
Before this commit, try/catchs when parsing the domain were used in the
search bar and in the search model. These try/catchs are not necessary,
because the domain is validated with the python view validation.
Also, the try/catch on the search bar was hiding the error, because it
was siliently ignored.