### PR TITLE
[FIX] mrp_account: fix missing company context for _compute_average_price

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -15,7 +15,7 @@ class SaleOrderLine(models.Model):
             if not line.move_ids:
                 lines_without_moves |= line
             elif product.categ_id.property_cost_method != 'standard':
-                purch_price = product._compute_average_price(0, line.product_uom_qty, line.move_ids)
+                purch_price = product._compute_average_price(0, line.product_uom_qty, line.move_ids.with_company(line.company_id))
                 if line.product_uom and line.product_uom != product.uom_id:
                     purch_price = product.uom_id._compute_price(purch_price, line.product_uom)
                 to_cur = line.currency_id or line.order_id.currency_id


### PR DESCRIPTION
Current behavior before commit:

The issue occurs when the product is a kit. The Procurement: run scheduler scheduled action updates some fields, triggering the _compute_purchase_price method. Within _compute_purchase_price, the method _compute_average_price is called with the company context of the sales order line (SOL).

Company Context https://github.com/odoo/odoo/blob/a823c4ef6962672fe68726682e94ff82db211772/addons/sale_stock_margin/models/sale_order_line.py#L14

Method Call https://github.com/odoo/odoo/blob/a823c4ef6962672fe68726682e94ff82db211772/addons/sale_stock_margin/models/sale_order_line.py#L18

During recursion in `_compute_average_price`, the company context incorrectly reverts to the global company instead of preserving the original company context from the initial call.

Recursive call https://github.com/odoo/odoo/blob/a823c4ef6962672fe68726682e94ff82db211772/addons/mrp_account/models/product.py#L77

Since the product is a kit, its cost is derived from its components. However, due to the incorrect company context switch, the purchase price is incorrectly set to 0 (because the product does not exist in the global company). This distorts sales margins in ongoing sales orders.

Root Cause:

The stock_moves passed into the method have env.company set to Company 1. At
https://github.com/odoo/odoo/blob/a823c4ef6962672fe68726682e94ff82db211772/addons/mrp_account/models/product.py#L66

bom_lines are extracted, inheriting the environment from stock_moves. As a result, _compute_average_price is executed within the context of Company 1, which may lead to incorrect computations when the intended company context is different.

Fix:

Ensure that stock_moves is explicitly passed into the method with the correct company context. This guarantees that the company context remains consistent throughout the execution, preventing unintended company switching.

opw-4222976

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
