### PR TITLE
[FIX] web_editor: extract link from HTML

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -78,6 +78,8 @@ export const CLIPBOARD_WHITELISTS = {
     styledTags: ["SPAN", "B", "STRONG", "I", "S", "U", "FONT", "TD"],
 };
 
+const ONLY_LINK_REGEX = /^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w-./?%&=]*)?$/i;
+
 /**
  * @typedef {Object} ClipboardShared
  * @property {ClipboardPlugin['pasteText']} pasteText
@@ -260,6 +262,10 @@ export class ClipboardPlugin extends Plugin {
      */
     handlePasteOdooEditorHtml(clipboardData) {
         const odooEditorHtml = clipboardData.getData("application/vnd.odoo.odoo-editor");
+        const textContent = clipboardData.getData("text/plain");
+        if (ONLY_LINK_REGEX.test(textContent)) {
+            return false;
+        }
         if (odooEditorHtml) {
             const fragment = parseHTML(this.document, odooEditorHtml);
             this.dependencies.sanitize.sanitize(fragment);
@@ -276,6 +282,10 @@ export class ClipboardPlugin extends Plugin {
     handlePasteHtml(selection, clipboardData) {
         const files = getImageFiles(clipboardData);
         const clipboardHtml = clipboardData.getData("text/html");
+        const textContent = clipboardData.getData("text/plain");
+        if (ONLY_LINK_REGEX.test(textContent)) {
+            return false;
+        }
         if (files.length || clipboardHtml) {
             const clipboardElem = this.prepareClipboardData(clipboardHtml);
             // @phoenix @todo: should it be handled in table plugin?


### PR DESCRIPTION
**Problem**:
When a link is copied with HTML content, `handlePasteText` is called after `handlePasteHtml`, and the content type is `text/html`.

**Solution**:
Extract the pasted content as text inside `handlePasteHtml` and check if it is a single valid link. If so, skip further processing.

**Steps to Reproduce**:
1. Copy a link from Visual Studio Code.
2. Paste the link into the editor.
3. Observe that the link is not created.

opw-4460599

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
