### PR TITLE
[IMP] mail: canned response with :: instead of :

### DIFF
--- a/addons/im_livechat/static/tests/suggestions.test.js
+++ b/addons/im_livechat/static/tests/suggestions.test.js
@@ -12,7 +12,7 @@ import { defineLivechatModels } from "./livechat_test_helpers";
 describe.current.tags("desktop");
 defineLivechatModels();
 
-test("Suggestions are shown after delimiter was used in text (:)", async () => {
+test("Suggestions are shown after delimiter was used in text (::)", async () => {
     const pyEnv = await startServer();
     pyEnv["mail.canned.response"].create({
         source: "hello",
@@ -29,11 +29,11 @@ test("Suggestions are shown after delimiter was used in text (:)", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", "::");
     await contains(".o-mail-Composer-suggestion strong", { text: "hello" });
     await insertText(".o-mail-Composer-input", ")");
     await contains(".o-mail-Composer-suggestion strong", { count: 0 });
-    await insertText(".o-mail-Composer-input", " :");
+    await insertText(".o-mail-Composer-input", " ::");
     await contains(".o-mail-Composer-suggestion strong", { text: "hello" });
 });
 

--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -4818,6 +4818,12 @@ msgstr ""
 
 #. module: mail
 #. odoo-javascript
+#: code:addons/mail/static/src/core/common/composer_actions.js:0
+msgid "Insert a Canned response"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
 #: code:addons/mail/static/src/core/web/messaging_menu_patch.xml:0
 msgid "Install"
 msgstr ""
@@ -9085,12 +9091,6 @@ msgstr ""
 #: model:ir.model.fields.selection,name:mail.selection__mail_compose_message__message_type__notification
 #: model:ir.model.fields.selection,name:mail.selection__mail_message__message_type__notification
 msgid "System notification"
-msgstr ""
-
-#. module: mail
-#. odoo-javascript
-#: code:addons/mail/static/src/core/common/composer.js:0
-msgid "Tab to select"
 msgstr ""
 
 #. module: mail

--- a/addons/mail/models/discuss/res_users.py
+++ b/addons/mail/models/discuss/res_users.py
@@ -62,6 +62,11 @@ class ResUsers(models.Model):
         store.add_global_values(
             hasGifPickerFeature=bool(get_param("discuss.tenor_api_key")),
             hasMessageTranslationFeature=bool(get_param("mail.google_translate_api_key")),
+            hasCannedResponses=bool(self.env["mail.canned.response"].sudo().search([
+                "|",
+                ("create_uid", "=", self.env.user.id),
+                ("group_ids", "in", self.env.user.groups_id.ids),
+            ], limit=1)) if self.env.user else False,
             channel_types_with_seen_infos=sorted(
                 self.env["discuss.channel"]._types_allowing_seen_infos()
             ),

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -123,7 +123,8 @@ export class Composer extends Component {
                     isEventHandled(ev, "emoji.selectEmoji") ||
                     isEventHandled(ev, "Composer.onClickAddEmoji") ||
                     isEventHandled(ev, "composer.clickOnAddAttachment") ||
-                    isEventHandled(ev, "composer.selectSuggestion")
+                    isEventHandled(ev, "composer.selectSuggestion") ||
+                    isEventHandled(ev, "composer.clickInsertCannedResponse")
                 );
             },
         });
@@ -404,8 +405,6 @@ export class Composer extends Component {
             case "mail.canned.response":
                 return {
                     ...props,
-                    autoSelectFirst: false,
-                    hint: _t("Tab to select"),
                     optionTemplate: "mail.Composer.suggestionCannedResponse",
                     options: suggestions.map((suggestion) => ({
                         cannedResponse: suggestion,
@@ -702,6 +701,20 @@ export class Composer extends Component {
             });
         }
         this.suggestion?.clearRawMentions();
+    }
+
+    onClickInsertCannedResponse(ev) {
+        markEventHandled(ev, "composer.clickInsertCannedResponse");
+        const composer = toRaw(this.props.composer);
+        const text = composer.text;
+        const firstPart = text.slice(0, composer.selection.start);
+        const secondPart = text.slice(composer.selection.end, text.length);
+        const toInsertPart = firstPart.length === 0 || firstPart.at(-1) === " " ? "::" : " ::";
+        composer.text = firstPart + toInsertPart + secondPart;
+        this.selection.moveCursor((firstPart + toInsertPart).length);
+        if (!this.ui.isSmall || !this.env.inChatter) {
+            composer.autofocus++;
+        }
     }
 
     addEmoji(str) {

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -132,6 +132,18 @@ composerActionsRegistry
         name: _t("Open Full Composer"),
         onClick: (component) => component.onClickFullComposer(),
         sequence: 30,
+    })
+    .add("add-canned-response", {
+        condition: (component) =>
+            component.store.hasCannedResponses &&
+            component.thread &&
+            component.env.services["mail.suggestion"]
+                .getSupportedDelimiters(component.thread)
+                .find(([delimiter]) => delimiter === "::"),
+        icon: "fa fa-file-text-o",
+        name: _t("Insert a Canned response"),
+        onClick: (component, action, ev) => component.onClickInsertCannedResponse(ev),
+        sequence: 5,
     });
 
 function transformAction(component, id, action) {

--- a/addons/mail/static/src/core/common/navigable_list.js
+++ b/addons/mail/static/src/core/common/navigable_list.js
@@ -13,9 +13,7 @@ export class NavigableList extends Component {
     static template = "mail.NavigableList";
     static props = {
         anchorRef: { optional: true },
-        autoSelectFirst: { type: Boolean, optional: true },
         class: { type: String, optional: true },
-        hint: { type: String, optional: true },
         onSelect: { type: Function },
         options: { type: Array },
         optionTemplate: { type: String, optional: true },
@@ -25,7 +23,6 @@ export class NavigableList extends Component {
     static defaultProps = {
         position: "bottom",
         isLoading: false,
-        autoSelectFirst: true,
     };
 
     setup() {
@@ -80,9 +77,7 @@ export class NavigableList extends Component {
     open() {
         this.state.open = true;
         this.state.activeIndex = null;
-        if (this.props.autoSelectFirst) {
-            this.navigate("first");
-        }
+        this.navigate("first");
     }
 
     close() {

--- a/addons/mail/static/src/core/common/navigable_list.xml
+++ b/addons/mail/static/src/core/common/navigable_list.xml
@@ -22,7 +22,6 @@
                     </a>
                     <t t-set="lastGroup" t-value="option.group"/>
                 </div>
-                <span t-if="props.hint" class="text-muted fst-italic form-text align-self-end m-0 me-1 smaller" t-esc="props.hint"/>
             </div>
         </div>
     </t>

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -105,14 +105,23 @@ class UseSuggestion {
             if (candidatePosition < 0 || candidatePosition >= text.length) {
                 continue;
             }
-            const candidateChar = text[candidatePosition];
-            if (
-                !supportedDelimiters.find(
-                    ([delimiter, allowedPosition]) =>
-                        delimiter === candidateChar &&
-                        (allowedPosition === undefined || allowedPosition === candidatePosition)
-                )
-            ) {
+
+            const findAppropriateDelimiter = () => {
+                let goodCandidate;
+                for (const [delimiter, allowedPosition] of supportedDelimiters) {
+                    if (
+                        text.substring(candidatePosition).startsWith(delimiter) && // delimiter is used
+                        (allowedPosition === undefined || allowedPosition === candidatePosition) && // delimiter is allowed
+                        (!goodCandidate || delimiter.length > goodCandidate) // delimiter is more specific
+                    ) {
+                        goodCandidate = delimiter;
+                    }
+                }
+                return goodCandidate;
+            };
+
+            const candidateDelimiter = findAppropriateDelimiter();
+            if (!candidateDelimiter) {
                 continue;
             }
             const charBeforeCandidate = text[candidatePosition - 1];
@@ -120,9 +129,9 @@ class UseSuggestion {
                 continue;
             }
             Object.assign(this.search, {
-                delimiter: candidateChar,
+                delimiter: candidateDelimiter,
                 position: candidatePosition,
-                term: text.substring(candidatePosition + 1, start),
+                term: text.substring(candidatePosition + candidateDelimiter.length, start),
             });
             this.state.count++;
             return;
@@ -137,7 +146,7 @@ class UseSuggestion {
         const text = this.composer.text;
         let before = text.substring(0, this.search.position + 1);
         let after = text.substring(position, text.length);
-        if (this.search.delimiter === ":") {
+        if (this.search.delimiter === "::") {
             before = text.substring(0, this.search.position);
             after = text.substring(position, text.length);
         }

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -16,7 +16,7 @@ export class SuggestionService {
     }
 
     getSupportedDelimiters(thread) {
-        return [["@"], ["#"], [":"]];
+        return [["@"], ["#"], ["::"]];
     }
 
     async fetchSuggestions({ delimiter, term }, { thread, abortSignal } = {}) {
@@ -29,7 +29,7 @@ export class SuggestionService {
             case "#":
                 await this.fetchThreads(cleanedSearchTerm, { abortSignal });
                 break;
-            case ":":
+            case "::":
                 await this.store.cannedReponses.fetch();
                 break;
         }
@@ -150,7 +150,7 @@ export class SuggestionService {
             }
             case "#":
                 return this.searchChannelSuggestions(cleanedSearchTerm, sort);
-            case ":":
+            case "::":
                 return this.searchCannedResponseSuggestions(cleanedSearchTerm, sort);
         }
         return {

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -842,7 +842,7 @@ test("Message is sent only once when pressing enter twice in a row", async () =>
     await contains(".o-mail-Message-content", { text: "Hello World!" });
 });
 
-test('display canned response suggestions on typing ":"', async () => {
+test('display canned response suggestions on typing "::"', async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Mario" });
     const channelId = pyEnv["discuss.channel"].create({
@@ -860,7 +860,7 @@ test('display canned response suggestions on typing ":"', async () => {
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-input");
     await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", "::");
     await contains(".o-mail-Composer-suggestionList .o-open");
     await contains(".o-mail-NavigableList-item", { text: "helloHello! How are you?" });
 });
@@ -884,7 +884,7 @@ test("select a canned response suggestion", async () => {
     await contains(".o-mail-Composer-suggestionList");
     await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await contains(".o-mail-Composer-input", { value: "" });
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", "::");
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", { value: "Hello! How are you? " });
 });
@@ -909,7 +909,7 @@ test("select a canned response suggestion with some text", async () => {
     await contains(".o-mail-Composer-input", { value: "" });
     await insertText(".o-mail-Composer-input", "bluhbluh ");
     await contains(".o-mail-Composer-input", { value: "bluhbluh " });
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", "::");
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", { value: "bluhbluh Hello! How are you? " });
 });
@@ -932,7 +932,7 @@ test("add an emoji after a canned response", async () => {
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-suggestionList");
     await contains(".o-mail-Composer-input", { value: "" });
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", "::");
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", { value: "Hello! How are you? " });
     await click("button[title='Add Emojis']");
@@ -953,7 +953,7 @@ test("Canned response can be inserted from the bus", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-input");
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", "::");
     await contains(".o-mail-NavigableList-item", { count: 0 });
     await insertText(".o-mail-Composer-input", "", { replace: true });
     pyEnv["mail.canned.response"].create({
@@ -961,7 +961,7 @@ test("Canned response can be inserted from the bus", async () => {
         substitution: "Hello! How are you?",
     });
     await contains(".o-mail-NavigableList-item", { count: 0 });
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", "::");
     await contains(".o-mail-NavigableList-item", { text: "helloHello! How are you?" });
 });
 
@@ -982,14 +982,14 @@ test("Canned response can be updated from the bus", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-input");
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", "::");
     await contains(".o-mail-NavigableList-item", { count: 1 });
     await insertText(".o-mail-Composer-input", "", { replace: true });
     pyEnv["mail.canned.response"].write([cannedResponseId], {
         substitution: "Howdy! How are you?",
     });
     await contains(".o-mail-NavigableList-item", { count: 0 });
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", "::");
     await contains(".o-mail-NavigableList-item", { text: "helloHowdy! How are you?" });
 });
 
@@ -1015,14 +1015,14 @@ test("Canned response can be deleted from the bus", async () => {
     ]);
     await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", "::");
     await contains(".o-mail-NavigableList-item", { count: 2 });
     await contains(".o-mail-NavigableList-item", { text: "hello" });
     await contains(".o-mail-NavigableList-item", { text: "test" });
     await insertText(".o-mail-Composer-input", "", { replace: true });
     await contains(".o-mail-NavigableList-item", { count: 0 });
     pyEnv["mail.canned.response"].unlink([cannedResponseId]);
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", "::");
     await contains(".o-mail-NavigableList-item", { count: 1 });
     await contains(".o-mail-NavigableList-item", { text: "test" });
 });
@@ -1039,7 +1039,7 @@ test("Canned response last used changes on posting", async () => {
     ])[0];
     await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", "::");
     await click(".o-mail-NavigableList-item", { text: "testTest a canned response?" });
     await contains(".o-mail-Composer-input", { value: "Test a canned response? " });
     expect(cannedResponse.last_used).toBeEmpty();
@@ -1057,41 +1057,9 @@ test("Does not auto-select 1st canned response suggestion", async () => {
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
     await contains(".o-mail-NavigableList-active", { text: "Mitchell Admin" });
-    await insertText(".o-mail-Composer-input", ":", { replace: true });
+    await insertText(".o-mail-Composer-input", "::", { replace: true });
     await contains(".o-mail-NavigableList-item", { text: "HelloHello! How are you?" });
     await contains(".o-mail-NavigableList-active", { count: 0 });
-});
-
-test("TAB/ARROW focuses 1st canned response suggestion", async () => {
-    const pyEnv = await startServer();
-    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
-    pyEnv["mail.canned.response"].create([
-        { source: "Hello", substitution: "Hello! How are you?" },
-        { source: "Goodbye", substitution: "Goodbye! See you soon!" },
-    ]);
-    await start();
-    await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", ":");
-    // Assuming the suggestions are displayed in alphabetical order
-    await contains(".o-mail-NavigableList-item", {
-        text: "GoodbyeGoodbye! See you soon!",
-        before: [".o-mail-NavigableList-item", { text: "HelloHello! How are you?" }],
-    });
-    await contains(".o-mail-NavigableList-active", { count: 0 });
-    await triggerHotkey("Tab");
-    await contains(".o-mail-NavigableList-active", { text: "GoodbyeGoodbye! See you soon!" });
-    await triggerHotkey("Escape");
-    await contains(".o-mail-NavigableList-item", { count: 0 });
-    await insertText(".o-mail-Composer-input", ":", { replace: true });
-    await contains(".o-mail-NavigableList-item", { count: 2 });
-    await triggerHotkey("ArrowDown");
-    await contains(".o-mail-NavigableList-active", { text: "GoodbyeGoodbye! See you soon!" });
-    await triggerHotkey("Escape");
-    await contains(".o-mail-NavigableList-active", { count: 0 });
-    await insertText(".o-mail-Composer-input", ":", { replace: true });
-    await contains(".o-mail-NavigableList-item", { count: 2 });
-    await triggerHotkey("ArrowUp");
-    await contains(".o-mail-NavigableList-active", { text: "GoodbyeGoodbye! See you soon!" });
 });
 
 test("ENTER closes canned response suggestions", async () => {
@@ -1100,7 +1068,7 @@ test("ENTER closes canned response suggestions", async () => {
     pyEnv["mail.canned.response"].create({ source: "Hello", substitution: "Hello! How are you?" });
     await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", "::");
     await contains(".o-mail-NavigableList-item", { text: "HelloHello! How are you?" });
     await contains(".o-mail-NavigableList-active", { count: 0 });
     await triggerHotkey("Enter");
@@ -1130,17 +1098,18 @@ test("Tab to select of canned response suggestion works in chat window", async (
     ]);
     await start();
     await contains(".o-mail-ChatWindow", { count: 2 });
-    await insertText(".o-mail-ChatWindow:eq(0) .o-mail-Composer-input", ":");
+    await insertText(".o-mail-ChatWindow:eq(0) .o-mail-Composer-input", "::");
     // Assuming the suggestions are displayed in alphabetical order
     await contains(".o-mail-NavigableList-item", {
         text: "GoodbyeGoodbye! See you soon!",
         before: [".o-mail-NavigableList-item", { text: "HelloHello! How are you?" }],
     });
-    await triggerHotkey("Tab");
     await contains(".o-mail-NavigableList-active", { text: "GoodbyeGoodbye! See you soon!" });
+    await triggerHotkey("Tab");
+    await contains(".o-mail-NavigableList-active", { text: "HelloHello! How are you?" });
     await animationFrame();
     await triggerHotkey("Enter");
     await contains(".o-mail-ChatWindow:eq(0) .o-mail-Composer-input", {
-        value: "Goodbye! See you soon! ",
+        value: "Hello! How are you? ",
     });
 });

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -20,14 +20,16 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - _compute_im_status (_read_format/_to_store)
     #       - _get_on_leave_ids (_compute_im_status override)
     #       - fetch res_users (_to_store)
-    #   6: settings:
+    #   8: settings:
     #       - search (_find_or_create_for_user)
     #       - fetch res_partner (_format_settings: display_name of user_id because classic load)
     #       - fetch res_users_settings (_format_settings)
     #       - search res_users_settings_volumes (_format_settings)
     #       - search res_lang_res_users_settings_rel (_format_settings)
     #       - search im_livechat_expertise_res_users_settings_rel (_format_settings)
-    _query_count_init_store = 12
+    #       - search mail_canned_response
+    #       - fetch res_groups_users_rel (for search mail_canned_response that user can use)
+    _query_count_init_store = 14
     # Queries for _query_count_init_messaging (in order):
     #   1: insert res_device_log
     #   1: fetch res_users (for current user, first occurence _get_channels_as_member of _init_messaging)
@@ -391,6 +393,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             "Store": {
                 "channel_types_with_seen_infos": sorted(["chat", "group", "livechat"]),
                 "action_discuss_id": xmlid_to_res_id("mail.action_discuss"),
+                "hasCannedResponses": False,
                 "hasGifPickerFeature": False,
                 "hasLinkPreviewFeature": True,
                 "has_access_livechat": False,

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -18,16 +18,16 @@ class TestPerfSessionInfo(common.HttpCase):
         self.authenticate(user.login, "info")
 
         self.env.registry.clear_all_caches()
-        # cold ormcache (only web: 42, all module: 115)
-        with self.assertQueryCount(115):
+        # cold ormcache (only web: 42, all module: 116)
+        with self.assertQueryCount(116):
             self.url_open(
                 "/web/session/get_session_info",
                 data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),
                 headers={"Content-Type": "application/json"},
             )
 
-        # cold fields cache - warm ormcache (only web: 6, all module: 23)
-        with self.assertQueryCount(23):
+        # cold fields cache - warm ormcache (only web: 6, all module: 25)
+        with self.assertQueryCount(25):
             self.url_open(
                 "/web/session/get_session_info",
                 data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),


### PR DESCRIPTION
Before this commit, delimiter to use canned response was ":". This puts some conflicts with emoji substitution, which has been minimized a bit by not putting the focus on the suggestion list of emojis.

However this is still bothersome, so it's worth changing it slightly. This PR minimises the impact of change by replacing it to "::", which is relatively close to the former ":".

Since the discovery of the feature was only through typing ":", we added a new item in the "+" button of composer to insert a new canned response, which simply adds the "::" in the composer to help select the canned response. This composer action only shows the shortcut to trigger canned response: it let the user learns of this feature, and in case the delimiter changes like with this PR, the user can relatively easily re-learn the new trigger thanks to this composer action.

The "Insert a Canned response" composer action is visible when the user can at least find a canned response. Also the canned response suggestions are focused by default, now that they do not conflict with emoji substitution.

Task-4110505

https://github.com/odoo/enterprise/pull/77184

![Jan-14-2025 16-15-44](https://github.com/user-attachments/assets/a106962b-b38e-4a4f-b99c-d1ecd2a2202a)
