### PR TITLE
[FIX] web_editor: extract link from HTML

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4708,8 +4708,10 @@ export class OdooEditor extends EventTarget {
         ev.preventDefault();
         const sel = this.document.getSelection();
         const files = getImageFiles(ev.clipboardData);
-        const odooEditorHtml = ev.clipboardData.getData('text/odoo-editor');
-        const clipboardHtml = ev.clipboardData.getData('text/html');
+        const textContent = ev.clipboardData.getData("text/plain");
+        const isContentSingleLink = /^https?:\/\//i.test(textContent);
+        const odooEditorHtml = isContentSingleLink ? '' : ev.clipboardData.getData('text/odoo-editor');
+        const clipboardHtml = isContentSingleLink ? '' : ev.clipboardData.getData('text/html');
         const targetSupportsHtmlContent = isHtmlContentSupported(sel.anchorNode);
         // Replace entire link if its label is fully selected.
         const link = closestElement(sel.anchorNode, 'a');
@@ -4719,8 +4721,7 @@ export class OdooEditor extends EventTarget {
             setSelection(...start, ...start, false);
         }
         if (!targetSupportsHtmlContent) {
-            const text = ev.clipboardData.getData("text/plain");
-            this._applyCommand("insert", text);
+            this._applyCommand("insert", textContent);
         } else if (odooEditorHtml) {
             const fragment = parseHTML(odooEditorHtml);
             const selector = this.options.renderingClasses.map(c => `.${c}`).join(',');


### PR DESCRIPTION
**Problem**:
When a link is copied with HTML content, the `_onPaste` method does not recognize it as a link because the content type is `text/html`.

**Solution**:
Extract the pasted content as text and check if it is a single link. If so, treat it as a link instead of HTML.

**Steps to Reproduce**:
1. Copy a link from Visual Studio Code.
2. Paste the link into the editor.
3. Observe that the link is not created.

opw-4460599

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
