### PR TITLE
[FIX] l10n_jo_edi: Fixed unit tests dependencies

### DIFF
--- a/addons/l10n_jo_edi/tests/jo_edi_common.py
+++ b/addons/l10n_jo_edi/tests/jo_edi_common.py
@@ -1,12 +1,11 @@
 from odoo import Command
 from odoo.tools import misc
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
-from odoo.addons.account_reports.tests.common import TestAccountReportsCommon
 
 
 class JoEdiCommon(AccountTestInvoicingCommon):
     @classmethod
-    @TestAccountReportsCommon.setup_country('jo')
+    @AccountTestInvoicingCommon.setup_country('jo')
     def setUpClass(cls):
         super().setUpClass()
         cls.company_data['company'].write({


### PR DESCRIPTION
The unit tests were having a dependency from account_reports module which is not a dependency of the l10n_jo_edi module nor even a community module. This commit removes this dependency.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
