### PR TITLE
[IMP] account: Raise a User error rather than assert

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -15132,6 +15132,14 @@ msgid ""
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_move_send.py:0
+msgid ""
+"The sending of invoices is not set up properly, make sure the report used is"
+" set for invoices."
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,help:account.field_account_tax__sequence
 msgid ""
 "The sequence field is used to define order in which the tax lines are "

--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -257,6 +257,16 @@ class AccountMoveSend(models.AbstractModel):
             raise UserError(_("You can only Print & Send sales documents."))
 
     @api.model
+    def _check_invoice_report(self, moves, **custom_settings):
+        if ((
+                custom_settings.get('pdf_report')
+                and not custom_settings['pdf_report'].is_invoice_report
+            )
+            or any(not self._get_default_pdf_report_id(move).is_invoice_report for move in moves)
+        ):
+            raise UserError(_("The sending of invoices is not set up properly, make sure the report used is set for invoices."))
+
+    @api.model
     def _format_error_text(self, error):
         """ Format the error that can be either a dict (complex format needed) or a string (simple format) into a
         regular string.
@@ -655,8 +665,7 @@ class AccountMoveSend(models.AbstractModel):
         This is a security in case the method is called directly without going through the wizards.
         """
         self._check_move_constrains(moves)
-        assert all(self._get_default_pdf_report_id(move).is_invoice_report for move in moves)
-        assert custom_settings['pdf_report'].is_invoice_report if custom_settings.get('pdf_report') else True
+        self._check_invoice_report(moves, **custom_settings)
         assert all(
             sending_method in dict(self.env['res.partner']._fields['invoice_sending_method'].selection)
             for sending_method in custom_settings.get('sending_methods', [])


### PR DESCRIPTION
Problem
---------
When you use a Invoice report with the checkbox "Invoice report" unselected (misconfiguration), you get a traceback.

Objective
---------
Replace it with an error message instead, saying there's no invoice report configured in the database.

Solution
---------
Turn the asserts into a if condition that raises a user error.

task-4421065

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
