### PR TITLE
[FIX] account: Fix quick encoding with reverse charge tax

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3690,7 +3690,12 @@ class AccountMove(models.Model):
             price_untaxed = self.currency_id.round(
                 remaining_amount / (((1.0 - discount_percentage / 100.0) * (taxes.amount / 100.0)) + 1.0))
         else:
-            price_untaxed = taxes.with_context(force_price_include=True).compute_all(remaining_amount)['total_excluded']
+            tax_results = taxes.with_context(force_price_include=True).compute_all(remaining_amount)
+            price_untaxed = tax_results['total_excluded'] - sum(
+                tax_data['amount']
+                for tax_data in tax_results['taxes']
+                if tax_data['is_reverse_charge']
+            )
         return {'account_id': account_id, 'tax_ids': taxes.ids, 'price_unit': price_untaxed}
 
     @api.onchange('quick_edit_mode', 'journal_id', 'company_id')

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2319,6 +2319,7 @@ class AccountTax(models.Model):
                     'account_id': tax_rep_data['account'].id,
                     'analytic': tax.analytic,
                     'use_in_tax_closing': rep_line.use_in_tax_closing,
+                    'is_reverse_charge': tax_data['is_reverse_charge'],
                     'price_include': tax.price_include,
                     'tax_exigibility': tax.tax_exigibility,
                     'tax_repartition_line_id': rep_line.id,

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -3791,6 +3791,35 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertRecordValues(invoice, [{'amount_total': 120.58, 'amount_untaxed': 100, 'amount_tax': 20.58}])
         self.assertEqual(len(invoice.invoice_line_ids), 2)
 
+    def test_quick_edit_total_amount_with_reverse_charge(self):
+        tax = self.env['account.tax'].create({
+            'name': "test_quick_edit_total_amount_with_reverse_charge",
+            'amount': 15.0,
+            'invoice_repartition_line_ids': [
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': -100.0}),
+            ],
+            'refund_repartition_line_ids': [
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': -100.0}),
+            ],
+        })
+        self.env.company.quick_edit_mode = "out_and_in_invoices"
+        self.env.company.account_sale_tax_id = tax
+
+        move_form = Form(self.env['account.move'].with_context(default_move_type='out_invoice'))
+        move_form.invoice_date = fields.Date.from_string('2022-01-01')
+        move_form.quick_edit_total_amount = 100.0
+        invoice = move_form.save()
+        self.assertRecordValues(invoice.line_ids, [
+            {'display_type': 'product', 'balance': -100.0},
+            {'display_type': 'tax', 'balance': -15.0},
+            {'display_type': 'tax', 'balance': 15.0},
+            {'display_type': 'payment_term', 'balance': 100.0},
+        ])
+
     def test_out_invoice_depreciated_account(self):
         move = self.env['account.move'].create({
             'move_type': 'out_invoice',


### PR DESCRIPTION
Suppose a tax 15% +100 -100.
Use the quick encoding with an amount of 100.0.
=> The base of the created invoice line is 86.96 and the created tax lines are +13.04 -26.08. That's wrong. Both have to produce the same amount.

In 17.0, we get a base of 100 and +15 -15 as tax amounts. In 18.0, we changed the management of reverse charge so the total excluded amount is computed as 100 / 1.15 ~= 86.96.
It produces tax lines computed on 86.96. 86.96 * 0.15 ~= 13.04. But at the end, the quick encoding algorithmn "fixes" the tax amount. It expect a total of 100 and it has a missing amount of 100 - 86.96 - 13.04 + 13.04 = 13.04 to reach the objective. So it adds 13.04 in the biggest tax line.

opw-4428842

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
