### PR TITLE
[FIX] mail: volume of ptt on/off sound effects are too loud

### DIFF
--- a/addons/mail/static/src/core/common/sound_effects_service.js
+++ b/addons/mail/static/src/core/common/sound_effects_service.js
@@ -15,9 +15,9 @@ export class SoundEffects {
             "member-leave": { defaultVolume: 0.5, path: "/mail/static/src/audio/channel_01_out" },
             mute: { defaultVolume: 0.2, path: "/mail/static/src/audio/mute_1" },
             "new-message": { path: "/mail/static/src/audio/dm_02" },
-            "push-to-talk-on": { defaultVolume: 0.05, path: "/mail/static/src/audio/ptt_push_1" },
+            "push-to-talk-on": { defaultVolume: 0.02, path: "/mail/static/src/audio/ptt_push_1" },
             "push-to-talk-off": {
-                defaultVolume: 0.05,
+                defaultVolume: 0.02,
                 path: "/mail/static/src/audio/ptt_release_1",
             },
             "screen-sharing": { defaultVolume: 0.5, path: "/mail/static/src/audio/share_02" },

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -333,7 +333,7 @@ export class Rtc extends Record {
         this.state.pttReleaseTimeout = browser.setTimeout(() => {
             this.setTalking(false);
             if (!this.selfSession?.isMute) {
-                this.soundEffectsService.play("push-to-talk-off", { volume: 0.3 });
+                this.soundEffectsService.play("push-to-talk-off");
             }
         }, Math.max(this.store.settings.voice_active_duration || 0, duration));
     }
@@ -348,7 +348,7 @@ export class Rtc extends Record {
         }
         browser.clearTimeout(this.state.pttReleaseTimeout);
         if (!this.selfSession.isTalking && !this.selfSession.isMute) {
-            this.soundEffectsService.play("push-to-talk-on", { volume: 0.3 });
+            this.soundEffectsService.play("push-to-talk-on");
         }
         this.setTalking(true);
     }


### PR DESCRIPTION
Before this commit, when using push-to-talk during discuss call, the sound effect from press and release of ptt was too loud.

This commit reduces the volume drastically, so this can still be heard but it's low enough to not be distracting.

Before
https://github.com/user-attachments/assets/af330e28-4351-44ab-a1df-46730b658379


After
https://github.com/user-attachments/assets/77e34eec-6099-4172-b1b5-f407122bd1ca


