### PR TITLE
[FIX] mrp: bypass set_qty_producing on lot creation for MO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -796,7 +796,8 @@ class MrpProduction(models.Model):
 
     @api.onchange('qty_producing', 'lot_producing_id')
     def _onchange_producing(self):
-        self._set_qty_producing()
+        productions_bypass_qty_producting = self.filtered(lambda p: p.lot_producing_id and p.product_tracking == 'lot' and p._origin and p._origin.qty_producing == p.qty_producing)
+        (self - productions_bypass_qty_producting)._set_qty_producing()
 
     @api.onchange('lot_producing_id')
     def _onchange_lot_producing(self):


### PR DESCRIPTION
### Steps to reproduce:

- Create a product tracked by LOT (not SN)
- Create a BOM for that product and a BOM line with a tracked product
- Put a an SN for your component in STOCK.
- Create an MO for 1 unit of your product and confirm.
> The SN should be set on your component line.
- Set an LOT on the finished product with the create option but without clicking on the [+]
#### > The quantity of the component line was updated to 0 and the SN of the comp was removed.

### Cause of the issue:

Changing the lot on the MO form will trigger the `_onchange_producing` which will in turn `_set_qty_producing`:
https://github.com/odoo/odoo/blob/83445d91a588958417fef8a04d1187974d4b3d9a/addons/mrp/models/mrp_production.py#L797-L799 In case the product is tracked by SN this `_set_qty_producing` will set a qty_producing of 1 and the move raws will reserve a quantity accordingly but if the product is tracked by lot or not tracked at all the quantities of the move raw will just be adapted to match the `qty_producing` (that was at 0 from the start):
https://github.com/odoo/odoo/blob/83445d91a588958417fef8a04d1187974d4b3d9a/addons/mrp/models/mrp_production.py#L1217-L1227

opw-4418809
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
