### PR TITLE
[FIX] pos_loyalty: mitigate race condition

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -645,7 +645,8 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                 programsToCheck.add(program.id);
             }
         }
-        for (const pe of Object.values(this.couponPointChanges)) {
+        const newPointChanges = Object.assign({}, JSON.parse(JSON.stringify(this.couponPointChanges)));
+        for (const pe of Object.values(newPointChanges)) {
             if (!changesPerProgram[pe.program_id]) {
                 changesPerProgram[pe.program_id] = [];
                 programsToCheck.add(pe.program_id);
@@ -672,13 +673,11 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
             }
             if (pointsAdded.length < oldChanges.length) {
                 const removedIds = oldChanges.map((pe) => pe.coupon_id);
-                this.couponPointChanges = Object.fromEntries(Object.entries(this.couponPointChanges).filter(([k, pe]) => {
-                    return !removedIds.includes(pe.coupon_id);
-                }));
+                removedIds.forEach(id => delete newPointChanges[id]);
             } else if (pointsAdded.length > oldChanges.length) {
                 for (const pa of pointsAdded.splice(oldChanges.length)) {
                     const coupon = await this._couponForProgram(program);
-                    this.couponPointChanges[coupon.id] = {
+                    newPointChanges[coupon.id] = {
                         points: pa.points,
                         program_id: program.id,
                         coupon_id: coupon.id,
@@ -697,6 +696,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
             }
             return true;
         });
+        this.couponPointChanges = newPointChanges;
     }
     /**
      * @typedef {{ won: number, spend: number, total: number, balance: number, name: string}} LoyaltyPoints

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
@@ -272,7 +272,6 @@ ProductScreen.do.clickCustomer('AAA Partner');
 ProductScreen.do.clickDisplayedProduct('Product Test');
 ProductScreen.check.totalAmountIs('1.00');
 PosLoyalty.check.isRewardButtonHighlighted(true);
-PosLoyalty.do.clickRewardButton();
 PosLoyalty.do.claimReward('Free Product B');
 PosLoyalty.check.hasRewardLine('Free Product B', '-1.00');
 ProductScreen.check.totalAmountIs('1.00');


### PR DESCRIPTION
During tours a race condition can occur when loyalty rewards are being calculated, the race condition happens within the following lines:

https://github.com/odoo/odoo/blob/16.0/addons/pos_loyalty/static/src/js/Loyalty.js#L648-L680

If the method is called again between the computing of `changesPerProgram` and `await this._couponForProgram` changes to `couponPointChanges` are committed while the intent was to drop them (c.f. `dropPrevious`).

Runbot Error 56943
