### PR TITLE
[FIX] web_tour: checkForUndeterminisms must throw error

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -62,18 +62,11 @@ export class TourAutomatic {
                         initialDelay: () => {
                             return this.previousStepIsJustACheck ? 0 : null;
                         },
-                        trigger: () => step.findTrigger(),
+                        trigger: step.trigger ? () => step.findTrigger() : null,
                         timeout: (step.timeout || 10000) + this.config.stepDelay,
                         action: async () => {
                             if (this.checkForUndeterminisms) {
-                                try {
-                                    await step.checkForUndeterminisms();
-                                } catch (error) {
-                                    this.throwError([
-                                        ...this.currentStep.describeWhyIFailed,
-                                        error.message,
-                                    ]);
-                                }
+                                await step.checkForUndeterminisms();
                             }
                             this.previousStepIsJustACheck = !this.currentStep.hasAction;
                             if (this.debugMode) {

--- a/addons/web_tour/static/src/tour_service/tour_step_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_step_automatic.js
@@ -26,7 +26,10 @@ export class TourStepAutomatic extends TourStep {
                     } else {
                         reject(
                             new Error(
-                                `UNDETERMINISM: two differents elements have been found in ${delay}ms for trigger ${this.trigger}`
+                                [
+                                    ...this.describeWhyIFailed,
+                                    `UNDETERMINISM: two differents elements have been found in ${delay}ms for trigger ${this.trigger}`,
+                                ].join("\n")
                             )
                         );
                     }

--- a/addons/web_tour/static/tests/tour_automatic.test.js
+++ b/addons/web_tour/static/tests/tour_automatic.test.js
@@ -630,7 +630,7 @@ test("check for undeterminisms", async () => {
     await advanceTime(10000);
     expect.verifySteps([
         `error: FAILED: [2/3] Tour tour_und → Step .button1.
-Element has been found.
+ERROR IN ACTION: Element has been found.
 UNDETERMINISM: two differents elements have been found in 3000ms for trigger .button1`,
     ]);
 });


### PR DESCRIPTION
The function checkForUndeterminisms in the TourStepAutomatic class throws an error in the case where an indeterminism is found. However, in the TourAutomatic class, we used this.throwError which throws the error but does not stop the macro (Does not go through the stop method of the Macro class). As a result, the observable is not disconnected and the macro is not stopped properly.
In this commit, we make sure that the macro is stopped properly.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
