### PR TITLE
[REF] spreadsheet: rename copyForSheetId method

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart.js
@@ -111,7 +111,7 @@ export class OdooChart extends AbstractChart {
     /**
      * @returns {OdooChart}
      */
-    copyForSheetId() {
+    duplicateInDuplicatedSheet() {
         return this;
     }
 


### PR DESCRIPTION
Adapt code after the method was renamed in o-spreadsheet

The difference between both methods copyForSheetId and copyInSheetId has always been confusing to me.

This commits attemps to make it clearer by renaming one of the method.

Task: 4447450




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
