### PR TITLE
[FIX] crm: fix team assignation on lead quick create

### DIFF
--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -605,10 +605,7 @@ class Team(models.Model):
     @api.model
     def _action_update_to_pipeline(self, action):
         user_team_id = self.env.user.sale_team_id.id
-        if user_team_id:
-            # To ensure that the team is readable in multi company
-            user_team_id = self.search([('id', '=', user_team_id)], limit=1).id
-        else:
+        if not user_team_id:
             user_team_id = self.search([], limit=1).id
             action['help'] = "<p class='o_view_nocontent_smiling_face'>%s</p><p>" % _("Create an Opportunity")
             if user_team_id:
@@ -620,9 +617,6 @@ class Team(models.Model):
                     action['help'] += "<p>%s</p>" % _("""As you are a member of no Sales Team, you are showed the Pipeline of the <b>first team by default.</b>
                                         To work with the CRM, you should join a team.""")
         action_context = safe_eval(action['context'], {'uid': self.env.uid})
-        if user_team_id:
-            action_context['default_team_id'] = user_team_id
-
         action['context'] = action_context
         return action
 

--- a/addons/crm/static/tests/tours/crm_rainbowman.js
+++ b/addons/crm/static/tests/tours/crm_rainbowman.js
@@ -27,7 +27,7 @@
         }, {
             trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Lead 1')",
             content: "move to won stage",
-            run: "drag_and_drop_native .o_opportunity_kanban .o_kanban_group:eq(3) "
+            run: "drag_and_drop_native .o_opportunity_kanban .o_kanban_group:has(.o_column_title:contains('Won')) "
         }, {
             trigger: ".o_reward_rainbow",
             extra_trigger: ".o_reward_rainbow",


### PR DESCRIPTION
How to reproduce:
==============
- ​Have Marc Demo work in another sales team that yours.
- ​Go to a kanban view of leads, grouped by salesperson.
- ​Quick create a new lead.

Current behavior:
=============
​It gets assigned to your team, probably because
the default value is not properly updated.

Expected behavior:
==============
- ​The lead belongs to Marc and should be linked to his team.
- ​It works fine if you do it from the form view.

task-4438021

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
