### PR TITLE
[FIX] website: remove irrelevant tooltip for google fonts

### DIFF
--- a/addons/website/static/src/xml/website.editor.xml
+++ b/addons/website/static/src/xml/website.editor.xml
@@ -78,9 +78,6 @@
                         </div>
                         <label class="col-form-label col-md-4" for="google_font_serve">
                             Serve font from Google servers
-                            <sup class="text-info" title="To comply with some local regulations">
-                                <a target="_blank" href="https://www.odoo.com/forum/help-1/how-to-use-google-fonts-and-respecting-german-requirements-214049">?</a>
-                            </sup>
                         </label>
                         <label class="o_switch col-form-label col-md-8" t-att-class="{'o_switch_disabled': !state.googleFontFamily}" for="google_font_serve">
                             <input type="checkbox" checked="checked" t-att-disabled="!state.googleFontFamily" id="google_font_serve" t-model="state.googleServe"/>


### PR DESCRIPTION
Steps to reproduce:
1. Open website app
2. Click edit
3. Click on "Font Family"
4. Click on "Add a Custom Font"
5. Click on the question mark tooltip showing next to "Serve font from Google servers"

- Removed the tooltip since the form is only accessible internally and not relevant to all users. This was only added in v18+

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr