### PR TITLE
[FIX] web: graph: prevent rendering too many datasets

### DIFF
--- a/addons/web/static/src/views/graph/graph_controller.js
+++ b/addons/web/static/src/views/graph/graph_controller.js
@@ -46,6 +46,10 @@ export class GraphController extends Component {
         return context;
     }
 
+    loadAll() {
+        return this.model.forceLoadAll();
+    }
+
     /**
      * Execute the action to open the view on the current model.
      *

--- a/addons/web/static/src/views/graph/graph_controller.xml
+++ b/addons/web/static/src/views/graph/graph_controller.xml
@@ -60,6 +60,14 @@
                     <t t-if="!model.hasData() or model.useSampleModel and props.info.noContentHelp" t-call="web.ActionHelper">
                         <t t-set="noContentHelp" t-value="props.info.noContentHelp"/>
                     </t>
+                    <t t-if="model.data.exceeds">
+                        <div class="alert alert-info text-center o_graph_alert" role="status">
+                            There are too many data. The graph only shows a sample. Use the filters to refine the scope.
+                            <a class="o_graph_load_all_btn" href="#" t-on-click="() => this.loadAll()">
+                                Load everything anyway.
+                            </a>
+                        </div>
+                    </t>
                     <t t-component="props.Renderer" model="model" onGraphClicked.bind="onGraphClicked" />
                 </t>
                 <t t-else="" t-call="web.NoContentHelper">


### PR DESCRIPTION
Chart.js can be really slow when rendering a large number of datasets.
So this commit limits the amount of datasets displayed by default on the graph.
However a button is present to display all datasets even if it can take a moment to render them.

task-4351783