### PR TITLE
[FIX] calendar: remove end_type ambiguity in sql query

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -40,7 +40,7 @@ class AlarmManager(models.AbstractModel):
                         END as last_alarm,
                         cal.start as first_event_date,
                         CASE
-                            WHEN cal.recurrency AND end_type = 'end_date' THEN rrule.until
+                            WHEN cal.recurrency AND rrule.end_type = 'end_date' THEN rrule.until
                             ELSE cal.stop
                         END as last_event_date,
                         calcul_delta.min_delta,


### PR DESCRIPTION
__Current behavior before commit:__
In [`a27afdb`][1], the field `end_type` from the model `calendar.event` became computed and therefore not stored anymore.
Databases that upgraded from an anterior version still have the column `end_type` in their table `calendar_event`.

In [`f6df418`][2], a reference to `end_type` from the table `calendar_recurrence` has been added in the SQL query. If the field `end_type` is still in the table `calendar_event` it is ambiguous which one this query should use.

Ultimately leading to this error:
```
psycopg2.errors.AmbiguousColumn: column reference "end_type" is ambiguous
LINE 22: ...                          WHEN cal.recurrency AND end_type =...
```

__Description of the fix:__
Remove the ambiguity by explicitly specifying `rrule`, the alias of the `calendar_recurrence` table.

opw-4406814

[1]: https://github.com/odoo/odoo/commit/a27afdb
[2]: https://github.com/odoo/odoo/commit/f6df418