### PR TITLE
[IMP] hw_posbox_homepage: wifi UX improvements

### DIFF
--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -33,6 +33,9 @@ class ConnectionManager(Thread):
             self.pairing_uuid = False
 
     def _connect_box(self):
+        if not helpers.get_ip() or (platform.system() == 'Linux' and wifi.is_access_point()):
+            return
+
         data = {
             'jsonrpc': 2.0,
             'params': {

--- a/addons/hw_drivers/tools/wifi.py
+++ b/addons/hw_drivers/tools/wifi.py
@@ -119,18 +119,20 @@ def disconnect(forget_network=False):
     if forget_network and not _validate_configuration(ssid, forget_network):
         _logger.warning('Failed to remove network configuration from /root_bypass_ramdisks for %s', ssid)
 
+    if not get_ip():
+        toggle_access_point(START)
     return not is_current(ssid)
 
 
-def connect(ssid, password):
-    """Disables access point mode, disconnects from the current network and
-    connects to the given network using the provided password.
+def _connect(ssid, password):
+    """Disables access point mode and connects to the given
+    network using the provided password.
 
     :param str ssid: SSID of the network to connect to
     :param str password: Password of the network to connect to
     :return: True if connected successfully
     """
-    if ssid not in get_available_ssids() or not toggle_access_point(STOP) or not disconnect():
+    if ssid not in get_available_ssids() or not toggle_access_point(STOP):
         return False
 
     _logger.info('Connecting to network %s', ssid)
@@ -142,29 +144,37 @@ def connect(ssid, password):
     return is_current(ssid)
 
 
-def reconnect(ssid=None, password=None):
+def reconnect(ssid=None, password=None, force_update=False):
     """Reconnect to the given network. If a connection to the network already exists,
     we can reconnect to it without providing the password (e.g. after a reboot).
     If no SSID is provided, we will try to reconnect to the last connected network.
 
     :param str ssid: SSID of the network to reconnect to (optional)
     :param str password: Password of the network to reconnect to (optional)
+    :param bool force_update: Force connection, even if internet is already available through ethernet
     :return: True if reconnected successfully
     """
-    timer = time.time() + 10  # Required on boot: wait 10 sec (see: https://github.com/odoo/odoo/pull/187862)
-    while time.time() < timer:
-        if get_ip():
-            return True
-        time.sleep(.5)
+    should_start_access_point_on_failure = is_access_point() or not get_ip()
+
+    if not force_update:
+        timer = time.time() + 10  # Required on boot: wait 10 sec (see: https://github.com/odoo/odoo/pull/187862)
+        while time.time() < timer:
+            if get_ip():
+                return True
+            time.sleep(.5)
 
     if not ssid:
         return toggle_access_point(START)
 
     # Try to re-enable an existing connection, or set up a new persistent one
     if not _nmcli(['con', 'up', ssid], sudo=True):
-        connect(ssid, password)
+        _connect(ssid, password)
 
-    return is_current(ssid) or toggle_access_point(START)
+    connected_successfully = is_current(ssid)
+    if not connected_successfully and should_start_access_point_on_failure:
+        toggle_access_point(START)
+
+    return connected_successfully
 
 
 def _validate_configuration(ssid, forget_network=False):

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -290,18 +290,23 @@ class IotBoxOwlHomePage(http.Controller):
 
     @http.route('/hw_posbox_homepage/update_wifi', auth="none", type="jsonrpc", methods=['POST'], cors='*')
     def update_wifi(self, essid, password):
-        if wifi.connect(essid, password):
+        if wifi.reconnect(essid, password, force_update=True):
             helpers.update_conf({'wifi_ssid': essid, 'wifi_password': password})
-        server = helpers.get_odoo_server_url()
+            server = helpers.get_odoo_server_url()
 
-        res_payload = {
-            'status': 'success',
-            'message': 'Connecting to ' + essid,
-            'server': {
-                'url': server or 'http://' + helpers.get_ip() + ':8069',
-                'message': 'Redirect to Odoo Server' if server else 'Redirect to IoT Box'
+            res_payload = {
+                'status': 'success',
+                'message': 'Connecting to ' + essid,
+                'server': {
+                    'url': server or 'http://' + helpers.get_ip() + ':8069',
+                    'message': 'Redirect to Odoo Server' if server else 'Redirect to IoT Box'
+                }
             }
-        }
+        else:
+            res_payload = {
+                'status': 'error',
+                'message': 'Failed to connect to ' + essid,
+            }
 
         return res_payload
 

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/WifiDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/WifiDialog.js
@@ -14,8 +14,8 @@ export class WifiDialog extends Component {
         this.store = useStore();
         this.state = useState({
             scanning: true,
-            loading: false,
             waitRestart: false,
+            statusMessage: "",
             availableWiFi: [],
         });
         this.form = useState({
@@ -29,6 +29,17 @@ export class WifiDialog extends Component {
         this.state.scanning = true;
         this.form.essid = "";
         this.form.password = "";
+    }
+
+    isCurrentlyConnectedToWifi() {
+        return (
+            !this.store.base.is_access_point_up &&
+            this.store.base.network_interfaces.some((netInterface) => netInterface.is_wifi)
+        );
+    }
+
+    isCurrentlyConnectedToEthernet() {
+        return this.store.base.network_interfaces.some((netInterface) => !netInterface.is_wifi);
     }
 
     async getWiFiNetworks() {
@@ -51,13 +62,19 @@ export class WifiDialog extends Component {
         }
 
         this.state.waitRestart = true;
-        const data = await this.store.rpc({
+        const responsePromise = this.store.rpc({
             url: "/hw_posbox_homepage/update_wifi",
             method: "POST",
             params: this.form,
         });
-
-        if (data.status !== "success") {
+        if (this.isCurrentlyConnectedToEthernet()) {
+            const data = await responsePromise;
+            if (data.status !== "success") {
+                this.state.waitRestart = false;
+            }
+        } else {
+            // The IoT box is no longer reachable, so we can't await the response.
+            this.state.statusMessage = `The IoT Box will now attempt to connect to ${this.form.essid}. You may close this page.`;
             this.state.waitRestart = false;
         }
     }
@@ -65,11 +82,17 @@ export class WifiDialog extends Component {
     async clearConfiguration() {
         try {
             this.state.waitRestart = true;
-            const data = await this.store.rpc({
+            const responsePromise = this.store.rpc({
                 url: "/hw_posbox_homepage/wifi_clear",
             });
-
-            if (data.status !== "success") {
+            if (this.isCurrentlyConnectedToEthernet()) {
+                const data = await responsePromise;
+                if (data.status !== "success") {
+                    this.state.waitRestart = false;
+                }
+            } else {
+                // The IoT box is no longer reachable, so we can't await the response.
+                this.state.statusMessage = `The IoT Box Wi-Fi configuration has been cleared. You will need to connect to the IoT Box hotspot or connect an ethernet cable.`;
                 this.state.waitRestart = false;
             }
         } catch {
@@ -83,6 +106,10 @@ export class WifiDialog extends Component {
                 Processing your request please wait...
             </t>
         </LoadingFullScreen>
+
+        <div t-if="state.statusMessage" class="position-fixed top-0 start-0 bg-white vh-100 w-100 justify-content-center align-items-center d-flex always-on-top">
+            <div class="alert alert-success" t-out="state.statusMessage"/>
+        </div>
 
         <BootstrapDialog identifier="'wifi-configuration'" btnName="'Configure'" onOpen.bind="getWiFiNetworks" onClose.bind="onClose">
             <t t-set-slot="header">
@@ -116,7 +143,7 @@ export class WifiDialog extends Component {
                     </div>
 
                     <div class="d-flex justify-content-end gap-2">
-                        <button t-if="!this.store.base.is_access_point_up" type="submit" class="btn btn-secondary btn-sm" t-on-click="clearConfiguration">
+                        <button t-if="this.isCurrentlyConnectedToWifi()" type="submit" class="btn btn-secondary btn-sm" t-on-click="clearConfiguration">
                             Disconnect From Current
                         </button>
                         <button type="submit" class="btn btn-primary btn-sm" t-on-click="connectToWiFi">Connect</button>


### PR DESCRIPTION
When connecting an IoT box to a Wi-Fi network,
the user is left on an infinite loading spinner
due to the fact that the IoT box disables the
hotspot before the user receives a response.

This commit instead displays a blocking message
to the user explaining that the IoT box is now
connected to the desired network.

task-4456765

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
