### PR TITLE
[IMP] stock: use removal date to decide if stock is not expired

### DIFF
--- a/addons/product_expiry/__init__.py
+++ b/addons/product_expiry/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+from . import report
 from . import wizard
 
 from odoo import Command

--- a/addons/product_expiry/__manifest__.py
+++ b/addons/product_expiry/__manifest__.py
@@ -33,6 +33,9 @@ Also implements the removal strategy First Expiry First Out (FEFO) widely used, 
         'web.assets_tests': [
             'product_expiry/static/tests/tours/*.js',
         ],
+        'web.assets_backend': [
+            'product_expiry/static/src/**/*',
+        ],
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/product_expiry/models/product_product.py
+++ b/addons/product_expiry/models/product_product.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import datetime
 
 from odoo import fields, models
 
@@ -7,11 +8,28 @@ from odoo import fields, models
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
-    def action_open_quants(self):
-        # Override to hide the `removal_date` column if not needed.
-        if not any(product.use_expiration_date for product in self):
-            self = self.with_context(hide_removal_date=True)
-        return super().action_open_quants()
+    def _compute_quantities_dict(self, lot_id, owner_id, package_id, from_date=False, to_date=False):
+        return super(ProductProduct, self.with_context(with_expiration=datetime.date.today()))._compute_quantities_dict(lot_id, owner_id, package_id, from_date, to_date)
+
+    free_qty = fields.Float(help="Available quantity (computed as Quantity On Hand "
+             "- reserved quantity - quantity to remove)\n"
+             "In a context with a single Stock Location, this includes "
+             "goods stored in this location, or any of its children.\n"
+             "In a context with a single Warehouse, this includes "
+             "goods stored in the Stock Location of this Warehouse, or any "
+             "of its children.\n"
+             "Otherwise, this includes goods stored in any Stock Location "
+             "with 'internal' type.")
+
+    virtual_available = fields.Float(help="Forecast quantity (computed as Quantity On Hand "
+             "- Outgoing + Incoming - Quantity to Remove)\n"
+             "In a context with a single Stock Location, this includes "
+             "goods stored in this location, or any of its children.\n"
+             "In a context with a single Warehouse, this includes "
+             "goods stored in the Stock Location of this Warehouse, or any "
+             "of its children.\n"
+             "Otherwise, this includes goods stored in any Stock Location "
+             "with 'internal' type.")
 
 
 class ProductTemplate(models.Model):
@@ -29,7 +47,8 @@ class ProductTemplate(models.Model):
         ' deteriorating, without being dangerous yet. It will be computed on the lot/serial number.')
     removal_time = fields.Integer(string='Removal Date',
         help='Number of days before the Expiration Date after which the goods'
-        ' should be removed from the stock. It will be computed on the lot/serial number.')
+        ' should be removed from the stock and not be counted in the Fresh On Hand Stock anymore.'
+        'It will be computed on the lot/serial number.')
     alert_time = fields.Integer(string='Alert Date',
         help='Number of days before the Expiration Date after which an alert should be'
         ' raised on the lot/serial number. It will be computed on the lot/serial number.')

--- a/addons/product_expiry/models/production_lot.py
+++ b/addons/product_expiry/models/production_lot.py
@@ -15,7 +15,7 @@ class StockLot(models.Model):
     use_date = fields.Datetime(string='Best before Date', compute='_compute_dates', store=True, readonly=False,
         help='This is the date on which the goods with this Serial Number start deteriorating, without being dangerous yet.')
     removal_date = fields.Datetime(string='Removal Date', compute='_compute_dates', store=True, readonly=False,
-        help='This is the date on which the goods with this Serial Number should be removed from the stock. This date will be used in FEFO removal strategy.')
+        help='This is the date on which the goods with this Serial Number should be removed from the stock and not be counted in the Fresh On Hand Stock anymore. This date will be used in FEFO removal strategy.')
     alert_date = fields.Datetime(string='Alert Date', compute='_compute_dates', store=True, readonly=False,
         help='Date to determine the expired lots and serial numbers using the filter "Expiration Alerts".')
     product_expiry_alert = fields.Boolean(compute='_compute_product_expiry_alert', help="The Expiration Date has been reached.")

