### PR TITLE
[FIX] pos_self_order: ensure sending stand number to server

### DIFF
--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -363,11 +363,8 @@ export class SelfOrder extends Reactive {
         const paymentMethods = this.filterPaymentMethods(
             this.models["pos.payment.method"].getAll()
         ); // Stripe, Adyen, Online
-        const order = await this.sendDraftOrderToServer();
 
-        if (!order) {
-            return;
-        }
+        let order = this.currentOrder;
 
         // Stand number page will recall this function after the stand number is set
         if (
@@ -377,6 +374,12 @@ export class SelfOrder extends Reactive {
             !order.table_stand_number
         ) {
             this.router.navigate("stand_number");
+            return;
+        }
+
+        order = await this.sendDraftOrderToServer();
+
+        if (!order) {
             return;
         }
 


### PR DESCRIPTION
Before this commit, if the order was set to be served at a table, the assigned stand number was not sent to the server because the draft order was sent to the server before opening the stand number page.

opw-4457394

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
