### PR TITLE
[IMP] mail: improve quote reply detection

### DIFF
--- a/odoo/addons/base/tests/test_mail_examples.py
+++ b/odoo/addons/base/tests/test_mail_examples.py
@@ -361,7 +361,7 @@ TEXT_2_OUT = [u"""
 
 # MISC
 
-GMAIL_1 = u"""Hello,<div><br></div><div>Ok for me. I am replying directly in gmail, without signature.</div><div><br></div><div>Kind regards,</div><div><br></div><div>Demo.<br><br>
+GMAIL_1 = u"""Hello,<div><br></div><div>Ok for me. I am replying directly in gmail, with signature.</div><div><br></div><div>Kind regards,</div><div><br></div><div>Demo.<br><br>
 <div class="gmail_quote">
 <div dir="ltr" class="gmail_attr">On Thu, Nov 8, 2012 at 5:29 PM,  <span>&lt;<a href="mailto:dummy@example.com">dummy@example.com</a>&gt;</span> wrote:<br>
 <blockquote class="gmail_quote"><div>I contact you about our meeting for tomorrow. Here is the schedule I propose:</div><div><ul><li>9 AM: brainstorming about our new amazing business app&lt;/span&gt;&lt;/li&gt;</li>
@@ -369,13 +369,27 @@ GMAIL_1 = u"""Hello,<div><br></div><div>Ok for me. I am replying directly in gma
 <div><p>-- <br>Administrator</p></div>
 
 <div><p>Log in our portal at: <a href="http://localhost:8069#action=login&amp;db=mail_1&amp;login=demo">http://localhost:8069#action=login&amp;db=mail_1&amp;login=demo</a></p></div>
-</blockquote></div></div><br></div>"""
+</blockquote>
+<div><br clear="all"></div>
+<div><br></div>
+<span class="gmail_signature_prefix">-- </span><br>
+<div dir="ltr" class="gmail_signature">
+    <div dir="ltr">
+        This is a test signature
+        <div><br></div>
+        <div>123</div>
+    </div>
+</div>
+</div><br></div>"""
 
 GMAIL_1_IN = [
-    u'Ok for me. I am replying directly in gmail, without signature.',
+    u'Ok for me. I am replying directly in gmail, with signature.',
     '<div class="gmail_quote" data-o-mail-quote-container="1" data-o-mail-quote="1">',
     '<div dir="ltr" class="gmail_attr" data-o-mail-quote="1">On Thu, Nov 8, 2012 at 5:29 PM',
     '<blockquote class="gmail_quote" data-o-mail-quote-container="1" data-o-mail-quote="1" data-o-mail-quote-node="1">',
+    # blank spaces between signature and reply quote should be quoted too
+    '<div data-o-mail-quote="1"><br clear="all" data-o-mail-quote="1"></div>\n'
+    '<div data-o-mail-quote="1"><br data-o-mail-quote="1"></div>',
 ]
 GMAIL_1_OUT = []
 

--- a/odoo/addons/base/tests/test_mail_examples.py
+++ b/odoo/addons/base/tests/test_mail_examples.py
@@ -193,7 +193,7 @@ QUOTE_OUTLOOK_HTML = """
          color: rgb(0, 0, 0);">
          <br>
       </div>
-      <div id="testing_id">
+         <div class="elementToProof" id="Signature">John</div>
          <div id="appendonsend"></div>
          <div style="font-family:Calibri,Helvetica,sans-serif; font-size:12pt; col=
             or:rgb(0,0,0)">
@@ -209,7 +209,6 @@ QUOTE_OUTLOOK_HTML = """
          <div>
             <div dir="ltr">Parent email body</div>
          </div>
-      </div>
    </body>
 </html>
 """
@@ -219,8 +218,13 @@ QUOTE_OUTLOOK_HTML_IN = [
     """<div id="mail_body">""",
 ]
 QUOTE_OUTLOOK_HTML_OUT = [
-    """<div id="testing_id" data-o-mail-quote-container="1">""",
-    """<div id="divRplyFwdMsg" dir="ltr" data-o-mail-quote="1">""",
+    """<div class="elementToProof" id="Signature" data-o-mail-quote-container="1" data-o-mail-quote="1">John</div>""",
+    """<div id="appendonsend" data-o-mail-quote-container="1" data-o-mail-quote="1"></div>""",  # quoted when empty in case there's a signature before
+    """<hr tabindex="-1" style="display:inline-block; width:98%" data-o-mail-quote="1">""",
+    """<div data-o-mail-quote-container="1" data-o-mail-quote="1">
+            <div dir="ltr" data-o-mail-quote="1">Parent email body</div>
+         </div>""",
+    """<div id="divRplyFwdMsg" dir="ltr" data-o-mail-quote-container="1" data-o-mail-quote="1">""",
 ]
 
 
@@ -357,14 +361,22 @@ TEXT_2_OUT = [u"""
 
 # MISC
 
-GMAIL_1 = u"""Hello,<div><br></div><div>Ok for me. I am replying directly in gmail, without signature.</div><div><br></div><div>Kind regards,</div><div><br></div><div>Demo.<br><br><div>On Thu, Nov 8, 2012 at 5:29 PM,  <span>&lt;<a href="mailto:dummy@example.com">dummy@example.com</a>&gt;</span> wrote:<br><blockquote><div>I contact you about our meeting for tomorrow. Here is the schedule I propose:</div><div><ul><li>9 AM: brainstorming about our new amazing business app&lt;/span&gt;&lt;/li&gt;</li>
-<li>9.45 AM: summary</li><li>10 AM: meeting with Fabien to present our app</li></ul></div><div>Is everything ok for you ?</div>
+GMAIL_1 = u"""Hello,<div><br></div><div>Ok for me. I am replying directly in gmail, without signature.</div><div><br></div><div>Kind regards,</div><div><br></div><div>Demo.<br><br>
+<div class="gmail_quote">
+<div dir="ltr" class="gmail_attr">On Thu, Nov 8, 2012 at 5:29 PM,  <span>&lt;<a href="mailto:dummy@example.com">dummy@example.com</a>&gt;</span> wrote:<br>
+<blockquote class="gmail_quote"><div>I contact you about our meeting for tomorrow. Here is the schedule I propose:</div><div><ul><li>9 AM: brainstorming about our new amazing business app&lt;/span&gt;&lt;/li&gt;</li>
+<li>9.45 AM: summary</li><li>10 AM: meeting with Fabien to present our app</li></ul></div><div>Is everything ok for you?</div>
 <div><p>-- <br>Administrator</p></div>
 
 <div><p>Log in our portal at: <a href="http://localhost:8069#action=login&amp;db=mail_1&amp;login=demo">http://localhost:8069#action=login&amp;db=mail_1&amp;login=demo</a></p></div>
-</blockquote></div><br></div>"""
+</blockquote></div></div><br></div>"""
 
-GMAIL_1_IN = [u'Ok for me. I am replying directly in gmail, without signature.', '<blockquote data-o-mail-quote-node="1" data-o-mail-quote="1">']
+GMAIL_1_IN = [
+    u'Ok for me. I am replying directly in gmail, without signature.',
+    '<div class="gmail_quote" data-o-mail-quote-container="1" data-o-mail-quote="1">',
+    '<div dir="ltr" class="gmail_attr" data-o-mail-quote="1">On Thu, Nov 8, 2012 at 5:29 PM',
+    '<blockquote class="gmail_quote" data-o-mail-quote-container="1" data-o-mail-quote="1" data-o-mail-quote-node="1">',
+]
 GMAIL_1_OUT = []
 
 HOTMAIL_1 = u"""<div>

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -155,7 +155,6 @@ def tag_quote(el):
 
     # gmail or yahoo // # outlook, html // # msoffice
     if 'gmail_extra' in el_class or \
-            'divRplyFwdMsg' in el_id or \
             ('SkyDrivePlaceholder' in el_class or 'SkyDrivePlaceholder' in el_class):
         el.set('data-o-mail-quote', '1')
         if el.getparent() is not None:
@@ -167,6 +166,32 @@ def tag_quote(el):
         el.set('data-o-mail-quote', '1')
         for sibling in el.itersiblings(preceding=False):
             sibling.set('data-o-mail-quote', '1')
+
+    # odoo, gmail and outlook automatic signature wrapper
+    is_signature_wrapper = 'odoo_signature_wrapper' in el_class or 'gmail_signature' in el_class or el_id == "Signature"
+    is_outlook_auto_message = 'appendonsend' in el_id
+    # gmail and outlook reply quote
+    is_outlook_reply_quote = 'divRplyFwdMsg' in el_id
+    is_gmail_quote = 'gmail_quote' in el_class
+    is_quote_wrapper = is_signature_wrapper or is_gmail_quote or is_outlook_reply_quote
+    if is_quote_wrapper:
+        el.set('data-o-mail-quote-container', '1')
+        el.set('data-o-mail-quote', '1')
+
+    # outlook reply wrapper is preceded with <hr> and a div containing recipient info
+    if is_outlook_reply_quote:
+        hr = el.getprevious()
+        reply_quote = el.getnext()
+        if hr is not None and hr.tag == 'hr':
+            hr.set('data-o-mail-quote', '1')
+        if reply_quote is not None:
+            reply_quote.set('data-o-mail-quote-container', '1')
+            reply_quote.set('data-o-mail-quote', '1')
+
+    if is_outlook_auto_message:
+        if not el.text or not el.text.strip():
+            el.set('data-o-mail-quote-container', '1')
+            el.set('data-o-mail-quote', '1')
 
     # html signature (-- <br />blah)
     signature_begin = re.compile(r"((?:(?:^|\n)[-]{2}[\s]?$))")

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -211,6 +211,8 @@ def tag_quote(el):
         el.set('data-o-mail-quote', '1')
     if el.getparent() is not None and (el.getparent().get('data-o-mail-quote') or el.getparent().get('data-o-mail-quote-container')) and not el.getparent().get('data-o-mail-quote-node'):
         el.set('data-o-mail-quote', '1')
+    if el.getprevious() is not None and el.getprevious().get('data-o-mail-quote') and not el.text_content().strip():
+        el.set('data-o-mail-quote', '1')
 
 
 def html_normalize(src, filter_callback=None):


### PR DESCRIPTION
We update quote detection for gmail and outlook:
- gmail has simple wrapper divs with explicit classes
- outlook has a mix of div ids and simple pattern-based quoting (everything under "<hr><div id="divRplyFwdMsg"/> seems to be considered a quote)

Previously gmail just used blockquote, which still works but does not capture "On xx:xx:xx X <X@gmail.com> wrote:" headers, which are caught for outlook.

Previously outlook had a wrapper div around divRplyFwdMsg which would set data-o-mail-quote-container on it, and propagate to children. However it seems that outer div was either removed or is not always present, a heuristic is thus needed.

task-4381505