--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -14,6 +14,7 @@ class StockMoveLine(models.Model):
         string='Expiration Date', compute='_compute_expiration_date', store=True,
         help='This is the date on which the goods with this Serial Number may'
         ' become dangerous and must not be consumed.')
+    removal_date = fields.Datetime(string='Removal Date', compute='_compute_removal_date', store=True)
     is_expired = fields.Boolean(related='lot_id.product_expiry_alert')
     use_expiration_date = fields.Boolean(
         string='Use Expiration Date', related='product_id.use_expiration_date')
@@ -26,6 +27,8 @@ class StockMoveLine(models.Model):
         """
         if not column_exists(self._cr, "stock_move_line", "expiration_date"):
             create_column(self._cr, "stock_move_line", "expiration_date", "timestamp")
+        if not column_exists(self._cr, "stock_move_line", "removal_date"):
+            create_column(self._cr, "stock_move_line", "removal_date", "timestamp")
         return super()._auto_init()
 
     @api.depends('product_id', 'lot_id.expiration_date', 'picking_id.scheduled_date')
@@ -41,16 +44,16 @@ class StockMoveLine(models.Model):
                 else:
                     move_line.expiration_date = False
 
-    @api.onchange('product_id', 'product_uom_id', 'picking_id')
-    def _onchange_product_id(self):
-        res = super()._onchange_product_id()
-        if self.picking_type_use_create_lots:
-            if self.product_id.use_expiration_date:
-                from_date = self.picking_id.scheduled_date or fields.Datetime.today()
-                self.expiration_date = from_date + datetime.timedelta(days=self.product_id.expiration_time)
-            else:
-                self.expiration_date = False
-        return res
+    @api.depends('product_id', 'expiration_date', 'lot_id.removal_date')
+    def _compute_removal_date(self):
+        for move_line in self:
+            if move_line.lot_id.removal_date:
+                move_line.removal_date = move_line.lot_id.removal_date
+            elif move_line.picking_type_use_create_lots:
+                if move_line.product_id.use_expiration_date and move_line.expiration_date:
+                    move_line.removal_date = move_line.expiration_date - datetime.timedelta(days=move_line.product_id.removal_time)
+                else:
+                    move_line.removal_date = False
 
     def _prepare_new_lot_vals(self):
         vals = super()._prepare_new_lot_vals()

--- a/addons/product_expiry/models/stock_picking.py
+++ b/addons/product_expiry/models/stock_picking.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import datetime
 
 from odoo import models, _
 
@@ -18,11 +19,11 @@ class StockPicking(models.Model):
         return res
 
     def _check_expired_lots(self):
-        expired_pickings = self.move_line_ids.filtered(lambda ml: ml.lot_id.product_expiry_alert).picking_id
+        expired_pickings = self.move_line_ids.filtered(lambda ml: ml.lot_id.product_expiry_alert or (ml.removal_date and ml.removal_date <= datetime.datetime.now())).picking_id
         return expired_pickings
 
     def _action_generate_expired_wizard(self):
-        expired_lot_ids = self.move_line_ids.filtered(lambda ml: ml.lot_id.product_expiry_alert).lot_id.ids
+        expired_lot_ids = self.move_line_ids.filtered(lambda ml: ml.lot_id.product_expiry_alert or (ml.removal_date and ml.removal_date <= datetime.datetime.now())).lot_id.ids
         view_id = self.env.ref('product_expiry.confirm_expiry_view').id
         context = dict(self.env.context)
 

--- a/addons/product_expiry/report/__init__.py
+++ b/addons/product_expiry/report/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import stock_forecasted
+from . import report_stock_quantity

--- a/addons/product_expiry/report/report_stock_quantity.py
+++ b/addons/product_expiry/report/report_stock_quantity.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ReportStockQuantity(models.Model):
+    _inherit = 'report.stock.quantity'
+
+    _depends = {
+        'stock.quant': ['removal_date'],
+    }
+
+    def _get_product_qty_col(self):
+        # In case the quant is 'to be removed', only count the ones that are reserved as still being fresh
+        return "CASE WHEN q.removal_date IS NOT NULL AND q.removal_date::date <= (now() at time zone 'utc')::date AND date >= (now() at time zone 'utc')::date THEN q.reserved_quantity ELSE q.quantity END"

--- a/addons/product_expiry/report/stock_forecasted.py
+++ b/addons/product_expiry/report/stock_forecasted.py
@@ -1,0 +1,64 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import date
+
+from odoo import models
+from odoo.tools import float_is_zero, format_date
+
+
+class StockForecasted_Product_Product(models.AbstractModel):
+    _inherit = 'stock.forecasted_product_product'
+
+    def _get_report_header(self, product_template_ids, product_ids, wh_location_ids):
+        res = super()._get_report_header(product_template_ids, product_ids, wh_location_ids)
+        res["use_expiration_date"] = any(self.env['product.product'].browse(res["product_variants_ids"]).mapped('use_expiration_date'))
+        if res["use_expiration_date"]:
+            res["to_remove_qty"] = res['quantity_on_hand'] + res['incoming_qty'] - res['outgoing_qty'] - res['virtual_available']
+        return res
+
+    def _get_quant_domain(self, location_ids, products):
+        res = super()._get_quant_domain(location_ids, products)
+        if any(products.mapped('use_expiration_date')):
+            res += ['|', ('removal_date', '=', False), ('removal_date', '>', date.today())]
+        return res
+
+    def _get_expired_quant_domain(self, location_ids, products):
+        res = super()._get_quant_domain(location_ids, products)
+        res += [('removal_date', '<=', date.today())]
+        return res
+
+    def _prepare_report_line(self, quantity, move_out=None, move_in=None, replenishment_filled=True, product=False, reserved_move=False, in_transit=False, read=True):
+        res = super()._prepare_report_line(quantity, move_out, move_in, replenishment_filled, product, reserved_move, in_transit, read)
+        removal_date = self.env.context.get('removal_date')
+        if removal_date:
+            res["removal_date"] = removal_date if removal_date == -1 else format_date(self.env, removal_date)
+        return res
+
+    def _get_products_to_always_include(self, products, product_templates):
+        if not products:
+            return self.env['product.template'].browse(product_templates).product_variant_ids.filtered(lambda p: p.use_expiration_date)
+        return self.env['product.product'].browse(products).filtered(lambda p: p.use_expiration_date)
+
+    def _free_stock_lines(self, product, free_stock, moves_data, wh_location_ids, read):
+        res = []
+        if product.use_expiration_date:
+            reserved_expired, unreserved_expired = self.env['stock.quant']._read_group(self._get_expired_quant_domain(wh_location_ids, product), aggregates=['reserved_quantity:sum', 'available_quantity:sum'])[0]
+            # Insert the "To remove now" line here, before the free stock line
+            if not product.uom_id.is_zero(unreserved_expired):
+                res += [self.with_context(removal_date=-1)._prepare_report_line(unreserved_expired, product=product, read=read)]
+            # Insert the "To remove on" lines here, before the free stock line
+
+            to_reduce = sum(d['taken_from_stock'] for d in moves_data.values())
+
+            for removal_date, free_stock_at_date in self.env['stock.quant']._read_group(
+                    self._get_quant_domain(wh_location_ids, product),
+                ['removal_date:day'], ['available_quantity:sum']
+            ):
+                to_reduce_here = min(to_reduce, free_stock_at_date)
+                to_reduce -= to_reduce_here
+                free_stock_at_date -= to_reduce_here
+                if not float_is_zero(free_stock_at_date, precision_rounding=product.uom_id.rounding) and removal_date:
+                    res.append(self.with_context(removal_date=removal_date)._prepare_report_line(free_stock_at_date, product=product, read=read))
+
+            # Compensate for any reserved products that are no longer fresh
+            free_stock += reserved_expired
+        return res + super()._free_stock_lines(product, free_stock, moves_data, wh_location_ids, read)

--- a/addons/product_expiry/static/src/forecasted_details.js
+++ b/addons/product_expiry/static/src/forecasted_details.js
@@ -1,0 +1,12 @@
+import { patch } from "@web/core/utils/patch";
+import { ForecastedDetails } from "@stock/stock_forecasted/forecasted_details";
+import { _t } from "@web/core/l10n/translation";
+
+patch(ForecastedDetails.prototype, {
+    get freeStockLabel() {
+        if (this.props.docs.use_expiration_date) {
+            return _t('Fresh Free Stock');
+        }
+        return super.freeStockLabel;
+    }
+});

--- a/addons/product_expiry/static/src/forecasted_details.xml
+++ b/addons/product_expiry/static/src/forecasted_details.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="product_expiry.ForecastedDetails" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
+        <xpath expr="//t[@t-out='freeStockLabel']" position="before">
+            <t t-elif="line.removal_date">
+                <t t-if="line.removal_date === -1">
+                    To remove now
+                </t>
+                <t t-else="">
+                    To remove on <t t-out="line.removal_date"/>
+                </t>
+            </t>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/product_expiry/static/src/forecasted_header.xml
+++ b/addons/product_expiry/static/src/forecasted_header.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="product_expiry.ForecastedHeader" t-inherit="stock.ForecastedHeader" t-inherit-mode="extension">
+        <xpath expr="//div[@name='on_hand']" position="after">
+            <t t-if="props.docs.use_expiration_date">
+                <div class="h3 col-md-auto text-center">-</div>
+                <div t-attf-class="col-md-auto text-center #{props.docs.to_remove_qty}">
+                    <div class="h3">
+                        <t t-out="_formatFloat(props.docs.to_remove_qty)"/>
+                    </div>
+                    <div>To Remove</div>
+                </div>
+            </t>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/product_expiry/views/production_lot_views.xml
+++ b/addons/product_expiry/views/production_lot_views.xml
@@ -24,6 +24,9 @@
             <field name="product_expiry_alert" invisible="1"/>
             <span class="badge text-bg-danger" invisible="not product_expiry_alert">Expiration Alert</span>
         </xpath>
+            <xpath expr="//field[@name='ref']" position="after">
+                <field name="expiration_date" invisible="not use_expiration_date or display_complete"/>
+            </xpath>
         </field>
     </record>
 

--- a/addons/product_expiry/views/stock_move_views.xml
+++ b/addons/product_expiry/views/stock_move_views.xml
@@ -25,6 +25,9 @@
                 <field name="expiration_date" force_save="1" column_invisible="not parent.use_expiration_date" readonly="picking_type_use_existing_lots"
                  decoration-danger="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"
                  decoration-bf="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"/>
+                <field name="removal_date" force_save="1" column_invisible="not parent.use_expiration_date" readonly="picking_type_use_existing_lots"
+                 decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"
+                 decoration-bf="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
             </xpath>
         </field>
     </record>
@@ -40,6 +43,8 @@
                 <field name="expiration_date" decoration-danger="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"
                  decoration-bf="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"
                  force_save="1" readonly="picking_type_use_existing_lots" invisible="tracking == 'none'"/>
+                <field name="removal_date" force_save="1" readonly="1" invisible="tracking == 'none'"
+                 decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')" decoration-bf="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
             </xpath>
             <xpath expr="//field[@name='lot_id']" position="after">
                 <field name="is_expired" column_invisible="True"/>

--- a/addons/product_expiry/views/stock_quant_views.xml
+++ b/addons/product_expiry/views/stock_quant_views.xml
@@ -23,8 +23,12 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='lot_id']" position="after">
                 <field name="use_expiration_date" column_invisible="True"/>
-                <field name="expiration_date" optional="hide" column_invisible="context.get('hide_removal_date')"/>
-                <field name="removal_date" optional="hide" column_invisible="context.get('hide_removal_date')"/>
+                <field name="expiration_date" column_invisible="not context.get('show_removal_date')"
+                       decoration-danger="expiration_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"
+                       decoration-bf="expiration_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
+                <field name="removal_date" column_invisible="not context.get('show_removal_date')"
+                       decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"
+                       decoration-bf="expiration_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
             </xpath>
         </field>
     </record>
@@ -37,7 +41,11 @@
             <xpath expr="//field[@name='lot_id']" position="after">
                 <field name="use_expiration_date" column_invisible="True"/>
                 <field name="expiration_date" groups="stock.group_production_lot"
-                    optional="hide" column_invisible="context.get('hide_removal_date')"/>
+                       column_invisible="not context.get('show_removal_date')"
+                       decoration-danger="expiration_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')" decoration-bf="expiration_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
+                <field name="removal_date" groups="stock.group_production_lot"
+                       column_invisible="not context.get('show_removal_date')"
+                       decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')" decoration-bf="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
             </xpath>
         </field>
     </record>

--- a/addons/product_expiry/wizard/confirm_expiry.py
+++ b/addons/product_expiry/wizard/confirm_expiry.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime
 
 from odoo import api, fields, models, _
 
@@ -26,7 +27,7 @@ class ExpiryPickingConfirmation(models.TransientModel):
         else:
             # For one expired lot, its name is written in the wizard message.
             self.description = _(
-                "You are going to deliver the product %(product_name)s, %(lot_name)s which is expired."
+                "You are going to deliver the product %(product_name)s, %(lot_name)s which is expired or should at least be removed from stock."
                 "\nDo you confirm you want to proceed?",
                 product_name=self.lot_ids.product_id.display_name,
                 lot_name=self.lot_ids.name
@@ -42,12 +43,7 @@ class ExpiryPickingConfirmation(models.TransientModel):
         return True
 
     def process_no_expired(self):
-        """ Don't process for concerned pickings (ones with expired lots), but
-        process for all other pickings (in case of multi). """
-        # Remove `self.pick_ids` from `button_validate_picking_ids` and call
-        # `button_validate` with the subset (if any).
+        """ Remove the expired mls and confirm the picking. """
         pickings_to_validate = self.env['stock.picking'].browse(self.env.context.get('button_validate_picking_ids'))
-        pickings_to_validate = pickings_to_validate - self.picking_ids
-        if pickings_to_validate:
-            return pickings_to_validate.with_context(skip_expired=True).button_validate()
-        return True
+        self.picking_ids.move_line_ids.filtered(lambda ml: ml.use_expiration_date and ml.removal_date < datetime.now()).unlink()
+        return pickings_to_validate.button_validate()

--- a/addons/product_expiry/wizard/confirm_expiry_view.xml
+++ b/addons/product_expiry/wizard/confirm_expiry_view.xml
@@ -22,7 +22,7 @@
                         data-hotkey="q"
                         class="btn-primary"/>
                     <button name="process_no_expired"
-                        string="Proceed except for expired one"
+                        string="Proceed except expired"
                         type="object"
                         data-hotkey="w"
                         class="btn-secondary"/>

--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
@@ -6,6 +6,7 @@ import { usePopover } from "@web/core/popover/popover_hook";
 import { Component, onWillRender } from "@odoo/owl";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 import { roundPrecision } from "@web/core/utils/numbers";
+import { _t } from "@web/core/l10n/translation";
 
 export class QtyAtDatePopover extends Component {
     static template = "sale_stock.QtyAtDatePopover";
@@ -28,6 +29,14 @@ export class QtyAtDatePopover extends Component {
                 sale_line_to_match_id: this.props.record.resId,
             },
         });
+    }
+
+    get forecastedLabel() {
+        return _t('Forecasted Stock')
+    }
+
+    get availableLabel() {
+        return _t('Available')
     }
 }
 

--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.xml
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.xml
@@ -16,7 +16,7 @@
             <tbody>
                 <t t-if="!props.record.data.is_mto and ['draft', 'sent'].includes(props.record.data.state)">
                     <tr>
-                        <td><strong>Forecasted Stock</strong><br/><small>On <span t-out="props.calcData.delivery_date"/></small></td>
+                        <td><strong t-out="forecastedLabel"/><br/><small>On <span t-out="props.calcData.delivery_date"/></small></td>
                         <td class="text-end">
                             <b t-out='props.record.data.virtual_available_at_date'/> <t t-out='props.record.data.product_uom_id[1]'/>
                             <t t-if="props.record.data.product_uom_id[1] !== props.calcData.product_uom_name">
@@ -25,7 +25,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <td><strong>Available</strong><br /><small>All planned operations included</small></td>
+                        <td><strong t-out="availableLabel"/><br /><small>All planned operations included</small></td>
                         <td class="text-end">
                             <b t-out='props.record.data.free_qty_today' t-att-class="!props.calcData.will_be_fulfilled ? 'text-danger': ''"/> <t t-out='props.record.data.product_uom_id[1]'/>
                             <t t-if="props.record.data.product_uom_id[1] !== props.calcData.product_uom_name">

--- a/addons/sale_stock_product_expiry/__init__.py
+++ b/addons/sale_stock_product_expiry/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/sale_stock_product_expiry/__manifest__.py
+++ b/addons/sale_stock_product_expiry/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    'name': "Sale Stock Product Expiry",
+    'category': 'Sales/Sales',
+    'description': 'Modifications to the forecast widget on SO lines to show fresh stock, i.e. ignoring stock to be removed due to expiration.',
+    'version': '0.1',
+    'depends': ['sale_stock', 'product_expiry'],
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+    'author': 'Odoo S.A.',
+    'assets': {
+        'web.assets_backend': [
+            'sale_stock_product_expiry/static/src/**/*',
+        ],
+    },
+}

--- a/addons/sale_stock_product_expiry/models/__init__.py
+++ b/addons/sale_stock_product_expiry/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import sale_order_line

--- a/addons/sale_stock_product_expiry/models/sale_order_line.py
+++ b/addons/sale_stock_product_expiry/models/sale_order_line.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    use_expiration_date = fields.Boolean(related='product_id.use_expiration_date')
+
+    def _read_qties(self, date, wh):
+        res = super()._read_qties(date, wh)
+        if any(self.mapped('use_expiration_date')):
+            for res_record, read_record in zip(res, self.mapped('product_id').with_context(warehouse_id=wh).read(['free_qty'])):
+                res_record['free_qty'] = read_record['free_qty']
+        return res

--- a/addons/sale_stock_product_expiry/static/src/widgets/qty_at_date_widget.js
+++ b/addons/sale_stock_product_expiry/static/src/widgets/qty_at_date_widget.js
@@ -1,0 +1,27 @@
+import { patch } from "@web/core/utils/patch";
+import { QtyAtDatePopover, qtyAtDateWidget } from "@sale_stock/widgets/qty_at_date_widget";
+import { _t } from "@web/core/l10n/translation";
+
+patch(QtyAtDatePopover.prototype, {
+    get forecastedLabel() {
+        if (this.props.record.data.use_expiration_date) {
+            return _t('Fresh Forecasted Stock')
+        }
+        return super.forecastedLabel;
+    },
+    get availableLabel() {
+        if (this.props.record.data.use_expiration_date) {
+            return _t('Fresh Available')
+        }
+        return super.availableLabel;
+    }
+});
+
+export const expiryQtyAtDateWidget = {
+    ...qtyAtDateWidget,
+    fieldDependencies: [
+        ...qtyAtDateWidget.fieldDependencies,
+        { name: 'use_expiration_date', type: 'boolean' },
+    ],
+};
+patch(qtyAtDateWidget, expiryQtyAtDateWidget);

--- a/addons/sale_stock_product_expiry/static/src/widgets/qty_at_date_widget.xml
+++ b/addons/sale_stock_product_expiry/static/src/widgets/qty_at_date_widget.xml
@@ -1,0 +1,7 @@
+<t t-name="sale_stock_product_expiry.QtyAtDatePopover" t-inherit="sale_stock.QtyAtDatePopover" t-inherit-mode="extension">
+        <xpath expr="//strong[@t-out='availableLabel']" position="after">
+            <t t-if="props.record.data.use_expiration_date">
+                <br /><small>Today</small>
+            </t>
+        </xpath>
+    </t>

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -74,7 +74,7 @@ class ProductProduct(models.Model):
     free_qty = fields.Float(
         'Free To Use Quantity ', compute='_compute_quantities', search='_search_free_qty',
         digits='Product Unit', compute_sudo=False,
-        help="Forecast quantity (computed as Quantity On Hand "
+        help="Available quantity (computed as Quantity On Hand "
              "- reserved quantity)\n"
              "In a context with a single Stock Location, this includes "
              "goods stored in this location, or any of its children.\n"
@@ -192,7 +192,6 @@ class ProductProduct(models.Model):
             date_date_expected_domain_to = [('date', '<=', to_date)]
             domain_move_in += date_date_expected_domain_to
             domain_move_out += date_date_expected_domain_to
-
         Move = self.env['stock.move'].with_context(active_test=False)
         Quant = self.env['stock.quant'].with_context(active_test=False)
         domain_move_in_todo = [('state', 'in', ('waiting', 'confirmed', 'assigned', 'partially_available'))] + domain_move_in
@@ -200,6 +199,10 @@ class ProductProduct(models.Model):
         moves_in_res = {product.id: product_qty for product, product_qty in Move._read_group(domain_move_in_todo, ['product_id'], ['product_qty:sum'])}
         moves_out_res = {product.id: product_qty for product, product_qty in Move._read_group(domain_move_out_todo, ['product_id'], ['product_qty:sum'])}
         quants_res = {product.id: (quantity, reserved_quantity) for product, quantity, reserved_quantity in Quant._read_group(domain_quant, ['product_id'], ['quantity:sum', 'reserved_quantity:sum'])}
+        expired_unreserved_quants_res = {}
+        if self.env.context.get('with_expiration'):
+            domain_quant += [('removal_date', '<=', self.env.context['with_expiration'])]
+            expired_unreserved_quants_res = {product.id: quantity - reserved_quantity for product, quantity, reserved_quantity in Quant._read_group(domain_quant, ['product_id'], ['quantity:sum', 'reserved_quantity:sum'])}
         if dates_in_the_past:
             # Calculate the moves that were done before now to calculate back in time (as most questions will be recent ones)
             domain_move_in_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_in_done
@@ -230,12 +233,13 @@ class ProductProduct(models.Model):
             else:
                 qty_available = quants_res.get(origin_product_id, [0.0])[0]
             reserved_quantity = quants_res.get(origin_product_id, [False, 0.0])[1]
+            expired_unreserved_qty = expired_unreserved_quants_res.get(origin_product_id, 0.0)
             res[product_id]['qty_available'] = product.uom_id.round(qty_available)
-            res[product_id]['free_qty'] = product.uom_id.round(qty_available - reserved_quantity)
+            res[product_id]['free_qty'] = product.uom_id.round(qty_available - reserved_quantity - expired_unreserved_qty)
             res[product_id]['incoming_qty'] = product.uom_id.round(moves_in_res.get(origin_product_id, 0.0))
             res[product_id]['outgoing_qty'] = product.uom_id.round(moves_out_res.get(origin_product_id, 0.0))
             res[product_id]['virtual_available'] = product.uom_id.round(
-                qty_available + res[product_id]['incoming_qty'] - res[product_id]['outgoing_qty'],
+                qty_available + res[product_id]['incoming_qty'] - res[product_id]['outgoing_qty'] - expired_unreserved_qty,
             )
 
         return res

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -767,7 +767,7 @@ class StockQuant(models.Model):
             domain = expression.AND([[('owner_id', '=', owner_id and owner_id.id or False)], domain])
             domain = expression.AND([[('location_id', '=', location_id.id)], domain])
         if self.env.context.get('with_expiration'):
-            domain = expression.AND([['|', ('expiration_date', '>=', self.env.context['with_expiration']), ('expiration_date', '=', False)], domain])
+            domain = expression.AND([['|', ('removal_date', '>=', self.env.context['with_expiration']), ('removal_date', '=', False)], domain])
         return domain
 
     def _gather(self, product_id, location_id, lot_id=None, package_id=None, owner_id=None, strict=False, qty=0):

--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -30,6 +30,9 @@ class ReportStockQuantity(models.Model):
     company_id = fields.Many2one('res.company', readonly=True)
     warehouse_id = fields.Many2one('stock.warehouse', readonly=True)
 
+    def _get_product_qty_col(self):
+        return "q.quantity"
+
     def init(self):
         """
         Because we can transfer a product from a warehouse to another one thanks to a stock move, we need to
