### PR TITLE
[FIX] stock: Reintroduce global visibility_days for reordering rules

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -649,7 +649,7 @@ class StockWarehouseOrderpoint(models.Model):
                             origin = orderpoint.name
                         if float_compare(orderpoint.qty_to_order, 0.0, precision_rounding=orderpoint.product_uom.rounding) == 1:
                             date = orderpoint._get_orderpoint_procurement_date()
-                            global_visibility_days = self.env.context.get('global_visibility_days', 0)
+                            global_visibility_days = self.env.context.get('global_visibility_days', self.env['ir.config_parameter'].sudo().get_param('stock.visibility_days', 0))
                             if global_visibility_days:
                                 date -= relativedelta.relativedelta(days=int(global_visibility_days))
                             values = orderpoint._prepare_procurement_values(date=date)

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -386,7 +386,7 @@ class StockRule(models.Model):
         delays = defaultdict(float)
         delay = sum(self.filtered(lambda r: r.action in ['pull', 'pull_push']).mapped('delay'))
         delays['total_delay'] += delay
-        global_visibility_days = self.env.context.get('global_visibility_days', 0)
+        global_visibility_days = self.env.context.get('global_visibility_days', self.env['ir.config_parameter'].sudo().get_param('stock.visibility_days', 0))
         if global_visibility_days:
             delays['total_delay'] += int(global_visibility_days)
         if self.env.context.get('bypass_delay_description'):

--- a/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
+++ b/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
-import { useState } from '@odoo/owl';
+import { useService } from "@web/core/utils/hooks";
+import { onWillStart, useState } from '@odoo/owl';
 import { SearchPanel } from "@web/search/search_panel/search_panel";
 
 
@@ -8,9 +9,16 @@ export class StockOrderpointSearchPanel extends SearchPanel {
     static template = "stock.StockOrderpointSearchPanel";
 
     setup() {
+        this.orm = useService("orm");
         super.setup(...arguments);
         this.globalVisibilityDays = useState({value: 0});
         this.state.sidebarExpanded = false;
+        onWillStart(this.getVisibilityParameter);
+    }
+
+    async getVisibilityParameter() {
+        let res = await this.orm.call("ir.config_parameter", "get_param", ["stock.visibility_days", 0]);
+        this.globalVisibilityDays.value = Math.abs(parseInt(res)) || 0;
     }
 
     async applyGlobalVisibilityDays(ev) {


### PR DESCRIPTION
Backport of odoo/odoo#190450

Odoo 18 introduced a new horizon concept for reordering rules, but it lacks persistence and usability. The horizon value resets when navigating away from the replenishment dashboard, affecting both usability and automatic reordering functionality:

1. Users must manually reset the horizon after consulting other views, disrupting workflows.
2. The horizon fails as a replacement for the old `visibility_days` parameter, rendering automatic reordering unreliable.

This commit reintroduces the `stock.visibility_days` system parameter:
- Acts as the default horizon when no custom value is set or after navigating away.
- Ensures consistency for automatic reordering rules in the back-end.
- Defaults to 0, aligning with prior behavior.

This approach prevents arbitrary horizon changes by users from persisting globally, while maintaining a manageable and reliable workflow for all use cases.

Task 4346100

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
