### PR TITLE
[FIX] calendar: Prevent email reminders from Odoo for Google/Microsoft synced events

### DIFF
--- a/addons/google_calendar/models/__init__.py
+++ b/addons/google_calendar/models/__init__.py
@@ -8,3 +8,4 @@ from . import calendar_recurrence_rule
 from . import res_users
 from . import calendar_attendee
 from . import google_credentials
+from . import calendar_alarm_manager

--- a/addons/google_calendar/models/calendar_alarm_manager.py
+++ b/addons/google_calendar/models/calendar_alarm_manager.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class AlarmManager(models.AbstractModel):
+    _inherit = 'calendar.alarm_manager'
+
+    @api.model
+    def _get_notify_alert_extra_conditions(self):
+        res = super()._get_notify_alert_extra_conditions()
+        return f'{res} AND "event"."google_id" IS NULL'

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -1275,6 +1275,49 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         self.assertGoogleAPINotCalled()
 
     @patch_api
+    def test_event_reminder_emails_with_google_id(self):
+        """
+        Odoo shouldn't send email reminders for synced events.
+        Test that events synced to Google (with a `google_id`)
+        are excluded from email alarm notifications.
+        """
+        now = datetime.now()
+        google_id = 'oj44nep1ldf8a3ll02uip0c9aa'
+        start = now - relativedelta(minutes=30)
+        end = now + relativedelta(hours=2)
+        alarm = self.env['calendar.alarm'].create({
+            'name': 'Alarm',
+            'alarm_type': 'email',
+            'interval': 'minutes',
+            'duration': 30,
+        })
+        values = {
+            'id': google_id,
+            "alarm_id": alarm.id,
+            'description': 'Small mini desc',
+            'organizer': {'email': 'odoocalendarref@gmail.com', 'self': True},
+            'summary': 'Pricing new update',
+            'visibility': 'public',
+            'attendees': [{
+                'displayName': 'Mitchell Admin',
+                'email': self.public_partner.email,
+                'responseStatus': 'needsAction'
+            }],
+            'start': {
+                'dateTime': pytz.utc.localize(start).isoformat(),
+                'timeZone': 'Europe/Brussels'
+            },
+            'reminders': {'overrides': [{"method": "email", "minutes": 30}], 'useDefault': False},
+            'end': {
+                'dateTime': pytz.utc.localize(end).isoformat(),
+                'timeZone': 'Europe/Brussels'
+            },
+        }
+        self.env['calendar.event']._sync_google2odoo(GoogleEvent([values]))
+        events_by_alarm = self.env['calendar.alarm_manager']._get_events_by_alarm_to_notify('email')
+        self.assertFalse(events_by_alarm, "Events with google_id should not trigger reminders")
+
+    @patch_api
     def test_attendee_state(self):
         user = new_test_user(self.env, login='calendar-user')
         google_id = 'oj44nep1ldf8a3ll02uip0c9aa'

--- a/addons/microsoft_calendar/models/__init__.py
+++ b/addons/microsoft_calendar/models/__init__.py
@@ -7,3 +7,4 @@ from . import calendar
 from . import calendar_recurrence_rule
 from . import res_users
 from . import calendar_attendee
+from . import calendar_alarm_manager

--- a/addons/microsoft_calendar/models/calendar_alarm_manager.py
+++ b/addons/microsoft_calendar/models/calendar_alarm_manager.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class AlarmManager(models.AbstractModel):
+    _inherit = 'calendar.alarm_manager'
+
+    @api.model
+    def _get_notify_alert_extra_conditions(self):
+        res = super()._get_notify_alert_extra_conditions()
+        return f'{res} AND "event"."microsoft_id" IS NULL'

--- a/addons/microsoft_calendar/tests/test_sync_microsoft2odoo.py
+++ b/addons/microsoft_calendar/tests/test_sync_microsoft2odoo.py
@@ -339,3 +339,36 @@ class TestSyncMicrosoft2Odoo(TransactionCase):
 
         event = self.env['calendar.event'].search([("microsoft_id", "=", ms_event[0]["id"])])
         self.assertEqual(event.videocall_location, ms_event[0]["onlineMeeting"]["joinUrl"])
+
+    def test_event_reminder_emails_with_microsoft_id(self):
+        """
+        Odoo shouldn't send email reminders for synced events.
+        Test that events synced to Microsoft (with a `microsoft_id`)
+        are excluded from email alarm notifications.
+        """
+        now = datetime.now()
+        start = now - relativedelta(minutes=30)
+        end = now + relativedelta(hours=2)
+        alarm = self.env['calendar.alarm'].create({
+            'name': 'Alarm',
+            'alarm_type': 'email',
+            'interval': 'minutes',
+            'duration': 30,
+        })
+        ms_event = self.single_event
+        ms_event[0].update({
+            'isOnlineMeeting': True,
+            'alarm_id': alarm.id,
+            'start': {
+                'dateTime': pytz.utc.localize(start).isoformat(),
+                'timeZone': 'Europe/Brussels'
+            },
+            'reminders': {'overrides': [{"method": "email", "minutes": 30}], 'useDefault': False},
+            'end': {
+                'dateTime': pytz.utc.localize(end).isoformat(),
+                'timeZone': 'Europe/Brussels'
+            },
+        })
+        self.env['calendar.event']._sync_microsoft2odoo(MicrosoftEvent(ms_event))
+        events_by_alarm = self.env['calendar.alarm_manager']._get_events_by_alarm_to_notify('email')
+        self.assertFalse(events_by_alarm, "Events with microsoft_id should not trigger reminders")


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

When an event is synced with an external calendar (Google/ Microsoft), the external calendar is responsible for sending reminders, and Odoo should not send any additional reminders. 

However, the current implementation does not properly handle this, with the default crone job running daily sending  email reminders up to one day late.


### Current behavior before PR:

Although the current implementation ensures the crone is not triggered for alarms of external-calendars-synced events, the default crone job that is running daily is going all over the events with reminders need to be sent and send them up to one day late.  

### Desired behavior after PR is merged:
When the crone goes to trigger the _send_reminder method, it will check first if the events are synced or not, and if synced then no reminders will be sent from odoo's side.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr


task-id: 4316693