@@ -44,7 +47,7 @@ class ReportStockQuantity(models.Model):
                 OR the SM is the duplicated one and is an interwarehouse
         """
         tools.drop_view_if_exists(self._cr, 'report_stock_quantity')
-        query = """
+        query = f"""
 CREATE or REPLACE VIEW report_stock_quantity AS (
 WITH
     warehouse_cte AS(
@@ -125,7 +128,7 @@ FROM (SELECT
         pp.product_tmpl_id,
         'forecast' as state,
         date.*::date,
-        q.quantity as product_qty,
+        {self._get_product_qty_col()} as product_qty,
         q.company_id,
         wh.id as warehouse_id
     FROM

--- a/addons/stock/static/src/stock_forecasted/forecasted_details.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.js
@@ -1,6 +1,7 @@
 import { formatFloat } from "@web/views/fields/formatters";
 import { useService } from "@web/core/utils/hooks";
 import { Component } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 
 export class ForecastedDetails extends Component {
     static template = "stock.ForecastedDetails";
@@ -53,5 +54,21 @@ export class ForecastedDetails extends Component {
 
     get futureVirtualAvailable() {
         return this.props.docs.virtual_available + this.props.docs.qty.in - this.props.docs.qty.out;
+    }
+
+    get freeStockLabel() {
+        return _t('Free Stock');
+    }
+
+    classForLine(line) {
+        const greyBackground = !line.document_in && !line.reservation &&
+            (!line.in_transit && line.replenishment_filled && !line.document_out && !line.removal_date)
+            ||
+            (line.in_transit && !line.move_out);
+        return greyBackground ? 'bg-200' : '';
+    }
+
+    should_have_grey_bg(line){
+
     }
 }

--- a/addons/stock/static/src/stock_forecasted/forecasted_details.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.xml
@@ -24,7 +24,7 @@
                     <td/>
                 </tr>
                 <tr t-foreach="props.docs.lines" t-as="line" t-key="line_index" t-attf-class="#{line.is_matched and 'table-info'}">
-                    <td t-attf-class="#{line.is_late and 'table-danger'}">
+                    <td t-attf-class="#{line.is_late and 'table-danger' or classForLine(line)}">
                         <a t-if="line.document_in"
                             href="#"
                             t-on-click.prevent="() => this.props.openView(line.document_in._name, 'form', line.document_in.id)"
@@ -59,14 +59,14 @@
                                     Reserve
                                 </button>
                             </t>
-                            <t t-else="">Free Stock</t>
+                            <t t-else="" t-out="freeStockLabel"/>
                         </t>
                         <span t-else="" class="text-muted">Not Available</span>
                     </td>
                     <td t-out="line.receipt_date or ''"
-                        t-attf-class="#{line.is_late and 'table-danger'}"/>
-                    <td t-if="props.docs.multiple_product" t-out="line.product.display_name"/>
-                    <td class="text-end"><t t-if="! line.replenishment_filled">- </t><t t-out="_formatFloat(line.quantity)"/></td>
+                        t-attf-class="#{line.is_late and 'table-danger' or classForLine(line)}"/>
+                    <td t-if="props.docs.multiple_product" t-out="line.product.display_name" t-att-class="classForLine(line)"/>
+                    <td class="text-end" t-att-class="classForLine(line)"><t t-if="! line.replenishment_filled">- </t><t t-out="_formatFloat(line.quantity)"/></td>
                     <td t-attf-class="#{! line.replenishment_filled and 'table-danger'}" name="usedby_cell">
                         <button t-if="line.move_out and line.move_out.picking_id"
                             t-attf-class="o_priority o_priority_star me-1 fa fa-star#{line.move_out.picking_id.priority=='1' ? '' : '-o'}"

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.xml
@@ -30,7 +30,7 @@
                 </h6>
             </div>
             <div class="row">
-                <div class="col-md-auto text-center">
+                <div class="col-md-auto text-center" name="on_hand">
                     <div class="h3">
                         <a href="#"
                             t-on-click.prevent="() => this._onClickInventory()"


### PR DESCRIPTION
Since [1], any lots that are past their expiration date have no longer been considered as available quantity.
However, we now change this to use the removal date instead, as this is the date when they should no longer be in stock.

[1] https://github.com/odoo/odoo/pull/117138

task-4040821

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr