### PR TITLE
[FIX] mrp: find all child MO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1195,7 +1195,9 @@ class MrpProduction(models.Model):
         self.ensure_one()
         procurement_moves = self.procurement_group_id.stock_move_ids
         child_moves = procurement_moves.move_orig_ids
-        return (procurement_moves | child_moves).created_production_id.procurement_group_id.mrp_production_ids.filtered(lambda p: p.origin != self.origin) - self
+        return ((procurement_moves | child_moves).created_production_id.procurement_group_id.mrp_production_ids\
+                | child_moves.production_id)\
+                .filtered(lambda p: p.origin != self.origin) - self
 
     def _get_sources(self):
         self.ensure_one()


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “C1”:
     - MTO + Manufacture
     - BoM:
        - Component: 1 unit of C2
- Create a storable product “P1”
    - Component: 1 unit of C1

- Create a MO to produce one unit of P1:
    - Confirm
- A child MO with one unit of C1 is created
- Update the qty producing of P1 to 2
- A new MO to produce one unit of C1 is created

Problem:
The MO of P1 is linked only to the last MO of C1.
This occurs because the “created_production_id” field in the stock move of C1 (associated with the MO of P1) is updated to reference the most recent MO of C1. Additionally, since the following fix:
https://github.com/odoo/odoo/commit/c5b3f41fbd442def9e97acb023a00862e7d03eb3#diff-6d86bc8c3e9aa22586656b702849c5bbbb00c9b97ffd08bc0842e0e68f8948f9R74
Each new MO has its own procurement group.
As a result, when using the _get_children method:
- The method retrieves stock moves linked to the current procurement group.
- It uses their created_production_id to fetch the associated procurement group and then retrieves the related production_id.
However, since the two child MOs of C1 belong to different procurement groups, only the latest MO is returned.

opw-4450210
